### PR TITLE
chore: pin Rust toolchain to 1.95

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- Adds `rust-toolchain.toml` pinning Rust to 1.95 minor channel
- Fixes a latent local-build issue where stale toolchains fail in
  `libsqlite3-sys` 0.38.0's build script (`cfg_select!` was unstable
  before 1.95)

## Why now
`cargo build --workspace` on Rust 1.94 fails with:
`error[E0658]: use of unstable library feature 'cfg_select'`
in libsqlite3-sys-0.38.0/build.rs:110. Tracking issue:
https://github.com/rust-lang/rust/issues/115585

CI passes today because Arch's rust package ships 1.95, but nothing
enforces this — contributors with mise/rustup defaults can be stuck.

## Test plan
- [x] `cargo build --workspace` on a fresh rustup install (1.95 auto-installs from the pin)
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] CI green on this branch