### PR TITLE
fix(packaging): close uninstall cleanup gaps across all four paths

### DIFF
--- a/dist/debian/prerm
+++ b/dist/debian/prerm
@@ -13,6 +13,9 @@ case "$1" in
         if [ -x /usr/sbin/pam-auth-update ]; then
             pam-auth-update --remove facelock 2>/dev/null || true
         fi
+
+        # Kill facelock polkit agent if running (lets the DE's agent take over)
+        pkill -f facelock-polkit-agent 2>/dev/null || true
         ;;
 
     upgrade|deconfigure)

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -1,5 +1,3 @@
-PAM_LINE="auth  sufficient  pam_facelock.so"
-
 post_install() {
     systemd-sysusers
     systemd-tmpfiles --create
@@ -41,13 +39,16 @@ post_upgrade() {
 
 pre_remove() {
     # Stop and disable daemon
-    systemctl stop facelock-daemon 2>/dev/null || true
-    systemctl disable facelock-daemon 2>/dev/null || true
+    systemctl stop facelock-daemon.service 2>/dev/null || true
+    systemctl disable facelock-daemon.service 2>/dev/null || true
 
-    # Remove PAM lines
+    # Kill facelock polkit agent if running (lets the DE's agent take over)
+    pkill -f facelock-polkit-agent 2>/dev/null || true
+
+    # Remove PAM lines (regex match — tolerates whitespace/option variations)
     for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
-        if [ -f "$PAM_FILE" ] && grep -qF "$PAM_LINE" "$PAM_FILE"; then
-            sed -i "\|^${PAM_LINE}$|d" "$PAM_FILE"
+        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
+            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
             echo "==> Removed face authentication from $PAM_FILE"
         fi
     done

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -112,6 +112,19 @@ echo "  2. sudo facelock enroll      (register your face)"
 %preun
 %systemd_preun facelock-daemon.service
 
+# Only on full uninstall ($1 == 0), not upgrade.
+# Remove PAM lines that `facelock setup` may have added — otherwise stale
+# references to pam_facelock.so survive removal and can break sudo auth.
+if [ $1 -eq 0 ]; then
+    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
+            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
+        fi
+    done
+    # Kill facelock polkit agent if running (lets the DE's agent take over)
+    pkill -f facelock-polkit-agent 2>/dev/null || true
+fi
+
 %postun
 %systemd_postun_with_restart facelock-daemon.service
 

--- a/justfile
+++ b/justfile
@@ -259,6 +259,12 @@ uninstall-files:
     rm -f /usr/share/dbus-1/system-services/org.facelock.Daemon.service
     rm -f /usr/bin/facelock-polkit-agent
     rm -f /etc/xdg/autostart/org.facelock.AuthAgent.desktop
+
+    # Remove quirks database and source-install config artifacts
+    # (these would otherwise collide with a subsequent package install)
+    rm -rf /usr/share/facelock
+    rm -f /etc/facelock/config.toml.default
+
     systemctl daemon-reload 2>/dev/null || true
 
     echo "Uninstalled. Config and data preserved in /etc/facelock and /var/lib/facelock."


### PR DESCRIPTION
## Summary

Each packaging path (source `just uninstall`, AUR, Debian, RPM) had at least one cleanup gap that could leave the system in a broken or conflicting state. This PR closes all four.

### What you'd hit today

- **Source → package migration**: `just uninstall` left `/usr/share/facelock/quirks.d/*.toml` and `/etc/facelock/config.toml.default` behind, so a subsequent `yay -S facelock` (or `apt`/`dnf`) fails with a file-conflict error and forces manual cleanup.
- **AUR uninstall**: PAM line removal used exact-string match on `auth  sufficient  pam_facelock.so` (two spaces). Any whitespace/option drift from `facelock setup` and the line survived. The polkit agent was also never killed, so it kept running after removal.
- **Debian uninstall**: `pam-auth-update --remove facelock` runs correctly, but the polkit agent was never killed.
- **RPM uninstall (most serious)**: `%preun` only handled systemd. PAM lines added by `facelock setup` to `/etc/pam.d/sudo`, `polkit-1`, `hyprlock` were never removed — leaving stale references to `pam_facelock.so` after the module is deleted. Risk: broken `sudo` PAM stack on the next login attempt.

### Changes

- **`justfile`**: `uninstall-files` now removes `/usr/share/facelock` and `/etc/facelock/config.toml.default`.
- **`dist/facelock.install`** (AUR): regex-based PAM line removal (`sed -i '/pam_facelock\.so/d'`), added `pkill -f facelock-polkit-agent`, and aligned `systemctl` arguments to use the full `.service` unit name.
- **`dist/debian/prerm`**: added `pkill -f facelock-polkit-agent` on remove/purge.
- **`dist/facelock.spec`**: on full uninstall (`$1 -eq 0`, not upgrade), strip `pam_facelock.so` lines from the three PAM service files and kill the polkit agent.

User data (`/etc/facelock/{config.toml,encryption.key.sealed}`, `/var/lib/facelock/`) is still preserved across uninstall in all paths.

## Test plan

- [ ] `just install` then `just uninstall`, confirm `/usr/share/facelock` and `/etc/facelock/config.toml.default` are gone.
- [ ] After above, `yay -S facelock` (or local PKGBUILD `makepkg -si`) installs cleanly with no file conflicts.
- [ ] On Arch: `facelock setup` adds PAM lines, then `pacman -R facelock` removes them (verify `grep pam_facelock /etc/pam.d/sudo` is empty) and the polkit agent is no longer in `pgrep -f facelock-polkit-agent`.
- [ ] On Fedora (container or COPR): same sequence — `dnf remove facelock` cleans PAM lines.
- [ ] On Debian: install `.deb`, run `facelock setup`, then `apt remove facelock` — confirm polkit agent killed.
- [ ] RPM upgrade path (`$1 == 1`) does NOT remove PAM lines (verify by simulating with a re-install).