### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.1.4] - 2026-05-31
+
+Robustness pass: setup-wizard UX improvements, an `facelock-bin` AUR package, and a sweep of workspace dependency bumps with the cross-cutting API-change fixes they required.
+
+### Added
+
+- **AUR `facelock-bin` package**: prebuilt-binary AUR variant alongside source-build `facelock` and VCS `facelock-git`. The release workflow now publishes all three on tag push.
+- **Setup wizard: PAM edit preview and confirmation**: setup shows exactly which lines will be added to each PAM service file (with top-of-file fallback described) and asks for confirmation before mutating anything on disk.
+- **Setup wizard: display-manager and screen-locker detection**: setup detects installed display managers and lockers (Hyprland, sway, SDDM, GDM, etc.) and offers per-service opt-in via multi-select. SDDM and GDM integrations are marked experimental.
+
+### Changed
+
+- **Workspace dependency bumps**: clap 4.5→4.6, dialoguer 0.11→0.12, indicatif 0.17→0.18, ndarray 0.16→0.17, nix 0.29→0.31, rand 0.9→0.10, reqwest 0.12→0.13, rusqlite 0.32→0.40, sha2 0.10→0.11, signal-hook 0.3→0.4, tokio 1.50→1.52, tracing-subscriber 0.3.22→0.3.23, wayland-client 0.31.13→0.31.14, xkbcommon 0.8→0.9, plus libc, serde_json, toml, and `trixie` container patches.
+- **CI: GitHub Release published via PAT**: switched from `GITHUB_TOKEN` to a PAT so Packit's release-event listener fires reliably for COPR builds.
+- **GitHub Actions versions**: `actions/checkout@v6`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `softprops/action-gh-release@v3`, `cachix/install-nix-action@v31`, plus consolidated GitHub artifact actions.
+
+### Fixed
+
+- **Uninstall cleanup**: closed gaps across all four uninstall paths (deb purge, rpm erase, makepkg/AUR remove, `just uninstall`). The installed systemd unit name is now captured *before* deletion, and user-data handling messaging is clearer.
+- **`facelock clear` requires root before prompting**, not after — previously asked the confirmation question and then errored on missing privileges.
+- **AUR publish script**: distinguishes "AUR repo doesn't exist yet" from other clone failures (previously masked real errors with a fresh `git init`), and derives the GitHub repo name from `GITHUB_REPOSITORY` instead of hardcoding it.
+- **`facelock-git` AUR version display**: bumped the static `pkgver=` (used by AUR's web page because `pkgver()` doesn't run in the SRCINFO container) and extended `just release` to keep it in sync going forward.
+- **Cross-version dependency portability**: SHA256 hex encoding rewritten by-byte (in both `facelock-face::models` and `facelock-cli::commands::setup`) so the code compiles against `sha2 0.10`'s `GenericArray` and `0.11`'s `hybrid_array::Array`. SQLite timestamps in `facelock-store` cast through `i64` to avoid rusqlite 0.40 type mismatches. CLI setup wizard uses `&options[..]` so `Select::items` is correct under both `dialoguer 0.11` (slice arg) and `0.12` (generic `IntoIterator` arg, clippy-clean). TPM crate migrated to `rand` 0.10's `thread_rng → rng` and `RngCore → Rng` rename.
+
 ## [0.1.3] - 2026-05-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-bench"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-camera"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "facelock-core",
  "image",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "subtle",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-daemon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytemuck",
  "facelock-camera",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-face"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "facelock-core",
  "image",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-polkit"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "facelock-core",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "facelock-store"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytemuck",
  "facelock-core",
@@ -1237,14 +1237,14 @@ dependencies = [
 
 [[package]]
 name = "facelock-test-support"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "facelock-core",
 ]
 
 [[package]]
 name = "facelock-tpm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "facelock-core",
@@ -2449,7 +2449,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 
 [[package]]
 name = "pam-facelock"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: facelock contributors
 pkgname=facelock
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux"
 arch=('x86_64')

--- a/dist/PKGBUILD-bin
+++ b/dist/PKGBUILD-bin
@@ -1,7 +1,7 @@
 # Maintainer: facelock contributors
 pkgname=facelock-bin
 _pkgname=facelock
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux (prebuilt binaries)"
 arch=('x86_64')

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -1,6 +1,6 @@
 # Maintainer: facelock contributors
 pkgname=facelock-git
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux (development build)"
 arch=('x86_64')

--- a/dist/debian/changelog
+++ b/dist/debian/changelog
@@ -1,3 +1,9 @@
+facelock (0.1.4-1) unstable; urgency=medium
+
+  * Release v0.1.4.
+
+ -- Facelock Contributors <facelock@m.tysmith.me>  Sun, 31 May 2026 11:38:33 -0700
+
 facelock (0.1.3-1) unstable; urgency=medium
 
   * Release v0.1.3.

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -1,5 +1,5 @@
 Name:           facelock
-Version:        0.1.3
+Version:        0.1.4
 Release:        1%{?dist}
 Summary:        Face authentication for Linux PAM
 License:        MIT OR Apache-2.0


### PR DESCRIPTION
## Summary

Cut **v0.1.4** — version bump from 0.1.3 across all packaging files plus CHANGELOG entry.

**Release theme:** setup-wizard UX improvements, an AUR `facelock-bin` package, and a sweep of workspace dependency bumps with the cross-cutting API-change fixes they required.

Generated via `just release 0.1.4`, which bumped:
- `Cargo.toml`
- `dist/PKGBUILD`, `dist/PKGBUILD-bin`, `dist/PKGBUILD-git` (the `-git` bump is from the new sed line added in #51)
- `dist/facelock.spec`
- `dist/debian/changelog`

See `CHANGELOG.md` [0.1.4] for the full per-area breakdown.

## Local verification

Verified with **rustc stable** (1.96) on this branch's tree:

- ✅ `cargo build --workspace`
- ✅ `cargo build --workspace --features tpm`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo clippy --workspace --features tpm -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace` — 332 unit + integration tests pass

## Test plan

- [ ] CI green (Build/Test/Lint, Container PAM Smoke, TPM Tests)
- [ ] On merge: tag `v0.1.4` from `main` and `git push --tags` to trigger the release workflow
- [ ] `release.yml` produces:
  - [ ] GitHub Release with binaries and `SHA256SUMS`
  - [ ] `.deb` (trixie main + Ubuntu 24.04 legacy)
  - [ ] `.rpm` (Fedora container with TPM)
  - [ ] AUR pushes for `facelock`, `facelock-bin`, `facelock-git`
  - [ ] APT repo regenerated and signed
  - [ ] Pages rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)