### PR TITLE
Harden facelock auth paths and verification

### DIFF
--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -4,7 +4,9 @@
 # sensible defaults. Uncomment and edit only what you need to change.
 #
 # Location: /etc/facelock/config.toml
-# Override: set FACELOCK_CONFIG=/path/to/config.toml
+# Override (unprivileged CLI only): set FACELOCK_CONFIG=/path/to/config.toml
+# Privileged PAM/root auth flows ignore the environment and use either
+# an explicit --config path or /etc/facelock/config.toml.
 
 
 # ── Camera ──────────────────────────────────────────────────────────
@@ -24,6 +26,27 @@
 # Values: 0, 90, 180, 270
 # Default: 0
 # rotation = 0
+
+# Frames to discard immediately after opening the camera so exposure
+# and gain can stabilize. Hardware quirks may override this.
+# Default: 3
+# warmup_frames = 3
+
+# Dark-frame rejection. If this fraction of pixels is below
+# dark_pixel_value, the frame is treated as unusably dark.
+# Defaults: threshold = 0.6, dark_pixel_value = 10
+# dark_threshold = 0.6
+# dark_pixel_value = 10
+
+# Attempt to enable a controllable IR emitter when the camera opens.
+# Only needed for hardware that does not auto-enable its IR LED.
+# Default: false
+# ir_emitter = false
+
+# In daemon mode, keep the camera open for this many seconds after
+# auth before releasing it to avoid repeated warmup cost.
+# Default: 5
+# camera_release_secs = 5
 
 
 # ── Face Recognition ────────────────────────────────────────────────
@@ -60,7 +83,11 @@
 #
 # Default: "scrfd_2.5g_bnkps.onnx" / "w600k_r50.onnx" (standard)
 # detector_model = "scrfd_2.5g_bnkps.onnx"
+# Bundled models are verified against the manifest automatically.
+# For custom model files, set the matching SHA256 explicitly.
+# detector_sha256 = "..."
 # embedder_model = "w600k_r50.onnx"
+# embedder_sha256 = "..."
 
 # ONNX Runtime execution provider.
 # Values: "cpu", "cuda", "rocm", "openvino"
@@ -165,6 +192,13 @@
 # [security.rate_limit]
 # max_attempts = 5   # Max auth attempts per user per window (default: 5)
 # window_secs = 60   # Rate limit window in seconds (default: 60)
+
+# PAM service policy — allow/deny specific PAM service names.
+# If allowed_services is non-empty, only those services may use facelock.
+# denied_services always takes precedence.
+# [security.pam_policy]
+# allowed_services = ["sudo", "polkit-1"]
+# denied_services = ["login", "sshd", "su"]
 
 
 # ── Encryption ────────────────────────────────────────────────────

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -11,6 +11,7 @@ use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
 use facelock_daemon::audit::{self, AuditEntry};
 use facelock_daemon::auth;
+use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 use tracing::{error, info};
@@ -85,8 +86,10 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     };
 
     // SQLite-based rate limiting: survives across oneshot process invocations.
+    // Only failed authentications consume the budget.
     let rl = &config.security.rate_limit;
