### PR TITLE
[codex] Address post-merge review follow-ups

### DIFF
--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -579,7 +579,7 @@ impl Config {
             && !is_sha256_hex(sha256)
         {
             return Err(ConfigError::Validation(format!(
-                "recognition.detector_sha256 must be a 64-character lowercase hex SHA256, got {}",
+                "recognition.detector_sha256 must be a 64-character hex SHA256, got {}",
                 sha256
             )));
         }
@@ -587,7 +587,7 @@ impl Config {
             && !is_sha256_hex(sha256)
         {
             return Err(ConfigError::Validation(format!(
-                "recognition.embedder_sha256 must be a 64-character lowercase hex SHA256, got {}",
+                "recognition.embedder_sha256 must be a 64-character hex SHA256, got {}",
                 sha256
             )));
         }
@@ -779,6 +779,35 @@ embedder_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
             config.recognition.embedder_sha256.as_deref(),
             Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
         );
+    }
+
+    #[test]
+    fn recognition_sha256_fields_accept_uppercase_hex() {
+        let toml = r#"
+[device]
+path = "/dev/video0"
+[recognition]
+detector_sha256 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+"#;
+        let config = Config::parse(toml).unwrap();
+        assert_eq!(
+            config.recognition.detector_sha256.as_deref(),
+            Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        );
+    }
+
+    #[test]
+    fn recognition_sha256_validation_message_matches_allowed_format() {
+        let toml = r#"
+[device]
+path = "/dev/video0"
+[recognition]
+detector_sha256 = "not-a-sha256"
+"#;
+        let err = Config::parse(toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("64-character hex SHA256"));
+        assert!(!msg.contains("lowercase"));
     }
 
     #[test]

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -94,9 +94,9 @@ mod tests {
 
     static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
-    // These tests must run sequentially in a single test because they mutate
-    // a shared process-wide env var. Separate #[test] functions race when
-    // cargo runs tests in parallel.
+    // These tests mutate shared process-wide state (env vars, process overrides)
+    // and must not run concurrently. We keep them as separate #[test] functions
+    // but serialize them with TEST_MUTEX to avoid races when cargo runs tests in
     #[test]
     fn config_path_default_and_env_override() {
         let _guard = TEST_MUTEX.lock().unwrap();

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -33,11 +33,7 @@ fn process_config_override() -> Option<PathBuf> {
         .and_then(|guard| guard.clone())
 }
 
-fn is_privileged_process() -> bool {
-    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
-        return false;
-    };
-
+fn effective_uid_from_status(status: &str) -> Option<u32> {
     status
         .lines()
         .find(|line| line.starts_with("Uid:"))
@@ -47,7 +43,17 @@ fn is_privileged_process() -> bool {
             let _real = fields.next()?;
             fields.next()?.parse::<u32>().ok()
         })
-        .is_some_and(|euid| euid == 0)
+}
+
+fn is_privileged_effective_uid(effective_uid: Option<u32>) -> bool {
+    effective_uid.is_none_or(|euid| euid == 0)
+}
+
+fn is_privileged_process() -> bool {
+    let effective_uid = std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|status| effective_uid_from_status(&status));
+    is_privileged_effective_uid(effective_uid)
 }
 
 /// Set a process-local config override path.
@@ -84,12 +90,16 @@ pub fn config_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     // These tests must run sequentially in a single test because they mutate
     // a shared process-wide env var. Separate #[test] functions race when
     // cargo runs tests in parallel.
     #[test]
     fn config_path_default_and_env_override() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         clear_process_config_override();
         let resolved = resolve_config_path(None, None, false);
@@ -104,19 +114,40 @@ mod tests {
 
     #[test]
     fn privileged_process_ignores_env_override() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         let resolved = resolve_config_path(None, Some("/tmp/test-facelock.toml"), true);
         assert_eq!(resolved, PathBuf::from(DEFAULT_CONFIG_PATH));
     }
 
     #[test]
     fn process_override_beats_env_and_privilege_rules() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         let path = PathBuf::from("/tmp/explicit.toml");
         let resolved = resolve_config_path(Some(&path), Some("/tmp/test-facelock.toml"), true);
         assert_eq!(resolved, path);
     }
 
     #[test]
