### PR TITLE
docs: comprehensive documentation review and accuracy fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Facelock is a Linux face authentication PAM module written in Rust. Single unifi
 
 ## Repository Structure
 
-Cargo workspace with 11 crates:
+Cargo workspace with 10 crates:
 
 | Crate | Type | Purpose |
 |-------|------|---------|
@@ -15,11 +15,10 @@ Cargo workspace with 11 crates:
 | `facelock-face` | lib | ONNX inference (SCRFD + ArcFace) |
 | `facelock-store` | lib | SQLite face embedding storage |
 | `facelock-daemon` | lib | Auth/enroll logic, rate limiting, liveness, audit |
-| `facelock-cli` | bin | Unified CLI (`facelock` binary) |
+| `facelock-cli` | bin | Unified CLI (`facelock` binary, includes `bench` subcommand) |
 | `pam-facelock` | cdylib | PAM module (libc + toml + serde + zbus only) |
 | `facelock-tpm` | lib | TPM-sealed key encryption, software AES-256-GCM |
 | `facelock-polkit` | bin | Polkit authentication agent |
-| `facelock-bench` | bin | Performance benchmarking (camera, inference, store) |
 | `facelock-test-support` | lib | Mocks and fixtures for testing |
 
 ## Build & Verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Facelock is a Cargo workspace with 10 crates:
 | `facelock-face` | lib | ONNX inference (SCRFD + ArcFace) |
 | `facelock-store` | lib | SQLite face embedding storage |
 | `facelock-daemon` | lib | Auth/enroll logic, rate limiting, liveness, audit |
-| `facelock-cli` | bin | Unified CLI (`facelock` binary) |
+| `facelock-cli` | bin | Unified CLI (`facelock` binary, includes `bench` subcommand) |
 | `pam-facelock` | cdylib | PAM module (libc + toml + serde, zbus only) |
 | `facelock-tpm` | lib | Optional TPM encryption |
 | `facelock-polkit` | bin | Polkit face authentication agent |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **v0.1.0-alpha** — Pre-release. Under active development. Functional, daily-driveable, but experimental. APIs will change before 1.0. See [CHANGELOG.md](CHANGELOG.md).
 
-A modern face authentication system for Linux PAM. Provides Windows Hello-style facial auth with IR anti-spoofing, configurable as a persistent daemon or daemonless one-shot.
+A modern face authentication system for Linux PAM. Provides Windows Hello-style facial auth with IR anti-spoofing, configurable as a persistent daemon or daemonless one-shot. All inference runs locally on your hardware -- no cloud services, no network requests, no telemetry. Your biometric data never leaves your machine.
 
 ## Quick Start
 
@@ -64,6 +64,7 @@ facelock tpm status     TPM status/management
 facelock bench          Benchmarks and calibration
 facelock encrypt        Encrypt stored embeddings
 facelock decrypt        Decrypt stored embeddings
+facelock restart        Restart daemon
 facelock audit          View structured audit log
 ```
 
@@ -113,6 +114,17 @@ All keys are optional. Camera is auto-detected if `device.path` is omitted.
 
 Full reference: `config/facelock.toml`.
 
+## Omarchy / Hyprlock Integration
+
+If you use [Omarchy](https://github.com/nicholasgasior/omarchy) (Hyprland desktop environment), Facelock can integrate with hyprlock:
+
+```bash
+just omarchy-enable     # add face auth icon to hyprlock placeholder
+just omarchy-disable    # remove face auth from hyprlock
+```
+
+This adds a face icon to the hyprlock password prompt and optionally sources a `hyprlock-faceauth.conf` overlay. No root required.
+
 ## Testing
 
 ```bash
@@ -125,7 +137,11 @@ just test-shell         # interactive container for manual testing
 
 See [docs/testing-safety.md](docs/testing-safety.md) before editing PAM config on your system.
 
-## Security
+## Privacy & Security
+
+**Privacy**: Facelock is 100% local. Face detection and recognition run entirely on your hardware via ONNX Runtime. No images, embeddings, or metadata are ever sent to any external server. There is no telemetry, no analytics, no phone-home behavior. Models are downloaded once during setup and verified by SHA256 checksum -- after that, Facelock never touches the network.
+
+**Security**:
 
 - IR camera enforcement on by default (anti-spoofing)
 - Frame variance + landmark liveness checks reject photo/video attacks

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ just uninstall
 
 | Mode | Config | How it works | Latency |
 |------|--------|-------------|---------|
-| **Daemon** | `mode = "daemon"` (default) | PAM → D-Bus → persistent daemon | ~200ms warm |
-| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms cold |
-| **Oneshot** | `mode = "oneshot"` | PAM → `facelock auth` subprocess | ~700ms |
+| **Daemon** | `mode = "daemon"` (default) | PAM → D-Bus → persistent daemon | ~150-600ms |
+| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms+ cold |
+| **Oneshot** | `mode = "oneshot"` | PAM → `facelock auth` subprocess | ~700ms+ |
+
+Daemon latency depends on camera state: ~600ms with a cold camera, ~150-180ms on back-to-back auths when the camera is already warm. The lighter default model (`scrfd_2.5g`) keeps inference fast.
 
 The CLI works in all modes — it connects to the daemon if available, otherwise operates directly.
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Introduction](introduction.md)
 - [Quick Start](quickstart.md)
 - [Configuration](configuration.md)
