### PR TITLE
refactor(auth): unify oneshot on daemon pre_check; TPM in direct loader; hardcode auth_bin (N7/N8/N9, D11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "facelock-daemon",
  "facelock-face",
  "facelock-store",
+ "facelock-test-support",
  "facelock-tpm",
  "futures-util",
  "image",

--- a/crates/facelock-cli/Cargo.toml
+++ b/crates/facelock-cli/Cargo.toml
@@ -44,6 +44,7 @@ bytemuck = "1"
 
 [dev-dependencies]
 tempfile = "3"
+facelock-test-support = { path = "../facelock-test-support" }
 
 [features]
 default = ["wayland"]

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -14,7 +14,7 @@ use facelock_daemon::auth;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 pub fn run(user: String, config_path: Option<String>) -> i32 {
     let config = match config_path {
@@ -51,70 +51,8 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         }
     }
 
-    // --- Pre-flight security checks (mirrors daemon pre_check) ---
-
-    if config.security.disabled {
-        error!("facelock is disabled");
-        return 2;
-    }
-
-    if config.security.abort_if_ssh
-        && (std::env::var("SSH_CONNECTION").is_ok() || std::env::var("SSH_TTY").is_ok())
-    {
-        error!("SSH session detected, aborting");
-        return 2;
-    }
-
-    if config.security.abort_if_lid_closed {
-        let lid_closed = std::fs::read_to_string("/proc/acpi/button/lid/LID0/state")
-            .map(|s| s.contains("closed"))
-            .unwrap_or(false);
-        if lid_closed {
-            error!("lid closed, aborting");
-            return 2;
-        }
-    }
-
-    // Open a writable store for rate limiting (the oneshot path runs as root
-    // or the facelock group, so write access is available).
-    let store = match FaceStore::open(Path::new(&config.storage.db_path)) {
-        Ok(s) => s,
-        Err(e) => {
-            error!("database: {e}");
-            return 2;
-        }
-    };
-
-    // SQLite-based rate limiting: survives across oneshot process invocations.
-    // Only failed authentications consume the budget.
-    let rl = &config.security.rate_limit;
-    let rate_limiter = RateLimiter::new(rl.max_attempts, rl.window_secs);
-    match rate_limiter.check(&store, &user) {
-        Ok(true) => {}
-        Ok(false) => {
-            error!(user = %user, "rate limited");
-            return 2;
-        }
-        Err(e) => {
-            error!("rate limit check: {e}");
-            return 2;
-        }
-    }
-
-    match store.has_models(&user) {
-        Ok(true) => {}
-        Ok(false) => {
-            info!(user = %user, "no enrolled models");
-            return 2;
-        }
-        Err(e) => {
-            error!("storage: {e}");
-            return 2;
-        }
-    }
-
-    // --- End pre-flight checks ---
-
+    // Resolve the live device before the pre-flight gates so `pre_check` sees
+    // the real IR classification, exactly like the daemon does at startup.
     let device_path = config.device.path.clone().unwrap();
     let quirks = QuirksDb::load();
     let device_info = validate_device(&device_path);
@@ -125,11 +63,6 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         .map(|dev| is_ir_camera_resolved(dev, Some(&quirks)))
         .unwrap_or(false);
 
-    if config.security.require_ir && !device_is_ir {
-        error!("IR camera required but device is not IR");
-        return 2;
-    }
-
     // Device coupling (Plan 02): fingerprint the live camera so the compare loop
     // can skip templates enrolled on a different camera.
     let live_fingerprint = facelock_camera::device_fingerprint(&device_path);
@@ -137,6 +70,42 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     let device_quirk = device_info
         .ok()
         .and_then(|info| quirks.find_match(&info).cloned());
+
+    // Open a writable store (the oneshot path runs as root or the facelock
+    // group). The rate limiter is SQLite-backed through this database, so its
+    // window is shared with the daemon and survives across process invocations.
+    let store = match FaceStore::open(Path::new(&config.storage.db_path)) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("database: {e}");
+            return 2;
+        }
+    };
+
+    let rl = &config.security.rate_limit;
+    let rate_limiter = RateLimiter::new(rl.max_attempts, rl.window_secs);
+
+    // The daemon's pre-flight gates (disabled/SSH/lid, enrollment +
+    // suppress_unknown, rate limit, require_ir), with the daemon's rejection
+    // auditing. This used to be an inline mirror that drifted (#95): rate-limit
+    // rejections were never audited and suppress_unknown was ignored.
+    if let Some(resp) = auth::pre_check_audited(
+        &config,
+        &store,
+        &user,
+        &rate_limiter,
+        device_is_ir,
+        AuditSource::Oneshot,
+    ) {
+        // Every pre-flight rejection exits 2 ("error"), which the PAM module
+        // maps to PAM_IGNORE — the same code the deleted mirror used for each
+        // gate, so a rate-limited or not-enrolled user still falls through to
+        // password rather than registering a failed match (exit 1). The
+        // suppressed / not-enrolled / rate-limited distinction is carried by
+        // the audit record and the tracing output, not the exit code.
+        debug!(?resp, "pre-check short-circuit");
+        return 2;
+    }
 
     let mut camera = match Camera::open(&config.device, device_quirk.as_ref()) {
         Ok(c) => c,
@@ -167,7 +136,7 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     // handles encrypted templates (encrypt-by-default, Plan 04) — the bare
     // `auth::authenticate` helper reads plaintext only. Decrypt failure degrades
     // to no-match (exit 1 via an empty compare set), never a hard error.
-    let stored = match crate::direct::load_user_embeddings(&store, &config, &user) {
+    let mut stored = match crate::direct::load_user_embeddings(&store, &config, &user) {
         Ok(v) => v,
         Err(e) => {
             error!(user = %user, "failed to load embeddings: {e}");
@@ -177,10 +146,10 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     let models = store.list_models(&user).unwrap_or_default();
 
     let start = std::time::Instant::now();
-    let response = auth::authenticate_with_embeddings(
+    let response = crate::direct::authenticate_and_wipe(
         &mut camera,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         &config,
         &user,
@@ -257,5 +226,173 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             error!("unexpected response");
             2
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use facelock_core::config::Config;
+    use facelock_core::ipc::DaemonResponse;
+    use facelock_core::types::MatchResult;
+    use facelock_daemon::audit::AuditSource;
+    use facelock_daemon::auth::pre_check_audited;
+    use facelock_daemon::rate_limit::RateLimiter;
+    use facelock_store::FaceStore;
+    use std::path::Path;
+
+    /// Config for exercising the oneshot pre-flight gates: audit to a temp
+    /// file, SSH/lid gates off so the environment cannot short-circuit first.
+    fn gate_config(audit_path: &str, suppress_unknown: bool) -> Config {
+        Config::parse(&format!(
+            r#"
+[security]
+require_ir = false
+abort_if_ssh = false
+abort_if_lid_closed = false
+suppress_unknown = {suppress_unknown}
+
+[security.rate_limit]
+max_attempts = 2
+window_secs = 60
+
+[audit]
+enabled = true
+path = "{audit_path}"
+"#
+        ))
+        .unwrap()
+    }
+
+    fn audit_lines(path: &Path) -> Vec<serde_json::Value> {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        content
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    fn rate_limiter(config: &Config) -> RateLimiter {
+        let rl = &config.security.rate_limit;
+        RateLimiter::new(rl.max_attempts, rl.window_secs)
+    }
+
+    /// #95 symptom (a): a rate-limited oneshot attempt used to be rejected
+    /// with no audit record. Unified on `pre_check_audited`, the rejection
+    /// must produce the same `rate_limited` entry the daemon path writes,
+    /// stamped with the oneshot source.
+    #[test]
+    fn rate_limit_rejection_on_oneshot_path_writes_audit_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit_path = dir.path().join("audit.jsonl");
+        let config = gate_config(audit_path.to_str().unwrap(), false);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model("alice", "front", &[0.5f32; 512], "test-embedder")
+            .unwrap();
+
+        let limiter = rate_limiter(&config);
+        limiter.record_failure(&store, "alice").unwrap();
+        limiter.record_failure(&store, "alice").unwrap();
+
+        let resp = pre_check_audited(
+            &config,
+            &store,
+            "alice",
+            &limiter,
+            true,
+            AuditSource::Oneshot,
+        )
+        .expect("rate-limited user must short-circuit");
+        assert!(
+            matches!(resp, DaemonResponse::Error { ref message } if message.contains("rate limited")),
+            "expected rate-limited error, got {resp:?}"
+        );
+
+        let lines = audit_lines(&audit_path);
+        assert_eq!(lines.len(), 1, "exactly one audit record for the rejection");
+        assert_eq!(lines[0]["result"], "rate_limited");
+        assert_eq!(lines[0]["source"], "oneshot");
+        assert_eq!(lines[0]["user"], "alice");
+    }
+
+    /// #95 symptom (b): `suppress_unknown` was ignored on the oneshot path.
+    /// With it enabled, an un-enrolled user must yield `Suppressed` (audited
+    /// as such), not a plain not-enrolled failure.
+    #[test]
+    fn suppress_unknown_honored_on_oneshot_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit_path = dir.path().join("audit.jsonl");
+        let config = gate_config(audit_path.to_str().unwrap(), true);
+        let store = FaceStore::open_memory().unwrap();
+
+        let resp = pre_check_audited(
+            &config,
+            &store,
+            "nobody",
+            &rate_limiter(&config),
+            true,
+            AuditSource::Oneshot,
+        )
+        .expect("un-enrolled user must short-circuit");
+        assert!(matches!(resp, DaemonResponse::Suppressed));
+
+        let lines = audit_lines(&audit_path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["result"], "suppressed");
+        assert_eq!(lines[0]["source"], "oneshot");
+    }
+
+    /// Counterpart to the suppress test: with `suppress_unknown` off, the
+    /// same un-enrolled user is a plain non-match, audited as `failure` —
+    /// matching the daemon path.
+    #[test]
+    fn no_models_without_suppress_audits_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit_path = dir.path().join("audit.jsonl");
+        let config = gate_config(audit_path.to_str().unwrap(), false);
+        let store = FaceStore::open_memory().unwrap();
+
+        let resp = pre_check_audited(
+            &config,
+            &store,
+            "nobody",
+            &rate_limiter(&config),
+            true,
+            AuditSource::Oneshot,
+        )
+        .expect("un-enrolled user must short-circuit");
+        assert!(matches!(
+            resp,
+            DaemonResponse::AuthResult(MatchResult { matched: false, .. })
+        ));
+
+        let lines = audit_lines(&audit_path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["result"], "failure");
+        assert_eq!(lines[0]["source"], "oneshot");
+    }
+
+    /// An enrolled, un-limited user passes the gates with no audit record —
+    /// the auth loop itself owns success/failure auditing.
+    #[test]
+    fn passing_pre_check_writes_no_audit_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit_path = dir.path().join("audit.jsonl");
+        let config = gate_config(audit_path.to_str().unwrap(), false);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model("alice", "front", &[0.5f32; 512], "test-embedder")
+            .unwrap();
+
+        let resp = pre_check_audited(
+            &config,
+            &store,
+            "alice",
+            &rate_limiter(&config),
+            true,
+            AuditSource::Oneshot,
+        );
+        assert!(resp.is_none(), "gates must pass, got {resp:?}");
+        assert!(audit_lines(&audit_path).is_empty());
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -13,7 +13,8 @@ use facelock_camera::{
 use facelock_core::config::DeviceConfig;
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::DaemonResponse;
-use facelock_core::types::MatchResult;
+use facelock_core::traits::{CameraSource, FaceProcessor};
+use facelock_core::types::{MatchResult, zeroize_stored_embeddings};
 use facelock_daemon::audit::AuditSource;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
@@ -131,15 +132,15 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
     let mut engine = load_engine(config)?;
 
     // Load embeddings with encryption support, matching the daemon handler path.
-    let stored = load_user_embeddings(&store, config, user)?;
+    let mut stored = load_user_embeddings(&store, config, user)?;
     let models = store.list_models(user).unwrap_or_default();
 
     // Shared with daemon mode (crates/facelock-daemon/src/auth.rs). A local copy
     // of this loop previously lived here and silently drifted — do not re-fork it.
-    let response = facelock_daemon::auth::authenticate_with_embeddings(
+    let response = authenticate_and_wipe(
         &mut camera,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         config,
         user,
@@ -153,6 +154,37 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         DaemonResponse::Error { message } => bail!("{message}"),
         _ => bail!("unexpected auth response"),
     }
+}
+
+/// Run the shared camera auth loop, then wipe the caller-side decrypted
+/// embeddings (#100). `authenticate_with_embeddings` copies the compare set
+/// and zeroizes only its own copies, so without this the plaintext templates
+/// passed in would outlive authentication in the caller's memory.
+#[allow(clippy::too_many_arguments)]
+pub fn authenticate_and_wipe<C: CameraSource, E: FaceProcessor>(
+    camera: &mut C,
+    engine: &mut E,
+    stored: &mut [(u32, facelock_core::types::FaceEmbedding)],
+    models: &[facelock_core::types::FaceModelInfo],
+    config: &Config,
+    user: &str,
+    device_is_ir: bool,
+    live_fingerprint: &facelock_core::types::DeviceFingerprint,
+    source: AuditSource,
+) -> DaemonResponse {
+    let response = facelock_daemon::auth::authenticate_with_embeddings(
+        camera,
+        engine,
+        stored,
+        models,
+        config,
+        user,
+        device_is_ir,
+        live_fingerprint,
+        source,
+    );
+    zeroize_stored_embeddings(stored);
+    response
 }
 
 /// Initialize a software sealer based on encryption config.
@@ -196,8 +228,11 @@ fn init_software_sealer(config: &Config) -> anyhow::Result<Option<facelock_tpm::
     }
 }
 
-/// Load user embeddings, decrypting software-encrypted or TPM-sealed blobs as needed.
-/// Mirrors `Handler::load_user_embeddings` from the daemon path.
+/// Load user embeddings, decrypting software-encrypted or TPM-sealed blobs as
+/// needed. Mirrors `Handler::load_user_embeddings` from the daemon path,
+/// including directly TPM-sealed rows (version byte 0x01/0x03) written when
+/// `tpm.seal_database` is enabled — previously those failed here, which broke
+/// `bench`, `preview --text-only`, `test` and oneshot on sealed stores (B3).
 pub fn load_user_embeddings(
     store: &FaceStore,
     config: &Config,
@@ -205,37 +240,49 @@ pub fn load_user_embeddings(
 ) -> anyhow::Result<Vec<(u32, facelock_core::types::FaceEmbedding)>> {
     let software_sealer = init_software_sealer(config)?;
 
-    // Fast path: no encryption configured
-    if software_sealer.is_none() {
+    // Fast path: nothing is configured that could have written encrypted rows.
+    // `seal_database` forces the raw path even without a software sealer, so a
+    // TPM-sealed blob is never misread as a raw embedding.
+    if software_sealer.is_none() && !config.tpm.seal_database {
         return store
             .get_user_embeddings(user)
             .context("storage error loading embeddings");
     }
 
     // Slow path: load raw blobs (with device ids for opt-in AAD) and decrypt
-    let sealer = software_sealer.unwrap();
     let raw_rows = store
         .get_user_embeddings_raw_with_device(user)
         .context("storage error loading raw embeddings")?;
 
+    // Connect to the TPM lazily, only when a TPM-sealed row is present.
+    let mut tpm_sealer: Option<facelock_tpm::TpmSealer> = None;
+
     let mut results = Vec::with_capacity(raw_rows.len());
     for (id, blob, sealed, device_id) in &raw_rows {
         let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
+            let sealer = software_sealer.as_ref().with_context(|| {
+                format!("embedding {id} is software-encrypted but no key is configured")
+            })?;
             let aad = config.security.device_aad(device_id.as_deref());
             sealer
                 .unseal_embedding_with_aad(blob, aad.as_deref())
                 .with_context(|| format!("software decryption failed for embedding {id}"))?
         } else if *sealed {
-            #[cfg(feature = "tpm")]
-            {
-                bail!(
-                    "embedding {id} is TPM-sealed but direct path only supports software encryption — use the daemon"
-                );
-            }
-            #[cfg(not(feature = "tpm"))]
-            {
-                bail!("embedding {id} is TPM-sealed but TPM support is not compiled in");
-            }
+            // TPM-sealed (version byte 0x01/0x03), matching the daemon at
+            // `Handler::load_user_embeddings`. Without the `tpm` feature the
+            // passthrough sealer reports a clear "compile with tpm" error
+            // instead of misreading the blob.
+            let sealer = match tpm_sealer.as_mut() {
+                Some(s) => s,
+                None => {
+                    let s = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
+                        .context("TPM initialization failed")?;
+                    tpm_sealer.insert(s)
+                }
+            };
+            sealer
+                .unseal_embedding(blob)
+                .with_context(|| format!("TPM unseal failed for embedding {id}"))?
         } else {
             // Plaintext raw embedding
             anyhow::ensure!(
@@ -425,5 +472,147 @@ warmup_frames = 9
         assert_eq!(resolved.device.warmup_frames, 2);
         assert!(!resolved.device_is_ir);
         assert!(resolved.device_quirk.is_none());
+    }
+
+    // --- N8: encrypted-store loading in the direct path ---
+
+    #[test]
+    fn load_user_embeddings_decrypts_software_sealed_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let config = Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap();
+
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let sealer = facelock_tpm::SoftwareSealer::from_key_file(&key_path).unwrap();
+        let emb: facelock_core::types::FaceEmbedding = [0.25; 512];
+        let blob = sealer.seal_embedding(&emb).unwrap();
+
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &blob, true, "embedder")
+            .unwrap();
+
+        let loaded = load_user_embeddings(&store, &config, "alice").unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].1, emb);
+    }
+
+    /// B3: a TPM-sealed row (version byte 0x01, written under
+    /// `tpm.seal_database`) must reach the TPM unseal path — never be misread
+    /// as a raw embedding via the fast path. Without the `tpm` feature the
+    /// passthrough sealer reports a clear "without TPM support" error; actual
+    /// hardware unsealing cannot be asserted in CI and is exercised only on a
+    /// machine with a TPM.
+    #[cfg(not(feature = "tpm"))]
+    #[test]
+    fn tpm_sealed_rows_error_clearly_without_tpm_support() {
+        let config =
+            Config::parse("[encryption]\nmethod = \"none\"\n\n[tpm]\nseal_database = true\n")
+                .unwrap();
+        let store = FaceStore::open_memory().unwrap();
+        let mut blob = vec![0x01u8];
+        blob.extend_from_slice(&[0u8; 64]);
+        store
+            .add_model_raw("alice", "front", &blob, true, "embedder")
+            .unwrap();
+
+        let err = load_user_embeddings(&store, &config, "alice").unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(chain.contains("TPM unseal failed for embedding"), "{chain}");
+        assert!(chain.contains("without TPM support"), "{chain}");
+    }
+
+    /// `seal_database` forces the raw-row path even with no software sealer;
+    /// plaintext rows stored before sealing was enabled must still load.
+    #[test]
+    fn seal_database_slow_path_still_loads_plaintext_rows() {
+        let config =
+            Config::parse("[encryption]\nmethod = \"none\"\n\n[tpm]\nseal_database = true\n")
+                .unwrap();
+        let store = FaceStore::open_memory().unwrap();
+        let emb: facelock_core::types::FaceEmbedding = [0.75; 512];
+        store.add_model("alice", "front", &emb, "embedder").unwrap();
+
+        let loaded = load_user_embeddings(&store, &config, "alice").unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].1, emb);
+    }
+
+    // --- D11 (#100): caller-side wipe of decrypted embeddings ---
+
+    /// The compare set handed to `authenticate_with_embeddings` is copied
+    /// internally and only the copies are zeroized; `authenticate_and_wipe`
+    /// must wipe the caller's buffer too. Covers the `facelock auth` and
+    /// direct-mode callers, which both go through this helper; the daemon
+    /// handler's inline wipe at its call site cannot be black-box asserted
+    /// from here.
+    #[test]
+    fn authenticate_and_wipe_zeroizes_caller_embeddings() {
+        use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
+
+        let emb = fixtures::known_embedding(1);
+        let mut camera = MockCamera::bright(64, 64, 4);
+        let mut engine = MockFaceEngine::one_face(emb);
+        let config = Config::parse(
+            r#"
+[recognition]
+threshold = 0.45
+timeout_secs = 2
+
+[security]
+require_ir = false
+require_frame_variance = false
+require_landmark_liveness = false
+abort_if_ssh = false
+abort_if_lid_closed = false
+"#,
+        )
+        .unwrap();
+
+        let mut stored = vec![(1u32, emb)];
+        let models = vec![facelock_core::types::FaceModelInfo {
+            id: 1,
+            user: "alice".into(),
+            label: "front".into(),
+            created_at: 0,
+            embedder_model: String::new(),
+            device_id: None,
+        }];
+        let fingerprint = facelock_core::types::DeviceFingerprint {
+            vid: None,
+            pid: None,
+            serial: None,
+            by_path: None,
+        };
+
+        let response = authenticate_and_wipe(
+            &mut camera,
+            &mut engine,
+            &mut stored,
+            &models,
+            &config,
+            "alice",
+            false,
+            &fingerprint,
+            AuditSource::Test,
+        );
+
+        assert!(
+            matches!(
+                response,
+                DaemonResponse::AuthResult(MatchResult { matched: true, .. })
+            ),
+            "auth loop must run to completion: {response:?}"
+        );
+        for (id, e) in &stored {
+            assert!(
+                e.iter().all(|&v| v == 0.0),
+                "caller-side embedding {id} was not wiped"
+            );
+        }
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -436,7 +436,7 @@ warmup_frames = 2
     #[test]
     fn auto_detected_device_inherits_quirk_state() {
         let config = test_config();
-        let device = make_device("/dev/video2", "Logitech BRIO IR", "MJPG");
+        let device = make_device("/dev/video2", "BRIO IR", "GREY");
         let dir = write_quirks_dir(
             r#"
 [[quirk]]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -101,6 +101,47 @@ pub fn pre_check(
     None
 }
 
+/// Run [`pre_check`] and, when a gate short-circuits, write the audit entry
+/// for the rejection. The daemon handler and the oneshot `facelock auth`
+/// binary both go through this wrapper so rejection auditing cannot drift
+/// between the two paths (#95: rate-limit rejections on the oneshot path
+/// were never audited).
+pub fn pre_check_audited(
+    config: &Config,
+    store: &FaceStore,
+    user: &str,
+    rate_limiter: &RateLimiter,
+    device_is_ir: bool,
+    source: AuditSource,
+) -> Option<DaemonResponse> {
+    let resp = pre_check(config, store, user, rate_limiter, device_is_ir)?;
+    let (result, error) = match &resp {
+        DaemonResponse::Error { message } if message.contains("rate limited") => {
+            ("rate_limited".to_string(), Some(message.clone()))
+        }
+        DaemonResponse::Error { message } => ("error".to_string(), Some(message.clone())),
+        DaemonResponse::AuthResult(mr) if !mr.matched => ("failure".to_string(), None),
+        DaemonResponse::Suppressed => ("suppressed".to_string(), None),
+        _ => ("error".to_string(), None),
+    };
+    audit::write_audit_entry(
+        &config.audit,
+        &AuditEntry {
+            timestamp: audit::now_iso8601(),
+            user: user.to_string(),
+            result,
+            source: Some(source),
+            similarity: None,
+            frame_count: None,
+            duration_ms: None,
+            device: config.device.path.clone(),
+            model_label: None,
+            error,
+        },
+    );
+    Some(resp)
+}
+
 /// Run the camera-based authentication loop with pre-loaded (decrypted) embeddings.
 ///
 /// This is the only entry point: callers MUST load embeddings through their

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::{DaemonRequest, DaemonResponse, PreviewFace};
 use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::best_match;
+use facelock_core::types::{best_match, zeroize_stored_embeddings};
 use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
@@ -377,7 +377,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 }
 
                 // Pre-load and decrypt embeddings (handles TPM + software encryption)
-                let stored = match self.load_user_embeddings(&user) {
+                let mut stored = match self.load_user_embeddings(&user) {
                     Ok(s) => s,
                     Err(resp) => return resp,
                 };
@@ -396,6 +396,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     &self.device_fingerprint,
                     AuditSource::Daemon,
                 );
+                // `authenticate_with_embeddings` works on an internal copy;
+                // wipe the caller-side plaintext set too (#100).
+                zeroize_stored_embeddings(&mut stored);
                 self.camera = Some(camera);
                 self.camera_last_used = Instant::now();
                 // Only failed auths count against the rate limit

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -8,7 +8,7 @@ use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
 
-use crate::audit::{self, AuditEntry, AuditSource};
+use crate::audit::AuditSource;
 use crate::auth;
 use crate::enroll;
 use crate::rate_limit::RateLimiter;
@@ -334,41 +334,14 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
 
             DaemonRequest::Authenticate { user } => {
-                if let Some(resp) = auth::pre_check(
+                if let Some(resp) = auth::pre_check_audited(
                     &self.config,
                     &self.store,
                     &user,
                     &self.rate_limiter,
                     self.device_is_ir,
+                    AuditSource::Daemon,
                 ) {
-                    let (result, error) = match &resp {
-                        DaemonResponse::Error { message } if message.contains("rate limited") => {
-                            ("rate_limited".to_string(), Some(message.clone()))
-                        }
-                        DaemonResponse::Error { message } => {
-                            ("error".to_string(), Some(message.clone()))
-                        }
-                        DaemonResponse::AuthResult(mr) if !mr.matched => {
-                            ("failure".to_string(), None)
-                        }
-                        DaemonResponse::Suppressed => ("suppressed".to_string(), None),
-                        _ => ("error".to_string(), None),
-                    };
-                    audit::write_audit_entry(
-                        &self.config.audit,
-                        &AuditEntry {
-                            timestamp: audit::now_iso8601(),
-                            user: user.clone(),
-                            result,
-                            source: Some(AuditSource::Daemon),
-                            similarity: None,
-                            frame_count: None,
-                            duration_ms: None,
-                            device: self.config.device.path.clone(),
-                            model_label: None,
-                            error,
-                        },
-                    );
                     return resp;
                 }
 

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -36,6 +36,12 @@ const LOG_WARNING: libc::c_int = 4;
 const DEFAULT_CONFIG_PATH: &str = "/etc/facelock/config.toml";
 const DEFAULT_TIMEOUT_SECS: u32 = 5;
 
+/// The binary spawned for oneshot authentication. Hardcoded: a configurable
+/// path would let anyone who can influence the config select which binary a
+/// root PAM context executes (E7/N9). The path is still validated as
+/// root-owned and non-writable before spawning.
+const AUTH_BIN: &str = "/usr/bin/facelock";
+
 // D-Bus constants
 const DBUS_BUS_NAME: &str = "org.facelock.Daemon";
 const DBUS_OBJECT_PATH: &str = "/org/facelock/Daemon";
@@ -62,16 +68,14 @@ struct PamDaemonConfig {
     /// "daemon" (default) or "oneshot"
     #[serde(default = "default_mode")]
     mode: String,
-    /// Path to the facelock binary for oneshot mode
-    #[serde(default = "default_auth_bin")]
-    auth_bin: String,
+    // The oneshot binary path is NOT configurable — see `AUTH_BIN`. A leftover
+    // `auth_bin` key in an existing config is silently ignored (serde default).
 }
 
 impl Default for PamDaemonConfig {
     fn default() -> Self {
         Self {
             mode: default_mode(),
-            auth_bin: default_auth_bin(),
         }
     }
 }
@@ -173,10 +177,6 @@ fn default_timeout() -> u32 {
 
 fn default_mode() -> String {
     "daemon".to_string()
-}
-
-fn default_auth_bin() -> String {
-    "/usr/bin/facelock".to_string()
 }
 
 fn default_true() -> bool {
@@ -750,7 +750,7 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
 
     let timeout_secs = config.recognition.timeout_secs as u64 + 3; // buffer for model load
 
-    let auth_bin = match validate_auth_bin(&config.daemon.auth_bin) {
+    let auth_bin = match validate_auth_bin(AUTH_BIN) {
         Ok(path) => path,
         Err(e) => {
             log_auth(
@@ -1115,6 +1115,19 @@ db_path = "/tmp/test.db"
 "#;
         let config: PamConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.daemon.mode, "daemon");
+    }
+
+    #[test]
+    fn config_with_removed_auth_bin_key_still_parses() {
+        // N9 removed the `auth_bin` key. Existing installs may still have it
+        // in /etc/facelock/config.toml; it must be ignored, never an error.
+        let toml_str = r#"
+[daemon]
+mode = "oneshot"
+auth_bin = "/usr/local/bin/evil"
+"#;
+        let config: PamConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.daemon.mode, "oneshot");
     }
 
     #[test]


### PR DESCRIPTION
Implements DEC-2's oneshot unification (gap register N7/N8/N9 + D11).

Closes #95
Closes #100

## N7 — oneshot calls the real `pre_check` (closes #95)

`facelock auth` (commands/auth.rs) re-implemented the daemon's pre-flight gates inline — the comment literally said "mirrors daemon pre_check" — and had drifted. The mirror is deleted; the oneshot path now calls the daemon's own gate logic via a new `auth::pre_check_audited` wrapper in `facelock-daemon`, which runs `pre_check` and writes the same rejection audit entry the daemon writes, stamped with the caller's `AuditSource`. The daemon handler now goes through the same wrapper, so rejection auditing *cannot* drift between the two paths again.

**The two documented drift symptoms, both pinned by tests:**

| #95 symptom | Before | After | Pinning test |
|---|---|---|---|
| (a) rate-limit rejections on the oneshot path produced **no audit record** | rejected silently | audited as `result: "rate_limited"`, `source: "oneshot"` | `rate_limit_rejection_on_oneshot_path_writes_audit_record` |
| (b) `suppress_unknown` **ignored** on the oneshot path | un-enrolled user always treated as plain not-enrolled | `Suppressed` short-circuit, audited as `result: "suppressed"` (and `"failure"` when the option is off) | `suppress_unknown_honored_on_oneshot_path`, `no_models_without_suppress_audits_failure` |

**Exact unified pre-flight behavior on the oneshot path** (now byte-identical logic to the daemon, same order):

1. `security.disabled` → error
2. `abort_if_ssh` (env `SSH_CONNECTION`/`SSH_TTY` — forwarded to the child by the PAM env allow-list precisely for this check) → error
3. `abort_if_lid_closed` → error
4. enrollment check; no models → `Suppressed` when `suppress_unknown`, else non-match
5. rate limit check
6. `require_ir` vs the resolved live device → error

**Rate limiter**: there is no daemon-in-memory state to lose — `RateLimiter` is and was SQLite-backed (`rate_limit` table in the shared store). Daemon and oneshot share the same persistent window; nothing new was invented. Only failed auth attempts consume budget (unchanged, both paths identical).

**Exit codes unchanged**: every pre-flight rejection exits 2 (→ `PAM_IGNORE` → password fallthrough), the same code the deleted mirror used for each gate. The only behavioral deltas are the two specified symptom fixes, plus one corner: a user who is *both* un-enrolled *and* rate-limited now reports not-enrolled/suppressed (daemon gate order) where the old mirror reported rate-limited — the mirror checked the gates in the opposite order.

Device resolution (quirks/IR/fingerprint) moved *before* the gates so `pre_check` sees the real IR classification, exactly like the daemon computes it at startup. Camera open still happens after the gates.

## N8 — TPM unsealing in the direct loader (gap B3)

`direct::load_user_embeddings` could not decrypt directly TPM-sealed rows (version byte `0x01`/`0x03`, written under `tpm.seal_database = true`), breaking `bench`, `preview --text-only`, `test` (direct mode) and oneshot on sealed stores. It now mirrors `Handler::load_user_embeddings`: a lazily-created `TpmSealer` unseals those rows, and — critically — `seal_database = true` forces the raw-row path even when no software sealer is configured, so a TPM-sealed blob can never be misread as a raw embedding.

Tests: software-sealed roundtrip; plaintext rows still load through the forced slow path; a `0x01` row in a non-`tpm` build fails with a clear "without TPM support" error instead of being misparsed. **Honesty note:** actual TPM-hardware unsealing cannot be asserted in CI; that path is plumbing identical to the daemon's and is exercised only on a machine with a TPM.

## N9 — `auth_bin` hardcoded

The PAM module now spawns the compile-time constant `/usr/bin/facelock` (exactly the previous default, `default_auth_bin()`); the `daemon.auth_bin` key is removed from `PamConfig`. The full `validate_auth_bin` path-trust validation (root-owned, no group/world-write, all parents checked) is retained on the hardcoded path.

- **Spec correction:** the plan said to remove the key from "both schemas", but `auth_bin` never existed in the facelock-core `DaemonConfig` — only `PamConfig` had it. No core change was needed (and none was made).
- **Existing-config compatibility:** neither config parser uses `deny_unknown_fields`, so a leftover `auth_bin = "..."` line in `/etc/facelock/config.toml` is **silently ignored** — parse still succeeds, nothing breaks, no deliberate error handling was needed. Pinned by `config_with_removed_auth_bin_key_still_parses`. (The core parser already tolerated the key, since it never knew it.)
- Spawn environment semantics untouched: `env_clear()` + allow-list (`SSH_CONNECTION`/`SSH_TTY`, pinned `PATH`) are exactly as before.

## D11 — caller-side zeroization (closes #100)

`authenticate_with_embeddings` copies the compare set and zeroizes only its own copies; the callers' decrypted plaintext survived the call. All three call sites fixed:

- `commands/auth.rs` and `direct.rs::authenticate` now go through a new `direct::authenticate_and_wipe` helper that runs the shared loop and then `zeroize_stored_embeddings` on the caller's buffer — pinned by `authenticate_and_wipe_zeroizes_caller_embeddings` (mock camera/engine, asserts the buffer is all-zero after a completed auth).
- `handler.rs` (daemon) wipes inline after the call (it cannot use a facelock-cli helper).

**Honesty note:** the test proves the helper wipes what is passed through it; that `run()`/`Handler::handle` reach it is enforced by code shape (both non-helper paths are gone), not by a black-box memory assertion — wiring a memory-forensics test around a monolithic `run() -> i32` would be fake coverage.

## Out-of-ownership touches (declared)

1. **`crates/facelock-daemon`** (authorized): `auth.rs` gains `pre_check_audited` (the pre_check-callable API change — `pre_check` itself was already `pub`, but the unified *audit* behavior demanded by #95's symptom (a) lives here so it cannot be re-mirrored in the CLI); `handler.rs` switches its `Authenticate` arm to that wrapper (net −30 lines, byte-identical audit output) and adds the D11 wipe at its `authenticate_with_embeddings` call site.
2. **`crates/facelock-cli/Cargo.toml`**: added `facelock-test-support` as a dev-dependency — required for the mandated mock-based D11 test. (`Cargo.lock` updated accordingly.)
3. **facelock-core**: *no change* — see the N9 spec correction above.

## Cross-PR notes (files owned by other PRs — NOT edited here)

- ⚠️ **`test/run-container-tests.sh` (PR B, `test-arch-pam` tier): the three `env_clear` assertions break by design under N9.** They capture the oneshot child environment by pointing `auth_bin` at `/usr/local/bin/facelock-env-capture` (line ~142) — a redirect that no longer exists (that redirect being attack surface is the point of N9). Fix: swap the real binary in place instead, e.g. `mv /usr/bin/facelock /usr/bin/facelock.orig && install -m 755 /usr/local/bin/facelock-env-capture /usr/bin/facelock`, run `pamtester`, restore; drop the `auth_bin` sed lines (keep `mode = "oneshot"`).
- ⚠️ **`test/run-integration-tests.sh` line ~217–219 (PR B): the "no oneshot child spawned when the daemon answers" marker test becomes vacuous** (its `auth_bin` marker redirect is ignored, so the marker can never fire even if a child *were* spawned). Same in-place binary-swap fix.
- **`docs/security.md` ~line 437 (PR B owns docs/)**: "a writable config could redirect `auth_bin`" — should now read that the oneshot binary path is hardcoded (the config-trust validation still matters for the other knobs). No other doc/template/man references to `auth_bin` exist (`config/facelock.toml`, `man/*`, `book/src/**` are all clean).
- **`handler.rs::detect_and_match` (preview path)** loads decrypted embeddings and does not wipe them — outside D11's scope (not a caller of `authenticate_with_embeddings`) and adjacent to PR C's preview-oracle work; flagging rather than touching.
- **Pre-existing PAM-visible asymmetry, unchanged**: over D-Bus a rate-limited reply maps to `PAM_AUTH_ERR`; the oneshot subprocess maps every pre-flight rejection (exit 2) to `PAM_IGNORE`. Unifying that would change auth semantics beyond this PR's mandate; noting for a future decision.
- direct.rs quirk-inheritance test fixture updated for compatibility with #110's evidence-derived IR classification (verified against both branches).

## Docs to reconcile (PR B)

- Remove/adjust the `auth_bin` mention in `docs/security.md` §"Config File Trust" (~437) as above. The shipped config template never listed `auth_bin`, so no template change is needed.

## Follow-on

- #70 (TPM PCR binding off by default, no re-seal recovery path) sequences after this PR — it needs the direct TPM loader added here.

## Verification

- `just check` green: `cargo test --workspace` (all crates, including the 9 new tests), `clippy -D warnings`, `fmt --check`, `cargo audit`.
- `just test-arch-pam` deliberately **not** run here (shared podman image tag; orchestrator runs it centrally). Note the expected env_clear failures above until PR B's script change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