-    match store.check_rate_limit(&user, rl.max_attempts, rl.window_secs) {
+    let rate_limiter = RateLimiter::new(rl.max_attempts, rl.window_secs);
+    match rate_limiter.check(&store, &user) {
         Ok(true) => {}
         Ok(false) => {
             error!(user = %user, "rate limited");
@@ -97,15 +100,6 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             return 2;
         }
     }
-
-    // Record attempt *before* auth so the window tracks even failed attempts.
-    if let Err(e) = store.record_auth_attempt(&user) {
-        error!("rate limit record: {e}");
-        return 2;
-    }
-
-    // Opportunistically clean up stale rate-limit rows.
-    let _ = store.cleanup_rate_limit(rl.window_secs);
 
     match store.has_models(&user) {
         Ok(true) => {}
@@ -177,6 +171,15 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     // Note: authenticate_inner already writes audit entries for the camera-based
     // auth loop. The oneshot path relies on those entries, so no additional audit
     // logging is needed here for the auth result itself.
+
+    if matches!(
+        response,
+        DaemonResponse::AuthResult(MatchResult { matched: false, .. })
+    ) {
+        if let Err(e) = rate_limiter.record_failure(&store, &user) {
+            error!("rate limit record: {e}");
+        }
+    }
 
     match response {
         DaemonResponse::AuthResult(MatchResult {

--- a/crates/facelock-cli/src/commands/config.rs
+++ b/crates/facelock-cli/src/commands/config.rs
@@ -144,6 +144,7 @@ fn restart_daemon() {
 
 /// Restart the facelock daemon. Called by `facelock restart`.
 pub fn restart() -> anyhow::Result<()> {
+    crate::ipc_client::require_root("sudo facelock restart")?;
     restart_daemon();
     Ok(())
 }

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -15,6 +15,7 @@ use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 use futures_util::StreamExt;
+use nix::unistd::{Group, Uid, User};
 use tracing::{error, info, warn};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
@@ -64,12 +65,25 @@ fn lock_handler_with_timeout(
     }
 }
 
-/// Verify the D-Bus caller is root.
-/// Used for privileged operations: enroll, remove, clear.
-async fn verify_caller_is_root(
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CallerIdentity {
+    uid: u32,
+    username: Option<String>,
+    in_facelock_group: bool,
+}
+
+impl CallerIdentity {
+    fn display_name(&self) -> String {
+        self.username
+            .clone()
+            .unwrap_or_else(|| format!("UID {}", self.uid))
+    }
+}
+
+async fn resolve_caller_identity(
     hdr: &zbus::message::Header<'_>,
     connection: &zbus::Connection,
-) -> fdo::Result<()> {
+) -> fdo::Result<CallerIdentity> {
     let sender = hdr
         .sender()
         .ok_or_else(|| fdo::Error::Failed("no sender in D-Bus message".into()))?;
@@ -82,86 +96,149 @@ async fn verify_caller_is_root(
         .await
         .map_err(|e| fdo::Error::Failed(format!("failed to get caller UID: {e}")))?;
 
-    if uid != 0 {
-        let caller_name = uid_to_username(uid).unwrap_or_else(|| format!("UID {uid}"));
-        warn!(
-            caller_uid = uid,
-            caller_name = %caller_name,
-            "D-Bus caller not authorized for privileged operation"
-        );
-        return Err(fdo::Error::AccessDenied(format!(
-            "root required (caller: '{caller_name}', UID {uid})"
-        )));
-    }
-
-    Ok(())
+    let username = uid_to_username(uid);
+    Ok(CallerIdentity {
+        uid,
+        in_facelock_group: is_facelock_group_member(uid, username.as_deref()),
+        username,
+    })
 }
 
-/// Verify the D-Bus caller is authorized to act on behalf of `user`.
-/// Root (UID 0) can act on any user. Non-root callers must match `user`.
+fn require_root(caller: &CallerIdentity, operation: &str) -> fdo::Result<()> {
+    if caller.uid == 0 {
+        return Ok(());
+    }
+
+    let caller_name = caller.display_name();
+    warn!(
+        operation = operation,
+        caller_uid = caller.uid,
+        caller_name = %caller_name,
+        "D-Bus caller not authorized for privileged operation"
+    );
+    Err(fdo::Error::AccessDenied(format!(
+        "{operation} requires root (caller: '{caller_name}', UID {})",
+        caller.uid
+    )))
+}
+
+fn require_user_authorized(
+    caller: &CallerIdentity,
+    user: &str,
+    operation: &str,
+) -> fdo::Result<()> {
+    if caller.uid == 0 {
+        return Ok(());
+    }
+
+    let caller_name = caller.username.clone().ok_or_else(|| {
+        fdo::Error::Failed(format!("failed to resolve UID {} to username", caller.uid))
+    })?;
+
+    if caller_name == user {
+        return Ok(());
+    }
+
+    warn!(
+        operation = operation,
+        caller_uid = caller.uid,
+        caller_name = %caller_name,
+        requested_user = %user,
+        "D-Bus caller not authorized to act on behalf of requested user"
+    );
+    Err(fdo::Error::AccessDenied(format!(
+        "{operation} not authorized: caller '{caller_name}' (UID {}) cannot act as '{user}'",
+        caller.uid
+    )))
+}
+
+fn require_camera_owner_or_root(
+    caller: &CallerIdentity,
+    owner_uid: Option<u32>,
+    operation: &str,
+) -> fdo::Result<()> {
+    if caller.uid == 0 {
+        return Ok(());
+    }
+
+    if owner_uid == Some(caller.uid) {
+        return Ok(());
+    }
+
+    let caller_name = caller.display_name();
+    warn!(
+        operation = operation,
+        caller_uid = caller.uid,
+        caller_name = %caller_name,
+        owner_uid,
+        "D-Bus caller does not own the active preview camera session"
+    );
+    Err(fdo::Error::AccessDenied(format!(
+        "{operation} not authorized: caller '{caller_name}' (UID {}) does not own the active preview camera session",
+        caller.uid
+    )))
+}
+
+fn require_facelock_access(caller: &CallerIdentity, operation: &str) -> fdo::Result<()> {
+    if caller.uid == 0 || caller.in_facelock_group {
+        return Ok(());
+    }
+
+    let caller_name = caller.display_name();
+    warn!(
+        operation = operation,
+        caller_uid = caller.uid,
+        caller_name = %caller_name,
+        "D-Bus caller is not in facelock group"
+    );
+    Err(fdo::Error::AccessDenied(format!(
+        "{operation} requires root or facelock group membership (caller: '{caller_name}', UID {})",
+        caller.uid
+    )))
+}
+
+async fn verify_caller_is_root(
+    hdr: &zbus::message::Header<'_>,
+    connection: &zbus::Connection,
+    operation: &str,
+) -> fdo::Result<()> {
+    let caller = resolve_caller_identity(hdr, connection).await?;
+    require_root(&caller, operation)
+}
+
 async fn verify_caller_authorized(
     hdr: &zbus::message::Header<'_>,
     connection: &zbus::Connection,
     user: &str,
+    operation: &str,
 ) -> fdo::Result<()> {
-    let sender = hdr
-        .sender()
-        .ok_or_else(|| fdo::Error::Failed("no sender in D-Bus message".into()))?;
-
-    // Ask the bus daemon for the sender's Unix UID
-    let dbus_proxy = fdo::DBusProxy::new(connection)
-        .await
-        .map_err(|e| fdo::Error::Failed(format!("failed to create DBus proxy: {e}")))?;
-    let uid = dbus_proxy
-        .get_connection_unix_user(sender.as_ref().into())
-        .await
-        .map_err(|e| fdo::Error::Failed(format!("failed to get caller UID: {e}")))?;
-
-    // Root can operate on any user
-    if uid == 0 {
-        return Ok(());
-    }
-
-    // Resolve UID to username
-    let caller_name = uid_to_username(uid)
-        .ok_or_else(|| fdo::Error::Failed(format!("failed to resolve UID {uid} to username")))?;
-
-    if caller_name != user {
-        warn!(
-            caller_uid = uid,
-            caller_name = %caller_name,
-            requested_user = %user,
-            "D-Bus caller not authorized to act on behalf of requested user"
-        );
-        return Err(fdo::Error::AccessDenied(format!(
-            "caller '{caller_name}' (UID {uid}) not authorized to act as '{user}'"
-        )));
-    }
-
-    Ok(())
+    let caller = resolve_caller_identity(hdr, connection).await?;
+    require_user_authorized(&caller, user, operation)
 }
 
-/// Resolve a Unix UID to a username via getpwuid_r.
 fn uid_to_username(uid: u32) -> Option<String> {
-    use std::ffi::CStr;
-    let mut buf = vec![0u8; 4096];
-    let mut passwd = std::mem::MaybeUninit::<libc::passwd>::uninit();
-    let mut result: *mut libc::passwd = std::ptr::null_mut();
-    let ret = unsafe {
-        libc::getpwuid_r(
-            uid,
-            passwd.as_mut_ptr(),
-            buf.as_mut_ptr() as *mut libc::c_char,
-            buf.len(),
-            &mut result,
-        )
+    User::from_uid(Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|user| user.name)
+}
+
+fn is_facelock_group_member(uid: u32, username: Option<&str>) -> bool {
+    let Some(group) = Group::from_name("facelock").ok().flatten() else {
+        return false;
     };
-    if ret != 0 || result.is_null() {
-        return None;
-    }
-    let passwd = unsafe { passwd.assume_init() };
-    let name = unsafe { CStr::from_ptr(passwd.pw_name) };
-    name.to_str().ok().map(|s| s.to_string())
+
+    let in_primary_group = User::from_uid(Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|user| user.gid == group.gid)
+        .unwrap_or(false);
+
+    let listed_in_group = username
+        .map(|name| group.mem.iter().any(|member| member == name))
+        .unwrap_or(false);
+
+    in_primary_group || listed_in_group
 }
 
 /// Current time as seconds since an arbitrary epoch (Instant-based).
@@ -179,9 +256,27 @@ struct FacelockService {
     /// Config file mtime when the handler was last built.
     /// Used to detect config changes and reload on next request.
     config_mtime: Arc<Mutex<Option<std::time::SystemTime>>>,
+    /// UID of the caller that currently owns preview camera cleanup rights.
+    camera_owner_uid: Arc<Mutex<Option<u32>>>,
 }
 
 impl FacelockService {
+    fn clear_camera_owner(&self) {
+        if let Ok(mut owner) = self.camera_owner_uid.lock() {
+            *owner = None;
+        }
+    }
+
+    fn set_camera_owner(&self, uid: u32) {
+        if let Ok(mut owner) = self.camera_owner_uid.lock() {
+            *owner = Some(uid);
+        }
+    }
+
+    fn camera_owner_uid(&self) -> Option<u32> {
+        self.camera_owner_uid.lock().ok().and_then(|owner| *owner)
+    }
+
     /// Check if the config file has been modified since the handler was built.
     /// If so, reload config, rebuild the engine/store/handler, and swap it in.
     /// Called at the start of authenticate and enroll — the two methods that
@@ -218,6 +313,7 @@ impl FacelockService {
         if let Ok(mut guard) = self.handler.lock() {
             *guard = new_handler;
         }
+        self.clear_camera_owner();
 
         // Update stored mtime
         if let Ok(mut stored) = self.config_mtime.lock() {
@@ -239,7 +335,8 @@ impl FacelockService {
     ) -> fdo::Result<AuthResult> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
-        verify_caller_authorized(&hdr, connection, user).await?;
+        verify_caller_authorized(&hdr, connection, user, "Authenticate").await?;
+        self.clear_camera_owner();
         let handler = self.handler.clone();
         let user = user.to_string();
         let signal_user = user.clone();
@@ -316,7 +413,8 @@ impl FacelockService {
     ) -> fdo::Result<(u32, u32)> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
-        verify_caller_is_root(&hdr, connection).await?;
+        verify_caller_is_root(&hdr, connection, "Enroll").await?;
+        self.clear_camera_owner();
         let handler = self.handler.clone();
         let user = user.to_string();
         let label = label.to_string();
@@ -346,7 +444,7 @@ impl FacelockService {
         user: &str,
     ) -> fdo::Result<Vec<ModelInfo>> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_authorized(&hdr, connection, user).await?;
+        verify_caller_authorized(&hdr, connection, user, "ListModels").await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         tokio::task::spawn_blocking(move || {
@@ -382,7 +480,7 @@ impl FacelockService {
         model_id: u32,
     ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_is_root(&hdr, connection).await?;
+        verify_caller_is_root(&hdr, connection, "RemoveModel").await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         tokio::task::spawn_blocking(move || {
@@ -408,7 +506,7 @@ impl FacelockService {
         user: &str,
     ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_is_root(&hdr, connection).await?;
+        verify_caller_is_root(&hdr, connection, "ClearModels").await?;
         let handler = self.handler.clone();
         let user = user.to_string();
         tokio::task::spawn_blocking(move || {
@@ -427,10 +525,16 @@ impl FacelockService {
         .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
     }
 
-    async fn preview_frame(&self) -> fdo::Result<Vec<u8>> {
+    async fn preview_frame(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> fdo::Result<Vec<u8>> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
+        let caller = resolve_caller_identity(&hdr, connection).await?;
+        require_root(&caller, "PreviewFrame")?;
         let handler = self.handler.clone();
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
             let request = DaemonRequest::PreviewFrame;
             let response = handler.handle(request);
@@ -443,7 +547,11 @@ impl FacelockService {
             }
         })
         .await
-        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
+        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?;
+        if result.is_ok() {
+            self.set_camera_owner(caller.uid);
+        }
+        result
     }
 
     async fn preview_detect_frame(
@@ -453,10 +561,11 @@ impl FacelockService {
         user: &str,
     ) -> fdo::Result<(Vec<u8>, Vec<PreviewFaceInfo>)> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
-        verify_caller_authorized(&hdr, connection, user).await?;
+        let caller = resolve_caller_identity(&hdr, connection).await?;
+        require_user_authorized(&caller, user, "PreviewDetectFrame")?;
         let handler = self.handler.clone();
         let user = user.to_string();
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
             let request = DaemonRequest::PreviewDetectFrame { user };
             let response = handler.handle(request);
@@ -483,11 +592,21 @@ impl FacelockService {
             }
         })
         .await
-        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
+        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?;
+        if result.is_ok() {
+            self.set_camera_owner(caller.uid);
+        }
+        result
     }
 
-    async fn list_devices(&self) -> fdo::Result<Vec<DeviceInfo>> {
+    async fn list_devices(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> fdo::Result<Vec<DeviceInfo>> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
+        let caller = resolve_caller_identity(&hdr, connection).await?;
+        require_facelock_access(&caller, "ListDevices")?;
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
@@ -513,10 +632,16 @@ impl FacelockService {
         .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
     }
 
-    async fn release_camera(&self) -> fdo::Result<()> {
+    async fn release_camera(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
+        let caller = resolve_caller_identity(&hdr, connection).await?;
+        require_camera_owner_or_root(&caller, self.camera_owner_uid(), "ReleaseCamera")?;
         let handler = self.handler.clone();
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
             let request = DaemonRequest::ReleaseCamera;
             let response = handler.handle(request);
@@ -529,21 +654,41 @@ impl FacelockService {
             }
         })
         .await
-        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
+        .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?;
+        if result.is_ok() {
+            self.clear_camera_owner();
+        }
+        result
     }
 
-    async fn ping(&self) -> fdo::Result<String> {
+    async fn ping(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> fdo::Result<String> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
+        let _ = resolve_caller_identity(&hdr, connection).await?;
         Ok("pong".to_string())
     }
 
-    async fn shutdown(&self) -> fdo::Result<()> {
+    async fn shutdown(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
+        verify_caller_is_root(&hdr, connection, "Shutdown").await?;
+        self.clear_camera_owner();
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
-            handler.shutdown_requested = true;
-            Ok::<(), fdo::Error>(())
+            match handler.handle(DaemonRequest::Shutdown) {
+                DaemonResponse::Ok => Ok(()),
+                DaemonResponse::Error { message } => Err(fdo::Error::Failed(message)),
+                other => Err(fdo::Error::Failed(format!(
+                    "unexpected response: {other:?}"
+                ))),
+            }
         })
         .await
         .map_err(|e| fdo::Error::Failed(format!("task join error: {e}")))?
@@ -746,6 +891,7 @@ async fn run_dbus_server(
         handler: handler.clone(),
         last_activity: last_activity.clone(),
         config_mtime: Arc::new(Mutex::new(startup_config_mtime)),
+        camera_owner_uid: Arc::new(Mutex::new(None)),
     };
 
     let _connection = zbus::connection::Builder::system()?
@@ -884,9 +1030,81 @@ async fn poll_shutdown(
 mod tests {
     use super::*;
 
+    fn caller(uid: u32, username: Option<&str>) -> CallerIdentity {
+        CallerIdentity {
+            uid,
+            in_facelock_group: false,
+            username: username.map(str::to_string),
+        }
+    }
+
+    fn facelock_caller(uid: u32, username: Option<&str>) -> CallerIdentity {
+        CallerIdentity {
+            uid,
+            in_facelock_group: true,
+            username: username.map(str::to_string),
+        }
+    }
+
     #[test]
     fn bus_name_constants() {
         assert_eq!(BUS_NAME, "org.facelock.Daemon");
         assert_eq!(OBJECT_PATH, "/org/facelock/Daemon");
+    }
+
+    #[test]
+    fn root_is_allowed_for_privileged_operations() {
+        assert!(require_root(&caller(0, Some("root")), "Shutdown").is_ok());
+    }
+
+    #[test]
+    fn same_user_is_allowed_for_user_scoped_methods() {
+        assert!(
+            require_user_authorized(&caller(1000, Some("alice")), "alice", "Authenticate").is_ok()
+        );
+    }
+
+    #[test]
+    fn different_user_is_denied_for_user_scoped_methods() {
+        let err = require_user_authorized(&caller(1000, Some("alice")), "bob", "Authenticate")
+            .unwrap_err();
+        assert!(matches!(err, fdo::Error::AccessDenied(_)));
+    }
+
+    #[test]
+    fn facelock_group_member_can_access_group_scoped_methods() {
+        assert!(
+            require_facelock_access(&facelock_caller(1000, Some("alice")), "ListDevices").is_ok()
+        );
+    }
+
+    #[test]
+    fn non_member_cannot_access_group_scoped_methods() {
+        let err = require_facelock_access(&caller(1000, Some("alice")), "ListDevices").unwrap_err();
+        assert!(matches!(err, fdo::Error::AccessDenied(_)));
+    }
+
+    #[test]
+    fn preview_owner_can_release_camera() {
+        assert!(
+            require_camera_owner_or_root(&caller(1000, Some("alice")), Some(1000), "ReleaseCamera")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn root_can_release_camera() {
+        assert!(
+            require_camera_owner_or_root(&caller(0, Some("root")), Some(1000), "ReleaseCamera")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn non_owner_cannot_release_camera() {
+        let err =
+            require_camera_owner_or_root(&caller(1001, Some("bob")), Some(1000), "ReleaseCamera")
+                .unwrap_err();
+        assert!(matches!(err, fdo::Error::AccessDenied(_)));
     }
 }

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -9,6 +9,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
 
 use facelock_core::Config;
+use facelock_core::fs_security::{
+    create_truncate_file, ensure_mode, ensure_private_dir, write_file,
+};
 
 /// Embedded systemd unit file.
 const SERVICE_UNIT: &str = include_str!("../../../../systemd/facelock-daemon.service");
@@ -41,6 +44,12 @@ struct ModelEntry {
     url: String,
     #[serde(default)]
     optional: bool,
+}
+
+impl ModelManifest {
+    fn find(&self, filename: &str) -> Option<&ModelEntry> {
+        self.models.iter().find(|m| m.filename == filename)
+    }
 }
 
 /// Check whether stdin is connected to an interactive terminal.
@@ -250,6 +259,9 @@ fn run_wizard() -> anyhow::Result<()> {
     }
     println!();
 
+    let manifest: ModelManifest =
+        toml::from_str(MANIFEST_TOML).context("failed to parse model manifest")?;
+    secure_setup_paths(&config, Some(&manifest))?;
     write_setup_marker()?;
     Ok(())
 }
@@ -257,9 +269,9 @@ fn run_wizard() -> anyhow::Result<()> {
 fn write_setup_marker() -> anyhow::Result<()> {
     let path = std::path::Path::new(SETUP_COMPLETE_MARKER);
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        ensure_private_dir(parent, 0o755)?;
     }
-    std::fs::write(path, "")?;
+    write_file(path, b"", 0o644)?;
     Ok(())
 }
 
@@ -322,6 +334,8 @@ fn wizard_camera_selection(theme: &ColorfulTheme, config: &mut Config) -> anyhow
 }
 
 fn wizard_model_quality(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
+    let manifest: ModelManifest =
+        toml::from_str(MANIFEST_TOML).context("failed to parse model manifest")?;
     let current_detector = &config.recognition.detector_model;
     let current_embedder = &config.recognition.embedder_model;
 
@@ -346,17 +360,31 @@ fn wizard_model_quality(theme: &ColorfulTheme, config: &mut Config) -> anyhow::R
     match selection {
         0 => {
             config.recognition.detector_model = "scrfd_2.5g_bnkps.onnx".to_string();
+            config.recognition.detector_sha256 = manifest
+                .find("scrfd_2.5g_bnkps.onnx")
+                .map(|m| m.sha256.clone());
             config.recognition.embedder_model = "w600k_r50.onnx".to_string();
+            config.recognition.embedder_sha256 =
+                manifest.find("w600k_r50.onnx").map(|m| m.sha256.clone());
             println!("  Selected standard models (fast, good accuracy).");
         }
         1 => {
             config.recognition.detector_model = "scrfd_2.5g_bnkps.onnx".to_string();
+            config.recognition.detector_sha256 = manifest
+                .find("scrfd_2.5g_bnkps.onnx")
+                .map(|m| m.sha256.clone());
             config.recognition.embedder_model = "glintr100.onnx".to_string();
+            config.recognition.embedder_sha256 =
+                manifest.find("glintr100.onnx").map(|m| m.sha256.clone());
             println!("  Selected balanced models (fast detection, high-accuracy embedding).");
         }
         _ => {
             config.recognition.detector_model = "det_10g.onnx".to_string();
+            config.recognition.detector_sha256 =
+                manifest.find("det_10g.onnx").map(|m| m.sha256.clone());
             config.recognition.embedder_model = "glintr100.onnx".to_string();
+            config.recognition.embedder_sha256 =
+                manifest.find("glintr100.onnx").map(|m| m.sha256.clone());
             println!("  Selected high-accuracy models (larger, ~40-50ms slower).");
         }
     }
@@ -454,7 +482,7 @@ fn update_config_provider(config: &Config) -> anyhow::Result<()> {
         if in_recognition && !provider_written {
             new_content.push_str(&format!("execution_provider = \"{provider}\"\n"));
         }
-        fs::write(&config_path, new_content)?;
+        write_file(&config_path, new_content.as_bytes(), 0o644)?;
     } else {
         let mut content = content;
         if !content.ends_with('\n') {
@@ -463,7 +491,7 @@ fn update_config_provider(config: &Config) -> anyhow::Result<()> {
         content.push_str(&format!(
             "\n[recognition]\nexecution_provider = \"{provider}\"\n",
         ));
-        fs::write(&config_path, content)?;
+        write_file(&config_path, content.as_bytes(), 0o644)?;
     }
 
     Ok(())
@@ -696,7 +724,7 @@ fn update_config_encryption(config: &Config, method: &str) -> anyhow::Result<()>
         if in_encryption && !method_written {
             new_content.push_str(&format!("method = \"{method}\"\n"));
         }
-        fs::write(&config_path, new_content)?;
+        write_file(&config_path, new_content.as_bytes(), 0o644)?;
     } else {
         // Append new section
         let mut content = content;
@@ -707,7 +735,7 @@ fn update_config_encryption(config: &Config, method: &str) -> anyhow::Result<()>
             "\n[encryption]\nmethod = \"{method}\"\nkey_path = \"{}\"\n",
             config.encryption.key_path
         ));
-        fs::write(&config_path, content)?;
+        write_file(&config_path, content.as_bytes(), 0o644)?;
     }
 
     Ok(())
@@ -721,15 +749,29 @@ fn update_config_models(config: &Config) -> anyhow::Result<()> {
 
     let content = fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let manifest: ModelManifest =
+        toml::from_str(MANIFEST_TOML).context("failed to parse model manifest")?;
 
     let detector = &config.recognition.detector_model;
     let embedder = &config.recognition.embedder_model;
+    let detector_sha = resolve_configured_model_sha256(
+        &manifest,
+        detector,
+        config.recognition.detector_sha256.as_deref(),
+    )?;
+    let embedder_sha = resolve_configured_model_sha256(
+        &manifest,
+        embedder,
+        config.recognition.embedder_sha256.as_deref(),
+    )?;
 
     if content.contains("[recognition]") {
         let mut new_content = String::new();
         let mut in_recognition = false;
         let mut detector_written = false;
         let mut embedder_written = false;
+        let mut detector_sha_written = false;
+        let mut embedder_sha_written = false;
 
         for line in content.lines() {
             if line.trim() == "[recognition]" {
@@ -743,17 +785,33 @@ fn update_config_models(config: &Config) -> anyhow::Result<()> {
                 detector_written = true;
                 continue;
             }
+            if in_recognition && line.trim_start().starts_with("detector_sha256") {
+                new_content.push_str(&format!("detector_sha256 = \"{detector_sha}\"\n"));
+                detector_sha_written = true;
+                continue;
+            }
             if in_recognition && line.trim_start().starts_with("embedder_model") {
                 new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
                 embedder_written = true;
+                continue;
+            }
+            if in_recognition && line.trim_start().starts_with("embedder_sha256") {
+                new_content.push_str(&format!("embedder_sha256 = \"{embedder_sha}\"\n"));
+                embedder_sha_written = true;
                 continue;
             }
             if in_recognition && line.starts_with('[') {
                 if !detector_written {
                     new_content.push_str(&format!("detector_model = \"{detector}\"\n"));
                 }
+                if !detector_sha_written {
+                    new_content.push_str(&format!("detector_sha256 = \"{detector_sha}\"\n"));
+                }
                 if !embedder_written {
                     new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
+                }
+                if !embedder_sha_written {
+                    new_content.push_str(&format!("embedder_sha256 = \"{embedder_sha}\"\n"));
                 }
                 in_recognition = false;
             }
@@ -764,23 +822,53 @@ fn update_config_models(config: &Config) -> anyhow::Result<()> {
             if !detector_written {
                 new_content.push_str(&format!("detector_model = \"{detector}\"\n"));
             }
+            if !detector_sha_written {
+                new_content.push_str(&format!("detector_sha256 = \"{detector_sha}\"\n"));
+            }
             if !embedder_written {
                 new_content.push_str(&format!("embedder_model = \"{embedder}\"\n"));
             }
+            if !embedder_sha_written {
+                new_content.push_str(&format!("embedder_sha256 = \"{embedder_sha}\"\n"));
+            }
         }
-        fs::write(&config_path, new_content)?;
+        write_file(&config_path, new_content.as_bytes(), 0o644)?;
     } else {
         let mut content = content;
         if !content.ends_with('\n') {
             content.push('\n');
         }
         content.push_str(&format!(
-            "\n[recognition]\ndetector_model = \"{detector}\"\nembedder_model = \"{embedder}\"\n",
+            "\n[recognition]\ndetector_model = \"{detector}\"\ndetector_sha256 = \"{detector_sha}\"\nembedder_model = \"{embedder}\"\nembedder_sha256 = \"{embedder_sha}\"\n",
         ));
-        fs::write(&config_path, content)?;
+        write_file(&config_path, content.as_bytes(), 0o644)?;
     }
 
     Ok(())
+}
+
+fn resolve_configured_model_sha256(
+    manifest: &ModelManifest,
+    filename: &str,
+    configured_sha256: Option<&str>,
+) -> anyhow::Result<String> {
+    if let Some(entry) = manifest.find(filename) {
+        if let Some(explicit) = configured_sha256
+            && explicit != entry.sha256
+        {
+            anyhow::bail!("configured SHA256 for {filename} does not match bundled manifest");
+        }
+        return Ok(entry.sha256.clone());
+    }
+
+    if let Some(explicit) = configured_sha256 {
+        if explicit.is_empty() {
+            anyhow::bail!("custom model {filename} requires a non-empty SHA256");
+        }
+        return Ok(explicit.to_string());
+    }
+
+    anyhow::bail!("custom model {filename} requires an explicit SHA256 in config")
 }
 
 fn wizard_face_enroll(theme: &ColorfulTheme) -> anyhow::Result<bool> {
@@ -963,6 +1051,7 @@ fn run_non_interactive() -> anyhow::Result<()> {
     // 4. Auto-configure encryption
     setup_encryption_auto(&config)?;
 
+    secure_setup_paths(&config, Some(&manifest))?;
     write_setup_marker()?;
     println!("\nSetup complete. Run `facelock enroll` to register your face.");
     Ok(())
@@ -1025,31 +1114,149 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn chown_path(path: &Path, uid: u32, gid: u32) -> anyhow::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .with_context(|| format!("path contains embedded NUL: {}", path.display()))?;
+    let result = unsafe { libc::chown(c_path.as_ptr(), uid, gid) };
+    if result != 0 {
+        anyhow::bail!(
+            "failed to chown {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn chown_path(_path: &Path, _uid: u32, _gid: u32) -> anyhow::Result<()> {
+    Ok(())
+}
+
+fn facelock_group_gid() -> anyhow::Result<u32> {
+    nix::unistd::Group::from_name("facelock")
+        .context("failed to look up facelock group")?
+        .map(|group| group.gid.as_raw())
+        .context(
+            "facelock group is missing; install package assets or create the facelock system group",
+        )
+}
+
+fn secure_existing_path(path: &Path, mode: u32, gid: u32) -> anyhow::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    ensure_mode(path, mode)
+        .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+
+    if nix::unistd::Uid::current().is_root() {
+        chown_path(path, 0, gid)?;
+    }
+
+    Ok(())
+}
+
+fn secure_dir_if_exists(path: &Path, mode: u32, gid: u32) -> anyhow::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if !path.is_dir() {
+        bail!(
+            "expected directory but found non-directory path: {}",
+            path.display()
+        );
+    }
+
+    ensure_private_dir(path, mode)
+        .with_context(|| format!("failed to secure directory {}", path.display()))?;
+    if nix::unistd::Uid::current().is_root() {
+        chown_path(path, 0, gid)?;
+    }
+
+    Ok(())
+}
+
+fn secure_setup_paths(config: &Config, manifest: Option<&ModelManifest>) -> anyhow::Result<()> {
+    let facelock_gid = facelock_group_gid()?;
+    let config_path = facelock_core::paths::config_path();
+    let config_dir = config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("/etc/facelock"));
+    let db_path = Path::new(&config.storage.db_path);
+    let audit_path = Path::new(&config.audit.path);
+    let key_path = Path::new(&config.encryption.key_path);
+    let sealed_key_path = Path::new(&config.encryption.sealed_key_path);
+
+    secure_dir_if_exists(config_dir, 0o755, 0)?;
+    secure_dir_if_exists(Path::new(&config.daemon.model_dir), 0o755, 0)?;
+    secure_dir_if_exists(Path::new(&config.snapshots.dir), 0o750, facelock_gid)?;
+
+    if let Some(parent) = db_path.parent() {
+        secure_dir_if_exists(parent, 0o750, facelock_gid)?;
+    }
+    if let Some(parent) = audit_path.parent() {
+        secure_dir_if_exists(parent, 0o750, facelock_gid)?;
+    }
+    if let Some(parent) = key_path.parent() {
+        secure_dir_if_exists(parent, 0o755, 0)?;
+    }
+    if let Some(parent) = sealed_key_path.parent() {
+        secure_dir_if_exists(parent, 0o755, 0)?;
+    }
+
+    secure_existing_path(&config_path, 0o644, 0)?;
+    secure_existing_path(db_path, 0o640, facelock_gid)?;
+    secure_existing_path(audit_path, 0o640, facelock_gid)?;
+    secure_existing_path(key_path, 0o600, 0)?;
+    secure_existing_path(sealed_key_path, 0o600, 0)?;
+    secure_existing_path(Path::new(SETUP_COMPLETE_MARKER), 0o644, 0)?;
+
+    if let Some(manifest) = manifest {
+        for entry in &manifest.models {
+            let model_path = Path::new(&config.daemon.model_dir).join(&entry.filename);
+            secure_existing_path(&model_path, 0o644, 0)?;
+        }
+    }
+
+    Ok(())
+}
+
 fn create_directories(config: &Config) -> anyhow::Result<()> {
-    let mut all_dirs: Vec<String> = vec![
-        config.daemon.model_dir.clone(),
-        config.snapshots.dir.clone(),
+    let config_path = facelock_core::paths::config_path();
+    let mut dirs: Vec<(&Path, u32)> = vec![
+        (Path::new(&config.daemon.model_dir), 0o755),
+        (Path::new(&config.snapshots.dir), 0o750),
     ];
 
-    // Also ensure parent dir for db
-    for path_str in [&config.storage.db_path] {
-        if let Some(parent) = Path::new(path_str.as_str()).parent() {
-            all_dirs.push(parent.to_string_lossy().to_string());
+    for (path, mode) in [
+        (&config.storage.db_path, 0o750),
+        (&config.audit.path, 0o750),
+        (&config.encryption.key_path, 0o755),
+        (&config.encryption.sealed_key_path, 0o755),
+    ] {
+        if let Some(parent) = Path::new(path.as_str()).parent() {
+            dirs.push((parent, mode));
         }
     }
 
-    for dir in &all_dirs {
-        if !dir.is_empty() {
-            fs::create_dir_all(dir)
-                .with_context(|| format!("failed to create directory: {dir}"))?;
-            tracing::debug!("ensured directory: {dir}");
-        }
+    if let Some(parent) = config_path.parent() {
+        dirs.push((parent, 0o755));
     }
 
-    // Config directory
-    if let Some(parent) = Path::new(&facelock_core::paths::config_path()).parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create config directory: {}", parent.display()))?;
+    for (dir, mode) in dirs {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+
+        ensure_private_dir(dir, mode)
+            .with_context(|| format!("failed to create directory {}", dir.display()))?;
+        tracing::debug!("ensured directory: {}", dir.display());
     }
 
     println!("  Directories created.");
@@ -1063,13 +1270,13 @@ fn create_default_config() -> anyhow::Result<()> {
     }
 
     if let Some(parent) = config_path.parent() {
-        fs::create_dir_all(parent).context("failed to create config directory")?;
+        ensure_private_dir(parent, 0o755).context("failed to create config directory")?;
     }
 
     let default_config = r#"[device]
 path = "/dev/video0"
 "#;
-    fs::write(&config_path, default_config).with_context(|| {
+    write_file(&config_path, default_config.as_bytes(), 0o644).with_context(|| {
         format!(
             "failed to write default config to {}",
             config_path.display()
@@ -1150,7 +1357,7 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
 
     // Write atomically: write to temp file first, then rename
     let tmp_path = dest.with_extension("tmp");
-    let mut file = fs::File::create(&tmp_path)
+    let mut file = create_truncate_file(&tmp_path, 0o644)
         .with_context(|| format!("failed to create {}", tmp_path.display()))?;
     file.write_all(&bytes)?;
     file.sync_all()?;
@@ -1158,6 +1365,7 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
 
     fs::rename(&tmp_path, dest)
         .with_context(|| format!("failed to rename temp file to {}", dest.display()))?;
+    ensure_mode(dest, 0o644).with_context(|| format!("failed to secure {}", dest.display()))?;
 
     Ok(())
 }
@@ -1329,6 +1537,10 @@ const DBUS_SYSTEM_SERVICES_DIR: &str = "/usr/share/dbus-1/system-services";
 const DBUS_SYSTEM_CONF_DIR: &str = "/usr/share/dbus-1/system.d";
 const DBUS_SERVICE_FILENAME: &str = "org.facelock.Daemon.service";
 const DBUS_POLICY_FILENAME: &str = "org.facelock.Daemon.conf";
+const LEGACY_SYSTEMD_UNIT_PATH: &str = "/etc/systemd/system/facelock-daemon.service";
+const LEGACY_DBUS_SYSTEM_SERVICE_PATH: &str =
+    "/etc/dbus-1/system-services/org.facelock.Daemon.service";
+const LEGACY_DBUS_SYSTEM_CONF_PATH: &str = "/etc/dbus-1/system.d/org.facelock.Daemon.conf";
 
 fn check_systemd() -> anyhow::Result<()> {
     if !Path::new("/run/systemd/system").exists() {
@@ -1357,6 +1569,23 @@ fn run_cmd(program: &str, args: &[&str]) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn refresh_legacy_copy_if_present(path: &Path, contents: &str, marker: &str) -> anyhow::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let existing = fs::read_to_string(path)
+        .with_context(|| format!("failed to read existing legacy file {}", path.display()))?;
+    if !existing.contains(marker) {
+        return Ok(());
+    }
+
+    write_file(path, contents.as_bytes(), 0o644)
+        .with_context(|| format!("failed to refresh {}", path.display()))?;
+    println!("  Refreshed legacy {}", path.display());
+    Ok(())
+}
+
 pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
     check_root()?;
     check_systemd()?;
@@ -1374,9 +1603,14 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
             .with_context(|| format!("failed to create {SYSTEMD_UNIT_DIR}"))?;
 
         let service_path = unit_dir.join(SERVICE_FILENAME);
-        fs::write(&service_path, SERVICE_UNIT)
+        write_file(&service_path, SERVICE_UNIT.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", service_path.display()))?;
         println!("  Wrote {}", service_path.display());
+        refresh_legacy_copy_if_present(
+            Path::new(LEGACY_SYSTEMD_UNIT_PATH),
+            SERVICE_UNIT,
+            "ExecStart=/usr/bin/facelock daemon",
+        )?;
 
         // Install D-Bus policy file
         let conf_dir = Path::new(DBUS_SYSTEM_CONF_DIR);
@@ -1384,9 +1618,14 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
             .with_context(|| format!("failed to create {DBUS_SYSTEM_CONF_DIR}"))?;
 
         let policy_path = conf_dir.join(DBUS_POLICY_FILENAME);
-        fs::write(&policy_path, DBUS_POLICY)
+        write_file(&policy_path, DBUS_POLICY.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", policy_path.display()))?;
         println!("  Wrote {}", policy_path.display());
+        refresh_legacy_copy_if_present(
+            Path::new(LEGACY_DBUS_SYSTEM_CONF_PATH),
+            DBUS_POLICY,
+            "org.facelock.Daemon",
+        )?;
 
         // Install D-Bus activation service
         let svc_dir = Path::new(DBUS_SYSTEM_SERVICES_DIR);
@@ -1394,9 +1633,14 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
             .with_context(|| format!("failed to create {DBUS_SYSTEM_SERVICES_DIR}"))?;
 
         let dbus_svc_path = svc_dir.join(DBUS_SERVICE_FILENAME);
-        fs::write(&dbus_svc_path, DBUS_SERVICE)
+        write_file(&dbus_svc_path, DBUS_SERVICE.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", dbus_svc_path.display()))?;
         println!("  Wrote {}", dbus_svc_path.display());
+        refresh_legacy_copy_if_present(
+            Path::new(LEGACY_DBUS_SYSTEM_SERVICE_PATH),
+            DBUS_SERVICE,
+            "org.facelock.Daemon",
+        )?;
 
         run_cmd("systemctl", &["daemon-reload"])?;
         println!("  systemctl daemon-reload done.");
@@ -1547,7 +1791,13 @@ account include   system-login
         let result = std::fs::read_to_string(&config_path).unwrap();
         assert!(result.contains("[recognition]"));
         assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains(
+            "detector_sha256 = \"5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91\""
+        ));
         assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+        assert!(result.contains(
+            "embedder_sha256 = \"4ab1d6435d639628a6f3e5008dd4f929edf4c4124b1a7169e1048f9fef534cdf\""
+        ));
 
         // Scenario 2: updates existing model fields, preserves other fields
         std::fs::write(
@@ -1562,7 +1812,13 @@ account include   system-login
 
         let result = std::fs::read_to_string(&config_path).unwrap();
         assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains(
+            "detector_sha256 = \"5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91\""
+        ));
         assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+        assert!(result.contains(
+            "embedder_sha256 = \"4ab1d6435d639628a6f3e5008dd4f929edf4c4124b1a7169e1048f9fef534cdf\""
+        ));
         assert!(!result.contains("scrfd_2.5g_bnkps.onnx"));
         assert!(!result.contains("w600k_r50.onnx"));
         assert!(result.contains("threshold = 0.80"));
@@ -1580,7 +1836,13 @@ account include   system-login
 
         let result = std::fs::read_to_string(&config_path).unwrap();
         assert!(result.contains("detector_model = \"det_10g.onnx\""));
+        assert!(result.contains(
+            "detector_sha256 = \"5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91\""
+        ));
         assert!(result.contains("embedder_model = \"glintr100.onnx\""));
+        assert!(result.contains(
+            "embedder_sha256 = \"4ab1d6435d639628a6f3e5008dd4f929edf4c4124b1a7169e1048f9fef534cdf\""
+        ));
         assert!(result.contains("threshold = 0.75"));
 
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1779,11 +1779,21 @@ account include   system-login
         std::fs::create_dir_all(&dir).unwrap();
         let config_path = dir.join("config.toml");
 
-        unsafe { std::env::set_var("FACELOCK_CONFIG", config_path.display().to_string()) };
+        struct ProcessConfigOverrideGuard;
+
+        impl Drop for ProcessConfigOverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+
+        facelock_core::paths::clear_process_config_override();
+        facelock_core::paths::set_process_config_override(config_path.clone());
+        let _override_guard = ProcessConfigOverrideGuard;
 
         // Scenario 1: appends [recognition] section when absent
         std::fs::write(&config_path, "[device]\npath = \"/dev/video0\"\n").unwrap();
-        let mut config = Config::load().unwrap();
+        let mut config = Config::load_from(&config_path).unwrap();
         config.recognition.detector_model = "det_10g.onnx".to_string();
         config.recognition.embedder_model = "glintr100.onnx".to_string();
         update_config_models(&config).unwrap();
@@ -1805,7 +1815,7 @@ account include   system-login
             "[device]\npath = \"/dev/video0\"\n\n[recognition]\ndetector_model = \"scrfd_2.5g_bnkps.onnx\"\nembedder_model = \"w600k_r50.onnx\"\nthreshold = 0.80\n",
         )
         .unwrap();
-        let mut config = Config::load().unwrap();
+        let mut config = Config::load_from(&config_path).unwrap();
         config.recognition.detector_model = "det_10g.onnx".to_string();
         config.recognition.embedder_model = "glintr100.onnx".to_string();
         update_config_models(&config).unwrap();
@@ -1829,7 +1839,7 @@ account include   system-login
             "[device]\npath = \"/dev/video0\"\n\n[recognition]\nthreshold = 0.75\n",
         )
         .unwrap();
-        let mut config = Config::load().unwrap();
+        let mut config = Config::load_from(&config_path).unwrap();
         config.recognition.detector_model = "det_10g.onnx".to_string();
         config.recognition.embedder_model = "glintr100.onnx".to_string();
         update_config_models(&config).unwrap();
@@ -1845,7 +1855,6 @@ account include   system-login
         ));
         assert!(result.contains("threshold = 0.75"));
 
-        unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use facelock_camera::quirks::QuirksDb;
 use facelock_camera::{
-    Camera, DeviceInfo, auto_detect_device, is_ir_camera, is_ir_camera_with_quirks,
-    list_devices, validate_device,
+    Camera, DeviceInfo, auto_detect_device, is_ir_camera, is_ir_camera_with_quirks, list_devices,
+    validate_device,
 };
 use facelock_core::config::DeviceConfig;
 use facelock_core::config::{Config, EncryptionMethod};
@@ -55,7 +55,9 @@ fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCameraDevice
     let device_info = match config.device.path.as_deref() {
         Some(path) => validate_device(path)
             .with_context(|| format!("failed to query configured camera {path}"))?,
-        None => auto_detect_device().context("no camera device specified and auto-detection failed")?,
+        None => {
+            auto_detect_device().context("no camera device specified and auto-detection failed")?
+        }
     };
 
     Ok(build_resolved_camera_device(config, device_info, &quirks))

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -8,8 +8,10 @@ use std::path::Path;
 use anyhow::{Context, bail};
 use facelock_camera::quirks::QuirksDb;
 use facelock_camera::{
-    Camera, is_ir_camera, is_ir_camera_with_quirks, list_devices, validate_device,
+    Camera, DeviceInfo, auto_detect_device, is_ir_camera, is_ir_camera_with_quirks,
+    list_devices, validate_device,
 };
+use facelock_core::config::DeviceConfig;
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::types::MatchResult;
@@ -21,24 +23,55 @@ pub fn open_store(config: &Config) -> anyhow::Result<FaceStore> {
     FaceStore::open(Path::new(&config.storage.db_path)).context("failed to open database")
 }
 
-/// Open camera with quirks support and warmup frame discarding.
-pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
-    let quirks = QuirksDb::load();
-    let device_quirk = config
-        .device
-        .path
-        .as_deref()
-        .and_then(|p| validate_device(p).ok())
-        .and_then(|info| quirks.find_match(&info).cloned());
+#[derive(Clone)]
+struct ResolvedCameraDevice {
+    device: DeviceConfig,
+    device_quirk: Option<facelock_camera::quirks::Quirk>,
+    device_is_ir: bool,
+}
 
-    let mut camera =
-        Camera::open(&config.device, device_quirk.as_ref()).context("failed to open camera")?;
+struct OpenedCamera {
+    camera: Camera<'static>,
+    device_is_ir: bool,
+}
+
+fn build_resolved_camera_device(
+    config: &Config,
+    device_info: DeviceInfo,
+    quirks: &QuirksDb,
+) -> ResolvedCameraDevice {
+    let mut device = config.device.clone();
+    device.path = Some(device_info.path.clone());
+
+    ResolvedCameraDevice {
+        device,
+        device_quirk: quirks.find_match(&device_info).cloned(),
+        device_is_ir: is_ir_camera_with_quirks(&device_info, Some(quirks)),
+    }
+}
+
+fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCameraDevice> {
+    let quirks = QuirksDb::load();
+    let device_info = match config.device.path.as_deref() {
+        Some(path) => validate_device(path)
+            .with_context(|| format!("failed to query configured camera {path}"))?,
+        None => auto_detect_device().context("no camera device specified and auto-detection failed")?,
+    };
+
+    Ok(build_resolved_camera_device(config, device_info, &quirks))
+}
+
+fn open_camera_context(config: &Config) -> anyhow::Result<OpenedCamera> {
+    let resolved = resolve_camera_device(config)?;
+    let mut camera = Camera::open(&resolved.device, resolved.device_quirk.as_ref())
+        .context("failed to open camera")?;
 
     // Discard warmup frames for AGC/AE stabilization.
     // Quirk override takes precedence over config value.
-    let warmup = device_quirk
+    let warmup = resolved
+        .device_quirk
         .and_then(|q| q.warmup_frames)
-        .unwrap_or(config.device.warmup_frames);
+        .unwrap_or(resolved.device.warmup_frames);
     if warmup > 0 {
         debug!(warmup, "discarding warmup frames");
         for _ in 0..warmup {
@@ -46,7 +79,15 @@ pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
         }
     }
 
-    Ok(camera)
+    Ok(OpenedCamera {
+        camera,
+        device_is_ir: resolved.device_is_ir,
+    })
+}
+
+/// Open camera with quirks support and warmup frame discarding.
+pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
+    Ok(open_camera_context(config)?.camera)
 }
 
 pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
@@ -62,17 +103,11 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<bool> {
         return Ok(false);
     }
 
-    let mut camera = open_camera(config)?;
+    let OpenedCamera {
+        mut camera,
+        device_is_ir,
+    } = open_camera_context(config)?;
     let mut engine = load_engine(config)?;
-
-    let quirks = QuirksDb::load();
-    let device_is_ir = config
-        .device
-        .path
-        .as_deref()
-        .and_then(|p| validate_device(p).ok())
-        .map(|dev| is_ir_camera_with_quirks(&dev, Some(&quirks)))
-        .unwrap_or(false);
 
     // Load embeddings with encryption support, matching the daemon handler path.
     let stored = load_user_embeddings(&store, config, user)?;
@@ -189,7 +224,7 @@ pub fn load_user_embeddings(
 /// Direct enrollment — returns (model_id, embedding_count).
 pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, u32)> {
     let store = open_store(config)?;
-    let mut camera = open_camera(config)?;
+    let mut camera = open_camera_context(config)?.camera;
     let mut engine = load_engine(config)?;
 
     // Initialize sealer if encryption is configured
@@ -484,6 +519,91 @@ mod facelock_daemon_auth {
             label: None,
             similarity: best_similarity,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facelock_camera::FormatInfo;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_config() -> Config {
+        Config::parse(
+            r#"
+[device]
+warmup_frames = 2
+"#,
+        )
+        .unwrap()
+    }
+
+    fn make_device(path: &str, name: &str, fourcc: &str) -> DeviceInfo {
+        DeviceInfo {
+            path: path.to_string(),
+            name: name.to_string(),
+            driver: "uvcvideo".to_string(),
+            capabilities: vec!["VIDEO_CAPTURE".to_string()],
+            formats: vec![FormatInfo {
+                fourcc: fourcc.to_string(),
+                description: "Test".to_string(),
+                sizes: vec![(640, 480)],
+            }],
+        }
+    }
+
+    fn write_quirks_dir(contents: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("facelock-direct-tests-{unique}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("test.toml"), contents).unwrap();
+        dir
+    }
+
+    #[test]
+    fn auto_detected_device_inherits_quirk_state() {
+        let config = test_config();
+        let device = make_device("/dev/video2", "Logitech BRIO IR", "MJPG");
+        let dir = write_quirks_dir(
+            r#"
+[[quirk]]
+name_pattern = "(?i)brio.*ir"
+force_ir = true
+warmup_frames = 9
+"#,
+        );
+        let mut quirks = QuirksDb::default();
+        quirks.load_dir(&dir);
+
+        let resolved = build_resolved_camera_device(&config, device, &quirks);
+
+        assert_eq!(resolved.device.path.as_deref(), Some("/dev/video2"));
+        assert!(resolved.device_is_ir);
+        assert_eq!(
+            resolved.device_quirk.as_ref().and_then(|q| q.warmup_frames),
+            Some(9)
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unmatched_device_keeps_default_warmup_and_non_ir_state() {
+        let config = test_config();
+        let device = make_device("/dev/video3", "USB Camera", "MJPG");
+        let quirks = QuirksDb::default();
+
+        let resolved = build_resolved_camera_device(&config, device, &quirks);
+
+        assert_eq!(resolved.device.path.as_deref(), Some("/dev/video3"));
+        assert_eq!(resolved.device.warmup_frames, 2);
+        assert!(!resolved.device_is_ir);
+        assert!(resolved.device_quirk.is_none());
     }
 }
 

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -3,6 +3,8 @@ pub mod direct;
 mod ipc_client;
 pub mod notifications;
 
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
@@ -12,6 +14,9 @@ use commands::bench::BenchCommand;
 #[derive(Parser)]
 #[command(name = "facelock", about = "Linux face authentication", version)]
 struct Cli {
+    /// Path to config file
+    #[arg(long, global = true)]
+    config: Option<String>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -156,11 +161,24 @@ enum Commands {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    let Cli { config, command } = cli;
 
-    match cli.command {
+    if let Some(path) = config {
+        facelock_core::paths::set_process_config_override(PathBuf::from(path));
+    }
+
+    match command {
         // Daemon and auth init their own tracing, so handle them separately
-        Commands::Daemon { config } => commands::daemon::run(config),
+        Commands::Daemon { config } => {
+            if let Some(ref path) = config {
+                facelock_core::paths::set_process_config_override(PathBuf::from(path));
+            }
+            commands::daemon::run(config)
+        }
         Commands::Auth { user, config } => {
+            if let Some(ref path) = config {
+                facelock_core::paths::set_process_config_override(PathBuf::from(path));
+            }
             let exit_code = commands::auth::run(user, config);
             std::process::exit(exit_code);
         }

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -95,8 +95,16 @@ pub struct RecognitionConfig {
     pub nms_threshold: f32,
     #[serde(default = "default_detector_model")]
     pub detector_model: String,
+    /// SHA256 for `detector_model` when the model is not covered by the bundled manifest.
+    /// Bundled models are verified against their manifest hash at load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detector_sha256: Option<String>,
     #[serde(default = "default_embedder_model")]
     pub embedder_model: String,
+    /// SHA256 for `embedder_model` when the model is not covered by the bundled manifest.
+    /// Bundled models are verified against their manifest hash at load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedder_sha256: Option<String>,
     /// ORT execution provider: "cpu", "cuda", "rocm", or "openvino".
     #[serde(default = "default_execution_provider")]
     pub execution_provider: String,
@@ -113,7 +121,9 @@ impl Default for RecognitionConfig {
             detection_confidence: default_confidence(),
             nms_threshold: default_nms(),
             detector_model: default_detector_model(),
+            detector_sha256: None,
             embedder_model: default_embedder_model(),
+            embedder_sha256: None,
             execution_provider: default_execution_provider(),
             threads: default_threads(),
         }
@@ -565,8 +575,28 @@ impl Config {
                 "recognition.timeout_secs must be > 0".into(),
             ));
         }
+        if let Some(ref sha256) = self.recognition.detector_sha256
+            && !is_sha256_hex(sha256)
+        {
+            return Err(ConfigError::Validation(format!(
+                "recognition.detector_sha256 must be a 64-character lowercase hex SHA256, got {}",
+                sha256
+            )));
+        }
+        if let Some(ref sha256) = self.recognition.embedder_sha256
+            && !is_sha256_hex(sha256)
+        {
+            return Err(ConfigError::Validation(format!(
+                "recognition.embedder_sha256 must be a 64-character lowercase hex SHA256, got {}",
+                sha256
+            )));
+        }
         Ok(())
     }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
@@ -710,6 +740,45 @@ threads = 8
         let config = Config::parse(toml).unwrap();
         assert_eq!(config.recognition.execution_provider, "cuda");
         assert_eq!(config.recognition.threads, 8);
+    }
+
+    #[test]
+    fn recognition_sha256_fields_default_to_none() {
+        let config = RecognitionConfig::default();
+        assert!(config.detector_sha256.is_none());
+        assert!(config.embedder_sha256.is_none());
+    }
+
+    #[test]
+    fn recognition_sha256_fields_validate_format() {
+        let toml = r#"
+[device]
+path = "/dev/video0"
+[recognition]
+detector_sha256 = "not-a-sha256"
+"#;
+        let err = Config::parse(toml).unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn recognition_sha256_fields_accept_valid_hex() {
+        let toml = r#"
+[device]
+path = "/dev/video0"
+[recognition]
+detector_sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+embedder_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+"#;
+        let config = Config::parse(toml).unwrap();
+        assert_eq!(
+            config.recognition.detector_sha256.as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(
+            config.recognition.embedder_sha256.as_deref(),
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        );
     }
 
     #[test]

--- a/crates/facelock-core/src/fs_security.rs
+++ b/crates/facelock-core/src/fs_security.rs
@@ -1,0 +1,144 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+pub fn ensure_mode(path: &Path, mode: u32) -> io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    }
+
+    Ok(())
+}
+
+pub fn ensure_dir(path: &Path, mode: u32) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    ensure_mode(path, mode)
+}
+
+pub fn ensure_private_dir(path: &Path, mode: u32) -> io::Result<()> {
+    if is_shared_system_dir(path) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to manage shared system directory {}; configure a dedicated facelock path",
+                path.display()
+            ),
+        ));
+    }
+
+    ensure_dir(path, mode)
+}
+
+pub fn is_shared_system_dir(path: &Path) -> bool {
+    const SHARED_SYSTEM_DIRS: &[&str] = &[
+        "/", "/tmp", "/var/tmp", "/var", "/etc", "/var/lib", "/var/log", "/run", "/home", "/root",
+        "/usr", "/opt",
+    ];
+
+    SHARED_SYSTEM_DIRS.iter().any(|dir| path == Path::new(dir))
+}
+
+pub fn create_truncate_file(path: &Path, mode: u32) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+
+    #[cfg(unix)]
+    {
+        options.mode(mode);
+    }
+
+    let file = options.open(path)?;
+    ensure_mode(path, mode)?;
+    Ok(file)
+}
+
+pub fn open_append_file(path: &Path, mode: u32) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).append(true).write(true);
+
+    #[cfg(unix)]
+    {
+        options.mode(mode);
+    }
+
+    let file = options.open(path)?;
+    ensure_mode(path, mode)?;
+    Ok(file)
+}
+
+pub fn write_file(path: &Path, data: &[u8], mode: u32) -> io::Result<()> {
+    let mut file = create_truncate_file(path, mode)?;
+    file.write_all(data)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "facelock-fs-security-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn ensure_dir_creates_directory() {
+        let path = temp_path("dir");
+        let _ = fs::remove_dir_all(&path);
+        ensure_dir(&path, 0o750).unwrap();
+        assert!(path.is_dir());
+        let _ = fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn write_file_creates_file() {
+        let path = temp_path("file");
+        let _ = fs::remove_file(&path);
+        write_file(&path, b"test", 0o640).unwrap();
+        assert_eq!(fs::read(&path).unwrap(), b"test");
+        let _ = fs::remove_file(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_file_sets_requested_mode() {
+        let path = temp_path("mode");
+        let _ = fs::remove_file(&path);
+        write_file(&path, b"test", 0o640).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o640);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ensure_private_dir_rejects_shared_system_dir() {
+        let err = ensure_private_dir(Path::new("/tmp"), 0o750).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}

--- a/crates/facelock-core/src/lib.rs
+++ b/crates/facelock-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod dbus_interface;
 pub mod error;
+pub mod fs_security;
 pub mod ipc;
 pub mod paths;
 pub mod traits;

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -1,15 +1,84 @@
 use std::path::PathBuf;
+use std::sync::RwLock;
 
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/facelock/config.toml";
 pub const DEFAULT_MODEL_DIR: &str = "/var/lib/facelock/models";
 pub const DEFAULT_DB_PATH: &str = "/var/lib/facelock/facelock.db";
 pub const DEFAULT_SNAPSHOT_DIR: &str = "/var/log/facelock/snapshots";
 
-/// Returns the config file path, respecting `FACELOCK_CONFIG` env var.
+static PROCESS_CONFIG_OVERRIDE: RwLock<Option<PathBuf>> = RwLock::new(None);
+
+fn resolve_config_path(
+    process_override: Option<&PathBuf>,
+    env_override: Option<&str>,
+    is_privileged: bool,
+) -> PathBuf {
+    if let Some(path) = process_override {
+        return path.clone();
+    }
+
+    if !is_privileged {
+        if let Some(path) = env_override {
+            return PathBuf::from(path);
+        }
+    }
+
+    PathBuf::from(DEFAULT_CONFIG_PATH)
+}
+
+fn process_config_override() -> Option<PathBuf> {
+    PROCESS_CONFIG_OVERRIDE
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+fn is_privileged_process() -> bool {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return false;
+    };
+
+    status
+        .lines()
+        .find(|line| line.starts_with("Uid:"))
+        .and_then(|line| {
+            let mut fields = line.split_whitespace();
+            let _label = fields.next()?;
+            let _real = fields.next()?;
+            fields.next()?.parse::<u32>().ok()
+        })
+        .is_some_and(|euid| euid == 0)
+}
+
+/// Set a process-local config override path.
+/// This is preferred over environment variables for privileged commands.
+pub fn set_process_config_override(path: PathBuf) {
+    if let Ok(mut guard) = PROCESS_CONFIG_OVERRIDE.write() {
+        *guard = Some(path);
+    }
+}
+
+/// Clear the process-local config override path.
+pub fn clear_process_config_override() {
+    if let Ok(mut guard) = PROCESS_CONFIG_OVERRIDE.write() {
+        *guard = None;
+    }
+}
+
+/// Returns the config file path.
+///
+/// Resolution order:
+/// 1. Process-local override set by the CLI (`--config`)
+/// 2. `FACELOCK_CONFIG` env var for unprivileged processes only
+/// 3. Default path
 pub fn config_path() -> PathBuf {
-    std::env::var("FACELOCK_CONFIG")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_CONFIG_PATH))
+    let env_override = std::env::var("FACELOCK_CONFIG").ok();
+    let process_override = process_config_override();
+    resolve_config_path(
+        process_override.as_ref(),
+        env_override.as_deref(),
+        is_privileged_process(),
+    )
 }
 
 #[cfg(test)]
@@ -21,13 +90,36 @@ mod tests {
     // cargo runs tests in parallel.
     #[test]
     fn config_path_default_and_env_override() {
-        // Test default (env var not set)
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };
-        assert_eq!(config_path(), PathBuf::from(DEFAULT_CONFIG_PATH));
+        clear_process_config_override();
+        let resolved = resolve_config_path(None, None, false);
+        assert_eq!(resolved, PathBuf::from(DEFAULT_CONFIG_PATH));
 
-        // Test env var override
+        let resolved = resolve_config_path(None, Some("/tmp/test-facelock.toml"), false);
+        assert_eq!(resolved, PathBuf::from("/tmp/test-facelock.toml"));
+
         unsafe { std::env::set_var("FACELOCK_CONFIG", "/tmp/test-facelock.toml") };
-        assert_eq!(config_path(), PathBuf::from("/tmp/test-facelock.toml"));
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };
+    }
+
+    #[test]
+    fn privileged_process_ignores_env_override() {
+        let resolved = resolve_config_path(None, Some("/tmp/test-facelock.toml"), true);
+        assert_eq!(resolved, PathBuf::from(DEFAULT_CONFIG_PATH));
+    }
+
+    #[test]
+    fn process_override_beats_env_and_privilege_rules() {
+        let path = PathBuf::from("/tmp/explicit.toml");
+        let resolved = resolve_config_path(Some(&path), Some("/tmp/test-facelock.toml"), true);
+        assert_eq!(resolved, path);
+    }
+
+    #[test]
+    fn config_path_uses_process_override() {
+        clear_process_config_override();
+        set_process_config_override(PathBuf::from("/tmp/process-override.toml"));
+        assert_eq!(config_path(), PathBuf::from("/tmp/process-override.toml"));
+        clear_process_config_override();
     }
 }

--- a/crates/facelock-daemon/src/audit.rs
+++ b/crates/facelock-daemon/src/audit.rs
@@ -1,9 +1,10 @@
-use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use facelock_core::config::AuditConfig;
+use facelock_core::fs_security::{ensure_dir, ensure_private_dir, open_append_file};
+use nix::unistd::Uid;
 use serde::Serialize;
 use tracing::{debug, warn};
 
@@ -47,8 +48,16 @@ pub fn write_audit_entry(config: &AuditConfig, entry: &AuditEntry) {
 
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            warn!("failed to create audit log directory: {e}");
+        let ensure_parent = if Uid::current().is_root() {
+            ensure_private_dir(parent, 0o750)
+        } else {
+            ensure_dir(parent, 0o750)
+        };
+        if let Err(e) = ensure_parent {
+            warn!(
+                "failed to secure audit log directory {}: {e}",
+                parent.display()
+            );
             return;
         }
     }
@@ -70,7 +79,7 @@ pub fn write_audit_entry(config: &AuditConfig, entry: &AuditEntry) {
         }
     };
 
-    match OpenOptions::new().create(true).append(true).open(path) {
+    match open_append_file(path, 0o640) {
         Ok(mut file) => {
             if let Err(e) = writeln!(file, "{line}") {
                 warn!("failed to write audit entry: {e}");

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use facelock_camera::capture::is_dark_with_config;
 use facelock_camera::preprocess::check_ir_texture;
 use facelock_core::config::{Config, SnapshotConfig};
+use facelock_core::fs_security::{ensure_dir, ensure_private_dir, write_file};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::traits::{CameraSource, FaceProcessor};
 use facelock_core::types::{
@@ -12,6 +13,7 @@ use facelock_core::types::{
 };
 use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
+use nix::unistd::Uid;
 use tracing::{debug, info, warn};
 
 use crate::audit::{self, AuditEntry};
@@ -24,7 +26,7 @@ pub fn pre_check(
     config: &Config,
     store: &FaceStore,
     user: &str,
-    rate_limiter: &mut RateLimiter,
+    rate_limiter: &RateLimiter,
     device_is_ir: bool,
 ) -> Option<DaemonResponse> {
     if config.security.disabled {
@@ -72,11 +74,20 @@ pub fn pre_check(
         }));
     }
 
-    if !rate_limiter.check(user) {
-        warn!(user, "rate limited");
-        return Some(DaemonResponse::Error {
-            message: "rate limited".into(),
-        });
+    match rate_limiter.check(store, user) {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(user, "rate limited");
+            return Some(DaemonResponse::Error {
+                message: "rate limited".into(),
+            });
+        }
+        Err(e) => {
+            warn!(user, error = %e, "rate limit check failed");
+            return Some(DaemonResponse::Error {
+                message: format!("rate limit check failed: {e}"),
+            });
+        }
     }
 
     if config.security.require_ir && !device_is_ir {
@@ -148,8 +159,13 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
 /// Failures are logged but never propagate — snapshots must not block auth.
 fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, frame: &Frame) {
     let dir = Path::new(&snapshot_config.dir);
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        warn!(dir = %dir.display(), error = %e, "failed to create snapshot directory");
+    let ensure_snapshot_dir = if Uid::current().is_root() {
+        ensure_private_dir(dir, 0o750)
+    } else {
+        ensure_dir(dir, 0o750)
+    };
+    if let Err(e) = ensure_snapshot_dir {
+        warn!(dir = %dir.display(), error = %e, "failed to secure snapshot directory");
         return;
     }
 
@@ -172,7 +188,7 @@ fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, 
         return;
     }
 
-    if let Err(e) = std::fs::write(&path, &buf) {
+    if let Err(e) = write_file(&path, &buf, 0o640) {
         warn!(path = %path.display(), error = %e, "failed to write snapshot");
         return;
     }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -289,7 +289,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     &self.config,
                     &self.store,
                     &user,
-                    &mut self.rate_limiter,
+                    &self.rate_limiter,
                     self.device_is_ir,
                 ) {
                     let (result, error) = match &resp {
@@ -349,7 +349,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 // Only failed auths count against the rate limit
                 if let DaemonResponse::AuthResult(ref mr) = result {
                     if !mr.matched {
-                        self.rate_limiter.record_failure(&user);
+                        if let Err(e) = self.rate_limiter.record_failure(&self.store, &user) {
+                            warn!(user, error = %e, "failed to record auth failure");
+                        }
                     }
                 }
                 result

--- a/crates/facelock-daemon/src/rate_limit.rs
+++ b/crates/facelock-daemon/src/rate_limit.rs
@@ -1,89 +1,93 @@
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use facelock_store::FaceStore;
 
-/// Per-user authentication rate limiter.
-/// Only failed attempts count against the limit — successful auths don't
-/// consume the budget so normal unlock usage never triggers rate limiting.
+/// Per-user authentication rate limiter backed by the shared SQLite store.
+/// Only failed attempts are recorded, so successful unlocks never consume the
+/// budget and daemon restarts do not clear the window.
 pub struct RateLimiter {
-    failures: HashMap<String, Vec<Instant>>,
     max_failures: u32,
-    window: Duration,
+    window_secs: u64,
 }
 
 impl RateLimiter {
     pub fn new(max_failures: u32, window_secs: u64) -> Self {
         Self {
-            failures: HashMap::new(),
             max_failures,
-            window: Duration::from_secs(window_secs),
+            window_secs,
         }
     }
 
     /// Check if the user is rate-limited. Returns true if auth may proceed.
-    pub fn check(&mut self, user: &str) -> bool {
-        let now = Instant::now();
-        let failures = self.failures.entry(user.to_string()).or_default();
-        failures.retain(|t| now.duration_since(*t) < self.window);
-        failures.len() < self.max_failures as usize
+    pub fn check(&self, store: &FaceStore, user: &str) -> Result<bool, String> {
+        // Stale rows do not affect correctness, but opportunistic cleanup keeps
+        // the shared table bounded over time.
+        let _ = store.cleanup_rate_limit(self.window_secs);
+        store
+            .check_rate_limit(user, self.max_failures, self.window_secs)
+            .map_err(|e| e.to_string())
     }
 
     /// Record a failed authentication attempt for the user.
-    pub fn record_failure(&mut self, user: &str) {
-        let failures = self.failures.entry(user.to_string()).or_default();
-        failures.push(Instant::now());
+    pub fn record_failure(&self, store: &FaceStore, user: &str) -> Result<(), String> {
+        store.record_auth_attempt(user).map_err(|e| e.to_string())?;
+        let _ = store.cleanup_rate_limit(self.window_secs);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use facelock_store::FaceStore;
+
     use super::*;
 
     #[test]
     fn allows_under_limit() {
-        let mut rl = RateLimiter::new(3, 60);
-        assert!(rl.check("alice"));
-        rl.record_failure("alice");
-        assert!(rl.check("alice"));
-        rl.record_failure("alice");
-        assert!(rl.check("alice"));
+        let store = FaceStore::open_memory().unwrap();
+        let rl = RateLimiter::new(3, 60);
+        assert!(rl.check(&store, "alice").unwrap());
+        rl.record_failure(&store, "alice").unwrap();
+        assert!(rl.check(&store, "alice").unwrap());
+        rl.record_failure(&store, "alice").unwrap();
+        assert!(rl.check(&store, "alice").unwrap());
     }
 
     #[test]
     fn blocks_over_limit() {
-        let mut rl = RateLimiter::new(2, 60);
-        assert!(rl.check("bob"));
-        rl.record_failure("bob");
-        assert!(rl.check("bob"));
-        rl.record_failure("bob");
-        assert!(!rl.check("bob"));
+        let store = FaceStore::open_memory().unwrap();
+        let rl = RateLimiter::new(2, 60);
+        assert!(rl.check(&store, "bob").unwrap());
+        rl.record_failure(&store, "bob").unwrap();
+        assert!(rl.check(&store, "bob").unwrap());
+        rl.record_failure(&store, "bob").unwrap();
+        assert!(!rl.check(&store, "bob").unwrap());
     }
 
     #[test]
     fn success_does_not_count() {
-        let mut rl = RateLimiter::new(2, 60);
-        // Two checks without recording failure — should never block
-        assert!(rl.check("alice"));
-        assert!(rl.check("alice"));
-        assert!(rl.check("alice"));
-        // Now record failures
-        rl.record_failure("alice");
-        rl.record_failure("alice");
-        assert!(!rl.check("alice"));
+        let store = FaceStore::open_memory().unwrap();
+        let rl = RateLimiter::new(2, 60);
+        assert!(rl.check(&store, "alice").unwrap());
+        assert!(rl.check(&store, "alice").unwrap());
+        assert!(rl.check(&store, "alice").unwrap());
+        rl.record_failure(&store, "alice").unwrap();
+        rl.record_failure(&store, "alice").unwrap();
+        assert!(!rl.check(&store, "alice").unwrap());
     }
 
     #[test]
     fn separate_users() {
-        let mut rl = RateLimiter::new(1, 60);
-        assert!(rl.check("alice"));
-        rl.record_failure("alice");
-        assert!(!rl.check("alice"));
-        // Different user is unaffected
-        assert!(rl.check("bob"));
+        let store = FaceStore::open_memory().unwrap();
+        let rl = RateLimiter::new(1, 60);
+        assert!(rl.check(&store, "alice").unwrap());
+        rl.record_failure(&store, "alice").unwrap();
+        assert!(!rl.check(&store, "alice").unwrap());
+        assert!(rl.check(&store, "bob").unwrap());
     }
 
     #[test]
     fn zero_limit_blocks_all() {
-        let mut rl = RateLimiter::new(0, 60);
-        assert!(!rl.check("alice"));
+        let store = FaceStore::open_memory().unwrap();
+        let rl = RateLimiter::new(0, 60);
+        assert!(!rl.check(&store, "alice").unwrap());
     }
 }

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1,5 +1,9 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use facelock_core::config::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
+use facelock_core::types::MatchResult;
 use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
 use facelock_test_support::{MockCamera, MockFaceEngine};
@@ -27,6 +31,25 @@ use facelock_test_support::{MockCamera, MockFaceEngine};
 fn test_config() -> Config {
     let toml = fixtures::test_config_toml("/tmp/facelock-test-integ.db");
     Config::parse(&toml).unwrap()
+}
+
+fn temp_db_path(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "facelock-{test_name}-{}-{unique}.db",
+        std::process::id()
+    ))
+}
+
+fn cleanup_db(path: &Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    let _ = std::fs::remove_file(format!("{}-wal", path.display()));
 }
 
 #[test]
@@ -215,4 +238,81 @@ fn warmup_frames_zero_skips_discard() {
         !matches!(resp, DaemonResponse::Error { .. }),
         "expected successful preview with zero warmup, got: {resp:?}"
     );
+}
+
+#[test]
+fn failed_auth_rate_limit_persists_across_handler_restart() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let db_path = temp_db_path("rate-limit-persist");
+    cleanup_db(&db_path);
+
+    let db_path_str = db_path.to_string_lossy().into_owned();
+    let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
+    config.recognition.timeout_secs = 0;
+    config.security.rate_limit.max_attempts = 1;
+    config.security.require_frame_variance = false;
+    config.security.require_landmark_liveness = false;
+
+    {
+        let store = FaceStore::open(&db_path).unwrap();
+        store
+            .add_model("testuser", "front", &fixtures::known_embedding(0), "")
+            .unwrap();
+    }
+
+    let factory1: Box<
+        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
+    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+
+    let mut first_handler = Handler::new(
+        config.clone(),
+        MockFaceEngine::no_faces(),
+        FaceStore::open(&db_path).unwrap(),
+        RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        ),
+        false,
+        Some(factory1),
+        None,
+    )
+    .unwrap();
+
+    let first = first_handler.handle(DaemonRequest::Authenticate {
+        user: "testuser".into(),
+    });
+    assert!(matches!(
+        first,
+        DaemonResponse::AuthResult(MatchResult { matched: false, .. })
+    ));
+
+    let factory2: Box<
+        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
+    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+
+    let mut restarted_handler = Handler::new(
+        config.clone(),
+        MockFaceEngine::no_faces(),
+        FaceStore::open(&db_path).unwrap(),
+        RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        ),
+        false,
+        Some(factory2),
+        None,
+    )
+    .unwrap();
+
+    let second = restarted_handler.handle(DaemonRequest::Authenticate {
+        user: "testuser".into(),
+    });
+    assert!(matches!(
+        second,
+        DaemonResponse::Error { ref message } if message.contains("rate limited")
+    ));
+
+    cleanup_db(&db_path);
 }

--- a/crates/facelock-face/src/detector.rs
+++ b/crates/facelock-face/src/detector.rs
@@ -32,6 +32,9 @@ impl FaceDetector {
         threads: u32,
         execution_provider: &str,
     ) -> Result<Self> {
+        crate::provider::ensure_runtime_loaded()
+            .map_err(|e| FacelockError::Detection(format!("Failed to load ONNX Runtime: {e}")))?;
+
         let builder = Session::builder()
             .map_err(|e| {
                 FacelockError::Detection(format!("Failed to create session builder: {e}"))

--- a/crates/facelock-face/src/embedder.rs
+++ b/crates/facelock-face/src/embedder.rs
@@ -19,6 +19,9 @@ impl FaceEmbedder {
     ///
     /// `threads` controls the number of intra-op threads for ORT inference.
     pub fn load(model_path: &Path, threads: u32, execution_provider: &str) -> Result<Self> {
+        crate::provider::ensure_runtime_loaded()
+            .map_err(|e| FacelockError::Embedding(format!("Failed to load ONNX Runtime: {e}")))?;
+
         let builder = Session::builder()
             .map_err(|e| {
                 FacelockError::Embedding(format!("Failed to create session builder: {e}"))

--- a/crates/facelock-face/src/lib.rs
+++ b/crates/facelock-face/src/lib.rs
@@ -14,7 +14,7 @@ use facelock_core::types::{Detection, FaceEmbedding, Frame};
 pub use align::{AlignedFace, align_face, compute_affine_matrix};
 pub use detector::FaceDetector;
 pub use embedder::FaceEmbedder;
-pub use models::{ModelManifest, verify_model};
+pub use models::{ModelManifest, resolve_model_sha256, verify_model};
 
 /// Full face-processing pipeline: detect, align, embed.
 pub struct FaceEngine {
@@ -27,19 +27,34 @@ impl FaceEngine {
     pub fn load(config: &RecognitionConfig, model_dir: &Path) -> Result<Self> {
         let manifest = ModelManifest::load()?;
 
-        for model in manifest.default_models() {
-            let path = model_dir.join(&model.filename);
-            if !verify_model(&path, &model.sha256)? {
-                return Err(FacelockError::Detection(format!(
-                    "Model integrity check failed for {}. Expected SHA256: {}. \
-                     Re-run `facelock setup` to re-download.",
-                    model.filename, model.sha256
-                )));
-            }
-        }
-
         let detector_path = model_dir.join(&config.detector_model);
         let embedder_path = model_dir.join(&config.embedder_model);
+        let detector_sha256 = resolve_model_sha256(
+            &manifest,
+            &config.detector_model,
+            config.detector_sha256.as_deref(),
+        )?;
+        let embedder_sha256 = resolve_model_sha256(
+            &manifest,
+            &config.embedder_model,
+            config.embedder_sha256.as_deref(),
+        )?;
+
+        if !verify_model(&detector_path, &detector_sha256)? {
+            return Err(FacelockError::Detection(format!(
+                "Model integrity check failed for {}. Expected SHA256: {}. \
+                 Re-run `facelock setup` to re-download or update the configured checksum.",
+                config.detector_model, detector_sha256
+            )));
+        }
+
+        if !verify_model(&embedder_path, &embedder_sha256)? {
+            return Err(FacelockError::Detection(format!(
+                "Model integrity check failed for {}. Expected SHA256: {}. \
+                 Re-run `facelock setup` to re-download or update the configured checksum.",
+                config.embedder_model, embedder_sha256
+            )));
+        }
 
         let detector = FaceDetector::load(
             &detector_path,

--- a/crates/facelock-face/src/models.rs
+++ b/crates/facelock-face/src/models.rs
@@ -34,15 +34,14 @@ impl ModelManifest {
     pub fn default_models(&self) -> Vec<&ModelEntry> {
         self.models.iter().filter(|m| !m.optional).collect()
     }
+
+    pub fn find_by_filename(&self, filename: &str) -> Option<&ModelEntry> {
+        self.models.iter().find(|m| m.filename == filename)
+    }
 }
 
 /// Verify a model file's SHA256 checksum.
-/// If `expected_sha256` is empty, returns `Ok(true)` (no verification needed).
 pub fn verify_model(path: &Path, expected_sha256: &str) -> Result<bool> {
-    if expected_sha256.is_empty() {
-        return Ok(true);
-    }
-
     let data = std::fs::read(path)?;
     let mut hasher = Sha256::new();
     hasher.update(&data);
@@ -50,6 +49,33 @@ pub fn verify_model(path: &Path, expected_sha256: &str) -> Result<bool> {
     let hex = format!("{result:x}");
 
     Ok(hex == expected_sha256)
+}
+
+/// Resolve the integrity hash for a configured model filename.
+///
+/// Bundled models are verified against the manifest. Custom models must provide
+/// an explicit checksum in config so we never load an unsigned file silently.
+pub fn resolve_model_sha256(
+    manifest: &ModelManifest,
+    filename: &str,
+    configured_sha256: Option<&str>,
+) -> Result<String> {
+    if let Some(entry) = manifest.find_by_filename(filename) {
+        if let Some(explicit) = configured_sha256 {
+            if explicit != entry.sha256 {
+                return Err(FacelockError::Detection(format!(
+                    "configured SHA256 for {filename} does not match bundled manifest"
+                )));
+            }
+        }
+        return Ok(entry.sha256.clone());
+    }
+
+    configured_sha256.map(str::to_string).ok_or_else(|| {
+        FacelockError::Detection(format!(
+            "custom model {filename} requires an explicit SHA256 in config"
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -77,12 +103,6 @@ mod tests {
     }
 
     #[test]
-    fn verify_model_empty_sha256_returns_true() {
-        let result = verify_model(Path::new("/nonexistent"), "").unwrap();
-        assert!(result);
-    }
-
-    #[test]
     fn verify_model_correct_sha256() {
         let dir = std::env::temp_dir().join("facelock_test_verify");
         std::fs::create_dir_all(&dir).unwrap();
@@ -103,5 +123,52 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_model_sha256_uses_manifest_for_bundled_models() {
+        let manifest = ModelManifest::load().unwrap();
+        let sha = resolve_model_sha256(&manifest, "scrfd_2.5g_bnkps.onnx", None).unwrap();
+        assert_eq!(
+            sha,
+            manifest
+                .find_by_filename("scrfd_2.5g_bnkps.onnx")
+                .unwrap()
+                .sha256
+        );
+    }
+
+    #[test]
+    fn resolve_model_sha256_rejects_mismatched_bundled_override() {
+        let manifest = ModelManifest::load().unwrap();
+        let err = resolve_model_sha256(
+            &manifest,
+            "scrfd_2.5g_bnkps.onnx",
+            Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FacelockError::Detection(_)));
+    }
+
+    #[test]
+    fn resolve_model_sha256_requires_custom_checksum() {
+        let manifest = ModelManifest::load().unwrap();
+        let err = resolve_model_sha256(&manifest, "custom.onnx", None).unwrap_err();
+        assert!(matches!(err, FacelockError::Detection(_)));
+    }
+
+    #[test]
+    fn resolve_model_sha256_accepts_custom_checksum() {
+        let manifest = ModelManifest::load().unwrap();
+        let sha = resolve_model_sha256(
+            &manifest,
+            "custom.onnx",
+            Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+        )
+        .unwrap();
+        assert_eq!(
+            sha,
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        );
     }
 }

--- a/crates/facelock-face/src/provider.rs
+++ b/crates/facelock-face/src/provider.rs
@@ -83,6 +83,13 @@ fn load_ort() -> std::result::Result<(), String> {
     }
 }
 
+/// Ensure the ONNX Runtime shared library is loaded before any session builders
+/// are created. Some ORT builds can deadlock if session construction re-enters
+/// runtime initialization.
+pub(crate) fn ensure_runtime_loaded() -> std::result::Result<(), String> {
+    load_ort()
+}
+
 /// Register an execution provider on the session builder based on config.
 ///
 /// All providers load the ONNX Runtime shared library at runtime.

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rusqlite::params;
 
 use facelock_core::error::{FacelockError, Result};
+use facelock_core::fs_security::ensure_mode;
 use facelock_core::types::{FaceEmbedding, FaceModelInfo};
 
 use crate::migrations::run_migrations;
@@ -23,6 +24,7 @@ impl FaceStore {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .map_err(map_err)?;
         run_migrations(&conn)?;
+        secure_database_files(db_path)?;
         Ok(Self { conn })
     }
 
@@ -350,7 +352,7 @@ impl FaceStore {
         Ok(results)
     }
 
-    /// Record an authentication attempt for rate limiting.
+    /// Record a failed authentication attempt for rate limiting.
     /// Inserts the current unix timestamp for the given user.
     pub fn record_auth_attempt(&self, user: &str) -> Result<()> {
         let now = SystemTime::now()
@@ -449,6 +451,23 @@ impl FaceStore {
             .map_err(map_err)?;
         Ok(count > 0)
     }
+}
+
+fn secure_database_files(db_path: &Path) -> Result<()> {
+    for path in [
+        db_path.to_path_buf(),
+        db_path.with_extension("db-wal"),
+        db_path.with_extension("db-shm"),
+    ] {
+        ensure_mode(&path, 0o640).map_err(|e| {
+            FacelockError::Storage(format!(
+                "failed to secure database file {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -777,6 +796,29 @@ mod tests {
         let store = FaceStore::open_memory().unwrap();
         // With max_attempts=0, even zero attempts should block
         assert!(!store.check_rate_limit("alice", 0, 60).unwrap());
+    }
+
+    #[test]
+    fn test_rate_limit_persists_across_reopen() {
+        let db_path = std::env::temp_dir().join(format!(
+            "facelock-rate-limit-{}-{}.db",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let store = FaceStore::open(&db_path).unwrap();
+        store.record_auth_attempt("alice").unwrap();
+        drop(store);
+
+        let reopened = FaceStore::open(&db_path).unwrap();
+        assert!(!reopened.check_rate_limit("alice", 1, 60).unwrap());
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
     }
 
     #[test]

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::ffi::{CStr, CString};
 use std::panic;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -495,12 +496,66 @@ fn daemon_authenticate(config: &PamConfig, user: &str) -> Result<AuthResponse, S
 // ---------------------------------------------------------------------------
 
 fn load_config() -> Result<PamConfig, String> {
-    let config_path =
-        std::env::var("FACELOCK_CONFIG").unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_string());
+    let config_path = DEFAULT_CONFIG_PATH;
 
-    let content = std::fs::read_to_string(&config_path).map_err(|e| format!("read config: {e}"))?;
+    let content = std::fs::read_to_string(config_path).map_err(|e| format!("read config: {e}"))?;
 
     toml::from_str(&content).map_err(|e| format!("parse config: {e}"))
+}
+
+fn validate_auth_bin(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty() {
+        return Err("auth_bin must not be empty".into());
+    }
+
+    let candidate = Path::new(path);
+    if !candidate.is_absolute() {
+        return Err("auth_bin must be an absolute path".into());
+    }
+
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve auth_bin: {e}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let metadata = std::fs::metadata(&canonical)
+            .map_err(|e| format!("failed to stat auth_bin {}: {e}", canonical.display()))?;
+
+        validate_root_owned_nonwritable(
+            metadata.uid(),
+            metadata.permissions().mode(),
+            &format!("auth_bin {}", canonical.display()),
+        )?;
+
+        let mut current = canonical.parent();
+        while let Some(dir) = current {
+            let meta = std::fs::metadata(dir)
+                .map_err(|e| format!("failed to stat parent dir {}: {e}", dir.display()))?;
+            validate_root_owned_nonwritable(
+                meta.uid(),
+                meta.permissions().mode(),
+                &format!("parent dir {}", dir.display()),
+            )?;
+
+            current = dir.parent();
+        }
+    }
+
+    Ok(canonical)
+}
+
+#[cfg(unix)]
+fn validate_root_owned_nonwritable(uid: u32, mode: u32, label: &str) -> Result<(), String> {
+    if uid != 0 {
+        return Err(format!("{label} must be owned by root"));
+    }
+    if mode & 0o022 != 0 {
+        return Err(format!("{label} must not be group- or world-writable"));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -514,16 +569,25 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
 
     let timeout_secs = config.recognition.timeout_secs as u64 + 3; // buffer for model load
 
-    // Resolve config path (same logic as load_config)
-    let config_path =
-        std::env::var("FACELOCK_CONFIG").unwrap_or_else(|_| DEFAULT_CONFIG_PATH.to_string());
+    let auth_bin = match validate_auth_bin(&config.daemon.auth_bin) {
+        Ok(path) => path,
+        Err(e) => {
+            log_auth(
+                service,
+                &format!("error: unsafe_auth_bin: {e}"),
+                user,
+                LOG_WARNING,
+            );
+            return PAM_IGNORE;
+        }
+    };
 
-    let result = Command::new(&config.daemon.auth_bin)
+    let result = Command::new(&auth_bin)
         .arg("auth")
         .arg("--user")
         .arg(user)
         .arg("--config")
-        .arg(&config_path)
+        .arg(DEFAULT_CONFIG_PATH)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
@@ -853,5 +917,33 @@ db_path = "/tmp/test.db"
 "#;
         let config: PamConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.daemon.mode, "daemon");
+    }
+
+    #[test]
+    fn validate_auth_bin_rejects_relative_paths() {
+        let err = validate_auth_bin("facelock").unwrap_err();
+        assert!(err.contains("absolute"));
+    }
+
+    #[test]
+    fn validate_auth_bin_rejects_missing_paths() {
+        let err = validate_auth_bin("/definitely/missing/facelock").unwrap_err();
+        assert!(err.contains("failed to resolve"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_root_owned_nonwritable_rejects_group_writable_mode() {
+        let err =
+            validate_root_owned_nonwritable(0, 0o100775, "auth_bin /usr/bin/facelock").unwrap_err();
+        assert!(err.contains("group- or world-writable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_root_owned_nonwritable_rejects_non_root_owner() {
+        let err = validate_root_owned_nonwritable(1000, 0o100755, "auth_bin /usr/bin/facelock")
+            .unwrap_err();
+        assert!(err.contains("owned by root"));
     }
 }

--- a/dist/debian/postinst
+++ b/dist/debian/postinst
@@ -9,8 +9,13 @@ case "$1" in
 
         # Set ownership on data directories
         chown root:facelock /var/lib/facelock 2>/dev/null || true
+        chmod 750 /var/lib/facelock 2>/dev/null || true
+        chown root:root /var/lib/facelock/models 2>/dev/null || true
+        chmod 755 /var/lib/facelock/models 2>/dev/null || true
         chown root:facelock /var/log/facelock 2>/dev/null || true
+        chmod 750 /var/log/facelock 2>/dev/null || true
         chown root:facelock /var/log/facelock/snapshots 2>/dev/null || true
+        chmod 750 /var/log/facelock/snapshots 2>/dev/null || true
 
         # Reload systemd for D-Bus activation
         if [ -d /run/systemd/system ]; then

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -3,6 +3,14 @@ PAM_LINE="auth  sufficient  pam_facelock.so"
 post_install() {
     systemd-sysusers
     systemd-tmpfiles --create
+    chown root:facelock /var/lib/facelock 2>/dev/null || true
+    chmod 750 /var/lib/facelock 2>/dev/null || true
+    chown root:root /var/lib/facelock/models 2>/dev/null || true
+    chmod 755 /var/lib/facelock/models 2>/dev/null || true
+    chown root:facelock /var/log/facelock 2>/dev/null || true
+    chmod 750 /var/log/facelock 2>/dev/null || true
+    chown root:facelock /var/log/facelock/snapshots 2>/dev/null || true
+    chmod 750 /var/log/facelock/snapshots 2>/dev/null || true
 
     # Reload systemd for D-Bus activation
     systemctl daemon-reload 2>/dev/null || true
@@ -15,6 +23,14 @@ post_install() {
 post_upgrade() {
     systemd-sysusers
     systemd-tmpfiles --create
+    chown root:facelock /var/lib/facelock 2>/dev/null || true
+    chmod 750 /var/lib/facelock 2>/dev/null || true
+    chown root:root /var/lib/facelock/models 2>/dev/null || true
+    chmod 755 /var/lib/facelock/models 2>/dev/null || true
+    chown root:facelock /var/log/facelock 2>/dev/null || true
+    chmod 750 /var/log/facelock 2>/dev/null || true
+    chown root:facelock /var/log/facelock/snapshots 2>/dev/null || true
+    chmod 750 /var/log/facelock/snapshots 2>/dev/null || true
 
     # Restart daemon if running
     if systemctl is-active --quiet facelock-daemon; then

--- a/dist/nix/module.nix
+++ b/dist/nix/module.nix
@@ -52,6 +52,15 @@ in
 
     # Configuration file
     environment.etc."facelock/config.toml".source = configFile;
+    environment.etc."dbus-1/system.d/org.facelock.Daemon.conf".source =
+      "${facelockPackage}/share/dbus-1/system.d/org.facelock.Daemon.conf";
+    environment.etc."dbus-1/system-services/org.facelock.Daemon.service".text = ''
+      [D-BUS Service]
+      Name=org.facelock.Daemon
+      Exec=${facelockPackage}/bin/facelock daemon
+      User=root
+      SystemdService=facelock-daemon.service
+    '';
 
     # Create facelock group
     users.groups.facelock = { };
@@ -60,14 +69,29 @@ in
     systemd.services.facelock-daemon = {
       description = "Facelock Face Authentication Daemon";
       after = [ "local-fs.target" ];
+      wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        Type = "simple";
+        Type = "dbus";
+        BusName = "org.facelock.Daemon";
         ExecStart = "${facelockPackage}/bin/facelock daemon";
         StandardOutput = "journal";
         StandardError = "journal";
         Restart = "on-failure";
         RestartSec = 3;
         LimitNOFILE = 1024;
+        UMask = "0027";
+        ProtectSystem = "strict";
+        InaccessiblePaths = [ "/home" "/root" ];
+        ReadWritePaths = [ "/var/lib/facelock" "/var/log/facelock" ];
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
       };
     };
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,8 @@ facelock bench report                   # full benchmark report
 
 Restart the persistent daemon. On systemd systems, runs `systemctl restart facelock-daemon.service`. Otherwise, sends a D-Bus shutdown request and the daemon restarts on next use via D-Bus activation.
 
+Requires root. If run interactively as a non-root user, the CLI prompts to re-run via `sudo`.
+
 ```bash
 facelock restart
 ```
@@ -171,5 +173,5 @@ For commands that accept `--user`:
 
 | Variable | Purpose |
 |----------|---------|
-| `FACELOCK_CONFIG` | Override config file path |
+| `FACELOCK_CONFIG` | Override config file path for unprivileged CLI commands. Ignored by privileged PAM/root auth flows; use `--config` there. |
 | `RUST_LOG` | Control log verbosity (e.g., `facelock_daemon=debug`) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,8 @@
 # Configuration Reference
 
-Facelock reads its configuration from `/etc/facelock/config.toml`. Override the path with the `FACELOCK_CONFIG` environment variable.
+Facelock reads its configuration from `/etc/facelock/config.toml`.
+Unprivileged CLI commands may override the path with `FACELOCK_CONFIG`.
+Privileged PAM and root auth flows ignore that environment variable and use either an explicit `--config` path or `/etc/facelock/config.toml`.
 
 All settings are optional. Facelock auto-detects the camera and uses sensible defaults. The annotated config file at `config/facelock.toml` in the repository serves as the canonical example.
 
@@ -13,6 +15,11 @@ Camera settings.
 | `path` | string (optional) | Auto-detect | Camera device path (e.g., `/dev/video2`). When omitted, Facelock auto-detects the best available camera, preferring IR over RGB. |
 | `max_height` | u32 | `480` | Maximum frame height in pixels. Frames taller than this are downscaled to improve processing speed. |
 | `rotation` | u16 | `0` | Rotate captured frames. Values: `0`, `90`, `180`, `270`. Useful for cameras mounted sideways. |
+| `warmup_frames` | u32 | `3` | Frames to discard immediately after opening the camera to let exposure and gain stabilize. Device quirks may override this. |
+| `dark_threshold` | f32 | `0.6` | Fraction of pixels that must be darker than `dark_pixel_value` before the frame is treated as unusably dark. |
+| `dark_pixel_value` | u8 | `10` | Pixel brightness cutoff used by the dark-frame check. |
+| `ir_emitter` | bool | `false` | Attempt to enable a controllable IR emitter when the camera opens. Only needed for hardware that does not auto-enable its IR LED. |
+| `camera_release_secs` | u32 | `5` | Seconds to keep the camera open after daemon-mode auth before releasing it, to avoid repeated warmup cost on back-to-back requests. |
 
 ## [recognition]
 
@@ -24,8 +31,10 @@ Face detection and embedding parameters.
 | `timeout_secs` | u32 | `5` | Maximum seconds to attempt recognition before giving up. Must be > 0. |
 | `detection_confidence` | f32 | `0.5` | Minimum confidence for the face detector to report a detection. Lower values detect more faces but increase false positives. |
 | `nms_threshold` | f32 | `0.4` | Non-maximum suppression threshold for overlapping detections. |
-| `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. |
-| `embedder_model` | string | `"w600k_r50.onnx"` | ONNX embedder model filename. Must exist in `daemon.model_dir`. |
+| `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. Bundled models are verified against the manifest; custom models require `detector_sha256`. |
+| `detector_sha256` | string (optional) | unset | SHA256 for `detector_model`. Required for custom model files. Bundled models use the manifest hash. |
+| `embedder_model` | string | `"w600k_r50.onnx"` | ONNX embedder model filename. Must exist in `daemon.model_dir`. Bundled models are verified against the manifest; custom models require `embedder_sha256`. |
+| `embedder_sha256` | string (optional) | unset | SHA256 for `embedder_model`. Required for custom model files. Bundled models use the manifest hash. |
 | `execution_provider` | string | `"cpu"` | ONNX Runtime execution provider. Values: `"cpu"`, `"cuda"`, `"rocm"`, `"openvino"`. GPU providers require a GPU-enabled ONNX Runtime package installed on the system. |
 | `threads` | u32 | `4` | Number of CPU threads for ONNX inference. |
 
@@ -50,6 +59,7 @@ Run `facelock test` to see your similarity scores, then set the threshold below 
 | High accuracy | `det_10g.onnx` (17MB) | `glintr100.onnx` (249MB) | ~266MB | ~40-50ms slower, best accuracy |
 
 Run `facelock setup` to select a model tier interactively and download the required models.
+If you point `detector_model` or `embedder_model` at a custom file, you must also set the matching SHA256 so the daemon can verify it at load time.
 
 ## [daemon]
 
@@ -86,6 +96,13 @@ Controls how the PAM module reaches the face engine.
 |-----|------|---------|-------------|
 | `max_attempts` | u32 | `5` | Maximum auth attempts per user per window. |
 | `window_secs` | u64 | `60` | Rate limit window in seconds. |
+
+### [security.pam_policy]
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `allowed_services` | list of strings | `[]` | If non-empty, only these PAM services may use facelock. |
+| `denied_services` | list of strings | `[]` | PAM services that must always skip facelock, even if otherwise allowed. |
 
 ## [notification]
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -59,11 +59,13 @@ The CLI silently falls back to direct mode when the daemon is not available on D
 | `/etc/facelock/config.toml` | root:root | 644 | Configuration |
 | `/var/lib/facelock/facelock.db` | root:facelock | 640 | Face embeddings |
 | `/var/lib/facelock/models/` | root:root | 755 | ONNX models |
+| `/var/log/facelock/audit.jsonl` | root:facelock | 640 | Structured audit log |
 | `/var/log/facelock/snapshots/` | root:facelock | 750 | Auth snapshots |
 | `/usr/bin/facelock` | root:root | 755 | CLI binary |
 | `/lib/security/pam_facelock.so` | root:root | 755 | PAM module |
 
-All paths overridable via config. `FACELOCK_CONFIG` env var overrides config location.
+All paths overridable via config. `FACELOCK_CONFIG` is honored for unprivileged processes, but privileged PAM/root auth flows ignore the environment and use either an explicit `--config` path or `/etc/facelock/config.toml`.
+Runtime-created DB sidecars (`-wal`, `-shm`), audit logs, and snapshots are created with explicit restrictive modes. The packaged systemd unit also sets `UMask=0027`.
 
 ## Config Schema
 
@@ -73,11 +75,11 @@ TOML format. All keys optional — camera auto-detected, sensible defaults for e
 
 | Section | Key fields |
 |---------|-----------|
-| `[device]` | `path` (Option), `max_height`, `rotation` |
-| `[recognition]` | `threshold`, `timeout_secs`, `detector_model`, `embedder_model`, `threads`, `execution_provider` |
+| `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs` |
+| `[recognition]` | `threshold`, `timeout_secs`, `detector_model`, `detector_sha256`, `embedder_model`, `embedder_sha256`, `threads`, `execution_provider` |
 | `[daemon]` | `mode` (DaemonMode enum), `model_dir`, `idle_timeout_secs` |
 | `[storage]` | `db_path` |
-| `[security]` | `disabled`, `suppress_unknown`, `require_landmark_liveness`, `require_ir`, `require_frame_variance`, `min_auth_frames`, `abort_if_ssh`, `abort_if_lid_closed`, rate_limit sub-section |
+| `[security]` | `disabled`, `suppress_unknown`, `require_landmark_liveness`, `require_ir`, `require_frame_variance`, `min_auth_frames`, `abort_if_ssh`, `abort_if_lid_closed`, `pam_policy`, `rate_limit` |
 | `[notification]` | `mode` (off/terminal/desktop/both), `notify_prompt`, `notify_on_success`, `notify_on_failure` |
 | `[snapshots]` | `mode` (off/all/failure/success), `dir` |
 | `[encryption]` | `method` (none/keyfile/tpm), `key_path`, `sealed_key_path` |
@@ -111,7 +113,14 @@ CREATE TABLE face_embeddings (
     embedding BLOB NOT NULL,  -- 512 x f32 = 2048 bytes (or encrypted blob)
     sealed INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE TABLE rate_limit (
+    user TEXT NOT NULL,
+    attempt_time INTEGER NOT NULL
+);
 ```
+
+Only failed authentication attempts are recorded in `rate_limit`. Daemon mode and oneshot mode share the same SQLite-backed window, so daemon restarts do not clear lockout state.
 
 ## IPC Protocol
 
@@ -125,6 +134,12 @@ The daemon registers on the system bus via D-Bus activation.
 
 ### Methods
 `Authenticate`, `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`, `Ping`, `Shutdown`
+
+Method authorization contract:
+- `Authenticate`, `ListModels`, `PreviewDetectFrame`: root or the matching Unix user.
+- `Enroll`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `Shutdown`: root only.
+- `ReleaseCamera`: root or the Unix user that owns the active preview camera session.
+- `ListDevices`, `Ping`: resolve caller UID before replying and rely on the system bus policy for admission control.
 
 ### Response types
 `AuthResult`, `Enrolled`, `Models`, `Removed`, `Frame`, `DetectFrame`, `Devices`, `Ok`, `Error`
@@ -168,3 +183,4 @@ These defaults must not be weakened without security review.
 | ArcFace R100 | `glintr100.onnx` | ~249MB | Optional |
 
 Configurable via `recognition.detector_model` and `recognition.embedder_model`.
+Bundled model filenames are verified against the manifest hash at load time. Custom model files require matching `recognition.detector_sha256` or `recognition.embedder_sha256`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -168,6 +168,11 @@ chown root:facelock /var/lib/facelock/facelock.db
 chmod 640 /var/lib/facelock/facelock.db
 ```
 
+Runtime note:
+- The daemon/setup paths must also secure SQLite `-wal` and `-shm` sidecar files to `0640`
+- Audit logs and snapshots must be created with explicit restrictive modes instead of relying on ambient umask
+- The systemd service should set `UMask=0027` as a baseline defense-in-depth default
+
 #### B. Embedding Sensitivity Warning (Required)
 
 Face embeddings are **biometric data**. Unlike passwords, they cannot be changed. Document this:
@@ -187,36 +192,39 @@ For high-security deployments, embeddings can be encrypted with AES-256-GCM usin
 
 #### A. D-Bus System Bus Policy (Required)
 
-Access to the daemon is restricted by the D-Bus system bus policy defined in `dbus/org.facelock.Daemon.conf`. Only root and members of the `facelock` group are allowed to send messages to the daemon interface. The policy file is installed to `/etc/dbus-1/system.d/` and enforced by the bus daemon itself.
+Access to the daemon is restricted by the D-Bus system bus policy defined in `dbus/org.facelock.Daemon.conf`. Only root and members of the `facelock` group are allowed to send messages to the daemon interface. The policy file is installed to `/usr/share/dbus-1/system.d/` and enforced by the bus daemon itself. Setup and package install may also refresh a legacy `/etc/dbus-1/system.d/` copy when present, but `/usr/share/...` is the canonical install path.
+
+The daemon must also verify the caller UID via `GetConnectionUnixUser` on every method call and apply method-level authorization:
+- `Authenticate`, `ListModels`, `PreviewDetectFrame`: root or the matching Unix user
+- `Enroll`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `Shutdown`: root only
+- `ReleaseCamera`: root or the Unix user that owns the active preview camera session
+- `ListDevices`: root or a caller in the `facelock` group
 
 #### B. D-Bus Message Size Limits (Enforced by Bus)
 
 The D-Bus bus daemon enforces message size limits (typically 128MB by default, configurable in the bus configuration). This prevents oversized messages from consuming daemon memory without requiring application-level size checks.
 
-#### C. Rate Limiting (Recommended)
+#### C. Persistent Rate Limiting (Implemented)
 
 Throttle authentication attempts to prevent brute-force:
 
 ```rust
-struct RateLimiter {
-    attempts: HashMap<String, Vec<Instant>>,
-    max_attempts: usize,    // 5
-    window: Duration,       // 60 seconds
+let rate_limiter = RateLimiter::new(5, 60);
+if !rate_limiter.check(&store, user)? {
+    return Err("rate limited");
 }
 
-impl RateLimiter {
-    fn check(&mut self, user: &str) -> bool {
-        let now = Instant::now();
-        let attempts = self.attempts.entry(user.to_string()).or_default();
-        attempts.retain(|t| now.duration_since(*t) < self.window);
-        if attempts.len() >= self.max_attempts {
-            return false;  // Rate limited
-        }
-        attempts.push(now);
-        true
-    }
+// ... authentication attempt ...
+
+if auth_failed {
+    rate_limiter.record_failure(&store, user)?;
 }
 ```
+
+Implementation note:
+- Failed attempts are stored in the shared SQLite `rate_limit` table
+- Daemon mode and oneshot mode use the same window and thresholds
+- Restarting the daemon must not reset a user's lockout state
 
 ### 5. PAM Module Hardening
 
@@ -272,13 +280,13 @@ caps::clear(None, CapSet::Permitted)?;
 
 The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
 
-**Phase 1 (safe):** `ProtectSystem=strict`, `ProtectHome=yes`, `ReadWritePaths=/var/lib/facelock /var/log/facelock`, `PrivateTmp=yes`, `NoNewPrivileges=yes`
+**Phase 1 (shipped):** `ProtectSystem=strict`, `InaccessiblePaths=/home /root`, `ReadWritePaths=/var/lib/facelock /var/log/facelock`, `PrivateTmp=yes`, `NoNewPrivileges=yes`, `UMask=0027`
 
-**Phase 2 (kernel):** `ProtectKernelTunables/Modules/ControlGroups=yes`, `RestrictNamespaces=yes`, `LockPersonality=yes`, `RestrictRealtime=yes`, `RestrictSUIDSGID=yes`
+**Phase 2 (shipped):** `ProtectKernelTunables/Modules/ControlGroups=yes`, `RestrictNamespaces=yes`, `LockPersonality=yes`, `RestrictRealtime=yes`, `RestrictSUIDSGID=yes`
 
-**Phase 3 (devices/syscalls):** `DeviceAllow=/dev/video* rw`, `DeviceAllow=/dev/tpmrm0 rw`, `SystemCallFilter=@system-service @io-event`
+**Deferred device/seccomp phase:** `DevicePolicy`/`DeviceAllow` is intentionally omitted because cgroup device ACLs interfered with camera auto-detection, and seccomp filtering is deferred to future work. Standard Unix permissions still restrict `/dev/video*` and `/dev/tpmrm0`.
 
-**GPU compatibility note:** `MemoryDenyWriteExecute=yes` is commented out because it breaks CUDA and TensorRT GPU inference (JIT compilation requires W+X pages). Enable it only when using the CPU execution provider. Verify hardening score with:
+**GPU compatibility note:** `MemoryDenyWriteExecute=yes` is still intentionally omitted because it breaks ONNX Runtime JIT paths such as CUDA and TensorRT. Verify hardening score with:
 ```bash
 systemd-analyze security facelock-daemon.service
 ```

--- a/justfile
+++ b/justfile
@@ -121,17 +121,29 @@ install-files:
 
     # systemd unit
     install -Dm644 systemd/facelock-daemon.service /usr/lib/systemd/system/facelock-daemon.service
+    if [ -f /etc/systemd/system/facelock-daemon.service ] && \
+       grep -q 'ExecStart=/usr/bin/facelock daemon' /etc/systemd/system/facelock-daemon.service; then
+        install -Dm644 systemd/facelock-daemon.service /etc/systemd/system/facelock-daemon.service
+    fi
 
     # D-Bus policy and activation
     install -Dm644 dbus/org.facelock.Daemon.conf /usr/share/dbus-1/system.d/org.facelock.Daemon.conf
     install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service
+    if [ -f /etc/dbus-1/system.d/org.facelock.Daemon.conf ] && \
+       grep -q 'org.facelock.Daemon' /etc/dbus-1/system.d/org.facelock.Daemon.conf; then
+        install -Dm644 dbus/org.facelock.Daemon.conf /etc/dbus-1/system.d/org.facelock.Daemon.conf
+    fi
+    if [ -f /etc/dbus-1/system-services/org.facelock.Daemon.service ] && \
+       grep -q 'org.facelock.Daemon' /etc/dbus-1/system-services/org.facelock.Daemon.service; then
+        install -Dm644 dbus/org.facelock.Daemon.service /etc/dbus-1/system-services/org.facelock.Daemon.service
+    fi
 
     # Polkit agent binary (optional, do NOT install autostart — agent is not production-ready
     # and will steal polkit auth from the DE's agent, causing all privilege prompts to hang)
     [ -f target/release/facelock-polkit-agent ] && install -Dm755 target/release/facelock-polkit-agent /usr/bin/facelock-polkit-agent || true
 
     # Directories
-    install -dm770 -o root -g facelock /var/lib/facelock
+    install -dm750 -o root -g facelock /var/lib/facelock
     install -dm755 -o root -g root /var/lib/facelock/models
     install -dm750 -o root -g facelock /var/log/facelock
     install -dm750 -o root -g facelock /var/log/facelock/snapshots
@@ -146,8 +158,17 @@ install-files:
     fi
 
     # Fix permissions on existing data
+    [ -d /etc/facelock ] && chown root:root /etc/facelock && chmod 755 /etc/facelock || true
+    [ -f /etc/facelock/config.toml ] && chown root:root /etc/facelock/config.toml && chmod 644 /etc/facelock/config.toml || true
+    [ -f /etc/facelock/config.toml.default ] && chown root:root /etc/facelock/config.toml.default && chmod 644 /etc/facelock/config.toml.default || true
+    [ -d /var/lib/facelock ] && chown root:facelock /var/lib/facelock && chmod 750 /var/lib/facelock || true
+    [ -d /var/lib/facelock/models ] && chown root:root /var/lib/facelock/models && chmod 755 /var/lib/facelock/models || true
+    [ -d /var/log/facelock ] && chown root:facelock /var/log/facelock && chmod 750 /var/log/facelock || true
+    [ -d /var/log/facelock/snapshots ] && chown root:facelock /var/log/facelock/snapshots && chmod 750 /var/log/facelock/snapshots || true
     [ -d /var/lib/facelock/models ] && chmod 644 /var/lib/facelock/models/*.onnx 2>/dev/null || true
     [ -f /var/lib/facelock/facelock.db ] && chown root:facelock /var/lib/facelock/facelock.db && chmod 640 /var/lib/facelock/facelock.db || true
+    [ -f /var/lib/facelock/facelock.db-wal ] && chown root:facelock /var/lib/facelock/facelock.db-wal && chmod 640 /var/lib/facelock/facelock.db-wal || true
+    [ -f /var/lib/facelock/facelock.db-shm ] && chown root:facelock /var/lib/facelock/facelock.db-shm && chmod 640 /var/lib/facelock/facelock.db-shm || true
 
     echo ""
     echo ""

--- a/systemd/facelock-daemon.service
+++ b/systemd/facelock-daemon.service
@@ -11,6 +11,7 @@ StandardError=journal
 Restart=on-failure
 RestartSec=3
 LimitNOFILE=1024
+UMask=0027
 
 # Phase 1: Filesystem isolation
 ProtectSystem=strict

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -11,7 +11,7 @@ RUN cargo build --release --workspace
 FROM archlinux:latest
 
 # Install dependencies
-RUN pacman -Syu --noconfirm pam sudo base-devel libxkbcommon just dbus && pacman -Scc --noconfirm
+RUN pacman -Syu --noconfirm pam sudo base-devel libxkbcommon just dbus onnxruntime-cpu protobuf && pacman -Scc --noconfirm
 
 # Build pamtester from upstream source
 RUN curl -sL https://sourceforge.net/projects/pamtester/files/pamtester/0.1.2/pamtester-0.1.2.tar.gz/download | tar xz -C /tmp && \

--- a/test/container-config.toml
+++ b/test/container-config.toml
@@ -1,9 +1,10 @@
 [device]
 max_height = 480
+dark_threshold = 1.0
 
 [recognition]
 threshold = 0.80
-timeout_secs = 5
+timeout_secs = 10
 
 [daemon]
 model_dir = "/var/lib/facelock/models"

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -3,11 +3,38 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+LIVE_TIMEOUT="${FACELOCK_LIVE_TIMEOUT:-90s}"
 
 run_test() {
     local name="$1"
     local cmd="$2"
     local expected_result="${3:-0}"
+
+    echo -n "TEST: $name ... "
+    set +o pipefail
+    if eval "$cmd" > /tmp/test-output 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+    set -o pipefail
+
+    if [ "$expected_result" = "any" ] || [ "$result" -eq "$expected_result" ]; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+        return 0
+    else
+        echo "FAIL (exit=$result, expected=$expected_result)"
+        cat /tmp/test-output
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+}
+
+run_test_contains() {
+    local name="$1"
+    local cmd="$2"
+    local pattern="$3"
 
     echo -n "TEST: $name ... "
     if eval "$cmd" > /tmp/test-output 2>&1; then
@@ -16,14 +43,32 @@ run_test() {
         result=$?
     fi
 
-    if [ "$expected_result" = "any" ] || [ "$result" -eq "$expected_result" ]; then
+    if [ "$result" -eq 0 ] && grep -q -- "$pattern" /tmp/test-output; then
         echo "PASS"
         PASS=$((PASS + 1))
-    else
-        echo "FAIL (exit=$result, expected=$expected_result)"
-        cat /tmp/test-output
-        FAIL=$((FAIL + 1))
+        return 0
     fi
+
+    echo "FAIL (exit=$result, pattern=$pattern)"
+    cat /tmp/test-output
+    FAIL=$((FAIL + 1))
+    return 1
+}
+
+wait_for_daemon() {
+    local deadline=$((SECONDS + 30))
+    local output=""
+
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        output="$(facelock status 2>&1 || true)"
+        if printf '%s\n' "$output" | grep -q '\[ok\] responding'; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    printf '%s\n' "$output"
+    return 1
 }
 
 echo "=== Integration Tests (with camera) ==="
@@ -33,6 +78,20 @@ echo ""
 # to a writable location since default may not be writable in containers
 sed -i 's|db_path.*|db_path = "/tmp/facelock-test.db"|' /etc/facelock/config.toml 2>/dev/null || true
 
+# Start a real system bus so CLI commands use the D-Bus daemon path.
+mkdir -p /run/dbus
+dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true
+dbus-daemon --system --fork --nopidfile
+
+cleanup() {
+    if [ -n "${DAEMON_PID:-}" ]; then
+        kill "$DAEMON_PID" 2>/dev/null || true
+        wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+    pkill dbus-daemon 2>/dev/null || true
+}
+trap cleanup EXIT
+
 # Start daemon in background
 facelock daemon &
 DAEMON_PID=$!
@@ -40,35 +99,35 @@ sleep 2
 
 # Verify daemon is running
 run_test "Daemon responds to ping" \
-    "facelock status"
+    "wait_for_daemon" || exit 1
 
 # Test device listing
-run_test "Device listing works" \
-    "facelock devices"
+run_test_contains "Device listing works" \
+    "facelock devices" \
+    "/dev/video" || exit 1
 
 # Test enrollment (will capture faces from camera)
-run_test "Enroll a face" \
-    "facelock enroll --user testuser --label test-face"
+run_test_contains "Enroll a face" \
+    "timeout --foreground $LIVE_TIMEOUT facelock enroll --user testuser --label test-face --skip-setup-check" \
+    "Face enrolled successfully" || exit 1
 
 # Test listing enrolled models
-run_test "List enrolled models" \
-    "facelock list --user testuser"
+run_test_contains "List enrolled models" \
+    "facelock list --user testuser" \
+    "test-face"
 
 # Test authentication via CLI
-run_test "Authenticate enrolled face (CLI)" \
-    "facelock test --user testuser"
+run_test_contains "Authenticate enrolled face (CLI)" \
+    "timeout --foreground $LIVE_TIMEOUT facelock test --user testuser" \
+    "Matched model"
 
 # Test authentication via PAM (the real auth path)
 run_test "Authenticate enrolled face (PAM)" \
-    "pamtester facelock-test testuser authenticate"
+    "timeout --foreground $LIVE_TIMEOUT pamtester facelock-test testuser authenticate"
 
 # Clean up
 run_test "Clear enrolled models" \
     "facelock clear --user testuser --yes"
-
-# Stop daemon
-kill $DAEMON_PID 2>/dev/null || true
-wait $DAEMON_PID 2>/dev/null || true
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+LIVE_TIMEOUT="${FACELOCK_LIVE_TIMEOUT:-90s}"
 
 run_test() {
     local name="$1"
@@ -10,20 +11,50 @@ run_test() {
     local expected_result="${3:-0}"
 
     echo -n "TEST: $name ... "
+    set +o pipefail
     if eval "$cmd" > /tmp/test-output 2>&1; then
         result=0
     else
         result=$?
     fi
+    set -o pipefail
 
     if [ "$expected_result" = "any" ] || [ "$result" -eq "$expected_result" ]; then
         echo "PASS"
         PASS=$((PASS + 1))
+        return 0
     else
         echo "FAIL (exit=$result, expected=$expected_result)"
         cat /tmp/test-output
         FAIL=$((FAIL + 1))
+        return 1
     fi
+}
+
+run_test_contains() {
+    local name="$1"
+    local cmd="$2"
+    local pattern="$3"
+
+    echo -n "TEST: $name ... "
+    set +o pipefail
+    if eval "$cmd" > /tmp/test-output 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+    set -o pipefail
+
+    if [ "$result" -eq 0 ] && grep -q -- "$pattern" /tmp/test-output; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+        return 0
+    fi
+
+    echo "FAIL (exit=$result, pattern=$pattern)"
+    cat /tmp/test-output
+    FAIL=$((FAIL + 1))
+    return 1
 }
 
 echo "=== Oneshot Mode Tests (fully daemonless, with camera) ==="
@@ -42,41 +73,46 @@ run_test "No daemon socket exists" \
 # --- CLI commands in oneshot mode (no daemon) ---
 
 # Device listing
-run_test "facelock devices (oneshot)" \
-    "facelock devices"
+run_test_contains "facelock devices (oneshot)" \
+    "facelock devices" \
+    "/dev/video" || exit 1
 
 # Enrollment (direct, no daemon)
-run_test "facelock enroll (oneshot)" \
-    "facelock enroll --user testuser --label test-face"
+run_test_contains "facelock enroll (oneshot)" \
+    "timeout --foreground $LIVE_TIMEOUT facelock enroll --user testuser --label test-face --skip-setup-check" \
+    "Face enrolled successfully" || exit 1
 
 # List enrolled models (direct DB access)
-run_test "facelock list (oneshot)" \
-    "facelock list --user testuser"
+run_test_contains "facelock list (oneshot)" \
+    "facelock list --user testuser" \
+    "test-face"
 
 # Test auth via CLI (direct)
-run_test "facelock test (oneshot)" \
-    "facelock test --user testuser"
+run_test_contains "facelock test (oneshot)" \
+    "timeout --foreground $LIVE_TIMEOUT facelock test --user testuser" \
+    "Matched in"
 
 # facelock auth binary (used by PAM module)
 run_test "facelock auth authenticates (oneshot)" \
-    "facelock auth --user testuser --config /etc/facelock/config.toml"
+    "timeout --foreground $LIVE_TIMEOUT facelock auth --user testuser --config /etc/facelock/config.toml"
 
 # PAM authentication (the real deal — no daemon)
 run_test "pamtester authenticates (oneshot, no daemon)" \
-    "pamtester facelock-test testuser authenticate"
+    "timeout --foreground $LIVE_TIMEOUT pamtester facelock-test testuser authenticate"
 
 # facelock auth rejects unknown user
 run_test "facelock auth rejects unknown user" \
     "facelock auth --user nobody --config /etc/facelock/config.toml" \
-    1
+    2
 
 # Clear models (direct DB access)
 run_test "facelock clear (oneshot)" \
     "facelock clear --user testuser --yes"
 
 # Verify models cleared
-run_test "facelock list empty after clear (oneshot)" \
-    "facelock list --user testuser 2>&1 | grep -q 'No face models'"
+run_test_contains "facelock list empty after clear (oneshot)" \
+    "facelock list --user testuser" \
+    "No face models"
 
 # Still no daemon socket
 run_test "Still no daemon socket" \


### PR DESCRIPTION
## Summary
- harden privileged config handling, model verification, D-Bus authorization, rate limiting, and filesystem permissions
- align installer, systemd, dbus, and test container behavior with the hardened runtime paths
- update contracts, security docs, and config reference to match the shipped behavior

## Verification
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- just test-pam
- daemon container E2E: 7 passed, 0 failed
- oneshot container E2E: 11 passed, 0 failed