### PR TITLE
fix(camera): derive IR classification from device evidence; anchor quirk patterns (#98, #99)

### DIFF
--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -43,8 +43,15 @@ notes = "Intel RealSense D455 IR module"
 
 # --- Lenovo ThinkPad IR cameras ---
 
+# Anchored (#99): name_pattern now matches the WHOLE device name, not a
+# substring of it, so this requires the name to literally START with
+# "IR Camera" (a trailing wildcard still allows a model-number suffix, e.g.
+# "IR Camera 5MP"). It intentionally does NOT match names where "IR Camera"
+# isn't the leading text (e.g. "Integrated IR Camera") — add a corrected,
+# still-anchored pattern for your exact device string (see `facelock
+# list-devices`) rather than reintroducing a bare leading wildcard here.
 [[quirk]]
-name_pattern = "(?i)ir.*camera"
+name_pattern = "(?i)ir camera.*"
 force_ir = true
 warmup_frames = 8
 notes = "ThinkPad integrated IR camera (various models)"
@@ -65,8 +72,13 @@ notes = "Logitech BRIO 4K with IR sensor"
 
 # --- Microsoft Surface cameras ---
 
+# Anchored (#99): requires the name to START with "surface", then a
+# word-bounded " ir" later (the literal leading space stops an unrelated
+# word ending in "...ir", e.g. "Air", from matching). Does NOT match names
+# where "Microsoft" precedes "Surface" — add a corrected pattern for your
+# exact device string if needed.
 [[quirk]]
-name_pattern = "(?i)surface.*ir"
+name_pattern = "(?i)surface.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "Microsoft Surface IR camera"
@@ -80,8 +92,10 @@ notes = "Microsoft Surface Pro IR camera"
 
 # --- HP IR cameras ---
 
+# Anchored (#99): see the ThinkPad/Surface entries above for the pattern
+# rationale (start-anchored vendor prefix + word-bounded " ir").
 [[quirk]]
-name_pattern = "(?i)hp.*ir"
+name_pattern = "(?i)hp.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "HP IR camera (various models)"
@@ -89,7 +103,7 @@ notes = "HP IR camera (various models)"
 # --- Dell IR cameras ---
 
 [[quirk]]
-name_pattern = "(?i)dell.*ir"
+name_pattern = "(?i)dell.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "Dell IR camera (various models)"

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -51,17 +51,23 @@ pub fn validate_device(path: &str) -> Result<DeviceInfo> {
 
 /// Provenance of an IR classification decision, for logging and honesty.
 ///
-/// Ordered by authoritativeness: a `Quirk` hit is definitive; `Format` means a
-/// native IR capture format (GREY/Y16) corroborated by an IR name token; `Name`
-/// means an IR name token alone; `None` means not classified as IR.
+/// Ordered by authoritativeness: a `Quirk` hit is definitive (a USB-ID match
+/// always; a name-only match only when corroborated — see
+/// [`ir_source_with_quirks`]); `Format` means the device's OWN queried
+/// capture formats support IR; `None` means not classified as IR.
+///
+/// The device's free-text name is NEVER, by itself, sufficient to classify a
+/// device as IR (#98) — IR-ness is derived from queried evidence. The name is
+/// still consulted, but only as a tiebreak hint during auto-detection
+/// selection (see [`pick_auto_device`]) and as part of quirk-match
+/// corroboration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IrSource {
-    /// Hardware quirks DB `force_ir = true` — authoritative.
+    /// Hardware quirks DB `force_ir = true`, corroborated — authoritative.
     Quirk,
-    /// Native IR format (GREY/Y16) corroborated by an IR name token.
+    /// The device's own queried capture formats support IR (mono-only
+    /// format enumeration — see [`has_mono_only_formats`]).
     Format,
-    /// IR name token ("ir"/"infrared") present, no IR capture format.
-    Name,
     /// Not classified as IR.
     None,
 }
@@ -95,38 +101,101 @@ pub fn ir_source(device: &DeviceInfo) -> IrSource {
     ir_source_with_quirks(device, None)
 }
 
-/// True if the device natively exposes an IR-like capture format (GREY/Y16).
+/// V4L2 pixel formats intrinsic to IR/mono sensors. Fourcc strings are
+/// space-padded to 4 chars by the V4L2 API; compare trimmed.
+const IR_TYPICAL_FOURCCS: [&str; 5] = ["GREY", "Y16", "Y12", "Y10", "Y8"];
+
+fn is_ir_typical_fourcc(fourcc: &str) -> bool {
+    IR_TYPICAL_FOURCCS.contains(&fourcc.trim())
+}
+
+/// True if the device enumerates at least one IR-typical mono format
+/// (GREY/Y8/Y10/Y12/Y16), possibly alongside other (e.g. color) formats.
+///
+/// Used for multi-node USB device disambiguation, where a sibling node's
+/// mere *offering* of a mono format (not necessarily its ONLY format) is the
+/// relevant signal. See [`has_mono_only_formats`] for the stricter "this
+/// node IS an IR sensor" evidence used in classification.
 fn has_native_ir_format(device: &DeviceInfo) -> bool {
     device
         .formats
         .iter()
-        .any(|f| matches!(f.fourcc.as_str(), "GREY" | "Y16 "))
+        .any(|f| is_ir_typical_fourcc(&f.fourcc))
 }
 
-/// The quirk-free heuristic classification (name token / format corroboration).
+/// True if this device enumerates ONLY IR-typical mono capture formats
+/// (GREY/Y8/Y10/Y12/Y16), with at least one such format present.
+///
+/// A node that ALSO enumerates a color format (YUYV, MJPG, ...) alongside a
+/// mono one is an ordinary color sensor that happens to offer a mono mode
+/// too — not IR evidence (many ordinary RGB UVC webcams enumerate GREY
+/// alongside YUYV/MJPG). A node whose ENTIRE format set is mono/IR-typical is
+/// a genuine dedicated mono/IR sensor node.
+fn has_mono_only_formats(device: &DeviceInfo) -> bool {
+    !device.formats.is_empty()
+        && device
+            .formats
+            .iter()
+            .all(|f| is_ir_typical_fourcc(&f.fourcc))
+}
+
+/// Queryable IR-relevant evidence about a device — the facts a future
+/// `CameraCaps.is_ir` (gap D8) should be derived from. Populated strictly
+/// from queried V4L2 data (the capture formats the device actually
+/// enumerates), NEVER from the free-text device/card name, which is
+/// attacker-controlled on virtual devices such as v4l2loopback (#98).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct IrEvidence {
+    /// The device enumerates ONLY IR-typical mono capture formats — see
+    /// [`has_mono_only_formats`].
+    pub mono_only_formats: bool,
+}
+
+/// Query IR-relevant evidence for a device from its enumerated capture
+/// formats. Never looks at `device.name`.
+fn query_ir_evidence(device: &DeviceInfo) -> IrEvidence {
+    IrEvidence {
+        mono_only_formats: has_mono_only_formats(device),
+    }
+}
+
+/// Derive an IR-ness verdict purely from queried device evidence — never
+/// from the free-text device name. This is the function a future
+/// `CameraCaps.is_ir` (gap D8) can adopt directly.
+pub fn derive_ir_from_evidence(evidence: &IrEvidence) -> bool {
+    evidence.mono_only_formats
+}
+
+/// The quirk-free heuristic classification, derived SOLELY from queried
+/// device evidence (#98 — never the free-text name). The device name is not
+/// consulted here at all; it is used only as a tiebreak hint during
+/// auto-detection selection (see [`pick_auto_device`]).
 fn heuristic_ir_source(device: &DeviceInfo) -> IrSource {
-    match (
-        has_ir_name_token(&device.name),
-        has_native_ir_format(device),
-    ) {
-        // Native IR format corroborated by the name token — strongest heuristic.
-        (true, true) => IrSource::Format,
-        // Name token alone is sufficient (e.g. "Infrared Camera").
-        (true, false) => IrSource::Name,
-        // Format alone (or nothing) is NOT sufficient — this is the H1 bypass fix.
-        (false, _) => IrSource::None,
+    if derive_ir_from_evidence(&query_ir_evidence(device)) {
+        IrSource::Format
+    } else {
+        IrSource::None
     }
 }
 
 /// Classify a device's IR provenance, honoring the quirks DB as authoritative.
 ///
-/// Decision rules (H1 fix — mere *availability* of GREY/Y16 is NOT proof of IR):
-/// 1. A quirks DB `force_ir` value is authoritative in both directions.
-/// 2. A native IR capture format (GREY/Y16) counts only when corroborated by an
-///    IR name token → [`IrSource::Format`].
-/// 3. An IR name token alone → [`IrSource::Name`].
-/// 4. Otherwise → [`IrSource::None`] (a plain RGB webcam that merely enumerates
-///    GREY is not treated as IR).
+/// Decision rules:
+/// 1. A quirks DB `force_ir = false` is authoritative "not IR", regardless of
+///    how the quirk matched.
+/// 2. A quirks DB `force_ir = true` matched by USB vendor:product ID is
+///    authoritative "IR" — a virtual device (e.g. v4l2loopback) has no real
+///    USB node, so it can never win this path.
+/// 3. A quirks DB `force_ir = true` matched by device NAME ONLY requires
+///    corroboration before it is trusted: either the device has a real (if
+///    DB-unlisted) USB identity, or its own queried formats independently
+///    support IR (rule 4). Without corroboration a crafted device name alone
+///    cannot win `force_ir` through the quirks path either (#98 Task 3).
+/// 4. Otherwise, IR-ness is derived SOLELY from the device's own queried
+///    capture formats (mono-only enumeration — GREY/Y8/Y10/Y12/Y16). The
+///    free-text device name is NEVER, by itself, sufficient (#98): a crafted
+///    `CARD_LABEL` on a color-only device does not classify as IR no matter
+///    what it is called.
 ///
 /// CAVEAT (multi-node USB devices): one physical USB camera can expose several
 /// V4L2 capture nodes sharing the same VID:PID (e.g. the Logitech BRIO's RGB
@@ -151,15 +220,32 @@ fn ir_source_with_quirks_and_ids(
     quirks: Option<&crate::quirks::QuirksDb>,
     usb_ids: Option<&(String, String)>,
 ) -> IrSource {
-    // 1. Quirks database is authoritative (both true and false).
     if let Some(db) = quirks {
-        if let Some(quirk) = db.find_match_with_ids(device, usb_ids) {
-            if let Some(force_ir) = quirk.force_ir {
-                return if force_ir {
-                    IrSource::Quirk
-                } else {
-                    IrSource::None
-                };
+        if let Some((quirk, kind)) = db.find_match_with_kind(device, usb_ids) {
+            match quirk.force_ir {
+                Some(false) => return IrSource::None,
+                Some(true) => {
+                    let corroborated = match kind {
+                        // A real hardware identity match — authoritative on
+                        // its own.
+                        crate::quirks::QuirkMatchKind::UsbId => true,
+                        // A name-only match needs corroboration: either a
+                        // real (if DB-unlisted) USB identity, or the
+                        // device's own queried evidence. A virtual
+                        // v4l2loopback node has neither, so a crafted name
+                        // alone can no longer win force_ir through the
+                        // quirks path (#98 Task 3).
+                        crate::quirks::QuirkMatchKind::NameOnly => {
+                            usb_ids.is_some() || derive_ir_from_evidence(&query_ir_evidence(device))
+                        }
+                    };
+                    if corroborated {
+                        return IrSource::Quirk;
+                    }
+                    // Uncorroborated name-only force_ir: fall through to the
+                    // evidence-only heuristic below.
+                }
+                None => {}
             }
         }
     }
@@ -291,10 +377,13 @@ pub fn is_ir_camera_resolved(
 ///
 /// Classifies all nodes with [`classify_ir_sources`] (so multi-node USB devices
 /// resolve to their actual IR sensor node), then prefers: a quirks-confirmed IR
-/// node with a native IR format, then any quirks-confirmed IR node, then a
-/// heuristically-IR node (name token), then the first enumerated device. It
-/// never auto-selects an unknown camera *just because* it self-reports a
-/// GREY/Y16 format (H1).
+/// node with a native IR format, then any quirks-confirmed IR node, then an
+/// evidence-classified IR node (preferring one whose name also carries an IR
+/// token, as a tiebreak hint only), then the first enumerated device. It never
+/// auto-selects an unknown camera *just because* its NAME claims to be IR
+/// (#98) or *just because* it self-reports a GREY/Y16 format alongside color
+/// formats (H1) — only queried mono-only format evidence, or a corroborated
+/// quirk, counts.
 ///
 /// NOTE (seam for Plan 02): device selection here is by capability/heuristic, not
 /// by stable device identity. Plan 02 will pin the enrolled camera by identity.
@@ -308,14 +397,22 @@ pub fn auto_detect_device() -> Result<DeviceInfo> {
 }
 
 /// Selection order for auto-detection, over pre-classified nodes.
+///
 /// Prefers the format-corroborated IR node so a multi-node camera's RGB
-/// sibling is never picked over its IR sensor.
+/// sibling is never picked over its IR sensor. Among evidence-classified
+/// nodes with no quirk, the device name is consulted only as a tiebreak hint
+/// (an IR name token breaks ties among already-qualified nodes; it never
+/// promotes a node with no format evidence — see [`heuristic_ir_source`]).
 fn pick_auto_device<'a>(devices: &'a [DeviceInfo], sources: &[IrSource]) -> Option<&'a DeviceInfo> {
     let nodes = || devices.iter().zip(sources);
     nodes()
         .find(|(d, s)| **s == IrSource::Quirk && has_native_ir_format(d))
         .or_else(|| nodes().find(|(_, s)| **s == IrSource::Quirk))
-        .or_else(|| nodes().find(|(_, s)| **s != IrSource::None))
+        .or_else(|| {
+            nodes()
+                .find(|(d, s)| **s != IrSource::None && has_ir_name_token(&d.name))
+                .or_else(|| nodes().find(|(_, s)| **s != IrSource::None))
+        })
         .map(|(d, _)| d)
         .or_else(|| devices.first())
 }
@@ -399,10 +496,23 @@ mod tests {
     }
 
     #[test]
-    fn is_ir_camera_grey_format_alone_is_not_ir() {
-        // H1 fix: merely enumerating GREY is NOT proof of IR. An RGB webcam that
-        // advertises a GREY format with no IR name token / quirk is not-IR.
+    fn is_ir_camera_mono_format_alone_is_ir_by_evidence() {
+        // #98 fix: IR-ness is DERIVED from queried device evidence, never
+        // from the free-text name. A device with an unrelated name that
+        // enumerates ONLY a mono/IR-typical format is genuine IR evidence
+        // ("a genuine IR-evidence device still classifies as IR" — no name
+        // corroboration needed).
         let device = device_with("USB Camera", &["GREY"]);
+        assert!(is_ir_camera(&device));
+        assert_eq!(ir_source(&device), IrSource::Format);
+    }
+
+    #[test]
+    fn crafted_card_label_with_color_formats_only_is_not_ir() {
+        // #98 regression: a v4l2loopback device can set CARD_LABEL to
+        // anything. A crafted "Fake IR Camera" label backed only by
+        // ordinary color formats must not defeat require_ir.
+        let device = device_with("Fake IR Camera", &["YUYV", "MJPG"]);
         assert!(!is_ir_camera(&device));
         assert_eq!(ir_source(&device), IrSource::None);
     }
@@ -410,7 +520,8 @@ mod tests {
     #[test]
     fn ir_classification_corpus() {
         // Real RGB camera name strings must classify not-IR, even the ones
-        // whose names contain the substring "ir" but not the token "ir".
+        // whose names contain the substring "ir" but not the token "ir" —
+        // and even though these carry no format evidence either.
         for name in [
             "Integrated Webcam",
             "USB2.0 HD UVC WebCam",
@@ -421,16 +532,21 @@ mod tests {
             let dev = device_with(name, &["YUYV", "MJPG"]);
             assert!(!is_ir_camera(&dev), "{name} should be not-IR");
         }
-        // A GREY-only RGB cam is still not-IR without corroboration.
-        assert!(!is_ir_camera(&device_with("Generic Cam", &["GREY"])));
-        // A name IR token classifies IR.
+        // A GREY-and-color mix (the H1 case) is still not-IR: only a
+        // mono-ONLY format set counts as evidence.
+        assert!(!is_ir_camera(&device_with(
+            "Generic Cam",
+            &["GREY", "YUYV"]
+        )));
+        // #98: an IR name token with only color formats is NOT sufficient —
+        // IR-ness must be derived from queried evidence, never the name.
         assert_eq!(
             ir_source(&device_with("Integrated IR Camera", &["YUYV"])),
-            IrSource::Name
+            IrSource::None
         );
         assert_eq!(
             ir_source(&device_with("Infrared Camera", &["MJPG"])),
-            IrSource::Name
+            IrSource::None
         );
     }
 
@@ -441,35 +557,69 @@ mod tests {
     }
 
     #[test]
-    fn is_ir_camera_infrared_name() {
-        // Name token "infrared" is sufficient on its own.
+    fn is_ir_camera_name_token_alone_is_not_ir() {
+        // #98 fix: a bare name token ("Infrared Camera") with only a color
+        // format (MJPG) must NOT classify as IR — name alone is never
+        // sufficient.
         let device = device_with("Infrared Camera", &["MJPG"]);
-        assert!(is_ir_camera(&device));
-        assert_eq!(ir_source(&device), IrSource::Name);
+        assert!(!is_ir_camera(&device));
+        assert_eq!(ir_source(&device), IrSource::None);
     }
 
     #[test]
-    fn is_ir_camera_y16_name_token_corroborated_is_format() {
-        // Y16 native format corroborated by an IR name token → Format provenance.
+    fn is_ir_camera_y16_alone_is_format_regardless_of_name() {
+        // Y16 native mono format alone → Format provenance, independent of
+        // the device name (#98: evidence-derived, not name-derived).
         let device = device_with("Integrated IR Camera", &["Y16 "]);
         assert!(is_ir_camera(&device));
         assert_eq!(ir_source(&device), IrSource::Format);
     }
 
     #[test]
-    fn is_ir_camera_y16_without_name_is_not_ir() {
-        // Y16 alone (no IR name token, no quirk) is no longer proof of IR.
+    fn is_ir_camera_y16_alone_is_ir_even_with_unrelated_name() {
+        // #98 fix: mono format evidence alone is sufficient, even when the
+        // device's name gives no IR hint at all — proving classification
+        // does not depend on the name in either direction.
         let device = device_with("Depth Camera", &["Y16 "]);
-        assert!(!is_ir_camera(&device));
+        assert!(is_ir_camera(&device));
+        assert_eq!(ir_source(&device), IrSource::Format);
     }
 
     #[test]
-    fn quirk_force_ir_is_authoritative() {
+    fn quirk_force_ir_usb_id_match_is_authoritative() {
+        let mut db = crate::quirks::QuirksDb::default();
+        db.push_quirk_for_test(crate::quirks::Quirk {
+            vendor_id: Some("dead".into()),
+            product_id: Some("beef".into()),
+            name_pattern: None,
+            force_ir: Some(true),
+            emitter_xu_guid: None,
+            emitter_xu_selector: None,
+            warmup_frames: None,
+            format_preference: None,
+            rotation: None,
+            notes: Some("test force_ir via USB ID".into()),
+        });
+        // No IR name token, no IR format — a USB-ID quirk match alone makes
+        // it IR, no corroboration needed.
+        let device = device_with("Generic Camera", &["YUYV"]);
+        let ids = Some(("dead".into(), "beef".into()));
+        assert_eq!(
+            ir_source_with_quirks_and_ids(&device, Some(&db), ids.as_ref()),
+            IrSource::Quirk
+        );
+    }
+
+    #[test]
+    fn quirk_force_ir_name_only_requires_corroboration() {
+        // #98 Task 3: a name-only quirk match must not grant force_ir on its
+        // own — it needs corroboration from a real USB identity or the
+        // device's own format evidence.
         let mut db = crate::quirks::QuirksDb::default();
         db.push_quirk_for_test(crate::quirks::Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)generic".into()),
+            name_pattern: Some("(?i)generic.*".into()),
             force_ir: Some(true),
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -478,18 +628,42 @@ mod tests {
             rotation: None,
             notes: Some("test force_ir".into()),
         });
-        // No IR name token, no IR format — quirk alone makes it IR.
-        let device = device_with("Generic Camera", &["YUYV"]);
-        assert!(is_ir_camera_with_quirks(&device, Some(&db)));
-        assert_eq!(ir_source_with_quirks(&device, Some(&db)), IrSource::Quirk);
 
-        // A quirk with force_ir = false is authoritative "not IR" even if the
-        // name has an IR token.
+        // No usb_ids (as on a virtual v4l2loopback node) and no format
+        // evidence of its own — must NOT be trusted.
+        let uncorroborated = device_with("Generic Camera", &["YUYV"]);
+        assert_eq!(
+            ir_source_with_quirks_and_ids(&uncorroborated, Some(&db), None),
+            IrSource::None,
+            "uncorroborated name-only force_ir must not grant IR"
+        );
+
+        // Corroborated by a real (if DB-unlisted) USB identity.
+        let real_ids = Some(("1234".into(), "5678".into()));
+        assert_eq!(
+            ir_source_with_quirks_and_ids(&uncorroborated, Some(&db), real_ids.as_ref()),
+            IrSource::Quirk,
+            "a name-only match backed by a real USB identity is corroborated"
+        );
+
+        // Corroborated by the device's own mono-format evidence.
+        let mono_evidence = device_with("Generic Camera", &["GREY"]);
+        assert_eq!(
+            ir_source_with_quirks_and_ids(&mono_evidence, Some(&db), None),
+            IrSource::Quirk,
+            "a name-only match backed by the device's own mono format evidence is corroborated"
+        );
+    }
+
+    #[test]
+    fn quirk_force_ir_false_is_authoritative_regardless_of_corroboration() {
+        // A quirk with force_ir = false is authoritative "not IR" even if
+        // the name has an IR token and the format looks IR-typical.
         let mut db_off = crate::quirks::QuirksDb::default();
         db_off.push_quirk_for_test(crate::quirks::Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)ir".into()),
+            name_pattern: Some("(?i)ir camera".into()),
             force_ir: Some(false),
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -498,8 +672,11 @@ mod tests {
             rotation: None,
             notes: None,
         });
-        let ir_named = device_with("Integrated IR Camera", &["GREY"]);
-        assert!(!is_ir_camera_with_quirks(&ir_named, Some(&db_off)));
+        let ir_named = device_with("IR Camera", &["GREY"]);
+        assert_eq!(
+            ir_source_with_quirks_and_ids(&ir_named, Some(&db_off), None),
+            IrSource::None
+        );
     }
 
     fn device_at(path: &str, name: &str, fourccs: &[&str]) -> DeviceInfo {
@@ -616,9 +793,10 @@ mod tests {
     }
 
     #[test]
-    fn multi_node_demoted_sibling_keeps_name_heuristic() {
-        // A demoted sibling falls back to the (quirk-free) heuristic: an IR
-        // name token still classifies it, honestly, as Name.
+    fn multi_node_demoted_sibling_falls_back_to_no_evidence() {
+        // A demoted sibling falls back to the (quirk-free) heuristic, which
+        // is evidence-only (#98): an IR name token alone does NOT resurrect
+        // an IR classification for a node with no format evidence of its own.
         let mut db = crate::quirks::QuirksDb::default();
         db.push_quirk_for_test(brio_quirk(None));
 
@@ -629,7 +807,7 @@ mod tests {
         let ids = vec![brio_ids(), brio_ids()];
 
         let sources = classify_ir_sources_with_ids(&devices, Some(&db), &ids);
-        assert_eq!(sources[0], IrSource::Name);
+        assert_eq!(sources[0], IrSource::None);
         assert_eq!(sources[1], IrSource::Quirk);
         // Selection still prefers the format-corroborated quirk node.
         let picked = pick_auto_device(&devices, &sources).expect("a device is picked");
@@ -637,14 +815,19 @@ mod tests {
     }
 
     #[test]
-    fn classify_without_usb_ids_leaves_quirk_nodes_alone() {
-        // Nodes whose USB identity is unreadable cannot be grouped as siblings;
-        // a name-pattern quirk match stays authoritative (current behavior).
+    fn classify_without_usb_ids_uncorroborated_name_quirk_falls_back() {
+        // #98 Task 3: nodes whose USB identity is unreadable (as on a
+        // virtual v4l2loopback device) cannot corroborate a name-only quirk
+        // match. A node with no format evidence of its own is NOT granted
+        // force_ir just because its (attacker-controlled) name matches the
+        // pattern. A sibling node that DOES carry its own mono format
+        // evidence still classifies IR — via that evidence, not blind trust
+        // in the quirk.
         let mut db = crate::quirks::QuirksDb::default();
         db.push_quirk_for_test(crate::quirks::Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)generic".into()),
+            name_pattern: Some("(?i)generic.*".into()),
             force_ir: Some(true),
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -661,8 +844,16 @@ mod tests {
         let ids = vec![None, None];
 
         let sources = classify_ir_sources_with_ids(&devices, Some(&db), &ids);
-        assert_eq!(sources[0], IrSource::Quirk);
-        assert_eq!(sources[1], IrSource::Quirk);
+        assert_eq!(
+            sources[0],
+            IrSource::None,
+            "uncorroborated name-only force_ir must not grant IR"
+        );
+        assert_eq!(
+            sources[1],
+            IrSource::Quirk,
+            "corroborated by its own mono format evidence"
+        );
     }
 
     #[test]

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -46,6 +46,22 @@ struct QuirksFile {
     quirk: Vec<Quirk>,
 }
 
+/// Provenance of a [`QuirksDb`] match — how strongly the match is
+/// corroborated by evidence the device cannot forge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuirkMatchKind {
+    /// Matched by USB vendor:product ID, read from sysfs. Not spoofable by
+    /// a virtual device (e.g. v4l2loopback exposes no real USB node, so it
+    /// can never win a USB-ID match).
+    UsbId,
+    /// Matched by `name_pattern` against the free-text device/card name
+    /// only. The name is attacker-controlled on virtual devices — see
+    /// `facelock_camera::device::ir_source_with_quirks` for how a
+    /// `force_ir = true` name-only match is required to be corroborated
+    /// before it is trusted (#98 Task 3).
+    NameOnly,
+}
+
 /// Database of hardware quirks loaded from TOML files.
 #[derive(Debug, Default)]
 pub struct QuirksDb {
@@ -119,6 +135,21 @@ impl QuirksDb {
         device: &DeviceInfo,
         usb_ids: Option<&(String, String)>,
     ) -> Option<&Quirk> {
+        self.find_match_with_kind(device, usb_ids).map(|(q, _)| q)
+    }
+
+    /// Like [`find_match_with_ids`](Self::find_match_with_ids) but also
+    /// reports HOW the quirk matched. Callers that gate a security-relevant
+    /// decision (like `force_ir`, see `facelock_camera::device`) on the
+    /// result need this: a [`QuirkMatchKind::NameOnly`] match rests on the
+    /// free-text device name, which is attacker-controlled on virtual
+    /// devices such as v4l2loopback, and should not be trusted the same way
+    /// as a [`QuirkMatchKind::UsbId`] match.
+    pub fn find_match_with_kind(
+        &self,
+        device: &DeviceInfo,
+        usb_ids: Option<&(String, String)>,
+    ) -> Option<(&Quirk, QuirkMatchKind)> {
         // First pass: match by USB vendor:product ID (most specific)
         if let Some((vendor, product)) = usb_ids {
             for quirk in &self.quirks {
@@ -130,7 +161,7 @@ impl QuirksDb {
                             notes = quirk.notes.as_deref().unwrap_or(""),
                             "matched quirk by USB ID"
                         );
-                        return Some(quirk);
+                        return Some((quirk, QuirkMatchKind::UsbId));
                     }
                 }
             }
@@ -149,7 +180,7 @@ impl QuirksDb {
                         notes = quirk.notes.as_deref().unwrap_or(""),
                         "matched quirk by name pattern"
                     );
-                    return Some(quirk);
+                    return Some((quirk, QuirkMatchKind::NameOnly));
                 }
             }
         }
@@ -240,14 +271,21 @@ fn try_read_sysfs_attr(base: &str, attr: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Simple pattern matching: supports (?i) prefix for case-insensitive, .* for wildcards.
-/// This is a simplified matcher that handles the most common quirks patterns
-/// without pulling in the full regex crate.
+/// Simple pattern matching: supports (?i) prefix for case-insensitive, .* for
+/// wildcards. This is a simplified matcher that handles the most common
+/// quirks patterns without pulling in the full regex crate.
+///
+/// Matches against the WHOLE `name`, not a substring of it (#99): a part of
+/// the pattern that isn't adjacent to a leading/trailing `.*` must anchor to
+/// the corresponding end of `name`. Without this, `(?i)ir.*camera` matches
+/// "Sirius Camera" — the "ir" inside "Sirius" satisfies the first part, and
+/// "camera" appears later — silently granting `force_ir` to an unrelated RGB
+/// webcam. `.*` at either end still means "anything may precede/follow
+/// here", so `(?i).*ir camera.*` still matches "Integrated IR Camera 5MP".
 fn name_matches(pattern: &str, name: &str) -> bool {
-    let (case_insensitive, pattern) = if let Some(p) = pattern.strip_prefix("(?i)") {
-        (true, p)
-    } else {
-        (false, pattern)
+    let (case_insensitive, pattern) = match pattern.strip_prefix("(?i)") {
+        Some(p) => (true, p),
+        None => (false, pattern),
     };
 
     let name = if case_insensitive {
@@ -261,16 +299,46 @@ fn name_matches(pattern: &str, name: &str) -> bool {
         pattern.to_string()
     };
 
-    // Split pattern on .* and check that all parts appear in order
-    let parts: Vec<&str> = pattern.split(".*").collect();
-    let mut pos = 0;
-    for part in parts {
-        if part.is_empty() {
-            continue;
-        }
-        match name[pos..].find(part) {
-            Some(idx) => pos += idx + part.len(),
-            None => return false,
+    // Splitting on the literal ".*" tells us, from the emptiness of the
+    // first/last raw segment, whether the pattern opens/closes with a
+    // wildcard (an empty segment there means ".*" was right at that edge).
+    let raw_parts: Vec<&str> = pattern.split(".*").collect();
+    let starts_wild = raw_parts.len() > 1 && raw_parts.first().is_some_and(|p| p.is_empty());
+    let ends_wild = raw_parts.len() > 1 && raw_parts.last().is_some_and(|p| p.is_empty());
+    let parts: Vec<&str> = raw_parts.into_iter().filter(|p| !p.is_empty()).collect();
+
+    if parts.is_empty() {
+        // Pattern is empty, or entirely wildcard (".*", ".*.*", ...) — matches anything.
+        return true;
+    }
+
+    let mut pos = 0usize;
+    for (i, part) in parts.iter().enumerate() {
+        let is_first = i == 0;
+        let is_last = i == parts.len() - 1;
+        if is_first && !starts_wild {
+            // No leading wildcard: this part must anchor the very start of `name`.
+            if !name[pos..].starts_with(part) {
+                return false;
+            }
+            pos += part.len();
+            // A single unwildcarded part must also anchor the end.
+            if is_last && !ends_wild && pos != name.len() {
+                return false;
+            }
+        } else if is_last && !ends_wild {
+            // No trailing wildcard: this part must anchor the very end of
+            // `name`, without re-consuming bytes already matched by an
+            // earlier part.
+            if part.len() > name.len() || name.len() - part.len() < pos || !name.ends_with(part) {
+                return false;
+            }
+            pos = name.len();
+        } else {
+            match name[pos..].find(part) {
+                Some(idx) => pos += idx + part.len(),
+                None => return false,
+            }
         }
     }
     true
@@ -292,30 +360,60 @@ mod tests {
 
     #[test]
     fn name_matches_case_insensitive() {
-        assert!(name_matches("(?i)integrated.*ir", "Integrated IR Camera"));
-        // "infrared" doesn't contain substring "ir", so use a separate pattern
         assert!(name_matches(
-            "(?i)integrated.*infrared",
-            "Integrated Infrared Camera"
+            "(?i).*integrated.*ir camera.*",
+            "Integrated IR Camera"
         ));
-        // Both keywords covered by searching for just the common part
         assert!(name_matches(
-            "(?i)integrated.*in",
+            "(?i).*integrated.*infrared camera.*",
             "Integrated Infrared Camera"
         ));
     }
 
     #[test]
-    fn name_matches_simple_pattern() {
-        assert!(name_matches("(?i)hp.*ir", "HP IR Camera 5MP"));
-        assert!(name_matches("(?i)dell.*ir", "Dell IR Camera"));
-        assert!(!name_matches("(?i)dell.*ir", "Logitech Webcam"));
+    fn name_matches_anchors_start_and_end() {
+        // No wildcard at either end: the pattern must describe the WHOLE name.
+        assert!(name_matches("(?i)hp ir camera", "HP IR Camera"));
+        assert!(!name_matches("(?i)hp ir camera", "HP IR Camera 5MP"));
+        assert!(!name_matches("(?i)hp ir camera", "New HP IR Camera"));
+    }
+
+    #[test]
+    fn name_matches_trailing_wildcard_anchors_start_only() {
+        assert!(name_matches("(?i)hp.* ir.*", "HP IR Camera 5MP"));
+        // Vendor token must still be the literal start of the name.
+        assert!(!name_matches("(?i)hp.* ir.*", "New HP IR Camera"));
+        assert!(!name_matches("(?i)dell.* ir.*", "Logitech Webcam"));
     }
 
     #[test]
     fn name_matches_case_sensitive() {
-        assert!(name_matches("IR Camera", "My IR Camera"));
-        assert!(!name_matches("IR Camera", "My ir camera"));
+        assert!(name_matches("IR Camera", "IR Camera"));
+        assert!(!name_matches("IR Camera", "ir camera"));
+        assert!(!name_matches("IR Camera", "My IR Camera"));
+    }
+
+    #[test]
+    fn name_matches_anchoring_rejects_substring_false_positive() {
+        // #99 regression: the unmodified, unanchored pattern must no longer
+        // match an unrelated RGB webcam whose name merely contains the "ir"
+        // substring ("Sirius") or ("AIR-Cam") ahead of "camera" elsewhere.
+        assert!(!name_matches("(?i)ir.*camera", "Sirius Camera"));
+        assert!(!name_matches("(?i)ir.*camera", "AIR-Cam"));
+        // A real anchored pattern for the same intent still matches its
+        // actual device.
+        assert!(name_matches("(?i)ir camera.*", "IR Camera 720p"));
+        assert!(name_matches("(?i)ir camera.*", "IR Camera"));
+    }
+
+    #[test]
+    fn name_matches_word_boundary_within_wildcard_span() {
+        // A trailing wildcard after a vendor prefix must not let "ir" match
+        // via an unrelated word that merely contains the letters "ir"
+        // (e.g. "Air") — the pattern's " ir" requires a literal space
+        // immediately before "ir".
+        assert!(!name_matches("(?i)hp.* ir.*", "HP Air Camera"));
+        assert!(!name_matches("(?i)surface.* ir.*", "Surface Air Camera"));
     }
 
     #[test]
@@ -341,7 +439,7 @@ notes = "Test camera"
         db.quirks.push(Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)hp.*ir".into()),
+            name_pattern: Some("(?i)hp.* ir.*".into()),
             force_ir: Some(true),
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -383,7 +481,7 @@ notes = "Test camera"
         db.quirks.push(Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)realsense".into()),
+            name_pattern: Some("(?i).*realsense.*".into()),
             force_ir: Some(false), // Different value to test priority
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -443,7 +541,7 @@ notes = "Test camera"
         db.quirks.push(Quirk {
             vendor_id: None,
             product_id: None,
-            name_pattern: Some("(?i)second.*camera".into()),
+            name_pattern: Some("(?i)second.*camera.*".into()),
             force_ir: Some(false),
             emitter_xu_guid: None,
             emitter_xu_selector: None,
@@ -453,6 +551,8 @@ notes = "Test camera"
             notes: Some("second pattern".into()),
         });
 
+        // "first.*camera" (no trailing wildcard) anchors to the end too —
+        // still matches because the device name happens to end in "Camera".
         let dev1 = make_device("First IR Camera");
         let q1 = db.find_match(&dev1);
         assert!(q1.is_some());
@@ -468,9 +568,12 @@ notes = "Test camera"
     }
 
     #[test]
-    fn name_matches_multiple_wildcards() {
-        assert!(name_matches("(?i)a.*b.*c", "Alpha Beta Camera"));
+    fn name_matches_multiple_wildcards_anchored() {
+        // Anchored: the final part must now match at the very end of the name.
+        assert!(name_matches("(?i)a.*b.*c", "Alpha Beta Attic"));
         assert!(!name_matches("(?i)a.*b.*c", "Alpha Delta"));
+        assert!(!name_matches("(?i)a.*b.*c", "Alpha Beta Camera"));
+        assert!(name_matches("(?i)a.*b.*c.*", "Alpha Beta Camera"));
     }
 
     #[test]
@@ -543,5 +646,73 @@ notes = "Full test quirk"
             let quirks = QuirksDb::load_file(&path).unwrap();
             assert!(!quirks.is_empty(), "defaults file should have quirks");
         }
+    }
+
+    /// Table-driven regression for #99: every shipped `name_pattern` quirk
+    /// in `config/quirks.d/00-defaults.toml` must still match a plausible
+    /// real device name after anchoring, and none of them may match an
+    /// ordinary RGB webcam name — including the specific decoys ("Sirius
+    /// Camera", "AIR-Cam") that the pre-anchoring substring matcher was
+    /// fooled by. This mirrors `device::tests::ir_classification_corpus`'s
+    /// decoy corpus.
+    #[test]
+    fn shipped_quirk_name_patterns_match_intended_devices_and_reject_decoys() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("config/quirks.d/00-defaults.toml");
+        if !path.exists() {
+            return;
+        }
+        let quirks = QuirksDb::load_file(&path).expect("defaults file parses");
+
+        // (substring identifying which pattern this is, a representative
+        // real device name it must still match)
+        let cases: &[(&str, &str)] = &[
+            ("ir camera", "IR Camera"),
+            ("surface", "Surface Pro IR Camera"),
+            ("hp", "HP IR Camera 5MP"),
+            ("dell", "Dell IR Camera"),
+        ];
+
+        let decoys = [
+            "Integrated Webcam",
+            "USB2.0 HD UVC WebCam",
+            "AIR-Cam",
+            "Sirius Camera",
+            "Chicony USB2.0 Camera",
+        ];
+
+        let mut exercised = 0;
+        for quirk in &quirks {
+            let Some(pattern) = &quirk.name_pattern else {
+                continue;
+            };
+            let lower = pattern.to_lowercase();
+            let (_, expected_name) = cases
+                .iter()
+                .find(|(needle, _)| lower.contains(needle))
+                .unwrap_or_else(|| {
+                    panic!("no test case wired up for shipped pattern {pattern:?} — add one")
+                });
+            assert!(
+                name_matches(pattern, expected_name),
+                "pattern {pattern:?} should still match {expected_name:?} after anchoring"
+            );
+            for decoy in decoys {
+                assert!(
+                    !name_matches(pattern, decoy),
+                    "pattern {pattern:?} must NOT match decoy {decoy:?}"
+                );
+            }
+            exercised += 1;
+        }
+        assert_eq!(
+            exercised,
+            cases.len(),
+            "every expected shipped name_pattern quirk was exercised"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`security.require_ir` (default `true`) is one of three defenses bounding the hill-climbing attack in #103 (liveness + `require_ir` + rate limiting). #98 and #99 each let a crafted/misclassified camera defeat it. This PR fixes both, plus a residual interaction between them (Task 3 below).

- **#98** — IR classification trusted a bare `"ir"`/`"infrared"` name **token** by itself (`IrSource::Name`). A `v4l2loopback` device with a crafted `CARD_LABEL` ("Fake IR Camera") backed by nothing but ordinary color formats (YUYV/MJPG) classified as IR with **zero** format evidence.
- **#99** — `quirks` `name_pattern` matched as an **unanchored substring**, so the shipped pattern `(?i)ir.*camera` matched **"Sirius Camera"** (the "ir" inside "Sirius") and would have granted `force_ir` to an unrelated RGB webcam.

## Threat model — how each bug defeats `require_ir`

Both bugs let an attacker who can create/configure a virtual capture device (the well-known `v4l2loopback` technique) make `require_ir` believe it is looking at an IR sensor when it is not, bypassing the anti-photo-replay defense entirely:

1. **#98**: no quirk needed at all — just set `CARD_LABEL` to contain the word "ir" or "infrared" as a whole token. The old code's `heuristic_ir_source` returned `IrSource::Name` (non-`None`) purely from the name.
2. **#99**: a shipped quirk (`(?i)ir.*camera`, `(?i)hp.*ir`, `(?i)dell.*ir`, `(?i)surface.*ir`) could be triggered by a name that merely *contains* the right substrings in order, anywhere — e.g. "Sirius Camera" (`ir` inside `Sirius`) — silently granting `force_ir = true`, the *most* authoritative classification tier.
3. **Task 3 interaction**: even after anchoring #99's matcher, a device that names itself **exactly** "IR Camera" (matching the corrected, anchored ThinkPad pattern) would still win `force_ir` through the quirks path via name alone — no format evidence, no real USB identity. This is now also closed (see below).

## What "derived, not self-asserted" means here (D8 adoption shape)

`crates/facelock-camera/src/device.rs` now has:

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
pub struct IrEvidence {
    /// The device enumerates ONLY IR-typical mono capture formats.
    pub mono_only_formats: bool,
}

pub fn derive_ir_from_evidence(evidence: &IrEvidence) -> bool {
    evidence.mono_only_formats
}
```

`IrEvidence` is populated strictly from **queried V4L2 data** (`has_mono_only_formats`: the device enumerates *only* IR-typical mono formats — `GREY`/`Y8`/`Y10`/`Y12`/`Y16` — widened from the old GREY/Y16-only set), never from `device.name`. A node that ALSO offers a color format (YUYV/MJPG) alongside a mono one is treated as an ordinary color sensor with a mono side-mode, not IR evidence (this preserves the original "H1" concern: many ordinary RGB UVC webcams enumerate GREY *alongside* YUYV/MJPG).

`IrSource::Name` is **removed** — it can no longer be produced. `IrSource` is now just `Quirk | Format | None`. The device name is still consulted, but only:
- as a **tiebreak hint** in `pick_auto_device`'s auto-detection ordering (among nodes that *already* qualify via evidence, prefer the one whose name also carries an IR token — never promotes a node with no evidence), and
- as part of quirk-match **corroboration** (see Task 3).

When gap D8 lands `CameraCaps.is_ir`, it can call `derive_ir_from_evidence` directly over its own queried `IrEvidence` — this PR is shaped so that seam is a drop-in.

## Task 3 fix: name-only quirk matches now require corroboration

`QuirksDb::find_match_with_kind` (new, additive — `find_match`/`find_match_with_ids` keep their existing signatures and callers) reports **how** a quirk matched:

```rust
pub enum QuirkMatchKind { UsbId, NameOnly }
```

In `ir_source_with_quirks_and_ids`:
- `force_ir = false` — authoritative unconditionally, any match kind (no bypass risk in the conservative direction).
- `force_ir = true` matched by **USB vendor:product ID** — authoritative unconditionally (a virtual device like v4l2loopback has no real USB node, so it can never win this path).
- `force_ir = true` matched by **name only** — now requires corroboration: either the device has a real (even if DB-unlisted) USB identity, or its own queried formats independently support IR (`derive_ir_from_evidence`). Without either, it falls through to the evidence-only heuristic instead of being trusted. **This closes the Task 3 residual cleanly inside the owned files** — no residual is left open.

## #99 anchoring

`name_matches` in `quirks.rs` now requires the pattern to describe the **whole** name: a part not adjacent to a leading/trailing `.*` must anchor to the corresponding end of the string. `.*` at either end still means "anything may precede/follow here" (e.g. `(?i).*ir camera.*` still matches "Integrated IR Camera 5MP"). Verified against 17 hand-checked edge cases (script run, all passing) before implementing, including the exact Sirius/AIR-Cam/Air-word-boundary failure modes.

### Quirk patterns adjusted (`config/quirks.d/00-defaults.toml`)

All four `name_pattern` entries needed adjustment — none of them full-match under the new semantics unmodified:

| Quirk | Old pattern | New pattern | Rationale |
|---|---|---|---|
| ThinkPad IR | `(?i)ir.*camera` | `(?i)ir camera.*` | Anchored start ("IR Camera" as the literal name prefix), open suffix for model variation. |
| Surface IR | `(?i)surface.*ir` | `(?i)surface.* ir.*` | Anchored start on vendor token; ` ir` keeps a literal leading space so an unrelated word ending in "...ir" (e.g. "Air") can't match — this is what stops the Sirius-class bug from reopening inside the wildcard span. |
| HP IR | `(?i)hp.*ir` | `(?i)hp.* ir.*` | Same technique. |
| Dell IR | `(?i)dell.*ir` | `(?i)dell.* ir.*` | Same technique. |

**Residual, documented in the TOML comments**: these are now anchored-start, so a name where the vendor token isn't literally the first word (e.g. real hardware reporting `"Microsoft Surface Pro IR Camera"` instead of `"Surface Pro IR Camera"`) will **not** match and needs its own corrected, still-anchored pattern added — verify via `facelock list-devices` and extend `quirks.d` rather than reintroducing a bare leading wildcard. I chose the conservative (narrower-matching, no-false-positive) direction deliberately: for a security-relevant `force_ir` field, a false negative just means a manual quirk update; a false positive defeats `require_ir`.

## Test evidence

**`facelock-camera` (owned crate):** `cargo test -p facelock-camera` → **63 passed, 0 failed, 4 ignored** (ignored = hardware-only tests, pre-existing). Includes:
- `crafted_card_label_with_color_formats_only_is_not_ir` — "Fake IR Camera" + YUYV/MJPG → not IR (pins #98's literal example).
- `is_ir_camera_mono_format_alone_is_ir_by_evidence`, `is_ir_camera_y16_alone_is_ir_even_with_unrelated_name` — mono-only format enumeration alone → IR, even with a name giving no hint (pins "derived, not self-asserted", both directions).
- `ir_classification_corpus` — Sirius/AIR-Cam/etc. still not-IR; a bare name token with only color formats is now `IrSource::None` (previously `Name`); GREY-and-color mix (H1 case) stays not-IR.
- `quirk_force_ir_name_only_requires_corroboration`, `classify_without_usb_ids_uncorroborated_name_quirk_falls_back` — pin Task 3 directly.
- `quirks::name_matches_anchoring_rejects_substring_false_positive` — the exact required case: `(?i)ir.*camera` rejects "Sirius Camera"/"AIR-Cam"; `(?i)ir camera.*` still matches "IR Camera 720p".
- `quirks::name_matches_word_boundary_within_wildcard_span` — "HP Air Camera" / "Surface Air Camera" correctly rejected by the shipped patterns (the residual word-boundary case within a wildcard span).
- `quirks::shipped_quirk_name_patterns_match_intended_devices_and_reject_decoys` — table-driven over `config/quirks.d/00-defaults.toml`: every shipped `name_pattern` quirk matches a representative real device name AND rejects the full RGB decoy corpus (Sirius Camera, AIR-Cam, Integrated Webcam, USB2.0 HD UVC WebCam, Chicony USB2.0 Camera).

**Full workspace gate** (`just check` = test + lint + fmt-check + audit):
- `cargo clippy --workspace -- -D warnings` → clean.
- `cargo fmt --check` → clean (after `cargo fmt`).
- `cargo audit` → clean (2 pre-existing yanked-crate warnings, unrelated: `core2`, `uds_windows`).
- `cargo test --workspace --no-fail-fast` → **every crate passes except one test outside this PR's ownership** — see Cross-PR notes.

Did **not** run `just test-arch-pam` per instructions (shared podman image tag; orchestrator runs it centrally).

## Cross-PR notes

- **`crates/facelock-cli/src/direct.rs:390-414`, test `auto_detected_device_inherits_quirk_state`** (NOT edited — outside this PR's ownership contract): this test constructs a device named `"Logitech BRIO IR"` with format `MJPG` only, matched by a **name-only** quirk (`(?i)brio.*ir`, no `vendor_id`/`product_id`), and asserts `resolved.device_is_ir == true`. This is *exactly* the vulnerable pattern this PR closes (name-only match, no real USB ids in test context, no mono-format evidence) — it was inadvertently testing the old insecure behavior. It now fails because the fix correctly refuses to trust it. **Fix needed (two parts, both fixture values)**: change the device name `"Logitech BRIO IR"` → `"BRIO IR"` (the inline pattern `(?i)brio.*ir` has no leading wildcard under this PR's anchored `name_matches`, so "brio" must anchor to the start of the name — "Logitech BRIO IR" no longer matches it at all, which drops `device_quirk` to `None` and fails the separate `warmup_frames` assertion) **and** the fourcc `"MJPG"` → `"GREY"` (so the device carries genuine corroborating format evidence for the name-only quirk match, satisfying this PR's Task 3 corroboration requirement). This two-part fix has been verified passing on this branch and is landing via PR E (#109), which owns `direct.rs`.
- Full workspace `cargo test --workspace --no-fail-fast` confirms this is the **only** failure anywhere in the tree from this change — every other crate (core, daemon, store, face, tpm, pam-facelock, polkit, bench, plus all integration test binaries) passes unmodified.
- Companion to `fix/similarity-oracle` (PR C) — treat as a set (#103): PR C makes tuning the similarity threshold cheap; this PR ensures `require_ir` (one of the two other defenses PR C's oracle doesn't touch) can't be trivially defeated by a crafted virtual camera.

## Docs to reconcile (owned by PR B — proposed wording below, not applied)

Both `docs/security.md` and `docs/contracts.md` describe the *old* (now-incorrect) classification model and will mislead readers/operators until updated:

- **`docs/security.md:46-52`** (code comment block inside the security doc) and **`docs/security.md:80`** (the "H1" rationale paragraph): currently says *"a native GREY/Y16 format counts ONLY when corroborated by a name token; ... a name token alone is sufficient"* — this is now backwards. Proposed replacement text: *"IR classification is derived solely from queried device evidence (`has_mono_only_formats`: the device enumerates ONLY IR-typical mono formats — GREY/Y8/Y10/Y12/Y16 — not mixed with color formats). The device's free-text name is never, by itself, sufficient (#98) — a crafted `CARD_LABEL` on a v4l2loopback device with only YUYV/MJPG formats does not classify as IR no matter what it is called. The name is used only as a tiebreak hint during auto-detection and as part of quirk-match corroboration."*
- **`docs/security.md`**: add a paragraph on the #99 anchoring fix and the Task 3 corroboration requirement (a name-only `force_ir = true` quirk match now needs a real USB identity or the device's own format evidence).
- **`docs/contracts.md:143-151`** (auto-detect algorithm description, step 4: *"then a name-token IR node"*) and **`docs/contracts.md:350-351`** (*"IR classification requires a whole `ir`/`infrared` name token or a quirks `force_ir` entry; a GREY/Y16 format alone is not treated as IR"*): both need rewriting to match the new model (opposite of what's currently documented — format evidence is now what's required/sufficient; name token alone is not).
- `book/src/security.md` and `book/src/contracts.md` likely mirror the same stale text (mdbook copies) — sweep both alongside `docs/`.

## Anything in the original spec that turned out wrong / needed judgment calls

- The spec's phrase "a name/label may act as a negative signal or a tiebreak hint" was somewhat open-ended; I resolved it as: (a) tiebreak in `pick_auto_device` auto-detection ordering only, never promoting evidence-lacking nodes, and (b) as one of two acceptable corroboration paths for a name-only `force_ir` quirk match (the other being a real, DB-unlisted USB identity) — never as a standalone classification signal. I did not find a concrete need for a "negative signal" use beyond what quirk `force_ir = false` already provides.
- The existing (pre-PR) design had a documented "H1" concern that format evidence *alone* (GREY/Y16 present) was insufficient and needed name corroboration. This PR's required test ("a genuine IR-evidence device — mono-format enumeration — still classifies as IR") directly supersedes that: mono-only format enumeration is now sufficient **on its own**, regardless of name. I preserved the *substance* of the H1 concern differently — by requiring the mono format(s) to be the device's **entire** format set (not mixed with color formats), rather than requiring name corroboration — since a plain RGB webcam that also happens to offer a GREY side-mode still won't qualify, but a genuinely dedicated mono/IR sensor node (which, in every real example I could find — including the Logitech BRIO's IR node — exposes only mono formats) does.

Closes #98
Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