+- [GPU Acceleration](gpu.md)
 - [Architecture](architecture.md)
 - [CLI Reference](cli-reference.md)
 - [Security](security.md)

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -209,8 +209,8 @@ flowchart LR
 
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
-- ~200ms auth latency (models already loaded)
-- Camera stays warm between requests
+- ~600ms typical auth latency (~150ms with warm camera)
+- Camera stays warm between back-to-back requests
 - Single point of resource management
 
 ### Oneshot Mode

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Facelock is a face authentication system for Linux PAM. It detects faces via SCRFD, extracts embeddings via ArcFace, and matches against stored models using cosine similarity.
+Facelock is a face authentication system for Linux PAM. It detects faces via SCRFD, extracts embeddings via ArcFace, and matches against stored models using cosine similarity. All processing is local -- no network calls, no cloud services, no telemetry.
 
 ## System Diagram
 
@@ -16,7 +16,7 @@ Facelock is a face authentication system for Linux PAM. It detects faces via SCR
          │                               │ or IPC to daemon
     ┌────▼────────────┐                  │
     │  pam_facelock.so  │──────────────────┤
-    │  (~600KB cdylib) │                  │
+    │  (~2MB cdylib) │                  │
     │                 │                  │
     │  daemon mode:   │                  │
     │  → D-Bus IPC    │          ┌───────▼──────────────┐

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -151,6 +151,14 @@ facelock bench model-load               # model loading time
 facelock bench report                   # full benchmark report
 ```
 
+## facelock restart
+
+Restart the persistent daemon. Sends a shutdown command via D-Bus and waits for it to restart via D-Bus activation.
+
+```bash
+facelock restart
+```
+
 ## User Resolution
 
 For commands that accept `--user`:

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -153,7 +153,7 @@ facelock bench report                   # full benchmark report
 
 ## facelock restart
 
-Restart the persistent daemon. Sends a shutdown command via D-Bus and waits for it to restart via D-Bus activation.
+Restart the persistent daemon. On systemd systems, runs `systemctl restart facelock-daemon.service`. Otherwise, sends a D-Bus shutdown request and the daemon restarts on next use via D-Bus activation.
 
 ```bash
 facelock restart

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -75,7 +75,7 @@ Controls how the PAM module reaches the face engine.
 | `abort_if_lid_closed` | bool | `true` | Refuse face auth when the laptop lid is closed (camera blocked). |
 | `require_ir` | bool | `true` | Require an IR camera for authentication. RGB cameras are trivially spoofed with a printed photo. Only set to `false` for development/testing. |
 | `require_frame_variance` | bool | `true` | Require multiple frames with different embeddings before accepting. Defends against static photo attacks. |
-| `require_landmark_liveness` | bool | `true` | Require landmark movement between frames to pass liveness check. Detects static images by tracking facial landmark positions across frames. |
+| `require_landmark_liveness` | bool | `false` | Require landmark movement between frames to pass liveness check. Detects static images by tracking facial landmark positions across frames. Experimental; off by default. |
 | `suppress_unknown` | bool | `false` | Suppress warnings for unknown users (users with no enrolled face). |
 | `min_auth_frames` | u32 | `3` | Minimum number of matching frames required before accepting. Only applies when `require_frame_variance` is true. |
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -56,7 +56,7 @@ Controls how the PAM module reaches the face engine.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (fast, ~200ms). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~700ms, no background process). |
+| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (~150-600ms depending on camera state). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~700ms+, no background process). |
 | `model_dir` | string | `"/var/lib/facelock/models"` | Directory containing ONNX model files. |
 | `idle_timeout_secs` | u64 | `0` | Shut down the daemon after this many idle seconds. `0` means never. Useful with D-Bus activation. |
 

--- a/book/src/contracts.md
+++ b/book/src/contracts.md
@@ -7,7 +7,7 @@ Stable contracts. Do not change without updating this document.
 | Binary | Crate | Purpose |
 |--------|-------|---------|
 | `facelock` | facelock-cli | Unified CLI (daemon, auth, enroll, test, setup, etc.) |
-| `libpam_facelock.so` | pam-facelock | PAM authentication module |
+| `pam_facelock.so` | pam-facelock | PAM authentication module |
 
 ## CLI Subcommands
 
