### PR TITLE
feat: add model quality and inference device selection to setup wizard

### DIFF
--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -4,10 +4,10 @@ All commands are subcommands of the `facelock` binary.
 
 ## facelock setup
 
-Download models and create directories.
+Interactive setup wizard. Walks through camera selection, model quality, inference device (CPU/CUDA), model downloads, encryption, enrollment, and PAM configuration. Can also be run with flags for individual setup tasks.
 
 ```bash
-facelock setup                          # download models
+facelock setup                          # interactive wizard
 facelock setup --systemd                # install systemd units
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -41,14 +41,15 @@ Face detection and embedding parameters.
 
 Run `facelock test` to see your similarity scores, then set the threshold below your typical match score with some margin.
 
-### Model options
+### Model tiers
 
-| Preset | Detector | Embedder | Total size | Notes |
-|--------|----------|----------|------------|-------|
-| Default | `scrfd_2.5g_bnkps.onnx` (3MB) | `w600k_r50.onnx` (166MB) | ~170MB | Good accuracy, fast |
-| High-accuracy | `det_10g.onnx` (17MB) | `glintr100.onnx` (249MB) | ~266MB | ~200ms slower |
+| Tier | Detector | Embedder | Total size | Notes |
+|------|----------|----------|------------|-------|
+| Standard | `scrfd_2.5g_bnkps.onnx` (3MB) | `w600k_r50.onnx` (166MB) | ~170MB | Fast, good accuracy (default) |
+| Balanced | `scrfd_2.5g_bnkps.onnx` (3MB) | `glintr100.onnx` (249MB) | ~252MB | ~15-30ms slower, better recognition |
+| High accuracy | `det_10g.onnx` (17MB) | `glintr100.onnx` (249MB) | ~266MB | ~40-50ms slower, best accuracy |
 
-Run `facelock setup` after changing models to download them.
+Run `facelock setup` to select a model tier interactively and download the required models.
 
 ## [daemon]
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -19,7 +19,7 @@ just build
 ### 2. Download Models and Enroll
 
 ```bash
-sudo facelock setup     # download ONNX models (~170MB)
+sudo facelock setup     # interactive wizard (camera, models, encryption)
 sudo facelock enroll    # capture your face (look at camera)
 sudo facelock test      # verify recognition works
 ```
@@ -72,7 +72,9 @@ You should see "Identifying face..." and authenticate by looking at the camera.
 
 ### GPU Acceleration (Optional)
 
-GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package for your hardware:
+GPU support is runtime-only -- no special build flags needed. The setup wizard (`facelock setup`) offers CPU or CUDA selection and warns if dependencies are missing.
+
+For manual configuration, install a GPU-enabled ONNX Runtime package:
 
 ```bash
 sudo pacman -S onnxruntime-opt-cuda      # NVIDIA

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -50,26 +50,15 @@
 # Default: 5
 # timeout_secs = 5
 
-# Minimum confidence for the face detector to report a detection.
-# Lower values detect more faces but increase false positives.
-# Default: 0.5
-# detection_confidence = 0.5
-
-# Non-maximum suppression threshold for overlapping detections.
-# Default: 0.4
-# nms_threshold = 0.4
-
 # ONNX model files (must exist in daemon.model_dir).
+# Run `facelock setup` to select a model tier and download automatically.
 #
-# Default models (~170MB total, good accuracy):
-#   detector_model = "scrfd_2.5g_bnkps.onnx"   (3MB,  SCRFD 2.5G)
-#   embedder_model = "w600k_r50.onnx"           (166MB, ArcFace R50)
+# Available tiers:
+#   Standard  (~170MB, fast) — default
+#   Balanced  (~252MB, ~15-30ms slower)
+#   High accuracy (~266MB, ~40-50ms slower)
 #