+    fn effective_uid_parser_extracts_euid() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        assert_eq!(
+            effective_uid_from_status("Name:\tbash\nUid:\t1000\t0\t1000\t1000\n"),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn missing_or_unreadable_uid_fails_safe_to_privileged() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        assert_eq!(effective_uid_from_status("Name:\tbash\n"), None);
+        assert!(is_privileged_effective_uid(None));
+        assert!(is_privileged_effective_uid(Some(0)));
+        assert!(!is_privileged_effective_uid(Some(1000)));
+    }
+
+    #[test]
     fn config_path_uses_process_override() {
+        let _guard = TEST_MUTEX.lock().unwrap();
         clear_process_config_override();
         set_process_config_override(PathBuf::from("/tmp/process-override.toml"));
         assert_eq!(config_path(), PathBuf::from("/tmp/process-override.toml"));

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::params;
@@ -456,8 +457,8 @@ impl FaceStore {
 fn secure_database_files(db_path: &Path) -> Result<()> {
     for path in [
         db_path.to_path_buf(),
-        db_path.with_extension("db-wal"),
-        db_path.with_extension("db-shm"),
+        sqlite_sidecar_path(db_path, "-wal"),
+        sqlite_sidecar_path(db_path, "-shm"),
     ] {
         ensure_mode(&path, 0o640).map_err(|e| {
             FacelockError::Storage(format!(
@@ -470,9 +471,18 @@ fn secure_database_files(db_path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = OsString::from(db_path.as_os_str());
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     fn test_embedding() -> FaceEmbedding {
         let mut e = [0.0f32; 512];
@@ -817,8 +827,50 @@ mod tests {
         assert!(!reopened.check_rate_limit("alice", 1, 60).unwrap());
 
         let _ = std::fs::remove_file(&db_path);
-        let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
-        let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+        let _ = std::fs::remove_file(sqlite_sidecar_path(&db_path, "-wal"));
+        let _ = std::fs::remove_file(sqlite_sidecar_path(&db_path, "-shm"));
+    }
+
+    #[test]
+    fn test_sqlite_sidecar_paths_append_to_full_filename() {
+        assert_eq!(
+            sqlite_sidecar_path(Path::new("/tmp/facelock.sqlite"), "-wal"),
+            PathBuf::from("/tmp/facelock.sqlite-wal")
+        );
+        assert_eq!(
+            sqlite_sidecar_path(Path::new("/tmp/facelock"), "-shm"),
+            PathBuf::from("/tmp/facelock-shm")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secure_database_files_secures_real_sqlite_sidecars() {
+        let db_path = std::env::temp_dir().join(format!(
+            "facelock-sidecars-{}-{}.sqlite",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let wal_path = sqlite_sidecar_path(&db_path, "-wal");
+        let shm_path = sqlite_sidecar_path(&db_path, "-shm");
+
+        std::fs::write(&db_path, b"db").unwrap();
+        std::fs::write(&wal_path, b"wal").unwrap();
+        std::fs::write(&shm_path, b"shm").unwrap();
+
+        secure_database_files(&db_path).unwrap();
+
+        for path in [&db_path, &wal_path, &shm_path] {
+            let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o640, "unexpected mode for {}", path.display());
+        }
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(&wal_path);
+        let _ = std::fs::remove_file(&shm_path);
     }
 
     #[test]

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -37,11 +37,13 @@ run_test_contains() {
     local pattern="$3"
 
     echo -n "TEST: $name ... "
+    set +o pipefail
     if eval "$cmd" > /tmp/test-output 2>&1; then
         result=0
     else
         result=$?
     fi
+    set -o pipefail
 
     if [ "$result" -eq 0 ] && grep -q -- "$pattern" /tmp/test-output; then
         echo "PASS"


### PR DESCRIPTION
## Summary
- fix SQLite sidecar permission hardening so custom database filenames secure the real `-wal` and `-shm` files
- make privileged config-path detection fail safe when procfs UID parsing is unavailable
- align SHA256 validation messaging with the accepted format and cover uppercase hex in tests
- make `run_test_contains` in the integration container harness handle `pipefail` consistently with `run_test`

## Why
PR #16 merged with four unresolved review threads. Two were real hardening/correctness gaps:
- SQLite sidecar permissions were derived by replacing the extension instead of appending to the full filename
- privileged config detection failed open if `/proc/self/status` could not be read

The other two were smaller follow-ups:
- SHA256 validation text claimed lowercase-only input while the parser accepts uppercase hex
- the integration test helper was slightly more fragile than the oneshot helper under `pipefail`

## Impact
- custom `db_path` values now secure the actual SQLite sidecar files
- privileged config resolution remains locked down even if procfs status parsing is unavailable
- config validation errors now match real accepted input
- the integration harness is more robust for future pipeline-based assertions

## Verification
- `cargo test -p facelock-core -p facelock-store`
- `bash -n test/run-integration-tests.sh`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `just test-pam`
- `just test-integration`

## Notes
- `just test-oneshot` was skipped because this patch set does not change the oneshot-specific direct camera/auth flow; it only touches shared config/storage logic already covered by workspace tests, plus the daemon integration test harness.