### PR TITLE
chore: self-host model downloads from GitHub assets release

### DIFF
--- a/models/manifest.toml
+++ b/models/manifest.toml
@@ -1,11 +1,9 @@
 # Model manifest -- URLs, checksums, and metadata for ONNX models
 #
-# For official releases, models are also attached to the GitHub release
-# tagged `v0.1.0-models`. To use the self-hosted URLs instead of the
-# upstream sources below, replace the url fields with:
-#   https://github.com/tyvsmith/facelock/releases/download/v0.1.0-models/<filename>
+# Models are hosted in the GitHub "assets" release:
+#   https://github.com/tyvsmith/facelock/releases/tag/assets
 #
-# The sha256 checksums remain the same regardless of hosting source.
+# The sha256 checksums are verified at download time and at daemon startup.
 
 [[models]]
 name = "scrfd_2.5g"
@@ -13,7 +11,7 @@ filename = "scrfd_2.5g_bnkps.onnx"
 purpose = "Face detection + 5-point landmarks (default)"
 size_mb = 3
 sha256 = "bc24bb349491481c3ca793cf89306723162c280cb284c5a5e49df3760bf5c2ce"
-url = "https://github.com/visomaster/visomaster-assets/releases/download/v0.1.0/scrfd_2.5g_bnkps.onnx"
+url = "https://github.com/tyvsmith/facelock/releases/download/assets/scrfd_2.5g_bnkps.onnx"
 
 [[models]]
 name = "arcface_r50"
@@ -21,7 +19,7 @@ filename = "w600k_r50.onnx"
 purpose = "512-D face embedding (default)"
 size_mb = 166
 sha256 = "4c06341c33c2ca1f86781dab0e829f88ad5b64be9fba56e56bc9ebdefc619e43"
-url = "https://github.com/visomaster/visomaster-assets/releases/download/v0.1.0/w600k_r50.onnx"
+url = "https://github.com/tyvsmith/facelock/releases/download/assets/w600k_r50.onnx"
 
 [[models]]
 name = "scrfd_10g"
@@ -29,7 +27,7 @@ filename = "det_10g.onnx"
 purpose = "Higher accuracy face detection"
 size_mb = 17
 sha256 = "5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91"
-url = "https://github.com/visomaster/visomaster-assets/releases/download/v0.1.0/det_10g.onnx"
+url = "https://github.com/tyvsmith/facelock/releases/download/assets/det_10g.onnx"
 optional = true
 
 [[models]]
@@ -38,5 +36,5 @@ filename = "glintr100.onnx"
 purpose = "Higher accuracy 512-D face embedding (R100 backbone)"
 size_mb = 249
 sha256 = "4ab1d6435d639628a6f3e5008dd4f929edf4c4124b1a7169e1048f9fef534cdf"
-url = "https://huggingface.co/LPDoctor/insightface/resolve/main/models/antelopev2/glintr100.onnx"
+url = "https://github.com/tyvsmith/facelock/releases/download/assets/glintr100.onnx"
 optional = true


### PR DESCRIPTION
## Summary

- Created a new GitHub release (`assets`) containing all 4 ONNX model files
- Updated `models/manifest.toml` to download models from our own repo instead of third-party sources

## What changed

All model download URLs in `models/manifest.toml` now point to:
```
https://github.com/tyvsmith/facelock/releases/download/assets/<filename>
```

Previously they pointed to `visomaster/visomaster-assets` (3 models) and HuggingFace (1 model).

SHA256 checksums are unchanged — same files, just self-hosted.

## Models in the assets release

| Model | Size | Purpose |
|-------|------|---------|
| `scrfd_2.5g_bnkps.onnx` | 3 MB | Face detection (default) |
| `w600k_r50.onnx` | 166 MB | Face embedding (default) |
| `det_10g.onnx` | 17 MB | Higher accuracy detection (optional) |
| `glintr100.onnx` | 249 MB | Higher accuracy embedding (optional) |

## Why

Eliminates dependency on third-party hosting for model downloads. Users no longer need to rely on visomaster's GitHub releases or HuggingFace being available.