@@ -29,6 +29,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock auth --user X` | One-shot auth (PAM helper) |
 | `facelock tpm status` | TPM status |
 | `facelock bench` | Benchmarks |
+| `facelock restart` | Restart daemon |
 
 ## Operating Modes
 
@@ -55,7 +56,6 @@ The CLI silently falls back to direct mode when the daemon is not available on D
 | `/var/lib/facelock/facelock.db` | root:facelock | 640 | Face embeddings |
 | `/var/lib/facelock/models/` | root:root | 755 | ONNX models |
 | `/var/log/facelock/snapshots/` | root:facelock | 750 | Auth snapshots |
-| `/run/facelock/facelock.sock` | daemon | 660 | Legacy IPC socket (unused; D-Bus activation is now used) |
 | `/usr/bin/facelock` | root:root | 755 | CLI binary |
 | `/lib/security/pam_facelock.so` | root:root | 755 | PAM module |
 
@@ -141,7 +141,7 @@ pam_facelock(<service>): <result> for user <username>
 |---------|--------|---------|
 | IR camera enforcement | `security.require_ir` | **true** |
 | Frame variance check | `security.require_frame_variance` | **true** |
-| Landmark liveness | `security.require_landmark_liveness` | **true** |
+| Landmark liveness | `security.require_landmark_liveness` | **false** |
 | Minimum auth frames | `security.min_auth_frames` | 3 |
 | Variance threshold | `FRAME_VARIANCE_THRESHOLD` | 0.998 |
 

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -24,7 +24,7 @@ Facelock is a Cargo workspace with 10 crates:
 | `facelock-face` | lib | ONNX inference (SCRFD + ArcFace) |
 | `facelock-store` | lib | SQLite face embedding storage |
 | `facelock-daemon` | lib | Auth/enroll logic, liveness, audit, rate limiting, handler |
-| `facelock-cli` | bin | Unified CLI (`facelock` binary) |
+| `facelock-cli` | bin | Unified CLI (`facelock` binary, includes `bench` subcommand) |
 | `pam-facelock` | cdylib | PAM module (libc + toml + serde + zbus only) |
 | `facelock-tpm` | lib | Optional TPM-bound encryption for embeddings at rest |
 | `facelock-polkit` | bin | Polkit authentication agent for face auth |
@@ -97,7 +97,7 @@ Read the [Security](security.md) chapter before implementing any auth-related co
 - `security.require_ir` defaults to **true**. Never weaken this default.
 - Frame variance checks must remain in the auth path.
 - Model files are SHA256-verified at load time.
-- IPC messages have size limits (10MB max). Never allocate unbounded buffers.
+- D-Bus message size limits are enforced by the bus daemon. Never allocate unbounded buffers.
 - D-Bus system bus policy restricts daemon access.
 - The PAM module logs all auth attempts to syslog.
 - Rate limiting is enforced in the daemon (5 attempts/user/60s default).

--- a/book/src/gpu.md
+++ b/book/src/gpu.md
@@ -1,0 +1,69 @@
+# GPU Acceleration
+
+GPU support in Facelock is **runtime-only** -- no special build flags or recompilation needed. Install a GPU-enabled ONNX Runtime package for your hardware and set `execution_provider` in the configuration.
+
+## Setup
+
+### 1. Install a GPU-enabled ONNX Runtime
+
+| GPU Vendor | Arch Linux Package | Other Distros |
+|------------|-------------------|---------------|
+| NVIDIA | `onnxruntime-opt-cuda` | Install CUDA toolkit + ONNX Runtime with CUDA provider |
+| AMD | `onnxruntime-opt-rocm` | Install ROCm runtime + ONNX Runtime with ROCm provider |
+| Intel | `onnxruntime-opt-openvino` | Install OpenVINO runtime + ONNX Runtime with OpenVINO provider |
+
+On Arch Linux:
+
+```bash
+sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
+sudo pacman -S onnxruntime-opt-rocm      # AMD
+sudo pacman -S onnxruntime-opt-openvino  # Intel
+```
+
+### 2. Set the execution provider
+
+Edit `/etc/facelock/config.toml`:
+
+```toml
+[recognition]
+execution_provider = "cuda"    # or "rocm" or "openvino"
+```
+
+### 3. Restart the daemon
+
+```bash
+facelock restart
+```
+
+### 4. Verify
+
+```bash
+facelock bench warm-auth
+```
+
+Compare latency with `execution_provider = "cpu"` to confirm GPU acceleration is active.
+
+## How it works
+
+Facelock uses the `ort` crate with the `load-dynamic` feature. At startup, it loads `libonnxruntime.so` from the system library path. If a GPU-enabled ONNX Runtime is installed, it provides CUDA/ROCm/OpenVINO execution providers automatically. The `execution_provider` config selects which provider to register.
+
+If the requested provider is not available (e.g., CUDA requested but only CPU ORT installed), Facelock falls back to CPU with a warning.
+
+## Supported providers
+
+| Provider | Config value | Status |
+|----------|-------------|--------|
+| CPU | `"cpu"` | Default, tested |
+| CUDA (NVIDIA) | `"cuda"` | Config ready, requires GPU-enabled ORT |
+| ROCm (AMD) | `"rocm"` | Config ready, requires GPU-enabled ORT |
+| OpenVINO (Intel) | `"openvino"` | Config ready, requires GPU-enabled ORT |
+
+## systemd note
+
+The systemd service has `MemoryDenyWriteExecute=yes` commented out because GPU inference runtimes (CUDA, TensorRT) use JIT compilation which requires writable+executable memory pages. If you are using CPU-only, you can re-enable this directive for additional hardening.
+
+## Troubleshooting
+
+- **"Failed to load execution provider"**: The GPU-enabled ONNX Runtime package is not installed or `libonnxruntime.so` does not include the requested provider.
+- **Slower than CPU**: Ensure the GPU driver is loaded (`nvidia-smi` for NVIDIA, `rocm-smi` for AMD). Small models like SCRFD 2.5G may not benefit from GPU due to transfer overhead.
+- **Daemon crashes on startup**: Check `journalctl -u facelock-daemon` for ORT initialization errors. GPU memory allocation failures are the most common cause.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -17,9 +17,11 @@ No daemon needed -- the CLI auto-falls back to direct mode when no daemon is run
 
 | Mode | Config | How it works | Latency |
 |------|--------|-------------|---------|
-| **Daemon** | `mode = "daemon"` (default) | PAM connects via D-Bus, persistent daemon | ~200ms warm |
-| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms cold |
-| **Oneshot** | `mode = "oneshot"` | PAM spawns `facelock auth` subprocess | ~700ms |
+| **Daemon** | `mode = "daemon"` (default) | PAM connects via D-Bus, persistent daemon | ~150-600ms |
+| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms+ cold |
+| **Oneshot** | `mode = "oneshot"` | PAM spawns `facelock auth` subprocess | ~700ms+ |
+
+Daemon latency depends on camera state: ~600ms with a cold camera, ~150-180ms on back-to-back auths when the camera is already warm.
 
 The CLI works in all modes -- it connects to the daemon if available, otherwise operates directly.
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Facelock is a modern face authentication system for Linux PAM. It provides Windows Hello-style facial authentication with IR anti-spoofing, configurable as a persistent daemon or daemonless one-shot.
+Facelock is a modern face authentication system for Linux PAM. It provides Windows Hello-style facial authentication with IR anti-spoofing, configurable as a persistent daemon or daemonless one-shot. All inference runs locally on your hardware -- no cloud services, no network requests, no telemetry. Your biometric data never leaves your machine.
 
 ## Quick Start
 
@@ -18,7 +18,7 @@ No daemon needed -- the CLI auto-falls back to direct mode when no daemon is run
 | Mode | Config | How it works | Latency |
 |------|--------|-------------|---------|
 | **Daemon** | `mode = "daemon"` (default) | PAM connects via D-Bus, persistent daemon | ~200ms warm |
-| **Socket activation** | systemd `.socket` unit | systemd starts daemon on demand | ~700ms cold |
+| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms cold |
 | **Oneshot** | `mode = "oneshot"` | PAM spawns `facelock auth` subprocess | ~700ms |
 
 The CLI works in all modes -- it connects to the daemon if available, otherwise operates directly.
@@ -53,7 +53,7 @@ pam_facelock.so (PAM module)
 | `facelock-face` | lib | ONNX inference (SCRFD detection + ArcFace embedding) |
 | `facelock-store` | lib | SQLite face embedding storage |
 | `facelock-daemon` | lib | Auth/enroll logic, liveness, audit, rate limiting, request handler |
-| `facelock-cli` | bin | All CLI commands, daemon runner, direct mode |
+| `facelock-cli` | bin | All CLI commands, daemon runner, direct mode, benchmarks |
 | `pam-facelock` | cdylib | PAM module (libc + toml + serde + zbus only) |
 | `facelock-tpm` | lib | Optional TPM-bound encryption for embeddings at rest |
 | `facelock-polkit` | bin | Polkit authentication agent for face auth |
@@ -91,10 +91,16 @@ All keys are optional. Camera is auto-detected if `device.path` is omitted. See 
 
 See [Quick Start](quickstart.md) for full instructions.
 
-## Security
+## Privacy & Security
+
+**Privacy**: Facelock is 100% local. Face detection and recognition run entirely on your hardware via ONNX Runtime. No images, embeddings, or metadata are ever sent to any external server. There is no telemetry, no analytics, no phone-home behavior. Models are downloaded once during setup -- after that, Facelock never touches the network.
+
+**Security**:
 
 - IR camera enforcement on by default (anti-spoofing)
 - Frame variance checks reject static photo attacks
+- Constant-time embedding comparison via `subtle` crate
+- AES-256-GCM encryption at rest with optional TPM-sealed keys
 - Model SHA256 verification at every load
 - D-Bus system bus policy
 - PAM audit logging to syslog

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -9,6 +9,16 @@ Facelock is a **local biometric authentication system**. The threat model assume
 - **Attacker does not have root** (if they do, game over regardless)
 - **Attacker cannot modify files** in `/etc/facelock/`, `/var/lib/facelock/`, or `/lib/security/`
 
+## Privacy Guarantees
+
+Facelock is designed to keep biometric data under the user's exclusive control:
+
+- **Local-only inference**: All face detection and recognition runs on-device via ONNX Runtime. No images, embeddings, or metadata are ever transmitted over the network.
+- **No telemetry**: Facelock contains zero analytics, tracking, or phone-home code. After the one-time model download during `facelock setup`, it never contacts any server.
+- **No cloud dependencies**: Authentication works fully offline. No account registration, no API keys, no external services.
+- **Data stays on disk**: Face embeddings are stored in a local SQLite database (`/var/lib/facelock/facelock.db`) with restrictive permissions (640, root:facelock). Optional AES-256-GCM encryption with TPM-sealed keys provides defense in depth.
+- **Open source**: All code is MIT/Apache-2.0 licensed. No proprietary blobs or obfuscated network calls. Privacy claims are verifiable by reading the source.
+
 ## Attack Vectors & Mitigations
 
 ### 1. Photo/Video Spoofing (CRITICAL)
@@ -152,7 +162,7 @@ abort_if_ssh = true          # Refuse face auth over SSH
 abort_if_lid_closed = true   # Refuse if laptop lid closed
 require_ir = true            # CRITICAL: refuse RGB-only cameras (anti-spoof)
 require_frame_variance = true # Reject static images (photo defense)
-require_landmark_liveness = true # Require landmark movement between frames
+require_landmark_liveness = false # Require landmark movement between frames (off by default)
 min_auth_frames = 3          # Minimum frames before accepting (variance check)
 
 [notification]

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -44,7 +44,7 @@
 
 ### First-start latency (~700ms -- 2s)
 
-The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode take ~200ms.
+The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode typically take ~600ms (or ~150ms if the camera is still warm from a recent auth).
 
 ### Consistently slow (~700ms+ every time)
 

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -159,8 +159,9 @@
 
 # Require landmark movement between frames to pass liveness check.
 # Tracks facial landmark positions across frames to detect static images.
-# Default: true
-# require_landmark_liveness = true
+# Experimental; off by default.
+# Default: false
+# require_landmark_liveness = false
 
 # Suppress warnings for unknown users (users with no enrolled face).
 # Default: false

--- a/crates/facelock-bench/Cargo.toml
+++ b/crates/facelock-bench/Cargo.toml
@@ -19,6 +19,3 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-[features]
-cuda = ["facelock-face/cuda"]
-tensorrt = ["facelock-face/tensorrt"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,8 +208,8 @@ flowchart LR
 
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
-- ~200ms auth latency (models already loaded)
-- Camera stays warm between requests
+- ~600ms typical auth latency (~150ms with warm camera)
+- Camera stays warm between back-to-back requests
 - Single point of resource management
 
 ### Oneshot Mode

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Facelock is a face authentication system for Linux PAM. It detects faces via SCRFD, extracts embeddings via ArcFace, and matches against stored models using cosine similarity.
+Facelock is a face authentication system for Linux PAM. It detects faces via SCRFD, extracts embeddings via ArcFace, and matches against stored models using cosine similarity. All processing is local -- no network calls, no cloud services, no telemetry.
 
 ## System Diagram
 
@@ -16,7 +16,7 @@ Facelock is a face authentication system for Linux PAM. It detects faces via SCR
          │                               │ or IPC to daemon
     ┌────▼────────────┐                  │
     │  pam_facelock.so  │──────────────────┤
-    │  (~600KB cdylib) │                  │
+    │  (~2MB cdylib) │                  │
     │                 │                  │
     │  daemon mode:   │                  │
     │  → D-Bus IPC    │          ┌───────▼──────────────┐

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,14 @@ facelock bench model-load               # model loading time
 facelock bench report                   # full benchmark report
 ```
 
