### PR TITLE
feat(camera): NV12/Y16 decode + skip undecodable devices in auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   negotiating an unsupported format (and then failing every capture), opening a
   device with no decodable format errors immediately with the advertised and
   supported format lists.
+- **Pixel-format names lose V4L2's trailing-space padding on machine-readable
+  surfaces** (#89): FourCCs are normalized where they enter facelock (device
+  enumeration and quirks-file parsing), so `facelock devices --json` and the
+  `ListDevices` D-Bus reply now carry `"Y16"` where they previously carried
+  `"Y16 "`. The human-readable `facelock devices` table already trimmed and is
+  unchanged. A consumer matching the padded spelling exactly needs updating; one
+  that trims already does not.
 
 ### Fixed
 
@@ -404,6 +411,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (hardware truth, no frame inspected); otherwise it is calibrated from the peak
   of a short burst of frames rather than a single frame, so a dark pre-AGC frame
   at open no longer pins an 8-bit scale that clips the rest of the session.
+  "The session" is the lifetime of one open camera: the daemon's warm camera
+  hold keeps the scale it pinned, and a reopen recalibrates — no scale is
+  carried across a reopen onto a device that did not produce it. On IR hardware
+  the burst is emitter-LED-on time inside `Camera::open` (bounded by one
+  second); declaring `y16_bit_depth` skips it.
 
 ## [0.1.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,13 +280,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   negotiating an unsupported format (and then failing every capture), opening a
   device with no decodable format errors immediately with the advertised and
   supported format lists.
-- **Pixel-format names lose V4L2's trailing-space padding on machine-readable
-  surfaces** (#89): FourCCs are normalized where they enter facelock (device
-  enumeration and quirks-file parsing), so `facelock devices --json` and the
-  `ListDevices` D-Bus reply now carry `"Y16"` where they previously carried
-  `"Y16 "`. The human-readable `facelock devices` table already trimmed and is
-  unchanged. A consumer matching the padded spelling exactly needs updating; one
-  that trims already does not.
+- **Pixel-format names lose V4L2's trailing-space padding** (#89): FourCCs are
+  normalized where they enter facelock (device enumeration and quirks-file
+  parsing), so `facelock devices --json` now carries `"Y16"` where it
+  previously carried `"Y16 "`. This applies on the direct backend only, which
+  is the one that reports formats at all: the D-Bus `DeviceInfo` carries no
+  formats field, so a daemon-backed `--json` reports `"formats": []` either
+  way. The human-readable `facelock devices` table already trimmed and is
+  unchanged. A consumer that reads formats from the direct backend and matches
+  the padded spelling exactly needs updating; one that trims already does not.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,8 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Intel IPU6/IPU7 processed cameras via v4l2-relayd) and Y16 (16-bit IR grayscale,
   bit-depth-aware conversion) are decoded natively. Negotiation priority is now
   `GREY > Y16 > YUYV > NV12 > MJPG`. IPU6/IPU7 relay cameras can now be opened,
