### PR TITLE
feat(setup): show change preview and confirm before editing PAM files

### DIFF
--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1395,7 +1395,9 @@ fn print_pam_extension_hint() {
     println!();
     println!("==> facelock PAM line for manual extension to other services:");
     println!("==>   {PAM_LINE}");
-    println!("==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file.");
+    println!(
+        "==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
+    );
 }
 
 const PAM_MODULE_PATH: &str = "/lib/security/pam_facelock.so";
@@ -1460,9 +1462,16 @@ fn pam_install(service: &str, yes: bool) -> anyhow::Result<()> {
     // 4. Preview change and confirm before any modification
     let backup_path = format!("{pam_path}.facelock-backup");
 
+    // Decide where the line will go BEFORE prompting, so the preview is accurate.
+    let insertion_hint = if content.lines().any(|l| l.trim_start().starts_with("auth")) {
+        "inserted before the first 'auth' line"
+    } else {
+        "no 'auth' line found — inserted at the top of the file"
+    };
+
     println!();
     println!("About to modify {pam_path}:");
-    println!("  + {PAM_LINE}    (inserted before first 'auth' line)");
+    println!("  + {PAM_LINE}    ({insertion_hint})");
     println!("  Backup will be saved to: {backup_path}");
     println!();
     println!("(To configure manually instead, add the line above to each service yourself.)");

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -211,6 +211,8 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     };
 
+    print_pam_extension_hint();
+
     // -- Summary --
     println!("\n--- Setup Complete ---\n");
     let encryption_label = match config.encryption.method {
@@ -1387,6 +1389,15 @@ fn download_model(entry: &ModelEntry, dest: &Path) -> anyhow::Result<()> {
 // --- PAM installation ---
 
 const PAM_LINE: &str = "auth      sufficient pam_facelock.so";
+
+/// Print a copy-pasteable hint so users can extend PAM integration to any service.
+fn print_pam_extension_hint() {
+    println!();
+    println!("==> facelock PAM line for manual extension to other services:");
+    println!("==>   {PAM_LINE}");
+    println!("==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file.");
+}
+
 const PAM_MODULE_PATH: &str = "/lib/security/pam_facelock.so";
 const SENSITIVE_SERVICES: &[&str] = &["system-auth", "login", "sshd"];
 
@@ -1405,7 +1416,9 @@ pub fn run_pam(service: &str, remove: bool, yes: bool) -> anyhow::Result<()> {
     if remove {
         pam_remove(service)
     } else {
-        pam_install(service, yes)
+        pam_install(service, yes)?;
+        print_pam_extension_hint();
+        Ok(())
     }
 }
 
@@ -1444,8 +1457,32 @@ fn pam_install(service: &str, yes: bool) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // 4. Create backup (always, before any modification)
+    // 4. Preview change and confirm before any modification
     let backup_path = format!("{pam_path}.facelock-backup");
+
+    println!();
+    println!("About to modify {pam_path}:");
+    println!("  + {PAM_LINE}    (inserted before first 'auth' line)");
+    println!("  Backup will be saved to: {backup_path}");
+    println!();
+    println!("(To configure manually instead, add the line above to each service yourself.)");
+
+    let proceed = if yes || !std::io::stdin().is_terminal() {
+        true
+    } else {
+        Confirm::new()
+            .with_prompt("Proceed?")
+            .default(true)
+            .interact()
+            .context("failed to read confirmation")?
+    };
+
+    if !proceed {
+        println!("Skipped {pam_path}.");
+        return Ok(());
+    }
+
+    // 4b. Create backup (always, before any modification)
     fs::copy(pam_file, &backup_path)
         .with_context(|| format!("failed to back up {pam_path} to {backup_path}"))?;
     println!("Backed up {pam_path} -> {backup_path}");

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -40,8 +40,8 @@ enum Commands {
         /// Remove the PAM line instead of adding it
         #[arg(long)]
         remove: bool,
-        /// Skip confirmation for sensitive services
-        #[arg(short, long)]
+        /// Skip the confirmation prompt before modifying PAM files (also: --no-confirm)
+        #[arg(short, long, alias = "no-confirm")]
         yes: bool,
         /// Run in non-interactive mode (skip wizard)
         #[arg(long)]


### PR DESCRIPTION
## Summary

- Before touching any `/etc/pam.d/<service>` file, `pam_install()` now prints a multi-line preview showing the exact line being inserted, where it will go, and the backup destination — then prompts the user to confirm (default: yes, Enter proceeds)
- The prompt is automatically skipped when stdin is not a TTY (CI, scripts, piped use) or when `--yes` / `-y` / `--no-confirm` is passed, so existing automation is unaffected
- The `--yes` / `-y` flag on `facelock setup --pam` now also accepts `--no-confirm` as an alias for script-friendly invocations
- After all per-service PAM configuration (both the interactive wizard and direct `--pam` invocations), a copy-pasteable summary line is printed so users can extend integration to any `/etc/pam.d/<service>` themselves

## Behavior notes

- **Defaults preserve current UX**: pressing Enter at the prompt accepts and proceeds, exactly as before
- **Non-TTY auto-proceeds**: scripts, CI pipelines, and any invocation where stdin is not a terminal skip the prompt entirely — no breakage
- **Declining is not an error**: if the user types `n`, the service is skipped with `Skipped /etc/pam.d/<service>.` and `Ok(())` is returned; setup continues with other services

## Scope note

This PR is intentionally limited to the confirmation prompt and CLI flag. It does not add new PAM services (that is a separate PR) and does not refactor `pam_install` beyond what's needed for the prompt.

Related: PR #1 (uninstall cleanup) and PR #3 (additional PAM service detection) may also be in flight; this PR has no dependency on either.

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [ ] `cargo run --bin facelock -- setup --help 2>&1 | grep -E '(yes|no-confirm)'` shows the flag
- [ ] Interactive: `sudo facelock setup --pam` prints preview and prompts; Enter proceeds, `n` prints "Skipped" and exits cleanly
- [ ] Non-interactive: `echo "" | sudo facelock setup --pam` skips the prompt and proceeds automatically
- [ ] Flag: `sudo facelock setup --pam --yes` skips the prompt
- [ ] Alias: `sudo facelock setup --pam --no-confirm` also skips the prompt
- [ ] End-of-setup summary line is printed after the PAM loop in both wizard and `--pam` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>