### PR TITLE
Runtime GPU providers, bench fixes, security hardening, and UX improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,21 @@ jobs:
   build-and-test:
     name: Build, Test, Lint
     runs-on: ubuntu-latest
+    container: archlinux:base-devel
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install system dependencies
         run: |
-          sudo add-apt-repository -y ppa:tpm2-software/main
-          sudo apt-get update
-          sudo apt-get install -y \
-            libv4l-dev \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libpam0g-dev \
+          pacman -Syu --noconfirm \
+            git \
+            rust \
             clang \
-            libtss2-dev
+            v4l-utils \
+            libxkbcommon \
+            wayland \
+            pam \
+            tpm2-tss
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+      - uses: actions/checkout@v4
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
@@ -58,25 +54,23 @@ jobs:
   tpm-tests:
     name: TPM Tests (swtpm)
     runs-on: ubuntu-latest
+    container: archlinux:base-devel
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v4
-
       - name: Install dependencies
         run: |
-          sudo add-apt-repository -y ppa:tpm2-software/main
-          sudo apt-get update
-          sudo apt-get install -y \
-            libv4l-dev \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libpam0g-dev \
+          pacman -Syu --noconfirm \
+            git \
+            rust \
             clang \
-            libtss2-dev \
+            v4l-utils \
+            libxkbcommon \
+            wayland \
+            pam \
+            tpm2-tss \
             swtpm
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v4
 
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@v2
@@ -106,34 +100,16 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo add-apt-repository -y ppa:tpm2-software/main
           sudo apt-get update
-          sudo apt-get install -y \
-            libv4l-dev \
-            libxkbcommon-dev \
-            libwayland-dev \
-            libpam0g-dev \
-            clang \
-            libtss2-dev \
-            podman
+          sudo apt-get install -y podman
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --workspace
-
-      - name: Build container
+      - name: Build release in container
         run: |
-          if [ -f test/Containerfile ]; then
-            podman build -t facelock-pam-test -f test/Containerfile .
-          else
-            echo "No Containerfile found, skipping container build"
+          if [ ! -f test/Containerfile ]; then
+            echo "No Containerfile found, skipping"
             exit 0
           fi
+          podman build -t facelock-pam-test -f test/Containerfile .
 
       - name: Run container PAM tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo add-apt-repository -y ppa:tpm2-software/main
           sudo apt-get update
           sudo apt-get install -y \
             libv4l-dev \
@@ -63,6 +64,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo add-apt-repository -y ppa:tpm2-software/main
           sudo apt-get update
           sudo apt-get install -y \
             libv4l-dev \
@@ -104,6 +106,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo add-apt-repository -y ppa:tpm2-software/main
           sudo apt-get update
           sudo apt-get install -y \
             libv4l-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
             --tpm2 \
             --ctrl type=tcp,port=2322 \
             --server type=tcp,port=2321 \
-            --flags not-need-init &
-          sleep 1
+            --flags startup-clear &
+          sleep 2
 
       - name: Run TPM tests
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,15 @@ cargo run --bin facelock -- --help
 
 ## GPU Support (Optional)
 
+GPU acceleration is a runtime option — no special build flags needed. Install a
+GPU-enabled ONNX Runtime package and set `execution_provider` in config:
+
 ```bash
-cargo build --workspace --features cuda      # NVIDIA CUDA
-cargo build --workspace --features tensorrt   # NVIDIA TensorRT
+sudo pacman -S onnxruntime-opt-cuda   # NVIDIA
+# Then edit /etc/facelock/config.toml: execution_provider = "cuda"
 ```
 
-CPU is the default. GPU features require CUDA toolkit or TensorRT SDK.
+Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` (Intel).
 
 ## Core Rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,12 +494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,12 +1508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-
-[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,12 +2019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-rust2"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
-
-[[package]]
 name = "malloced"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,7 +2368,6 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
 ]
 
 [[package]]
@@ -2394,11 +2375,6 @@ name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
-dependencies = [
- "hmac-sha256",
- "lzma-rust2",
- "ureq",
-]
 
 [[package]]
 name = "pam-facelock"
@@ -3232,17 +3208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,36 +3737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
-dependencies = [
- "base64",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pki-types",
- "socks",
- "ureq-proto",
- "utf-8",
- "webpki-root-certs",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,12 +3747,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4156,15 +4085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4181,28 +4101,6 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ That's it. Face auth is now active for `sudo`. Keep a root shell open until you'
 
 ### GPU Acceleration (Optional)
 
-```bash
-sudo pacman -S onnxruntime-opt-cuda   # system ORT with CUDA support
-just install-cuda                      # build + install with GPU support
-```
+GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package for your hardware and set `execution_provider` in `/etc/facelock/config.toml`:
 
-Supports CUDA and TensorRT execution providers. Set `execution_provider = "cuda"` or `"tensorrt"` in `/etc/facelock/config.toml`.
+| GPU Vendor | Package (Arch) | Config value |
+|------------|---------------|--------------|
+| NVIDIA | `onnxruntime-opt-cuda` | `"cuda"` |
+| AMD | `onnxruntime-opt-rocm` | `"rocm"` |
+| Intel | `onnxruntime-opt-openvino` | `"openvino"` |
+
+Supports CUDA, ROCm, and OpenVINO execution providers. CPU is the default.
 
 ### Uninstall
 
@@ -97,7 +100,7 @@ All keys are optional. Camera is auto-detected if `device.path` is omitted.
 
 [recognition]
 # threshold = 0.80         # cosine similarity threshold
-# execution_provider = "cpu"  # "cpu", "cuda", or "tensorrt"
+# execution_provider = "cpu"  # "cpu", "cuda", "rocm", or "openvino"
 # threads = 4              # ORT inference threads
 
 [daemon]

--- a/book/src/compatibility.md
+++ b/book/src/compatibility.md
@@ -131,10 +131,13 @@ Facelock uses the `ort` crate (Rust bindings for ONNX Runtime). The runtime bina
 
 ### Execution Providers
 
-| Provider | Config | Build Feature | Status |
-|----------|--------|--------------|--------|
-| CPU | `execution_provider = "cpu"` | default | Working |
-| CUDA | `execution_provider = "cuda"` | `--features cuda` | Config ready, build untested |
-| TensorRT | `execution_provider = "tensorrt"` | `--features tensorrt` | Config ready, build untested |
+GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package and set `execution_provider` in config.
 
-CPU is the default and only tested provider. GPU providers require additional system libraries (CUDA toolkit, TensorRT SDK).
+| Provider | Config | Runtime Requirement | Status |
+|----------|--------|---------------------|--------|
+| CPU | `execution_provider = "cpu"` | none (default) | Working |
+| CUDA (NVIDIA) | `execution_provider = "cuda"` | CUDA toolkit + GPU-enabled ORT | Config ready, untested |
+| ROCm (AMD) | `execution_provider = "rocm"` | ROCm runtime + GPU-enabled ORT | Config ready, untested |
+| OpenVINO (Intel) | `execution_provider = "openvino"` | OpenVINO runtime + GPU-enabled ORT | Config ready, untested |
+
+CPU is the default and only tested provider.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -26,7 +26,7 @@ Face detection and embedding parameters.
 | `nms_threshold` | f32 | `0.4` | Non-maximum suppression threshold for overlapping detections. |
 | `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. |
 | `embedder_model` | string | `"w600k_r50.onnx"` | ONNX embedder model filename. Must exist in `daemon.model_dir`. |
-| `execution_provider` | string | `"cpu"` | ONNX Runtime execution provider. Values: `"cpu"`, `"cuda"`, `"tensorrt"`. GPU providers require building with `--features cuda` or `--features tensorrt`. |
+| `execution_provider` | string | `"cpu"` | ONNX Runtime execution provider. Values: `"cpu"`, `"cuda"`, `"rocm"`, `"openvino"`. GPU providers require a GPU-enabled ONNX Runtime package installed on the system. |
 | `threads` | u32 | `4` | Number of CPU threads for ONNX inference. |
 
 ### Threshold range guide (ArcFace cosine similarity)

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -72,14 +72,15 @@ You should see "Identifying face..." and authenticate by looking at the camera.
 
 ### GPU Acceleration (Optional)
 
-For NVIDIA GPUs with CUDA support:
+GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package for your hardware:
 
 ```bash
-sudo pacman -S onnxruntime-opt-cuda   # Arch: system ORT with CUDA
-just install-cuda                      # build + install with GPU
+sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
+sudo pacman -S onnxruntime-opt-rocm      # AMD
+sudo pacman -S onnxruntime-opt-openvino  # Intel
 ```
 
-Set `execution_provider = "cuda"` or `"tensorrt"` in `/etc/facelock/config.toml`. CPU is the default.
+Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, or `"openvino"`. CPU is the default.
 
 ### Uninstall
 
@@ -103,7 +104,7 @@ Key settings:
 |---------|---------|-------------|
 | `device.path` | auto-detect | Camera path (prefers IR cameras) |
 | `recognition.threshold` | `0.80` | Cosine similarity threshold |
-| `recognition.execution_provider` | `"cpu"` | `"cpu"`, `"cuda"`, or `"tensorrt"` |
+| `recognition.execution_provider` | `"cpu"` | `"cpu"`, `"cuda"`, `"rocm"`, or `"openvino"` |
 | `daemon.mode` | `"daemon"` | `"daemon"` or `"oneshot"` |
 | `security.require_ir` | `true` | Reject RGB-only cameras |
 

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -74,8 +74,11 @@
 # embedder_model = "w600k_r50.onnx"
 
 # ONNX Runtime execution provider.
-# Values: "cpu", "cuda", "tensorrt"
-# GPU providers require building with --features cuda or --features tensorrt.
+# Values: "cpu", "cuda", "rocm", "openvino"
+# GPU providers require installing a GPU-enabled ONNX Runtime package:
+#   NVIDIA:  sudo pacman -S onnxruntime-opt-cuda
+#   AMD:     install onnxruntime with ROCm support
+#   Intel:   install openvino runtime
 # Default: "cpu"
 # execution_provider = "cpu"
 

--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -55,7 +55,7 @@ notes = "ThinkPad integrated IR camera (various models)"
 vendor_id = "046d"
 product_id = "085e"
 force_ir = true
