### PR TITLE
feat(aur): publish facelock-bin alongside facelock and facelock-git

### DIFF
--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -24,9 +24,11 @@ chmod 600 ~/.ssh/aur
 ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
 
 # Per-binary checksums for facelock-bin come from the Release SHA256SUMS file.
+# GITHUB_REPOSITORY is set by GitHub Actions; fall back to the canonical repo for local runs.
+REPO="${GITHUB_REPOSITORY:-tyvsmith/facelock}"
 SHA_FILE="$(mktemp)"
 trap 'rm -f "$SHA_FILE"' EXIT
-curl -fsSL "https://github.com/tyvsmith/facelock/releases/download/v${VERSION}/SHA256SUMS" -o "$SHA_FILE"
+curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/SHA256SUMS" -o "$SHA_FILE"
 SHA_FACELOCK=$(awk '/[[:space:]]facelock-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
 SHA_PAM=$(awk '/[[:space:]]pam_facelock\.so$/{print $1}' "$SHA_FILE")
 SHA_POLKIT=$(awk '/[[:space:]]facelock-polkit-agent-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
@@ -50,21 +52,31 @@ generate_srcinfo() {
 
 # AUR creates a package on first push to a non-existent repo. If clone fails
 # because the repo doesn't exist yet, init a fresh one pointing at the same URL.
+# Auth / network failures must surface — don't paper over them with a fresh init.
 get_or_init_repo() {
   local dir="$1"
   local repo="$2"
+  local url="ssh://aur@aur.archlinux.org/${repo}.git"
+  local clone_err
   rm -rf "$dir"
-  if git clone "ssh://aur@aur.archlinux.org/${repo}.git" "$dir" 2>/dev/null; then
+  if clone_err="$(git clone "$url" "$dir" 2>&1)"; then
     echo "Cloned existing AUR repo: ${repo}"
-  else
+    return 0
+  fi
+  # AUR returns one of these messages when the package doesn't exist yet.
+  if echo "$clone_err" | grep -qE "does not appear to be a git repository|Repository not found|fatal: repository '[^']*' not found"; then
     echo "AUR repo ${repo} not found — initializing for first push"
     rm -rf "$dir"
     mkdir -p "$dir"
     ( cd "$dir"
       git init -b master
-      git remote add origin "ssh://aur@aur.archlinux.org/${repo}.git"
+      git remote add origin "$url"
     )
+    return 0
   fi
+  echo "ERROR: git clone of ${url} failed for a reason other than 'not found':" >&2
+  echo "$clone_err" >&2
+  return 1
 }
 
 commit_and_push() {

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -16,39 +16,113 @@ fi
 mkdir -p ~/.ssh
 echo "$AUR_SSH_KEY" > ~/.ssh/aur
 chmod 600 ~/.ssh/aur
-echo "Host aur.archlinux.org" >> ~/.ssh/config
-echo "  IdentityFile ~/.ssh/aur" >> ~/.ssh/config
-echo "  User aur" >> ~/.ssh/config
+{
+  echo "Host aur.archlinux.org"
+  echo "  IdentityFile ~/.ssh/aur"
+  echo "  User aur"
+} >> ~/.ssh/config
 ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
 
-# Clone AUR repo
-git clone ssh://aur@aur.archlinux.org/facelock.git aur-facelock
+# Per-binary checksums for facelock-bin come from the Release SHA256SUMS file.
+SHA_FILE="$(mktemp)"
+trap 'rm -f "$SHA_FILE"' EXIT
+curl -fsSL "https://github.com/tyvsmith/facelock/releases/download/v${VERSION}/SHA256SUMS" -o "$SHA_FILE"
+SHA_FACELOCK=$(awk '/[[:space:]]facelock-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
+SHA_PAM=$(awk '/[[:space:]]pam_facelock\.so$/{print $1}' "$SHA_FILE")
+SHA_POLKIT=$(awk '/[[:space:]]facelock-polkit-agent-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
+: "${SHA_FACELOCK:?missing facelock binary checksum in Release SHA256SUMS}"
+: "${SHA_PAM:?missing pam_facelock.so checksum in Release SHA256SUMS}"
+: "${SHA_POLKIT:?missing polkit agent checksum in Release SHA256SUMS}"
 
-# Copy and update PKGBUILD
-cp dist/PKGBUILD aur-facelock/PKGBUILD
-cp dist/facelock.install aur-facelock/facelock.install
-sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur-facelock/PKGBUILD
-sed -i "s/sha256sums=('SKIP')/sha256sums=('${CHECKSUM}')/" aur-facelock/PKGBUILD
-
-# Generate .SRCINFO via Arch container.
-# makepkg refuses to run as root, so we create a non-root builder user
-# inside the container and restore host-runner ownership afterwards.
-cd aur-facelock
 RUNNER_UID="$(id -u)"
 RUNNER_GID="$(id -g)"
-docker run --rm -v "$(pwd):/pkg" -w /pkg archlinux:base-devel bash -c "
-  pacman -Sy --noconfirm pacman-contrib >/dev/null
-  useradd -m builder
-  chown -R builder:builder /pkg
-  su builder -c 'makepkg --printsrcinfo > .SRCINFO'
-  chown -R ${RUNNER_UID}:${RUNNER_GID} /pkg
-"
 
-# Commit and push if changed
-git config user.name "facelock-bot"
-git config user.email "facelock@users.noreply.github.com"
-git add PKGBUILD facelock.install .SRCINFO
-git diff --cached --quiet || git commit -m "Update to v${VERSION}"
-git push
+generate_srcinfo() {
+  local dir="$1"
+  ( cd "$dir" && docker run --rm -v "$(pwd):/pkg" -w /pkg archlinux:base-devel bash -c "
+      pacman -Sy --noconfirm pacman-contrib >/dev/null
+      useradd -m builder
+      chown -R builder:builder /pkg
+      su builder -c 'makepkg --printsrcinfo > .SRCINFO'
+      chown -R ${RUNNER_UID}:${RUNNER_GID} /pkg
+    " )
+}
+
+# AUR creates a package on first push to a non-existent repo. If clone fails
+# because the repo doesn't exist yet, init a fresh one pointing at the same URL.
+get_or_init_repo() {
+  local dir="$1"
+  local repo="$2"
+  rm -rf "$dir"
+  if git clone "ssh://aur@aur.archlinux.org/${repo}.git" "$dir" 2>/dev/null; then
+    echo "Cloned existing AUR repo: ${repo}"
+  else
+    echo "AUR repo ${repo} not found — initializing for first push"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    ( cd "$dir"
+      git init -b master
+      git remote add origin "ssh://aur@aur.archlinux.org/${repo}.git"
+    )
+  fi
+}
+
+commit_and_push() {
+  local dir="$1"
+  local message="$2"
+  ( cd "$dir"
+    git config user.name "facelock-bot"
+    git config user.email "facelock@users.noreply.github.com"
+    git add PKGBUILD facelock.install .SRCINFO
+    if git diff --cached --quiet; then
+      echo "No changes to commit for $(basename "$dir")"
+      return 0
+    fi
+    git commit -m "$message"
+    git push --set-upstream origin master
+  )
+}
+
+publish_facelock() {
+  local dir="aur-facelock"
+  echo "--- Publishing facelock (source build) ---"
+  get_or_init_repo "$dir" facelock
+  cp dist/PKGBUILD "$dir/PKGBUILD"
+  cp dist/facelock.install "$dir/facelock.install"
+  sed -i "s/^pkgver=.*/pkgver=${VERSION}/" "$dir/PKGBUILD"
+  sed -i "s/sha256sums=('SKIP')/sha256sums=('${CHECKSUM}')/" "$dir/PKGBUILD"
+  generate_srcinfo "$dir"
+  commit_and_push "$dir" "Update to v${VERSION}"
+}
+
+publish_facelock_bin() {
+  local dir="aur-facelock-bin"
+  echo "--- Publishing facelock-bin (prebuilt binaries) ---"
+  get_or_init_repo "$dir" facelock-bin
+  cp dist/PKGBUILD-bin "$dir/PKGBUILD"
+  cp dist/facelock.install "$dir/facelock.install"
+  sed -i "s/^pkgver=.*/pkgver=${VERSION}/" "$dir/PKGBUILD"
+  sed -i "s/__SRC_SHA256__/${CHECKSUM}/" "$dir/PKGBUILD"
+  sed -i "s/__FACELOCK_SHA256__/${SHA_FACELOCK}/" "$dir/PKGBUILD"
+  sed -i "s/__PAM_SHA256__/${SHA_PAM}/" "$dir/PKGBUILD"
+  sed -i "s/__POLKIT_SHA256__/${SHA_POLKIT}/" "$dir/PKGBUILD"
+  generate_srcinfo "$dir"
+  commit_and_push "$dir" "Update to v${VERSION}"
+}
+
+publish_facelock_git() {
+  local dir="aur-facelock-git"
+  echo "--- Publishing facelock-git (VCS) ---"
+  get_or_init_repo "$dir" facelock-git
+  cp dist/PKGBUILD-git "$dir/PKGBUILD"
+  cp dist/facelock.install "$dir/facelock.install"
+  # pkgver is computed by pkgver() at build time from git; no substitution needed.
+  generate_srcinfo "$dir"
+  commit_and_push "$dir" "Refresh PKGBUILD for v${VERSION}"
+}
+
+publish_facelock
+publish_facelock_bin
+publish_facelock_git
 
 echo "=== AUR publish complete ==="

--- a/dist/PKGBUILD-bin
+++ b/dist/PKGBUILD-bin
@@ -1,0 +1,46 @@
+# Maintainer: facelock contributors
+pkgname=facelock-bin
+_pkgname=facelock
+pkgver=0.1.3
+pkgrel=1
+pkgdesc="Face authentication PAM module for Linux (prebuilt binaries)"
+arch=('x86_64')
+url="https://github.com/tyvsmith/facelock"
+license=('MIT OR Apache-2.0')
+depends=('glibc' 'dbus' 'pam' 'gcc-libs' 'tpm2-tss' 'libxkbcommon' 'onnxruntime')
+optdepends=(
+    'onnxruntime-opt-cuda: NVIDIA GPU acceleration (replaces onnxruntime)'
+    'onnxruntime-opt-rocm: AMD GPU acceleration (replaces onnxruntime)'
+)
+provides=('facelock')
+conflicts=('facelock' 'facelock-git')
+backup=('etc/facelock/config.toml')
+install=facelock.install
+source=(
+    "$_pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+    "facelock-$pkgver-x86_64::$url/releases/download/v$pkgver/facelock-x86_64-linux-gnu"
+    "pam_facelock-$pkgver.so::$url/releases/download/v$pkgver/pam_facelock.so"
+    "facelock-polkit-agent-$pkgver-x86_64::$url/releases/download/v$pkgver/facelock-polkit-agent-x86_64-linux-gnu"
+)
+sha256sums=('__SRC_SHA256__' '__FACELOCK_SHA256__' '__PAM_SHA256__' '__POLKIT_SHA256__')
+
+package() {
+    cd "$_pkgname-$pkgver"
+
+    # Prebuilt binaries from the GitHub Release
+    install -Dm755 "$srcdir/facelock-$pkgver-x86_64" "$pkgdir/usr/bin/facelock"
+    install -Dm755 "$srcdir/facelock-polkit-agent-$pkgver-x86_64" "$pkgdir/usr/bin/facelock-polkit-agent"
+    install -Dm755 "$srcdir/pam_facelock-$pkgver.so" "$pkgdir/usr/lib/security/pam_facelock.so"
+
+    # Ancillary assets from the source tarball
+    install -Dm644 config/facelock.toml "$pkgdir/etc/facelock/config.toml"
+    install -Dm644 -t "$pkgdir/usr/share/facelock/quirks.d/" config/quirks.d/*.toml
+    install -Dm644 systemd/facelock-daemon.service "$pkgdir/usr/lib/systemd/system/facelock-daemon.service"
+    install -Dm644 dbus/org.facelock.Daemon.conf "$pkgdir/usr/share/dbus-1/system.d/org.facelock.Daemon.conf"
+    install -Dm644 dbus/org.facelock.Daemon.service "$pkgdir/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+    install -Dm644 dist/facelock.sysusers "$pkgdir/usr/lib/sysusers.d/facelock.conf"
+    install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
+
+    install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
+    install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,7 +29,7 @@ just release 0.2.0
 ```
 
 This will:
-1. Bump version in `Cargo.toml`, `dist/PKGBUILD`, `dist/facelock.spec`, `dist/debian/changelog`
+1. Bump version in `Cargo.toml`, `dist/PKGBUILD`, `dist/PKGBUILD-bin`, `dist/facelock.spec`, `dist/debian/changelog`
 2. Run `cargo check --workspace` to verify the version bump compiles
 3. Prompt you to update `CHANGELOG.md` (add entries under the new version heading)
 4. Print the `git commit` / `git tag` / `git push` commands for you to run
@@ -49,7 +49,7 @@ The `.github/workflows/release.yml` workflow:
 3. Builds `.deb` package — **TPM** (Debian trixie container) and **legacy** (Ubuntu 24.04)
 4. Builds `.rpm` package in Fedora container (with TPM feature) and validates contents
 5. Validates Nix flake evaluation
-6. Publishes to AUR (if `AUR_SSH_KEY` secret is configured)
+6. Publishes to AUR — `facelock` (source build), `facelock-bin` (prebuilt), and `facelock-git` (VCS) — if `AUR_SSH_KEY` secret is configured
 7. Publishes signed APT repository (if `APT_GPG_PRIVATE_KEY` and `APT_GPG_PASSPHRASE` are configured)
 8. Triggers GitHub Pages rebuild to include updated APT repo
 
@@ -129,10 +129,13 @@ Automated after setup. The release workflow publishes to AUR when `AUR_SSH_KEY` 
 
 1. Create an AUR account at https://aur.archlinux.org/register
 2. Add your SSH public key to your AUR account at https://aur.archlinux.org/account
-3. Register the package names:
+3. Register the package names. CI's `publish-aur.sh` will create any of
+   these on first push if they don't already exist, but you can also pre-register
+   them manually:
    ```bash
    REPO_ROOT="$(pwd)"
 
+   # facelock (source build — default for `yay -S facelock`)
    git clone ssh://aur@aur.archlinux.org/facelock.git aur-facelock
    cd aur-facelock
    cp "$REPO_ROOT/dist/PKGBUILD" .
@@ -143,6 +146,18 @@ Automated after setup. The release workflow publishes to AUR when `AUR_SSH_KEY` 
    git push
    cd ..
 
+   # facelock-bin (prebuilt binaries from the GitHub Release — no cargo build)
+   git clone ssh://aur@aur.archlinux.org/facelock-bin.git aur-facelock-bin
+   cd aur-facelock-bin
+   cp "$REPO_ROOT/dist/PKGBUILD-bin" PKGBUILD
+   cp "$REPO_ROOT/dist/facelock.install" .
+   makepkg --printsrcinfo > .SRCINFO
+   git add PKGBUILD facelock.install .SRCINFO
+   git commit -m "Initial commit"
+   git push
+   cd ..
+
+   # facelock-git (VCS package tracking main)
    git clone ssh://aur@aur.archlinux.org/facelock-git.git aur-facelock-git
    cd aur-facelock-git
    cp "$REPO_ROOT/dist/PKGBUILD-git" PKGBUILD

--- a/justfile
+++ b/justfile
@@ -359,6 +359,12 @@ release version:
         echo "  ✓ dist/PKGBUILD"
     fi
 
+    # 2b. dist/PKGBUILD-bin (per-binary sha256sums are filled in by CI)
+    if [ -f dist/PKGBUILD-bin ]; then
+        sed -i "s/^pkgver=.*/pkgver=$VERSION/" dist/PKGBUILD-bin
+        echo "  ✓ dist/PKGBUILD-bin"
+    fi
+
     # 3. dist/facelock.spec
     if [ -f dist/facelock.spec ]; then
         sed -i "s/^Version:.*/Version:        $VERSION/" dist/facelock.spec


### PR DESCRIPTION
## Summary
- Adds `dist/PKGBUILD-bin` — a `facelock-bin` AUR variant that installs prebuilt binaries from the GitHub Release instead of running `cargo build`. Ancillary assets (config, systemd, D-Bus, sysusers, tmpfiles) still come from the source tarball.
- Rewrites `.github/workflows/scripts/publish-aur.sh` to publish all three AUR variants on each non-prerelease tag: `facelock` (source), `facelock-bin` (prebuilt), `facelock-git` (VCS). Per-binary sha256sums for `facelock-bin` are pulled from the Release's `SHA256SUMS` file.
- Handles the first-publish case: if `git clone` fails because the AUR repo doesn't exist yet, the script inits a fresh repo and pushes — AUR auto-creates the package on first push. No manual website registration required.
- `just release X.Y.Z` now also bumps `dist/PKGBUILD-bin`'s `pkgver`.
- Updates `docs/releasing.md` with the new variant, its one-time manual setup, and the expanded version-bump file list.

## Why three packages
This is the AUR convention for projects with non-trivial build times: unsuffixed = source build (default), `-bin` = prebuilt binary install, `-git` = bleeding-edge VCS. Users running `yay -S facelock-bin` skip the ~5 minute Rust build.

## Test plan
- [x] `bash -n` on `PKGBUILD-bin` and `publish-aur.sh`
- [x] `shellcheck` clean on `publish-aur.sh`
- [x] `justfile` still parses (`just --list`)
- [x] Dry-run of all sed substitutions produces a valid PKGBUILD with 4-entry `source`/`sha256sums` arrays, no placeholders remaining
- [ ] End-to-end verification on next tagged release (requires `AUR_SSH_KEY`, network, docker — not testable locally)
- [ ] Confirm `facelock-bin` and `facelock-git` names are still unclaimed on AUR before tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)