### PR TITLE
fix(release): bump dist/PKGBUILD-git pkgver alongside other packaging

### DIFF
--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -1,6 +1,6 @@
 # Maintainer: facelock contributors
 pkgname=facelock-git
-pkgver=0.1.0
+pkgver=0.1.3
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux (development build)"
 arch=('x86_64')

--- a/justfile
+++ b/justfile
@@ -401,6 +401,15 @@ release version:
         echo "  ✓ dist/PKGBUILD-bin"
     fi
 
+    # 2c. dist/PKGBUILD-git: the runtime pkgver() function computes the real
+    # version from `git describe`, but generate_srcinfo in publish-aur.sh runs
+    # without a git checkout, so AUR's web display falls back to this static
+    # pkgver. Keep it in sync with the release so the AUR page doesn't drift.
+    if [ -f dist/PKGBUILD-git ]; then
+        sed -i "s/^pkgver=.*/pkgver=$VERSION/" dist/PKGBUILD-git
+        echo "  ✓ dist/PKGBUILD-git"
+    fi
+
     # 3. dist/facelock.spec
     if [ -f dist/facelock.spec ]; then
         sed -i "s/^Version:.*/Version:        $VERSION/" dist/facelock.spec


### PR DESCRIPTION
## Summary

- AUR's `facelock-git` page shows `pkgver=0.1.0` even though the runtime `pkgver()` resolves to the current commit's version. `publish-aur.sh::generate_srcinfo` runs `makepkg --printsrcinfo` in a container that doesn't fetch the git source, so the `pkgver()` function never runs at SRCINFO generation time — AUR's metadata falls back to the static `pkgver=` line.
- Bump the stale static value (`0.1.0` → `0.1.3`) so the AUR display is in sync with `facelock` and `facelock-bin` for the current release.
- Extend the `just release` recipe to also sed-bump `dist/PKGBUILD-git`, matching what it already does for `dist/PKGBUILD` and `dist/PKGBUILD-bin`, so future releases don't re-drift.

Runtime install behavior is unchanged — `paru -S facelock-git` still computes the real version via `pkgver()` against the user's local clone.

## Test plan
- [x] Confirm `just release X.Y.Z` now bumps `dist/PKGBUILD-git`'s static `pkgver=` (visual sed inspection)
- [ ] CI green
- [ ] Next release should show matching versions for `facelock`, `facelock-bin`, and `facelock-git` on AUR

🤖 Generated with [Claude Code](https://claude.com/claude-code)