### PR TITLE
fix(tpm): migrate to rand 0.10 (thread_rng -> rng, RngCore -> Rng)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -564,6 +564,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +726,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1160,7 +1180,7 @@ version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "facelock-core",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tracing",
@@ -1400,6 +1420,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2513,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2651,33 +2672,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2709,6 +2720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,7 +2753,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -3100,7 +3117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/crates/facelock-tpm/Cargo.toml
+++ b/crates/facelock-tpm/Cargo.toml
@@ -12,7 +12,7 @@ tss-esapi = { workspace = true, optional = true }
 serde = { workspace = true }
 zeroize = "1"
 aes-gcm = "0.10"
-rand = "0.8"
+rand = "0.10"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -648,10 +648,10 @@ impl SoftwareSealer {
     /// Generate a new random 256-bit key and write it to a file.
     /// Sets file permissions to 0600 (owner read/write only).
     pub fn generate_key_file(path: &std::path::Path) -> Result<()> {
-        use rand::RngCore;
+        use rand::Rng;
 
         let mut key = [0u8; AES_KEY_SIZE];
-        rand::thread_rng().fill_bytes(&mut key);
+        rand::rng().fill_bytes(&mut key);
 
         // Write atomically: write to temp file, then rename
         let dir = path.parent().ok_or_else(|| {
@@ -700,13 +700,13 @@ impl SoftwareSealer {
     pub fn seal_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
         use aes_gcm::aead::Aead;
         use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
-        use rand::RngCore;
+        use rand::Rng;
 
         let cipher = Aes256Gcm::new_from_slice(&self.key)
             .map_err(|e| FacelockError::Encryption(format!("failed to create AES cipher: {e}")))?;
 
         let mut nonce_bytes = [0u8; AES_NONCE_SIZE];
-        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        rand::rng().fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
 
         let ciphertext = cipher
@@ -769,7 +769,7 @@ pub fn generate_and_seal_key(
     path: &Path,
     pcr_indices: Option<&[u32]>,
 ) -> Result<()> {
-    use rand::RngCore;
+    use rand::Rng;
     use zeroize::Zeroize;
 
     let mut key = [0u8; 32];

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -773,7 +773,7 @@ pub fn generate_and_seal_key(
     use zeroize::Zeroize;
 
     let mut key = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut key);
+    rand::rng().fill_bytes(&mut key);
 
     let result = tpm.seal_key_to_file(&key, path, pcr_indices);
     key.zeroize();


### PR DESCRIPTION
## Summary

Third unblock for PR #30 (renovate: minor and patch deps), after #46 (sha2) and #47 (rusqlite). The next compile failure was \`rand\`:

\`\`\`
error[E0432]: unresolved import \`rand::RngCore\`
error[E0425]: cannot find function \`thread_rng\` in crate \`rand\`
\`\`\`

In rand 0.10:
- \`rand::thread_rng()\` was renamed to \`rand::rng()\`.
- \`fill_bytes\` is now accessed through the higher-level \`Rng\` trait, not \`RngCore\`.

Three production call sites in \`crates/facelock-tpm/src/sealing.rs\` use this to fill cryptographic buffers from OS entropy:
- \`SoftwareSealer::generate_key_file\` (AES key)
- \`SoftwareSealer::seal_bytes\` (per-call nonce)
- \`generate_and_seal_key\` (AES key sealed by TPM)

All three swap \`use rand::RngCore; rand::thread_rng().fill_bytes(..)\` → \`use rand::Rng; rand::rng().fill_bytes(..)\`. Semantic unchanged (both ultimately seed from getrandom).

Also bumps \`rand = \"0.8\" → \"0.10\"\` in \`facelock-tpm/Cargo.toml\` and Cargo.lock so the workspace resolves the version that matches the new API. Once landed, Renovate's bump line in #30 is a no-op and that PR moves on.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` — passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

## Note

This is the third batch-breakage I've encountered while trying to unblock #30. Expect more (ndarray 0.16→0.17, nix 0.29→0.31, signal-hook 0.3→0.4, reqwest 0.12→0.13 are likely to need similar adapters). Worth discussing whether to keep iterating fix-ups or close #30 and have Renovate re-split per-crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)