### PR TITLE
fix(face): hex-encode SHA256 digest portably across sha2 versions

### DIFF
--- a/crates/facelock-face/src/models.rs
+++ b/crates/facelock-face/src/models.rs
@@ -46,7 +46,10 @@ pub fn verify_model(path: &Path, expected_sha256: &str) -> Result<bool> {
     let mut hasher = Sha256::new();
     hasher.update(&data);
     let result = hasher.finalize();
-    let hex = format!("{result:x}");
+    // Encode the digest by iterating bytes so this works with both sha2 0.10
+    // (`GenericArray`) and sha2 0.11 (`hybrid_array::Array`), since only the
+    // older type implements `LowerHex` directly.
+    let hex: String = result.iter().map(|b| format!("{b:02x}")).collect();
 
     Ok(hex == expected_sha256)
 }


### PR DESCRIPTION
## Summary

Unblocks PR #30 (renovate: minor and patch dependencies), which fails to build because the bump to `sha2 v0.11` changed the digest output type from `generic_array::GenericArray<u8, _>` (impls `LowerHex`) to `hybrid_array::Array<u8, _>` (does not impl `LowerHex`).

The call site at \`crates/facelock-face/src/models.rs:49\`:
\`\`\`rust
let hex = format!(\"{result:x}\");
\`\`\`
no longer compiles under sha2 0.11.

Switch to iterating bytes and formatting each — both digest types deref to \`[u8]\`, the produced string is byte-identical to the old \`{:x}\` output, and the code compiles cleanly against both 0.10 and 0.11.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — 262 tests pass
- [x] \`cargo test -p facelock-face verify_model\` — direct coverage passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

Once this lands, Renovate will rebase #30 onto main and that PR should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)