### PR TITLE
feat: download only config-selected models in setup

### DIFF
--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -43,6 +43,7 @@ struct ModelEntry {
     #[serde(default)]
     url: String,
     #[serde(default)]
+    #[allow(dead_code)] // parsed from manifest TOML; used in tests
     optional: bool,
 }
 
@@ -505,12 +506,13 @@ fn wizard_model_download(theme: &ColorfulTheme, config: &Config) -> anyhow::Resu
     let configured_detector = &config.recognition.detector_model;
     let configured_embedder = &config.recognition.embedder_model;
 
+    // Only download the models actually selected in the config.
+    // Non-optional (default) models that aren't selected are skipped — the user
+    // chose different models, so there is no point fetching the defaults too.
     let needed: Vec<&ModelEntry> = manifest
         .models
         .iter()
-        .filter(|m| {
-            !m.optional || m.filename == *configured_detector || m.filename == *configured_embedder
-        })
+        .filter(|m| m.filename == *configured_detector || m.filename == *configured_embedder)
         .collect();
 
     // Check which models actually need downloading
@@ -1003,18 +1005,18 @@ fn run_non_interactive() -> anyhow::Result<()> {
 
     let model_dir = Path::new(&config.daemon.model_dir);
 
-    // 3. Check and download needed models:
-    //    - All non-optional models (defaults)
-    //    - Any model whose filename matches the current config (user switched to optional models)
+    // 3. Check and download only the models actually selected in the config.
+    //    Non-optional (default) models that aren't referenced by the config are
+    //    skipped — if the user chose different models there is no reason to fetch
+    //    the defaults as well.  On a first run the config defaults resolve to the
+    //    standard models (scrfd_2.5g + w600k_r50) so those are still downloaded.
     let configured_detector = &config.recognition.detector_model;
     let configured_embedder = &config.recognition.embedder_model;
 
     let needed: Vec<&ModelEntry> = manifest
         .models
         .iter()
-        .filter(|m| {
-            !m.optional || m.filename == *configured_detector || m.filename == *configured_embedder
-        })
+        .filter(|m| m.filename == *configured_detector || m.filename == *configured_embedder)
         .collect();
 
     println!("Checking {} model(s)...\n", needed.len());


### PR DESCRIPTION
## Summary

- Previously `facelock setup` always downloaded all non-optional models (scrfd_2.5g + w600k_r50) plus any optional models the config referenced, even when the user had configured a completely different model pair
- Changed the filter in both `wizard_model_download` and `run_non_interactive` to select exactly the models named in `recognition.detector_model` and `recognition.embedder_model`
- First-run behavior is unchanged: config defaults resolve to scrfd_2.5g + w600k_r50 so those are still downloaded on fresh installs
- Re-running setup after changing the config (e.g. switching to det_10g + glintr100 for high accuracy) now downloads only the newly-selected models
- Already-present models are still verified and skipped (no re-download)
- Added `#[allow(dead_code)]` to `ModelEntry::optional` which is still deserialized from the manifest TOML and used in tests

Stacks on top of #24 (streaming download fix).

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings/errors
- [x] `cargo test --workspace` passes (all 274 tests pass)
- [ ] Manually verify: configure `det_10g.onnx` + `glintr100.onnx` in config, run `facelock setup --non-interactive`, confirm only those two models are downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)