### PR TITLE
fix(store): cast face_models created_at via i64 for rusqlite portability

### DIFF
--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -61,9 +61,12 @@ impl FaceStore {
     ) -> Result<u32> {
         let tx = self.conn.unchecked_transaction().map_err(map_err)?;
 
-        let created_at = SystemTime::now()
+        // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
+        // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
+        // because SQLite INTEGER is signed 64-bit).
+        let created_at: i64 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
+            .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
 
         tx.execute(
@@ -175,7 +178,8 @@ impl FaceStore {
                     id: row.get(0)?,
                     user: row.get(1)?,
                     label: row.get(2)?,
-                    created_at: row.get(3)?,
+                    // Read as i64 and widen; rusqlite 0.39 dropped FromSql for u64.
+                    created_at: row.get::<_, i64>(3)? as u64,
                     embedder_model: row.get(4)?,
                 })
             })
@@ -253,9 +257,12 @@ impl FaceStore {
     ) -> Result<u32> {
         let tx = self.conn.unchecked_transaction().map_err(map_err)?;
 
-        let created_at = SystemTime::now()
+        // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
+        // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
+        // because SQLite INTEGER is signed 64-bit).
+        let created_at: i64 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
+            .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
 
         tx.execute(


### PR DESCRIPTION
## Summary

Second unblock for PR #30 (renovate: minor and patch deps). After #46 fixed the sha2 0.11 hex-encoding break, the next failure surfaced: rusqlite 0.39 dropped `ToSql`/`FromSql` for `u64` (SQLite INTEGER is signed 64-bit, so values above i64::MAX can't round-trip).

Three call sites in `crates/facelock-store/src/db.rs` were affected, all writing or reading the `face_models.created_at` column:

- `add_model` (line 71)
- `add_model_raw` (line 263)
- `list_models` (line 178)

The rate-limit code path already used `as i64` casts; this PR brings the face_models path in line with that pattern.

## Approach

- Compute `created_at` as `i64` on insert.
- Read `created_at` as `i64` on select and widen to `u64` for the public `FaceModelInfo::created_at` field. The public type is unchanged.
- No schema migration: SQLite INTEGER storage is identical; we were always writing values well below i64::MAX.

Builds cleanly against both current rusqlite (0.32) and the bumped version in #30 (0.39).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Once this lands, Renovate rebases #30 against main and the rusqlite portion should compile. If further hidden breakages remain from the other bumps in #30 (sha2, ndarray, rand, etc.), we'll iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)