+## facelock restart
+
+Restart the persistent daemon. Sends a shutdown command via D-Bus and waits for it to restart via D-Bus activation.
+
+```bash
+facelock restart
+```
+
 ## User Resolution
 
 For commands that accept `--user`:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -153,7 +153,7 @@ facelock bench report                   # full benchmark report
 
 ## facelock restart
 
-Restart the persistent daemon. Sends a shutdown command via D-Bus and waits for it to restart via D-Bus activation.
+Restart the persistent daemon. On systemd systems, runs `systemctl restart facelock-daemon.service`. Otherwise, sends a D-Bus shutdown request and the daemon restarts on next use via D-Bus activation.
 
 ```bash
 facelock restart

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,7 @@ Controls how the PAM module reaches the face engine.
 | `abort_if_lid_closed` | bool | `true` | Refuse face auth when the laptop lid is closed (camera blocked). |
 | `require_ir` | bool | `true` | Require an IR camera for authentication. RGB cameras are trivially spoofed with a printed photo. Only set to `false` for development/testing. |
 | `require_frame_variance` | bool | `true` | Require multiple frames with different embeddings before accepting. Defends against static photo attacks. |
-| `require_landmark_liveness` | bool | `true` | Require landmark movement between frames to pass liveness check. Detects static images by tracking facial landmark positions across frames. |
+| `require_landmark_liveness` | bool | `false` | Require landmark movement between frames to pass liveness check. Detects static images by tracking facial landmark positions across frames. Experimental; off by default. |
 | `suppress_unknown` | bool | `false` | Suppress warnings for unknown users (users with no enrolled face). |
 | `min_auth_frames` | u32 | `3` | Minimum number of matching frames required before accepting. Only applies when `require_frame_variance` is true. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ Controls how the PAM module reaches the face engine.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (fast, ~200ms). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~700ms, no background process). |
+| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (~150-600ms depending on camera state). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~700ms+, no background process). |
 | `model_dir` | string | `"/var/lib/facelock/models"` | Directory containing ONNX model files. |
 | `idle_timeout_secs` | u64 | `0` | Shut down the daemon after this many idle seconds. `0` means never. Useful with D-Bus activation. |
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -7,7 +7,7 @@ Stable contracts. Do not change without updating this document.
 | Binary | Crate | Purpose |
 |--------|-------|---------|
 | `facelock` | facelock-cli | Unified CLI (daemon, auth, enroll, test, setup, etc.) |
-| `libpam_facelock.so` | pam-facelock | PAM authentication module |
+| `pam_facelock.so` | pam-facelock | PAM authentication module |
 | `facelock-polkit-agent` | facelock-polkit | Polkit face authentication agent |
 
 ## CLI Subcommands
@@ -33,6 +33,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock decrypt` | Decrypt face database |
 | `facelock audit` | View audit log |
 | `facelock bench` | Benchmarks |