-warmup_frames = 10
+warmup_frames = 1
 notes = "Logitech BRIO 4K with IR sensor"
 
 # --- Microsoft Surface cameras ---

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -143,9 +143,7 @@ impl<'a> Camera<'a> {
 
         // Apply quirk overrides for rotation (warmup_frames is handled by the caller
         // since Camera::open doesn't consume warmup frames itself).
-        let rotation = quirk
-            .and_then(|q| q.rotation)
-            .unwrap_or(config.rotation);
+        let rotation = quirk.and_then(|q| q.rotation).unwrap_or(config.rotation);
         if let Some(q) = quirk {
             if q.rotation.is_some() || q.warmup_frames.is_some() || q.format_preference.is_some() {
                 tracing::info!(
@@ -311,10 +309,7 @@ impl Drop for Camera<'_> {
                 match ir_emitter::disable_emitter_with_info(&self.device_path, xu_info) {
                     Ok(()) => tracing::debug!("IR emitter disabled on {}", self.device_path),
                     Err(e) => {
-                        tracing::warn!(
-                            "failed to disable IR emitter on {}: {e}",
-                            self.device_path
-                        )
+                        tracing::warn!("failed to disable IR emitter on {}: {e}", self.device_path)
                     }
                 }
             }

--- a/crates/facelock-camera/src/ir_emitter.rs
+++ b/crates/facelock-camera/src/ir_emitter.rs
@@ -88,9 +88,7 @@ pub fn enable_emitter(device_path: &str, quirk: Option<&Quirk>) -> Result<bool, 
     let xu_info = match quirk.and_then(EmitterXuInfo::from_quirk) {
         Some(info) => info,
         None => {
-            tracing::debug!(
-                "no emitter XU info available for {device_path}, skipping"
-            );
+            tracing::debug!("no emitter XU info available for {device_path}, skipping");
             return Ok(false);
         }
     };
@@ -109,7 +107,10 @@ pub fn enable_emitter(device_path: &str, quirk: Option<&Quirk>) -> Result<bool, 
 ///
 /// This variant is used by the `Camera` drop path where the original `Quirk`
 /// reference is no longer available.
-pub fn enable_emitter_with_info(device_path: &str, xu_info: &EmitterXuInfo) -> Result<bool, String> {
+pub fn enable_emitter_with_info(
+    device_path: &str,
+    xu_info: &EmitterXuInfo,
+) -> Result<bool, String> {
     if !Path::new(device_path).exists() {
         return Err(format!("device not found: {device_path}"));
     }
@@ -129,9 +130,7 @@ pub fn disable_emitter(device_path: &str, quirk: Option<&Quirk>) -> Result<(), S
     let xu_info = match quirk.and_then(EmitterXuInfo::from_quirk) {
         Some(info) => info,
         None => {
-            tracing::debug!(
-                "no emitter XU info available for {device_path}, skipping"
-            );
+            tracing::debug!("no emitter XU info available for {device_path}, skipping");
             return Ok(());
         }
     };
@@ -180,7 +179,11 @@ pub fn has_controllable_emitter(device_path: &str, quirk: Option<&Quirk>) -> boo
 }
 
 /// Send a `UVC_SET_CUR` to the emitter XU control.
-fn set_emitter_control(device_path: &str, xu_info: &EmitterXuInfo, value: u8) -> Result<(), String> {
+fn set_emitter_control(
+    device_path: &str,
+    xu_info: &EmitterXuInfo,
+    value: u8,
+) -> Result<(), String> {
     let file = OpenOptions::new()
         .read(true)
         .write(true)

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -9,6 +9,6 @@ pub use device::{
     DeviceInfo, FormatInfo, auto_detect_device, is_ir_camera, is_ir_camera_with_quirks,
     list_devices, validate_device,
 };
-pub use preprocess::{check_ir_texture, clahe, extract_bbox_region, rgb_to_gray, yuyv_to_rgb};
 pub use ir_emitter::EmitterXuInfo;
+pub use preprocess::{check_ir_texture, clahe, extract_bbox_region, rgb_to_gray, yuyv_to_rgb};
 pub use quirks::{Quirk, QuirksDb};

--- a/crates/facelock-cli/Cargo.toml
+++ b/crates/facelock-cli/Cargo.toml
@@ -46,5 +46,3 @@ bytemuck = "1"
 default = ["wayland"]
 wayland = ["dep:smithay-client-toolkit", "dep:wayland-client", "dep:xkbcommon"]
 tpm = ["facelock-tpm/tpm", "facelock-daemon/tpm", "dep:tss-esapi"]
-cuda = ["facelock-face/cuda", "facelock-daemon/cuda"]
-tensorrt = ["facelock-face/tensorrt", "facelock-daemon/tensorrt"]

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -4,7 +4,8 @@
 
 use std::path::Path;
 
-use facelock_camera::{Camera, auto_detect_device, is_ir_camera, validate_device};
+use facelock_camera::{Camera, auto_detect_device, is_ir_camera_with_quirks, validate_device};
+use facelock_camera::quirks::QuirksDb;
 use facelock_core::config::Config;
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
@@ -121,8 +122,11 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     // --- End pre-flight checks ---
 
     let device_path = config.device.path.clone().unwrap();
-    let device_is_ir = validate_device(&device_path)
-        .map(|dev| is_ir_camera(&dev))
+    let quirks = QuirksDb::load();
+    let device_info = validate_device(&device_path);
+    let device_is_ir = device_info
+        .as_ref()
+        .map(|dev| is_ir_camera_with_quirks(dev, Some(&quirks)))
         .unwrap_or(false);
 
     if config.security.require_ir && !device_is_ir {
@@ -130,13 +134,25 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         return 2;
     }
 
-    let mut camera = match Camera::open(&config.device, None) {
+    let device_quirk = device_info
+        .ok()
+        .and_then(|info| quirks.find_match(&info).cloned());
+
+    let mut camera = match Camera::open(&config.device, device_quirk.as_ref()) {
         Ok(c) => c,
         Err(e) => {
             error!("camera: {e}");
             return 2;
         }
     };
+
+    // Discard warmup frames for AGC/AE stabilization.
+    let warmup = device_quirk
+        .and_then(|q| q.warmup_frames)
+        .unwrap_or(config.device.warmup_frames);
+    for _ in 0..warmup {
+        let _ = camera.capture();
+    }
 
     let mut engine =
         match FaceEngine::load(&config.recognition, Path::new(&config.daemon.model_dir)) {

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -4,8 +4,8 @@
 
 use std::path::Path;
 
-use facelock_camera::{Camera, auto_detect_device, is_ir_camera_with_quirks, validate_device};
 use facelock_camera::quirks::QuirksDb;
+use facelock_camera::{Camera, auto_detect_device, is_ir_camera_with_quirks, validate_device};
 use facelock_core::config::Config;
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
@@ -164,7 +164,14 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         };
 
     let start = std::time::Instant::now();
-    let response = auth::authenticate(&mut camera, &mut engine, &store, &config, &user, device_is_ir);
+    let response = auth::authenticate(
+        &mut camera,
+        &mut engine,
+        &store,
+        &config,
+        &user,
+        device_is_ir,
+    );
     let duration_ms = start.elapsed().as_millis() as u64;
 
     // Note: authenticate_inner already writes audit entries for the camera-based

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -7,12 +7,13 @@ use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use tracing::{info, warn};
 
-use facelock_camera::capture::Camera;
-use facelock_camera::device::{is_ir_camera, validate_device};
+use facelock_camera::Camera;
 use facelock_core::Config;
 use facelock_core::types::{FaceEmbedding, cosine_similarity};
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
+
+use crate::direct;
 
 /// Performance targets in milliseconds.
 const TARGET_COLD_AUTH_MS: u64 = 3000;
@@ -46,6 +47,22 @@ pub enum BenchCommand {
 }
 
 pub fn run(command: BenchCommand) -> Result<()> {
+    // Auth benchmarks need to decrypt embeddings, which may require root for TPM access
+    let needs_embeddings = matches!(
+        command,
+        BenchCommand::ColdAuth
+            | BenchCommand::WarmAuth
+            | BenchCommand::Calibrate
+            | BenchCommand::Report
+    );
+    if needs_embeddings {
+        if let Ok(config) = Config::load() {
+            if config.encryption.method == facelock_core::config::EncryptionMethod::Tpm {
+                crate::ipc_client::require_root("sudo facelock bench <subcommand>")?;
+            }
+        }
+    }
+
     match command {
         BenchCommand::ColdAuth => cmd_cold_auth(),
         BenchCommand::WarmAuth => cmd_warm_auth(),
@@ -69,15 +86,9 @@ fn model_dir(config: &Config) -> &Path {
     Path::new(&config.daemon.model_dir)
 }
 
-/// Open the camera from config.
+/// Open the camera from config (with quirks and warmup frame discarding).
 fn open_camera(config: &Config) -> Result<Camera<'static>> {
-    let path_display = config.device.path.as_deref().unwrap_or("(auto-detect)");
-    if let Some(ref path) = config.device.path {
-        let device_info = validate_device(path)
-            .with_context(|| format!("Camera device {path} not accessible"))?;
-        info!(device = %path, ir = is_ir_camera(&device_info), "Camera validated");
-    }
-    Camera::open(&config.device, None).with_context(|| format!("Failed to open camera ({path_display})"))
+    direct::open_camera(config).context("Failed to open camera")
 }
 
 /// Load FaceEngine from config.
@@ -110,7 +121,7 @@ fn cmd_cold_auth() -> Result<()> {
     let store =
         FaceStore::open(Path::new(&config.storage.db_path)).context("Failed to open face store")?;
 
-    let embeddings = store.get_user_embeddings(&user)?;
+    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -118,9 +129,22 @@ fn cmd_cold_auth() -> Result<()> {
         );
     }
 
-    // Capture and match
-    let frame = camera.capture().context("Failed to capture frame")?;
-    let faces = engine.process(&frame)?;
+    // Capture frames until we detect a face or timeout, like the real auth loop.
+    // The first few frames from a V4L2 camera are often dark/blank while the
+    // sensor adjusts exposure.
+    let timeout = std::time::Duration::from_secs(config.recognition.timeout_secs as u64);
+    let deadline = start + timeout;
+    let mut faces = Vec::new();
+    let mut frames_captured = 0u32;
+
+    while Instant::now() < deadline {
+        let frame = camera.capture().context("Failed to capture frame")?;
+        frames_captured += 1;
+        faces = engine.process(&frame)?;
+        if !faces.is_empty() {
+            break;
+        }
+    }
 
     let elapsed = start.elapsed();
     let elapsed_ms = elapsed.as_millis() as u64;
@@ -133,6 +157,7 @@ fn cmd_cold_auth() -> Result<()> {
         "Result:          {}",
         pass_fail(elapsed_ms, TARGET_COLD_AUTH_MS)
     );
+    println!("Frames captured: {}", frames_captured);
     println!("Faces detected:  {}", faces.len());
     println!(
         "Auth result:     {}",
@@ -159,7 +184,7 @@ fn cmd_warm_auth() -> Result<()> {
     let store =
         FaceStore::open(Path::new(&config.storage.db_path)).context("Failed to open face store")?;
 
-    let embeddings = store.get_user_embeddings(&user)?;
+    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -351,7 +376,7 @@ fn cmd_calibrate() -> Result<()> {
     let store =
         FaceStore::open(Path::new(&config.storage.db_path)).context("Failed to open face store")?;
 
-    let enrolled = store.get_user_embeddings(&user)?;
+    let enrolled = direct::load_user_embeddings(&store, &config, &user)?;
     if enrolled.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -530,7 +555,7 @@ fn cmd_report() -> Result<()> {
     // Warm auth benchmark
     let store =
         FaceStore::open(Path::new(&config.storage.db_path)).context("Failed to open face store")?;
-    let embeddings = store.get_user_embeddings(&user)?;
+    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
     let has_enrolled = !embeddings.is_empty();
 
     let warm_auth_ms = if has_enrolled {
@@ -661,9 +686,10 @@ fn find_best_match(
     false
 }
 
-/// Get the current username.
+/// Get the current username, preferring SUDO_USER when running under sudo.
 fn current_user() -> String {
-    std::env::var("USER")
+    std::env::var("SUDO_USER")
+        .or_else(|_| std::env::var("USER"))
         .or_else(|_| std::env::var("LOGNAME"))
         .unwrap_or_else(|_| "unknown".to_string())
 }

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -564,9 +564,7 @@ type CameraFactory = Box<dyn Fn(&Config) -> Result<Camera<'static>, String> + Se
 
 /// Build a new handler from config. Used at startup and for live config reload.
 /// Returns the handler and idle_timeout_secs from the loaded config.
-fn build_handler(
-    config_path: Option<&str>,
-) -> Result<(ProductionHandler, u64), String> {
+fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), String> {
     let config = match config_path {
         Some(p) => Config::load_from(Path::new(p)),
         None => Config::load(),
@@ -576,9 +574,8 @@ fn build_handler(
     let quirks = QuirksDb::load();
 
     if config.device.path.is_none() {
-        let info = auto_detect_device().map_err(|e| {
-            format!("no camera device specified and auto-detection failed: {e}")
-        })?;
+        let info = auto_detect_device()
+            .map_err(|e| format!("no camera device specified and auto-detection failed: {e}"))?;
         let is_ir = is_ir_camera_with_quirks(&info, Some(&quirks));
         info!(device = %info.path, name = %info.name, ir = is_ir, "auto-detected camera device");
         config.device.path = Some(info.path);

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -64,6 +64,39 @@ fn lock_handler_with_timeout(
     }
 }
 
+/// Verify the D-Bus caller is root.
+/// Used for privileged operations: enroll, remove, clear.
+async fn verify_caller_is_root(
+    hdr: &zbus::message::Header<'_>,
+    connection: &zbus::Connection,
+) -> fdo::Result<()> {
+    let sender = hdr
+        .sender()
+        .ok_or_else(|| fdo::Error::Failed("no sender in D-Bus message".into()))?;
+
+    let dbus_proxy = fdo::DBusProxy::new(connection)
+        .await
+        .map_err(|e| fdo::Error::Failed(format!("failed to create DBus proxy: {e}")))?;
+    let uid = dbus_proxy
+        .get_connection_unix_user(sender.as_ref().into())
+        .await
+        .map_err(|e| fdo::Error::Failed(format!("failed to get caller UID: {e}")))?;
+
+    if uid != 0 {
+        let caller_name = uid_to_username(uid).unwrap_or_else(|| format!("UID {uid}"));
+        warn!(
+            caller_uid = uid,
+            caller_name = %caller_name,
+            "D-Bus caller not authorized for privileged operation"
+        );
+        return Err(fdo::Error::AccessDenied(format!(
+            "root required (caller: '{caller_name}', UID {uid})"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Verify the D-Bus caller is authorized to act on behalf of `user`.
 /// Root (UID 0) can act on any user. Non-root callers must match `user`.
 async fn verify_caller_authorized(
@@ -283,7 +316,7 @@ impl FacelockService {
     ) -> fdo::Result<(u32, u32)> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
-        verify_caller_authorized(&hdr, connection, user).await?;
+        verify_caller_is_root(&hdr, connection).await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         let label = label.to_string();
@@ -349,7 +382,7 @@ impl FacelockService {
         model_id: u32,
     ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_authorized(&hdr, connection, user).await?;
+        verify_caller_is_root(&hdr, connection).await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         tokio::task::spawn_blocking(move || {
@@ -375,7 +408,7 @@ impl FacelockService {
         user: &str,
     ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_authorized(&hdr, connection, user).await?;
+        verify_caller_is_root(&hdr, connection).await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         tokio::task::spawn_blocking(move || {

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -11,9 +11,8 @@ pub fn run() -> anyhow::Result<()> {
         return crate::direct::list_devices_direct();
     }
 
-    let response =
-        ipc_client::send_request(&DaemonRequest::ListDevices)
-            .context("failed to query daemon — is facelock-daemon running?")?;
+    let response = ipc_client::send_request(&DaemonRequest::ListDevices)
+        .context("failed to query daemon — is facelock-daemon running?")?;
 
     match response {
         DaemonResponse::Devices(devices) => {

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -194,10 +194,7 @@ pub fn run_decrypt() -> Result<()> {
 
     // Decrypt TPM-sealed embeddings
     if !tpm_sealed.is_empty() {
-        println!(
-            "Decrypting {} TPM-sealed embedding(s)...",
-            tpm_sealed.len()
-        );
+        println!("Decrypting {} TPM-sealed embedding(s)...", tpm_sealed.len());
 
         #[cfg(feature = "tpm")]
         {

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -6,7 +6,11 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use crate::ipc_client;
 
-pub fn run(user: Option<String>, label: Option<String>, skip_setup_check: bool) -> anyhow::Result<()> {
+pub fn run(
+    user: Option<String>,
+    label: Option<String>,
+    skip_setup_check: bool,
+) -> anyhow::Result<()> {
     // Setup gate: prompt user if setup hasn't been run.
     // Setup includes model downloads, encryption, and face enrollment,
     // so if setup runs successfully we're done — no need to enroll again.
@@ -66,9 +70,10 @@ pub fn run(user: Option<String>, label: Option<String>, skip_setup_check: bool) 
         } else {
             let request = DaemonRequest::ListModels { user: user.clone() };
             match ipc_client::send_request(&request) {
-                Ok(DaemonResponse::Models(ref m)) if !m.is_empty() => {
-                    Some(!m.iter().any(|model| model.embedder_model == *config_embedder))
-                }
+                Ok(DaemonResponse::Models(ref m)) if !m.is_empty() => Some(
+                    !m.iter()
+                        .any(|model| model.embedder_model == *config_embedder),
+                ),
                 _ => None,
             }
         };
@@ -76,7 +81,9 @@ pub fn run(user: Option<String>, label: Option<String>, skip_setup_check: bool) 
             println!(
                 "Note: existing models don't use the configured embedder '{config_embedder}'."
             );
-            println!("Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n");
+            println!(
+                "Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
+            );
         }
     }
 

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -29,6 +29,8 @@ pub fn run(user: Option<String>, label: Option<String>, skip_setup_check: bool) 
         }
     }
 
+    ipc_client::require_root("sudo facelock enroll")?;
+
     let config = Config::load().context("failed to load config")?;
 
     // Check models exist

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -64,7 +64,10 @@ fn print_table(user: &str, models: &[FaceModelInfo]) {
         } else {
             model.embedder_model.clone()
         };
-        println!("  {:<6} {:<20} {:<24} {}", model.id, model.label, created, model_name);
+        println!(
+            "  {:<6} {:<20} {:<24} {}",
+            model.id, model.label, created, model_name
+        );
     }
 
     println!("\n  Total: {} model(s)", models.len());

--- a/crates/facelock-cli/src/commands/preview/text_only.rs
+++ b/crates/facelock-cli/src/commands/preview/text_only.rs
@@ -26,11 +26,9 @@ pub fn run(user: &str) -> anyhow::Result<()> {
     let stdout = std::io::stdout();
 
     while !stop.load(Ordering::Relaxed) {
-        let response = match ipc_client::send_request(
-            &DaemonRequest::PreviewDetectFrame {
-                user: user.to_string(),
-            },
-        ) {
+        let response = match ipc_client::send_request(&DaemonRequest::PreviewDetectFrame {
+            user: user.to_string(),
+        }) {
             Ok(r) => r,
             Err(_) => break,
         };

--- a/crates/facelock-cli/src/commands/preview/wayland_preview.rs
+++ b/crates/facelock-cli/src/commands/preview/wayland_preview.rs
@@ -137,8 +137,7 @@ impl PreviewState {
         let user = self.user.clone();
 
         // Request a frame with detection from the daemon
-        let frame_result =
-            ipc_client::send_request(&DaemonRequest::PreviewDetectFrame { user });
+        let frame_result = ipc_client::send_request(&DaemonRequest::PreviewDetectFrame { user });
 
         // Update FPS tracking
         let fps = match &frame_result {

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -581,10 +581,11 @@ fn wizard_pam_setup(theme: &ColorfulTheme) -> anyhow::Result<Vec<String>> {
         return Ok(Vec::new());
     }
 
-    let available_services = ["sudo", "polkit-1"];
+    let available_services = ["sudo", "polkit-1", "hyprlock"];
     let service_descriptions = [
-        "sudo    - authenticate sudo commands with face recognition",
+        "sudo     - authenticate sudo commands with face recognition",
         "polkit-1 - authenticate graphical privilege prompts with face recognition",
+        "hyprlock - authenticate lock screen with face recognition",
     ];
 
     // Filter to services that actually exist on the system
@@ -903,9 +904,15 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
 
 // --- PAM installation ---
 
-const PAM_LINE: &str = "auth  sufficient  pam_facelock.so";
+const PAM_LINE: &str = "auth      sufficient pam_facelock.so";
 const PAM_MODULE_PATH: &str = "/lib/security/pam_facelock.so";
 const SENSITIVE_SERVICES: &[&str] = &["system-auth", "login", "sshd"];
+
+/// Check if a PAM config line references pam_facelock, regardless of spacing.
+fn is_facelock_pam_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    !trimmed.starts_with('#') && trimmed.contains("pam_facelock.so")
+}
 
 pub fn run_pam(service: &str, remove: bool, yes: bool) -> anyhow::Result<()> {
     // 1. Check root
@@ -949,8 +956,8 @@ fn pam_install(service: &str, yes: bool) -> anyhow::Result<()> {
     let content =
         fs::read_to_string(pam_file).with_context(|| format!("failed to read {pam_path}"))?;
 
-    // Check idempotency
-    if content.lines().any(|line| line.trim() == PAM_LINE) {
+    // Check idempotency — match on the module name, not exact spacing
+    if content.lines().any(|line| is_facelock_pam_line(line)) {
         println!("PAM line already present in {pam_path}. Nothing to do.");
         return Ok(());
     }
@@ -1008,7 +1015,7 @@ fn pam_remove(service: &str) -> anyhow::Result<()> {
     let original_count = content.lines().count();
     let new_lines: Vec<&str> = content
         .lines()
-        .filter(|line| line.trim() != PAM_LINE)
+        .filter(|line| !is_facelock_pam_line(line))
         .collect();
 
     if new_lines.len() == original_count {
@@ -1209,22 +1216,29 @@ account include   system-login
 
     #[test]
     fn pam_idempotent_detection() {
+        // Exact match
         let content = format!("#%PAM-1.0\n{PAM_LINE}\nauth    include   system-login\n");
-        let already_present = content.lines().any(|line| line.trim() == PAM_LINE);
-        assert!(already_present);
+        assert!(content.lines().any(|line| is_facelock_pam_line(line)));
+
+        // Different spacing should still match
+        let content2 = "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\n";
+        assert!(content2.lines().any(|line| is_facelock_pam_line(line)));
+
+        // Commented-out line should not match
+        let content3 = "#%PAM-1.0\n#auth sufficient pam_facelock.so\nauth    include   system-login\n";
+        assert!(!content3.lines().any(|line| is_facelock_pam_line(line)));
     }
 
     #[test]
     fn pam_remove_filters_line() {
-        let content = format!(
-            "#%PAM-1.0\n{PAM_LINE}\nauth    include   system-login\naccount include   system-login\n"
-        );
+        // Should remove regardless of spacing
+        let content = "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\naccount include   system-login\n";
         let new_lines: Vec<&str> = content
             .lines()
-            .filter(|line| line.trim() != PAM_LINE)
+            .filter(|line| !is_facelock_pam_line(line))
             .collect();
         assert_eq!(new_lines.len(), 3);
-        assert!(!new_lines.iter().any(|l| l.trim() == PAM_LINE));
+        assert!(!new_lines.iter().any(|l| is_facelock_pam_line(l)));
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -957,7 +957,7 @@ fn pam_install(service: &str, yes: bool) -> anyhow::Result<()> {
         fs::read_to_string(pam_file).with_context(|| format!("failed to read {pam_path}"))?;
 
     // Check idempotency — match on the module name, not exact spacing
-    if content.lines().any(|line| is_facelock_pam_line(line)) {
+    if content.lines().any(is_facelock_pam_line) {
         println!("PAM line already present in {pam_path}. Nothing to do.");
         return Ok(());
     }
@@ -1221,11 +1221,13 @@ account include   system-login
         assert!(content.lines().any(|line| is_facelock_pam_line(line)));
 
         // Different spacing should still match
-        let content2 = "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\n";
+        let content2 =
+            "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\n";
         assert!(content2.lines().any(|line| is_facelock_pam_line(line)));
 
         // Commented-out line should not match
-        let content3 = "#%PAM-1.0\n#auth sufficient pam_facelock.so\nauth    include   system-login\n";
+        let content3 =
+            "#%PAM-1.0\n#auth sufficient pam_facelock.so\nauth    include   system-login\n";
         assert!(!content3.lines().any(|line| is_facelock_pam_line(line)));
     }
 

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -298,14 +298,29 @@ fn check_security(config: &Option<Config>) {
         print_result(false, "ALL SECURITY CHECKS DISABLED");
         return;
     }
-    print_detail("require_ir", if config.security.require_ir { "yes" } else { "no" });
+    print_detail(
+        "require_ir",
+        if config.security.require_ir {
+            "yes"
+        } else {
+            "no"
+        },
+    );
     print_detail(
         "liveness (frame variance)",
-        if config.security.require_frame_variance { "yes" } else { "no" },
+        if config.security.require_frame_variance {
+            "yes"
+        } else {
+            "no"
+        },
     );
     print_detail(
         "liveness (landmark movement)",
-        if config.security.require_landmark_liveness { "yes" } else { "no" },
+        if config.security.require_landmark_liveness {
+            "yes"
+        } else {
+            "no"
+        },
     );
     print_detail(
         "min_auth_frames",
@@ -326,9 +341,30 @@ fn check_notifications(config: &Option<Config>) {
     };
     print_status_item("Notifications", mode_str);
     if config.notification.mode != facelock_core::config::NotificationMode::Off {
-        print_detail("prompt", if config.notification.notify_prompt { "yes" } else { "no" });
-        print_detail("on success", if config.notification.notify_on_success { "yes" } else { "no" });
-        print_detail("on failure", if config.notification.notify_on_failure { "yes" } else { "no" });
+        print_detail(
+            "prompt",
+            if config.notification.notify_prompt {
+                "yes"
+            } else {
+                "no"
+            },
+        );
+        print_detail(
+            "on success",
+            if config.notification.notify_on_success {
+                "yes"
+            } else {
+                "no"
+            },
+        );
+        print_detail(
+            "on failure",
+            if config.notification.notify_on_failure {
+                "yes"
+            } else {
+                "no"
+            },
+        );
     }
 }
 

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -21,10 +21,22 @@ pub fn run() -> anyhow::Result<()> {
     // 4. Models
     check_models(&config);
 
-    // 5. Encryption
+    // 5. Inference
+    check_inference(&config);
+
+    // 6. Encryption
     check_encryption(&config);
 
-    // 6. PAM
+    // 7. Enrolled faces
+    check_enrolled(&config);
+
+    // 8. Security
+    check_security(&config);
+
+    // 9. Notifications
+    check_notifications(&config);
+
+    // 10. PAM
     check_pam();
 
     Ok(())
@@ -150,6 +162,34 @@ fn check_models(config: &Option<Config>) {
     }
 }
 
+fn check_inference(config: &Option<Config>) {
+    let Some(config) = config else {
+        return;
+    };
+
+    let provider = &config.recognition.execution_provider;
+    let label = match provider.as_str() {
+        "cpu" => "CPU",
+        "cuda" => "CUDA (NVIDIA GPU)",
+        "rocm" => "ROCm (AMD GPU)",
+        "openvino" => "OpenVINO (Intel)",
+        other => other,
+    };
+    print_status_item("Execution provider", label);
+
+    // Check that the ORT library is loadable
+    let ort_paths = [
+        "/usr/lib/libonnxruntime.so",
+        "/usr/lib64/libonnxruntime.so",
+        "/usr/lib/facelock/libonnxruntime.so",
+    ];
+    if let Some(path) = ort_paths.iter().find(|p| Path::new(p).exists()) {
+        print_result(true, &format!("ONNX Runtime found at {path}"));
+    } else {
+        print_result(false, "ONNX Runtime not found (install onnxruntime)");
+    }
+}
+
 fn check_encryption(config: &Option<Config>) {
     let Some(config) = config else {
         return;
@@ -213,6 +253,82 @@ fn check_encryption(config: &Option<Config>) {
                 print_detail("plaintext", &unsealed.to_string());
             }
         }
+    }
+}
+
+fn check_enrolled(config: &Option<Config>) {
+    let Some(config) = config else {
+        return;
+    };
+
+    let user = std::env::var("SUDO_USER")
+        .or_else(|_| std::env::var("USER"))
+        .unwrap_or_else(|_| "unknown".into());
+
+    print_status_item("Enrolled faces", &user);
+
+    match facelock_store::FaceStore::open_readonly(Path::new(&config.storage.db_path)) {
+        Ok(store) => match store.list_models(&user) {
+            Ok(models) if models.is_empty() => {
+                print_result(false, "no faces enrolled (run 'facelock enroll')");
+            }
+            Ok(models) => {
+                print_result(true, &format!("{} model(s)", models.len()));
+                for m in &models {
+                    print_detail(&format!("#{}", m.id), &m.label);
+                }
+            }
+            Err(e) => {
+                print_result(false, &format!("error reading models: {e}"));
+            }
+        },
+        Err(_) => {
+            print_detail("database", "not accessible (may need root)");
+        }
+    }
+}
+
+fn check_security(config: &Option<Config>) {
+    let Some(config) = config else {
+        return;
+    };
+
+    print_status_item("Security", "");
+    if config.security.disabled {
+        print_result(false, "ALL SECURITY CHECKS DISABLED");
+        return;
+    }
+    print_detail("require_ir", if config.security.require_ir { "yes" } else { "no" });
+    print_detail(
+        "liveness (frame variance)",
+        if config.security.require_frame_variance { "yes" } else { "no" },
+    );
+    print_detail(
+        "liveness (landmark movement)",
+        if config.security.require_landmark_liveness { "yes" } else { "no" },
+    );
+    print_detail(
+        "min_auth_frames",
+        &config.security.min_auth_frames.to_string(),
+    );
+}
+
+fn check_notifications(config: &Option<Config>) {
+    let Some(config) = config else {
+        return;
+    };
+
+    let mode_str = match config.notification.mode {
+        facelock_core::config::NotificationMode::Off => "off",
+        facelock_core::config::NotificationMode::Terminal => "terminal",
+        facelock_core::config::NotificationMode::Desktop => "desktop",
+        facelock_core::config::NotificationMode::Both => "terminal + desktop",
+    };
+    print_status_item("Notifications", mode_str);
+    if config.notification.mode != facelock_core::config::NotificationMode::Off {
+        print_detail("prompt", if config.notification.notify_prompt { "yes" } else { "no" });
+        print_detail("on success", if config.notification.notify_on_success { "yes" } else { "no" });
+        print_detail("on failure", if config.notification.notify_on_failure { "yes" } else { "no" });
     }
 }
 

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -61,9 +61,9 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
         } else {
             let request = DaemonRequest::ListModels { user: user.clone() };
             match ipc_client::send_request(&request) {
-                Ok(DaemonResponse::Models(ref m)) => {
-                    m.iter().any(|model| model.embedder_model == *config_embedder)
-                }
+                Ok(DaemonResponse::Models(ref m)) => m
+                    .iter()
+                    .any(|model| model.embedder_model == *config_embedder),
                 _ => true, // can't check, proceed anyway
             }
         };

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 
 use anyhow::{Context, bail};
 use facelock_camera::quirks::QuirksDb;
-use facelock_camera::{Camera, is_ir_camera, is_ir_camera_with_quirks, list_devices, validate_device};
+use facelock_camera::{
+    Camera, is_ir_camera, is_ir_camera_with_quirks, list_devices, validate_device,
+};
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
@@ -29,8 +31,8 @@ pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
         .and_then(|p| validate_device(p).ok())
         .and_then(|info| quirks.find_match(&info).cloned());
 
-    let mut camera = Camera::open(&config.device, device_quirk.as_ref())
-        .context("failed to open camera")?;
+    let mut camera =
+        Camera::open(&config.device, device_quirk.as_ref()).context("failed to open camera")?;
 
     // Discard warmup frames for AGC/AE stabilization.
     // Quirk override takes precedence over config value.
@@ -95,9 +97,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<bool> {
 
 /// Initialize a software sealer based on encryption config.
 /// Returns `None` if encryption is disabled.
-fn init_software_sealer(
-    config: &Config,
-) -> anyhow::Result<Option<facelock_tpm::SoftwareSealer>> {
+fn init_software_sealer(config: &Config) -> anyhow::Result<Option<facelock_tpm::SoftwareSealer>> {
     match config.encryption.method {
         EncryptionMethod::Keyfile => {
             let key_path = Path::new(&config.encryption.key_path);
@@ -160,7 +160,9 @@ pub fn load_user_embeddings(
         } else if *sealed {
             #[cfg(feature = "tpm")]
             {
-                bail!("embedding {id} is TPM-sealed but direct path only supports software encryption — use the daemon");
+                bail!(
+                    "embedding {id} is TPM-sealed but direct path only supports software encryption — use the daemon"
+                );
             }
             #[cfg(not(feature = "tpm"))]
             {
@@ -297,8 +299,8 @@ mod facelock_daemon_auth {
             models.iter().find(|m| m.id == id).map(|m| m.label.clone())
         };
 
-        let deadline = Instant::now()
-            + std::time::Duration::from_secs(config.recognition.timeout_secs as u64);
+        let deadline =
+            Instant::now() + std::time::Duration::from_secs(config.recognition.timeout_secs as u64);
         let threshold = config.recognition.threshold;
         let mut best_similarity: f32 = 0.0;
         let mut matched_frame_embeddings: Vec<FaceEmbedding> =
@@ -423,9 +425,7 @@ mod facelock_daemon_auth {
                 }
             } else if best_similarity >= threshold {
                 // If landmark liveness is required, check it even without variance
-                if config.security.require_landmark_liveness
-                    && !landmark_tracker.check_liveness()
-                {
+                if config.security.require_landmark_liveness && !landmark_tracker.check_liveness() {
                     debug!(
                         frame = frame_count,
                         landmark_frames = landmark_tracker.frame_count(),
@@ -567,11 +567,15 @@ mod facelock_daemon_enroll {
                 match sealer.seal_embedding(embedding) {
                     Ok(encrypted) => match model_id {
                         None => store
-                            .add_model_raw(user, label, &encrypted, true, &config.recognition.embedder_model)
+                            .add_model_raw(
+                                user,
+                                label,
+                                &encrypted,
+                                true,
+                                &config.recognition.embedder_model,
+                            )
                             .map(Some),
-                        Some(id) => store
-                            .add_embedding_raw(id, &encrypted, true)
-                            .map(|()| None),
+                        Some(id) => store.add_embedding_raw(id, &encrypted, true).map(|()| None),
                     },
                     Err(e) => {
                         warn!("failed to encrypt embedding: {e}");
@@ -582,7 +586,9 @@ mod facelock_daemon_enroll {
                 }
             } else {
                 match model_id {
-                    None => store.add_model(user, label, embedding, &config.recognition.embedder_model).map(Some),
+                    None => store
+                        .add_model(user, label, embedding, &config.recognition.embedder_model)
+                        .map(Some),
                     Some(id) => store.add_embedding(id, embedding).map(|()| None),
                 }
             };

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -6,19 +6,45 @@
 use std::path::Path;
 
 use anyhow::{Context, bail};
-use facelock_camera::{Camera, is_ir_camera, list_devices, validate_device};
+use facelock_camera::quirks::QuirksDb;
+use facelock_camera::{Camera, is_ir_camera, is_ir_camera_with_quirks, list_devices, validate_device};
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
+use tracing::debug;
 
 pub fn open_store(config: &Config) -> anyhow::Result<FaceStore> {
     FaceStore::open(Path::new(&config.storage.db_path)).context("failed to open database")
 }
 
+/// Open camera with quirks support and warmup frame discarding.
 pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
-    Camera::open(&config.device, None).context("failed to open camera")
+    let quirks = QuirksDb::load();
+    let device_quirk = config
+        .device
+        .path
+        .as_deref()
+        .and_then(|p| validate_device(p).ok())
+        .and_then(|info| quirks.find_match(&info).cloned());
+
+    let mut camera = Camera::open(&config.device, device_quirk.as_ref())
+        .context("failed to open camera")?;
+
+    // Discard warmup frames for AGC/AE stabilization.
+    // Quirk override takes precedence over config value.
+    let warmup = device_quirk
+        .and_then(|q| q.warmup_frames)
+        .unwrap_or(config.device.warmup_frames);
+    if warmup > 0 {
+        debug!(warmup, "discarding warmup frames");
+        for _ in 0..warmup {
+            let _ = camera.capture();
+        }
+    }
+
+    Ok(camera)
 }
 
 pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
@@ -37,12 +63,13 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<bool> {
     let mut camera = open_camera(config)?;
     let mut engine = load_engine(config)?;
 
+    let quirks = QuirksDb::load();
     let device_is_ir = config
         .device
         .path
         .as_deref()
         .and_then(|p| validate_device(p).ok())
-        .map(|dev| is_ir_camera(&dev))
+        .map(|dev| is_ir_camera_with_quirks(&dev, Some(&quirks)))
         .unwrap_or(false);
 
     // Load embeddings with encryption support, matching the daemon handler path.

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -189,7 +189,11 @@ fn main() -> anyhow::Result<()> {
                         commands::setup::run(non_interactive)
                     }
                 }
-                Commands::Enroll { user, label, skip_setup_check } => commands::enroll::run(user, label, skip_setup_check),
+                Commands::Enroll {
+                    user,
+                    label,
+                    skip_setup_check,
+                } => commands::enroll::run(user, label, skip_setup_check),
                 Commands::Remove {
                     model_id,
                     user,

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -97,7 +97,7 @@ pub struct RecognitionConfig {
     pub detector_model: String,
     #[serde(default = "default_embedder_model")]
     pub embedder_model: String,
-    /// ORT execution provider: "cpu", "cuda", or "tensorrt".
+    /// ORT execution provider: "cpu", "cuda", "rocm", or "openvino".
     #[serde(default = "default_execution_provider")]
     pub execution_provider: String,
     /// Number of intra-op threads for ORT inference.

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -16,15 +16,16 @@ pub fn config_path() -> PathBuf {
 mod tests {
     use super::*;
 
+    // These tests must run sequentially in a single test because they mutate
+    // a shared process-wide env var. Separate #[test] functions race when
+    // cargo runs tests in parallel.
     #[test]
-    fn config_path_default() {
-        // Clear env var to test default
+    fn config_path_default_and_env_override() {
+        // Test default (env var not set)
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         assert_eq!(config_path(), PathBuf::from(DEFAULT_CONFIG_PATH));
-    }
 
-    #[test]
-    fn config_path_env_override() {
+        // Test env var override
         unsafe { std::env::set_var("FACELOCK_CONFIG", "/tmp/test-facelock.toml") };
         assert_eq!(config_path(), PathBuf::from("/tmp/test-facelock.toml"));
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };

--- a/crates/facelock-daemon/Cargo.toml
+++ b/crates/facelock-daemon/Cargo.toml
@@ -26,8 +26,6 @@ serde_json = "1"
 
 [features]
 tpm = ["facelock-tpm/tpm"]
-cuda = ["facelock-face/cuda"]
-tensorrt = ["facelock-face/tensorrt"]
 
 [dev-dependencies]
 facelock-test-support = { path = "../facelock-test-support" }

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -58,7 +58,10 @@ pub fn pre_check(
     };
     if !has_models {
         if config.security.suppress_unknown {
-            info!(user, "no enrolled models, suppressing (suppress_unknown=true)");
+            info!(
+                user,
+                "no enrolled models, suppressing (suppress_unknown=true)"
+            );
             return Some(DaemonResponse::Suppressed);
         }
         return Some(DaemonResponse::AuthResult(MatchResult {
@@ -106,7 +109,15 @@ pub fn authenticate<C: CameraSource, E: FaceProcessor>(
         }
     };
     let models = store.list_models(user).unwrap_or_default();
-    authenticate_inner(camera, engine, &mut stored, &models, config, user, device_is_ir)
+    authenticate_inner(
+        camera,
+        engine,
+        &mut stored,
+        &models,
+        config,
+        user,
+        device_is_ir,
+    )
 }
 
 /// Run the camera-based authentication loop with pre-loaded (decrypted) embeddings.
@@ -122,7 +133,15 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
 ) -> DaemonResponse {
     let mut stored = stored.to_vec();
     let models = models.to_vec();
-    authenticate_inner(camera, engine, &mut stored, &models, config, user, device_is_ir)
+    authenticate_inner(
+        camera,
+        engine,
+        &mut stored,
+        &models,
+        config,
+        user,
+        device_is_ir,
+    )
 }
 
 /// Save a snapshot of the last captured frame to disk.
@@ -236,7 +255,11 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
 
         // Compute CLAHE-enhanced grayscale only for IR texture checks
         let clahe_gray = if device_is_ir {
-            Some(facelock_camera::preprocess::clahe(&frame.gray, frame.width, frame.height))
+            Some(facelock_camera::preprocess::clahe(
+                &frame.gray,
+                frame.width,
+                frame.height,
+            ))
         } else {
             None
         };
@@ -262,7 +285,13 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
         let mut frame_matched = false;
         for (det, embedding) in &faces {
             // Skip individual faces that fail IR texture check
-            if device_is_ir && !check_ir_texture(clahe_gray.as_deref().unwrap_or(&frame.gray), &det.bbox, frame.width) {
+            if device_is_ir
+                && !check_ir_texture(
+                    clahe_gray.as_deref().unwrap_or(&frame.gray),
+                    &det.bbox,
+                    frame.width,
+                )
+            {
                 debug!(
                     frame = frame_count,
                     "IR texture check failed for face, skipping"

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -119,11 +119,15 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
             match sealer.seal_embedding(embedding) {
                 Ok(encrypted) => match model_id {
                     None => store
-                        .add_model_raw(user, label, &encrypted, true, &config.recognition.embedder_model)
+                        .add_model_raw(
+                            user,
+                            label,
+                            &encrypted,
+                            true,
+                            &config.recognition.embedder_model,
+                        )
                         .map(Some),
-                    Some(id) => store
-                        .add_embedding_raw(id, &encrypted, true)
-                        .map(|()| None),
+                    Some(id) => store.add_embedding_raw(id, &encrypted, true).map(|()| None),
                 },
                 Err(e) => {
                     warn!("failed to encrypt embedding: {e}");
@@ -134,7 +138,9 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
             }
         } else {
             match model_id {
-                None => store.add_model(user, label, embedding, &config.recognition.embedder_model).map(Some),
+                None => store
+                    .add_model(user, label, embedding, &config.recognition.embedder_model)
+                    .map(Some),
                 Some(id) => store.add_embedding(id, embedding).map(|()| None),
             }
         };
@@ -179,8 +185,7 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     }
 
     // Check angle diversity: reject if all embeddings are too similar
-    if stored_count >= MIN_CAPTURES as u32
-        && !quality::check_angle_diversity(&enrolled_embeddings)
+    if stored_count >= MIN_CAPTURES as u32 && !quality::check_angle_diversity(&enrolled_embeddings)
     {
         warn!(
             user,

--- a/crates/facelock-daemon/src/liveness.rs
+++ b/crates/facelock-daemon/src/liveness.rs
@@ -15,7 +15,11 @@ pub struct LandmarkTracker {
 }
 
 impl LandmarkTracker {
-    pub fn new(max_frames: usize, displacement_threshold: f32, min_moving_landmarks: usize) -> Self {
+    pub fn new(
+        max_frames: usize,
+        displacement_threshold: f32,
+        min_moving_landmarks: usize,
+    ) -> Self {
         Self {
             history: Vec::with_capacity(max_frames),
             max_frames,

--- a/crates/facelock-daemon/src/quality.rs
+++ b/crates/facelock-daemon/src/quality.rs
@@ -425,7 +425,6 @@ mod tests {
     fn angle_diversity_at_threshold() {
         // Create two embeddings with similarity exactly at threshold
         let mut emb1 = [0.0f32; 512];
-        let mut emb2 = [0.0f32; 512];
 
         // Construct embeddings with specific similarity
         // For unit vectors that share most components but differ slightly
@@ -433,7 +432,7 @@ mod tests {
         for x in emb1.iter_mut() {
             *x = val;
         }
-        emb2 = emb1;
+        let mut emb2 = emb1;
         // Perturb one component slightly — this should change similarity below 0.95
         emb2[0] = -val * 5.0;
         // Re-normalize (approximate)

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1,6 +1,5 @@
 use facelock_core::config::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
-use facelock_core::types::MatchResult;
 use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
 use facelock_test_support::{MockCamera, MockFaceEngine};
@@ -147,7 +146,7 @@ fn warmup_frames_discarded_on_camera_open() {
 
     // Track captures via a shared counter
     let capture_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let counter = capture_count.clone();
+    let _counter = capture_count.clone();
 
     let factory: Box<
         dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -156,8 +156,16 @@ fn warmup_frames_discarded_on_camera_open() {
         Ok(MockCamera::bright(64, 64, 20))
     });
 
-    let mut handler =
-        Handler::new(config, engine, store, rate_limiter, false, Some(factory), None).unwrap();
+    let mut handler = Handler::new(
+        config,
+        engine,
+        store,
+        rate_limiter,
+        false,
+        Some(factory),
+        None,
+    )
+    .unwrap();
 
     // Ping triggers no camera open
     let resp = handler.handle(DaemonRequest::Ping);
@@ -191,8 +199,16 @@ fn warmup_frames_zero_skips_discard() {
         dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
     > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
 
-    let mut handler =
-        Handler::new(config, engine, store, rate_limiter, false, Some(factory), None).unwrap();
+    let mut handler = Handler::new(
+        config,
+        engine,
+        store,
+        rate_limiter,
+        false,
+        Some(factory),
+        None,
+    )
+    .unwrap();
 
     // Should work fine with zero warmup
     let resp = handler.handle(DaemonRequest::PreviewFrame);

--- a/crates/facelock-face/Cargo.toml
+++ b/crates/facelock-face/Cargo.toml
@@ -7,14 +7,10 @@ license.workspace = true
 
 [dependencies]
 facelock-core = { path = "../facelock-core" }
-ort = { version = "2.0.0-rc.12", features = ["download-binaries", "ndarray"] }
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "load-dynamic", "copy-dylibs", "api-24", "cuda", "rocm", "openvino"] }
 ndarray = "0.16"
 image = "0.25"
 sha2 = "0.10"
 serde = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-
-[features]
-cuda = ["ort/load-dynamic", "ort/cuda", "ort/tensorrt"]
-tensorrt = ["cuda"]

--- a/crates/facelock-face/src/detector.rs
+++ b/crates/facelock-face/src/detector.rs
@@ -1,3 +1,4 @@
+use std::mem::ManuallyDrop;
 use std::path::Path;
 
 use facelock_core::error::{FacelockError, Result};
@@ -7,7 +8,10 @@ use ort::session::builder::GraphOptimizationLevel;
 use ort::value::Tensor;
 
 pub struct FaceDetector {
-    session: Session,
+    // ManuallyDrop: ORT's Session destructor corrupts the heap on process exit
+    // when the global ORT environment is torn down before sessions. Leaking the
+    // session is safe — the OS reclaims all memory on exit anyway.
+    session: ManuallyDrop<Session>,
     input_width: u32,
     input_height: u32,
     confidence_threshold: f32,
@@ -52,7 +56,7 @@ impl FaceDetector {
         })?;
 
         Ok(Self {
-            session,
+            session: ManuallyDrop::new(session),
             input_width: 640,
             input_height: 640,
             confidence_threshold: confidence,

--- a/crates/facelock-face/src/embedder.rs
+++ b/crates/facelock-face/src/embedder.rs
@@ -42,7 +42,9 @@ impl FaceEmbedder {
             ))
         })?;
 
-        Ok(Self { session: ManuallyDrop::new(session) })
+        Ok(Self {
+            session: ManuallyDrop::new(session),
+        })
     }
 
     /// Extract a 512-D embedding from an aligned face image.

--- a/crates/facelock-face/src/embedder.rs
+++ b/crates/facelock-face/src/embedder.rs
@@ -1,3 +1,4 @@
+use std::mem::ManuallyDrop;
 use std::path::Path;
 
 use facelock_core::error::{FacelockError, Result};
@@ -9,7 +10,8 @@ use ort::value::Tensor;
 use crate::align::AlignedFace;
 
 pub struct FaceEmbedder {
-    session: Session,
+    // ManuallyDrop: see FaceDetector comment — avoids ORT heap corruption on exit.
+    session: ManuallyDrop<Session>,
 }
 
 impl FaceEmbedder {
@@ -40,7 +42,7 @@ impl FaceEmbedder {
             ))
         })?;
 
-        Ok(Self { session })
+        Ok(Self { session: ManuallyDrop::new(session) })
     }
 
     /// Extract a 512-D embedding from an aligned face image.

--- a/crates/facelock-face/src/provider.rs
+++ b/crates/facelock-face/src/provider.rs
@@ -1,22 +1,25 @@
 use ort::session::builder::SessionBuilder;
 
-/// Paths to search for the system-installed libonnxruntime.so.
-/// The onnxruntime-opt-cuda package on Arch installs here.
-#[cfg(any(feature = "cuda", feature = "tensorrt"))]
+/// Paths to search for a system-installed libonnxruntime.so.
+/// A GPU-enabled system ORT (e.g. onnxruntime-opt-cuda) is preferred
+/// so that GPU execution providers work. The bundled CPU-only ORT
+/// is used as a last resort.
 const SYSTEM_ORT_PATHS: &[&str] = &[
     "/usr/lib/libonnxruntime.so",
     "/usr/lib64/libonnxruntime.so",
     "/usr/local/lib/libonnxruntime.so",
 ];
 
-/// Load the system-installed ONNX Runtime shared library.
+/// Bundled CPU-only ORT fallback, shipped with the facelock package.
+const BUNDLED_ORT_PATH: &str = "/usr/lib/facelock/libonnxruntime.so";
+
+/// Load the ONNX Runtime shared library.
 ///
-/// With `load-dynamic`, ORT is not statically linked. We must load
-/// `libonnxruntime.so` from the system before creating any sessions.
-/// The system ORT (e.g. `onnxruntime-opt-cuda`) is built against the
-/// locally installed CUDA version, so GPU EPs work correctly.
-#[cfg(any(feature = "cuda", feature = "tensorrt"))]
-fn load_system_ort() -> std::result::Result<(), String> {
+/// Search order:
+/// 1. `ORT_DYLIB_PATH` env var (explicit override)
+/// 2. System paths (may have GPU support)
+/// 3. Bundled CPU-only fallback
+fn load_ort() -> std::result::Result<(), String> {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
@@ -35,7 +38,7 @@ fn load_system_ort() -> std::result::Result<(), String> {
             }
         }
 
-        // Search standard system paths
+        // Search system paths (may have GPU support)
         for path_str in SYSTEM_ORT_PATHS {
             let path = std::path::Path::new(path_str);
             if path.exists() {
@@ -51,9 +54,24 @@ fn load_system_ort() -> std::result::Result<(), String> {
             }
         }
 
+        // Fall back to bundled CPU-only ORT
+        let bundled = std::path::Path::new(BUNDLED_ORT_PATH);
+        if bundled.exists() {
+            match ort::init_from(bundled) {
+                Ok(_) => {
+                    tracing::info!("Loaded bundled CPU ONNX Runtime from {BUNDLED_ORT_PATH}");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("Found bundled ORT but failed to load: {e}");
+                }
+            }
+        }
+
         init_err = Some(
-            "Could not find system libonnxruntime.so. \
-             Install with: sudo pacman -S onnxruntime-opt-cuda"
+            "Could not find libonnxruntime.so. \
+             Ensure the facelock package is installed correctly, \
+             or set ORT_DYLIB_PATH to point to a compatible libonnxruntime.so"
                 .into(),
         );
     });
@@ -65,53 +83,35 @@ fn load_system_ort() -> std::result::Result<(), String> {
     }
 }
 
-/// Register an execution provider on the session builder based on the provider name.
+/// Register an execution provider on the session builder based on config.
 ///
-/// For `"cuda"` and `"tensorrt"`, loads the system ONNX Runtime (which has GPU
-/// support built in) and registers the corresponding execution provider.
-/// Falls back to CPU with a warning if GPU is unavailable.
+/// All providers load the ONNX Runtime shared library at runtime.
+/// GPU providers (cuda, rocm, openvino) require a system ORT built
+/// with the corresponding support — install the appropriate package
+/// (e.g. `onnxruntime-opt-cuda`) and it will be picked up automatically.
 pub(crate) fn register_execution_provider(
     builder: SessionBuilder,
     provider: &str,
 ) -> std::result::Result<SessionBuilder, String> {
+    load_ort()?;
+    tracing::info!("Using execution provider: {provider}");
     match provider {
         "cpu" => Ok(builder),
 
-        #[cfg(feature = "cuda")]
-        "cuda" => {
-            load_system_ort()?;
-            builder
-                .with_execution_providers([ort::ep::CUDA::default().build()])
-                .map_err(|e| format!("CUDA execution provider: {e}"))
-        }
+        "cuda" => builder
+            .with_execution_providers([ort::ep::CUDA::default().build()])
+            .map_err(|e| format!("CUDA execution provider: {e}")),
 
-        #[cfg(not(feature = "cuda"))]
-        "cuda" => Err(
-            "CUDA execution provider requested but facelock was not built with --features cuda. \
-             Rebuild with: just build-cuda"
-                .into(),
-        ),
+        "rocm" => builder
+            .with_execution_providers([ort::ep::ROCm::default().build()])
+            .map_err(|e| format!("ROCm execution provider: {e}")),
 
-        #[cfg(feature = "tensorrt")]
-        "tensorrt" => {
-            load_system_ort()?;
-            builder
-                .with_execution_providers([
-                    ort::ep::TensorRT::default().build(),
-                    ort::ep::CUDA::default().build(), // fallback
-                ])
-                .map_err(|e| format!("TensorRT execution provider: {e}"))
-        }
-
-        #[cfg(not(feature = "tensorrt"))]
-        "tensorrt" => Err(
-            "TensorRT execution provider requested but facelock was not built with --features tensorrt. \
-             Rebuild with: cargo build --workspace --features tensorrt"
-                .into(),
-        ),
+        "openvino" => builder
+            .with_execution_providers([ort::ep::OpenVINO::default().build()])
+            .map_err(|e| format!("OpenVINO execution provider: {e}")),
 
         other => Err(format!(
-            "Unknown execution provider '{other}'. Valid values: cpu, cuda, tensorrt"
+            "Unknown execution provider '{other}'. Valid values: cpu, cuda, rocm, openvino"
         )),
     }
 }

--- a/crates/facelock-polkit/src/main.rs
+++ b/crates/facelock-polkit/src/main.rs
@@ -86,7 +86,10 @@ impl PolkitAgent {
             let _ = cancel_tx.send(());
             tracing::info!(cookie, "cancel signal sent to in-flight auth");
         } else {
-            tracing::debug!(cookie, "no in-flight auth found for cookie (already completed or never started)");
+            tracing::debug!(
+                cookie,
+                "no in-flight auth found for cookie (already completed or never started)"
+            );
         }
         Ok(())
     }

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -49,7 +49,13 @@ impl FaceStore {
     }
 
     /// Add a face model with its embedding. Returns the new model ID.
-    pub fn add_model(&self, user: &str, label: &str, embedding: &FaceEmbedding, embedder_model: &str) -> Result<u32> {
+    pub fn add_model(
+        &self,
+        user: &str,
+        label: &str,
+        embedding: &FaceEmbedding,
+        embedder_model: &str,
+    ) -> Result<u32> {
         let tx = self.conn.unchecked_transaction().map_err(map_err)?;
 
         let created_at = SystemTime::now()
@@ -234,7 +240,14 @@ impl FaceStore {
     }
 
     /// Add a face model with raw bytes and a sealed flag. Returns the new model ID.
-    pub fn add_model_raw(&self, user: &str, label: &str, data: &[u8], sealed: bool, embedder_model: &str) -> Result<u32> {
+    pub fn add_model_raw(
+        &self,
+        user: &str,
+        label: &str,
+        data: &[u8],
+        sealed: bool,
+        embedder_model: &str,
+    ) -> Result<u32> {
         let tx = self.conn.unchecked_transaction().map_err(map_err)?;
 
         let created_at = SystemTime::now()
@@ -357,7 +370,12 @@ impl FaceStore {
     /// Returns `true` if the user has fewer than `max_attempts` in the last
     /// `window_secs` seconds (i.e. auth may proceed). Returns `false` if
     /// the limit has been reached.
-    pub fn check_rate_limit(&self, user: &str, max_attempts: u32, window_secs: u64) -> Result<bool> {
+    pub fn check_rate_limit(
+        &self,
+        user: &str,
+        max_attempts: u32,
+        window_secs: u64,
+    ) -> Result<bool> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)

--- a/crates/facelock-store/tests/store_integration.rs
+++ b/crates/facelock-store/tests/store_integration.rs
@@ -102,7 +102,9 @@ fn embedding_round_trip_bit_exact() {
     emb[100] = 0.123_456_79;
     emb[511] = 42.0;
 
-    store.add_model("alice", "precision-test", &emb, "").unwrap();
+    store
+        .add_model("alice", "precision-test", &emb, "")
+        .unwrap();
 
     let results = store.get_user_embeddings("alice").unwrap();
     assert_eq!(results.len(), 1);

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -859,6 +859,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "tpm"))]
     fn seal_unseal_round_trip_passthrough() {
         let mut sealer = TpmSealer::new(&test_tcti()).unwrap();
         let mut emb = [0.0f32; 512];
@@ -1145,6 +1146,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "tpm"))]
     fn seal_bytes_passthrough() {
         let mut sealer = TpmSealer::new(&test_tcti()).unwrap();
         let data = b"hello world";

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -854,6 +854,7 @@ mod tests {
     use super::*;
 
     /// Get TCTI string from env (for swtpm in CI) or fall back to device path.
+    #[cfg(not(feature = "tpm"))]
     fn test_tcti() -> String {
         std::env::var("TCTI").unwrap_or_else(|_| "device:/dev/tpmrm0".into())
     }

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -364,13 +364,10 @@ impl TpmSealer {
             attributes::SessionAttributesBuilder,
             constants::SessionType,
             interface_types::{
-                algorithm::HashingAlgorithm,
-                reserved_handles::Hierarchy,
+                algorithm::HashingAlgorithm, reserved_handles::Hierarchy,
                 session_handles::PolicySession,
             },
-            structures::{
-                MaxBuffer, PcrSelectionListBuilder, SymmetricDefinition,
-            },
+            structures::{MaxBuffer, PcrSelectionListBuilder, SymmetricDefinition},
         };
 
         // Convert u32 indices to PcrSlot values
@@ -382,9 +379,7 @@ impl TpmSealer {
         let pcr_selection_list = PcrSelectionListBuilder::new()
             .with_selection(HashingAlgorithm::Sha256, &slots)
             .build()
-            .map_err(|e| {
-                FacelockError::Tpm(format!("failed to build PCR selection list: {e}"))
-            })?;
+            .map_err(|e| FacelockError::Tpm(format!("failed to build PCR selection list: {e}")))?;
 
         // Read current PCR values so the policy binds to the current state
         let (_update_counter, _pcr_selection_out, pcr_digests) = self
@@ -428,12 +423,8 @@ impl TpmSealer {
                 SymmetricDefinition::AES_256_CFB,
                 HashingAlgorithm::Sha256,
             )
-            .map_err(|e| {
-                FacelockError::Tpm(format!("failed to start trial policy session: {e}"))
-            })?
-            .ok_or_else(|| {
-                FacelockError::Tpm("trial policy session returned None".into())
-            })?;
+            .map_err(|e| FacelockError::Tpm(format!("failed to start trial policy session: {e}")))?
+            .ok_or_else(|| FacelockError::Tpm("trial policy session returned None".into()))?;
 
         // Set session attributes for encrypt/decrypt
         let (attrs, mask) = SessionAttributesBuilder::new()
@@ -445,18 +436,16 @@ impl TpmSealer {
             .tr_sess_set_attributes(trial_session, attrs, mask)
             .map_err(|e| {
                 // Clean up session before returning error
-                let _ = self.context.flush_context(
-                    tss_esapi::handles::SessionHandle::from(trial_session).into(),
-                );
-                FacelockError::Tpm(format!(
-                    "failed to set trial session attributes: {e}"
-                ))
+                let _ = self
+                    .context
+                    .flush_context(tss_esapi::handles::SessionHandle::from(trial_session).into());
+                FacelockError::Tpm(format!("failed to set trial session attributes: {e}"))
             })?;
 
         let policy_session = PolicySession::try_from(trial_session).map_err(|e| {
-            let _ = self.context.flush_context(
-                tss_esapi::handles::SessionHandle::from(trial_session).into(),
-            );
+            let _ = self
+                .context
+                .flush_context(tss_esapi::handles::SessionHandle::from(trial_session).into());
             FacelockError::Tpm(format!(
                 "failed to convert auth session to policy session: {e}"
             ))
@@ -466,9 +455,9 @@ impl TpmSealer {
         self.context
             .policy_pcr(policy_session, hashed_pcr_values, pcr_selection_list)
             .map_err(|e| {
-                let _ = self.context.flush_context(
-                    tss_esapi::handles::SessionHandle::from(trial_session).into(),
-                );
+                let _ = self
+                    .context
+                    .flush_context(tss_esapi::handles::SessionHandle::from(trial_session).into());
                 FacelockError::Tpm(format!("policy_pcr failed: {e}"))
             })?;
 
@@ -477,20 +466,16 @@ impl TpmSealer {
             .context
             .policy_get_digest(policy_session)
             .map_err(|e| {
-                let _ = self.context.flush_context(
-                    tss_esapi::handles::SessionHandle::from(trial_session).into(),
-                );
+                let _ = self
+                    .context
+                    .flush_context(tss_esapi::handles::SessionHandle::from(trial_session).into());
                 FacelockError::Tpm(format!("policy_get_digest failed: {e}"))
             })?;
 
         // Clean up the trial session
         self.context
-            .flush_context(
-                tss_esapi::handles::SessionHandle::from(trial_session).into(),
-            )
-            .map_err(|e| {
-                FacelockError::Tpm(format!("failed to flush trial session: {e}"))
-            })?;
+            .flush_context(tss_esapi::handles::SessionHandle::from(trial_session).into())
+            .map_err(|e| FacelockError::Tpm(format!("failed to flush trial session: {e}")))?;
 
         debug!(
             digest_len = digest.len(),

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -853,9 +853,14 @@ pub fn raw_embedding_size() -> usize {
 mod tests {
     use super::*;
 
+    /// Get TCTI string from env (for swtpm in CI) or fall back to device path.
+    fn test_tcti() -> String {
+        std::env::var("TCTI").unwrap_or_else(|_| "device:/dev/tpmrm0".into())
+    }
+
     #[test]
     fn seal_unseal_round_trip_passthrough() {
-        let mut sealer = TpmSealer::new("device:/dev/tpmrm0").unwrap();
+        let mut sealer = TpmSealer::new(&test_tcti()).unwrap();
         let mut emb = [0.0f32; 512];
         emb[0] = 1.0;
         emb[1] = -1.0;
@@ -1141,7 +1146,7 @@ mod tests {
 
     #[test]
     fn seal_bytes_passthrough() {
-        let mut sealer = TpmSealer::new("device:/dev/tpmrm0").unwrap();
+        let mut sealer = TpmSealer::new(&test_tcti()).unwrap();
         let data = b"hello world";
         let result = sealer.seal_bytes(data, None).unwrap();
 

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -6,8 +6,12 @@ pkgdesc="Face authentication PAM module for Linux"
 arch=('x86_64')
 url="https://github.com/tyvsmith/facelock"
 license=('MIT OR Apache-2.0')
-depends=('glibc' 'dbus' 'pam' 'gcc-libs' 'tpm2-tss' 'libxkbcommon')
+depends=('glibc' 'dbus' 'pam' 'gcc-libs' 'tpm2-tss' 'libxkbcommon' 'onnxruntime')
 makedepends=('rust' 'cargo' 'clang' 'wayland' 'libxkbcommon')
+optdepends=(
+    'onnxruntime-opt-cuda: NVIDIA GPU acceleration (replaces onnxruntime)'
+    'onnxruntime-opt-rocm: AMD GPU acceleration (replaces onnxruntime)'
+)
 backup=('etc/facelock/config.toml')
 install=facelock.install
 options=(!lto)

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -7,21 +7,9 @@ post_install() {
     # Reload systemd for D-Bus activation
     systemctl daemon-reload 2>/dev/null || true
 
-    # Add to /etc/pam.d/sudo (if not already present)
-    if [ -f /etc/pam.d/sudo ]; then
-        if ! grep -qF "$PAM_LINE" /etc/pam.d/sudo; then
-            cp /etc/pam.d/sudo /etc/pam.d/sudo.facelock-backup
-            # Prepend before first auth line
-            sed -i "0,/^auth/{s/^auth/${PAM_LINE}\nauth/}" /etc/pam.d/sudo
-            echo "==> Added face authentication to /etc/pam.d/sudo"
-            echo "==> Backup at /etc/pam.d/sudo.facelock-backup"
-        fi
-    fi
-
     echo ""
-    echo "==> facelock installed. Two steps remaining:"
-    echo "    1. sudo facelock setup       (download face recognition models)"
-    echo "    2. sudo facelock enroll      (register your face)"
+    echo "==> facelock installed. Run 'sudo facelock setup' to complete configuration."
+    echo "    (downloads models, configures PAM services, enrolls your face)"
 }
 
 post_upgrade() {
@@ -40,11 +28,13 @@ pre_remove() {
     systemctl stop facelock-daemon 2>/dev/null || true
     systemctl disable facelock-daemon 2>/dev/null || true
 
-    # Remove PAM line from sudo
-    if [ -f /etc/pam.d/sudo ]; then
-        sed -i "\|^${PAM_LINE}$|d" /etc/pam.d/sudo
-        echo "==> Removed face authentication from /etc/pam.d/sudo"
-    fi
+    # Remove PAM lines
+    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+        if [ -f "$PAM_FILE" ] && grep -qF "$PAM_LINE" "$PAM_FILE"; then
+            sed -i "\|^${PAM_LINE}$|d" "$PAM_FILE"
+            echo "==> Removed face authentication from $PAM_FILE"
+        fi
+    done
 }
 
 post_remove() {

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -16,6 +16,7 @@ BuildRequires:  tpm2-tss-devel
 
 Requires:       pam
 Requires:       tpm2-tss
+Requires:       onnxruntime
 Recommends:     authselect
 
 %description

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -131,10 +131,13 @@ Facelock uses the `ort` crate (Rust bindings for ONNX Runtime). The runtime bina
 
 ### Execution Providers
 
-| Provider | Config | Build Feature | Status |
-|----------|--------|--------------|--------|
-| CPU | `execution_provider = "cpu"` | default | Working |
-| CUDA | `execution_provider = "cuda"` | `--features cuda` | Config ready, build untested |
-| TensorRT | `execution_provider = "tensorrt"` | `--features tensorrt` | Config ready, build untested |
+GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package and set `execution_provider` in config.
 
-CPU is the default and only tested provider. GPU providers require additional system libraries (CUDA toolkit, TensorRT SDK).
+| Provider | Config | Runtime Requirement | Status |
+|----------|--------|---------------------|--------|
+| CPU | `execution_provider = "cpu"` | none (default) | Working |
+| CUDA (NVIDIA) | `execution_provider = "cuda"` | CUDA toolkit + GPU-enabled ORT | Config ready, untested |
+| ROCm (AMD) | `execution_provider = "rocm"` | ROCm runtime + GPU-enabled ORT | Config ready, untested |
+| OpenVINO (Intel) | `execution_provider = "openvino"` | OpenVINO runtime + GPU-enabled ORT | Config ready, untested |
+
+CPU is the default and only tested provider.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Face detection and embedding parameters.
 | `nms_threshold` | f32 | `0.4` | Non-maximum suppression threshold for overlapping detections. |
 | `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. |
 | `embedder_model` | string | `"w600k_r50.onnx"` | ONNX embedder model filename. Must exist in `daemon.model_dir`. |
-| `execution_provider` | string | `"cpu"` | ONNX Runtime execution provider. Values: `"cpu"`, `"cuda"`, `"tensorrt"`. GPU providers require building with `--features cuda` or `--features tensorrt`. |
+| `execution_provider` | string | `"cpu"` | ONNX Runtime execution provider. Values: `"cpu"`, `"cuda"`, `"rocm"`, `"openvino"`. GPU providers require a GPU-enabled ONNX Runtime package installed on the system. |
 | `threads` | u32 | `4` | Number of CPU threads for ONNX inference. |
 
 ### Threshold range guide (ArcFace cosine similarity)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,14 +72,15 @@ You should see "Identifying face..." and authenticate by looking at the camera.
 
 ### GPU Acceleration (Optional)
 
-For NVIDIA GPUs with CUDA support:
+GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package for your hardware:
 
 ```bash
-sudo pacman -S onnxruntime-opt-cuda   # Arch: system ORT with CUDA
-just install-cuda                      # build + install with GPU
+sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
+sudo pacman -S onnxruntime-opt-rocm      # AMD
+sudo pacman -S onnxruntime-opt-openvino  # Intel
 ```
 
-Set `execution_provider = "cuda"` or `"tensorrt"` in `/etc/facelock/config.toml`. CPU is the default.
+Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, or `"openvino"`. CPU is the default.
 
 ### Uninstall
 
@@ -103,7 +104,7 @@ Key settings:
 |---------|---------|-------------|
 | `device.path` | auto-detect | Camera path (prefers IR cameras) |
 | `recognition.threshold` | `0.80` | Cosine similarity threshold |
-| `recognition.execution_provider` | `"cpu"` | `"cpu"`, `"cuda"`, or `"tensorrt"` |
+| `recognition.execution_provider` | `"cpu"` | `"cpu"`, `"cuda"`, `"rocm"`, or `"openvino"` |
 | `daemon.mode` | `"daemon"` | `"daemon"` or `"oneshot"` |
 | `security.require_ir` | `true` | Reject RGB-only cameras |
 

--- a/justfile
+++ b/justfile
@@ -10,24 +10,6 @@ build-release:
     cargo build --release --workspace
     cargo build --release -p facelock-cli --features tpm
 
-# Build with CUDA GPU acceleration (requires: sudo pacman -S onnxruntime-opt-cuda)
-build-cuda:
-    cargo build --workspace --features cuda
-
-# Build release with CUDA GPU acceleration
-build-release-cuda:
-    cargo build --release --workspace --features cuda
-    cargo build --release -p facelock-cli --features tpm,cuda
-
-# Build with TensorRT GPU acceleration (requires CUDA + TensorRT SDK)
-build-tensorrt:
-    cargo build --workspace --features cuda,tensorrt
-
-# Build release with TensorRT GPU acceleration
-build-release-tensorrt:
-    cargo build --release --workspace --features cuda,tensorrt
-    cargo build --release -p facelock-cli --features tpm,cuda,tensorrt
-
 # Run all unit tests
 test:
     cargo test --workspace
@@ -107,24 +89,10 @@ test-shell: build-release
 install: build-release
     sudo env PATH="$PATH" just install-files
 
-# Build release with CUDA and install to system
-# Requires: sudo pacman -S onnxruntime-opt-cuda
-install-cuda:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! pacman -Q onnxruntime-opt-cuda &>/dev/null && ! pacman -Q onnxruntime-cuda &>/dev/null; then
-        echo "System ONNX Runtime with CUDA not found."
-        echo "Install with: sudo pacman -S onnxruntime-opt-cuda"
-        exit 1
-    fi
-    just build-release-cuda
-    sudo env PATH="$PATH" just install-files install-cuda-config
-
 # Install pre-built binaries to system (requires root, no build)
 install-files:
     #!/usr/bin/env bash
     set -euo pipefail
-    PAM_LINE="auth  sufficient  pam_facelock.so"
 
     # Verify binaries exist
     for f in target/release/facelock target/release/libpam_facelock.so; do
@@ -177,80 +145,53 @@ install-files:
         echo "D-Bus activation enabled."
     fi
 
-    # Add to /etc/pam.d/sudo (if not already present)
-    if [ -f /etc/pam.d/sudo ] && ! grep -qF "$PAM_LINE" /etc/pam.d/sudo; then
-        cp /etc/pam.d/sudo /etc/pam.d/sudo.facelock-backup
-        sed -i "0,/^auth/{s/^auth/${PAM_LINE}\nauth/}" /etc/pam.d/sudo
-        echo "Added face auth to /etc/pam.d/sudo (backup: /etc/pam.d/sudo.facelock-backup)"
-    fi
-
     # Fix permissions on existing data
     [ -d /var/lib/facelock/models ] && chmod 644 /var/lib/facelock/models/*.onnx 2>/dev/null || true
     [ -f /var/lib/facelock/facelock.db ] && chown root:facelock /var/lib/facelock/facelock.db && chmod 640 /var/lib/facelock/facelock.db || true
 
     echo ""
-    echo "Installed. Two steps remaining:"
-    echo "  1. sudo facelock setup       (download face recognition models)"
-    echo "  2. sudo facelock enroll      (register your face)"
+    echo ""
 
-# Build release with TensorRT and install to system
-# Requires: CUDA toolkit + TensorRT SDK (libnvinfer)
-install-tensorrt:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Check for TensorRT library
-    if ! ldconfig -p 2>/dev/null | grep -q libnvinfer; then
-        echo "TensorRT SDK (libnvinfer) not found."
-        echo "Install from: https://developer.nvidia.com/tensorrt"
-        echo "  Arch/CachyOS: yay -S libnvinfer  (AUR)"
-        echo "  Ubuntu/Debian: apt install libnvinfer-dev"
-        exit 1
-    fi
-    if ! pacman -Q onnxruntime-opt-cuda &>/dev/null && ! pacman -Q onnxruntime-cuda &>/dev/null; then
-        echo "System ONNX Runtime with CUDA not found."
-        echo "Install with: sudo pacman -S onnxruntime-opt-cuda"
-        exit 1
-    fi
-    just build-release-tensorrt
-    sudo env PATH="$PATH" just install-files install-tensorrt-config
+    # Check what's still needed
+    NEEDS_SETUP=false
+    NEEDS_ORT=false
 
-# Enable TensorRT execution provider in installed config (requires root)
-install-tensorrt-config:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    CONFIG="/etc/facelock/config.toml"
-    [ -f "$CONFIG" ] || { echo "Error: $CONFIG not found. Run 'just install' first."; exit 1; }
-    if grep -q '^execution_provider' "$CONFIG"; then
-        sed -i 's/^execution_provider.*/execution_provider = "tensorrt"/' "$CONFIG"
-    elif grep -q '^# execution_provider' "$CONFIG"; then
-        sed -i 's/^# execution_provider.*/execution_provider = "tensorrt"/' "$CONFIG"
+    # Models present?
+    if ! ls /var/lib/facelock/models/*.onnx >/dev/null 2>&1; then
+        NEEDS_SETUP=true
+    fi
+
+    # Config present?
+    if [ ! -f /etc/facelock/config.toml ]; then
+        NEEDS_SETUP=true
+    fi
+
+    # PAM configured?
+    if ! grep -qs pam_facelock /etc/pam.d/sudo 2>/dev/null; then
+        NEEDS_SETUP=true
+    fi
+
+    # ORT installed? Check file paths directly.
+    if [ ! -f /usr/lib/libonnxruntime.so ] && \
+       [ ! -f /usr/lib64/libonnxruntime.so ] && \
+       [ ! -f /usr/lib/facelock/libonnxruntime.so ]; then
+        NEEDS_ORT=true
+    fi
+
+    if $NEEDS_SETUP || $NEEDS_ORT; then
+        echo "Installed."
+        if $NEEDS_ORT; then
+            echo ""
+            echo "Requires: onnxruntime (pacman -S onnxruntime-cpu)"
+            echo "Optional: onnxruntime-opt-cuda (NVIDIA) or onnxruntime-opt-rocm (AMD)"
+        fi
+        if $NEEDS_SETUP; then
+            echo ""
+            echo "Run 'sudo facelock setup' to complete configuration."
+            echo "  (downloads models, configures PAM services, enrolls your face)"
+        fi
     else
-        sed -i '/^\[recognition\]/a execution_provider = "tensorrt"' "$CONFIG"
-    fi
-    echo "TensorRT execution provider enabled in $CONFIG"
-    if systemctl is-active facelock-daemon.service &>/dev/null; then
-        systemctl restart facelock-daemon.service
-        echo "Daemon restarted with TensorRT."
-    fi
-
-# Enable CUDA execution provider in installed config (requires root)
-install-cuda-config:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    CONFIG="/etc/facelock/config.toml"
-    [ -f "$CONFIG" ] || { echo "Error: $CONFIG not found. Run 'just install' first."; exit 1; }
-    if grep -q '^execution_provider' "$CONFIG"; then
-        sed -i 's/^execution_provider.*/execution_provider = "cuda"/' "$CONFIG"
-    elif grep -q '^# execution_provider' "$CONFIG"; then
-        sed -i 's/^# execution_provider.*/execution_provider = "cuda"/' "$CONFIG"
-    else
-        sed -i '/^\[recognition\]/a execution_provider = "cuda"' "$CONFIG"
-    fi
-    echo "CUDA execution provider enabled in $CONFIG"
-    # Restart daemon to pick up new config
-    if systemctl is-active facelock-daemon.service &>/dev/null; then
-        systemctl restart facelock-daemon.service
-        echo "Daemon restarted with CUDA."
+        echo "Installed and up to date."
     fi
 
 # Uninstall from system
@@ -262,17 +203,17 @@ uninstall:
 uninstall-files:
     #!/usr/bin/env bash
     set -euo pipefail
-    PAM_LINE="auth  sufficient  pam_facelock.so"
-
     # Stop and disable daemon
     systemctl stop facelock-daemon.service 2>/dev/null || true
     systemctl disable facelock-daemon.service 2>/dev/null || true
 
-    # Remove PAM line
-    if [ -f /etc/pam.d/sudo ]; then
-        sed -i "\|^${PAM_LINE}$|d" /etc/pam.d/sudo
-        echo "Removed face auth from /etc/pam.d/sudo"
-    fi
+    # Remove PAM lines from all known services (match on module name, not exact spacing)
+    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
+            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
+            echo "Removed face auth from $PAM_FILE"
+        fi
+    done
 
     # Kill facelock polkit agent if running (so the DE's agent can take over)
     pkill -f facelock-polkit-agent 2>/dev/null || true
@@ -288,6 +229,69 @@ uninstall-files:
 
     echo "Uninstalled. Config and data preserved in /etc/facelock and /var/lib/facelock."
     echo "To remove all data: rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+
+# Add face auth icon to omarchy hyprlock placeholder text (no root required)
+omarchy-enable:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HYPRLOCK_CONF="$HOME/.config/hypr/hyprlock.conf"
+
+    if [ ! -d "$HOME/.local/share/omarchy" ]; then
+        echo "Error: omarchy not detected. This target is for omarchy systems only."
+        exit 1
+    fi
+
+    if [ ! -f "$HYPRLOCK_CONF" ]; then
+        echo "Error: $HYPRLOCK_CONF not found."
+        exit 1
+    fi
+
+    if grep -q '󰄀' "$HYPRLOCK_CONF"; then
+        echo "Face auth icon already present in hyprlock config."
+        exit 0
+    fi
+
+    # Preserve fingerprint icon if present
+    if grep -q '󰈷' "$HYPRLOCK_CONF"; then
+        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰄀 󰈷 <\/span>/' "$HYPRLOCK_CONF"
+    else
+        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰄀 <\/span>/' "$HYPRLOCK_CONF"
+    fi
+
+    # Source the faceauth overlay if not already sourced
+    if [ -f "$HOME/.config/hypr/hyprlock-faceauth.conf" ] && ! grep -q 'hyprlock-faceauth.conf' "$HYPRLOCK_CONF"; then
+        echo 'source = ~/.config/hypr/hyprlock-faceauth.conf' >> "$HYPRLOCK_CONF"
+    fi
+
+    echo "Enabled face auth in hyprlock."
+
+# Remove face auth icon from omarchy hyprlock placeholder text (no root required)
+omarchy-disable:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HYPRLOCK_CONF="$HOME/.config/hypr/hyprlock.conf"
+
+    if [ ! -f "$HYPRLOCK_CONF" ]; then
+        echo "Error: $HYPRLOCK_CONF not found."
+        exit 1
+    fi
+
+    if ! grep -q '󰄀' "$HYPRLOCK_CONF"; then
+        echo "Face auth icon not present in hyprlock config."
+        exit 0
+    fi
+
+    # Preserve fingerprint icon if present
+    if grep -q '󰈷' "$HYPRLOCK_CONF"; then
+        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰈷 <\/span>/' "$HYPRLOCK_CONF"
+    else
+        sed -i 's/placeholder_text = .*/placeholder_text = Enter Password/' "$HYPRLOCK_CONF"
+    fi
+
+    # Remove the faceauth overlay source line
+    sed -i '\|hyprlock-faceauth.conf|d' "$HYPRLOCK_CONF"
+
+    echo "Disabled face auth in hyprlock."
 
 # Bump version and prepare a release commit + tag
 # Usage: just release 0.2.0

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -35,23 +35,8 @@ RUN just install-files
 RUN cp models/*.onnx /var/lib/facelock/models/ 2>/dev/null || true
 RUN cp models/manifest.toml /var/lib/facelock/models/ 2>/dev/null || true
 
-# Override config for container testing (use /var/lib paths, not /tmp dev paths)
-RUN cat > /etc/facelock/config.toml <<'EOF'
-[device]
-max_height = 480
-
-[recognition]
-threshold = 0.80
-timeout_secs = 5
-
-[daemon]
-model_dir = "/var/lib/facelock/models"
-
-[security]
-disabled = false
-require_ir = false
-require_frame_variance = false
-EOF
+# Override config for container testing
+COPY test/container-config.toml /etc/facelock/config.toml
 
 # Facelock-test PAM config for pamtester
 COPY test/pam.d/facelock-test /etc/pam.d/facelock-test

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -1,3 +1,13 @@
+# Stage 1: Build
+FROM archlinux:latest AS builder
+
+RUN pacman -Syu --noconfirm rust clang base-devel v4l-utils libxkbcommon wayland pam tpm2-tss && pacman -Scc --noconfirm
+
+COPY . /build
+WORKDIR /build
+RUN cargo build --release --workspace
+
+# Stage 2: Test image
 FROM archlinux:latest
 
 # Install dependencies
@@ -12,7 +22,9 @@ RUN curl -sL https://sourceforge.net/projects/pamtester/files/pamtester/0.1.2/pa
 # Create test user
 RUN useradd -m testuser && echo "testuser:test" | chpasswd
 
-# Copy the repo (pre-built binaries in target/release/)
+# Copy repo with pre-built binaries from builder stage
+COPY --from=builder /build/target/release/facelock /build/target/release/facelock
+COPY --from=builder /build/target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
 COPY . /build
 WORKDIR /build
 

--- a/test/container-config.toml
+++ b/test/container-config.toml
@@ -1,0 +1,14 @@
+[device]
+max_height = 480
+
+[recognition]
+threshold = 0.80
+timeout_secs = 5
+
+[daemon]
+model_dir = "/var/lib/facelock/models"
+
+[security]
+disabled = false
+require_ir = false
+require_frame_variance = false


### PR DESCRIPTION
## Summary

- **Runtime GPU providers**: Remove compile-time `cuda`/`tensorrt` feature flags; GPU acceleration is now runtime-only via system ORT library. Adds ROCm and OpenVINO support.
- **ORT heap corruption fix**: Wrap ORT Sessions in `ManuallyDrop` to prevent destructor crash on exit.
- **Bench command fixes**: Handle encrypted embeddings, correct user under sudo, TPM root prompt, frame capture loop for cold-auth, quirks support.
- **Camera quirks consistency**: All code paths (daemon, direct, oneshot, bench) now load and apply the quirks database for warmup frames and IR detection.
- **Security hardening**: Enrollment and model management require root on both CLI and D-Bus sides.
- **Status enhancements**: Show execution provider, ORT location, enrolled faces, security posture, and notification settings.
- **PAM spacing resilience**: Detect and remove pam_facelock lines regardless of whitespace formatting.
- **Install/uninstall improvements**: Conditional post-install output, clean PAM from all services on uninstall, add omarchy hyprlock targets.
- **Documentation**: Update all docs for runtime GPU, add ROCm/OpenVINO, update packaging deps.

Resolves #3, resolves #4, resolves #5, resolves #6, resolves #7, resolves #8, resolves #9, resolves #10, resolves #11

## Test plan

- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo test --workspace` — 281 tests pass
- [ ] `sudo facelock bench cold-auth` works with encrypted embeddings
- [ ] `facelock enroll` without sudo prompts for root
- [ ] `facelock status` shows all new sections
- [ ] `just install` on configured system shows "Installed and up to date."
- [ ] `just uninstall` removes PAM lines from sudo, polkit-1, hyprlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)