### PR TITLE
chore: add Renovate config for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "rust patch updates",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "rust minor updates"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["major"],
+      "separateMinorPatch": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "automerge": true
+    }
+  ],
+  "schedule": ["before 9am on monday"]
+}


### PR DESCRIPTION
## Summary
- Adds Renovate configuration for automated dependency management
- Cargo patch updates grouped and auto-merged to reduce noise
- Cargo minor updates grouped into single PR for manual review
- Major updates get individual PRs for breaking change review
- GitHub Actions updates grouped and auto-merged
- Runs weekly (Monday before 9am)

## Setup
Install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo. It will read `.github/renovate.json` and start opening PRs.

## Test plan
- [x] Install Renovate GitHub App on the repo
- [ ] Verify Renovate opens a "Dependency Dashboard" issue
- [ ] Confirm first batch of update PRs follows the grouping rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)