-# High-accuracy models (~266MB total, ~200ms slower):
-#   detector_model = "det_10g.onnx"             (17MB,  SCRFD 10G)
-#   embedder_model = "glintr100.onnx"           (249MB, ArcFace R100)
-#
-# Run `facelock setup` after changing models to download them.
+# Default: "scrfd_2.5g_bnkps.onnx" / "w600k_r50.onnx" (standard)
 # detector_model = "scrfd_2.5g_bnkps.onnx"
 # embedder_model = "w600k_r50.onnx"
 

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -72,6 +72,7 @@ fn run_wizard() -> anyhow::Result<()> {
     println!();
     println!("  This wizard will walk you through initial setup:");
     println!("    - Camera detection");
+    println!("    - Model quality and inference device");
     println!("    - Model downloads");
     println!("    - Embedding encryption (TPM or software)");
     println!("    - Face enrollment");
@@ -105,8 +106,34 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     }
 
-    // -- Step 2: Model download --
-    println!("\n--- Step 2: Model Download ---\n");
+    // -- Step 2: Model quality --
+    println!("\n--- Step 2: Model Quality ---\n");
+    match wizard_model_quality(&theme, &mut config) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("  Model quality selection failed: {e}");
+            println!(
+                "  Continuing with current setting: {}",
+                config.recognition.detector_model
+            );
+        }
+    }
+
+    // -- Step 3: Execution provider --
+    println!("\n--- Step 3: Inference Device ---\n");
+    match wizard_execution_provider(&theme, &mut config) {
+        Ok(()) => {}
+        Err(e) => {
+            println!("  Inference device selection failed: {e}");
+            println!(
+                "  Continuing with current setting: {}",
+                config.recognition.execution_provider
+            );
+        }
+    }
+
+    // -- Step 4: Model download --
+    println!("\n--- Step 4: Model Download ---\n");
     match wizard_model_download(&theme, &config) {
         Ok(()) => {}
         Err(e) => {
@@ -115,8 +142,8 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     }
 
-    // -- Step 3: Encryption setup --
-    println!("\n--- Step 3: Embedding Encryption ---\n");
+    // -- Step 5: Encryption setup --
+    println!("\n--- Step 5: Embedding Encryption ---\n");
     match wizard_encryption_setup(&theme, &mut config) {
         Ok(()) => {}
         Err(e) => {
@@ -127,8 +154,8 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     }
 
-    // -- Step 4: Face enrollment --
-    println!("\n--- Step 4: Face Enrollment ---\n");
+    // -- Step 6: Face enrollment --
+    println!("\n--- Step 6: Face Enrollment ---\n");
     let enrolled = match wizard_face_enroll(&theme) {
         Ok(did_enroll) => did_enroll,
         Err(e) => {
@@ -138,9 +165,9 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     };
 
-    // -- Step 5: Test recognition --
+    // -- Step 7: Test recognition --
     if enrolled {
-        println!("\n--- Step 5: Test Recognition ---\n");
+        println!("\n--- Step 7: Test Recognition ---\n");
         match wizard_test_recognition(&theme) {
             Ok(()) => {}
             Err(e) => {
@@ -149,11 +176,11 @@ fn run_wizard() -> anyhow::Result<()> {
             }
         }
     } else {
-        println!("\n--- Step 5: Test Recognition (skipped, no face enrolled) ---\n");
+        println!("\n--- Step 7: Test Recognition (skipped, no face enrolled) ---\n");
     }
 
-    // -- Step 6: Systemd setup --
-    println!("\n--- Step 6: Daemon Configuration ---\n");
+    // -- Step 8: Systemd setup --
+    println!("\n--- Step 8: Daemon Configuration ---\n");
     let systemd_enabled = match wizard_systemd_setup(&theme) {
         Ok(enabled) => enabled,
         Err(e) => {
@@ -163,8 +190,8 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     };
 
-    // -- Step 7: PAM configuration --
-    println!("\n--- Step 7: PAM Configuration ---\n");
+    // -- Step 9: PAM configuration --
+    println!("\n--- Step 9: PAM Configuration ---\n");
     let pam_services = match wizard_pam_setup(&theme) {
         Ok(services) => services,
         Err(e) => {
@@ -181,11 +208,26 @@ fn run_wizard() -> anyhow::Result<()> {
         facelock_core::config::EncryptionMethod::Keyfile => "AES-256-GCM (keyfile)",
         facelock_core::config::EncryptionMethod::None => "none (NOT RECOMMENDED)",
     };
+    let model_quality_label = match (
+        config.recognition.detector_model.as_str(),
+        config.recognition.embedder_model.as_str(),
+    ) {
+        ("det_10g.onnx", "glintr100.onnx") => "high accuracy (SCRFD 10G + ArcFace R100)",
+        ("scrfd_2.5g_bnkps.onnx", "glintr100.onnx") => "balanced (SCRFD 2.5G + ArcFace R100)",
+        _ => "standard (SCRFD 2.5G + ArcFace R50)",
+    };
     println!(
         "  Camera:     {}",
         config.device.path.as_deref().unwrap_or("/dev/video0")
     );
-    println!("  Models:     {}", config.daemon.model_dir);
+    println!(
+        "  Models:     {} ({})",
+        config.daemon.model_dir, model_quality_label
+    );
+    println!(
+        "  Inference:  {}",
+        config.recognition.execution_provider.to_uppercase()
+    );
     println!("  Database:   {}", config.storage.db_path);
     println!("  Encryption: {}", encryption_label);
     println!(
@@ -275,6 +317,154 @@ fn wizard_camera_selection(theme: &ColorfulTheme, config: &mut Config) -> anyhow
     let selected = &devices[selection];
     config.device.path = Some(selected.path.clone());
     println!("  Selected: {} ({})", selected.path, selected.name);
+
+    Ok(())
+}
+
+fn wizard_model_quality(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
+    let current_detector = &config.recognition.detector_model;
+    let current_embedder = &config.recognition.embedder_model;
+
+    let default_idx = match (current_detector.as_str(), current_embedder.as_str()) {
+        ("det_10g.onnx", "glintr100.onnx") => 2,
+        ("scrfd_2.5g_bnkps.onnx", "glintr100.onnx") => 1,
+        _ => 0,
+    };
+
+    let options = [
+        "Standard (recommended) — SCRFD 2.5G + ArcFace R50 (~170MB, fast)",
+        "Balanced — SCRFD 2.5G + ArcFace R100 (~252MB, ~15-30ms slower)",
+        "High accuracy — SCRFD 10G + ArcFace R100 (~266MB, ~40-50ms slower)",
+    ];
+
+    let selection = Select::with_theme(theme)
+        .with_prompt("Select model quality")
+        .items(&options)
+        .default(default_idx)
+        .interact()?;
+
+    match selection {
+        0 => {
+            config.recognition.detector_model = "scrfd_2.5g_bnkps.onnx".to_string();
+            config.recognition.embedder_model = "w600k_r50.onnx".to_string();
+            println!("  Selected standard models (fast, good accuracy).");
+        }
+        1 => {
+            config.recognition.detector_model = "scrfd_2.5g_bnkps.onnx".to_string();
+            config.recognition.embedder_model = "glintr100.onnx".to_string();
+            println!("  Selected balanced models (fast detection, high-accuracy embedding).");
+        }
+        _ => {
+            config.recognition.detector_model = "det_10g.onnx".to_string();
+            config.recognition.embedder_model = "glintr100.onnx".to_string();
+            println!("  Selected high-accuracy models (larger, ~40-50ms slower).");
+        }
+    }
+
+    update_config_models(config)?;
+    Ok(())
+}
+
+fn wizard_execution_provider(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
+    let current = config.recognition.execution_provider.as_str();
+
+    let default_idx = match current {
+        "cuda" => 1,
+        _ => 0,
+    };
+
+    let options = [
+        "CPU (recommended — works everywhere)",
+        "CUDA (NVIDIA GPU — requires onnxruntime-opt-cuda package)",
+    ];
+
+    let selection = Select::with_theme(theme)
+        .with_prompt("Select inference device")
+        .items(&options)
+        .default(default_idx)
+        .interact()?;
+
+    let provider = match selection {
+        1 => "cuda",
+        _ => "cpu",
+    };
+
+    config.recognition.execution_provider = provider.to_string();
+    println!("  Selected: {}", provider);
+
+    if provider == "cuda" {
+        let has_nvidia_driver = Path::new("/dev/nvidiactl").exists();
+        let has_cuda_ort = ["/usr/lib/libonnxruntime.so", "/usr/lib64/libonnxruntime.so"]
+            .iter()
+            .any(|p| Path::new(p).exists());
+
+        if !has_nvidia_driver {
+            println!("  \u{26a0} NVIDIA driver not detected. Install the NVIDIA driver package");
+            println!("    before starting the daemon.");
+        }
+        if !has_cuda_ort {
+            println!(
+                "  \u{26a0} CUDA-enabled ONNX Runtime not found. Install onnxruntime-opt-cuda"
+            );
+            println!("    before starting the daemon, or inference will fall back to CPU.");
+        }
+    }
+
+    update_config_provider(config)?;
+    Ok(())
+}
+
+fn update_config_provider(config: &Config) -> anyhow::Result<()> {
+    let config_path = facelock_core::paths::config_path();
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+
+    let provider = &config.recognition.execution_provider;
+
+    if content.contains("[recognition]") {
+        let mut new_content = String::new();
+        let mut in_recognition = false;
+        let mut provider_written = false;
+
+        for line in content.lines() {
+            if line.trim() == "[recognition]" {
+                in_recognition = true;
+                new_content.push_str(line);
+                new_content.push('\n');
+                continue;
+            }
+            if in_recognition && line.trim_start().starts_with("execution_provider") {
+                new_content.push_str(&format!("execution_provider = \"{provider}\"\n"));
+                provider_written = true;
+                continue;
+            }
+            if in_recognition && line.starts_with('[') {
+                if !provider_written {
+                    new_content.push_str(&format!("execution_provider = \"{provider}\"\n"));
+                }
+                in_recognition = false;
+            }
+            new_content.push_str(line);
+            new_content.push('\n');
+        }
+        if in_recognition && !provider_written {
+            new_content.push_str(&format!("execution_provider = \"{provider}\"\n"));
+        }
+        fs::write(&config_path, new_content)?;
+    } else {
+        let mut content = content;
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(&format!(
+            "\n[recognition]\nexecution_provider = \"{provider}\"\n",
+        ));
+        fs::write(&config_path, content)?;
+    }
 
     Ok(())
 }
@@ -516,6 +706,76 @@ fn update_config_encryption(config: &Config, method: &str) -> anyhow::Result<()>
         content.push_str(&format!(
             "\n[encryption]\nmethod = \"{method}\"\nkey_path = \"{}\"\n",
             config.encryption.key_path
+        ));
+        fs::write(&config_path, content)?;
+    }
+
+    Ok(())
+}
+
+fn update_config_models(config: &Config) -> anyhow::Result<()> {
+    let config_path = facelock_core::paths::config_path();
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+
+    let detector = &config.recognition.detector_model;
+    let embedder = &config.recognition.embedder_model;
+
+    if content.contains("[recognition]") {
+        let mut new_content = String::new();
+        let mut in_recognition = false;
+        let mut detector_written = false;
+        let mut embedder_written = false;
+
+        for line in content.lines() {
+            if line.trim() == "[recognition]" {
+                in_recognition = true;
+                new_content.push_str(line);
+                new_content.push('\n');
+                continue;
+            }
+            if in_recognition && line.trim_start().starts_with("detector_model") {
+                new_content.push_str(&format!("detector_model = \"{detector}\"\n"));
+                detector_written = true;
+                continue;
+            }
+            if in_recognition && line.trim_start().starts_with("embedder_model") {
+                new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
+                embedder_written = true;
+                continue;
+            }
+            if in_recognition && line.starts_with('[') {
+                if !detector_written {
+                    new_content.push_str(&format!("detector_model = \"{detector}\"\n"));
+                }
+                if !embedder_written {
+                    new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
+                }
+                in_recognition = false;
+            }
+            new_content.push_str(line);
+            new_content.push('\n');
+        }
+        if in_recognition {
+            if !detector_written {
+                new_content.push_str(&format!("detector_model = \"{detector}\"\n"));
+            }
+            if !embedder_written {
+                new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
+            }
+        }
+        fs::write(&config_path, new_content)?;
+    } else {
+        let mut content = content;
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(&format!(
+            "\n[recognition]\ndetector_model = \"{detector}\"\nembedder_model = \"{embedder}\"\n",
         ));
         fs::write(&config_path, content)?;
     }
@@ -1266,6 +1526,64 @@ account include   system-login
         let status = check_model(&path, "0000000000000000").unwrap();
         assert!(matches!(status, ModelStatus::BadChecksum));
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn update_config_models_scenarios() {
+        let dir = std::env::temp_dir().join("facelock_test_models_scenarios");
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_path = dir.join("config.toml");
+
+        unsafe { std::env::set_var("FACELOCK_CONFIG", config_path.display().to_string()) };
+
+        // Scenario 1: appends [recognition] section when absent
+        std::fs::write(&config_path, "[device]\npath = \"/dev/video0\"\n").unwrap();
+        let mut config = Config::load().unwrap();
+        config.recognition.detector_model = "det_10g.onnx".to_string();
+        config.recognition.embedder_model = "glintr100.onnx".to_string();
+        update_config_models(&config).unwrap();
+
+        let result = std::fs::read_to_string(&config_path).unwrap();
+        assert!(result.contains("[recognition]"));
+        assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+
+        // Scenario 2: updates existing model fields, preserves other fields
+        std::fs::write(
+            &config_path,
+            "[device]\npath = \"/dev/video0\"\n\n[recognition]\ndetector_model = \"scrfd_2.5g_bnkps.onnx\"\nembedder_model = \"w600k_r50.onnx\"\nthreshold = 0.80\n",
+        )
+        .unwrap();
+        let mut config = Config::load().unwrap();
+        config.recognition.detector_model = "det_10g.onnx".to_string();
+        config.recognition.embedder_model = "glintr100.onnx".to_string();
+        update_config_models(&config).unwrap();
+
+        let result = std::fs::read_to_string(&config_path).unwrap();
+        assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+        assert!(!result.contains("scrfd_2.5g_bnkps.onnx"));
+        assert!(!result.contains("w600k_r50.onnx"));
+        assert!(result.contains("threshold = 0.80"));
+
+        // Scenario 3: adds model fields to existing [recognition] without them
+        std::fs::write(
+            &config_path,
+            "[device]\npath = \"/dev/video0\"\n\n[recognition]\nthreshold = 0.75\n",
+        )
+        .unwrap();
+        let mut config = Config::load().unwrap();
+        config.recognition.detector_model = "det_10g.onnx".to_string();
+        config.recognition.embedder_model = "glintr100.onnx".to_string();
+        update_config_models(&config).unwrap();
+
+        let result = std::fs::read_to_string(&config_path).unwrap();
+        assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+        assert!(result.contains("threshold = 0.75"));
+
+        unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,10 +4,10 @@ All commands are subcommands of the `facelock` binary.
 
 ## facelock setup
 
-Download models and create directories.
+Interactive setup wizard. Walks through camera selection, model quality, inference device (CPU/CUDA), model downloads, encryption, enrollment, and PAM configuration. Can also be run with flags for individual setup tasks.
 
 ```bash
-facelock setup                          # download models
+facelock setup                          # interactive wizard
 facelock setup --systemd                # install systemd units
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,14 +41,15 @@ Face detection and embedding parameters.
 
 Run `facelock test` to see your similarity scores, then set the threshold below your typical match score with some margin.
 
-### Model options
+### Model tiers
 
-| Preset | Detector | Embedder | Total size | Notes |
-|--------|----------|----------|------------|-------|
-| Default | `scrfd_2.5g_bnkps.onnx` (3MB) | `w600k_r50.onnx` (166MB) | ~170MB | Good accuracy, fast |
-| High-accuracy | `det_10g.onnx` (17MB) | `glintr100.onnx` (249MB) | ~266MB | ~200ms slower |
+| Tier | Detector | Embedder | Total size | Notes |
+|------|----------|----------|------------|-------|
+| Standard | `scrfd_2.5g_bnkps.onnx` (3MB) | `w600k_r50.onnx` (166MB) | ~170MB | Fast, good accuracy (default) |
+| Balanced | `scrfd_2.5g_bnkps.onnx` (3MB) | `glintr100.onnx` (249MB) | ~252MB | ~15-30ms slower, better recognition |
+| High accuracy | `det_10g.onnx` (17MB) | `glintr100.onnx` (249MB) | ~266MB | ~40-50ms slower, best accuracy |
 
-Run `facelock setup` after changing models to download them.
+Run `facelock setup` to select a model tier interactively and download the required models.
 
 ## [daemon]
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -14,7 +14,7 @@ Stable contracts. Do not change without updating this document.
 
 | Command | Purpose |
 |---------|---------|
-| `facelock setup` | Download models, create directories |
+| `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, enrollment, PAM) |
 | `facelock setup --systemd` | Install/enable systemd units |
 | `facelock setup --pam` | Install PAM module to `/etc/pam.d/` |
 | `facelock enroll` | Capture and store a face |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ just build
 ### 2. Download Models and Enroll
 
 ```bash
-sudo facelock setup     # download ONNX models (~170MB)
+sudo facelock setup     # interactive wizard (camera, models, encryption)
 sudo facelock enroll    # capture your face (look at camera)
 sudo facelock test      # verify recognition works
 ```
@@ -72,7 +72,9 @@ You should see "Identifying face..." and authenticate by looking at the camera.
 
 ### GPU Acceleration (Optional)
 
-GPU support is runtime-only -- no special build flags needed. Install a GPU-enabled ONNX Runtime package for your hardware:
+GPU support is runtime-only -- no special build flags needed. The setup wizard (`facelock setup`) offers CPU or CUDA selection and warns if dependencies are missing.
+
+For manual configuration, install a GPU-enabled ONNX Runtime package:
 
 ```bash
 sudo pacman -S onnxruntime-opt-cuda      # NVIDIA


### PR DESCRIPTION
## Summary

- **Model quality selection** — new wizard step offering three tiers: Standard (SCRFD 2.5G + ArcFace R50), Balanced (SCRFD 2.5G + ArcFace R100), and High Accuracy (SCRFD 10G + ArcFace R100) with size/speed tradeoffs shown inline
- **Inference device selection** — new wizard step for CPU vs CUDA, with dependency detection that warns if NVIDIA driver or CUDA-enabled ONNX Runtime package is missing (non-blocking — saves the selection either way)
- **Config template cleanup** — simplified model documentation (removed confusing reference blocks with broken trailing `#` comments), removed `detection_confidence` and `nms_threshold` from template (detector internals most users shouldn't touch), fixed `require_landmark_liveness` default mismatch (template said `true`, code defaults to `false`)

## Changes

| File | What |
|------|------|
| `crates/facelock-cli/src/commands/setup.rs` | `wizard_model_quality()`, `wizard_execution_provider()`, `update_config_models()`, `update_config_provider()`, step renumbering (7→9 steps), summary updates, tests |
| `config/facelock.toml` | Simplified model section, removed detector internals, fixed landmark liveness default |
| `docs/`, `book/src/` | Updated quickstart, configuration, CLI reference, contracts to reflect new wizard flow and model tiers |

## Testing

- `cargo check --workspace` — clean
- `cargo test --workspace` — 285 pass, 0 fail
- `cargo clippy --workspace -- -D warnings` — clean
- Manual testing of wizard flow with all three model tiers and both inference device options