-  previewed and enrolled — but they expose no Linux-reachable IR sensor, so
-  authentication still fails under the default `security.require_ir = true`.
+  previewed and enrolled — but their IR sensors have no in-tree Linux driver
+  yet, so authentication still fails under the default
+  `security.require_ir = true` on stock kernels (experimental community driver
+  support is tracked in #101).
 - **Intel IPU6/IPU7 + v4l2-relayd compatibility recipe** in `docs/compatibility.md`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,10 +396,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clear on every thread.
 
 - **Y16 8-bit scaling is pinned at camera open**: the bit-depth shift is derived
-  once from a calibration frame and reused for the whole session. Deriving it per
-  frame was contrast normalization upstream of the IR texture check — it moved the
-  scale `security.ir_texture_min_stddev` is calibrated against in response to
-  scene illumination, and a single saturated pixel blacked out whole frames.
+  once and reused for the whole session. Deriving it per frame was contrast
+  normalization upstream of the IR texture check — it moved the scale
+  `security.ir_texture_min_stddev` is calibrated against in response to scene
+  illumination, and a single saturated pixel blacked out whole frames. The shift
+  comes from the new quirk key `y16_bit_depth` when a device declares one
+  (hardware truth, no frame inspected); otherwise it is calibrated from the peak
+  of a short burst of frames rather than a single frame, so a dark pre-AGC frame
+  at open no longer pins an 8-bit scale that clips the rest of the session.
 
 ## [0.1.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is a property of the camera and its driver, not of facelock. Needs no
   enrolled face and loads no models.
 
+- **NV12 and Y16 pixel format support** (#89): NV12 (semi-planar 4:2:0, common on
+  Intel IPU6/IPU7 processed cameras via v4l2-relayd) and Y16 (16-bit IR grayscale,
+  bit-depth-aware conversion) are decoded natively. Negotiation priority is now
+  `GREY > Y16 > YUYV > NV12 > MJPG`.
+- **Intel IPU6/IPU7 + v4l2-relayd compatibility recipe** in `docs/compatibility.md`.
+
 ### Changed
 
 - **An authentication at an empty chair ends early and costs no rate-limit
@@ -261,6 +267,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filtered out. Both modes now call
   `facelock_daemon::auth::authenticate_with_embeddings`. The PAM path is
   unaffected — `facelock auth` already called the daemon implementation.
+
+- **Auto-detection skips undecodable devices** (#89): devices that advertise no
+  decodable pixel format (e.g. raw Bayer sensor nodes like the IPU7's `SGRBG10`)
+  are excluded from every auto-detection tier. When no decodable camera exists,
+  the error lists every detected device and its formats.
+- **Camera open fails fast on undecodable formats** (#89): instead of silently
+  negotiating an unsupported format (and then failing every capture), opening a
+  device with no decodable format errors immediately with the advertised and
+  supported format lists.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NV12 and Y16 pixel format support** (#89): NV12 (semi-planar 4:2:0, common on
   Intel IPU6/IPU7 processed cameras via v4l2-relayd) and Y16 (16-bit IR grayscale,
   bit-depth-aware conversion) are decoded natively. Negotiation priority is now
-  `GREY > Y16 > YUYV > NV12 > MJPG`.
+  `GREY > Y16 > YUYV > NV12 > MJPG`. IPU6/IPU7 relay cameras can now be opened,
+  previewed and enrolled — but they expose no Linux-reachable IR sensor, so
+  authentication still fails under the default `security.require_ir = true`.
 - **Intel IPU6/IPU7 + v4l2-relayd compatibility recipe** in `docs/compatibility.md`.
 
 ### Changed
@@ -343,6 +345,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured service kept its line. `prerm` now runs the same explicit removal
   loop as the other packagers in addition to the `pam-auth-update` call.
 
+- **Odd-width NV12 frames no longer panic**: a UV row is `2 * ceil(width/2)` bytes,
+  not `width`, so the short-buffer guard accepted frames that the row indexing then
+  ran past the end of.
+- **Padded camera strides are rejected at open**: devices whose `bytesperline`
+  exceeds the row size for the negotiated format (ISP hardware) now fail with an
+  error naming both values instead of decoding sheared frames.
+- **Quirk `format_preference` naming an undecodable format is ignored** with a
+  warning, rather than winning negotiation and failing every subsequent capture.
+- **IR cameras excluded from auto-detection for lacking a decodable format** are
+  logged with their path and advertised formats, so syslog explains a later
+  "not an IR camera" failure.
+
 ### Security
 
 - **`CAP_CHOWN` added to the daemon's capability bounding set, for startup
@@ -378,6 +392,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read-back that could not see it. `test/pkg-validate.sh` now walks
   `/proc/<pid>/task/*/status` on the running daemon and asserts `CAP_CHOWN` is
   clear on every thread.
+
+- **Y16 8-bit scaling is pinned at camera open**: the bit-depth shift is derived
+  once from a calibration frame and reused for the whole session. Deriving it per
+  frame was contrast normalization upstream of the IR texture check — it moved the
+  scale `security.ir_texture_min_stddev` is calibrated against in response to
+  scene illumination, and a single saturated pixel blacked out whole frames.
 
 ## [0.1.4] - 2026-05-31
 

--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -20,6 +20,10 @@
 #   emitter_xu_selector     - UVC XU control selector for emitter toggle
 #   warmup_frames           - override device.warmup_frames for this camera
 #   format_preference       - preferred pixel format (e.g. "GREY", "Y16 ", "YUYV")
+#   y16_bit_depth           - effective bit depth of this sensor's Y16 samples
+#                             (8..=16, e.g. 10 for a 10-bit sensor). Pins the
+#                             Y16 -> 8-bit scale from hardware truth instead of
+#                             calibrating it from frames at camera open.
 #   rotation                - image rotation in degrees (0, 90, 180, 270)
 #   notes                   - human-readable explanation
 

--- a/crates/facelock-camera/src/caps.rs
+++ b/crates/facelock-camera/src/caps.rs
@@ -121,6 +121,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         }

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -27,17 +27,48 @@ pub const MMAP_BUFFERS: u32 = 4;
 
 /// Pixel formats facelock can decode to RGB, in negotiation priority order:
 /// IR-native grayscale first, then cheap lossless raw conversions, then MJPG
-/// (JPEG decode). "Y16 " carries its FourCC trailing space; comparisons are
-/// whitespace-trimmed. Also used by device auto-detection to skip devices
-/// (e.g. raw Bayer sensor nodes) that advertise none of these.
-pub const DECODABLE_FORMATS: &[&str] = &["GREY", "Y16 ", "YUYV", "NV12", "MJPG"];
+/// (JPEG decode). Also used by device auto-detection to skip devices (e.g. raw
+/// Bayer sensor nodes) that advertise none of these. The order is part of the
+/// documented negotiation contract (`docs/contracts.md`).
+pub(crate) const DECODABLE_FORMATS: &[&str] = &["GREY", "Y16", "YUYV", "NV12", "MJPG"];
+
+/// V4L2 FourCCs are four characters padded with trailing spaces ("Y16 ").
+/// Normalize at every point a FourCC enters facelock so no comparison
+/// downstream has to trim.
+pub(crate) fn normalize_fourcc(fourcc: v4l::format::FourCC) -> String {
+    fourcc.to_string().trim().to_string()
+}
 
 /// Index into `available` of the first advertised format in `preferred`
-/// priority order. FourCC comparison is whitespace-trimmed.
+/// priority order. Both lists hold normalized FourCCs.
 fn select_format(preferred: &[&str], available: &[String]) -> Option<usize> {
     preferred
         .iter()
-        .find_map(|pref| available.iter().position(|f| f.trim() == pref.trim()))
+        .find_map(|pref| available.iter().position(|f| f == pref))
+}
+
+/// A quirk's `format_preference`, dropped when facelock cannot decode it —
+/// honoring it would negotiate a format every subsequent capture fails on.
+fn quirk_format_preference(quirk: Option<&Quirk>) -> Option<&str> {
+    let pref = quirk.and_then(|q| q.format_preference.as_deref())?;
+    if !DECODABLE_FORMATS.contains(&pref) {
+        tracing::warn!(
+            format = pref,
+            "quirk format_preference is not a decodable format — ignoring"
+        );
+        return None;
+    }
+    Some(pref)
+}
+
+/// Bytes per row facelock's converters assume for an uncompressed format.
+/// `None` for compressed formats, whose `bytesperline` is not a row size.
+fn expected_stride(format: &str, width: u32) -> Option<u32> {
+    match format {
+        "GREY" | "NV12" => Some(width),
+        "Y16" | "YUYV" => Some(width * 2),
+        _ => None,
+    }
 }
 
 use crate::ir_emitter;
@@ -61,6 +92,15 @@ pub struct Camera<'a> {
     emitter_xu_info: Option<EmitterXuInfo>,
     /// Capabilities computed at construction — see `crate::caps` (gap D8).
     caps: CameraCaps,
+    /// Y16 -> 8-bit shift, derived once at open. Never recomputed per frame:
+    /// a per-frame scale is contrast normalization upstream of the IR texture
+    /// check (see `docs/security.md` §1.C).
+    ///
+    /// Scoped to this `Camera` value, which is what makes it safe under the
+    /// daemon's warm camera hold (ADR 008 §4): a hold reuses this same struct,
+    /// so the scale it pinned stays pinned; a reopen constructs a new `Camera`
+    /// and recalibrates. Nothing carries a scale across a reopen.
+    y16_shift: u8,
 }
 
 impl<'a> Camera<'a> {
@@ -114,21 +154,19 @@ impl<'a> Camera<'a> {
         // Select format by DECODABLE_FORMATS priority. If a quirk specifies a
         // format_preference, prepend it to the priority list. A device that
         // advertises no decodable format (e.g. a raw Bayer sensor node) fails
-        // here with an actionable error instead of negotiating a format that
-        // every subsequent capture would fail to decode.
+        // here with an actionable error.
         let formats = dev
             .enum_formats()
             .map_err(|e| FacelockError::Camera(format!("failed to enum formats: {e}")))?;
 
-        let quirk_fmt = quirk.and_then(|q| q.format_preference.as_deref());
         let mut preferred: Vec<&str> = Vec::with_capacity(DECODABLE_FORMATS.len() + 1);
-        if let Some(fmt_pref) = quirk_fmt {
+        if let Some(fmt_pref) = quirk_format_preference(quirk) {
             tracing::debug!(format = fmt_pref, "quirk: prepending format preference");
             preferred.push(fmt_pref);
         }
         preferred.extend_from_slice(DECODABLE_FORMATS);
 
-        let available: Vec<String> = formats.iter().map(|f| f.fourcc.to_string()).collect();
+        let available: Vec<String> = formats.iter().map(|f| normalize_fourcc(f.fourcc)).collect();
         let selected_fourcc = select_format(&preferred, &available)
             .map(|idx| formats[idx].fourcc)
             .ok_or_else(|| {
@@ -137,16 +175,8 @@ impl<'a> Camera<'a> {
                      facelock supports [{}]. Raw sensor nodes (e.g. Intel IPU6/IPU7) cannot \
                      be used directly; set device.path to a processed camera instead \
                      (see docs/compatibility.md)",
-                    available
-                        .iter()
-                        .map(|f| f.trim())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    DECODABLE_FORMATS
-                        .iter()
-                        .map(|f| f.trim())
-                        .collect::<Vec<_>>()
-                        .join(", "),
+                    available.join(", "),
+                    DECODABLE_FORMATS.join(", "),
                 ))
             })?;
 
@@ -166,14 +196,26 @@ impl<'a> Camera<'a> {
 
         let width = fmt.width;
         let height = fmt.height;
-        let format_str = fmt.fourcc.to_string();
+        let format_str = normalize_fourcc(fmt.fourcc);
         tracing::info!(
             device = %device_path,
-            format = %format_str.trim(),
+            format = %format_str,
             width,
             height,
             "camera format negotiated"
         );
+
+        // The converters index rows by pixel width. ISP devices can pad
+        // bytesperline, which would shear every decoded frame silently.
+        if let Some(expected) = expected_stride(&format_str, width) {
+            if fmt.stride != expected {
+                return Err(FacelockError::Camera(format!(
+                    "{device_path}: {format_str} bytesperline is {} but facelock expects {expected} \
+                     for {width} pixels — padded strides are not supported",
+                    fmt.stride
+                )));
+            }
+        }
 
         // Create MMAP stream with `MMAP_BUFFERS` buffers and a capture timeout
         let mut stream = Stream::with_buffers(&dev, Type::VideoCapture, MMAP_BUFFERS)
@@ -204,6 +246,20 @@ impl<'a> Camera<'a> {
             false
         };
 
+        // Pin the Y16 -> 8-bit scale for the whole session from one calibration
+        // frame. Must run after the IR emitter is enabled, otherwise the scale
+        // is derived from an unlit frame and every lit frame clips to white.
+        let y16_shift = if format_str == "Y16" {
+            let (buf, _meta) = stream.next().map_err(|e| {
+                FacelockError::Camera(format!("{device_path}: Y16 calibration frame failed: {e}"))
+            })?;
+            let shift = preprocess::y16_shift(buf);
+            tracing::info!(device = %device_path, shift, "Y16 session scale pinned");
+            shift
+        } else {
+            0
+        };
+
         // Apply quirk overrides for rotation (warmup_frames is handled by the caller
         // since Camera::open doesn't consume warmup frames itself).
         let rotation = quirk.and_then(|q| q.rotation).unwrap_or(config.rotation);
@@ -228,6 +284,7 @@ impl<'a> Camera<'a> {
             ir_emitter_active,
             emitter_xu_info,
             caps,
+            y16_shift,
         })
     }
 
@@ -281,8 +338,7 @@ impl<'a> Camera<'a> {
             .next()
             .map_err(|e| FacelockError::Camera(format!("capture failed: {e}")))?;
 
-        // Convert to RGB based on format (trimmed: "Y16 " has a trailing space)
-        let rgb: Vec<u8> = match self.format.trim() {
+        let rgb: Vec<u8> = match self.format.as_str() {
             "GREY" => {
                 // Replicate single channel 3x
                 let mut rgb = Vec::with_capacity(buf.len() * 3);
@@ -294,8 +350,8 @@ impl<'a> Camera<'a> {
                 rgb
             }
             "Y16" => {
-                // 16-bit grayscale -> 8-bit (bit-depth aware), replicated 3x
-                let gray = preprocess::y16_to_gray(buf);
+                // 16-bit grayscale -> 8-bit at the session-fixed scale, replicated 3x
+                let gray = preprocess::y16_to_gray(buf, self.y16_shift);
                 let mut rgb = Vec::with_capacity(gray.len() * 3);
                 for &p in &gray {
                     rgb.push(p);
@@ -305,18 +361,14 @@ impl<'a> Camera<'a> {
                 rgb
             }
             "YUYV" => preprocess::yuyv_to_rgb(buf, self.width, self.height),
-            "NV12" => {
-                let rgb = preprocess::nv12_to_rgb(buf, self.width, self.height);
-                if rgb.is_empty() {
-                    return Err(FacelockError::Camera(format!(
-                        "NV12 frame too short: {} bytes for {}x{}",
-                        buf.len(),
-                        self.width,
-                        self.height
-                    )));
-                }
-                rgb
-            }
+            "NV12" => preprocess::nv12_to_rgb(buf, self.width, self.height).ok_or_else(|| {
+                FacelockError::Camera(format!(
+                    "NV12 frame too short: {} bytes for {}x{}",
+                    buf.len(),
+                    self.width,
+                    self.height
+                ))
+            })?,
             "MJPG" => {
                 let reader = ImageReader::with_format(Cursor::new(buf), image::ImageFormat::Jpeg)
                     .decode()
@@ -453,10 +505,28 @@ mod tests {
     }
 
     #[test]
-    fn select_format_trims_fourcc_whitespace() {
-        // "Y16 " (trailing space, as v4l reports it) matches the Y16 entry.
-        let available = fourccs(&["Y16 "]);
+    fn normalize_fourcc_strips_v4l2_padding() {
+        // v4l reports "Y16 " with its FourCC trailing space; every comparison
+        // downstream expects the normalized form.
+        let available = vec![normalize_fourcc(v4l::format::FourCC::new(b"Y16 "))];
+        assert_eq!(available[0], "Y16");
         assert_eq!(select_format(DECODABLE_FORMATS, &available), Some(0));
+    }
+
+    #[test]
+    fn decodable_formats_negotiation_order_is_pinned() {
+        // Changing this order changes the documented negotiation contract —
+        // update docs/contracts.md with it.
+        assert_eq!(DECODABLE_FORMATS, &["GREY", "Y16", "YUYV", "NV12", "MJPG"]);
+    }
+
+    #[test]
+    fn expected_stride_is_the_row_size_of_uncompressed_formats() {
+        assert_eq!(expected_stride("GREY", 640), Some(640));
+        assert_eq!(expected_stride("NV12", 640), Some(640));
+        assert_eq!(expected_stride("Y16", 640), Some(1280));
+        assert_eq!(expected_stride("YUYV", 640), Some(1280));
+        assert_eq!(expected_stride("MJPG", 640), None);
     }
 
     #[test]
@@ -473,6 +543,36 @@ mod tests {
         preferred.extend_from_slice(DECODABLE_FORMATS);
         let available = fourccs(&["GREY", "MJPG"]);
         assert_eq!(select_format(&preferred, &available), Some(1));
+    }
+
+    fn quirk_with_format(format_preference: &str) -> Quirk {
+        Quirk {
+            vendor_id: None,
+            product_id: None,
+            name_pattern: None,
+            force_ir: None,
+            emitter_xu_guid: None,
+            emitter_xu_selector: None,
+            warmup_frames: None,
+            format_preference: Some(format_preference.into()),
+            rotation: None,
+            notes: None,
+        }
+    }
+
+    #[test]
+    fn quirk_format_preference_accepts_decodable() {
+        let quirk = quirk_with_format("GREY");
+        assert_eq!(quirk_format_preference(Some(&quirk)), Some("GREY"));
+        assert_eq!(quirk_format_preference(None), None);
+    }
+
+    #[test]
+    fn quirk_format_preference_ignores_undecodable() {
+        // A quirk naming a format facelock cannot decode would otherwise win
+        // negotiation and then fail every capture.
+        let quirk = quirk_with_format("SGRBG10");
+        assert_eq!(quirk_format_preference(Some(&quirk)), None);
     }
 
     #[test]

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -4,7 +4,7 @@ use facelock_core::traits::CameraSource;
 use facelock_core::types::Frame;
 use image::ImageReader;
 use std::io::Cursor;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use v4l::Device;
 use v4l::buffer::Type;
 use v4l::io::mmap::Stream;
@@ -24,6 +24,25 @@ const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 /// right after the previous request. Reading the count from here is what
 /// keeps that discard correct if the buffer depth ever changes.
 pub const MMAP_BUFFERS: u32 = 4;
+
+/// Minimum frames sampled at open to calibrate the Y16 -> 8-bit scale when no
+/// quirk supplies a sensor bit depth. Calibrating from a single frame races the
+/// camera's own AGC/AE warmup: a dark first frame pins an 8-bit scale that
+/// clips every warmed-up 10/12-bit frame to flat white, which the IR texture
+/// check then rejects. A short burst gives exposure time to move.
+///
+/// This burst is paid on a COLD open only, and only on a Y16 device: the
+/// daemon's warm hold (ADR 008 §4) reuses the `Camera` and therefore its
+/// already-pinned scale. It is nonetheless emitter-LED-on time on IR
+/// hardware, which is exactly what ADR 008 set out to shorten — a device that
+/// declares `y16_bit_depth` in its quirk skips the burst entirely and is the
+/// preferred configuration on any camera where the reopen cost matters.
+const Y16_CALIBRATION_FRAMES: usize = 8;
+
+/// Wall-clock ceiling on that burst. Frames are already flowing when it runs,
+/// so it normally costs a fraction of a second; the budget keeps a stalling
+/// camera from stretching `Camera::open` by `CAPTURE_TIMEOUT` eight times over.
+const Y16_CALIBRATION_BUDGET: Duration = Duration::from_secs(1);
 
 /// Pixel formats facelock can decode to RGB, in negotiation priority order:
 /// IR-native grayscale first, then cheap lossless raw conversions, then MJPG
@@ -59,6 +78,96 @@ fn quirk_format_preference(quirk: Option<&Quirk>) -> Option<&str> {
         return None;
     }
     Some(pref)
+}
+
+/// The Y16 shift implied by a quirk's declared sensor bit depth, if any.
+/// A depth the 16-bit container cannot hold is a quirks-file typo rather than
+/// hardware truth: warn and let frame calibration decide instead.
+fn quirk_y16_shift(quirk: Option<&Quirk>) -> Option<u8> {
+    let bit_depth = quirk.and_then(|q| q.y16_bit_depth)?;
+    let shift = preprocess::y16_shift_from_bit_depth(bit_depth);
+    if shift.is_none() {
+        tracing::warn!(
+            bit_depth,
+            "quirk y16_bit_depth is outside 8..=16 — ignoring, calibrating from frames"
+        );
+    }
+    shift
+}
+
+/// How many frames the calibration burst aims for on this device. A quirk's
+/// `warmup_frames` is the device's own statement of how long its exposure takes
+/// to settle, so a camera that declares more than the default gets a burst at
+/// least that long. The wall-clock budget still bounds it.
+fn y16_calibration_frames(quirk: Option<&Quirk>) -> usize {
+    quirk
+        .and_then(|q| q.warmup_frames)
+        .unwrap_or(0)
+        .max(Y16_CALIBRATION_FRAMES as u32) as usize
+}
+
+/// Pin the session Y16 scale by sampling a burst of frames and taking the
+/// brightest sample any of them produced. The peak is a lower bound on the
+/// sensor's full scale, so more frames can only improve the estimate.
+///
+/// Individual capture errors are tolerated as long as one frame arrives; with
+/// none, opening fails rather than proceeding on a guessed scale.
+fn calibrate_y16_shift(stream: &mut Stream<'_>, device_path: &str, target: usize) -> Result<u8> {
+    let start = Instant::now();
+    let mut peak = 0u16;
+    let mut frames = 0usize;
+    let mut errors = 0usize;
+    let mut last_err = None;
+
+    while frames < target
+        && errors < Y16_CALIBRATION_FRAMES
+        && start.elapsed() < Y16_CALIBRATION_BUDGET
+    {
+        match stream.next() {
+            Ok((buf, _meta)) => {
+                peak = peak.max(preprocess::y16_peak(buf));
+                frames += 1;
+            }
+            Err(e) => {
+                errors += 1;
+                last_err = Some(e);
+            }
+        }
+    }
+
+    if frames == 0 {
+        let detail = match last_err {
+            Some(e) => e.to_string(),
+            None => "no frame arrived within the calibration budget".to_string(),
+        };
+        return Err(FacelockError::Camera(format!(
+            "{device_path}: Y16 calibration failed: {detail}"
+        )));
+    }
+
+    let (shift, verdict) = preprocess::y16_calibration(peak);
+    match verdict {
+        preprocess::Y16Calibration::LowRange => tracing::warn!(
+            device = %device_path,
+            peak,
+            frames,
+            "Y16 scale calibrated to 8-bit: no sample above 255 during calibration. \
+             Correct for a true 8-bit sensor, but a covered or unlit camera at open \
+             looks identical and makes later frames clip to white. Set the quirk's \
+             y16_bit_depth for this device to pin the scale from hardware instead."
+        ),
+        preprocess::Y16Calibration::Saturated => tracing::warn!(
+            device = %device_path,
+            peak,
+            frames,
+            "Y16 calibration saturated the 16-bit container: an IR glint or hot pixel \
+             at open pins a scale that darkens every later frame. Set the quirk's \
+             y16_bit_depth for this device to pin the scale from hardware instead."
+        ),
+        preprocess::Y16Calibration::Normal => {}
+    }
+    tracing::info!(device = %device_path, shift, peak, frames, "Y16 session scale pinned");
+    Ok(shift)
 }
 
 /// Bytes per row facelock's converters assume for an uncompressed format.
@@ -122,6 +231,7 @@ impl<'a> Camera<'a> {
     /// - `format_preference` is prepended to the format priority list.
     /// - `warmup_frames` replaces `config.warmup_frames`.
     /// - `rotation` replaces `config.rotation`.
+    /// - `y16_bit_depth` pins the Y16 scale, skipping frame calibration.
     pub(crate) fn open_resolved(
         config: &DeviceConfig,
         quirk: Option<&Quirk>,
@@ -246,16 +356,20 @@ impl<'a> Camera<'a> {
             false
         };
 
-        // Pin the Y16 -> 8-bit scale for the whole session from one calibration
-        // frame. Must run after the IR emitter is enabled, otherwise the scale
-        // is derived from an unlit frame and every lit frame clips to white.
+        // Pin the Y16 -> 8-bit scale for the whole session. A quirk-declared
+        // sensor bit depth is authoritative; otherwise calibrate from a burst
+        // of frames. Must run after the IR emitter is enabled, otherwise the
+        // scale is derived from unlit frames and every lit frame clips to white.
         let y16_shift = if format_str == "Y16" {
-            let (buf, _meta) = stream.next().map_err(|e| {
-                FacelockError::Camera(format!("{device_path}: Y16 calibration frame failed: {e}"))
-            })?;
-            let shift = preprocess::y16_shift(buf);
-            tracing::info!(device = %device_path, shift, "Y16 session scale pinned");
-            shift
+            match quirk_y16_shift(quirk) {
+                Some(shift) => {
+                    tracing::info!(device = %device_path, shift, "Y16 session scale from quirk bit depth");
+                    shift
+                }
+                None => {
+                    calibrate_y16_shift(&mut stream, &device_path, y16_calibration_frames(quirk))?
+                }
+            }
         } else {
             0
         };
@@ -555,6 +669,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: Some(format_preference.into()),
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         }
@@ -565,6 +680,46 @@ mod tests {
         let quirk = quirk_with_format("GREY");
         assert_eq!(quirk_format_preference(Some(&quirk)), Some("GREY"));
         assert_eq!(quirk_format_preference(None), None);
+    }
+
+    #[test]
+    fn quirk_y16_shift_uses_declared_bit_depth() {
+        let mut quirk = quirk_with_format("Y16");
+        quirk.y16_bit_depth = Some(10);
+        assert_eq!(quirk_y16_shift(Some(&quirk)), Some(2));
+        quirk.y16_bit_depth = Some(16);
+        assert_eq!(quirk_y16_shift(Some(&quirk)), Some(8));
+    }
+
+    #[test]
+    fn quirk_y16_shift_absent_falls_back_to_calibration() {
+        // No quirk, and a quirk without the field, both leave the burst
+        // calibration in charge.
+        assert_eq!(quirk_y16_shift(None), None);
+        assert_eq!(quirk_y16_shift(Some(&quirk_with_format("Y16"))), None);
+    }
+
+    #[test]
+    fn y16_calibration_frames_follows_declared_warmup() {
+        // Default burst when the device says nothing.
+        assert_eq!(y16_calibration_frames(None), Y16_CALIBRATION_FRAMES);
+        let mut quirk = quirk_with_format("Y16");
+        assert_eq!(y16_calibration_frames(Some(&quirk)), 8);
+        // A camera that declares a longer warmup (RealSense SR300) gets a burst
+        // that covers it; a shorter one never shortens the default.
+        quirk.warmup_frames = Some(10);
+        assert_eq!(y16_calibration_frames(Some(&quirk)), 10);
+        quirk.warmup_frames = Some(1);
+        assert_eq!(y16_calibration_frames(Some(&quirk)), 8);
+    }
+
+    #[test]
+    fn quirk_y16_shift_ignores_impossible_bit_depth() {
+        let mut quirk = quirk_with_format("Y16");
+        quirk.y16_bit_depth = Some(24);
+        assert_eq!(quirk_y16_shift(Some(&quirk)), None);
+        quirk.y16_bit_depth = Some(4);
+        assert_eq!(quirk_y16_shift(Some(&quirk)), None);
     }
 
     #[test]

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -42,7 +42,18 @@ const Y16_CALIBRATION_FRAMES: usize = 8;
 /// Wall-clock ceiling on that burst. Frames are already flowing when it runs,
 /// so it normally costs a fraction of a second; the budget keeps a stalling
 /// camera from stretching `Camera::open` by `CAPTURE_TIMEOUT` eight times over.
+///
+/// This bounds when the burst STOPS starting new captures, not when it
+/// returns: the check sits at the top of the loop, so a dequeue begun just
+/// under the budget can still block for `CAPTURE_TIMEOUT`. Worst case is
+/// therefore this budget plus one `CAPTURE_TIMEOUT`, not this budget alone.
 const Y16_CALIBRATION_BUDGET: Duration = Duration::from_secs(1);
+
+/// Consecutive-error ceiling for the calibration burst, kept separate from
+/// [`Y16_CALIBRATION_FRAMES`] deliberately: the frame target scales with a
+/// device's declared `warmup_frames`, and an error budget that rode along
+/// with it would silently loosen when someone lengthened the burst.
+const Y16_CALIBRATION_MAX_ERRORS: usize = 8;
 
 /// Pixel formats facelock can decode to RGB, in negotiation priority order:
 /// IR-native grayscale first, then cheap lossless raw conversions, then MJPG
@@ -116,8 +127,17 @@ fn y16_calibration_frames(quirk: Option<&Quirk>) -> usize {
 }
 
 /// Pin the session Y16 scale by sampling a burst of frames and taking the
-/// brightest sample any of them produced. The peak is a lower bound on the
-/// sensor's full scale, so more frames can only improve the estimate.
+/// brightest sample any of them produced.
+///
+/// More frames raise the peak toward the sensor's full scale, which is the
+/// point of the burst. They do NOT bound it from above: `y16_peak` is an
+/// unbounded max over every pixel, so one stuck pixel or one specular IR
+/// glint sets it alone. On a 10-bit sensor a pixel latched at 4095 pins
+/// shift 4 where 2 was right, and every later frame is scaled down 4x —
+/// enough to drop a real face under `ir_texture_min_stddev` for the whole
+/// session. `Y16Calibration::Saturated` only catches the `u16::MAX`
+/// endpoint, so that case warns nothing. A quirk's `y16_bit_depth` is the
+/// only way to take the scale out of the scene's hands entirely.
 ///
 /// Individual capture errors are tolerated as long as one frame arrives; with
 /// none, opening fails rather than proceeding on a guessed scale.
@@ -129,7 +149,7 @@ fn calibrate_y16_shift(stream: &mut Stream<'_>, device_path: &str, target: usize
     let mut last_err = None;
 
     while frames < target
-        && errors < Y16_CALIBRATION_FRAMES
+        && errors < Y16_CALIBRATION_MAX_ERRORS
         && start.elapsed() < Y16_CALIBRATION_BUDGET
     {
         match stream.next() {
@@ -152,6 +172,27 @@ fn calibrate_y16_shift(stream: &mut Stream<'_>, device_path: &str, target: usize
         return Err(FacelockError::Camera(format!(
             "{device_path}: Y16 calibration failed: {detail}"
         )));
+    }
+
+    // A burst cut short by the wall-clock budget or the error budget pins the
+    // scale from however few frames arrived, and at one frame that is the
+    // single-frame AGC race the burst exists to avoid. The peak is still a
+    // lower bound, so the shift is not wrong by construction — but it was
+    // decided on less evidence than intended, and nothing else says so: a
+    // mid-range peak from one dark frame takes the `Normal` arm below and
+    // logs nothing.
+    if frames < target {
+        tracing::warn!(
+            device = %device_path,
+            frames,
+            target,
+            errors,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "Y16 calibration burst ended early: pinned the session scale from \
+             fewer frames than intended, so the camera's exposure may not have \
+             settled. Set the quirk's y16_bit_depth for this device to pin the \
+             scale from hardware instead."
+        );
     }
 
     let (shift, verdict) = preprocess::y16_calibration(peak);

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -407,7 +407,33 @@ impl<'a> Camera<'a> {
                     shift
                 }
                 None => {
-                    calibrate_y16_shift(&mut stream, &device_path, y16_calibration_frames(quirk))?
+                    // Not `?`: the emitter is already lit and `Camera` does not
+                    // exist yet, so an early return here would skip the `Drop`
+                    // that is the only thing which turns it back off. Every
+                    // other failure path above runs before the emitter is
+                    // enabled; this one is the exception, so it cleans up.
+                    match calibrate_y16_shift(
+                        &mut stream,
+                        &device_path,
+                        y16_calibration_frames(quirk),
+                    ) {
+                        Ok(shift) => shift,
+                        Err(e) => {
+                            if ir_emitter_active {
+                                if let Some(ref xu_info) = emitter_xu_info {
+                                    if let Err(off) =
+                                        ir_emitter::disable_emitter_with_info(&device_path, xu_info)
+                                    {
+                                        tracing::warn!(
+                                            "failed to disable IR emitter on {device_path} after \
+                                             Y16 calibration failed: {off}"
+                                        );
+                                    }
+                                }
+                            }
+                            return Err(e);
+                        }
+                    }
                 }
             }
         } else {

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -25,6 +25,21 @@ const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 /// keeps that discard correct if the buffer depth ever changes.
 pub const MMAP_BUFFERS: u32 = 4;
 
+/// Pixel formats facelock can decode to RGB, in negotiation priority order:
+/// IR-native grayscale first, then cheap lossless raw conversions, then MJPG
+/// (JPEG decode). "Y16 " carries its FourCC trailing space; comparisons are
+/// whitespace-trimmed. Also used by device auto-detection to skip devices
+/// (e.g. raw Bayer sensor nodes) that advertise none of these.
+pub const DECODABLE_FORMATS: &[&str] = &["GREY", "Y16 ", "YUYV", "NV12", "MJPG"];
+
+/// Index into `available` of the first advertised format in `preferred`
+/// priority order. FourCC comparison is whitespace-trimmed.
+fn select_format(preferred: &[&str], available: &[String]) -> Option<usize> {
+    preferred
+        .iter()
+        .find_map(|pref| available.iter().position(|f| f.trim() == pref.trim()))
+}
+
 use crate::ir_emitter;
 use crate::ir_emitter::EmitterXuInfo;
 use crate::preprocess;
@@ -96,31 +111,44 @@ impl<'a> Camera<'a> {
             )));
         }
 
-        // Select format: prefer GREY > YUYV > MJPG > any
-        // If a quirk specifies a format_preference, prepend it to the priority list.
+        // Select format by DECODABLE_FORMATS priority. If a quirk specifies a
+        // format_preference, prepend it to the priority list. A device that
+        // advertises no decodable format (e.g. a raw Bayer sensor node) fails
+        // here with an actionable error instead of negotiating a format that
+        // every subsequent capture would fail to decode.
         let formats = dev
             .enum_formats()
             .map_err(|e| FacelockError::Camera(format!("failed to enum formats: {e}")))?;
 
-        let default_preferred: &[&str] = &["GREY", "YUYV", "MJPG"];
         let quirk_fmt = quirk.and_then(|q| q.format_preference.as_deref());
-        let mut preferred: Vec<&str> = Vec::with_capacity(4);
+        let mut preferred: Vec<&str> = Vec::with_capacity(DECODABLE_FORMATS.len() + 1);
         if let Some(fmt_pref) = quirk_fmt {
             tracing::debug!(format = fmt_pref, "quirk: prepending format preference");
             preferred.push(fmt_pref);
         }
-        preferred.extend_from_slice(default_preferred);
+        preferred.extend_from_slice(DECODABLE_FORMATS);
 
-        let selected_fourcc = preferred
-            .iter()
-            .find_map(|&pref| {
-                formats
-                    .iter()
-                    .find(|f| f.fourcc.to_string().trim() == pref.trim())
-                    .map(|f| f.fourcc)
-            })
-            .or_else(|| formats.first().map(|f| f.fourcc))
-            .ok_or_else(|| FacelockError::Camera(format!("{device_path}: no supported formats")))?;
+        let available: Vec<String> = formats.iter().map(|f| f.fourcc.to_string()).collect();
+        let selected_fourcc = select_format(&preferred, &available)
+            .map(|idx| formats[idx].fourcc)
+            .ok_or_else(|| {
+                FacelockError::Camera(format!(
+                    "{device_path}: no decodable pixel format — device advertises [{}] but \
+                     facelock supports [{}]. Raw sensor nodes (e.g. Intel IPU6/IPU7) cannot \
+                     be used directly; set device.path to a processed camera instead \
+                     (see docs/compatibility.md)",
+                    available
+                        .iter()
+                        .map(|f| f.trim())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    DECODABLE_FORMATS
+                        .iter()
+                        .map(|f| f.trim())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ))
+            })?;
 
         // Set format with resolution capped at 640x480, respecting max_height
         let max_h = config.max_height.min(480);
@@ -253,8 +281,8 @@ impl<'a> Camera<'a> {
             .next()
             .map_err(|e| FacelockError::Camera(format!("capture failed: {e}")))?;
 
-        // Convert to RGB based on format
-        let rgb: Vec<u8> = match self.format.as_str() {
+        // Convert to RGB based on format (trimmed: "Y16 " has a trailing space)
+        let rgb: Vec<u8> = match self.format.trim() {
             "GREY" => {
                 // Replicate single channel 3x
                 let mut rgb = Vec::with_capacity(buf.len() * 3);
@@ -265,7 +293,30 @@ impl<'a> Camera<'a> {
                 }
                 rgb
             }
+            "Y16" => {
+                // 16-bit grayscale -> 8-bit (bit-depth aware), replicated 3x
+                let gray = preprocess::y16_to_gray(buf);
+                let mut rgb = Vec::with_capacity(gray.len() * 3);
+                for &p in &gray {
+                    rgb.push(p);
+                    rgb.push(p);
+                    rgb.push(p);
+                }
+                rgb
+            }
             "YUYV" => preprocess::yuyv_to_rgb(buf, self.width, self.height),
+            "NV12" => {
+                let rgb = preprocess::nv12_to_rgb(buf, self.width, self.height);
+                if rgb.is_empty() {
+                    return Err(FacelockError::Camera(format!(
+                        "NV12 frame too short: {} bytes for {}x{}",
+                        buf.len(),
+                        self.width,
+                        self.height
+                    )));
+                }
+                rgb
+            }
             "MJPG" => {
                 let reader = ImageReader::with_format(Cursor::new(buf), image::ImageFormat::Jpeg)
                     .decode()
@@ -380,6 +431,49 @@ impl CameraSource for Camera<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fourccs(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn select_format_prefers_priority_order() {
+        // Device advertises MJPG and YUYV: YUYV wins (earlier in priority).
+        let available = fourccs(&["MJPG", "YUYV"]);
+        assert_eq!(select_format(DECODABLE_FORMATS, &available), Some(1));
+        // GREY beats everything.
+        let available = fourccs(&["MJPG", "YUYV", "GREY"]);
+        assert_eq!(select_format(DECODABLE_FORMATS, &available), Some(2));
+    }
+
+    #[test]
+    fn select_format_picks_nv12_over_mjpg() {
+        let available = fourccs(&["MJPG", "NV12"]);
+        assert_eq!(select_format(DECODABLE_FORMATS, &available), Some(1));
+    }
+
+    #[test]
+    fn select_format_trims_fourcc_whitespace() {
+        // "Y16 " (trailing space, as v4l reports it) matches the Y16 entry.
+        let available = fourccs(&["Y16 "]);
+        assert_eq!(select_format(DECODABLE_FORMATS, &available), Some(0));
+    }
+
+    #[test]
+    fn select_format_rejects_undecodable_only_device() {
+        // Raw Bayer IPU7 node (issue #89): nothing decodable -> None, so
+        // Camera::open fails fast instead of negotiating an unusable format.
+        let available = fourccs(&["SGRBG10", "SGBRG10"]);
+        assert_eq!(select_format(DECODABLE_FORMATS, &available), None);
+    }
+
+    #[test]
+    fn select_format_quirk_preference_first() {
+        let mut preferred = vec!["MJPG"];
+        preferred.extend_from_slice(DECODABLE_FORMATS);
+        let available = fourccs(&["GREY", "MJPG"]);
+        assert_eq!(select_format(&preferred, &available), Some(1));
+    }
 
     #[test]
     fn all_black_frame_is_dark_with_config() {

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -68,8 +68,17 @@ fn select_format(preferred: &[&str], available: &[String]) -> Option<usize> {
 
 /// A quirk's `format_preference`, dropped when facelock cannot decode it —
 /// honoring it would negotiate a format every subsequent capture fails on.
+///
+/// Trimmed rather than compared raw. `QuirksDb::load_file` already normalizes
+/// what it parses, but the shipped `config/quirks.d/00-defaults.toml` writes
+/// the PADDED V4L2 spelling (`format_preference = "Y16 "`) for all three
+/// RealSense entries — so if that normalization ever regressed, an exact
+/// comparison here would silently reclassify every one of them as
+/// "undecodable" and drop the preference that picks their IR sensor node.
+/// Trimming makes this predicate independent of where the `Quirk` came from
+/// (parsed file, `push_quirk_for_test`, or constructed in code).
 fn quirk_format_preference(quirk: Option<&Quirk>) -> Option<&str> {
-    let pref = quirk.and_then(|q| q.format_preference.as_deref())?;
+    let pref = quirk.and_then(|q| q.format_preference.as_deref())?.trim();
     if !DECODABLE_FORMATS.contains(&pref) {
         tracing::warn!(
             format = pref,
@@ -680,6 +689,18 @@ mod tests {
         let quirk = quirk_with_format("GREY");
         assert_eq!(quirk_format_preference(Some(&quirk)), Some("GREY"));
         assert_eq!(quirk_format_preference(None), None);
+    }
+
+    #[test]
+    fn quirk_format_preference_accepts_the_padded_v4l2_spelling() {
+        // `config/quirks.d/00-defaults.toml` writes `format_preference = "Y16 "`
+        // for the three RealSense entries. `QuirksDb::load_file` normalizes it,
+        // but this predicate must not DEPEND on that having happened: an exact
+        // comparison here would turn a regression in the loader into three
+        // silently-dropped IR-sensor preferences plus a misleading "not a
+        // decodable format" warning.
+        let quirk = quirk_with_format("Y16 ");
+        assert_eq!(quirk_format_preference(Some(&quirk)), Some("Y16"));
     }
 
     #[test]

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -49,12 +49,6 @@ const Y16_CALIBRATION_FRAMES: usize = 8;
 /// therefore this budget plus one `CAPTURE_TIMEOUT`, not this budget alone.
 const Y16_CALIBRATION_BUDGET: Duration = Duration::from_secs(1);
 
-/// Consecutive-error ceiling for the calibration burst, kept separate from
-/// [`Y16_CALIBRATION_FRAMES`] deliberately: the frame target scales with a
-/// device's declared `warmup_frames`, and an error budget that rode along
-/// with it would silently loosen when someone lengthened the burst.
-const Y16_CALIBRATION_MAX_ERRORS: usize = 8;
-
 /// Pixel formats facelock can decode to RGB, in negotiation priority order:
 /// IR-native grayscale first, then cheap lossless raw conversions, then MJPG
 /// (JPEG decode). Also used by device auto-detection to skip devices (e.g. raw
@@ -139,54 +133,50 @@ fn y16_calibration_frames(quirk: Option<&Quirk>) -> usize {
 /// endpoint, so that case warns nothing. A quirk's `y16_bit_depth` is the
 /// only way to take the scale out of the scene's hands entirely.
 ///
-/// Individual capture errors are tolerated as long as one frame arrives; with
-/// none, opening fails rather than proceeding on a guessed scale.
+/// A capture error ends the open. It is tempting to tolerate a few and keep
+/// sampling, but no `next()` error is transient here: `v4l`'s capture stream
+/// advances `arena_index` only on a successful dequeue and re-queues that
+/// same index on the following call, so one failed dequeue leaves the buffer
+/// queued in the kernel and every later call re-queues it and gets EINVAL.
+/// Tolerating errors would therefore trade a hard failure carrying the real
+/// message for a `Camera` that returns "Invalid argument" from every capture,
+/// having reported a successfully pinned scale on the way out.
 fn calibrate_y16_shift(stream: &mut Stream<'_>, device_path: &str, target: usize) -> Result<u8> {
     let start = Instant::now();
     let mut peak = 0u16;
     let mut frames = 0usize;
-    let mut errors = 0usize;
-    let mut last_err = None;
 
-    while frames < target
-        && errors < Y16_CALIBRATION_MAX_ERRORS
-        && start.elapsed() < Y16_CALIBRATION_BUDGET
-    {
+    while frames < target && start.elapsed() < Y16_CALIBRATION_BUDGET {
         match stream.next() {
             Ok((buf, _meta)) => {
                 peak = peak.max(preprocess::y16_peak(buf));
                 frames += 1;
             }
             Err(e) => {
-                errors += 1;
-                last_err = Some(e);
+                return Err(FacelockError::Camera(format!(
+                    "{device_path}: Y16 calibration failed after {frames} frame(s): {e}"
+                )));
             }
         }
     }
 
     if frames == 0 {
-        let detail = match last_err {
-            Some(e) => e.to_string(),
-            None => "no frame arrived within the calibration budget".to_string(),
-        };
         return Err(FacelockError::Camera(format!(
-            "{device_path}: Y16 calibration failed: {detail}"
+            "{device_path}: Y16 calibration failed: no frame arrived within the \
+             calibration budget"
         )));
     }
 
-    // A burst cut short by the wall-clock budget or the error budget pins the
-    // scale from however few frames arrived, and at one frame that is the
-    // single-frame AGC race the burst exists to avoid. The peak is still a
-    // lower bound, so the shift is not wrong by construction — but it was
-    // decided on less evidence than intended, and nothing else says so: a
-    // mid-range peak from one dark frame takes the `Normal` arm below and
-    // logs nothing.
+    // A burst cut short by the wall-clock budget pins the scale from however
+    // few frames arrived, and at one frame that is the single-frame AGC race
+    // the burst exists to avoid. It was decided on less evidence than
+    // intended, and nothing else says so: a mid-range peak off one dark frame
+    // takes the `Normal` arm below and logs nothing.
     if frames < target {
         tracing::warn!(
             device = %device_path,
             frames,
             target,
-            errors,
             elapsed_ms = start.elapsed().as_millis() as u64,
             "Y16 calibration burst ended early: pinned the session scale from \
              fewer frames than intended, so the camera's exposure may not have \

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -122,7 +122,7 @@ fn has_decodable_format(device: &DeviceInfo) -> bool {
     device
         .formats
         .iter()
-        .any(|f| crate::capture::DECODABLE_FORMATS.contains(&f.fourcc.as_str()))
+        .any(|f| crate::capture::DECODABLE_FORMATS.contains(&f.fourcc.trim()))
 }
 
 /// True if the device enumerates at least one IR-typical mono format
@@ -329,11 +329,20 @@ fn classify_ir_sources_with_ids(
         let pref = quirks
             .and_then(|db| db.find_match_with_ids(&devices[i], Some(ids)))
             .and_then(|q| q.format_preference.clone());
+        // Both sides trimmed. Ingest normalizes FourCCs now, but this
+        // comparison decides whether a node is demoted out of `force_ir`, and
+        // a false here in *every* node of the group means no node is demoted
+        // and `force_ir` is trusted for all of them — the RGB sibling
+        // included. That is the wrong direction to fail in, so it does not
+        // get to depend on normalization having happened upstream.
         let node_has_ir_format = |j: usize| {
             has_native_ir_format(&devices[j])
-                || pref
-                    .as_deref()
-                    .is_some_and(|p| devices[j].formats.iter().any(|f| f.fourcc == p))
+                || pref.as_deref().is_some_and(|p| {
+                    devices[j]
+                        .formats
+                        .iter()
+                        .any(|f| f.fourcc.trim() == p.trim())
+                })
         };
 
         // Only demote when format evidence exists within the group; otherwise
@@ -1006,6 +1015,47 @@ mod tests {
         let sources = [IrSource::Format, IrSource::None];
         let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
         assert_eq!(picked.path, "/dev/video2");
+    }
+
+    #[test]
+    fn ir_typical_and_decodable_format_sets_deliberately_disagree() {
+        // The rebase of #90 onto the evidence-based IR classification (#98)
+        // put two format lists side by side, and they are NOT the same set.
+        // Pinning the disagreement here so a later edit to either list is a
+        // deliberate act rather than an accident:
+        //
+        //   - Y8/Y10/Y12 are IR evidence but facelock cannot decode them, so a
+        //     node whose only IR evidence is one of them classifies as IR and
+        //     is then excluded from auto-detection.
+        //   - YUYV/NV12/MJPG are decodable but are not IR evidence.
+        //
+        // If Y8/Y10/Y12 decode support is ever added, the first assertion is
+        // what will fail and point at this comment.
+        let ir_only: Vec<&str> = IR_TYPICAL_FOURCCS
+            .iter()
+            .copied()
+            .filter(|f| !crate::capture::DECODABLE_FORMATS.contains(f))
+            .collect();
+        assert_eq!(
+            ir_only,
+            vec!["Y12", "Y10", "Y8"],
+            "IR-typical but undecodable — these classify as IR and are then \
+             excluded from auto-detection"
+        );
+
+        let decodable_only: Vec<&str> = crate::capture::DECODABLE_FORMATS
+            .iter()
+            .copied()
+            .filter(|f| !IR_TYPICAL_FOURCCS.contains(f))
+            .collect();
+        assert_eq!(decodable_only, vec!["YUYV", "NV12", "MJPG"]);
+
+        // And the consequence, stated as behavior: adding Y16 decode support
+        // did NOT make Y16 evidence of anything new — a Y16-only node was IR
+        // before #90 and is IR after it. #90 only made it openable.
+        let y16_only = device_at("/dev/video0", "Depth Camera", &["Y16"]);
+        assert!(has_decodable_format(&y16_only));
+        assert_eq!(heuristic_ir_source(&y16_only), IrSource::Format);
     }
 
     #[test]

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -674,6 +674,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("test force_ir via USB ID".into()),
         });
@@ -702,6 +703,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("test force_ir".into()),
         });
@@ -746,6 +748,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         });
@@ -773,6 +776,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: Some(1),
             format_preference: format_preference.map(Into::into),
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("Logitech BRIO 4K with IR sensor".into()),
         }
@@ -910,6 +914,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         });
@@ -948,6 +953,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         });

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -16,7 +16,8 @@ pub struct DeviceInfo {
 
 /// A supported pixel format with its available sizes. Defined in
 /// `facelock-core` so `CameraCaps` can carry it; re-exported here where the
-/// enumeration actually happens.
+/// enumeration actually happens. [`query_device`] normalizes each `fourcc`
+/// (V4L2's trailing-space padding stripped: "Y16", not "Y16 ").
 pub use facelock_core::types::FormatInfo;
 
 /// List all V4L2 video capture devices.
@@ -118,11 +119,10 @@ fn is_ir_typical_fourcc(fourcc: &str) -> bool {
 /// says so in syslog rather than leaving the operator with only the
 /// downstream "not an IR camera" error.
 fn has_decodable_format(device: &DeviceInfo) -> bool {
-    device.formats.iter().any(|f| {
-        crate::capture::DECODABLE_FORMATS
-            .iter()
-            .any(|d| f.fourcc.trim() == d.trim())
-    })
+    device
+        .formats
+        .iter()
+        .any(|f| crate::capture::DECODABLE_FORMATS.contains(&f.fourcc.as_str()))
 }
 
 /// True if the device enumerates at least one IR-typical mono format
@@ -137,6 +137,16 @@ fn has_native_ir_format(device: &DeviceInfo) -> bool {
         .formats
         .iter()
         .any(|f| is_ir_typical_fourcc(&f.fourcc))
+}
+
+/// Comma-separated format listing for operator-facing messages.
+fn format_listing(device: &DeviceInfo) -> String {
+    device
+        .formats
+        .iter()
+        .map(|f| f.fourcc.trim())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// True if this device enumerates ONLY IR-typical mono capture formats
@@ -321,12 +331,9 @@ fn classify_ir_sources_with_ids(
             .and_then(|q| q.format_preference.clone());
         let node_has_ir_format = |j: usize| {
             has_native_ir_format(&devices[j])
-                || pref.as_deref().is_some_and(|p| {
-                    devices[j]
-                        .formats
-                        .iter()
-                        .any(|f| f.fourcc.trim() == p.trim())
-                })
+                || pref
+                    .as_deref()
+                    .is_some_and(|p| devices[j].formats.iter().any(|f| f.fourcc == p))
         };
 
         // Only demote when format evidence exists within the group; otherwise
@@ -409,31 +416,21 @@ pub fn auto_detect_device_with(quirks: &crate::quirks::QuirksDb) -> Result<Devic
         return Err(FacelockError::Camera("no video devices found".into()));
     }
     let sources = classify_ir_sources(&devices, Some(quirks));
-    pick_auto_device(&devices, &sources).cloned().ok_or_else(|| {
-        let listing = devices
-            .iter()
-            .map(|d| {
-                let fmts = d
-                    .formats
-                    .iter()
-                    .map(|f| f.fourcc.trim())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{} \"{}\" [{fmts}]", d.path, d.name)
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        FacelockError::Camera(format!(
-            "no camera with a decodable pixel format ({}) found; detected: {listing}. \
+    pick_auto_device(&devices, &sources)
+        .cloned()
+        .ok_or_else(|| {
+            let listing = devices
+                .iter()
+                .map(|d| format!("{} \"{}\" [{}]", d.path, d.name, format_listing(d)))
+                .collect::<Vec<_>>()
+                .join("; ");
+            FacelockError::Camera(format!(
+                "no camera with a decodable pixel format ({}) found; detected: {listing}. \
              Raw sensor nodes (e.g. Intel IPU6/IPU7) are excluded from auto-detection — \
              set device.path to a processed camera (see docs/compatibility.md)",
-            crate::capture::DECODABLE_FORMATS
-                .iter()
-                .map(|f| f.trim())
-                .collect::<Vec<_>>()
-                .join("/"),
-        ))
-    })
+                crate::capture::DECODABLE_FORMATS.join("/"),
+            ))
+        })
 }
 
 /// Selection order for auto-detection, over pre-classified nodes.
@@ -452,6 +449,20 @@ pub fn auto_detect_device_with(quirks: &crate::quirks::QuirksDb) -> Result<Devic
 /// (the `require_ir` gate reads the caps of whatever node is finally picked),
 /// so the exclusion can only ever fail closed.
 fn pick_auto_device<'a>(devices: &'a [DeviceInfo], sources: &[IrSource]) -> Option<&'a DeviceInfo> {
+    // An excluded IR node is why auth later reports "not an IR camera" — say so
+    // in syslog rather than leaving the operator with only the downstream error.
+    for (device, source) in devices.iter().zip(sources) {
+        if *source != IrSource::None && !has_decodable_format(device) {
+            tracing::warn!(
+                device = %device.path,
+                name = %device.name,
+                formats = %format_listing(device),
+                source = ?source,
+                "IR-classified camera has no decodable pixel format — excluded from auto-detection"
+            );
+        }
+    }
+
     let nodes = || {
         devices
             .iter()
@@ -494,7 +505,7 @@ fn query_device(path: &str) -> Result<DeviceInfo> {
     let mut formats = Vec::new();
     if let Ok(fmt_list) = dev.enum_formats() {
         for fmt in fmt_list {
-            let fourcc = fmt.fourcc.to_string();
+            let fourcc = crate::capture::normalize_fourcc(fmt.fourcc);
             let description = fmt.description.clone();
             let mut sizes = Vec::new();
             if let Ok(size_list) = dev.enum_framesizes(fmt.fourcc) {
@@ -623,7 +634,17 @@ mod tests {
     fn is_ir_camera_y16_alone_is_format_regardless_of_name() {
         // Y16 native mono format alone → Format provenance, independent of
         // the device name (#98: evidence-derived, not name-derived).
+        //
+        // Deliberately the PADDED spelling: `query_device` now normalizes
+        // FourCCs at ingest, but IR classification must not start depending on
+        // that — a `DeviceInfo` reaching here from anywhere else (a test, a
+        // future caller, `CameraCaps`) still classifies the same. The trim in
+        // `is_ir_typical_fourcc` is what holds that, and this pins it.
         let device = device_with("Integrated IR Camera", &["Y16 "]);
+        assert!(is_ir_camera(&device));
+        assert_eq!(ir_source(&device), IrSource::Format);
+        // ...and the normalized spelling the real ingest path produces.
+        let device = device_with("Integrated IR Camera", &["Y16"]);
         assert!(is_ir_camera(&device));
         assert_eq!(ir_source(&device), IrSource::Format);
     }
@@ -634,6 +655,9 @@ mod tests {
         // device's name gives no IR hint at all — proving classification
         // does not depend on the name in either direction.
         let device = device_with("Depth Camera", &["Y16 "]);
+        assert!(is_ir_camera(&device));
+        assert_eq!(ir_source(&device), IrSource::Format);
+        let device = device_with("Depth Camera", &["Y16"]);
         assert!(is_ir_camera(&device));
         assert_eq!(ir_source(&device), IrSource::Format);
     }
@@ -991,7 +1015,7 @@ mod tests {
     #[test]
     fn pick_auto_device_y16_only_device_is_decodable() {
         // Y16 decode support means a Y16-only IR camera stays usable.
-        let devices = [device_at("/dev/video0", "Integrated IR Camera", &["Y16 "])];
+        let devices = [device_at("/dev/video0", "Integrated IR Camera", &["Y16"])];
         let sources = [IrSource::Format];
         let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
         assert_eq!(picked.path, "/dev/video0");

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -106,6 +106,25 @@ fn is_ir_typical_fourcc(fourcc: &str) -> bool {
     IR_TYPICAL_FOURCCS.contains(&fourcc.trim())
 }
 
+/// True if the device advertises at least one pixel format facelock can
+/// decode (see [`crate::capture::DECODABLE_FORMATS`]). Raw sensor nodes
+/// (e.g. Bayer-only Intel IPU6/IPU7 capture nodes) fail this check.
+///
+/// NOTE: this is a strictly different question from IR-ness. The two lists
+/// overlap on GREY and Y16 but neither contains the other: Y8/Y10/Y12 are
+/// IR-typical yet undecodable, and YUYV/NV12/MJPG are decodable yet not IR
+/// evidence. A device classified IR purely on Y8/Y10/Y12 evidence is
+/// therefore excluded from auto-detection — see [`pick_auto_device`], which
+/// says so in syslog rather than leaving the operator with only the
+/// downstream "not an IR camera" error.
+fn has_decodable_format(device: &DeviceInfo) -> bool {
+    device.formats.iter().any(|f| {
+        crate::capture::DECODABLE_FORMATS
+            .iter()
+            .any(|d| f.fourcc.trim() == d.trim())
+    })
+}
+
 /// True if the device enumerates at least one IR-typical mono format
 /// (GREY/Y8/Y10/Y12/Y16), possibly alongside other (e.g. color) formats.
 ///
@@ -386,10 +405,35 @@ pub fn auto_detect_device() -> Result<DeviceInfo> {
 /// changed in between, and costs a directory walk either way.
 pub fn auto_detect_device_with(quirks: &crate::quirks::QuirksDb) -> Result<DeviceInfo> {
     let devices = list_devices()?;
+    if devices.is_empty() {
+        return Err(FacelockError::Camera("no video devices found".into()));
+    }
     let sources = classify_ir_sources(&devices, Some(quirks));
-    pick_auto_device(&devices, &sources)
-        .cloned()
-        .ok_or_else(|| FacelockError::Camera("no video devices found".into()))
+    pick_auto_device(&devices, &sources).cloned().ok_or_else(|| {
+        let listing = devices
+            .iter()
+            .map(|d| {
+                let fmts = d
+                    .formats
+                    .iter()
+                    .map(|f| f.fourcc.trim())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{} \"{}\" [{fmts}]", d.path, d.name)
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        FacelockError::Camera(format!(
+            "no camera with a decodable pixel format ({}) found; detected: {listing}. \
+             Raw sensor nodes (e.g. Intel IPU6/IPU7) are excluded from auto-detection — \
+             set device.path to a processed camera (see docs/compatibility.md)",
+            crate::capture::DECODABLE_FORMATS
+                .iter()
+                .map(|f| f.trim())
+                .collect::<Vec<_>>()
+                .join("/"),
+        ))
+    })
 }
 
 /// Selection order for auto-detection, over pre-classified nodes.
@@ -399,8 +443,21 @@ pub fn auto_detect_device_with(quirks: &crate::quirks::QuirksDb) -> Result<Devic
 /// nodes with no quirk, the device name is consulted only as a tiebreak hint
 /// (an IR name token breaks ties among already-qualified nodes; it never
 /// promotes a node with no format evidence — see [`heuristic_ir_source`]).
+///
+/// Devices without a decodable pixel format (raw Bayer sensor nodes etc.) are
+/// excluded from every tier — selecting one would guarantee capture failure.
+/// The exclusion is applied AFTER classification, never before it: it changes
+/// which node is selected, never whether a node counts as IR. A device that
+/// would have been selected but is excluded here still cannot authenticate
+/// (the `require_ir` gate reads the caps of whatever node is finally picked),
+/// so the exclusion can only ever fail closed.
 fn pick_auto_device<'a>(devices: &'a [DeviceInfo], sources: &[IrSource]) -> Option<&'a DeviceInfo> {
-    let nodes = || devices.iter().zip(sources);
+    let nodes = || {
+        devices
+            .iter()
+            .zip(sources)
+            .filter(|(d, _)| has_decodable_format(d))
+    };
     nodes()
         .find(|(d, s)| **s == IrSource::Quirk && has_native_ir_format(d))
         .or_else(|| nodes().find(|(_, s)| **s == IrSource::Quirk))
@@ -410,7 +467,7 @@ fn pick_auto_device<'a>(devices: &'a [DeviceInfo], sources: &[IrSource]) -> Opti
                 .or_else(|| nodes().find(|(_, s)| **s != IrSource::None))
         })
         .map(|(d, _)| d)
-        .or_else(|| devices.first())
+        .or_else(|| devices.iter().find(|d| has_decodable_format(d)))
 }
 
 fn query_device(path: &str) -> Result<DeviceInfo> {
@@ -880,6 +937,64 @@ mod tests {
         // Different physical devices — both keep their quirk classification.
         assert_eq!(sources[0], IrSource::Quirk);
         assert_eq!(sources[1], IrSource::Quirk);
+    }
+
+    #[test]
+    fn pick_auto_device_skips_undecodable_raw_node() {
+        // Issue #89: Intel IPU7 exposes raw Bayer nodes first (/dev/video0)
+        // and a processed loopback camera later. Auto-detection must skip the
+        // raw node even though it enumerates first.
+        let devices = [
+            device_at("/dev/video0", "ipu7", &["SGRBG10"]),
+            device_at("/dev/video50", "Hardware ISP Camera", &["NV12", "YUYV"]),
+        ];
+        let sources = [IrSource::None, IrSource::None];
+        let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
+        assert_eq!(picked.path, "/dev/video50");
+    }
+
+    #[test]
+    fn pick_auto_device_skips_undecodable_ir_classified_node() {
+        // Even an IR-classified node is unusable without a decodable format;
+        // fall through to a decodable device rather than guarantee capture
+        // failure.
+        //
+        // Y10 is the reachable shape of this after #98: the IR-typical list
+        // (GREY/Y8/Y10/Y12/Y16) and the decodable list (GREY/Y16/YUYV/NV12/
+        // MJPG) are different sets, so a Y10-only sensor node classifies as
+        // `IrSource::Format` on its own evidence and is *still* excluded here.
+        // Note what this costs: on a machine whose only IR sensor is Y10-only,
+        // auto-detection now lands on the RGB webcam instead. That fails the
+        // `require_ir` gate (the gate reads the caps of the node finally
+        // picked), so it fails closed — but it fails with "not an IR camera"
+        // rather than "cannot decode Y10", which is why the exclusion is also
+        // logged with the device path and its formats.
+        let devices = [
+            device_at("/dev/video0", "Vendor IR Camera", &["Y10"]),
+            device_at("/dev/video2", "USB Camera", &["MJPG"]),
+        ];
+        let sources = [IrSource::Format, IrSource::None];
+        let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
+        assert_eq!(picked.path, "/dev/video2");
+    }
+
+    #[test]
+    fn pick_auto_device_none_when_nothing_decodable() {
+        let devices = [
+            device_at("/dev/video0", "ipu7", &["SGRBG10"]),
+            device_at("/dev/video1", "ipu7", &["SBGGR12"]),
+        ];
+        let sources = [IrSource::None, IrSource::None];
+        assert!(pick_auto_device(&devices, &sources).is_none());
+    }
+
+    #[test]
+    fn pick_auto_device_y16_only_device_is_decodable() {
+        // Y16 decode support means a Y16-only IR camera stays usable.
+        let devices = [device_at("/dev/video0", "Integrated IR Camera", &["Y16 "])];
+        let sources = [IrSource::Format];
+        let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
+        assert_eq!(picked.path, "/dev/video0");
     }
 
     #[test]

--- a/crates/facelock-camera/src/ir_emitter.rs
+++ b/crates/facelock-camera/src/ir_emitter.rs
@@ -352,6 +352,7 @@ mod tests {
             emitter_xu_selector: Some(3),
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         }
@@ -367,6 +368,7 @@ mod tests {
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         }

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -13,5 +13,8 @@ pub use device::{
     is_ir_camera_resolved, is_ir_camera_with_quirks, list_devices, validate_device,
 };
 pub use ir_emitter::EmitterXuInfo;
-pub use preprocess::{check_ir_texture, clahe, extract_bbox_region, rgb_to_gray, yuyv_to_rgb};
+pub use preprocess::{
+    check_ir_texture, clahe, extract_bbox_region, nv12_to_rgb, rgb_to_gray, y16_shift, y16_to_gray,
+    yuyv_to_rgb,
+};
 pub use quirks::{Quirk, QuirksDb, device_fingerprint};

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -14,7 +14,7 @@ pub use device::{
 };
 pub use ir_emitter::EmitterXuInfo;
 pub use preprocess::{
-    check_ir_texture, clahe, extract_bbox_region, nv12_to_rgb, rgb_to_gray, y16_shift, y16_to_gray,
+    check_ir_texture, clahe, extract_bbox_region, nv12_to_rgb, rgb_to_gray, y16_to_gray,
     yuyv_to_rgb,
 };
 pub use quirks::{Quirk, QuirksDb, device_fingerprint};

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -37,6 +37,65 @@ pub fn yuyv_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
     rgb
 }
 
+/// Convert NV12 (YUV 4:2:0 semi-planar) data to RGB.
+/// Layout: full-resolution Y plane followed by one interleaved UV plane at
+/// half resolution in both dimensions (each UV pair covers a 2x2 pixel block).
+/// Uses the same fixed-point (Q10) coefficients as [`yuyv_to_rgb`].
+/// Returns an empty vec if `data` is shorter than a full NV12 frame.
+pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
+    let w = width as usize;
+    let h = height as usize;
+    let y_len = w * h;
+    // UV plane: w * ceil(h/2) bytes (one interleaved row per two image rows).
+    if data.len() < y_len + w * h.div_ceil(2) {
+        return Vec::new();
+    }
+
+    const C_RV: i32 = 1436; // 1.402 * 1024
+    const C_GU: i32 = 352; // 0.344136 * 1024
+    const C_GV: i32 = 731; // 0.714136 * 1024
+    const C_BU: i32 = 1814; // 1.772 * 1024
+
+    let uv_plane = &data[y_len..];
+    let mut rgb = Vec::with_capacity(y_len * 3);
+    for row in 0..h {
+        let uv_row = &uv_plane[(row / 2) * w..];
+        for col in 0..w {
+            let u = uv_row[(col / 2) * 2] as i32 - 128;
+            let v = uv_row[(col / 2) * 2 + 1] as i32 - 128;
+            let y = (data[row * w + col] as i32) << 10;
+            let r = ((y + C_RV * v) >> 10).clamp(0, 255) as u8;
+            let g = ((y - (C_GU * u + C_GV * v)) >> 10).clamp(0, 255) as u8;
+            let b = ((y + C_BU * u) >> 10).clamp(0, 255) as u8;
+            rgb.push(r);
+            rgb.push(g);
+            rgb.push(b);
+        }
+    }
+    rgb
+}
+
+/// Convert Y16 (16-bit little-endian grayscale) data to 8-bit grayscale.
+///
+/// Many IR sensors deliver 10/12-bit samples right-justified in the 16-bit
+/// container, so a plain `>> 8` yields near-black frames. Instead the shift is
+/// derived from the effective bit depth of the frame (the highest set bit of
+/// the brightest pixel), which maps full-scale sensor output to full 8-bit
+/// range without stretching the contrast of genuinely dark frames.
+pub fn y16_to_gray(data: &[u8]) -> Vec<u8> {
+    let max = data
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .max()
+        .unwrap_or(0);
+    // Effective bit depth of the frame, floored at 8 so values <= 255 pass
+    // through unshifted.
+    let shift = (16 - max.leading_zeros()).saturating_sub(8);
+    data.chunks_exact(2)
+        .map(|c| (u16::from_le_bytes([c[0], c[1]]) >> shift) as u8)
+        .collect()
+}
+
 /// Convert RGB image to grayscale using luminance formula.
 /// Uses fixed-point integer math (Q8) to avoid per-pixel float conversion.
 pub fn rgb_to_gray(rgb: &[u8], _width: u32, _height: u32) -> Vec<u8> {
@@ -227,6 +286,92 @@ mod tests {
         assert_eq!(rgb[3], 128);
         assert_eq!(rgb[4], 128);
         assert_eq!(rgb[5], 128);
+    }
+
+    #[test]
+    fn nv12_to_rgb_neutral_gray() {
+        // 2x2 frame: Y plane all 128, one UV pair at (128, 128) -> neutral gray
+        let data = [128u8, 128, 128, 128, 128, 128];
+        let rgb = nv12_to_rgb(&data, 2, 2);
+        assert_eq!(rgb.len(), 12);
+        assert!(rgb.iter().all(|&c| c == 128));
+    }
+
+    #[test]
+    fn nv12_to_rgb_red_chroma() {
+        // Y=128, U=128 (neutral), V=255 -> strong red shift, like YUYV math:
+        // R = 128 + 1.402*127 ~= 306 -> clamped 255; B = 128 (U neutral)
+        let data = [128u8, 128, 128, 128, 128, 255];
+        let rgb = nv12_to_rgb(&data, 2, 2);
+        for px in rgb.chunks_exact(3) {
+            assert_eq!(px[0], 255, "red channel should clamp high");
+            assert!(px[1] < 100, "green pulled down by positive V");
+            assert_eq!(px[2], 128, "blue unaffected by neutral U");
+        }
+    }
+
+    #[test]
+    fn nv12_to_rgb_matches_yuyv_for_same_yuv() {
+        // The same (Y, U, V) triple must produce identical RGB through both
+        // converters (they share coefficients).
+        let (y, u, v) = (90u8, 100u8, 200u8);
+        let yuyv = yuyv_to_rgb(&[y, u, y, v], 2, 1);
+        let nv12 = nv12_to_rgb(&[y, y, y, y, u, v], 2, 2);
+        assert_eq!(&yuyv[0..3], &nv12[0..3]);
+    }
+
+    #[test]
+    fn nv12_to_rgb_short_buffer_returns_empty() {
+        // Y plane only, missing the UV plane entirely.
+        let data = [128u8; 4];
+        assert!(nv12_to_rgb(&data, 2, 2).is_empty());
+    }
+
+    #[test]
+    fn nv12_to_rgb_odd_height_uses_last_uv_row() {
+        // 2x3 frame: Y plane 6 bytes + UV plane w * ceil(3/2) = 4 bytes.
+        let mut data = vec![128u8; 6];
+        data.extend_from_slice(&[128, 128, 128, 128]);
+        let rgb = nv12_to_rgb(&data, 2, 3);
+        assert_eq!(rgb.len(), 18);
+        assert!(rgb.iter().all(|&c| c == 128));
+    }
+
+    #[test]
+    fn y16_full_range_uses_high_byte() {
+        // 16-bit full-scale data: 0xFFFF -> 255, 0x8000 -> 128
+        let data = [0xFF, 0xFF, 0x00, 0x80];
+        let gray = y16_to_gray(&data);
+        assert_eq!(gray, vec![255, 128]);
+    }
+
+    #[test]
+    fn y16_ten_bit_data_maps_to_full_range() {
+        // 10-bit sensor data right-justified in the 16-bit container:
+        // full-scale 1023 must map near 255, not to 3 (which >>8 would give).
+        let data = [
+            0xFF, 0x03, // 1023
+            0x00, 0x02, // 512
+        ];
+        let gray = y16_to_gray(&data);
+        assert_eq!(gray, vec![255, 128]);
+    }
+
+    #[test]
+    fn y16_dark_frame_stays_dark() {
+        // A genuinely dark frame (all values <= 255) passes through unshifted
+        // instead of being contrast-stretched to full range — the dark-frame
+        // quality gate must still see it as dark.
+        let data = [15, 0, 20, 0, 10, 0];
+        let gray = y16_to_gray(&data);
+        assert_eq!(gray, vec![15, 20, 10]);
+    }
+
+    #[test]
+    fn y16_all_zero_frame() {
+        let data = [0u8; 8];
+        let gray = y16_to_gray(&data);
+        assert_eq!(gray, vec![0, 0, 0, 0]);
     }
 
     #[test]

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -1,5 +1,37 @@
 use facelock_core::types::BoundingBox;
 
+/// BT.601 chroma coefficients in fixed point (multiplied by 1024).
+///
+/// One copy, shared by every YUV converter here. They were duplicated per
+/// converter once, with a test asserting the two produced identical output —
+/// which is the test you write when the math has been copied rather than
+/// shared. That test now guards this.
+const C_RV: i32 = 1436; // 1.402 * 1024
+const C_GU: i32 = 352; // 0.344136 * 1024
+const C_GV: i32 = 731; // 0.714136 * 1024
+const C_BU: i32 = 1814; // 1.772 * 1024
+
+/// The R/G/B chroma contributions of one (u, v) pair, centered and scaled to
+/// Q10. A 4:2:2 or 4:2:0 converter computes this once per chroma sample and
+/// reuses it for every luma sample the pair covers.
+#[inline]
+fn chroma_q10(u: u8, v: u8) -> (i32, i32, i32) {
+    let u = u as i32 - 128;
+    let v = v as i32 - 128;
+    (C_RV * v, -(C_GU * u + C_GV * v), C_BU * u)
+}
+
+/// One YUV pixel to RGB, given the chroma contributions from [`chroma_q10`].
+#[inline]
+fn yuv_to_rgb_px(y: u8, (cr, cg, cb): (i32, i32, i32)) -> [u8; 3] {
+    let y = (y as i32) << 10; // scale Y to Q10
+    [
+        ((y + cr) >> 10).clamp(0, 255) as u8,
+        ((y + cg) >> 10).clamp(0, 255) as u8,
+        ((y + cb) >> 10).clamp(0, 255) as u8,
+    ]
+}
+
 /// Convert YUYV (YUV 4:2:2) packed data to RGB.
 /// Each 4-byte YUYV group produces 2 RGB pixels.
 /// Uses fixed-point integer math (Q10) to avoid per-pixel float conversion.
@@ -7,30 +39,11 @@ pub fn yuyv_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
     let pixel_count = (width * height) as usize;
     let mut rgb = Vec::with_capacity(pixel_count * 3);
 
-    // Fixed-point coefficients (multiplied by 1024)
-    const C_RV: i32 = 1436; // 1.402 * 1024
-    const C_GU: i32 = 352; // 0.344136 * 1024
-    const C_GV: i32 = 731; // 0.714136 * 1024
-    const C_BU: i32 = 1814; // 1.772 * 1024
-
-    // Process 4 bytes at a time (2 pixels)
+    // Process 4 bytes at a time (2 pixels), which share one chroma pair.
     for chunk in data.chunks_exact(4) {
-        let u = chunk[1] as i32 - 128;
-        let v = chunk[3] as i32 - 128;
-
-        // Pre-compute chrominance contributions (shared by both pixels)
-        let cr = C_RV * v;
-        let cg = -(C_GU * u + C_GV * v);
-        let cb = C_BU * u;
-
+        let chroma = chroma_q10(chunk[1], chunk[3]);
         for &y_val in &[chunk[0], chunk[2]] {
-            let y = (y_val as i32) << 10; // scale Y to Q10
-            let r = ((y + cr) >> 10).clamp(0, 255) as u8;
-            let g = ((y + cg) >> 10).clamp(0, 255) as u8;
-            let b = ((y + cb) >> 10).clamp(0, 255) as u8;
-            rgb.push(r);
-            rgb.push(g);
-            rgb.push(b);
+            rgb.extend_from_slice(&yuv_to_rgb_px(y_val, chroma));
         }
     }
 
@@ -53,25 +66,13 @@ pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
         return None;
     }
 
-    const C_RV: i32 = 1436; // 1.402 * 1024
-    const C_GU: i32 = 352; // 0.344136 * 1024
-    const C_GV: i32 = 731; // 0.714136 * 1024
-    const C_BU: i32 = 1814; // 1.772 * 1024
-
     let uv_plane = &data[y_len..];
     let mut rgb = Vec::with_capacity(y_len * 3);
     for row in 0..h {
         let uv_row = &uv_plane[(row / 2) * uv_stride..];
         for col in 0..w {
-            let u = uv_row[(col / 2) * 2] as i32 - 128;
-            let v = uv_row[(col / 2) * 2 + 1] as i32 - 128;
-            let y = (data[row * w + col] as i32) << 10;
-            let r = ((y + C_RV * v) >> 10).clamp(0, 255) as u8;
-            let g = ((y - (C_GU * u + C_GV * v)) >> 10).clamp(0, 255) as u8;
-            let b = ((y + C_BU * u) >> 10).clamp(0, 255) as u8;
-            rgb.push(r);
-            rgb.push(g);
-            rgb.push(b);
+            let chroma = chroma_q10(uv_row[(col / 2) * 2], uv_row[(col / 2) * 2 + 1]);
+            rgb.extend_from_slice(&yuv_to_rgb_px(data[row * w + col], chroma));
         }
     }
     Some(rgb)
@@ -79,9 +80,12 @@ pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
 
 /// Brightest 16-bit sample in a Y16 buffer (little-endian).
 ///
-/// Callers accumulate this across a burst of calibration frames: the peak is a
-/// lower bound on the sensor's full scale, so taking the maximum over several
-/// frames can only move the estimate toward the true bit depth, never past it.
+/// Callers accumulate this across a burst of calibration frames, which raises
+/// the estimate toward the sensor's full scale. It does not bound it from
+/// above: this is an unbounded max over every pixel, so a single stuck pixel
+/// or specular IR glint sets it alone and pins a shift that is too large for
+/// the rest of the scene. See `calibrate_y16_shift` for what that costs and
+/// why a quirk's `y16_bit_depth` is the way out.
 pub fn y16_peak(data: &[u8]) -> u16 {
     data.chunks_exact(2)
         .map(|c| u16::from_le_bytes([c[0], c[1]]))

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -41,14 +41,16 @@ pub fn yuyv_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
 /// Layout: full-resolution Y plane followed by one interleaved UV plane at
 /// half resolution in both dimensions (each UV pair covers a 2x2 pixel block).
 /// Uses the same fixed-point (Q10) coefficients as [`yuyv_to_rgb`].
-/// Returns an empty vec if `data` is shorter than a full NV12 frame.
-pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
+/// Returns `None` if `data` is shorter than a full NV12 frame.
+pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
     let w = width as usize;
     let h = height as usize;
     let y_len = w * h;
-    // UV plane: w * ceil(h/2) bytes (one interleaved row per two image rows).
-    if data.len() < y_len + w * h.div_ceil(2) {
-        return Vec::new();
+    // One UV pair covers a 2x2 block, so a UV row is 2 * ceil(w/2) bytes — for
+    // odd widths that is wider than the Y row.
+    let uv_stride = 2 * w.div_ceil(2);
+    if data.len() < y_len + uv_stride * h.div_ceil(2) {
+        return None;
     }
 
     const C_RV: i32 = 1436; // 1.402 * 1024
@@ -59,7 +61,7 @@ pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
     let uv_plane = &data[y_len..];
     let mut rgb = Vec::with_capacity(y_len * 3);
     for row in 0..h {
-        let uv_row = &uv_plane[(row / 2) * w..];
+        let uv_row = &uv_plane[(row / 2) * uv_stride..];
         for col in 0..w {
             let u = uv_row[(col / 2) * 2] as i32 - 128;
             let v = uv_row[(col / 2) * 2 + 1] as i32 - 128;
@@ -72,27 +74,37 @@ pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Vec<u8> {
             rgb.push(b);
         }
     }
-    rgb
+    Some(rgb)
 }
 
-/// Convert Y16 (16-bit little-endian grayscale) data to 8-bit grayscale.
+/// Right-shift that maps a Y16 sensor's effective bit depth onto 8 bits.
 ///
 /// Many IR sensors deliver 10/12-bit samples right-justified in the 16-bit
-/// container, so a plain `>> 8` yields near-black frames. Instead the shift is
-/// derived from the effective bit depth of the frame (the highest set bit of
-/// the brightest pixel), which maps full-scale sensor output to full 8-bit
-/// range without stretching the contrast of genuinely dark frames.
-pub fn y16_to_gray(data: &[u8]) -> Vec<u8> {
+/// container, so a plain `>> 8` yields near-black frames. The shift is derived
+/// from the highest set bit of the brightest pixel in `data`, floored at 0 so
+/// samples that already fit in 8 bits pass through unshifted.
+///
+/// The shift MUST be derived once per camera session and reused for every
+/// frame. Recomputing it per frame is contrast normalization upstream of
+/// [`check_ir_texture`], whose `min_stddev` cutoff is calibrated against a
+/// fixed scale (see `docs/security.md` §1.C).
+pub fn y16_shift(data: &[u8]) -> u8 {
     let max = data
         .chunks_exact(2)
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .max()
         .unwrap_or(0);
-    // Effective bit depth of the frame, floored at 8 so values <= 255 pass
-    // through unshifted.
-    let shift = (16 - max.leading_zeros()).saturating_sub(8);
+    (16 - max.leading_zeros()).saturating_sub(8) as u8
+}
+
+/// Convert Y16 (16-bit little-endian grayscale) data to 8-bit grayscale using
+/// the session-fixed `shift` from [`y16_shift`].
+///
+/// Samples brighter than the session scale (e.g. an IR glint) clamp to white
+/// rather than wrapping to black.
+pub fn y16_to_gray(data: &[u8], shift: u8) -> Vec<u8> {
     data.chunks_exact(2)
-        .map(|c| (u16::from_le_bytes([c[0], c[1]]) >> shift) as u8)
+        .map(|c| (u16::from_le_bytes([c[0], c[1]]) >> shift).min(255) as u8)
         .collect()
 }
 
@@ -292,7 +304,7 @@ mod tests {
     fn nv12_to_rgb_neutral_gray() {
         // 2x2 frame: Y plane all 128, one UV pair at (128, 128) -> neutral gray
         let data = [128u8, 128, 128, 128, 128, 128];
-        let rgb = nv12_to_rgb(&data, 2, 2);
+        let rgb = nv12_to_rgb(&data, 2, 2).expect("full frame");
         assert_eq!(rgb.len(), 12);
         assert!(rgb.iter().all(|&c| c == 128));
     }
@@ -302,7 +314,7 @@ mod tests {
         // Y=128, U=128 (neutral), V=255 -> strong red shift, like YUYV math:
         // R = 128 + 1.402*127 ~= 306 -> clamped 255; B = 128 (U neutral)
         let data = [128u8, 128, 128, 128, 128, 255];
-        let rgb = nv12_to_rgb(&data, 2, 2);
+        let rgb = nv12_to_rgb(&data, 2, 2).expect("full frame");
         for px in rgb.chunks_exact(3) {
             assert_eq!(px[0], 255, "red channel should clamp high");
             assert!(px[1] < 100, "green pulled down by positive V");
@@ -316,33 +328,47 @@ mod tests {
         // converters (they share coefficients).
         let (y, u, v) = (90u8, 100u8, 200u8);
         let yuyv = yuyv_to_rgb(&[y, u, y, v], 2, 1);
-        let nv12 = nv12_to_rgb(&[y, y, y, y, u, v], 2, 2);
+        let nv12 = nv12_to_rgb(&[y, y, y, y, u, v], 2, 2).expect("full frame");
         assert_eq!(&yuyv[0..3], &nv12[0..3]);
     }
 
     #[test]
-    fn nv12_to_rgb_short_buffer_returns_empty() {
+    fn nv12_to_rgb_short_buffer_returns_none() {
         // Y plane only, missing the UV plane entirely.
         let data = [128u8; 4];
-        assert!(nv12_to_rgb(&data, 2, 2).is_empty());
+        assert!(nv12_to_rgb(&data, 2, 2).is_none());
     }
 
     #[test]
     fn nv12_to_rgb_odd_height_uses_last_uv_row() {
-        // 2x3 frame: Y plane 6 bytes + UV plane w * ceil(3/2) = 4 bytes.
+        // 2x3 frame: Y plane 6 bytes + UV plane 2 * ceil(3/2) = 4 bytes.
         let mut data = vec![128u8; 6];
         data.extend_from_slice(&[128, 128, 128, 128]);
-        let rgb = nv12_to_rgb(&data, 2, 3);
+        let rgb = nv12_to_rgb(&data, 2, 3).expect("full frame");
         assert_eq!(rgb.len(), 18);
         assert!(rgb.iter().all(|&c| c == 128));
+    }
+
+    #[test]
+    fn nv12_to_rgb_odd_width_uses_padded_uv_stride() {
+        // 3x3 frame: a UV row is 2 * ceil(3/2) = 4 bytes, wider than the Y row.
+        // Sizing the guard by the Y width instead accepts 15 bytes and then
+        // indexes past the end of the UV plane.
+        let mut data = vec![128u8; 9];
+        data.extend_from_slice(&[128; 8]);
+        let rgb = nv12_to_rgb(&data, 3, 3).expect("full frame");
+        assert_eq!(rgb.len(), 27);
+        assert!(rgb.iter().all(|&c| c == 128));
+        // 15 bytes is what the Y-width guard would have accepted.
+        assert!(nv12_to_rgb(&data[..15], 3, 3).is_none());
     }
 
     #[test]
     fn y16_full_range_uses_high_byte() {
         // 16-bit full-scale data: 0xFFFF -> 255, 0x8000 -> 128
         let data = [0xFF, 0xFF, 0x00, 0x80];
-        let gray = y16_to_gray(&data);
-        assert_eq!(gray, vec![255, 128]);
+        assert_eq!(y16_shift(&data), 8);
+        assert_eq!(y16_to_gray(&data, 8), vec![255, 128]);
     }
 
     #[test]
@@ -353,25 +379,38 @@ mod tests {
             0xFF, 0x03, // 1023
             0x00, 0x02, // 512
         ];
-        let gray = y16_to_gray(&data);
-        assert_eq!(gray, vec![255, 128]);
+        assert_eq!(y16_shift(&data), 2);
+        assert_eq!(y16_to_gray(&data, 2), vec![255, 128]);
     }
 
     #[test]
-    fn y16_dark_frame_stays_dark() {
-        // A genuinely dark frame (all values <= 255) passes through unshifted
-        // instead of being contrast-stretched to full range — the dark-frame
-        // quality gate must still see it as dark.
-        let data = [15, 0, 20, 0, 10, 0];
-        let gray = y16_to_gray(&data);
-        assert_eq!(gray, vec![15, 20, 10]);
+    fn y16_dim_frame_stays_dim_at_the_session_shift() {
+        // Session shift derived once from a full-scale 10-bit frame.
+        let shift = y16_shift(&[0xFF, 0x03]);
+        assert_eq!(shift, 2);
+        // A dim frame later in the session must stay dim. Deriving the shift
+        // from this frame's own max (300 -> shift 1) would instead have
+        // measured [140, 145, 150, 125] — twice the intensity, and a different
+        // std_dev for the IR texture check.
+        let data = [0x18, 0x01, 0x22, 0x01, 0x2C, 0x01, 0xFA, 0x00];
+        assert_eq!(y16_to_gray(&data, shift), vec![70, 72, 75, 62]);
+    }
+
+    #[test]
+    fn y16_bright_pixel_clamps_instead_of_wrapping() {
+        // A saturated glint pixel above the session scale clamps to white. At a
+        // per-frame shift it would have rescaled (and darkened) the whole frame;
+        // truncating instead of clamping would wrap 1024 >> 2 to black.
+        let shift = y16_shift(&[0xFF, 0x03]);
+        let data = [0xFF, 0xFF, 0x00, 0x04, 0x2C, 0x01];
+        assert_eq!(y16_to_gray(&data, shift), vec![255, 255, 75]);
     }
 
     #[test]
     fn y16_all_zero_frame() {
         let data = [0u8; 8];
-        let gray = y16_to_gray(&data);
-        assert_eq!(gray, vec![0, 0, 0, 0]);
+        assert_eq!(y16_shift(&data), 0);
+        assert_eq!(y16_to_gray(&data, 0), vec![0, 0, 0, 0]);
     }
 
     #[test]

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -77,24 +77,74 @@ pub fn nv12_to_rgb(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
     Some(rgb)
 }
 
-/// Right-shift that maps a Y16 sensor's effective bit depth onto 8 bits.
+/// Brightest 16-bit sample in a Y16 buffer (little-endian).
+///
+/// Callers accumulate this across a burst of calibration frames: the peak is a
+/// lower bound on the sensor's full scale, so taking the maximum over several
+/// frames can only move the estimate toward the true bit depth, never past it.
+pub fn y16_peak(data: &[u8]) -> u16 {
+    data.chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Right-shift implied by an observed Y16 `peak` sample.
 ///
 /// Many IR sensors deliver 10/12-bit samples right-justified in the 16-bit
-/// container, so a plain `>> 8` yields near-black frames. The shift is derived
-/// from the highest set bit of the brightest pixel in `data`, floored at 0 so
-/// samples that already fit in 8 bits pass through unshifted.
+/// container, so a plain `>> 8` yields near-black frames. The shift comes from
+/// the highest set bit of the peak, floored at 0 so samples that already fit in
+/// 8 bits pass through unshifted.
+pub fn y16_shift_from_peak(peak: u16) -> u8 {
+    (16 - peak.leading_zeros()).saturating_sub(8) as u8
+}
+
+/// Right-shift that maps a Y16 sensor's effective bit depth onto 8 bits,
+/// derived from the brightest sample in `data`.
 ///
 /// The shift MUST be derived once per camera session and reused for every
 /// frame. Recomputing it per frame is contrast normalization upstream of
 /// [`check_ir_texture`], whose `min_stddev` cutoff is calibrated against a
 /// fixed scale (see `docs/security.md` §1.C).
 pub fn y16_shift(data: &[u8]) -> u8 {
-    let max = data
-        .chunks_exact(2)
-        .map(|c| u16::from_le_bytes([c[0], c[1]]))
-        .max()
-        .unwrap_or(0);
-    (16 - max.leading_zeros()).saturating_sub(8) as u8
+    y16_shift_from_peak(y16_peak(data))
+}
+
+/// Right-shift for a sensor bit depth supplied by the hardware quirks DB.
+///
+/// `None` for a depth that cannot describe a Y16 sample (below 8 bits, or above
+/// the 16-bit container); the caller warns and falls back to frame calibration
+/// rather than trusting a typo in a quirks file.
+pub fn y16_shift_from_bit_depth(bit_depth: u8) -> Option<u8> {
+    (8..=16).contains(&bit_depth).then(|| bit_depth - 8)
+}
+
+/// What a Y16 calibration burst's peak says about the scale it produced.
+///
+/// The shift itself is usable in every case — this only distinguishes the peaks
+/// that are equally consistent with a correctly-calibrated sensor and with a
+/// camera that was covered, unlit, or still pre-AGC while the burst ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Y16Calibration {
+    /// The burst never saw a sample above 8 bits. True for a genuinely 8-bit
+    /// sensor padded into Y16, and equally true for a covered lens.
+    LowRange,
+    /// The burst saturated the 16-bit container, which is what an IR glint (or
+    /// a hot pixel) looks like on a sensor whose real range is narrower.
+    Saturated,
+    /// Peak landed inside the container with room on both sides.
+    Normal,
+}
+
+/// Pin a session Y16 shift from the peak sample of a calibration burst, along
+/// with a verdict on how trustworthy that peak is.
+pub fn y16_calibration(peak: u16) -> (u8, Y16Calibration) {
+    let verdict = match peak {
+        u16::MAX => Y16Calibration::Saturated,
+        p if p < 256 => Y16Calibration::LowRange,
+        _ => Y16Calibration::Normal,
+    };
+    (y16_shift_from_peak(peak), verdict)
 }
 
 /// Convert Y16 (16-bit little-endian grayscale) data to 8-bit grayscale using
@@ -411,6 +461,49 @@ mod tests {
         let data = [0u8; 8];
         assert_eq!(y16_shift(&data), 0);
         assert_eq!(y16_to_gray(&data, 0), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn y16_peak_accumulates_toward_the_true_bit_depth() {
+        // A dark pre-AGC frame alone pins an 8-bit scale that clips every later
+        // 10-bit frame to white. Taking the peak across a burst recovers the
+        // real depth, and can never overshoot it: no sample can exceed the
+        // sensor's full scale.
+        let dark = [0x40, 0x00, 0x10, 0x00]; // 64, 16
+        let warm = [0xFF, 0x03, 0x00, 0x02]; // 1023, 512
+        assert_eq!(y16_shift_from_peak(y16_peak(&dark)), 0);
+        let burst = y16_peak(&dark).max(y16_peak(&warm));
+        assert_eq!(y16_shift_from_peak(burst), 2);
+    }
+
+    #[test]
+    fn y16_shift_from_bit_depth_is_the_quirk_channel() {
+        assert_eq!(y16_shift_from_bit_depth(8), Some(0));
+        assert_eq!(y16_shift_from_bit_depth(10), Some(2));
+        assert_eq!(y16_shift_from_bit_depth(12), Some(4));
+        assert_eq!(y16_shift_from_bit_depth(16), Some(8));
+    }
+
+    #[test]
+    fn y16_shift_from_bit_depth_rejects_out_of_range() {
+        // A depth outside the container is a quirks-file typo, not hardware
+        // truth: the caller warns and calibrates from frames instead.
+        assert_eq!(y16_shift_from_bit_depth(0), None);
+        assert_eq!(y16_shift_from_bit_depth(7), None);
+        assert_eq!(y16_shift_from_bit_depth(17), None);
+        assert_eq!(y16_shift_from_bit_depth(u8::MAX), None);
+    }
+
+    #[test]
+    fn y16_calibration_flags_suspicious_peaks() {
+        // Indistinguishable from a covered lens.
+        assert_eq!(y16_calibration(0), (0, Y16Calibration::LowRange));
+        assert_eq!(y16_calibration(255), (0, Y16Calibration::LowRange));
+        // Full-container saturation: an IR glint on a narrower sensor.
+        assert_eq!(y16_calibration(u16::MAX), (8, Y16Calibration::Saturated));
+        // Ordinary 10/12-bit peaks.
+        assert_eq!(y16_calibration(1023), (2, Y16Calibration::Normal));
+        assert_eq!(y16_calibration(4095), (4, Y16Calibration::Normal));
     }
 
     #[test]

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -106,7 +106,14 @@ pub fn y16_shift_from_peak(peak: u16) -> u8 {
 /// frame. Recomputing it per frame is contrast normalization upstream of
 /// [`check_ir_texture`], whose `min_stddev` cutoff is calibrated against a
 /// fixed scale (see `docs/security.md` §1.C).
-pub fn y16_shift(data: &[u8]) -> u8 {
+///
+/// Test-only, deliberately: a one-shot whole-buffer helper is the shape a
+/// per-frame call takes, and shipping it as API invites exactly the recompute
+/// the paragraph above forbids. The capture path pins the scale from a burst
+/// instead (`calibrate_y16_shift`); this remains so the tests can pin the
+/// peak-to-shift mapping in one call.
+#[cfg(test)]
+fn y16_shift(data: &[u8]) -> u8 {
     y16_shift_from_peak(y16_peak(data))
 }
 

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -133,7 +133,15 @@ impl QuirksDb {
 
     fn load_file(path: &Path) -> Result<Vec<Quirk>, String> {
         let content = std::fs::read_to_string(path).map_err(|e| format!("read error: {e}"))?;
-        let file: QuirksFile = toml::from_str(&content).map_err(|e| format!("parse error: {e}"))?;
+        let mut file: QuirksFile =
+            toml::from_str(&content).map_err(|e| format!("parse error: {e}"))?;
+        // Quirk files are often written with the padded V4L2 FourCC ("Y16 ").
+        // Normalize here so comparisons against `FormatInfo::fourcc` match.
+        for quirk in &mut file.quirk {
+            if let Some(pref) = &mut quirk.format_preference {
+                *pref = pref.trim().to_string();
+            }
+        }
         Ok(file.quirk)
     }
 
@@ -506,7 +514,7 @@ notes = "Test camera"
             emitter_xu_guid: None,
             emitter_xu_selector: None,
             warmup_frames: Some(10),
-            format_preference: Some("Y16 ".into()),
+            format_preference: Some("Y16".into()),
             rotation: None,
             notes: Some("Intel RealSense".into()),
         });

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -829,6 +829,56 @@ notes = "Full test quirk"
         Some(QuirksDb::load_file(&path).expect("defaults file parses"))
     }
 
+    /// Every `format_preference` shipped in `config/quirks.d/00-defaults.toml`
+    /// must be a format facelock can actually decode.
+    ///
+    /// This is the coupling #90 introduced and nothing else guards: the file
+    /// writes the padded V4L2 spelling (`"Y16 "`), `load_file` normalizes it,
+    /// and `capture::quirk_format_preference` then checks it against
+    /// `DECODABLE_FORMATS` and *drops it with a warning* if it does not match.
+    /// A shipped preference that fails this check does not fail loudly at
+    /// runtime — it silently stops selecting the RealSense IR sensor node.
+    #[test]
+    fn shipped_quirk_format_preferences_are_decodable() {
+        let Some(quirks) = shipped_default_quirks() else {
+            return;
+        };
+        let mut checked = 0;
+        for q in &quirks {
+            let Some(pref) = q.format_preference.as_deref() else {
+                continue;
+            };
+            checked += 1;
+            assert!(
+                crate::capture::DECODABLE_FORMATS.contains(&pref.trim()),
+                "shipped quirk {:?} prefers {pref:?}, which facelock cannot decode — \
+                 it would be dropped at open with a warning",
+                q.notes
+            );
+        }
+        assert!(
+            checked >= 4,
+            "expected the shipped RealSense (Y16) and BRIO (GREY) preferences to be \
+             covered; only {checked} were found"
+        );
+    }
+
+    /// `load_file` is what turns the file's padded `"Y16 "` into the `"Y16"`
+    /// every comparison downstream expects. Asserted against the real shipped
+    /// file, not a fixture, because the padded spelling in *that* file is what
+    /// makes the normalization load-bearing.
+    #[test]
+    fn shipped_quirk_format_preferences_are_normalized_by_the_loader() {
+        let Some(quirks) = shipped_default_quirks() else {
+            return;
+        };
+        for q in &quirks {
+            if let Some(pref) = q.format_preference.as_deref() {
+                assert_eq!(pref, pref.trim(), "loader left padding on {pref:?}");
+            }
+        }
+    }
+
     /// Table-driven regression for #99: every shipped `name_pattern` quirk in
     /// `config/quirks.d/00-defaults.toml` must still match a device name of
     /// the shape it is written for, and none of them may match an ordinary

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -35,6 +35,12 @@ pub struct Quirk {
     /// Preferred pixel format
     #[serde(default)]
     pub format_preference: Option<String>,
+    /// Effective bit depth of this sensor's Y16 samples (8..=16). Authoritative
+    /// when present: the session Y16 -> 8-bit shift becomes `bit_depth - 8` and
+    /// no calibration frames are captured, so the scale cannot depend on what
+    /// the lens happened to see at open.
+    #[serde(default)]
+    pub y16_bit_depth: Option<u8>,
     /// Image rotation in degrees
     #[serde(default)]
     pub rotation: Option<u16>,
@@ -472,6 +478,22 @@ notes = "Test camera"
         assert_eq!(file.quirk[0].vendor_id.as_deref(), Some("8086"));
         assert_eq!(file.quirk[0].force_ir, Some(true));
         assert_eq!(file.quirk[0].warmup_frames, Some(10));
+        // Omitted keys stay None: an entry written before y16_bit_depth existed
+        // keeps calibrating the Y16 scale from frames.
+        assert_eq!(file.quirk[0].y16_bit_depth, None);
+    }
+
+    #[test]
+    fn quirk_deserialization_y16_bit_depth() {
+        let toml = r#"
+[[quirk]]
+vendor_id = "8086"
+product_id = "0b07"
+format_preference = "Y16 "
+y16_bit_depth = 10
+"#;
+        let file: QuirksFile = toml::from_str(toml).unwrap();
+        assert_eq!(file.quirk[0].y16_bit_depth, Some(10));
     }
 
     #[test]
@@ -486,6 +508,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: Some(8),
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("HP IR".into()),
         });
@@ -515,6 +538,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: Some(10),
             format_preference: Some("Y16".into()),
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("Intel RealSense".into()),
         });
@@ -528,6 +552,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: None,
         });
@@ -555,6 +580,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("Logitech".into()),
         });
@@ -576,6 +602,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("first pattern".into()),
         });
@@ -588,6 +615,7 @@ notes = "Test camera"
             emitter_xu_selector: None,
             warmup_frames: None,
             format_preference: None,
+            y16_bit_depth: None,
             rotation: None,
             notes: Some("second pattern".into()),
         });
@@ -748,6 +776,7 @@ emitter_xu_guid = "abcd-1234"
 emitter_xu_selector = 3
 warmup_frames = 15
 format_preference = "GREY"
+y16_bit_depth = 12
 rotation = 90
 notes = "Full test quirk"
 "#;
@@ -757,6 +786,7 @@ notes = "Full test quirk"
         assert_eq!(q.emitter_xu_selector, Some(3));
         assert_eq!(q.warmup_frames, Some(15));
         assert_eq!(q.format_preference.as_deref(), Some("GREY"));
+        assert_eq!(q.y16_bit_depth, Some(12));
         assert_eq!(q.rotation, Some(90));
     }
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -111,19 +111,32 @@ Working configuration (verified on a Dell XPS 14 with IPU7, issue #89):
    SPLASHSRC="videotestsrc is-live=true pattern=black"
    ```
 
-#### No IR sensor is reachable on IPU6/IPU7
+#### IR sensors on IPU6/IPU7: not supported out of the box
 
-These laptops ship an IR sensor for Windows Hello, but there is currently **no
-Linux driver for it** — neither `intel/ipu6-drivers` nor `intel/ipu7-drivers`
-exposes one, and the `v4l2-relayd` path relays the RGB sensor only. In practice
-that means `security.require_ir = true` (the default) **cannot be satisfied on
-IPU6/IPU7 hardware**.
+These laptops ship an IR sensor for Windows Hello (Himax HM1092 on recent Dell
+XPS models), but no **in-tree or Intel-shipped** Linux driver exists for it —
+neither `intel/ipu6-drivers` nor `intel/ipu7-drivers` includes one, and the
+`v4l2-relayd` path relays the RGB sensor only. On a stock distro,
+`security.require_ir = true` (the default) cannot be satisfied on this
+hardware.
 
 Facelock classifying the relay node as non-IR is therefore correct, not a
-detection bug: the pipeline really is RGB. Disabling `require_ir` does not
+detection bug: that pipeline really is RGB. Disabling `require_ir` does not
 recover the IR sensor — it trades away the spoof resistance that IR provides,
 leaving a camera that a printed photo or a phone screen can drive. See
 `docs/security.md` §1 for what each IR-dependent check stops covering.
+
+**Experimental community IR support exists.** The out-of-tree
+[svp7500-camera-fix-pack](https://github.com/jibsta210/svp7500-camera-fix-pack)
+(DKMS) has the HM1092 IR sensor streaming — including face unlock with the IR
+flood illuminator — on SVP7500-bridged IPU7 laptops (verified on a Dell XPS 16
+DA16260; see [intel/ipu7-drivers#26](https://github.com/intel/ipu7-drivers/issues/26)
+for the full history). The illuminator side is already in mainline
+(`intel_skl_int3472_discrete` registers `ir_flood_led` on kernels ≥ 7.1.4), and
+kernel 7.2-rc1 gained an in-tree `intel_cvs` bridge driver. Facelock does not
+yet consume that IR node (capture-node format and IR classification for
+`hm1092` are tracked in issue #101) — treat this path as experimental until the
+sensor driver lands upstream.
 
 ## Init System Support
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -72,6 +72,12 @@ Bayer — these nodes are skipped by auto-detection. The usable camera is the
 **processed loopback device** provided by `v4l2-relayd` + `v4l2loopback`
 (commonly `/dev/video50`), fed by the `icamerasrc` GStreamer element.
 
+On newer platforms (Panther Lake and later) the RGB path additionally needs the
+out-of-tree `intel_cvs` module from
+[intel/vision-drivers](https://github.com/intel/vision-drivers). Without it no
+`/dev/video*` node appears for the camera at all, so there is nothing for the
+relay — or facelock — to open.
+
 Working configuration (verified on a Dell XPS 14 with IPU7, issue #89):
 
 1. Install the vendor stack (`intel-ipu6-camera`/`intel-ipu7-camera`,
@@ -105,10 +111,19 @@ Working configuration (verified on a Dell XPS 14 with IPU7, issue #89):
    SPLASHSRC="videotestsrc is-live=true pattern=black"
    ```
 
-**Security note:** the relay path is an RGB pipeline — facelock correctly
-classifies it as non-IR (`ir=false`). Do **not** disable `security.require_ir`
-as a workaround; an RGB-only path provides no spoof protection (see
-`docs/security.md`).
+#### No IR sensor is reachable on IPU6/IPU7
+
+These laptops ship an IR sensor for Windows Hello, but there is currently **no
+Linux driver for it** — neither `intel/ipu6-drivers` nor `intel/ipu7-drivers`
+exposes one, and the `v4l2-relayd` path relays the RGB sensor only. In practice
+that means `security.require_ir = true` (the default) **cannot be satisfied on
+IPU6/IPU7 hardware**.
+
+Facelock classifying the relay node as non-IR is therefore correct, not a
+detection bug: the pipeline really is RGB. Disabling `require_ir` does not
+recover the IR sensor — it trades away the spoof resistance that IR provides,
+leaving a camera that a printed photo or a phone screen can drive. See
+`docs/security.md` §1 for what each IR-dependent check stops covering.
 
 ## Init System Support
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,8 +52,63 @@ RGB cameras work with `security.require_ir = false` but provide no anti-spoofing
 |--------|---------|-------|
 | MJPG | Full | Most common USB camera format |
 | YUYV | Full | Raw format, converted to RGB |
+| NV12 | Full | Semi-planar 4:2:0; common on Intel IPU processed cameras |
 | GREY | Full | IR cameras, replicated to RGB |
-| Other | Not supported | Camera negotiates to supported format |
+| Y16 | Full | 16-bit IR grayscale, bit-depth-aware conversion to 8-bit |
+| Raw Bayer (SGRBG10, ...) | Not supported | Raw sensor nodes are skipped by auto-detection |
+| Other | Not supported | Device is rejected at open with an error listing its formats |
+
+Negotiation priority: `GREY > Y16 > YUYV > NV12 > MJPG` (a hardware quirk's
+`format_preference` is tried first). Devices that advertise none of these are
+excluded from auto-detection, and opening one explicitly fails with an error
+naming the advertised formats.
+
+### Intel IPU6/IPU7 MIPI cameras (v4l2-relayd)
+
+Intel IPU6/IPU7 laptop cameras (many 2023+ Dell XPS, Lenovo ThinkPad, HP
+models) expose their sensors as **raw Bayer capture nodes** (`/dev/video0`
+through `/dev/video31`, formats like `SGRBG10`). Facelock cannot decode raw
+Bayer — these nodes are skipped by auto-detection. The usable camera is the
+**processed loopback device** provided by `v4l2-relayd` + `v4l2loopback`
+(commonly `/dev/video50`), fed by the `icamerasrc` GStreamer element.
+
+Working configuration (verified on a Dell XPS 14 with IPU7, issue #89):
+
+1. Install the vendor stack (`intel-ipu6-camera`/`intel-ipu7-camera`,
+   `v4l2-relayd`, `v4l2loopback-dkms`) and confirm the loopback node works:
+   `gst-launch-1.0 v4l2src device=/dev/video50 ! fakesink`
+
+2. Point facelock at the loopback node in `/etc/facelock/config.toml`:
+
+   ```toml
+   [device]
+   path = "/dev/video50"
+   ```
+
+3. The relay's default `FORMAT=NV12` is supported natively. If you need a
+   different format, set it in the v4l2-relayd config — but note that a bare
+   caps string cannot be appended to `VIDEOSRC` (v4l2-relayd attaches its own
+   `appsink` dynamically); end the pipeline with a `videoconvert` element and
+   set `FORMAT=` instead:
+
+   ```ini
+   VIDEOSRC="icamerasrc device-name=<sensor> ! videoconvert"
+   FORMAT=YUY2
+   ```
+
+4. With `v4l2loopback` option `exclusive_caps=1`, the loopback node flips to
+   *Video Output* while no producer is streaming, and facelock intermittently
+   sees "not a video capture device". Keep the relay's output side always
+   active with a splash source:
+
+   ```ini
+   SPLASHSRC="videotestsrc is-live=true pattern=black"
+   ```
+
+**Security note:** the relay path is an RGB pipeline — facelock correctly
+classifies it as non-IR (`ir=false`). Do **not** disable `security.require_ir`
+as a workaround; an RGB-only path provides no spoof protection (see
+`docs/security.md`).
 
 ## Init System Support
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -447,11 +447,24 @@ When `device.path` is omitted:
    devices: when several nodes share one quirk-matched VID:PID and at least one
    has an IR-like format (GREY/Y16 or the quirk's `format_preference`), only the
    format-bearing node(s) are IR
-4. Prefer a quirks-confirmed IR node with a native IR format, then any
-   quirks-confirmed IR node, then an evidence-classified IR node (breaking ties
-   toward one whose name also carries an `ir`/`infrared` token — a hint only,
-   never a promotion of a node that lacks format evidence)
-5. Fall back to first available device
+4. Exclude devices that advertise no decodable pixel format
+   (GREY/Y16/YUYV/NV12/MJPG) — e.g. raw Bayer sensor nodes (Intel IPU6/IPU7).
+   This filter runs *after* step 3 and never feeds back into it: it changes
+   which node is selected, never whether a node counts as IR. The IR-typical
+   list (step 3) and the decodable list are deliberately different sets — a
+   node whose only IR evidence is Y8/Y10/Y12 is IR **and** undecodable, and is
+   excluded here with a syslog warning naming its path and formats
+5. Among the remaining nodes, prefer a quirks-confirmed IR node with a native
+   IR format, then any quirks-confirmed IR node, then an evidence-classified IR
+   node (breaking ties toward one whose name also carries an `ir`/`infrared`
+   token — a hint only, never a promotion of a node that lacks format evidence)
+6. Fall back to first decodable device; if none, error listing every detected
+   device and its formats
+
+Opening a device (auto-detected or explicit `device.path`) negotiates a format
+in priority order `quirk format_preference > GREY > Y16 > YUYV > NV12 > MJPG`
+and **fails** if the device advertises none of them (no silent fallback to an
+undecodable format).
 
 ## Database Schema
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -466,6 +466,12 @@ in priority order `quirk format_preference > GREY > Y16 > YUYV > NV12 > MJPG`
 and **fails** if the device advertises none of them (no silent fallback to an
 undecodable format).
 
+On a Y16 device, open also pins the session's 16-bit-to-8-bit shift, which is
+never recomputed per frame (`docs/security.md` §1.C). A quirk's `y16_bit_depth`
+(8..=16) is authoritative and skips frame inspection; otherwise the shift comes
+from the brightest sample in a burst of frames captured at open (at least the
+device's `warmup_frames`, bounded by one second).
+
 ## Database Schema
 
 SQLite with WAL mode and foreign keys:

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -466,11 +466,30 @@ in priority order `quirk format_preference > GREY > Y16 > YUYV > NV12 > MJPG`
 and **fails** if the device advertises none of them (no silent fallback to an
 undecodable format).
 
+A quirk's `format_preference` is compared whitespace-trimmed and is **dropped
+with a warning** if it names a format facelock cannot decode, rather than
+winning negotiation and then failing every capture.
+
 On a Y16 device, open also pins the session's 16-bit-to-8-bit shift, which is
 never recomputed per frame (`docs/security.md` §1.C). A quirk's `y16_bit_depth`
 (8..=16) is authoritative and skips frame inspection; otherwise the shift comes
 from the brightest sample in a burst of frames captured at open (at least the
-device's `warmup_frames`, bounded by one second).
+device's `warmup_frames`, bounded by one second). The pinned shift belongs to
+the open camera: a warm hold (see "Camera hold" above) keeps it, and a reopen
+recalibrates. A Y16 device that produces no frame at all within the calibration
+budget fails `Camera::open` rather than opening with a guessed scale.
+
+Open also **rejects a padded stride**: for GREY/NV12 (`bytesperline == width`)
+and Y16/YUYV (`bytesperline == 2 * width`), a device reporting anything else
+errors at open instead of decoding sheared frames. Compressed formats (MJPG)
+are exempt — their `bytesperline` is not a row size.
+
+**FourCC normalization.** V4L2 pads FourCCs to four characters with trailing
+spaces (`"Y16 "`). Facelock strips that padding at every ingest point — device
+enumeration (`query_device`) and quirks-file parsing — so `DeviceInfo.formats`,
+the `ListDevices` D-Bus payload and `facelock devices --json` all carry the
+unpadded spelling (`"Y16"`, not `"Y16 "`). The human-readable `facelock devices`
+table already trimmed, so only the machine-readable surfaces change.
 
 ## Database Schema
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -474,7 +474,9 @@ On a Y16 device, open also pins the session's 16-bit-to-8-bit shift, which is
 never recomputed per frame (`docs/security.md` §1.C). A quirk's `y16_bit_depth`
 (8..=16) is authoritative and skips frame inspection; otherwise the shift comes
 from the brightest sample in a burst of frames captured at open (at least the
-device's `warmup_frames`, bounded by one second). The pinned shift belongs to
+device's `warmup_frames`; the burst stops starting captures after one second,
+so a dequeue already in flight can carry it to roughly one second plus one
+`CAPTURE_TIMEOUT`). The pinned shift belongs to
 the open camera: a warm hold (see "Camera hold" above) keeps it, and a reopen
 recalibrates. A Y16 device that produces no frame at all within the calibration
 budget fails `Camera::open` rather than opening with a guessed scale.
@@ -486,10 +488,15 @@ are exempt — their `bytesperline` is not a row size.
 
 **FourCC normalization.** V4L2 pads FourCCs to four characters with trailing
 spaces (`"Y16 "`). Facelock strips that padding at every ingest point — device
-enumeration (`query_device`) and quirks-file parsing — so `DeviceInfo.formats`,
-the `ListDevices` D-Bus payload and `facelock devices --json` all carry the
-unpadded spelling (`"Y16"`, not `"Y16 "`). The human-readable `facelock devices`
-table already trimmed, so only the machine-readable surfaces change.
+enumeration (`query_device`) and quirks-file parsing — so `DeviceInfo.formats`
+carries the unpadded spelling (`"Y16"`, not `"Y16 "`).
+
+The only machine-readable surface that changes is `facelock devices --json`
+**on the direct backend**, which is where format detail exists at all: the
+D-Bus `DeviceInfo` does not carry formats, so under the daemon backend
+`--json` reports `"formats": []` and there is no spelling to change
+(`BackendCaps::device_formats`, false for `BackendKind::Daemon`). The
+human-readable `facelock devices` table already trimmed.
 
 ## Database Schema
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -187,7 +187,13 @@ from the effective sensor bit depth. That shift is pinned once at camera open an
 for every frame of the session. Deriving it per frame is per-frame contrast normalization
 — the same class of mistake as feeding CLAHE output to this check — and it would move the
 scale `ir_texture_min_stddev` is calibrated against on every frame, including in response
-to attacker-controlled illumination.
+to attacker-controlled illumination. A quirk's `y16_bit_depth`
+(`/etc/facelock/quirks.d/`) is **authoritative** when present — the shift becomes
+`bit_depth - 8` and no frame is inspected; the fallback samples a burst of frames at open
+(at least the device's declared `warmup_frames`) and takes their peak, so the scale does
+not hinge on whatever a single pre-AGC frame happened to see. A scene-derived scale is a reliability risk rather than a bypass (a
+covered lens at open clips later frames to flat white, which this check *rejects*), but on
+hardware where it recurs, pin `y16_bit_depth`.
 
 **Raw-frame calibration**: on the raw frame, flat surfaces (photos/screens in IR) score
 std_dev **< 5**, real IR skin scores **> 15**. The cutoff `security.ir_texture_min_stddev`

--- a/docs/security.md
+++ b/docs/security.md
@@ -191,9 +191,34 @@ to attacker-controlled illumination. A quirk's `y16_bit_depth`
 (`/etc/facelock/quirks.d/`) is **authoritative** when present — the shift becomes
 `bit_depth - 8` and no frame is inspected; the fallback samples a burst of frames at open
 (at least the device's declared `warmup_frames`) and takes their peak, so the scale does
-not hinge on whatever a single pre-AGC frame happened to see. A scene-derived scale is a reliability risk rather than a bypass (a
-covered lens at open clips later frames to flat white, which this check *rejects*), but on
-hardware where it recurs, pin `y16_bit_depth`.
+not hinge on whatever a single pre-AGC frame happened to see.
+
+**A scene-derived scale is not purely a reliability risk. One of its two error directions
+is fail-open.** Both are worth stating plainly:
+
+- *Shift too high* (a stuck pixel or specular glint inflates the burst peak): frames go
+  dark, std_dev collapses, this check **rejects**. Fails closed.
+- *Shift too low* (the burst never saw anything bright): nothing clips while raw samples
+  stay under the truncated full scale, so it acts as a clean 2^k contrast stretch on
+  exactly the buffer this check measures — the Y16→8-bit output reaches `check_ir_texture`
+  unmodified, because the RGB replication is 3x and `rgb_to_gray`'s coefficients sum to
+  256. std_dev scales linearly with the stretch. On a 12-bit sensor whose burst peaks near
+  1000, the shift lands at 2 instead of 4 and every score is multiplied by 4: a flat
+  spoof at a true std_dev of 4, inside the "flat surfaces score < 5" band below, measures
+  16 and clears the 10.0 cutoff. **`ir_texture_min_stddev` is an absolute threshold on a
+  scale-dependent statistic, so at the wrong scale it stops discriminating at all.**
+
+Exploiting it needs a Y16 device with no `y16_bit_depth`, influence over the scene across
+a cold open, and a spoof dim enough to stay unclipped; the peak is a max over every pixel
+with the emitter lit, so holding it under a quarter of full scale needs a uniformly dim
+field of view. This is analysis, not a demonstration: facelock has no Y16 hardware, and
+the <5 / >15 bands below were measured on an **8-bit GREY** node and have never been
+validated through the Y16 path.
+
+Pin `y16_bit_depth` on any Y16 device you control — it removes the scene from the decision
+entirely. V4L2 cannot report a sensor's effective bit depth, so on an unlisted camera the
+shift is necessarily a guess; making this check scale-invariant is the generic fix and is
+tracked separately.
 
 "The session" is the lifetime of one open camera, and under the daemon's warm camera hold
 (ADR 008 §4) that can span several authentication attempts, not just one: a held stream

--- a/docs/security.md
+++ b/docs/security.md
@@ -204,9 +204,13 @@ for `is_ir` and the fingerprint.
 
 Cost note: on a Y16 device with no `y16_bit_depth` quirk, the calibration burst runs inside
 `Camera::open`, *before* the warmup discard and with the IR emitter already enabled — so it
-is emitter-LED-on time, bounded by one second, on every cold open. Declaring
-`y16_bit_depth` skips it entirely and is the preferred configuration on IR hardware. The
-shipped RealSense entries in `config/quirks.d/00-defaults.toml` do **not** declare one yet.
+is emitter-LED-on time on every cold open. The burst stops starting captures after one
+second, but the check sits at the top of its loop, so a dequeue already in flight can carry
+it to about one second plus one `CAPTURE_TIMEOUT`. It is also paid *in addition to* the
+caller's own warmup discard, so a device declaring `warmup_frames = 10` spends 10 burst
+frames and then discards 10 more. Declaring `y16_bit_depth` skips the burst entirely and is
+the preferred configuration on IR hardware. The shipped RealSense entries in
+`config/quirks.d/00-defaults.toml` do **not** declare one yet.
 
 **Raw-frame calibration**: on the raw frame, flat surfaces (photos/screens in IR) score
 std_dev **< 5**, real IR skin scores **> 15**. The cutoff `security.ir_texture_min_stddev`

--- a/docs/security.md
+++ b/docs/security.md
@@ -182,6 +182,13 @@ The auth loop previously fed a **CLAHE**-equalized frame into `check_ir_texture`
 i.e. CLAHE was masking exactly the spoof this check exists to catch. CLAHE now belongs
 only to the recognition/embedding path; texture measurement uses `frame.gray` directly.
 
+**Fixed Y16 scale**: 16-bit IR sensors are converted to 8-bit with a right-shift derived
+from the effective sensor bit depth. That shift is pinned once at camera open and reused
+for every frame of the session. Deriving it per frame is per-frame contrast normalization
+— the same class of mistake as feeding CLAHE output to this check — and it would move the
+scale `ir_texture_min_stddev` is calibrated against on every frame, including in response
+to attacker-controlled illumination.
+
 **Raw-frame calibration**: on the raw frame, flat surfaces (photos/screens in IR) score
 std_dev **< 5**, real IR skin scores **> 15**. The cutoff `security.ir_texture_min_stddev`
 defaults to **10.0** (between the two bands). Lower it if real faces are being rejected;

--- a/docs/security.md
+++ b/docs/security.md
@@ -195,6 +195,19 @@ not hinge on whatever a single pre-AGC frame happened to see. A scene-derived sc
 covered lens at open clips later frames to flat white, which this check *rejects*), but on
 hardware where it recurs, pin `y16_bit_depth`.
 
+"The session" is the lifetime of one open camera, and under the daemon's warm camera hold
+(ADR 008 §4) that can span several authentication attempts, not just one: a held stream
+keeps the scale it pinned. A **reopen** always recalibrates — the daemon's camera factory
+resolves and opens afresh on every cold open, so no scale is ever carried across a reopen
+onto a device that did not produce it. That is the same invariant `ResolvedCamera` holds
+for `is_ir` and the fingerprint.
+
+Cost note: on a Y16 device with no `y16_bit_depth` quirk, the calibration burst runs inside
+`Camera::open`, *before* the warmup discard and with the IR emitter already enabled — so it
+is emitter-LED-on time, bounded by one second, on every cold open. Declaring
+`y16_bit_depth` skips it entirely and is the preferred configuration on IR hardware. The
+shipped RealSense entries in `config/quirks.d/00-defaults.toml` do **not** declare one yet.
+
 **Raw-frame calibration**: on the raw frame, flat surfaces (photos/screens in IR) score
 std_dev **< 5**, real IR skin scores **> 15**. The cutoff `security.ir_texture_min_stddev`
 defaults to **10.0** (between the two bands). Lower it if real faces are being rejected;

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,26 @@
    Prefer a USB-ID quirk over a `name_pattern` one: a name-only `force_ir` is trusted only when corroborated by the device's own mono-format evidence or a real USB identity, so it will not, by itself, force a color-only device to IR.
 5. As a last resort you can set `security.require_ir = false` -- but understand this weakens spoofing resistance. Only do this for testing.
 
+## Enrollment captures 0 frames
+
+**Symptom**: `facelock enroll` ends with "only captured 0 frames, need at least 3".
+
+**Steps**:
+
+1. **Lighting**: frames with mean brightness below ~20 are rejected as too
+   dark. IR cameras usually self-illuminate, but RGB cameras need a lit room.
+   Add light and retry.
+2. **Wrong device / format**: if the configured camera is a raw sensor node
+   (e.g. Intel IPU6/IPU7 Bayer nodes, formats like `SGRBG10`), facelock now
+   refuses to open it with an error listing the advertised formats. Point
+   `device.path` at a processed camera instead — see "Intel IPU6/IPU7 MIPI
+   cameras" in `docs/compatibility.md`.
+3. **Verify frames are usable**: run `facelock preview --text-only` (or
+   `facelock preview`) and check that you see a live image with your face
+   detected.
+4. Run with `RUST_LOG=facelock_daemon=debug` to see per-frame rejection
+   reasons (dark frame, no face detected, low quality).
+
 ## Auth too slow
 
 ### First-start latency (~700ms -- 2s)


### PR DESCRIPTION
## Summary

- decode NV12 (semi-planar 4:2:0) and Y16 (16-bit IR grayscale, bit-depth aware)
- exclude devices with no decodable format from every auto-detection tier, so raw Bayer sensor nodes cannot be selected
- fail `Camera::open` with the advertised and supported format lists instead of negotiating a format every capture then rejects
- negotiate in priority order `quirk format_preference > GREY > Y16 > YUYV > NV12 > MJPG`
- pin the Y16 16-bit-to-8-bit shift once per camera session, from a quirk's `y16_bit_depth` when declared and a burst of frames at open otherwise
- reject a padded `bytesperline` at open rather than decoding sheared frames
- document the Intel IPU6/IPU7 + v4l2-relayd path, and why `require_ir` cannot be satisfied on that hardware

## Why

Auto-detection selected the raw IPU7 capture node on a Dell XPS 14, negotiated a format it could not decode, and captured zero usable frames — surfacing only as "insufficient face captures during enrollment" (#89). The undecodable-device exclusion is the actual fix for that class of silent failure and is independent of any one camera. NV12 support additionally makes the processed `v4l2-relayd` loopback usable without reconfiguring the relay.

## Contract changes

- negotiation priority is now documented in `docs/contracts.md` and pinned by a test
- FourCCs are normalized at ingest, so `facelock devices --json` reports `"Y16"` rather than `"Y16 "`. Direct backend only: the D-Bus `DeviceInfo` carries no formats field, so a daemon-backed `--json` reports `"formats": []` either way
- a device with a padded stride that previously decoded sheared frames now fails at open

## Files

| Path | Why it matters |
|---|---|
| `crates/facelock-camera/src/capture.rs` | format selection, stride check, Y16 scale pinning *(start here)* |
| `crates/facelock-camera/src/device.rs` | decodability filter and its interaction with IR classification |
| `crates/facelock-camera/src/preprocess.rs` | NV12 and Y16 converters, shared YUV math |
| `crates/facelock-camera/src/quirks.rs` | `y16_bit_depth` quirk key |
| `docs/security.md` | what the pinned scale protects, and where it does not |
| `docs/compatibility.md` | IPU6/IPU7 recipe and the IR situation on that hardware |

## Reviewer notes

- **A scene-derived Y16 scale has a fail-open direction, and it ships with this branch.** `ir_texture_min_stddev` is an absolute cutoff on a scale-dependent statistic. A shift below true acts as a contrast stretch on exactly the buffer `check_ir_texture` measures, and can carry a flat spoof past the cutoff. Documented in `docs/security.md` with its preconditions; the generic fix is #161. Reachable only on Y16 devices with no declared `y16_bit_depth`, which today cannot decode at all — Y16 is not in main's format list, so RealSense IR is currently non-functional rather than insecure.
- **V4L2 cannot report a sensor's effective bit depth**, so the shift on an unlisted camera is necessarily inferred. `v4l2_pix_format` carries `bytesperline`, which describes the container, not the valid bits. This is why the quirk key exists and why quirks alone do not generalize.
- **The calibration burst treats any dequeue error as fatal.** `v4l`'s capture stream advances `arena_index` only on a successful dequeue and re-queues that index on the next call, so one failure wedges the stream with EINVAL. Tolerating errors would have returned `Ok` for a camera whose every capture fails.
- **Rebased over 159 commits.** The four original commits replay; `a7dd419` carries the part that could not be expressed as a conflict resolution — reconciling the decodability filter with the evidence-based IR classification from #98/#99, where the two format lists deliberately disagree on Y8/Y10/Y12.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt`
- container tiers: PAM smoke, one-shot end-to-end, state layout, daemon integration
- one-shot tier covers both directions of the `require_ir` gate on a multi-node camera, and that the refusal is the IR gate rather than an earlier pre-flight rejection
- Logitech BRIO: auto-detection selects the IR node, negotiates GREY, IR emitter toggles, live capture and the `--ignored` hardware suite
- NV12 end-to-end on IPU7 hardware is unverified — no such device available

Part of #89
