### PR TITLE
fix: stream model downloads with incremental progress bar

### DIFF
--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1325,7 +1325,7 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
         .build()
         .context("failed to create HTTP client")?;
 
-    let response = client
+    let mut response = client
         .get(url)
         .send()
         .with_context(|| format!("failed to download {}", entry.name))?;
@@ -1351,15 +1351,27 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
         .progress_chars("#>-"),
     );
 
-    let bytes = response.bytes().context("failed to read response body")?;
-    pb.set_position(bytes.len() as u64);
-    pb.finish_and_clear();
-
     // Write atomically: write to temp file first, then rename
     let tmp_path = dest.with_extension("tmp");
     let mut file = create_truncate_file(&tmp_path, 0o644)
         .with_context(|| format!("failed to create {}", tmp_path.display()))?;
-    file.write_all(&bytes)?;
+
+    let mut downloaded: u64 = 0;
+    let mut buffer = vec![0u8; 8192];
+    loop {
+        use std::io::Read as _;
+        let n = response
+            .read(&mut buffer)
+            .context("failed to read response")?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buffer[..n])
+            .context("failed to write to temp file")?;
+        downloaded += n as u64;
+        pb.set_position(downloaded);
+    }
+    pb.finish_and_clear();
     file.sync_all()?;
     drop(file);
 


### PR DESCRIPTION
## Summary
- The `download_model` function previously buffered the entire HTTP response into memory with `response.bytes()` before writing to disk or updating the progress bar
- For the 166MB arcface_r50 model, this made the download appear frozen with no progress indication
- Replaced bulk buffering with an 8KB chunked streaming loop using `std::io::Read` on the blocking `reqwest::Response`, writing each chunk to the temp file and updating the progress bar incrementally
- Preserved the atomic write pattern (write to `.tmp`, then rename), the 600s timeout, the SHA256 verification, and the progress bar style unchanged

## Test plan
- `cargo build --workspace` passes
- `cargo clippy --workspace -- -D warnings` passes with zero warnings
- `cargo test --workspace` passes
- Manually verify: running `facelock setup` shows live progress during large model downloads instead of appearing frozen

🤖 Generated with [Claude Code](https://claude.com/claude-code)