### PR TITLE
chore(docs): bump v0.1.3 → v0.1.4 user-facing version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Facelock: Face Authentication for Linux
 
-> **v0.1.3** — Stable release. See [CHANGELOG.md](CHANGELOG.md) for details.
+> **v0.1.4** — Stable release. See [CHANGELOG.md](CHANGELOG.md) for details.
 
 A modern face authentication system for Linux PAM. Provides Windows Hello-style facial auth with IR anti-spoofing, configurable as a persistent daemon or daemonless one-shot. All inference runs locally on your hardware -- no cloud services, no network requests, no telemetry. Your biometric data never leaves your machine.
 

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -166,8 +166,8 @@ production-ready in the justfile install recipe.
 
 ## 4. Deployment Roadmap
 
-### Current state: v0.1.3 released
-- **v0.1.3 released on 2026-05-20** (tag-driven CI)
+### Current state: v0.1.4 released
+- **v0.1.4 released on 2026-05-31** (tag-driven CI)
 - Published packages: `.deb` (APT with signing key), `.rpm` (Fedora COPR via Packit), PKGBUILD (AUR)
 - `just install` / `just uninstall` for local development still available
 

--- a/website/index.html
+++ b/website/index.html
@@ -55,7 +55,7 @@
         <div class="terminal-body">
           <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
           <div>&nbsp;</div>
-          <div><span class="output">  Facelock v0.1.3</span></div>
+          <div><span class="output">  Facelock v0.1.4</span></div>
           <div><span class="output">  Linux face authentication</span></div>
           <div>&nbsp;</div>
           <div><span class="comment">  # 9 interactive steps: camera, models, encryption,</span></div>


### PR DESCRIPTION
## Summary

v0.1.4 shipped, but three places hardcode the current stable version string for human display and weren't touched by `just release`. This patches them:

- `README.md` — top banner ("**v0.1.3** — Stable release" → **v0.1.4**)
- `website/index.html` — setup-wizard mock terminal output ("Facelock v0.1.3" → v0.1.4)
- `docs/testing-roadmap.md` — "Current state: v0.1.3 released" section heading + body (also dated 2026-05-31)

## Out of scope

- `docs/superpowers/specs/2026-05-30-website-marketing-refresh-design.md` — spec snapshot, intentionally documents the state at design time.

## Noticed but not fixed (separate concern)

`docs/testing-roadmap.md:171` says **"PKGBUILD (AUR)"** in the singular. We now publish three: `facelock`, `facelock-bin`, `facelock-git`. Worth a follow-up to that line if you want the roadmap doc fully accurate, but it's adjacent to versioning rather than a version-string fix.

## Test plan

- [x] Diff is the 3 expected edits only
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)