### PR TITLE
fix(deps): bump event-listener to 5.4.2 (RUSTSEC-2026-0221)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,11 +1067,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Lockfile-only bump resolving the cargo-audit failure currently gating every open PR (#90-#94). `event-listener` 5.4.1 (transitive via zbus) is flagged unsound by [RUSTSEC-2026-0221](https://rustsec.org/advisories/RUSTSEC-2026-0221); 5.4.2 is the patched release.

Validated locally: `cargo audit` passes (2 pre-existing allowed warnings), full workspace build + 452 tests green.

Merge this first — it unblocks CI for the whole #89 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)