### PR TITLE
fix(pam): build zbus without default features (C1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+      - name: Verify pam-facelock dependency surface
+        run: |
+          cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u > /tmp/pam-deps
+          echo "pam-facelock crate count: $(wc -l < /tmp/pam-deps)"
+          if grep -Eq '^(async-io|async-signal|signal-hook-registry|polling)$' /tmp/pam-deps; then
+            echo "forbidden async crates in pam-facelock"
+            exit 1
+          fi
+          echo "pam-facelock dependency guard passed"
+
       - name: Build release binaries
         run: |
           cargo build --release --workspace

--- a/crates/pam-facelock/Cargo.toml
+++ b/crates/pam-facelock/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 libc = "0.2"
 toml = { workspace = true }
 serde = { workspace = true }
-zbus = { version = "5", features = ["blocking"] }
+zbus = { version = "5", default-features = false, features = ["blocking"] }


### PR DESCRIPTION
## Summary
Reduces pam-facelock's transitive dependency surface from 68 to 58 crates by disabling zbus default features. Removes async runtime crates that are unnecessary for the PAM module's blocking D-Bus client usage.

**Gap:** C1 / **Issue:** Closes #104

## Changes
- `crates/pam-facelock/Cargo.toml`: Added `default-features = false` to zbus dependency
- `.github/workflows/ci.yml`: Added CI guard step to prevent reintroduction of forbidden async crates

## Verification

**Before:**
```
cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u | wc -l
68
```

**After:**
```
cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u | wc -l
58
```

**Removed crates (10 total):**
- async-io, async-signal, signal-hook-registry, polling (forbidden async crates)
- async-broadcast, async-channel, async-executor, async-process, async-task
- blocking, concurrent-queue

**CI Guard Test:**
```
cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u > /tmp/pam-deps
echo "pam-facelock crate count: $(wc -l < /tmp/pam-deps)"
if grep -Eq '^(async-io|async-signal|signal-hook-registry|polling)$' /tmp/pam-deps; then
  echo "forbidden async crates in pam-facelock"
  exit 1
fi
echo "pam-facelock dependency guard passed"
```

**Output:**
```
pam-facelock crate count: 58
pam-facelock dependency guard passed
```

**Build & Test:**
```
just check
```
Result: ✅ PASS (all 295 tests pass, cargo fmt ok, clippy ok, cargo audit ok with 2 allowed warnings)

## Architecture Note

The PAM module (pam-facelock) uses only blocking D-Bus APIs:
- `zbus::blocking::connection::Builder::system()`
- `zbus::blocking::Proxy::new()`
- `zbus::blocking::fdo::DBusProxy::new()`

Concurrency is achieved via `std::thread` spawn with timeout (worker threads + mpsc channel), not async/await. Therefore, the async runtime (tokio, async-executor, polling, etc.) is purely overhead and now removed.

The `blocking` feature flag provides the blocking client API without pulling in the entire async runtime stack.

## Cross-PR Notes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)