### PR TITLE
fix(clear): require root before prompting, not after

### DIFF
--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -6,6 +6,10 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use crate::ipc_client;
 
 pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
+    // ClearModels is root-only on the daemon side too, so demand root up front.
+    // Otherwise the user gets prompted Y/N first and only then hits AccessDenied.
+    ipc_client::require_root("sudo facelock clear")?;
+
     let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
@@ -36,7 +40,6 @@ pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
     }
 
     if ipc_client::should_use_direct(&config) {
-        ipc_client::require_root("sudo facelock clear")?;
         let store = crate::direct::open_store(&config)?;
         let count = store
             .clear_user(&user)


### PR DESCRIPTION
## Summary

`facelock clear` had a UX bug: in daemon mode (the default after `facelock setup`) the client skipped its own `require_root` check and went straight to prompting the user `Remove ALL face models for user 'X'?`. After the user typed `y`, the daemon-side `verify_caller_is_root` rejected the call with `AccessDenied`, leaving the user staring at an error after agreeing to a destructive action they couldn't perform.

This PR hoists `ipc_client::require_root("sudo facelock clear")` to the top of `clear::run()`, before any has-models check, confirmation prompt, or D-Bus call. Interactive users now get the existing "Re-run with sudo? [Y/n]" prompt up front and the elevated process drives the rest of the flow cleanly.

The redundant `require_root` inside the direct-store branch is removed.

## Reproduction (before fix)

```
$ facelock clear
Remove ALL face models for user 'ty'? [y/N] y
Error: D-Bus ClearModels call failed

Caused by:
    org.freedesktop.DBus.Error.AccessDenied: ClearModels requires root (caller: 'ty', UID 1000).
```

## After fix

```
$ facelock clear
Root required. Re-run with sudo? [Y/n] y
[sudo password prompt]
Remove ALL face models for user 'ty'? [y/N] y
All face models removed for user 'ty'.
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: run `facelock clear` as non-root with daemon active; confirm sudo re-exec prompt fires before the destructive confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)