### PR TITLE
perf: speed up container tests ~20x by eliminating redundant build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude build artifacts (huge — 43GB+)
+target/
+# Re-include the release binaries needed by Containerfiles
+!target/release/facelock
+!target/release/libpam_facelock.so
+!target/release/facelock-polkit-agent
+
+# Git history not needed in containers
+.git/
+
+# Editor swap files
+*.swp
+*.swo
+*~

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+      - name: Build release binaries
+        run: |
+          cargo build --release --workspace
+          cargo build --release -p facelock-cli --features tpm
+
+      - name: Upload release binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-binaries
+          path: |
+            target/release/facelock
+            target/release/libpam_facelock.so
+          retention-days: 1
+
   tpm-tests:
     name: TPM Tests (swtpm)
     runs-on: ubuntu-latest
@@ -98,12 +112,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: release-binaries
+          path: target/release
+
+      - name: Make binaries executable
+        run: chmod +x target/release/facelock target/release/libpam_facelock.so
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y podman
 
-      - name: Build release in container
+      - name: Build test container
         run: |
           if [ ! -f test/Containerfile ]; then
             echo "No Containerfile found, skipping"

--- a/justfile
+++ b/justfile
@@ -33,23 +33,18 @@ fmt:
 # Run all checks (test + lint + format)
 check: test lint fmt-check
 
+# Build the PAM test container image (uses host-built release binaries)
+_build-test-container: build-release
+    podman build -t facelock-pam-test -f test/Containerfile .
+
 # Run container PAM smoke tests
-test-pam: build-release
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -f test/Containerfile ]; then
-        podman build -t facelock-pam-test -f test/Containerfile .
-        podman run --rm facelock-pam-test
-    else
-        echo "No test/Containerfile found"
-        exit 1
-    fi
+test-pam: _build-test-container
+    podman run --rm facelock-pam-test
 
 # Run end-to-end integration tests in container (requires camera)
-test-integration: build-release
+test-integration: _build-test-container
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build -t facelock-pam-test -f test/Containerfile .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -57,10 +52,9 @@ test-integration: build-release
     podman run --rm $devices facelock-pam-test /run-integration-tests.sh
 
 # Run oneshot (daemonless) end-to-end tests in container (requires camera)
-test-oneshot: build-release
+test-oneshot: _build-test-container
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build -t facelock-pam-test -f test/Containerfile .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -68,10 +62,9 @@ test-oneshot: build-release
     podman run --rm $devices facelock-pam-test /run-oneshot-tests.sh
 
 # Open interactive shell in PAM test container (requires camera)
-test-shell: build-release
+test-shell: _build-test-container
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build -t facelock-pam-test -f test/Containerfile .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -1,13 +1,4 @@
-# Stage 1: Build
-FROM archlinux:latest AS builder
-
-RUN pacman -Syu --noconfirm rust clang base-devel v4l-utils libxkbcommon wayland pam tpm2-tss && pacman -Scc --noconfirm
-
-COPY . /build
-WORKDIR /build
-RUN cargo build --release --workspace
-
-# Stage 2: Test image
+# Single-stage test image — uses host-built release binaries (from `just build-release`)
 FROM archlinux:latest
 
 # Install dependencies
@@ -22,18 +13,25 @@ RUN curl -sL https://sourceforge.net/projects/pamtester/files/pamtester/0.1.2/pa
 # Create test user
 RUN useradd -m testuser && echo "testuser:test" | chpasswd
 
-# Copy repo with pre-built binaries from builder stage
-COPY --from=builder /build/target/release/facelock /build/target/release/facelock
-COPY --from=builder /build/target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
-COPY . /build
+# Copy host-built release binaries
+COPY target/release/facelock /build/target/release/facelock
+COPY target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
+
+# Copy project files needed for install
+COPY justfile /build/justfile
+COPY config/ /build/config/
+COPY systemd/ /build/systemd/
+COPY dbus/ /build/dbus/
+COPY dist/ /build/dist/
+COPY models/ /build/models/
 WORKDIR /build
 
 # Install using the real install path
 RUN just install-files
 
 # Copy models to the configured model_dir for integration tests