+| `facelock restart` | Restart daemon |
 
 ## Operating Modes
 
@@ -59,7 +60,6 @@ The CLI silently falls back to direct mode when the daemon is not available on D
 | `/var/lib/facelock/facelock.db` | root:facelock | 640 | Face embeddings |
 | `/var/lib/facelock/models/` | root:root | 755 | ONNX models |
 | `/var/log/facelock/snapshots/` | root:facelock | 750 | Auth snapshots |
-| `/run/facelock/facelock.sock` | daemon | 660 | Legacy IPC socket (unused; D-Bus activation is now used) |
 | `/usr/bin/facelock` | root:root | 755 | CLI binary |
 | `/lib/security/pam_facelock.so` | root:root | 755 | PAM module |
 
@@ -152,7 +152,7 @@ pam_facelock(<service>): <result> for user <username>
 |---------|--------|---------|
 | IR camera enforcement | `security.require_ir` | **true** |
 | Frame variance check | `security.require_frame_variance` | **true** |
-| Landmark liveness | `security.require_landmark_liveness` | **true** |
+| Landmark liveness | `security.require_landmark_liveness` | **false** |
 | Minimum auth frames | `security.min_auth_frames` | 3 |
 | Variance threshold | `FRAME_VARIANCE_THRESHOLD` | 0.998 |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,16 @@ facelock is a **local biometric authentication system**. The threat model assume
 - **Attacker does not have root** (if they do, game over regardless)
 - **Attacker cannot modify files** in `/etc/facelock/`, `/var/lib/facelock/`, or `/lib/security/`
 
