### PR TITLE
ci(release): publish GitHub Release with a PAT so Packit triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Publish the release with a PAT, not the default GITHUB_TOKEN.
+          # Releases created by GITHUB_TOKEN do not trigger downstream
+          # automation, so Packit's release trigger never fires and COPR
+          # is never built. An empty/missing RELEASE_PAT falls back to
+          # GITHUB_TOKEN, so this is safe before the secret is set.
+          token: ${{ secrets.RELEASE_PAT }}
           files: |
             release/facelock-x86_64-linux-gnu
             release/pam_facelock.so


### PR DESCRIPTION
## Summary

The `release.yml` "Create GitHub Release" step published the release with the default `GITHUB_TOKEN`. **Releases created by `GITHUB_TOKEN` do not trigger downstream automation**, so Packit's `trigger: release` job never fired — COPR was not built for v0.1.3 and had to be submitted manually via `copr-cli`.

This passes a `RELEASE_PAT` secret to `softprops/action-gh-release` so the release is published as a real user release. GitHub then delivers the release event to the Packit GitHub App, and COPR builds automatically.

`action-gh-release` treats an empty/missing `token` as unset and falls back to `github.token` (`GITHUB_TOKEN`), so merging this **before** the secret exists is safe — behaviour is unchanged until `RELEASE_PAT` is added.

## Required before the next release

Create the `RELEASE_PAT` repository secret:
1. Generate a fine-grained PAT (https://github.com/settings/personal-access-tokens) — resource owner `tyvsmith`, repository `tyvsmith/facelock`, **Contents: Read and write**.
2. `gh secret set RELEASE_PAT --repo tyvsmith/facelock`

Note: fine-grained PATs expire — rotate before expiry or COPR auto-builds silently stop again.

## Test plan

- [x] One-line workflow change; YAML structure unchanged (`token:` is a valid `action-gh-release` input)
- [ ] Verified live on the next release tag — Packit reacts and the COPR build appears at https://copr.fedorainfracloud.org/coprs/tyvsmith/facelock/builds/ without manual `copr-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)