-RUN cp models/*.onnx /var/lib/facelock/models/ 2>/dev/null || true
-RUN cp models/manifest.toml /var/lib/facelock/models/ 2>/dev/null || true
+RUN cp models/*.onnx /var/lib/facelock/models/ 2>/dev/null || true && \
+    cp models/manifest.toml /var/lib/facelock/models/ 2>/dev/null || true
 
 # Override config for container testing
 COPY test/container-config.toml /etc/facelock/config.toml

--- a/test/Containerfile.fedora
+++ b/test/Containerfile.fedora
@@ -1,16 +1,15 @@
-FROM fedora:latest AS builder
-
-RUN dnf -y install rust cargo clang-devel pam-devel libv4l-devel systemd-rpm-macros gcc gcc-c++ wayland-devel libxkbcommon-devel tpm2-tss-devel rpm-build && dnf clean all
-
-COPY . /build
-WORKDIR /build
-RUN cargo build --release --workspace
-
+# Single-stage test image — uses host-built release binaries (from `just build-release`)
 FROM fedora:latest
 
-RUN dnf -y install pam dbus rpm-build libxkbcommon python3 systemd binutils glibc && dnf clean all
+RUN dnf -y install pam dbus rpm-build libxkbcommon python3 systemd binutils glibc tpm2-tss && dnf clean all
 
-COPY --from=builder /build /build
+# Copy host-built release binaries and project files
+COPY target/release/facelock /build/target/release/facelock
+COPY target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
+COPY config/ /build/config/
+COPY systemd/ /build/systemd/
+COPY dbus/ /build/dbus/
+COPY dist/ /build/dist/
 
 RUN install -Dm755 /build/target/release/facelock /usr/bin/facelock && \
     if [ -f /build/target/release/facelock-polkit-agent ]; then install -Dm755 /build/target/release/facelock-polkit-agent /usr/bin/facelock-polkit-agent; fi && \

--- a/test/Containerfile.ubuntu
+++ b/test/Containerfile.ubuntu
@@ -1,23 +1,17 @@
-FROM ubuntu:24.04 AS builder
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential clang libpam0g-dev libv4l-dev libxkbcommon-dev libwayland-dev libtss2-dev pkg-config ca-certificates curl && rm -rf /var/lib/apt/lists/*
-
-ENV PATH=/root/.cargo/bin:$PATH
-RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
-
-COPY . /build
-WORKDIR /build
-RUN cargo build --release --workspace
-
+# Single-stage test image — uses host-built release binaries (from `just build-release`)
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends libpam-runtime dbus python3 systemd binutils libc6 libxkbcommon0 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libpam-runtime dbus python3 systemd binutils libc6 libxkbcommon0 libtss2-esys-3.0.2-0t64 libtss2-tctildr0t64 && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build /build
+# Copy host-built release binaries and project files
+COPY target/release/facelock /build/target/release/facelock
+COPY target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
+COPY config/ /build/config/
+COPY systemd/ /build/systemd/
+COPY dbus/ /build/dbus/
+COPY dist/ /build/dist/
 
 RUN install -Dm755 /build/target/release/facelock /usr/bin/facelock && \
     if [ -f /build/target/release/facelock-polkit-agent ]; then install -Dm755 /build/target/release/facelock-polkit-agent /usr/bin/facelock-polkit-agent; fi && \


### PR DESCRIPTION
## Summary

- Add `.dockerignore` to exclude 43GB `target/` dir and `.git/` from build context
- Remove Stage 1 builder from all Containerfiles — use host-built release binaries directly instead of redundantly rebuilding inside the container with LTO
- Add TSS2 runtime deps to Fedora/Ubuntu containers (needed for host-built binaries)
- Extract shared `_build-test-container` justfile recipe to deduplicate podman build across 4 test recipes

Container build drops from **~21 minutes to ~52 seconds**.

Closes #19

## Test plan

- [x] `podman build` succeeds for all 3 Containerfiles (Arch, Fedora, Ubuntu)
- [x] `podman run facelock-pam-test` — 13/13 PAM smoke tests pass
- [x] `podman run facelock-fedora-test` — 16/16 package validation tests pass
- [x] `podman run facelock-ubuntu-test` — 16/16 package validation tests pass
- [x] Verified `facelock --version`, PAM module, and ONNX models all present in container
- [x] `just test-integration` with camera (requires hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)