+## Privacy Guarantees
+
+Facelock is designed to keep biometric data under the user's exclusive control:
+
+- **Local-only inference**: All face detection and recognition runs on-device via ONNX Runtime. No images, embeddings, or metadata are ever transmitted over the network.
+- **No telemetry**: Facelock contains zero analytics, tracking, or phone-home code. After the one-time model download during `facelock setup`, it never contacts any server.
+- **No cloud dependencies**: Authentication works fully offline. No account registration, no API keys, no external services.
+- **Data stays on disk**: Face embeddings are stored in a local SQLite database (`/var/lib/facelock/facelock.db`) with restrictive permissions (640, root:facelock). Optional AES-256-GCM encryption with TPM-sealed keys provides defense in depth.
+- **Open source**: All code is MIT/Apache-2.0 licensed. No proprietary blobs or obfuscated network calls. Privacy claims are verifiable by reading the source.
+
 ## Attack Vectors & Mitigations
 
 ### 1. Photo/Video Spoofing (CRITICAL)
@@ -282,7 +292,7 @@ abort_if_ssh = true          # Refuse face auth over SSH
 abort_if_lid_closed = true   # Refuse if laptop lid closed
 require_ir = true            # CRITICAL: refuse RGB-only cameras (anti-spoof)
 require_frame_variance = true # Reject static images (photo defense)
-require_landmark_liveness = true # Require landmark movement between frames
+require_landmark_liveness = false # Require landmark movement between frames (off by default)
 min_auth_frames = 3          # Minimum frames before accepting (variance check)
 
 [notification]

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -87,22 +87,22 @@ open as a recovery path.
 
 ## 2. Test Coverage Audit
 
-### Unit test counts by crate
+### Unit test counts by crate (approximate)
 
-| Crate | `#[test]` count | `#[ignore]` count | Notes |
-|-------|---------------:|------------------:|-------|
-| facelock-core | 43 | 0 | Good coverage: config parsing, types, paths, D-Bus types |
-| facelock-camera | 39 | 2 | Good: preprocessing, device detection, quirks. Hardware tests ignored. |
-| facelock-face | 18 | 6 | Moderate: alignment, detector, embedder, model verification. 5 integration tests need camera+models. |
-| facelock-store | 30 | 0 | Good: SQLite CRUD, embedding storage, migration. Plus integration test file. |
-| facelock-daemon | 54 | 0 | Strong: rate limiting, audit, quality scoring, auth logic, liveness. Plus integration test file. |
-| facelock-cli | 63 | 0 | Strong: daemon command, preview rendering, bench, list, encrypt, setup, TPM, IPC client, i18n, notifications. Plus CLI smoke test. |
-| facelock-tpm | 27 | 0 | Good: PCR policy, sealing/unsealing (swtpm in CI). |
-| pam-facelock | 0 | 0 | No unit tests. Tested via container PAM smoke (Tier 3a). |
-| facelock-polkit | 0 | 0 | No tests. Agent is not production-ready. |
-| facelock-bench | 0 | 0 | Benchmark binary, not a test target. |
-| facelock-test-support | 0 | 0 | Mocks/fixtures only, no self-tests. |
-| **Total** | **274** | **8** | |
+| Crate | Approx. tests | Notes |
+|-------|-------------:|-------|
+| facelock-core | ~40+ | Good coverage: config parsing, types, paths, D-Bus types |
+| facelock-camera | ~40+ | Good: preprocessing, device detection, quirks. A few hardware tests ignored. |
+| facelock-face | ~20 | Moderate: alignment, detector, embedder, model verification. Some integration tests need camera+models. |
+| facelock-store | ~30 | Good: SQLite CRUD, embedding storage, migration. |
+| facelock-daemon | ~50+ | Strong: rate limiting, audit, quality scoring, auth logic, liveness. |
+| facelock-cli | ~60+ | Strong: daemon command, preview rendering, bench, list, encrypt, setup, TPM, IPC client, notifications. |
+| facelock-tpm | ~25+ | Good: PCR policy, sealing/unsealing (swtpm in CI). |
+| pam-facelock | 0 | No unit tests. Tested via container PAM smoke (Tier 3a). |
+| facelock-polkit | 0 | No tests. Agent is not production-ready. |
+| facelock-bench | 0 | Benchmark binary, not a test target. |
+| facelock-test-support | 0 | Mocks/fixtures only, no self-tests. |
+| **Total** | **~270+** | |
 
 ### CI jobs
 
@@ -135,7 +135,7 @@ No `cargo-fuzz` targets exist. High-value fuzz targets would be:
 
 ### No coverage reporting
 Neither `cargo-tarpaulin` nor `llvm-cov` is configured. No visibility into
