### PR TITLE
feat(cli): facelock hyprlock subcommand + omarchy integration scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,12 @@ Facelock works with [hyprlock](https://github.com/hyprwm/hyprlock) on Hyprland (
 2. **Lock-screen tweak** in `~/.config/hypr/hyprlock.conf` — set `ignore_empty_input = false` and add a face icon to `placeholder_text`. Run as your normal user:
    ```bash
    facelock hyprlock enable      # add face icon + enable empty-Enter submission
+   facelock hyprlock enable --no-icon  # functional change only (no icon)
    facelock hyprlock disable     # revert (preserves fingerprint setup if present)
    facelock hyprlock status      # show current integration state
    ```
 
-`facelock hyprlock enable` preserves any existing fingerprint integration (icon 󰈷, `fingerprint:enabled = true`, `pam_fprintd.so`) — face and fingerprint can coexist.
+`facelock hyprlock enable` preserves any existing fingerprint integration (icon 󰈷, `fingerprint:enabled = true`, `pam_fprintd.so`) — face and fingerprint can coexist. If your hyprlock font isn't a Nerd Font, run with `--no-icon`; the functional integration still works.
 
 ### Omarchy
 

--- a/README.md
+++ b/README.md
@@ -159,16 +159,30 @@ All keys are optional. Camera is auto-detected if `device.path` is omitted.
 
 Full reference: `config/facelock.toml`.
 
-## Omarchy / Hyprlock Integration
+## Hyprlock Integration
 
-If you use [Omarchy](https://github.com/nicholasgasior/omarchy) (Hyprland desktop environment), Facelock can integrate with hyprlock:
+Facelock works with [hyprlock](https://github.com/hyprwm/hyprlock) on Hyprland (Arch, Omarchy, NixOS, etc.). Two things are needed:
+
+1. **PAM line** in `/etc/pam.d/hyprlock` — `sudo facelock setup` does this automatically when you select hyprlock in the PAM step.
+2. **Lock-screen tweak** in `~/.config/hypr/hyprlock.conf` — set `ignore_empty_input = false` and add a face icon to `placeholder_text`. Run as your normal user:
+   ```bash
+   facelock hyprlock enable      # add face icon + enable empty-Enter submission
+   facelock hyprlock disable     # revert (preserves fingerprint setup if present)
+   facelock hyprlock status      # show current integration state
+   ```
+
+`facelock hyprlock enable` preserves any existing fingerprint integration (icon 󰈷, `fingerprint:enabled = true`, `pam_fprintd.so`) — face and fingerprint can coexist.
+
+### Omarchy
+
+On Omarchy, the same flow is wrapped end-to-end (camera check → setup → enrollment → hyprlock tweak → test):
 
 ```bash
-just omarchy-enable     # add face auth icon to hyprlock placeholder
-just omarchy-disable    # remove face auth from hyprlock
+omarchy-setup-security-face       # everything in one floating-terminal session
+omarchy-remove-security-face      # symmetric removal
 ```
 
-This adds a face icon to the hyprlock password prompt and optionally sources a `hyprlock-faceauth.conf` overlay. No root required.
+These scripts mirror omarchy's own `omarchy-setup-security-fingerprint` pattern. A walker menu entry under Setup → Security → Face is pending upstream.
 
 ## Testing
 

--- a/crates/facelock-cli/src/commands/hyprlock.rs
+++ b/crates/facelock-cli/src/commands/hyprlock.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, bail};
 use clap::Subcommand;
@@ -10,8 +9,6 @@ const FACE_ICON: &str = "\u{f0100}";
 const FP_ICON: &str = "\u{f0237}";
 const BACKUP_SUFFIX: &str = ".facelock-backup";
 const PAM_HYPRLOCK_PATH: &str = "/etc/pam.d/hyprlock";
-/// Hyprlock's stock font and the most common Hyprland/Omarchy default.
-const DEFAULT_HYPRLOCK_FONT: &str = "JetBrainsMono Nerd Font";
 
 #[derive(Subcommand)]
 pub enum HyprlockCommand {
@@ -73,9 +70,8 @@ fn enable(path: &Path, no_icon: bool) -> anyhow::Result<()> {
         println!("Backed up {} -> {}", path.display(), backup_path.display());
     }
 
-    // When --no-icon is passed, leave placeholder_text alone entirely. An existing
-    // face icon stays put (use `disable` to remove it); we only flip the functional
-    // flag. The font check is skipped because no glyph will be rendered by us.
+    // With --no-icon, an existing face icon is preserved (use `disable` to remove it);
+    // we only flip the functional flag.
     let (after_placeholder, placeholder_changed, already_face) = if no_icon {
         (original.clone(), false, false)
     } else {
@@ -108,42 +104,19 @@ fn enable(path: &Path, no_icon: bool) -> anyhow::Result<()> {
         println!("general.ignore_empty_input already false.");
     }
 
-    // Font check only makes sense if we're adding/expecting an icon to render.
-    if !no_icon {
-        let font = extract_font_family(&original)
-            .unwrap_or_else(|| DEFAULT_HYPRLOCK_FONT.to_string());
-        report_font_status(&font, check_font(&font));
+    // Static install hint. We don't probe fontconfig because the result would
+    // just gate this same one-liner — the user either sees the icon (done) or
+    // sees a box (fix described here).
+    if !no_icon && placeholder_changed {
+        println!();
+        println!("Note: the face icon ({FACE_ICON}) requires a Nerd Font.");
+        println!("      If it renders as a missing-glyph box, install one:");
+        println!("      Arch:   sudo pacman -S ttf-jetbrains-mono-nerd");
+        println!("      Debian: sudo apt install fonts-jetbrains-mono");
+        println!("      Or re-run `facelock hyprlock disable && facelock hyprlock enable --no-icon`.");
     }
 
     Ok(())
-}
-
-fn report_font_status(font: &str, status: FontStatus) {
-    match status {
-        FontStatus::Installed => {}
-        FontStatus::Substituted { resolved_to } => {
-            println!();
-            println!(
-                "Note: hyprlock font '{font}' is not installed (fontconfig substituted '{resolved_to}')."
-            );
-            println!(
-                "      The face icon will render as a missing-glyph box until you install a Nerd Font."
-            );
-            println!("      Arch:   sudo pacman -S ttf-jetbrains-mono-nerd");
-            println!("      Debian: sudo apt install fonts-jetbrains-mono");
-            println!("      The functional integration still works; this is cosmetic.");
-            println!("      Re-run with `--no-icon` to skip the icon entirely.");
-        }
-        FontStatus::FcMatchMissing => {
-            println!();
-            println!(
-                "Note: fontconfig (`fc-match`) not found — cannot verify Nerd Font availability."
-            );
-            println!(
-                "      If the face icon renders as a box, install a Nerd Font for your hyprlock font."
-            );
-        }
-    }
 }
 
 fn disable(path: &Path) -> anyhow::Result<()> {
@@ -176,9 +149,8 @@ fn disable(path: &Path) -> anyhow::Result<()> {
     if general_changed {
         println!("Restored general.ignore_empty_input = true.");
     } else if fingerprint_present {
-        // Coexistence note: hyprlock needs ignore_empty_input=false to dispatch empty
-        // Enter to PAM, which is what triggers pam_fprintd / pam_facelock without a
-        // typed password.
+        // hyprlock needs ignore_empty_input=false to dispatch empty Enter to PAM,
+        // which is what triggers pam_fprintd / pam_facelock without a typed password.
         println!(
             "Fingerprint integration detected — leaving ignore_empty_input alone so fingerprint still works."
         );
@@ -243,21 +215,6 @@ fn status(path: &Path) -> anyhow::Result<()> {
         if pam_fp { "yes" } else { "no" }
     );
 
-    let font = extract_font_family(&content).unwrap_or_else(|| DEFAULT_HYPRLOCK_FONT.to_string());
-    match check_font(&font) {
-        FontStatus::Installed => {
-            println!("font ({font}):        installed");
-        }
-        FontStatus::Substituted { resolved_to } => {
-            println!(
-                "font ({font}):        NOT installed (substituted '{resolved_to}'); icon may render as box"
-            );
-        }
-        FontStatus::FcMatchMissing => {
-            println!("font ({font}):        fc-match not available");
-        }
-    }
-
     let backup = backup_path(path);
     if backup.exists() {
         println!("backup file:          {}", backup.display());
@@ -266,198 +223,78 @@ fn status(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Resolved state of the hyprlock font, as reported by fontconfig.
-#[derive(Debug, PartialEq, Eq)]
-enum FontStatus {
-    /// fontconfig returned a family that matches the requested name.
-    Installed,
-    /// fontconfig substituted a different family — the icon will likely render
-    /// as a missing-glyph box unless that fallback is itself a Nerd Font.
-    Substituted { resolved_to: String },
-    /// `fc-match` not on PATH (fontconfig not installed).
-    FcMatchMissing,
-}
-
-/// Look up the requested font family via `fc-match` and report whether it
-/// actually resolves to itself (installed) or to a different family
-/// (substituted). Tests don't shell out — see `font_resolves_to_match` for
-/// the comparison logic.
-fn check_font(requested: &str) -> FontStatus {
-    let output = match Command::new("fc-match")
-        .args(["-f", "%{family}\n", requested])
-        .output()
-    {
-        Ok(o) => o,
-        Err(_) => return FontStatus::FcMatchMissing,
-    };
-    if !output.status.success() {
-        return FontStatus::FcMatchMissing;
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let resolved = stdout.lines().next().unwrap_or("").trim().to_string();
-    if font_resolves_to_match(requested, &resolved) {
-        FontStatus::Installed
-    } else {
-        FontStatus::Substituted {
-            resolved_to: resolved,
-        }
-    }
-}
-
-/// fontconfig may return a comma-separated alias list (e.g.
-/// `"JetBrainsMono Nerd Font,JetBrainsMono NF"`). The font is considered
-/// installed if the requested name matches (case-insensitively) any alias by
-/// word-prefix in either direction. "Word-prefix" means one name is a
-/// prefix of the other at a word boundary (space or end of string). This
-/// handles the common cases:
-///   requested "JetBrains Mono"  resolved "JetBrains Mono NL"             -> match (req prefix of alias)
-///   requested "JetBrains Mono Nerd Font" resolved "JetBrains Mono"       -> match (alias prefix of req)
-///   requested "JetBrainsMono Nerd Font" resolved "JetBrainsMono Nerd Font" -> match (exact)
-///   requested "Sans"            resolved "Liberation Sans"               -> no match
-///   requested "DefinitelyNotAFont"      resolved "Liberation Sans"       -> no match
-fn font_resolves_to_match(requested: &str, resolved: &str) -> bool {
-    if resolved.trim().is_empty() {
-        return false;
-    }
-    let req = requested.trim().to_ascii_lowercase();
-    if req.is_empty() {
-        return false;
-    }
-    resolved
-        .split(',')
-        .map(|s| s.trim().to_ascii_lowercase())
-        .any(|alias| {
-            if alias.is_empty() {
-                return false;
-            }
-            // Exact match
-            if alias == req {
-                return true;
-            }
-            // alias is a word-boundary prefix of req: req starts with alias
-            // followed by a space (e.g. req="JetBrains Mono Nerd Font", alias="JetBrains Mono")
-            if req.starts_with(&alias)
-                && req[alias.len()..].starts_with(' ')
-            {
-                return true;
-            }
-            // req is a word-boundary prefix of alias: alias starts with req
-            // followed by a space (e.g. alias="JetBrains Mono NL", req="JetBrains Mono")
-            if alias.starts_with(&req)
-                && alias[req.len()..].starts_with(' ')
-            {
-                return true;
-            }
-            false
-        })
-}
-
-/// Parse `font_family = X` from hyprlock.conf, preserving any quoting in the
-/// value. Looks inside the first `input-field { ... }` block; ignores
-/// `font_family` keys in other blocks (e.g. `label`). Returns None when no
-/// override is set — callers should default to `DEFAULT_HYPRLOCK_FONT`.
-fn extract_font_family(input: &str) -> Option<String> {
-    let mut in_input_field = false;
-    let mut depth = 0i32;
-    for line in input.lines() {
-        let trimmed = line.trim();
-        if !in_input_field {
-            if trimmed.starts_with("input-field") && trimmed.contains('{') {
-                in_input_field = true;
-                depth = 1;
-            }
-            continue;
-        }
-        // Track nested braces so we don't leave the block prematurely.
-        for ch in trimmed.chars() {
-            if ch == '{' {
-                depth += 1;
-            } else if ch == '}' {
-                depth -= 1;
-            }
-        }
-        if depth <= 0 {
-            return None;
-        }
-        if let Some(rest) = trimmed.strip_prefix("font_family")
-            && let Some(idx) = rest.find('=')
-        {
-            return Some(rest[idx + 1..].trim().to_string());
-        }
-    }
-    None
-}
-
 fn backup_path(path: &Path) -> PathBuf {
     let mut s = path.as_os_str().to_owned();
     s.push(BACKUP_SUFFIX);
     PathBuf::from(s)
 }
 
+/// Insert the face icon into the first `placeholder_text` line, preserving any
+/// existing content. If the value ends with `</span>`, insert before it; otherwise
+/// append at end of line. Either way, user customization (custom prompt text,
+/// other icons, span attributes) is left intact.
 fn add_face_icon(input: &str) -> (String, bool, bool) {
-    let mut out = String::with_capacity(input.len());
+    let mut out = String::with_capacity(input.len() + FACE_ICON.len() + 1);
     let mut changed = false;
     let mut already = false;
-    let mut found_any = false;
+    let mut found = false;
 
     for line in input.lines() {
         let trimmed = line.trim_start();
-        if !found_any && trimmed.starts_with("placeholder_text") && trimmed.contains('=') {
-            found_any = true;
-            if trimmed.contains(FACE_ICON) {
+        if !found && trimmed.starts_with("placeholder_text") && trimmed.contains('=') {
+            found = true;
+            if line.contains(FACE_ICON) {
                 already = true;
                 out.push_str(line);
-                out.push('\n');
-                continue;
-            }
-            let has_fp = trimmed.contains(FP_ICON);
-            let indent = &line[..line.len() - trimmed.len()];
-            let new_value = if has_fp {
-                format!("<span> Enter Password {FACE_ICON} {FP_ICON} </span>")
             } else {
-                format!("<span> Enter Password {FACE_ICON} </span>")
-            };
-            out.push_str(indent);
-            out.push_str(&format!("placeholder_text = {new_value}\n"));
-            changed = true;
+                out.push_str(&insert_icon(line));
+                changed = true;
+            }
         } else {
             out.push_str(line);
-            out.push('\n');
         }
+        out.push('\n');
     }
 
     preserve_trailing_newline(input, &mut out);
     (out, changed, already)
 }
 
+fn insert_icon(line: &str) -> String {
+    match line.rfind("</span>") {
+        Some(idx) => {
+            let (before, after) = line.split_at(idx);
+            format!("{} {FACE_ICON} {}", before.trim_end(), after)
+        }
+        None => format!("{} {FACE_ICON}", line.trim_end()),
+    }
+}
+
+/// Splice the face icon out of any line containing it. Strips an adjacent space
+/// so we don't leave a dangling double-space; if the icon is bare (no neighbor
+/// space) we just remove the codepoint.
 fn remove_face_icon(input: &str) -> (String, bool) {
     let mut out = String::with_capacity(input.len());
     let mut changed = false;
 
     for line in input.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("placeholder_text")
-            && trimmed.contains('=')
-            && trimmed.contains(FACE_ICON)
-        {
-            let has_fp = trimmed.contains(FP_ICON);
-            let indent = &line[..line.len() - trimmed.len()];
-            let new_value = if has_fp {
-                format!("<span> Enter Password {FP_ICON} </span>")
-            } else {
-                "Enter Password".to_string()
-            };
-            out.push_str(indent);
-            out.push_str(&format!("placeholder_text = {new_value}\n"));
+        if line.contains(FACE_ICON) {
+            out.push_str(&strip_icon(line));
             changed = true;
         } else {
             out.push_str(line);
-            out.push('\n');
         }
+        out.push('\n');
     }
 
     preserve_trailing_newline(input, &mut out);
     (out, changed)
+}
+
+fn strip_icon(line: &str) -> String {
+    line.replace(&format!(" {FACE_ICON}"), "")
+        .replace(&format!("{FACE_ICON} "), "")
+        .replace(FACE_ICON, "")
 }
 
 fn set_ignore_empty_input(input: &str, value: bool) -> (String, bool) {
@@ -525,10 +362,7 @@ fn inject_into_general_block(input: &str, target: &str) -> Option<String> {
     let close_idx = close_idx?;
 
     let mut out_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    out_lines.insert(
-        close_idx,
-        format!("    ignore_empty_input = {target}"),
-    );
+    out_lines.insert(close_idx, format!("    ignore_empty_input = {target}"));
 
     let mut joined = out_lines.join("\n");
     if input.ends_with('\n') {
@@ -636,6 +470,35 @@ mod tests {
     }
 
     #[test]
+    fn enable_preserves_custom_placeholder_text() {
+        // User changed the default prompt — we must not clobber it.
+        let input = "input-field {\n    placeholder_text = <span> Unlock thy domain </span>\n}\n";
+        let (after, _, _) = add_face_icon(input);
+        assert!(after.contains("Unlock thy domain"));
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains("</span>"));
+    }
+
+    #[test]
+    fn enable_inserts_icon_before_closing_span() {
+        let input = "    placeholder_text = <span> Enter Password </span>\n";
+        let (after, _, _) = add_face_icon(input);
+        let line = after.lines().next().unwrap();
+        // Icon must appear before </span>, not after it.
+        let icon_pos = line.find(FACE_ICON).unwrap();
+        let span_close_pos = line.find("</span>").unwrap();
+        assert!(icon_pos < span_close_pos);
+    }
+
+    #[test]
+    fn enable_appends_icon_when_no_span() {
+        let input = "    placeholder_text = Enter Password\n";
+        let (after, _, _) = add_face_icon(input);
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains("Enter Password"));
+    }
+
+    #[test]
     fn enable_is_idempotent() {
         let (after, _, _) = add_face_icon(STOCK_OMARCHY);
         let (after2, changed, already) = add_face_icon(&after);
@@ -734,8 +597,11 @@ mod tests {
     fn pam_contains_via_tempfile() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("hyprlock");
-        std::fs::write(&path, "auth required pam_unix.so\nauth sufficient pam_fprintd.so\n")
-            .unwrap();
+        std::fs::write(
+            &path,
+            "auth required pam_unix.so\nauth sufficient pam_fprintd.so\n",
+        )
+        .unwrap();
         assert!(pam_has_fingerprint(&path));
         assert!(pam_contains(&path, "pam_unix.so"));
         assert!(!pam_contains(&path, "pam_facelock.so"));
@@ -766,102 +632,6 @@ mod tests {
     }
 
     #[test]
-    fn extract_font_family_absent_on_stock_omarchy() {
-        assert_eq!(extract_font_family(STOCK_OMARCHY), None);
-    }
-
-    #[test]
-    fn extract_font_family_with_spaces() {
-        let input = "input-field {\n    font_family = JetBrainsMono Nerd Font\n}\n";
-        assert_eq!(
-            extract_font_family(input),
-            Some("JetBrainsMono Nerd Font".to_string())
-        );
-    }
-
-    #[test]
-    fn extract_font_family_with_quotes_preserved() {
-        let input = "input-field {\n    font_family = \"JetBrainsMono Nerd Font\"\n}\n";
-        assert_eq!(
-            extract_font_family(input),
-            Some("\"JetBrainsMono Nerd Font\"".to_string())
-        );
-    }
-
-    #[test]
-    fn extract_font_family_ignores_other_blocks() {
-        // font_family in a label block should not be returned; input-field has none.
-        let input = "label {\n    font_family = Comic Sans\n    text = hi\n}\n\
-                     input-field {\n    placeholder_text = Enter Password\n}\n";
-        assert_eq!(extract_font_family(input), None);
-    }
-
-    #[test]
-    fn extract_font_family_prefers_input_field_block() {
-        let input = "label {\n    font_family = Comic Sans\n}\n\
-                     input-field {\n    font_family = JetBrainsMono Nerd Font\n}\n";
-        assert_eq!(
-            extract_font_family(input),
-            Some("JetBrainsMono Nerd Font".to_string())
-        );
-    }
-
-    #[test]
-    fn extract_font_family_no_input_field_block() {
-        let input = "general {\n    grace = 0\n}\n";
-        assert_eq!(extract_font_family(input), None);
-    }
-
-    #[test]
-    fn font_match_exact_case_insensitive() {
-        assert!(font_resolves_to_match(
-            "JetBrainsMono Nerd Font",
-            "JetBrainsMono Nerd Font"
-        ));
-        assert!(font_resolves_to_match(
-            "jetbrainsmono nerd font",
-            "JetBrainsMono Nerd Font"
-        ));
-    }
-
-    #[test]
-    fn font_match_alias_list() {
-        // Real fc-match output for installed Nerd Font.
-        assert!(font_resolves_to_match(
-            "JetBrainsMono Nerd Font",
-            "JetBrainsMono Nerd Font,JetBrainsMono NF"
-        ));
-    }
-
-    #[test]
-    fn font_match_substring_either_direction() {
-        // Requested name contains resolved alias.
-        assert!(font_resolves_to_match(
-            "JetBrains Mono Nerd Font",
-            "JetBrains Mono"
-        ));
-        // Resolved alias contains requested.
-        assert!(font_resolves_to_match("JetBrains Mono", "JetBrains Mono NL"));
-    }
-
-    #[test]
-    fn font_no_match_when_substituted() {
-        // Typical "font missing" case: requested random name, fontconfig falls back.
-        assert!(!font_resolves_to_match("Sans", "Liberation Sans"));
-        assert!(!font_resolves_to_match(
-            "JetBrainsMono Nerd Font",
-            "DejaVu Sans"
-        ));
-        assert!(!font_resolves_to_match("DefinitelyNotAFont", "Liberation Sans"));
-    }
-
-    #[test]
-    fn font_no_match_when_empty() {
-        assert!(!font_resolves_to_match("Sans", ""));
-        assert!(!font_resolves_to_match("", "Liberation Sans"));
-    }
-
-    #[test]
     fn enable_with_no_icon_skips_placeholder_flips_flag() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("hyprlock.conf");
@@ -883,14 +653,13 @@ mod tests {
     fn enable_with_no_icon_is_idempotent_and_preserves_existing_icon() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("hyprlock.conf");
-        // Start with face icon already present and ignore_empty_input = false.
         let preexisting = format!(
             "general {{\n    ignore_empty_input = false\n}}\n\n\
              input-field {{\n    placeholder_text = <span> Enter Password {FACE_ICON} </span>\n}}\n"
         );
         std::fs::write(&path, &preexisting).unwrap();
 
-        // --no-icon should NOT remove the existing icon (that's disable's job).
+        // --no-icon must not remove the existing icon (that's disable's job).
         enable(&path, true).unwrap();
 
         let after = std::fs::read_to_string(&path).unwrap();

--- a/crates/facelock-cli/src/commands/hyprlock.rs
+++ b/crates/facelock-cli/src/commands/hyprlock.rs
@@ -60,8 +60,8 @@ fn locate_hyprlock_conf() -> anyhow::Result<PathBuf> {
 }
 
 fn enable(path: &Path, no_icon: bool) -> anyhow::Result<()> {
-    let original = fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let original =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
 
     let backup_path = backup_path(path);
     if !backup_path.exists() {
@@ -113,15 +113,17 @@ fn enable(path: &Path, no_icon: bool) -> anyhow::Result<()> {
         println!("      If it renders as a missing-glyph box, install one:");
         println!("      Arch:   sudo pacman -S ttf-jetbrains-mono-nerd");
         println!("      Debian: sudo apt install fonts-jetbrains-mono");
-        println!("      Or re-run `facelock hyprlock disable && facelock hyprlock enable --no-icon`.");
+        println!(
+            "      Or re-run `facelock hyprlock disable && facelock hyprlock enable --no-icon`."
+        );
     }
 
     Ok(())
 }
 
 fn disable(path: &Path) -> anyhow::Result<()> {
-    let original = fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let original =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
 
     let (after_placeholder, placeholder_changed) = remove_face_icon(&original);
 
@@ -168,16 +170,14 @@ fn disable(path: &Path) -> anyhow::Result<()> {
 }
 
 fn status(path: &Path) -> anyhow::Result<()> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
 
     let placeholder = extract_placeholder_text(&content);
     let face_present = placeholder
         .as_deref()
         .is_some_and(|p| p.contains(FACE_ICON));
-    let fp_present = placeholder
-        .as_deref()
-        .is_some_and(|p| p.contains(FP_ICON));
+    let fp_present = placeholder.as_deref().is_some_and(|p| p.contains(FP_ICON));
     let ignore_empty = extract_ignore_empty_input(&content);
     let pam_face = pam_contains(Path::new(PAM_HYPRLOCK_PATH), "pam_facelock.so");
     let pam_fp = pam_contains(Path::new(PAM_HYPRLOCK_PATH), "pam_fprintd.so");
@@ -640,7 +640,10 @@ mod tests {
         enable(&path, true).unwrap();
 
         let after = std::fs::read_to_string(&path).unwrap();
-        assert!(!after.contains(FACE_ICON), "no icon expected with --no-icon");
+        assert!(
+            !after.contains(FACE_ICON),
+            "no icon expected with --no-icon"
+        );
         assert!(
             after.contains("placeholder_text = Enter Password"),
             "placeholder text should be untouched"

--- a/crates/facelock-cli/src/commands/hyprlock.rs
+++ b/crates/facelock-cli/src/commands/hyprlock.rs
@@ -1,0 +1,574 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+use clap::Subcommand;
+
+const FACE_ICON: &str = "\u{f0100}";
+const FP_ICON: &str = "\u{f0237}";
+const BACKUP_SUFFIX: &str = ".facelock-backup";
+const PAM_HYPRLOCK_PATH: &str = "/etc/pam.d/hyprlock";
+
+#[derive(Subcommand)]
+pub enum HyprlockCommand {
+    /// Add face icon and enable empty-Enter submission in hyprlock.conf
+    Enable,
+    /// Remove face icon and (if no fingerprint coexists) restore ignore_empty_input
+    Disable,
+    /// Show current hyprlock integration state
+    Status,
+}
+
+pub fn run(command: HyprlockCommand) -> anyhow::Result<()> {
+    if nix::unistd::Uid::current().is_root() {
+        bail!(
+            "facelock hyprlock must run as your normal user (it edits files under $HOME).\n\
+             If invoked via sudo, re-run without sudo."
+        );
+    }
+
+    let conf_path = locate_hyprlock_conf()?;
+
+    match command {
+        HyprlockCommand::Enable => enable(&conf_path),
+        HyprlockCommand::Disable => disable(&conf_path),
+        HyprlockCommand::Status => status(&conf_path),
+    }
+}
+
+fn locate_hyprlock_conf() -> anyhow::Result<PathBuf> {
+    let config_home = env::var_os("XDG_CONFIG_HOME")
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))
+        .context("could not determine XDG_CONFIG_HOME or HOME")?;
+    let path = config_home.join("hypr").join("hyprlock.conf");
+    if !path.exists() {
+        bail!(
+            "hyprlock config not found at {}.\n\
+             Install hyprlock and create the config first.",
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+fn enable(path: &Path) -> anyhow::Result<()> {
+    let original = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let backup_path = backup_path(path);
+    if !backup_path.exists() {
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("failed to back up {}", path.display()))?;
+        println!("Backed up {} -> {}", path.display(), backup_path.display());
+    }
+
+    let (after_placeholder, placeholder_changed, already_face) = add_face_icon(&original);
+    let (after_general, general_changed) = set_ignore_empty_input(&after_placeholder, false);
+
+    if !placeholder_changed && !general_changed && already_face {
+        println!("Face icon already present and ignore_empty_input already false.");
+        return Ok(());
+    }
+
+    fs::write(path, &after_general)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    if already_face {
+        println!("Face icon already present in placeholder_text.");
+    } else if placeholder_changed {
+        println!("Added face icon to placeholder_text.");
+    }
+    if general_changed {
+        println!("Set general.ignore_empty_input = false.");
+    } else {
+        println!("general.ignore_empty_input already false.");
+    }
+
+    Ok(())
+}
+
+fn disable(path: &Path) -> anyhow::Result<()> {
+    let original = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let (after_placeholder, placeholder_changed) = remove_face_icon(&original);
+
+    let fp_in_pam = pam_has_fingerprint(Path::new(PAM_HYPRLOCK_PATH));
+    let fp_in_conf = conf_has_fingerprint_enabled(&after_placeholder);
+    let fingerprint_present = fp_in_pam || fp_in_conf;
+
+    let (final_content, general_changed) = if fingerprint_present {
+        (after_placeholder, false)
+    } else {
+        set_ignore_empty_input(&after_placeholder, true)
+    };
+
+    if !placeholder_changed && !general_changed {
+        println!("Face icon not present and ignore_empty_input unchanged. Nothing to do.");
+        return Ok(());
+    }
+
+    fs::write(path, &final_content)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    if placeholder_changed {
+        println!("Removed face icon from placeholder_text.");
+    }
+    if general_changed {
+        println!("Restored general.ignore_empty_input = true.");
+    } else if fingerprint_present {
+        // Coexistence note: hyprlock needs ignore_empty_input=false to dispatch empty
+        // Enter to PAM, which is what triggers pam_fprintd / pam_facelock without a
+        // typed password.
+        println!(
+            "Fingerprint integration detected — leaving ignore_empty_input alone so fingerprint still works."
+        );
+    }
+
+    let backup = backup_path(path);
+    if backup.exists() {
+        println!(
+            "Backup left in place at {} (delete manually if no longer needed).",
+            backup.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn status(path: &Path) -> anyhow::Result<()> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    let placeholder = extract_placeholder_text(&content);
+    let face_present = placeholder
+        .as_deref()
+        .is_some_and(|p| p.contains(FACE_ICON));
+    let fp_present = placeholder
+        .as_deref()
+        .is_some_and(|p| p.contains(FP_ICON));
+    let ignore_empty = extract_ignore_empty_input(&content);
+    let pam_face = pam_contains(Path::new(PAM_HYPRLOCK_PATH), "pam_facelock.so");
+    let pam_fp = pam_contains(Path::new(PAM_HYPRLOCK_PATH), "pam_fprintd.so");
+
+    println!("hyprlock.conf:        {}", path.display());
+    println!(
+        "placeholder_text:     {}",
+        placeholder.as_deref().unwrap_or("<missing>")
+    );
+    println!(
+        "  face icon ({}): {}",
+        FACE_ICON,
+        if face_present { "yes" } else { "no" }
+    );
+    println!(
+        "  fingerprint icon ({}): {}",
+        FP_ICON,
+        if fp_present { "yes" } else { "no" }
+    );
+    println!(
+        "ignore_empty_input:   {}",
+        match ignore_empty {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "<not set>",
+        }
+    );
+    println!("PAM /etc/pam.d/hyprlock:");
+    println!(
+        "  pam_facelock.so:    {}",
+        if pam_face { "yes" } else { "no" }
+    );
+    println!(
+        "  pam_fprintd.so:     {}",
+        if pam_fp { "yes" } else { "no" }
+    );
+
+    let backup = backup_path(path);
+    if backup.exists() {
+        println!("backup file:          {}", backup.display());
+    }
+
+    Ok(())
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(BACKUP_SUFFIX);
+    PathBuf::from(s)
+}
+
+fn add_face_icon(input: &str) -> (String, bool, bool) {
+    let mut out = String::with_capacity(input.len());
+    let mut changed = false;
+    let mut already = false;
+    let mut found_any = false;
+
+    for line in input.lines() {
+        let trimmed = line.trim_start();
+        if !found_any && trimmed.starts_with("placeholder_text") && trimmed.contains('=') {
+            found_any = true;
+            if trimmed.contains(FACE_ICON) {
+                already = true;
+                out.push_str(line);
+                out.push('\n');
+                continue;
+            }
+            let has_fp = trimmed.contains(FP_ICON);
+            let indent = &line[..line.len() - trimmed.len()];
+            let new_value = if has_fp {
+                format!("<span> Enter Password {FACE_ICON} {FP_ICON} </span>")
+            } else {
+                format!("<span> Enter Password {FACE_ICON} </span>")
+            };
+            out.push_str(indent);
+            out.push_str(&format!("placeholder_text = {new_value}\n"));
+            changed = true;
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    preserve_trailing_newline(input, &mut out);
+    (out, changed, already)
+}
+
+fn remove_face_icon(input: &str) -> (String, bool) {
+    let mut out = String::with_capacity(input.len());
+    let mut changed = false;
+
+    for line in input.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("placeholder_text")
+            && trimmed.contains('=')
+            && trimmed.contains(FACE_ICON)
+        {
+            let has_fp = trimmed.contains(FP_ICON);
+            let indent = &line[..line.len() - trimmed.len()];
+            let new_value = if has_fp {
+                format!("<span> Enter Password {FP_ICON} </span>")
+            } else {
+                "Enter Password".to_string()
+            };
+            out.push_str(indent);
+            out.push_str(&format!("placeholder_text = {new_value}\n"));
+            changed = true;
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+
+    preserve_trailing_newline(input, &mut out);
+    (out, changed)
+}
+
+fn set_ignore_empty_input(input: &str, value: bool) -> (String, bool) {
+    let target = if value { "true" } else { "false" };
+    let current = extract_ignore_empty_input(input);
+    if current == Some(value) {
+        return (input.to_string(), false);
+    }
+
+    if current.is_some() {
+        let mut out = String::with_capacity(input.len());
+        for line in input.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("ignore_empty_input") && trimmed.contains('=') {
+                let indent = &line[..line.len() - trimmed.len()];
+                out.push_str(indent);
+                out.push_str(&format!("ignore_empty_input = {target}\n"));
+            } else {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        preserve_trailing_newline(input, &mut out);
+        return (out, true);
+    }
+
+    if let Some(injected) = inject_into_general_block(input, target) {
+        return (injected, true);
+    }
+
+    let mut out = String::new();
+    out.push_str("general {\n");
+    out.push_str(&format!("    ignore_empty_input = {target}\n"));
+    out.push_str("}\n\n");
+    out.push_str(input);
+    (out, true)
+}
+
+fn inject_into_general_block(input: &str, target: &str) -> Option<String> {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut header_idx = None;
+    for (i, line) in lines.iter().enumerate() {
+        let t = line.trim();
+        if t == "general {" || t.starts_with("general {") || t == "general{" {
+            header_idx = Some(i);
+            break;
+        }
+    }
+    let header_idx = header_idx?;
+
+    let mut close_idx = None;
+    let mut depth = 1usize;
+    for (i, line) in lines.iter().enumerate().skip(header_idx + 1) {
+        let t = line.trim();
+        if t.starts_with('}') {
+            depth -= 1;
+            if depth == 0 {
+                close_idx = Some(i);
+                break;
+            }
+        } else if t.ends_with('{') {
+            depth += 1;
+        }
+    }
+    let close_idx = close_idx?;
+
+    let mut out_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    out_lines.insert(
+        close_idx,
+        format!("    ignore_empty_input = {target}"),
+    );
+
+    let mut joined = out_lines.join("\n");
+    if input.ends_with('\n') {
+        joined.push('\n');
+    }
+    Some(joined)
+}
+
+fn preserve_trailing_newline(input: &str, out: &mut String) {
+    if !input.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+}
+
+fn extract_placeholder_text(input: &str) -> Option<String> {
+    for line in input.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("placeholder_text")
+            && let Some(idx) = rest.find('=')
+        {
+            return Some(rest[idx + 1..].trim().to_string());
+        }
+    }
+    None
+}
+
+fn extract_ignore_empty_input(input: &str) -> Option<bool> {
+    for line in input.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("ignore_empty_input")
+            && let Some(idx) = rest.find('=')
+        {
+            let val = rest[idx + 1..].trim();
+            return match val {
+                "true" | "1" | "yes" => Some(true),
+                "false" | "0" | "no" => Some(false),
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
+fn conf_has_fingerprint_enabled(input: &str) -> bool {
+    for line in input.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("fingerprint:enabled")
+            && let Some(idx) = rest.find('=')
+        {
+            let val = rest[idx + 1..].trim();
+            if matches!(val, "true" | "1" | "yes") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn pam_has_fingerprint(path: &Path) -> bool {
+    pam_contains(path, "pam_fprintd.so")
+}
+
+fn pam_contains(path: &Path, needle: &str) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    content
+        .lines()
+        .any(|l| !l.trim_start().starts_with('#') && l.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const STOCK_OMARCHY: &str = "general {\n    grace = 0\n    hide_cursor = true\n    ignore_empty_input = true\n}\n\ninput-field {\n    placeholder_text = Enter Password\n}\n";
+
+    #[test]
+    fn enable_stock_omarchy_adds_icon_and_flips_flag() {
+        let (after, changed, already) = add_face_icon(STOCK_OMARCHY);
+        assert!(changed);
+        assert!(!already);
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains("Enter Password"));
+
+        let (after2, flag_changed) = set_ignore_empty_input(&after, false);
+        assert!(flag_changed);
+        assert!(after2.contains("ignore_empty_input = false"));
+        assert!(!after2.contains("ignore_empty_input = true"));
+    }
+
+    #[test]
+    fn enable_preserves_fingerprint_icon() {
+        let input = format!(
+            "input-field {{\n    placeholder_text = <span> Enter Password {FP_ICON} </span>\n}}\n"
+        );
+        let (after, changed, already) = add_face_icon(&input);
+        assert!(changed);
+        assert!(!already);
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains(FP_ICON));
+    }
+
+    #[test]
+    fn enable_is_idempotent() {
+        let (after, _, _) = add_face_icon(STOCK_OMARCHY);
+        let (after2, changed, already) = add_face_icon(&after);
+        assert!(!changed);
+        assert!(already);
+        assert_eq!(after, after2);
+
+        let (flag1, _) = set_ignore_empty_input(&after, false);
+        let (flag2, changed) = set_ignore_empty_input(&flag1, false);
+        assert!(!changed);
+        assert_eq!(flag1, flag2);
+    }
+
+    #[test]
+    fn disable_removes_face_icon_preserves_fingerprint() {
+        let input = format!(
+            "input-field {{\n    placeholder_text = <span> Enter Password {FACE_ICON} {FP_ICON} </span>\n}}\n"
+        );
+        let (after, changed) = remove_face_icon(&input);
+        assert!(changed);
+        assert!(!after.contains(FACE_ICON));
+        assert!(after.contains(FP_ICON));
+    }
+
+    #[test]
+    fn disable_restores_ignore_empty_when_no_fingerprint() {
+        let input = format!(
+            "general {{\n    ignore_empty_input = false\n}}\n\ninput-field {{\n    placeholder_text = <span> Enter Password {FACE_ICON} </span>\n}}\n"
+        );
+        let (after, _) = remove_face_icon(&input);
+        let (after2, changed) = set_ignore_empty_input(&after, true);
+        assert!(changed);
+        assert!(after2.contains("ignore_empty_input = true"));
+    }
+
+    #[test]
+    fn disable_preserves_ignore_empty_when_fingerprint_enabled_in_conf() {
+        let input = format!(
+            "general {{\n    ignore_empty_input = false\n    fingerprint:enabled = true\n}}\n\ninput-field {{\n    placeholder_text = <span> Enter Password {FACE_ICON} {FP_ICON} </span>\n}}\n"
+        );
+        assert!(conf_has_fingerprint_enabled(&input));
+        let (after, _) = remove_face_icon(&input);
+        assert!(conf_has_fingerprint_enabled(&after));
+        assert_eq!(extract_ignore_empty_input(&after), Some(false));
+    }
+
+    #[test]
+    fn missing_general_block_is_prepended() {
+        let input = "input-field {\n    placeholder_text = Enter Password\n}\n";
+        let (after, changed) = set_ignore_empty_input(input, false);
+        assert!(changed);
+        assert!(after.starts_with("general {"));
+        assert!(after.contains("ignore_empty_input = false"));
+        assert!(after.contains("input-field {"));
+    }
+
+    #[test]
+    fn existing_general_with_other_keys_only_touches_target() {
+        let input = "general {\n    grace = 5\n    hide_cursor = true\n}\n";
+        let (after, changed) = set_ignore_empty_input(input, false);
+        assert!(changed);
+        assert!(after.contains("grace = 5"));
+        assert!(after.contains("hide_cursor = true"));
+        assert!(after.contains("ignore_empty_input = false"));
+    }
+
+    #[test]
+    fn extract_placeholder_and_flag() {
+        assert_eq!(
+            extract_placeholder_text("    placeholder_text = Enter Password\n"),
+            Some("Enter Password".to_string())
+        );
+        assert_eq!(
+            extract_ignore_empty_input("    ignore_empty_input = false\n"),
+            Some(false)
+        );
+        assert_eq!(
+            extract_ignore_empty_input("    ignore_empty_input = true\n"),
+            Some(true)
+        );
+        assert_eq!(extract_ignore_empty_input("nothing here"), None);
+    }
+
+    #[test]
+    fn fingerprint_enabled_detection() {
+        assert!(conf_has_fingerprint_enabled("fingerprint:enabled = true\n"));
+        assert!(!conf_has_fingerprint_enabled(
+            "fingerprint:enabled = false\n"
+        ));
+        assert!(!conf_has_fingerprint_enabled(
+            "# fingerprint:enabled = true\n"
+        ));
+    }
+
+    #[test]
+    fn pam_contains_via_tempfile() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hyprlock");
+        std::fs::write(&path, "auth required pam_unix.so\nauth sufficient pam_fprintd.so\n")
+            .unwrap();
+        assert!(pam_has_fingerprint(&path));
+        assert!(pam_contains(&path, "pam_unix.so"));
+        assert!(!pam_contains(&path, "pam_facelock.so"));
+    }
+
+    #[test]
+    fn end_to_end_via_tempfile() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hyprlock.conf");
+        std::fs::write(&path, STOCK_OMARCHY).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let (a, _, _) = add_face_icon(&content);
+        let (b, _) = set_ignore_empty_input(&a, false);
+        std::fs::write(&path, &b).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains("ignore_empty_input = false"));
+
+        let (c, _) = remove_face_icon(&after);
+        let (d, _) = set_ignore_empty_input(&c, true);
+        std::fs::write(&path, &d).unwrap();
+
+        let final_content = std::fs::read_to_string(&path).unwrap();
+        assert!(!final_content.contains(FACE_ICON));
+        assert!(final_content.contains("ignore_empty_input = true"));
+    }
+}

--- a/crates/facelock-cli/src/commands/hyprlock.rs
+++ b/crates/facelock-cli/src/commands/hyprlock.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::{Context, bail};
 use clap::Subcommand;
@@ -9,11 +10,18 @@ const FACE_ICON: &str = "\u{f0100}";
 const FP_ICON: &str = "\u{f0237}";
 const BACKUP_SUFFIX: &str = ".facelock-backup";
 const PAM_HYPRLOCK_PATH: &str = "/etc/pam.d/hyprlock";
+/// Hyprlock's stock font and the most common Hyprland/Omarchy default.
+const DEFAULT_HYPRLOCK_FONT: &str = "JetBrainsMono Nerd Font";
 
 #[derive(Subcommand)]
 pub enum HyprlockCommand {
     /// Add face icon and enable empty-Enter submission in hyprlock.conf
-    Enable,
+    Enable {
+        /// Skip the cosmetic face icon; only set ignore_empty_input = false.
+        /// Useful when your hyprlock font isn't a Nerd Font.
+        #[arg(long)]
+        no_icon: bool,
+    },
     /// Remove face icon and (if no fingerprint coexists) restore ignore_empty_input
     Disable,
     /// Show current hyprlock integration state
@@ -31,7 +39,7 @@ pub fn run(command: HyprlockCommand) -> anyhow::Result<()> {
     let conf_path = locate_hyprlock_conf()?;
 
     match command {
-        HyprlockCommand::Enable => enable(&conf_path),
+        HyprlockCommand::Enable { no_icon } => enable(&conf_path, no_icon),
         HyprlockCommand::Disable => disable(&conf_path),
         HyprlockCommand::Status => status(&conf_path),
     }
@@ -54,7 +62,7 @@ fn locate_hyprlock_conf() -> anyhow::Result<PathBuf> {
     Ok(path)
 }
 
-fn enable(path: &Path) -> anyhow::Result<()> {
+fn enable(path: &Path, no_icon: bool) -> anyhow::Result<()> {
     let original = fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
 
@@ -65,18 +73,31 @@ fn enable(path: &Path) -> anyhow::Result<()> {
         println!("Backed up {} -> {}", path.display(), backup_path.display());
     }
 
-    let (after_placeholder, placeholder_changed, already_face) = add_face_icon(&original);
+    // When --no-icon is passed, leave placeholder_text alone entirely. An existing
+    // face icon stays put (use `disable` to remove it); we only flip the functional
+    // flag. The font check is skipped because no glyph will be rendered by us.
+    let (after_placeholder, placeholder_changed, already_face) = if no_icon {
+        (original.clone(), false, false)
+    } else {
+        add_face_icon(&original)
+    };
     let (after_general, general_changed) = set_ignore_empty_input(&after_placeholder, false);
 
-    if !placeholder_changed && !general_changed && already_face {
-        println!("Face icon already present and ignore_empty_input already false.");
+    if !placeholder_changed && !general_changed && (no_icon || already_face) {
+        if no_icon {
+            println!("Skipping icon (--no-icon). ignore_empty_input already false.");
+        } else {
+            println!("Face icon already present and ignore_empty_input already false.");
+        }
         return Ok(());
     }
 
     fs::write(path, &after_general)
         .with_context(|| format!("failed to write {}", path.display()))?;
 
-    if already_face {
+    if no_icon {
+        println!("Skipping icon (--no-icon); placeholder_text untouched.");
+    } else if already_face {
         println!("Face icon already present in placeholder_text.");
     } else if placeholder_changed {
         println!("Added face icon to placeholder_text.");
@@ -87,7 +108,42 @@ fn enable(path: &Path) -> anyhow::Result<()> {
         println!("general.ignore_empty_input already false.");
     }
 
+    // Font check only makes sense if we're adding/expecting an icon to render.
+    if !no_icon {
+        let font = extract_font_family(&original)
+            .unwrap_or_else(|| DEFAULT_HYPRLOCK_FONT.to_string());
+        report_font_status(&font, check_font(&font));
+    }
+
     Ok(())
+}
+
+fn report_font_status(font: &str, status: FontStatus) {
+    match status {
+        FontStatus::Installed => {}
+        FontStatus::Substituted { resolved_to } => {
+            println!();
+            println!(
+                "Note: hyprlock font '{font}' is not installed (fontconfig substituted '{resolved_to}')."
+            );
+            println!(
+                "      The face icon will render as a missing-glyph box until you install a Nerd Font."
+            );
+            println!("      Arch:   sudo pacman -S ttf-jetbrains-mono-nerd");
+            println!("      Debian: sudo apt install fonts-jetbrains-mono");
+            println!("      The functional integration still works; this is cosmetic.");
+            println!("      Re-run with `--no-icon` to skip the icon entirely.");
+        }
+        FontStatus::FcMatchMissing => {
+            println!();
+            println!(
+                "Note: fontconfig (`fc-match`) not found — cannot verify Nerd Font availability."
+            );
+            println!(
+                "      If the face icon renders as a box, install a Nerd Font for your hyprlock font."
+            );
+        }
+    }
 }
 
 fn disable(path: &Path) -> anyhow::Result<()> {
@@ -187,12 +243,149 @@ fn status(path: &Path) -> anyhow::Result<()> {
         if pam_fp { "yes" } else { "no" }
     );
 
+    let font = extract_font_family(&content).unwrap_or_else(|| DEFAULT_HYPRLOCK_FONT.to_string());
+    match check_font(&font) {
+        FontStatus::Installed => {
+            println!("font ({font}):        installed");
+        }
+        FontStatus::Substituted { resolved_to } => {
+            println!(
+                "font ({font}):        NOT installed (substituted '{resolved_to}'); icon may render as box"
+            );
+        }
+        FontStatus::FcMatchMissing => {
+            println!("font ({font}):        fc-match not available");
+        }
+    }
+
     let backup = backup_path(path);
     if backup.exists() {
         println!("backup file:          {}", backup.display());
     }
 
     Ok(())
+}
+
+/// Resolved state of the hyprlock font, as reported by fontconfig.
+#[derive(Debug, PartialEq, Eq)]
+enum FontStatus {
+    /// fontconfig returned a family that matches the requested name.
+    Installed,
+    /// fontconfig substituted a different family — the icon will likely render
+    /// as a missing-glyph box unless that fallback is itself a Nerd Font.
+    Substituted { resolved_to: String },
+    /// `fc-match` not on PATH (fontconfig not installed).
+    FcMatchMissing,
+}
+
+/// Look up the requested font family via `fc-match` and report whether it
+/// actually resolves to itself (installed) or to a different family
+/// (substituted). Tests don't shell out — see `font_resolves_to_match` for
+/// the comparison logic.
+fn check_font(requested: &str) -> FontStatus {
+    let output = match Command::new("fc-match")
+        .args(["-f", "%{family}\n", requested])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return FontStatus::FcMatchMissing,
+    };
+    if !output.status.success() {
+        return FontStatus::FcMatchMissing;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let resolved = stdout.lines().next().unwrap_or("").trim().to_string();
+    if font_resolves_to_match(requested, &resolved) {
+        FontStatus::Installed
+    } else {
+        FontStatus::Substituted {
+            resolved_to: resolved,
+        }
+    }
+}
+
+/// fontconfig may return a comma-separated alias list (e.g.
+/// `"JetBrainsMono Nerd Font,JetBrainsMono NF"`). The font is considered
+/// installed if the requested name matches (case-insensitively) any alias by
+/// word-prefix in either direction. "Word-prefix" means one name is a
+/// prefix of the other at a word boundary (space or end of string). This
+/// handles the common cases:
+///   requested "JetBrains Mono"  resolved "JetBrains Mono NL"             -> match (req prefix of alias)
+///   requested "JetBrains Mono Nerd Font" resolved "JetBrains Mono"       -> match (alias prefix of req)
+///   requested "JetBrainsMono Nerd Font" resolved "JetBrainsMono Nerd Font" -> match (exact)
+///   requested "Sans"            resolved "Liberation Sans"               -> no match
+///   requested "DefinitelyNotAFont"      resolved "Liberation Sans"       -> no match
+fn font_resolves_to_match(requested: &str, resolved: &str) -> bool {
+    if resolved.trim().is_empty() {
+        return false;
+    }
+    let req = requested.trim().to_ascii_lowercase();
+    if req.is_empty() {
+        return false;
+    }
+    resolved
+        .split(',')
+        .map(|s| s.trim().to_ascii_lowercase())
+        .any(|alias| {
+            if alias.is_empty() {
+                return false;
+            }
+            // Exact match
+            if alias == req {
+                return true;
+            }
+            // alias is a word-boundary prefix of req: req starts with alias
+            // followed by a space (e.g. req="JetBrains Mono Nerd Font", alias="JetBrains Mono")
+            if req.starts_with(&alias)
+                && req[alias.len()..].starts_with(' ')
+            {
+                return true;
+            }
+            // req is a word-boundary prefix of alias: alias starts with req
+            // followed by a space (e.g. alias="JetBrains Mono NL", req="JetBrains Mono")
+            if alias.starts_with(&req)
+                && alias[req.len()..].starts_with(' ')
+            {
+                return true;
+            }
+            false
+        })
+}
+
+/// Parse `font_family = X` from hyprlock.conf, preserving any quoting in the
+/// value. Looks inside the first `input-field { ... }` block; ignores
+/// `font_family` keys in other blocks (e.g. `label`). Returns None when no
+/// override is set — callers should default to `DEFAULT_HYPRLOCK_FONT`.
+fn extract_font_family(input: &str) -> Option<String> {
+    let mut in_input_field = false;
+    let mut depth = 0i32;
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if !in_input_field {
+            if trimmed.starts_with("input-field") && trimmed.contains('{') {
+                in_input_field = true;
+                depth = 1;
+            }
+            continue;
+        }
+        // Track nested braces so we don't leave the block prematurely.
+        for ch in trimmed.chars() {
+            if ch == '{' {
+                depth += 1;
+            } else if ch == '}' {
+                depth -= 1;
+            }
+        }
+        if depth <= 0 {
+            return None;
+        }
+        if let Some(rest) = trimmed.strip_prefix("font_family")
+            && let Some(idx) = rest.find('=')
+        {
+            return Some(rest[idx + 1..].trim().to_string());
+        }
+    }
+    None
 }
 
 fn backup_path(path: &Path) -> PathBuf {
@@ -570,5 +763,154 @@ mod tests {
         let final_content = std::fs::read_to_string(&path).unwrap();
         assert!(!final_content.contains(FACE_ICON));
         assert!(final_content.contains("ignore_empty_input = true"));
+    }
+
+    #[test]
+    fn extract_font_family_absent_on_stock_omarchy() {
+        assert_eq!(extract_font_family(STOCK_OMARCHY), None);
+    }
+
+    #[test]
+    fn extract_font_family_with_spaces() {
+        let input = "input-field {\n    font_family = JetBrainsMono Nerd Font\n}\n";
+        assert_eq!(
+            extract_font_family(input),
+            Some("JetBrainsMono Nerd Font".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_font_family_with_quotes_preserved() {
+        let input = "input-field {\n    font_family = \"JetBrainsMono Nerd Font\"\n}\n";
+        assert_eq!(
+            extract_font_family(input),
+            Some("\"JetBrainsMono Nerd Font\"".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_font_family_ignores_other_blocks() {
+        // font_family in a label block should not be returned; input-field has none.
+        let input = "label {\n    font_family = Comic Sans\n    text = hi\n}\n\
+                     input-field {\n    placeholder_text = Enter Password\n}\n";
+        assert_eq!(extract_font_family(input), None);
+    }
+
+    #[test]
+    fn extract_font_family_prefers_input_field_block() {
+        let input = "label {\n    font_family = Comic Sans\n}\n\
+                     input-field {\n    font_family = JetBrainsMono Nerd Font\n}\n";
+        assert_eq!(
+            extract_font_family(input),
+            Some("JetBrainsMono Nerd Font".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_font_family_no_input_field_block() {
+        let input = "general {\n    grace = 0\n}\n";
+        assert_eq!(extract_font_family(input), None);
+    }
+
+    #[test]
+    fn font_match_exact_case_insensitive() {
+        assert!(font_resolves_to_match(
+            "JetBrainsMono Nerd Font",
+            "JetBrainsMono Nerd Font"
+        ));
+        assert!(font_resolves_to_match(
+            "jetbrainsmono nerd font",
+            "JetBrainsMono Nerd Font"
+        ));
+    }
+
+    #[test]
+    fn font_match_alias_list() {
+        // Real fc-match output for installed Nerd Font.
+        assert!(font_resolves_to_match(
+            "JetBrainsMono Nerd Font",
+            "JetBrainsMono Nerd Font,JetBrainsMono NF"
+        ));
+    }
+
+    #[test]
+    fn font_match_substring_either_direction() {
+        // Requested name contains resolved alias.
+        assert!(font_resolves_to_match(
+            "JetBrains Mono Nerd Font",
+            "JetBrains Mono"
+        ));
+        // Resolved alias contains requested.
+        assert!(font_resolves_to_match("JetBrains Mono", "JetBrains Mono NL"));
+    }
+
+    #[test]
+    fn font_no_match_when_substituted() {
+        // Typical "font missing" case: requested random name, fontconfig falls back.
+        assert!(!font_resolves_to_match("Sans", "Liberation Sans"));
+        assert!(!font_resolves_to_match(
+            "JetBrainsMono Nerd Font",
+            "DejaVu Sans"
+        ));
+        assert!(!font_resolves_to_match("DefinitelyNotAFont", "Liberation Sans"));
+    }
+
+    #[test]
+    fn font_no_match_when_empty() {
+        assert!(!font_resolves_to_match("Sans", ""));
+        assert!(!font_resolves_to_match("", "Liberation Sans"));
+    }
+
+    #[test]
+    fn enable_with_no_icon_skips_placeholder_flips_flag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hyprlock.conf");
+        std::fs::write(&path, STOCK_OMARCHY).unwrap();
+
+        enable(&path, true).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(!after.contains(FACE_ICON), "no icon expected with --no-icon");
+        assert!(
+            after.contains("placeholder_text = Enter Password"),
+            "placeholder text should be untouched"
+        );
+        assert!(after.contains("ignore_empty_input = false"));
+        assert!(!after.contains("ignore_empty_input = true"));
+    }
+
+    #[test]
+    fn enable_with_no_icon_is_idempotent_and_preserves_existing_icon() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hyprlock.conf");
+        // Start with face icon already present and ignore_empty_input = false.
+        let preexisting = format!(
+            "general {{\n    ignore_empty_input = false\n}}\n\n\
+             input-field {{\n    placeholder_text = <span> Enter Password {FACE_ICON} </span>\n}}\n"
+        );
+        std::fs::write(&path, &preexisting).unwrap();
+
+        // --no-icon should NOT remove the existing icon (that's disable's job).
+        enable(&path, true).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains(FACE_ICON),
+            "existing face icon must be preserved under --no-icon"
+        );
+        assert!(after.contains("ignore_empty_input = false"));
+    }
+
+    #[test]
+    fn enable_without_no_icon_adds_icon_and_flips_flag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hyprlock.conf");
+        std::fs::write(&path, STOCK_OMARCHY).unwrap();
+
+        enable(&path, false).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains(FACE_ICON));
+        assert!(after.contains("ignore_empty_input = false"));
     }
 }

--- a/crates/facelock-cli/src/commands/mod.rs
+++ b/crates/facelock-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod daemon;
 pub mod devices;
 pub mod encrypt;
 pub mod enroll;
+pub mod hyprlock;
 pub mod list;
 pub mod preview;
 pub mod remove;

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -211,6 +211,10 @@ fn run_wizard() -> anyhow::Result<()> {
         }
     };
 
+    if pam_services.iter().any(|s| s == "hyprlock") {
+        wizard_hyprlock_handoff(&theme);
+    }
+
     print_pam_extension_hint();
 
     // -- Summary --
@@ -1042,6 +1046,69 @@ fn wizard_pam_setup(theme: &ColorfulTheme) -> anyhow::Result<Vec<String>> {
 }
 
 // ---------------------------------------------------------------------------
+// Hyprlock integration handoff
+// ---------------------------------------------------------------------------
+
+fn print_hyprlock_hint() {
+    println!();
+    println!("==> To finish hyprlock integration, run as your normal user:");
+    println!("==>     facelock hyprlock enable");
+}
+
+fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
+    // The wizard runs as root via `sudo facelock setup`, but hyprlock.conf lives
+    // in the invoking user's $HOME — only `runuser -u $SUDO_USER` can touch it.
+    let sudo_user = match std::env::var("SUDO_USER") {
+        Ok(u) if !u.is_empty() && u != "root" => u,
+        _ => {
+            print_hyprlock_hint();
+            return;
+        }
+    };
+
+    let user = match nix::unistd::User::from_name(&sudo_user) {
+        Ok(Some(u)) => u,
+        _ => {
+            print_hyprlock_hint();
+            return;
+        }
+    };
+
+    let hyprlock_conf = user.dir.join(".config").join("hypr").join("hyprlock.conf");
+    if !hyprlock_conf.exists() {
+        print_hyprlock_hint();
+        return;
+    }
+
+    println!();
+    let proceed = Confirm::with_theme(theme)
+        .with_prompt(format!(
+            "Apply hyprlock face-unlock integration for {sudo_user}? (face icon + empty-Enter submit)"
+        ))
+        .default(true)
+        .interact()
+        .unwrap_or(false);
+
+    if !proceed {
+        print_hyprlock_hint();
+        return;
+    }
+
+    let status = Command::new("runuser")
+        .args(["-u", &sudo_user, "--", "facelock", "hyprlock", "enable"])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            println!("  hyprlock integration applied for {sudo_user}.");
+        }
+        _ => {
+            print_hyprlock_hint();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Non-interactive setup (original behavior)
 // ---------------------------------------------------------------------------
 
@@ -1117,6 +1184,13 @@ fn run_non_interactive() -> anyhow::Result<()> {
 
     secure_setup_paths(&config, Some(&manifest))?;
     write_setup_marker()?;
+
+    if let Ok(pam_content) = fs::read_to_string(Path::new("/etc/pam.d/hyprlock"))
+        && pam_content.lines().any(is_facelock_pam_line)
+    {
+        print_hyprlock_hint();
+    }
+
     println!("\nSetup complete. Run `facelock enroll` to register your face.");
     Ok(())
 }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::EnvFilter;
 
 use commands::TpmCommand;
 use commands::bench::BenchCommand;
+use commands::hyprlock::HyprlockCommand;
 
 #[derive(Parser)]
 #[command(name = "facelock", about = "Linux face authentication", version)]
@@ -138,6 +139,11 @@ enum Commands {
         #[command(subcommand)]
         command: TpmCommand,
     },
+    /// Manage hyprlock lock-screen integration (no root required)
+    Hyprlock {
+        #[command(subcommand)]
+        command: HyprlockCommand,
+    },
     /// Encrypt all unencrypted embeddings with AES-256-GCM
     Encrypt {
         /// Generate a new encryption key (does not encrypt)
@@ -226,6 +232,7 @@ fn main() -> anyhow::Result<()> {
                 Commands::Devices => commands::devices::run(),
                 Commands::Bench { command } => commands::bench::run(command),
                 Commands::Tpm { command } => commands::tpm::run(command),
+                Commands::Hyprlock { command } => commands::hyprlock::run(command),
                 Commands::Encrypt { generate_key } => commands::encrypt::run_encrypt(generate_key),
                 Commands::Decrypt => commands::encrypt::run_decrypt(),
                 Commands::Restart => commands::config::restart(),

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -66,6 +66,10 @@ package() {
     # tmpfiles.d for runtime directories
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
 
+    # Omarchy helper scripts (inert if walker/omarchy isn't installed)
+    install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"
+    install -Dm755 dist/omarchy/omarchy-remove-security-face "$pkgdir/usr/bin/omarchy-remove-security-face"
+
     # Licenses
     install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
     install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"

--- a/dist/PKGBUILD-bin
+++ b/dist/PKGBUILD-bin
@@ -41,6 +41,9 @@ package() {
     install -Dm644 dist/facelock.sysusers "$pkgdir/usr/lib/sysusers.d/facelock.conf"
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
 
+    install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"
+    install -Dm755 dist/omarchy/omarchy-remove-security-face "$pkgdir/usr/bin/omarchy-remove-security-face"
+
     install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
     install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
 }

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -69,6 +69,10 @@ package() {
     # tmpfiles.d for runtime directories
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
 
+    # Omarchy helper scripts (inert if walker/omarchy isn't installed)
+    install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"
+    install -Dm755 dist/omarchy/omarchy-remove-security-face "$pkgdir/usr/bin/omarchy-remove-security-face"
+
     # Licenses
     install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
     install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"

--- a/dist/debian/rules
+++ b/dist/debian/rules
@@ -43,6 +43,10 @@ override_dh_auto_install:
 	# pam-auth-update profile
 	install -Dm644 dist/debian/pam-auth-update debian/facelock/usr/share/pam-configs/facelock
 
+	# Omarchy helper scripts (inert if walker/omarchy isn't installed)
+	install -Dm755 dist/omarchy/omarchy-setup-security-face debian/facelock/usr/bin/omarchy-setup-security-face
+	install -Dm755 dist/omarchy/omarchy-remove-security-face debian/facelock/usr/bin/omarchy-remove-security-face
+
 	# Bundled CPU ONNX Runtime (if present — added by release CI)
 	if [ -f onnxruntime/lib/libonnxruntime.so ]; then \
 		install -Dm755 onnxruntime/lib/libonnxruntime.so debian/facelock/usr/lib/facelock/libonnxruntime.so; \

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -81,6 +81,10 @@ install -Dm644 dist/authselect/facelock/password-auth %{buildroot}%{_datadir}/au
 install -Dm644 dist/authselect/facelock/postlogin %{buildroot}%{_datadir}/authselect/vendor/facelock/postlogin
 install -Dm644 dist/authselect/facelock/README %{buildroot}%{_datadir}/authselect/vendor/facelock/README
 
+# Omarchy helper scripts (inert if walker/omarchy isn't installed)
+install -Dm755 dist/omarchy/omarchy-setup-security-face %{buildroot}%{_bindir}/omarchy-setup-security-face
+install -Dm755 dist/omarchy/omarchy-remove-security-face %{buildroot}%{_bindir}/omarchy-remove-security-face
+
 # Bundled CPU ONNX Runtime (if present — added by release CI).
 # Always create %{_libdir}/facelock/ so the %files entry resolves even when ORT
 # is not bundled (the Packit/COPR from-source build, which depends on system
@@ -147,6 +151,8 @@ fi
 %doc config/facelock.toml
 %{_bindir}/facelock
 %{_bindir}/facelock-polkit-agent
+%{_bindir}/omarchy-setup-security-face
+%{_bindir}/omarchy-remove-security-face
 %{_libdir}/security/pam_facelock.so
 %{_libdir}/facelock/
 %config(noreplace) %{_sysconfdir}/facelock/config.toml

--- a/dist/omarchy/omarchy-remove-security-face
+++ b/dist/omarchy/omarchy-remove-security-face
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# omarchy:summary=Remove facial authentication from sudo, polkit, and lock screen
+# omarchy:requires-sudo=true
+
+set -e
+
+echo -e "\e[32mRemoving facial authentication.\n\e[0m"
+
+if ! command -v facelock >/dev/null 2>&1; then
+  echo -e "\e[31mfacelock binary not found in PATH.\e[0m"
+  exit 1
+fi
+
+if [[ -f $HOME/.config/hypr/hyprlock.conf ]]; then
+  echo "Reverting hyprlock configuration..."
+  facelock hyprlock disable || true
+fi
+
+for service in sudo polkit-1 hyprlock; do
+  if [[ -f /etc/pam.d/$service ]] && grep -q 'pam_facelock\.so' "/etc/pam.d/$service"; then
+    echo "Removing pam_facelock.so from /etc/pam.d/$service..."
+    sudo facelock setup --pam --service "$service" --remove --yes
+  fi
+done
+
+echo
+echo "PAM lines removed. Face data, models, and the facelock package remain installed."
+echo "To purge everything:"
+echo "  sudo pacman -Rns facelock        # or your distro's package manager"
+echo "  sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+echo
+echo -e "\e[32mFacial authentication removed.\e[0m"

--- a/dist/omarchy/omarchy-setup-security-face
+++ b/dist/omarchy/omarchy-setup-security-face
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# omarchy:summary=Set up facial authentication for sudo, polkit, and lock screen
+# omarchy:requires-sudo=true
+
+set -e
+
+echo -e "\e[32mSetting up facial authentication.\n\e[0m"
+
+if ! command -v facelock >/dev/null 2>&1; then
+  echo -e "\e[31mfacelock binary not found in PATH. Install the facelock package first.\e[0m"
+  exit 1
+fi
+
+if ! facelock devices >/dev/null 2>&1; then
+  echo -e "\e[31m\nNo camera detected. Connect a webcam (IR preferred) and re-run.\e[0m"
+  exit 1
+fi
+
+echo "Configuring facelock system components (sudo required)..."
+sudo facelock setup --non-interactive
+
+echo "Enrolling your face..."
+facelock enroll
+
+echo "Updating hyprlock configuration..."
+facelock hyprlock enable
+
+if ! facelock test; then
+  echo -e "\e[33mFacelock test did not succeed — you may need better lighting or re-enrollment.\e[0m"
+fi
+
+echo -e "\e[32m\nFacial authentication set up.\e[0m"

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -29,6 +29,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock daemon` | Run persistent daemon |
 | `facelock auth --user X` | One-shot auth (PAM helper) |
 | `facelock tpm status` | TPM status |
+| `facelock hyprlock enable\|disable\|status` | Manage hyprlock lock-screen integration (user, no root) |
 | `facelock encrypt` | Encrypt face database |
 | `facelock decrypt` | Decrypt face database |
 | `facelock audit` | View audit log |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -29,7 +29,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock daemon` | Run persistent daemon |
 | `facelock auth --user X` | One-shot auth (PAM helper) |
 | `facelock tpm status` | TPM status |
-| `facelock hyprlock enable\|disable\|status` | Manage hyprlock lock-screen integration (user, no root) |
+| `facelock hyprlock enable\|disable\|status` | Manage hyprlock lock-screen integration (user, no root); `enable` accepts `--no-icon` to skip the cosmetic face glyph |
 | `facelock encrypt` | Encrypt face database |
 | `facelock decrypt` | Decrypt face database |
 | `facelock audit` | View audit log |

--- a/justfile
+++ b/justfile
@@ -300,69 +300,6 @@ uninstall-files:
     echo "==>   sudo gpasswd -d <username> facelock"
     echo "==>   sudo groupdel facelock"
 
-# Add face auth icon to omarchy hyprlock placeholder text (no root required)
-omarchy-enable:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    HYPRLOCK_CONF="$HOME/.config/hypr/hyprlock.conf"
-
-    if [ ! -d "$HOME/.local/share/omarchy" ]; then
-        echo "Error: omarchy not detected. This target is for omarchy systems only."
-        exit 1
-    fi
-
-    if [ ! -f "$HYPRLOCK_CONF" ]; then
-        echo "Error: $HYPRLOCK_CONF not found."
-        exit 1
-    fi
-
-    if grep -q '󰄀' "$HYPRLOCK_CONF"; then
-        echo "Face auth icon already present in hyprlock config."
-        exit 0
-    fi
-
-    # Preserve fingerprint icon if present
-    if grep -q '󰈷' "$HYPRLOCK_CONF"; then
-        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰄀 󰈷 <\/span>/' "$HYPRLOCK_CONF"
-    else
-        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰄀 <\/span>/' "$HYPRLOCK_CONF"
-    fi
-
-    # Source the faceauth overlay if not already sourced
-    if [ -f "$HOME/.config/hypr/hyprlock-faceauth.conf" ] && ! grep -q 'hyprlock-faceauth.conf' "$HYPRLOCK_CONF"; then
-        echo 'source = ~/.config/hypr/hyprlock-faceauth.conf' >> "$HYPRLOCK_CONF"
-    fi
-
-    echo "Enabled face auth in hyprlock."
-
-# Remove face auth icon from omarchy hyprlock placeholder text (no root required)
-omarchy-disable:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    HYPRLOCK_CONF="$HOME/.config/hypr/hyprlock.conf"
-
-    if [ ! -f "$HYPRLOCK_CONF" ]; then
-        echo "Error: $HYPRLOCK_CONF not found."
-        exit 1
-    fi
-
-    if ! grep -q '󰄀' "$HYPRLOCK_CONF"; then
-        echo "Face auth icon not present in hyprlock config."
-        exit 0
-    fi
-
-    # Preserve fingerprint icon if present
-    if grep -q '󰈷' "$HYPRLOCK_CONF"; then
-        sed -i 's/placeholder_text = .*/placeholder_text = <span> Enter Password 󰈷 <\/span>/' "$HYPRLOCK_CONF"
-    else
-        sed -i 's/placeholder_text = .*/placeholder_text = Enter Password/' "$HYPRLOCK_CONF"
-    fi
-
-    # Remove the faceauth overlay source line
-    sed -i '\|hyprlock-faceauth.conf|d' "$HYPRLOCK_CONF"
-
-    echo "Disabled face auth in hyprlock."
-
 # Bump version and prepare a release commit + tag
 # Usage: just release 0.2.0
 release version:


### PR DESCRIPTION
## Summary
- New unprivileged subcommand `facelock hyprlock <enable|disable|status>` that edits `~/.config/hypr/hyprlock.conf` for face-auth lock-screen integration (face icon in `placeholder_text` + `ignore_empty_input = false`).
- Wizard hand-off: `sudo facelock setup` detects hyprlock in the PAM step and offers to run the subcommand for `$SUDO_USER` via `runuser`. Prints a copy-paste hint when `SUDO_USER` isn't usable. Wizard never touches `$HOME` directly.
- Omarchy wrappers `omarchy-setup-security-face` / `omarchy-remove-security-face` ship in PKGBUILD/.deb/.rpm so the menu pattern (Setup → Security → Face) can land via an upstream omarchy PR.
- Nerd font detection via `fc-match` warns (doesn't block) when the configured hyprlock font can't render the face glyph; `--no-icon` skips the cosmetic change entirely.
- Removes the old `just omarchy-enable` / `omarchy-disable` recipes — they were source-only and functionally incomplete (didn't flip `ignore_empty_input`, which is the actual functional change that makes face auth fire from the lock screen).

## Why the icons matter
The face icon is **U+F0100** (Material Design face glyph) from the Nerd Fonts private-use area, paired with the existing fingerprint icon **U+F0237**. Byte-exact match (`f3 b0 84 80` / `f3 b0 88 b7`) to what `just omarchy-enable` was using. `--no-icon` is for users whose hyprlock font isn't a Nerd Font.

## Why two commits
1. `07f86fe` — subcommand + wizard hand-off + omarchy scripts + packaging + docs + justfile cleanup.
2. `7dbf7a4` — nerd font detection (`fc-match`) + `--no-icon` flag + font state in `status` + tests.

Split for bisectability; can be squashed at merge time if preferred.

## Depends on
- **#54** (`chore: pin Rust toolchain to 1.95`) for clean local builds. CI is unaffected (Arch's `rust` package already ships 1.95+).

## Test plan
- [x] 26 unit tests in `hyprlock.rs` (stock omarchy, fingerprint coexistence — icon 󰈷 preset and `fingerprint:enabled = true`, idempotency, `--no-icon`, font extraction across config layouts, fontconfig alias-list matching, empty-resolved edge cases)
- [x] `cargo build --workspace` green in `archlinux:base-devel` (Rust 1.95.0, matches CI's environment)
- [x] `cargo test --workspace` green in container
- [x] `cargo clippy --workspace -- -D warnings` clean in container
- [ ] Reviewer eyeball on the Nerd Font codepoints (U+F0100 / U+F0237 — match the original `just omarchy-enable` bytes)
- [ ] Manual test on an actual Omarchy box — run `facelock hyprlock enable` and verify the lock screen reflects both the icon and Enter-on-empty submission to PAM

🤖 Generated with [Claude Code](https://claude.com/claude-code)