-which code paths are actually exercised by the 274 unit tests.
+which code paths are actually exercised by the unit tests.
 
 ### No supply chain auditing
 No `cargo-audit` or `cargo-deny` in CI. The project pulls in `ort` (ONNX
@@ -217,7 +217,7 @@ before they ship.
 
 ### P1: Coverage reporting
 Add `cargo-llvm-cov` to CI with a coverage summary comment on PRs. Provides
-visibility into what the 274 tests actually cover and highlights dead code.
+visibility into what the ~270+ tests actually cover and highlights dead code.
 
 ### P2: PAM module unit tests
 Add unit tests to `pam-facelock` for config parsing, D-Bus client fallback

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,7 @@
 
 ### First-start latency (~700ms -- 2s)
 
-The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode take ~200ms.
+The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode typically take ~600ms (or ~150ms if the camera is still warm from a recent auth).
 
 ### Consistently slow (~700ms+ every time)
 

--- a/website/index.html
+++ b/website/index.html
@@ -17,6 +17,7 @@
         <li><a href="#how-it-works">How It Works</a></li>
         <li><a href="#features">Features</a></li>
         <li><a href="#security">Security</a></li>
+        <li><a href="#privacy">Privacy</a></li>
         <li><a href="#install">Install</a></li>
         <li><a href="docs/quickstart.html">Docs</a></li>
         <li><a href="https://github.com/tyvsmith/facelock">GitHub</a></li>
@@ -29,7 +30,7 @@
     <div class="container">
       <div class="hero-badge">Open Source / MIT + Apache 2.0</div>
       <h1><span class="accent">Facelock</span></h1>
-      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, local inference, and ~200ms daemon-mode latency.</p>
+      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, ~200ms daemon-mode latency, and complete privacy -- all inference runs locally on your hardware, with zero network calls and zero telemetry.</p>
 
       <div class="hero-actions">
         <a href="docs/quickstart.html" class="btn btn-primary">Get Started</a>
@@ -130,8 +131,8 @@
           <div class="feature-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path></svg>
           </div>
-          <h3>Local-Only Inference</h3>
-          <p>All processing happens on-device with ONNX Runtime. No cloud services, no network requests, no telemetry. Your biometrics never leave the machine.</p>
+          <h3>100% Local &amp; Private</h3>
+          <p>All processing happens on-device via ONNX Runtime. No cloud services, no network requests, no telemetry, no analytics. Your face data never leaves your machine, ever.</p>
         </div>
 
         <div class="feature-card">
@@ -222,6 +223,51 @@
     </div>
   </section>
 
+  <!-- Privacy -->
+  <section id="privacy">
+    <div class="container">
+      <div class="section-header">
+        <div class="section-label">Privacy</div>
+        <h2 class="section-title">Your face, your machine, nobody else</h2>
+        <p class="section-desc">Facelock is designed from the ground up to keep your biometric data private.</p>
+      </div>
+
+      <div class="security-grid">
+        <div class="security-item">
+          <div class="security-marker">LO</div>
+          <div>
+            <h4>Local-Only Processing</h4>
+            <p>Face detection and recognition run entirely on your CPU or GPU via ONNX Runtime. No images or embeddings are ever transmitted over the network.</p>
+          </div>
+        </div>
+
+        <div class="security-item">
+          <div class="security-marker">NT</div>
+          <div>
+            <h4>No Telemetry</h4>
+            <p>Facelock contains zero analytics, tracking, or phone-home code. After the one-time model download during setup, it never contacts any server.</p>
+          </div>
+        </div>
+
+        <div class="security-item">
+          <div class="security-marker">EN</div>
+          <div>
+            <h4>Encryption at Rest</h4>
+            <p>Face embeddings can be encrypted with AES-256-GCM, optionally sealed to your TPM. Even if someone copies your database, the biometric data is unreadable.</p>
+          </div>
+        </div>
+
+        <div class="security-item">
+          <div class="security-marker">OS</div>
+          <div>
+            <h4>Open Source &amp; Auditable</h4>
+            <p>Every line of code is MIT/Apache-2.0 licensed. No proprietary blobs, no obfuscated network calls. Verify the privacy claims yourself.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Install -->
   <section id="install">
     <div class="container">
@@ -234,6 +280,7 @@
       <div class="install-block">
         <div class="install-tabs">
           <span class="install-tab active">Arch Linux</span>
+          <span class="install-tab">From source</span>
         </div>
         <div class="terminal">
           <div class="terminal-bar">
@@ -263,6 +310,8 @@
           </div>
         </div>
       </div>
+
+      <p class="install-note" style="text-align: center; margin-top: 1.5rem; opacity: 0.7;">Also available as <code>.deb</code>, <code>.rpm</code>, and Nix flake. See <a href="docs/quickstart.html">docs</a> for details.</p>
     </div>
   </section>
 
@@ -326,8 +375,28 @@
               <td><span class="cross">No</span></td>
             </tr>
             <tr>
+              <td>Constant-time matching</td>
+              <td><span class="check">subtle crate (no timing leaks)</span></td>
+              <td><span class="cross">No</span></td>
+            </tr>
+            <tr>
+              <td>GPU acceleration</td>
+              <td><span class="check">CUDA / ROCm / OpenVINO (runtime)</span></td>
+              <td><span class="cross">No</span></td>
+            </tr>
+            <tr>
+              <td>Audit logging</td>
+              <td><span class="check">Structured JSONL + syslog</span></td>
+              <td><span class="cross">No</span></td>
+            </tr>
+            <tr>
+              <td>systemd hardening</td>
+              <td><span class="check">ProtectSystem, NoNewPrivileges, etc.</span></td>
+              <td><span class="cross">No</span></td>
+            </tr>
+            <tr>
               <td>PAM module size</td>
-              <td>~600KB (no heavy deps)</td>
+              <td>~2MB (no heavy deps)</td>
               <td>Full Python runtime</td>
             </tr>
           </tbody>

--- a/website/index.html
+++ b/website/index.html
@@ -30,7 +30,7 @@
     <div class="container">
       <div class="hero-badge">Open Source / MIT + Apache 2.0</div>
       <h1><span class="accent">Facelock</span></h1>
-      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, ~200ms daemon-mode latency, and complete privacy -- all inference runs locally on your hardware, with zero network calls and zero telemetry.</p>
+      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, ~200ms daemon-mode latency, and complete privacy -- all authentication runs locally on your hardware with no telemetry. After initial model download, Facelock never touches the network.</p>
 
       <div class="hero-actions">
         <a href="docs/quickstart.html" class="btn btn-primary">Get Started</a>
@@ -245,7 +245,7 @@
           <div class="security-marker">NT</div>
           <div>
             <h4>No Telemetry</h4>
-            <p>Facelock contains zero analytics, tracking, or phone-home code. After the one-time model download during setup, it never contacts any server.</p>
+            <p>Zero analytics, tracking, or phone-home code. Models are downloaded once during <code>facelock setup</code> -- after that, Facelock never contacts any server.</p>
           </div>
         </div>
 
@@ -280,7 +280,6 @@
       <div class="install-block">
         <div class="install-tabs">
           <span class="install-tab active">Arch Linux</span>
-          <span class="install-tab">From source</span>
         </div>
         <div class="terminal">
           <div class="terminal-bar">
@@ -311,7 +310,7 @@
         </div>
       </div>
 
-      <p class="install-note" style="text-align: center; margin-top: 1.5rem; opacity: 0.7;">Also available as <code>.deb</code>, <code>.rpm</code>, and Nix flake. See <a href="docs/quickstart.html">docs</a> for details.</p>
+      <p class="install-note">Also available as <code>.deb</code>, <code>.rpm</code>, and Nix flake. See <a href="docs/quickstart.html">docs</a> for details.</p>
     </div>
   </section>
 

--- a/website/index.html
+++ b/website/index.html
@@ -30,7 +30,7 @@
     <div class="container">
       <div class="hero-badge">Open Source / MIT + Apache 2.0</div>
       <h1><span class="accent">Facelock</span></h1>
-      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, ~200ms daemon-mode latency, and complete privacy -- all authentication runs locally on your hardware with no telemetry. After initial model download, Facelock never touches the network.</p>
+      <p class="hero-tagline">Face authentication for Linux. Windows Hello-style facial recognition with IR anti-spoofing, sub-second daemon-mode latency, and complete privacy -- all authentication runs locally on your hardware with no telemetry. After initial model download, Facelock never touches the network.</p>
 
       <div class="hero-actions">
         <a href="docs/quickstart.html" class="btn btn-primary">Get Started</a>
@@ -123,8 +123,8 @@
           <div class="feature-icon">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
           </div>
-          <h3>~200ms Latency</h3>
-          <p>Persistent daemon keeps ONNX models and camera warm. Authentication completes in ~200ms after initial model load.</p>
+          <h3>Sub-Second Auth</h3>
+          <p>Persistent daemon keeps ONNX models loaded. ~600ms typical, dropping to ~150ms on back-to-back auths when the camera stays warm.</p>
         </div>
 
         <div class="feature-card">
@@ -340,7 +340,7 @@
             </tr>
             <tr>
               <td>Daemon mode</td>
-              <td><span class="check">Yes (~200ms auth)</span></td>
+              <td><span class="check">Yes (~150-600ms auth)</span></td>
               <td><span class="cross">No (process per auth)</span></td>
             </tr>
             <tr>

--- a/website/style.css
+++ b/website/style.css
@@ -552,6 +552,12 @@ section + section {
   border-color: var(--border-color);
 }
 
+.install-note {
+  text-align: center;
+  margin-top: 1.5rem;
+  opacity: 0.7;
+}
+
 /* ── Comparison Table ── */
 .comparison-wrap {
   overflow-x: auto;


### PR DESCRIPTION
## Summary

Full review and update of all documentation, GitHub Pages site, and book content to match the current state of the codebase.

- **Fix doc/code mismatches**: `require_landmark_liveness` default corrected to `false`, PAM module name fixed (`pam_facelock.so` not `libpam_facelock.so`), "socket activation" → "D-Bus activation", workspace crate count corrected (10 not 11), PAM module size updated (~2MB verified, was ~600KB)
- **Remove broken code**: Removed `cuda`/`tensorrt` feature flags from facelock-bench Cargo.toml (referenced nonexistent features in facelock-face)
- **Add missing CLI docs**: `restart` command added to all CLI references (docs, book, contracts, README)
- **Clean up stale references**: Removed legacy `/run/facelock/facelock.sock` from contracts, switched to approximate test counts (~270+)
- **New content**: GPU acceleration page in book, omarchy/hyprlock integration in README, expanded website comparison table
- **Privacy messaging**: Added dedicated Privacy section to website, README, book intro, and security docs — emphasizing local-only processing, zero telemetry, no cloud dependencies, open source auditability

## Test plan

- [x] `cargo check --workspace` passes (only doc/config changes, no code logic)
- [x] Book builds with `mdbook build book/`
- [x] Website renders correctly (privacy section, expanded comparison table, install tabs)
- [x] Verify no remaining `libpam_facelock`, `facelock.sock`, or `274` references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)