### PR TITLE
feat(cli): root-by-default privilege map; root-only test with safe semantics (DEC-6, N11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,67 +192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,24 +200,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4668,12 +4589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
  "blocking",
  "enumflags2",

--- a/crates/facelock-cli/src/commands/audit.rs
+++ b/crates/facelock-cli/src/commands/audit.rs
@@ -5,6 +5,10 @@ use anyhow::{Context, Result};
 use facelock_core::config::Config;
 
 pub fn run(tail: bool, lines: usize) -> Result<()> {
+    // DEC-6: `audit` is typically invoked scripted/non-interactively, so it
+    // hard-errors rather than offering the usual sudo re-exec prompt.
+    crate::ipc_client::require_root_scripted("sudo facelock audit")?;
+
     let config = Config::load()?;
 
     if !config.audit.enabled {

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -47,21 +47,10 @@ pub enum BenchCommand {
 }
 
 pub fn run(command: BenchCommand) -> Result<()> {
-    // Auth benchmarks need to decrypt embeddings, which may require root for TPM access
-    let needs_embeddings = matches!(
-        command,
-        BenchCommand::ColdAuth
-            | BenchCommand::WarmAuth
-            | BenchCommand::Calibrate
-            | BenchCommand::Report
-    );
-    if needs_embeddings {
-        if let Ok(config) = Config::load() {
-            if config.encryption.method == facelock_core::config::EncryptionMethod::Tpm {
-                crate::ipc_client::require_root("sudo facelock bench <subcommand>")?;
-            }
-        }
-    }
+    // DEC-6: `bench` is root by default (direct-mode access needs the 0600
+    // root:root database regardless of subcommand, and auth benchmarks may
+    // need TPM access besides). Supersedes the old TPM-only conditional check.
+    crate::ipc_client::require_root("sudo facelock bench <subcommand>")?;
 
     match command {
         BenchCommand::ColdAuth => cmd_cold_auth(),

--- a/crates/facelock-cli/src/commands/config.rs
+++ b/crates/facelock-cli/src/commands/config.rs
@@ -6,6 +6,9 @@ pub fn run(edit: bool) -> anyhow::Result<()> {
     let config_path = facelock_core::paths::config_path();
 
     if edit {
+        // DEC-6: display stays unprivileged (it reads a 0644 file), but
+        // editing is root — must run before the editor ever opens (C6).
+        crate::ipc_client::require_root("sudo facelock config --edit")?;
         open_in_editor(&config_path)?;
     } else {
         show_config(&config_path)?;

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -704,8 +704,12 @@ impl FacelockService {
         let signal_user = user.clone();
         let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
-            let request = DaemonRequest::Authenticate { user: user.clone() };
-            let response = handler.handle(request);
+            // N11: a root caller (e.g. root-only `facelock test`) is exempt
+            // from rate-limit consumption on a failed attempt — root already
+            // has unrestricted access to the rate-limit table directly, and
+            // without this a few `facelock test` runs would lock the user
+            // out of real authentication. See `Handler::handle_authenticate`.
+            let response = handler.handle_authenticate(user.clone(), !caller_is_root);
             drop(handler);
             // Capture finished — free the slot before slower follow-up work
             // (notifications) so the next auth isn't rejected needlessly.

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -5,6 +5,9 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use crate::ipc_client;
 
 pub fn run() -> anyhow::Result<()> {
+    // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
+    ipc_client::require_root("sudo facelock devices")?;
+
     let config = Config::load().context("failed to load config")?;
 
     if ipc_client::should_use_direct(&config) {

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -8,6 +8,13 @@ use facelock_core::types::FaceModelInfo;
 use crate::ipc_client;
 
 pub fn run(user: Option<String>, json: bool) -> anyhow::Result<()> {
+    // DEC-6/N4: `ListModels` is root-only now (was facelock-group). The
+    // direct-mode fallback in `fetch_models` already required root when the
+    // 0600 root:root database wasn't readable; checking up front here gives
+    // the same interactive escalation prompt on the D-Bus path too, instead
+    // of a bare AccessDenied.
+    ipc_client::require_root("sudo facelock list")?;
+
     let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
@@ -23,7 +30,7 @@ pub fn run(user: Option<String>, json: bool) -> anyhow::Result<()> {
 }
 
 fn fetch_models(config: &Config, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
-    // Try D-Bus first (works without root)
+    // Try D-Bus first — `run` already required root above.
     if !ipc_client::should_use_direct(config) {
         let request = DaemonRequest::ListModels {
             user: user.to_string(),
@@ -35,16 +42,9 @@ fn fetch_models(config: &Config, user: &str) -> anyhow::Result<Vec<FaceModelInfo
         };
     }
 
-    // Direct mode: needs read access to DB (typically root or facelock group)
-    match crate::direct::open_store(config) {
-        Ok(store) => store.list_models(user).map_err(|e| anyhow::anyhow!("{e}")),
-        Err(_) => {
-            // DB not accessible — prompt for root
-            ipc_client::require_root("sudo facelock list")?;
-            let store = crate::direct::open_store(config)?;
-            store.list_models(user).map_err(|e| anyhow::anyhow!("{e}"))
-        }
-    }
+    // Direct mode: needs read access to the 0600 root:root database.
+    let store = crate::direct::open_store(config)?;
+    store.list_models(user).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 fn print_table(user: &str, models: &[FaceModelInfo]) {

--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -25,6 +25,11 @@ fn resolve_user(user: Option<String>) -> anyhow::Result<String> {
 }
 
 pub fn run(text_only: bool, user: Option<String>) -> anyhow::Result<()> {
+    // DEC-6/N13: `PreviewDetectFrame` is root-only now — it was the last
+    // unprivileged consumer of a per-frame similarity score (the
+    // hill-climbing oracle N12/N13 close by construction).
+    ipc_client::require_root("sudo facelock preview")?;
+
     let config = Config::load().context("failed to load config")?;
     let user = resolve_user(user)?;
 

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -6,6 +6,12 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use crate::ipc_client;
 
 pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()> {
+    // C6: root check must run before the confirmation prompt below — a group
+    // member confirming a destructive action only to then hit AccessDenied
+    // is exactly the bug this ordering fixes. RemoveModel is root-only on the
+    // daemon side too, so this applies regardless of transport.
+    ipc_client::require_root(&format!("sudo facelock remove {model_id}"))?;
+
     let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
@@ -19,7 +25,6 @@ pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()>
     }
 
     if ipc_client::should_use_direct(&config) {
-        ipc_client::require_root(&format!("sudo facelock remove {model_id}"))?;
         let store = crate::direct::open_store(&config)?;
         let removed = store
             .remove_model(&user, model_id)

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -7,6 +7,12 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use crate::ipc_client;
 
 pub fn run() -> anyhow::Result<()> {
+    // DEC-6/N4: every D-Bus method `status` calls (`Ping`, and `ListModels`
+    // via `check_enrolled`) is root-only now, and its direct-mode reads hit
+    // the same 0600 root:root database. Check before the first line of
+    // output (C6).
+    ipc_client::require_root("sudo facelock status")?;
+
     println!("facelock system status\n");
 
     // 1. Config

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -9,6 +9,13 @@ use crate::ipc_client;
 use crate::notifications::{NotifyEvent, notify_if_enabled};
 
 pub fn run(user: Option<String>) -> anyhow::Result<()> {
+    // N11 (issue #96): `facelock test` is root-only regardless of transport
+    // (direct or daemon-mediated) — keeps similarity scores and full detail,
+    // and lets both the daemon and direct paths safely exempt failed test
+    // runs from rate-limit consumption (root already has unrestricted access
+    // to the rate-limit table). Must run before any prompt or output (C6).
+    ipc_client::require_root("sudo facelock test")?;
+
     let config = Config::load().context("failed to load config")?;
 
     // Check models exist — offer to run setup if missing
@@ -16,7 +23,6 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     let detector = model_dir.join(&config.recognition.detector_model);
     let embedder = model_dir.join(&config.recognition.embedder_model);
     if !detector.exists() || !embedder.exists() {
-        crate::ipc_client::require_root("sudo facelock setup")?;
         println!("Face recognition models not found.");
         if crate::ipc_client::confirm("Download models now?")? {
             crate::commands::setup::run(false)?;
@@ -84,7 +90,6 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     notify_if_enabled(notif_config, &NotifyEvent::Scanning);
 
     if ipc_client::should_use_direct(&config) {
-        ipc_client::require_root("sudo facelock test")?;
         let start = Instant::now();
         match crate::direct::authenticate(&config, &user) {
             Ok(result) if result.matched => {

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -16,6 +16,8 @@ use facelock_core::ipc::DaemonResponse;
 use facelock_core::traits::{CameraSource, FaceProcessor};
 use facelock_core::types::{MatchResult, zeroize_stored_embeddings};
 use facelock_daemon::audit::AuditSource;
+use facelock_daemon::auth::{PreCheckContext, pre_check_audited_with_context};
+use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 use tracing::debug;
@@ -123,21 +125,51 @@ pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
 /// Direct authentication — returns the full match result (including an
 /// internal failure reason when frames matched but a liveness gate blocked).
 ///
-/// This backs `facelock test` only, and it deliberately skips `pre_check`
-/// (rate limiting, `require_ir`, SSH/lid abort), so its audit entries are
-/// stamped `AuditSource::Test`: a success here is a recognition result, not a
-/// policy-approved authentication.
+/// This backs `facelock test` only (root-only, N11/issue #96). It runs the
+/// same pre-flight gates real authentication does — disabled check,
+/// enrollment/`suppress_unknown`, rate-limit *check*, `require_ir` — via
+/// `pre_check_audited_with_context`, except SSH/lid abort, which exist to
+/// stop an *attacker*'s physical-access shortcuts and are explicitly skipped
+/// for `test` via [`PreCheckContext::test`]. A failed attempt here never
+/// consumes the shared rate-limit budget: unlike the daemon and oneshot
+/// paths, this function simply never calls `RateLimiter::record_failure`.
+/// Audit entries are stamped `AuditSource::Test`.
 pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> {
     let store = open_store(config)?;
 
-    if !store.has_models(user).context("storage error")? {
-        return Ok(MatchResult {
-            matched: false,
-            model_id: None,
-            label: None,
-            similarity: 0.0,
-            failure_reason: None,
-        });
+    // Cheap device classification only (no camera I/O), so a pre-check
+    // rejection never touches the camera. `open_camera_context` below
+    // re-resolves the same device once opening actually proceeds.
+    let device_is_ir = resolve_camera_device(config)
+        .context("failed to resolve camera device")?
+        .device_is_ir;
+
+    let rl = &config.security.rate_limit;
+    let rate_limiter = RateLimiter::new(rl.max_attempts, rl.window_secs);
+
+    if let Some(resp) = pre_check_audited_with_context(
+        config,
+        &store,
+        user,
+        &rate_limiter,
+        device_is_ir,
+        AuditSource::Test,
+        PreCheckContext::test(),
+    ) {
+        return match resp {
+            DaemonResponse::AuthResult(mr) => Ok(mr),
+            // `suppress_unknown` short-circuit: no result to report, same as
+            // the plain not-enrolled case below from `test`'s point of view.
+            DaemonResponse::Suppressed => Ok(MatchResult {
+                matched: false,
+                model_id: None,
+                label: None,
+                similarity: 0.0,
+                failure_reason: None,
+            }),
+            DaemonResponse::Error { message } => bail!("{message}"),
+            _ => bail!("unexpected pre-check response"),
+        };
     }
 
     let OpenedCamera {

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -45,6 +45,20 @@ pub fn require_root(hint: &str) -> anyhow::Result<()> {
     std::process::exit(status.code().unwrap_or(1));
 }
 
+/// Like [`require_root`], but never offers an interactive re-exec prompt.
+///
+/// For commands that are typically invoked non-interactively or scripted
+/// (`facelock audit`; `facelock daemon` has its own equivalent check) — a
+/// "Re-run with sudo? [Y/n]" prompt would just hang a script instead of
+/// failing loudly.
+pub fn require_root_scripted(hint: &str) -> anyhow::Result<()> {
+    if Uid::current().is_root() {
+        return Ok(());
+    }
+
+    bail!("Root required.\n  Run: {hint}");
+}
+
 /// Check whether we should use direct (daemonless) mode.
 /// Returns true if config says "oneshot" OR if the D-Bus service isn't available.
 /// When falling back from daemon mode, logs a warning.
@@ -173,32 +187,48 @@ pub fn is_access_denied(err: &anyhow::Error) -> bool {
     })
 }
 
+/// True if the D-Bus error chain carries the daemon's own "requires root"
+/// denial (`require_root` in `commands/daemon.rs`'s `authorize_method`), as
+/// opposed to a bus-policy rejection for a caller outside the `facelock`
+/// group. Matched on the rendered message rather than the `zbus::Error`
+/// shape, since the daemon's denial text is the only thing the wire
+/// preserves distinctly from a bus-policy AccessDenied.
+fn is_root_required_denial(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.to_string().contains("requires root"))
+}
+
 /// Append an actionable hint to AccessDenied errors.
 ///
-/// The system bus policy (dbus/org.facelock.Daemon.conf) denies callers that
-/// are neither root nor in the `facelock` group *before* the request reaches
-/// the daemon, so without this a normal user's first `facelock preview` after
-/// setup fails with a bare AccessDenied and no explanation (issue #89). The
-/// daemon itself also returns AccessDenied for root-only methods and
-/// cross-user requests, so the hint stays neutral and leaves the specific
-/// reason to the wrapped error.
-fn add_group_hint(err: anyhow::Error) -> anyhow::Error {
-    if is_access_denied(&err) {
+/// Under DEC-6 (root-by-default CLI), most D-Bus methods are root-only, so
+/// most AccessDenied errors are the daemon's own `require_root` rejection —
+/// those get a root-specific hint (Wave-1 cross-PR note, issue #108: telling
+/// a root-only rejection to "join the facelock group" is actively wrong).
+/// The remaining case is the system bus policy (dbus/org.facelock.Daemon.conf)
+/// denying a caller that is neither root nor in the `facelock` group *before*
+/// the request reaches the daemon — without a hint there, a first `facelock
+/// preview`-style call after setup fails with a bare AccessDenied and no
+/// explanation (issue #89).
+fn add_access_denied_hint(err: anyhow::Error) -> anyhow::Error {
+    if !is_access_denied(&err) {
+        return err;
+    }
+    if is_root_required_denial(&err) {
+        err.context("Access denied: this operation requires root.\n  Re-run with sudo, or as root.")
+    } else {
         err.context(
             "Access denied. If you are not in the 'facelock' group, add yourself:\n  \
              sudo usermod -aG facelock $USER\nthen log out and back in (or re-run: \
              sudo facelock setup). Note: some operations require root regardless of \
              group membership.",
         )
-    } else {
-        err
     }
 }
 
 /// Send a request to the daemon via D-Bus, translating to/from the old
 /// DaemonRequest/DaemonResponse types used by the command layer.
 pub fn send_request(request: &DaemonRequest) -> anyhow::Result<DaemonResponse> {
-    send_request_inner(request).map_err(add_group_hint)
+    send_request_inner(request).map_err(add_access_denied_hint)
 }
 
 fn send_request_inner(request: &DaemonRequest) -> anyhow::Result<DaemonResponse> {
@@ -390,16 +420,38 @@ mod tests {
     // Covers the locally constructed FDO variant, not the wire path: a denial
     // from the bus or the daemon arrives as `zbus::Error::MethodError`, whose
     // name is checked by `is_access_denied_name` above.
+    //
+    // "rejected by policy" deliberately does not contain "requires root", so
+    // this pins the bus-policy (non-root-specific) denial case.
     #[test]
     fn access_denied_fdo_error_gets_group_hint() {
         let err = anyhow::Error::new(zbus::Error::FDO(Box::new(zbus::fdo::Error::AccessDenied(
             "rejected by policy".into(),
         ))))
         .context("D-Bus PreviewFrame call failed");
-        let hinted = add_group_hint(err);
+        let hinted = add_access_denied_hint(err);
         let msg = format!("{hinted:#}");
         assert!(msg.contains("usermod -aG facelock"), "got: {msg}");
         assert!(msg.contains("log out"), "got: {msg}");
+    }
+
+    // The daemon's `authorize_method` -> `require_root` denial (issue #108,
+    // Wave-1 cross-PR note): under DEC-6 this is now the common case, and it
+    // must say root is required rather than suggesting group membership,
+    // which would not fix anything.
+    #[test]
+    fn access_denied_root_required_gets_root_hint() {
+        let err = anyhow::Error::new(zbus::Error::FDO(Box::new(zbus::fdo::Error::AccessDenied(
+            "ListModels requires root (caller: 'alice', UID 1000)".into(),
+        ))))
+        .context("D-Bus ListModels call failed");
+        let hinted = add_access_denied_hint(err);
+        let msg = format!("{hinted:#}");
+        assert!(msg.contains("requires root"), "got: {msg}");
+        assert!(
+            !msg.contains("usermod -aG facelock"),
+            "a root-only denial must not suggest joining the group, got: {msg}"
+        );
     }
 
     #[test]
@@ -407,8 +459,26 @@ mod tests {
         let err = anyhow::Error::new(zbus::Error::Failure("connection refused".into()))
             .context("D-Bus Ping call failed");
         let msg_before = format!("{err:#}");
-        let hinted = add_group_hint(err);
+        let hinted = add_access_denied_hint(err);
         assert_eq!(format!("{hinted:#}"), msg_before);
+    }
+
+    #[test]
+    fn require_root_scripted_passes_when_root() {
+        if Uid::current().is_root() {
+            assert!(require_root_scripted("sudo facelock audit").is_ok());
+        }
+    }
+
+    #[test]
+    fn require_root_scripted_never_prompts_non_root() {
+        // Can't simulate an attached TTY here, but the important property is
+        // structural: unlike `require_root`, this function has no branch that
+        // reads stdin or writes a prompt — it only checks the UID and bails.
+        if !Uid::current().is_root() {
+            let err = require_root_scripted("sudo facelock audit").unwrap_err();
+            assert!(format!("{err:#}").contains("Root required"));
+        }
     }
 
     #[test]

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -1,9 +1,124 @@
 //! Smoke tests for the facelock CLI binary.
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn facelock_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_facelock"))
+}
+
+/// DEC-6/C6 contract: every root-required command must refuse *before*
+/// emitting any prompt text or touching state, when invoked non-root with no
+/// TTY attached. Closing stdin (rather than leaving it inherited) forces
+/// `require_root`'s non-interactive branch: `isatty(0)` is false on a closed
+/// pipe, so it hard-errors instead of offering to re-exec with sudo — which
+/// would otherwise hang waiting for input that never arrives.
+///
+/// Skips (rather than failing) under an actual root test runner: these
+/// commands legitimately succeed as root, and this contract has nothing to
+/// assert in that case. Every dev/CI invocation of `cargo test` observed for
+/// this crate runs non-root, so the skip is the exceptional path, not the
+/// common one.
+fn assert_refuses_before_output(args: &[&str], forbidden_substrings: &[&str]) {
+    let output = facelock_bin()
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute facelock {args:?}: {e}"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.success() {
+        // Only a root test runner reaches here (see doc comment).
+        eprintln!("skipping {args:?}: process is root, command is expected to succeed");
+        return;
+    }
+
+    assert!(
+        stderr.contains("Root required"),
+        "facelock {args:?} should refuse with 'Root required', got:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    for forbidden in forbidden_substrings {
+        assert!(
+            !stdout.contains(forbidden) && !stderr.contains(forbidden),
+            "facelock {args:?} must refuse BEFORE emitting {forbidden:?} (C6 ordering), \
+             got:\nstdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn status_refuses_before_root_non_root() {
+    assert_refuses_before_output(&["status"], &["facelock system status"]);
+}
+
+#[test]
+fn devices_refuses_before_root_non_root() {
+    assert_refuses_before_output(
+        &["devices"],
+        &["Available video devices", "No video devices found"],
+    );
+}
+
+#[test]
+fn preview_refuses_before_root_non_root() {
+    assert_refuses_before_output(
+        &["preview", "--text-only"],
+        &["Graphical preview", "text-only mode"],
+    );
+}
+
+#[test]
+fn test_cmd_refuses_before_root_non_root() {
+    assert_refuses_before_output(
+        &["test", "--user", "nonexistent-test-user"],
+        &["Testing face recognition", "No face models enrolled"],
+    );
+}
+
+#[test]
+fn audit_refuses_before_root_non_root() {
+    // audit is scripted/hard-error only (never an interactive prompt), but
+    // the non-interactive refusal path is identical either way.
+    assert_refuses_before_output(&["audit"], &["Audit logging"]);
+}
+
+#[test]
+fn bench_refuses_before_root_non_root() {
+    assert_refuses_before_output(&["bench", "cold-auth"], &["cold auth", "Cold Auth"]);
+}
+
+#[test]
+fn config_edit_refuses_before_root_non_root() {
+    assert_refuses_before_output(&["config", "--edit"], &["Config file:", "Config saved"]);
+}
+
+#[test]
+fn list_refuses_before_root_non_root() {
+    assert_refuses_before_output(
+        &["list", "--user", "nonexistent-test-user"],
+        &["Face models for user", "No face models enrolled"],
+    );
+}
+
+#[test]
+fn remove_refuses_before_confirmation_prompt_non_root() {
+    // C6: historically remove.rs asked for Y/N confirmation *before* checking
+    // root. Pin that the root check now runs first — the confirmation prompt
+    // text must never appear.
+    assert_refuses_before_output(
+        &["remove", "1", "--user", "nonexistent-test-user"],
+        &["Remove face model #1"],
+    );
+}
+
+#[test]
+fn clear_refuses_before_confirmation_prompt_non_root() {
+    assert_refuses_before_output(
+        &["clear", "--user", "nonexistent-test-user"],
+        &["Remove ALL face models", "No face models enrolled"],
+    );
 }
 
 #[test]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -20,7 +20,41 @@ use crate::audit::{self, AuditEntry, AuditSource};
 use crate::liveness::LandmarkTracker;
 use crate::rate_limit::RateLimiter;
 
-/// Run pre-flight checks that don't need the camera.
+/// Which of [`pre_check`]'s environment gates a caller may skip.
+///
+/// The only intended consumer is `facelock test` (N11, issue #96): it is
+/// root-only, and an admin legitimately runs it over SSH or with the lid
+/// closed on a docked laptop while diagnosing recognition, which is exactly
+/// what `abort_if_ssh`/`abort_if_lid_closed` exist to stop an *attacker* from
+/// doing. Every other gate in `pre_check` (disabled, enrollment,
+/// rate-limiting, `require_ir`) still applies to `test` unchanged — this
+/// struct exists so that carve-out is explicit at every call site instead of
+/// a parallel copy of the gate logic (see #95, which this whole `pre_check`
+/// unification closes).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PreCheckContext {
+    pub skip_ssh_gate: bool,
+    pub skip_lid_gate: bool,
+}
+
+impl PreCheckContext {
+    /// The default, fully-enforced context every real authentication path
+    /// (daemon `Authenticate`, oneshot `facelock auth`) uses.
+    pub fn enforced() -> Self {
+        Self::default()
+    }
+
+    /// `facelock test`'s context (N11): skip the SSH/lid gates, keep
+    /// everything else enforced.
+    pub fn test() -> Self {
+        Self {
+            skip_ssh_gate: true,
+            skip_lid_gate: true,
+        }
+    }
+}
+
+/// Run pre-flight checks that don't need the camera, fully enforced.
 /// Returns Some(response) to short-circuit, or None to proceed with auth.
 pub fn pre_check(
     config: &Config,
@@ -29,6 +63,26 @@ pub fn pre_check(
     rate_limiter: &RateLimiter,
     device_is_ir: bool,
 ) -> Option<DaemonResponse> {
+    pre_check_with_context(
+        config,
+        store,
+        user,
+        rate_limiter,
+        device_is_ir,
+        PreCheckContext::enforced(),
+    )
+}
+
+/// Run pre-flight checks that don't need the camera, honoring `ctx`'s gate
+/// overrides. See [`PreCheckContext`].
+pub fn pre_check_with_context(
+    config: &Config,
+    store: &FaceStore,
+    user: &str,
+    rate_limiter: &RateLimiter,
+    device_is_ir: bool,
+    ctx: PreCheckContext,
+) -> Option<DaemonResponse> {
     if config.security.disabled {
         warn!(user, "facelock is disabled");
         return Some(DaemonResponse::Error {
@@ -36,14 +90,14 @@ pub fn pre_check(
         });
     }
 
-    if config.security.abort_if_ssh && is_ssh_session() {
+    if !ctx.skip_ssh_gate && config.security.abort_if_ssh && is_ssh_session() {
         info!(user, "SSH session detected, aborting");
         return Some(DaemonResponse::Error {
             message: "SSH session detected".into(),
         });
     }
 
-    if config.security.abort_if_lid_closed && is_lid_closed() {
+    if !ctx.skip_lid_gate && config.security.abort_if_lid_closed && is_lid_closed() {
         info!(user, "lid closed, aborting");
         return Some(DaemonResponse::Error {
             message: "lid closed".into(),
@@ -114,7 +168,28 @@ pub fn pre_check_audited(
     device_is_ir: bool,
     source: AuditSource,
 ) -> Option<DaemonResponse> {
-    let resp = pre_check(config, store, user, rate_limiter, device_is_ir)?;
+    pre_check_audited_with_context(
+        config,
+        store,
+        user,
+        rate_limiter,
+        device_is_ir,
+        source,
+        PreCheckContext::enforced(),
+    )
+}
+
+/// [`pre_check_audited`], honoring `ctx`'s gate overrides. See [`PreCheckContext`].
+pub fn pre_check_audited_with_context(
+    config: &Config,
+    store: &FaceStore,
+    user: &str,
+    rate_limiter: &RateLimiter,
+    device_is_ir: bool,
+    source: AuditSource,
+    ctx: PreCheckContext,
+) -> Option<DaemonResponse> {
+    let resp = pre_check_with_context(config, store, user, rate_limiter, device_is_ir, ctx)?;
     let (result, error) = match &resp {
         DaemonResponse::Error { message } if message.contains("rate limited") => {
             ("rate_limited".to_string(), Some(message.clone()))
@@ -622,8 +697,18 @@ fn is_lid_closed() -> bool {
 mod tests {
     use super::*;
 
+    /// `SSH_CONNECTION` is process-global state; `cargo test` runs this
+    /// file's tests on multiple threads, and four of them now mutate it
+    /// (previously just one). Serialize access so they can't interleave.
+    static SSH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_ssh_env() -> std::sync::MutexGuard<'static, ()> {
+        SSH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn ssh_detection_with_env_vars() {
+        let _guard = lock_ssh_env();
         let old_conn = std::env::var("SSH_CONNECTION").ok();
         let old_tty = std::env::var("SSH_TTY").ok();
         unsafe {
@@ -652,5 +737,141 @@ mod tests {
     #[test]
     fn lid_closed_returns_false_on_missing_file() {
         let _result = is_lid_closed();
+    }
+
+    fn test_pre_check_config() -> Config {
+        let toml =
+            facelock_test_support::fixtures::test_config_toml("/tmp/facelock-precheck-test.db");
+        let mut config = Config::parse(&toml).unwrap();
+        config.security.abort_if_ssh = true;
+        config
+    }
+
+    fn store_with_enrolled_user(user: &str) -> FaceStore {
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model(
+                user,
+                "front",
+                &facelock_test_support::fixtures::known_embedding(0),
+                "",
+            )
+            .unwrap();
+        store
+    }
+
+    #[test]
+    fn pre_check_context_test_skips_both_environment_gates() {
+        let ctx = PreCheckContext::test();
+        assert!(ctx.skip_ssh_gate);
+        assert!(ctx.skip_lid_gate);
+    }
+
+    #[test]
+    fn pre_check_context_enforced_skips_neither_gate() {
+        let ctx = PreCheckContext::enforced();
+        assert!(!ctx.skip_ssh_gate);
+        assert!(!ctx.skip_lid_gate);
+        // `Default` must agree with `enforced()` — `pre_check`/`pre_check_audited`
+        // rely on this to stay fully enforced without threading a context.
+        let default_ctx = PreCheckContext::default();
+        assert!(!default_ctx.skip_ssh_gate);
+        assert!(!default_ctx.skip_lid_gate);
+    }
+
+    #[test]
+    fn pre_check_test_context_skips_ssh_gate() {
+        let _guard = lock_ssh_env();
+        let config = test_pre_check_config();
+        let store = store_with_enrolled_user("alice");
+        let rate_limiter = RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        );
+
+        let old_conn = std::env::var("SSH_CONNECTION").ok();
+        unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 1 5.6.7.8 22") };
+        let resp = pre_check_with_context(
+            &config,
+            &store,
+            "alice",
+            &rate_limiter,
+            true,
+            PreCheckContext::test(),
+        );
+        unsafe {
+            match old_conn {
+                Some(v) => std::env::set_var("SSH_CONNECTION", v),
+                None => std::env::remove_var("SSH_CONNECTION"),
+            }
+        }
+
+        assert!(
+            resp.is_none(),
+            "PreCheckContext::test() must proceed past the SSH gate, got: {resp:?}"
+        );
+    }
+
+    #[test]
+    fn pre_check_enforced_context_still_blocks_ssh() {
+        let _guard = lock_ssh_env();
+        let config = test_pre_check_config();
+        let store = store_with_enrolled_user("alice");
+        let rate_limiter = RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        );
+
+        let old_conn = std::env::var("SSH_CONNECTION").ok();
+        unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 1 5.6.7.8 22") };
+        let resp = pre_check_with_context(
+            &config,
+            &store,
+            "alice",
+            &rate_limiter,
+            true,
+            PreCheckContext::enforced(),
+        );
+        unsafe {
+            match old_conn {
+                Some(v) => std::env::set_var("SSH_CONNECTION", v),
+                None => std::env::remove_var("SSH_CONNECTION"),
+            }
+        }
+
+        assert!(
+            matches!(resp, Some(DaemonResponse::Error { ref message }) if message.contains("SSH")),
+            "the default/enforced context must still reject an SSH session, got: {resp:?}"
+        );
+    }
+
+    #[test]
+    fn pre_check_without_context_matches_enforced() {
+        // `pre_check` (no context param) is a thin wrapper — pin that it stays
+        // equivalent to `pre_check_with_context(.., PreCheckContext::enforced())`
+        // so real auth paths (daemon `Authenticate`, oneshot `facelock auth`)
+        // never silently pick up a relaxed gate.
+        let _guard = lock_ssh_env();
+        let config = test_pre_check_config();
+        let store = store_with_enrolled_user("alice");
+        let rate_limiter = RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        );
+
+        let old_conn = std::env::var("SSH_CONNECTION").ok();
+        unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 1 5.6.7.8 22") };
+        let resp = pre_check(&config, &store, "alice", &rate_limiter, true);
+        unsafe {
+            match old_conn {
+                Some(v) => std::env::set_var("SSH_CONNECTION", v),
+                None => std::env::remove_var("SSH_CONNECTION"),
+            }
+        }
+
+        assert!(
+            matches!(resp, Some(DaemonResponse::Error { ref message }) if message.contains("SSH")),
+            "pre_check() must stay fully enforced, got: {resp:?}"
+        );
     }
 }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -333,57 +333,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 DaemonResponse::Ok
             }
 
-            DaemonRequest::Authenticate { user } => {
-                if let Some(resp) = auth::pre_check_audited(
-                    &self.config,
-                    &self.store,
-                    &user,
-                    &self.rate_limiter,
-                    self.device_is_ir,
-                    AuditSource::Daemon,
-                ) {
-                    return resp;
-                }
-
-                if let Err(resp) = self.acquire_camera() {
-                    return resp;
-                }
-
-                // Pre-load and decrypt embeddings (handles TPM + software encryption)
-                let mut stored = match self.load_user_embeddings(&user) {
-                    Ok(s) => s,
-                    Err(resp) => return resp,
-                };
-
-                // Split borrows: take camera out, run auth, put it back
-                let mut camera = self.camera.take().unwrap();
-                let models = self.store.list_models(&user).unwrap_or_default();
-                let result = auth::authenticate_with_embeddings(
-                    &mut camera,
-                    &mut self.engine,
-                    &stored,
-                    &models,
-                    &self.config,
-                    &user,
-                    self.device_is_ir,
-                    &self.device_fingerprint,
-                    AuditSource::Daemon,
-                );
-                // `authenticate_with_embeddings` works on an internal copy;
-                // wipe the caller-side plaintext set too (#100).
-                zeroize_stored_embeddings(&mut stored);
-                self.camera = Some(camera);
-                self.camera_last_used = Instant::now();
-                // Only failed auths count against the rate limit
-                if let DaemonResponse::AuthResult(ref mr) = result {
-                    if !mr.matched {
-                        if let Err(e) = self.rate_limiter.record_failure(&self.store, &user) {
-                            warn!(user, error = %e, "failed to record auth failure");
-                        }
-                    }
-                }
-                result
-            }
+            DaemonRequest::Authenticate { user } => self.handle_authenticate(user, true),
 
             DaemonRequest::Enroll { user, label } => {
                 // Refuse to enroll a plaintext template unless explicitly opted in.
@@ -541,6 +491,80 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 result
             }
         }
+    }
+
+    /// Run an `Authenticate` request.
+    ///
+    /// `charge_failed_attempt` controls whether a non-matching result
+    /// consumes the shared (SQLite-backed) rate-limit budget for `user`.
+    /// `handle()` always passes `true`, preserving real-authentication
+    /// behavior exactly.
+    ///
+    /// The D-Bus layer (`commands/daemon.rs`) passes `false` when the caller
+    /// is root (N11, issue #96): `facelock test` is root-only and reaches
+    /// the daemon through this same `Authenticate` method, and a failed test
+    /// run must not lock the user out of real authentication. This costs
+    /// nothing security-wise — root already has unrestricted access to the
+    /// rate-limit table directly. `pre_check_audited`'s rate-limit *check*
+    /// (whether `user` is already over budget) is unaffected either way: an
+    /// already-limited user still sees "rate limited" here regardless of
+    /// `charge_failed_attempt`, because that decision is made before this
+    /// function knows whether the attempt itself will fail.
+    pub fn handle_authenticate(
+        &mut self,
+        user: String,
+        charge_failed_attempt: bool,
+    ) -> DaemonResponse {
+        if let Some(resp) = auth::pre_check_audited(
+            &self.config,
+            &self.store,
+            &user,
+            &self.rate_limiter,
+            self.device_is_ir,
+            AuditSource::Daemon,
+        ) {
+            return resp;
+        }
+
+        if let Err(resp) = self.acquire_camera() {
+            return resp;
+        }
+
+        // Pre-load and decrypt embeddings (handles TPM + software encryption)
+        let mut stored = match self.load_user_embeddings(&user) {
+            Ok(s) => s,
+            Err(resp) => return resp,
+        };
+
+        // Split borrows: take camera out, run auth, put it back
+        let mut camera = self.camera.take().unwrap();
+        let models = self.store.list_models(&user).unwrap_or_default();
+        let result = auth::authenticate_with_embeddings(
+            &mut camera,
+            &mut self.engine,
+            &stored,
+            &models,
+            &self.config,
+            &user,
+            self.device_is_ir,
+            &self.device_fingerprint,
+            AuditSource::Daemon,
+        );
+        // `authenticate_with_embeddings` works on an internal copy;
+        // wipe the caller-side plaintext set too (#100).
+        zeroize_stored_embeddings(&mut stored);
+        self.camera = Some(camera);
+        self.camera_last_used = Instant::now();
+        // Only failed auths count against the rate limit, and only when the
+        // caller hasn't been exempted (see doc comment above).
+        if let DaemonResponse::AuthResult(ref mr) = result {
+            if !mr.matched && charge_failed_attempt {
+                if let Err(e) = self.rate_limiter.record_failure(&self.store, &user) {
+                    warn!(user, error = %e, "failed to record auth failure");
+                }
+            }
+        }
+        result
     }
 
     fn encode_frame_response(&mut self, rgb: &[u8], width: u32, height: u32) -> DaemonResponse {

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -744,3 +744,75 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
 
     cleanup_db(&db_path);
 }
+
+/// N11 (issue #96): `facelock test` runs through the daemon's `Authenticate`
+/// method exactly like real auth, but is root-only and must never consume
+/// the shared rate-limit budget on failure — the D-Bus layer calls
+/// `Handler::handle_authenticate(user, false)` for a root caller instead of
+/// `handle(DaemonRequest::Authenticate { .. })`. A handful of failed test
+/// runs must not lock the user out of real authentication afterward.
+#[test]
+fn exempted_authenticate_does_not_consume_rate_limit_budget() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let db_path = temp_db_path("rate-limit-exempt");
+    cleanup_db(&db_path);
+
+    let db_path_str = db_path.to_string_lossy().into_owned();
+    let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
+    config.recognition.timeout_secs = 0;
+    config.security.rate_limit.max_attempts = 1;
+    config.security.require_frame_variance = false;
+    config.security.require_landmark_liveness = false;
+
+    {
+        let store = FaceStore::create(&db_path).unwrap();
+        store
+            .add_model("testuser", "front", &fixtures::known_embedding(0), "")
+            .unwrap();
+    }
+
+    let factory: Box<
+        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
+    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+
+    let mut handler = Handler::new(
+        config.clone(),
+        MockFaceEngine::no_faces(),
+        FaceStore::create(&db_path).unwrap(),
+        RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        ),
+        false,
+        facelock_core::types::DeviceFingerprint::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+
+    // Run more failed attempts than max_attempts (1), all exempted from
+    // charging. None may report "rate limited" — the budget starts and stays
+    // at zero recorded failures.
+    for i in 0..3 {
+        let resp = handler.handle_authenticate("testuser".into(), false);
+        assert!(
+            matches!(
+                resp,
+                DaemonResponse::AuthResult(MatchResult { matched: false, .. })
+            ),
+            "exempted attempt {i} should run the auth loop normally, not report rate-limited: {resp:?}"
+        );
+    }
+
+    // Directly assert the on-disk rate_limit table is untouched: a fresh
+    // check against the same database must still report "not rate limited".
+    let inspect_store = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect_store.check_rate_limit("testuser", 1, 60).unwrap(),
+        "rate_limit table must be untouched by exempted (root/test) failures"
+    );
+
+    cleanup_db(&db_path);
+}

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -64,6 +64,109 @@ Supplying a choice flag suppresses the corresponding wizard step. `auto` means
 gives the default. Under `--non-interactive`, an unresolvable choice is an error,
 never a prompt.
 
+### CLI Privilege Model (DEC-6)
+
+The CLI is root by default: every subcommand requires root except the four
+listed below, which are unprivileged by design, not by omission.
+
+| Command | Why unprivileged |
+|---------|-------------------|
+| `facelock is-enrolled` | Answers from the caller's own `0600` marker file; the unprivileged integration point (see Exit Codes above). Never probes D-Bus |
+| `facelock hyprlock …` | Edits the user's own dotfile — root would write root-owned files into `$HOME`, which is wrong, not just unnecessary |
+| `facelock config` (display, no `--edit`) | Reads a `0644` file |
+| `--help`, `--version` | — |
+
+Every other command requires root. Two escalation behaviors apply, and each
+command uses exactly one:
+
+- **Interactive prompt.** `setup`, `enroll`, `test`, `preview`, `bench`,
+  `encrypt`, `decrypt`, `tpm`, `reseal`, `restart`, `config --edit`, `remove`,
+  `clear`, `list`, `status`, `devices`. Run as non-root with a TTY attached,
+  these ask `Root required. Re-run with sudo? [Y/n]` and re-exec via `sudo`
+  on yes. Run as non-root with no TTY (scripted, piped, or closed stdin),
+  they hard-error instead — `Root required.\n  Run: sudo facelock <cmd>` —
+  rather than hang waiting for input that will never arrive
+  (`ipc_client::require_root`).
+- **Hard error only.** `facelock audit` (and `facelock daemon`, whose own
+  root check predates this table) never offer the interactive prompt at all,
+  even with a TTY attached — both are typically invoked non-interactively or
+  as a long-running service, where a stray confirmation prompt is a hang, not
+  a convenience (`ipc_client::require_root_scripted`).
+
+`facelock auth` is not user-facing — PAM spawns it directly, and it is not
+part of this table.
+
+**Ordering guarantee (C6).** Every command that prompts for confirmation or
+runs an interactive question runs its root check **first**, before that
+prompt or any other output or side effect. `remove` and `clear` both ask a
+Y/N confirmation before deleting a face model; historically `remove`'s root
+check ran *after* that confirmation, so a facelock-group member (who lacks
+root) would confirm a destructive action and only then discover it was
+refused — this is fixed. The same ordering applies to `status`, `devices`,
+`preview`, `test`, `audit`, `bench`, and `config --edit`: the root check is
+the first statement in each command's entry point, before `Config::load()`
+or any `println!`.
+
+**AccessDenied hint.** A D-Bus `AccessDenied` reply carries an actionable
+hint (`ipc_client::add_access_denied_hint`) that distinguishes two causes: the
+daemon's own `require_root` rejection (most methods now, since almost every
+D-Bus method is root-only — see IPC Protocol below) gets a root-specific
+hint; a bus-policy rejection (caller is neither root nor in the `facelock`
+group) gets the group-membership hint. Telling a root-only rejection to
+"join the facelock group" is wrong — joining the group does not grant root.
+
+### facelock test Semantics (N11)
+
+`facelock test` is root-only (issue #96) and, being root, keeps full detail
+on both transports: on the daemon transport, `AuthResult.similarity` is
+redacted to non-root D-Bus callers only (`redact_similarity_unless_root` in
+`commands/daemon.rs`) — since `test` requires root, its `Authenticate` calls
+always get the real score. The direct transport never redacts.
+
+It runs through the same pre-flight gates as real authentication —
+`security.disabled`, enrollment / `suppress_unknown`, the rate-limit check,
+and `require_ir` — via `facelock_daemon::auth::pre_check_audited*`, with one
+explicit, narrow exception: the `abort_if_ssh` / `abort_if_lid_closed` gates
+are skippable via `PreCheckContext::test()`. Those two gates exist to stop an
+*attacker*'s physical-access shortcuts, not to block an admin who is already
+root (by construction, since `test` requires root) and is deliberately
+diagnosing recognition over SSH or with the lid closed on a docked laptop.
+Every other gate stays enforced — this is a context flag threaded through
+`pre_check`, not a parallel copy of the gate logic (issue #95 was exactly
+that kind of drift).
+
+The override applies uniformly on the **direct** (daemonless) transport,
+where the pre-flight check runs in the same process that has the invoking
+session's actual `SSH_CONNECTION`/lid state. It does **not** apply
+separately on the **daemon** transport: `test` there is just another
+`Authenticate` D-Bus call, indistinguishable from real auth at that layer,
+so `abort_if_ssh` is evaluated against the long-running daemon process's own
+environment (never an SSH session) and is already inert there regardless;
+`abort_if_lid_closed` reads a system-wide hardware file and so still applies
+uniformly to every daemon-mediated `Authenticate` call, `test` included. In
+practice this means: diagnosing over SSH works on both transports (direct
+because it's overridden, daemon because the gate was already a no-op there);
+diagnosing with the lid closed only bypasses the gate in direct/oneshot mode.
+
+**Rate-limit consumption is exempted; the check is not.** A failed `test`
+attempt never consumes the shared (SQLite-backed) rate-limit budget:
+- Direct transport: `direct::authenticate` never calls
+  `RateLimiter::record_failure` — structurally, not conditionally.
+- Daemon transport: `test` reaches the daemon through the same
+  `Authenticate` D-Bus method as real auth. The D-Bus layer
+  (`commands/daemon.rs`) calls `Handler::handle_authenticate(user, charge)`
+  with `charge = !caller_is_root`; since `test` requires root, its D-Bus
+  calls are always exempted. Real end-user authentication (hyprlock, screen
+  lockers) runs as the *unprivileged user themselves*, so it is always
+  charged as before — this exemption only ever fires for a root caller.
+
+The rate-limit *check* (whether `user` is already over budget) is
+unaffected by any of the above and still runs on both transports: an
+already-limited user's `test` run reports "rate limited", exactly like real
+auth would. Root can already clear the limiter directly (it owns the
+database), so exempting *consumption* costs nothing security-wise, while
+still surfacing an existing lockout instead of masking it.
+
 ## Operating Modes
 
 | Mode | Config | PAM Behavior | CLI Behavior |
@@ -299,11 +402,22 @@ The daemon registers on the system bus via D-Bus activation.
 ### Methods
 `Authenticate`, `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`, `Ping`, `Shutdown`
 
-Method authorization contract:
-- `Authenticate`, `ListModels`, `PreviewDetectFrame`: root or the matching Unix user.
-- `Enroll`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `Shutdown`: root only.
-- `ReleaseCamera`: root or the Unix user that owns the active preview camera session.
-- `ListDevices`, `Ping`: resolve caller UID before replying and rely on the system bus policy for admission control.
+Method authorization contract (updated under DEC-6/N13 — the CLI's
+root-by-default privilege map left no unprivileged consumer for most of
+these, so tightening them to root-only closes the per-frame similarity
+hill-climbing oracle by construction rather than by redacting fields):
+- `Authenticate`: root or the matching Unix user. The one user-scoped method
+  — screen lockers run their PAM stack as the user, so this is architecture,
+  not policy.
+- Every other method — `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`,
+  `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`,
+  `Ping`, `Shutdown` — is root only. The bus policy
+  (`dbus/org.facelock.Daemon.conf`) stays interface-scoped (grants send
+  access to root and the `facelock` group for the whole interface); the
+  per-method root/user-scoped decision is the in-daemon check on the caller
+  UID from `GetConnectionUnixUser`, keyed by a table-driven scope
+  (`authorize_method` in `commands/daemon.rs`) so a new method is root-only
+  by default until deliberately opened up.
 
 Raw camera frames require privilege. `PreviewFrame` remains root-only.
 `PreviewDetectFrame` returns the `jpeg_data` frame bytes to root


### PR DESCRIPTION
## Summary

Implements DEC-6 (CLI is root-by-default) and N11 (`facelock test` is root-only with safe rate-limit semantics), closes #96.

## Privilege table (as shipped)

**Unprivileged** (unchanged, pinned by tests): `is-enrolled`, `hyprlock …`, `config` (display), `--help`/`--version`.

**Root — interactive prompt, hard error when non-interactive/scripted** (`ipc_client::require_root`): `setup`, `enroll`, `test`, `preview`, `bench`, `encrypt`, `decrypt`, `tpm`, `reseal`, `restart`, `config --edit`, `remove`, `clear`, `list`, `status`, `devices`.

**Root — hard error only, never a prompt** (`ipc_client::require_root_scripted`): `audit` (`daemon`'s own equivalent check predates this PR and was not touched).

## Per-command delta

| Command | Before | After |
|---|---|---|
| `status` | No root check; D-Bus calls (`Ping`) already root-only on the wire → bare AccessDenied | `require_root` as the first statement, before any output |
| `devices` | No root check; `ListDevices` already root-only on the wire | `require_root` as the first statement |
| `preview` | No root check; `PreviewDetectFrame` already root-only on the wire | `require_root` as the first statement (privilege gate only — preview/text_only/render/wayland_preview submodules untouched) |
| `bench` | Root required only for `{cold-auth,warm-auth,calibrate,report}` **and** only when `encryption.method == tpm` | Unconditional `require_root` at the top of `run()`, all subcommands, superseding the old conditional |
| `config --edit` | No root check; display and edit shared the same unprivileged path | `require_root` before `open_in_editor`; display (`config`, no flag) stays unprivileged |
| `audit` | No root check | `require_root_scripted` (hard error only, never prompts — audit is typically scripted) |
| `list` | Direct-mode fallback only required root when the DB was unreadable; D-Bus branch had no proactive check (bare AccessDenied) | Proactive `require_root` at the top of `run()` for both transports; simplified `fetch_models`'s now-dead retry-after-AccessDenied branch |
| `remove` | **C6 bug**: Y/N confirmation ran before the root check (confirmed root-only historically) | Root check moved to the first statement, before the confirmation prompt |
| `clear` | Already correct (root check first) | Verified only — no change |
| `test` | Root required only on the direct branch (`ipc_client::require_root` at old line 87), after the models-exists prompt; D-Bus branch had no check at all | Root check is the first statement in `run()`, before the models-exists check/prompt; see N11 below for transport-specific semantics |

## N11 — `facelock test` design decisions

- **Root-only, both transports.** `require_root("sudo facelock test")` is the first statement in `test_cmd::run`.
- **Full detail preserved.** Root gets real similarity scores on the wire (`AuthResult.similarity` is redacted only for non-root D-Bus callers, from Wave-1 PR-C); nothing is stripped for `test`.
- **`pre_check` now applies on the direct branch** (previously it was explicitly skipped — see the removed doc comment on `direct::authenticate`). Added `PreCheckContext` (`crates/facelock-daemon/src/auth.rs`) with `skip_ssh_gate`/`skip_lid_gate`, and `pre_check_with_context`/`pre_check_audited_with_context`. `pre_check`/`pre_check_audited` keep their old signatures as thin wrappers over `PreCheckContext::enforced()`, so this is purely additive — zero signature change for existing callers (`commands/auth.rs`'s oneshot path, `handler.rs`'s daemon path — neither was touched).
  - The override is scoped to the **direct** transport only: `direct::authenticate` resolves the live camera device (cheap, no camera I/O) and calls `pre_check_audited_with_context(.., PreCheckContext::test())` before opening the camera.
  - It's intentionally **not** duplicated on the daemon transport: `test` there is just another `Authenticate` D-Bus call, indistinguishable from real auth at that layer. `abort_if_ssh` checks the *daemon process's* environment (never an SSH session) so it's already inert there; `abort_if_lid_closed` reads a system-wide hardware file, so it still applies uniformly — documented as an intentional asymmetry in `docs/contracts.md`, not a bug.
- **Rate-limit consumption exempted; the check is not.**
  - Direct: `direct::authenticate` structurally never calls `RateLimiter::record_failure` (it never did — this is preserved, not new).
  - Daemon: **the one authorized `facelock-daemon` touch.** Refactored `Handler::handle()`'s `Authenticate` arm into `pub fn handle_authenticate(&mut self, user: String, charge_failed_attempt: bool)`; `handle()` calls it with `true` (zero behavior change for every existing caller, including `facelock-daemon/tests/daemon_integration.rs`'s two `handle(DaemonRequest::Authenticate{..})` calls). `commands/daemon.rs`'s `authenticate()` D-Bus method now calls `handler.handle_authenticate(user.clone(), !caller_is_root)` instead of `handler.handle(DaemonRequest::Authenticate{..})` — `caller_is_root` was already computed there (for similarity redaction, Wave-1 PR-C), so this is a one-line swap at the single call site, not new plumbing.
  - The rate-limit **check** (is `user` already over budget?) is unaffected on both transports — an already-limited user's `test` run reports "rate limited" exactly like real auth. Root can already clear the limiter directly (it owns the database), so exempting *consumption* costs nothing security-wise while still surfacing an existing lockout instead of masking it.

### The declared facelock-daemon touch (and its one necessary companion edit)

- `crates/facelock-daemon/src/auth.rs`: additive only (`PreCheckContext` + two new `_with_context` functions; old functions become wrappers).
- `crates/facelock-daemon/src/handler.rs`: `Authenticate` arm extracted into `pub fn handle_authenticate(user, charge_failed_attempt)`; `handle()`'s dispatch becomes a one-line delegation. No other arm touched.
- `crates/facelock-cli/src/commands/daemon.rs`: **one line** in the `authenticate()` D-Bus method (not in my explicit ownership list, called out here per the "narrowly-authorized extra" instruction) — swaps `handler.handle(DaemonRequest::Authenticate{..})` for `handler.handle_authenticate(user.clone(), !caller_is_root)`. This is structurally unavoidable: `caller_is_root` is only knowable at the D-Bus layer (from `GetConnectionUnixUser`), and the daemon library has no visibility into caller identity. Blast radius: exactly one call site, one of `commands/daemon.rs`'s ten `handler.handle(...)` calls (the other nine — Enroll, ListModels, RemoveModel, ClearModels, PreviewFrame, PreviewDetectFrame, ListDevices, ReleaseCamera, Ping, Shutdown — untouched); no change to authorization, redaction, or any other method's behavior.
- `crates/facelock-cli/src/direct.rs`: not in my explicit ownership list either, but `direct::authenticate` is the *only* function backing `test`'s direct-mode path, and N11 can't be wired correctly without editing it. Rewrote it to resolve the camera device once for `pre_check`'s `device_is_ir`, call `pre_check_audited_with_context`, and removed the now-redundant manual `has_models` early return (pre_check's own not-enrolled/`suppress_unknown` branch supersedes it) — net simplification, not just an addition. No other function in the file was touched.

## Tests

- `crates/facelock-daemon/src/auth.rs`: `PreCheckContext::test()`/`enforced()` field pins; `pre_check_with_context` skips the SSH gate under `test()` and still blocks it under `enforced()`; `pre_check()` (no context) stays equivalent to `enforced()` (regression pin so real auth paths can't silently pick up a relaxed gate). SSH-env-mutating tests share a `Mutex` to avoid flaking against parallel test threads (4 tests in this file now touch `SSH_CONNECTION`, up from 1).
- `crates/facelock-daemon/tests/daemon_integration.rs`: `exempted_authenticate_does_not_consume_rate_limit_budget` — three failed exempted attempts against `max_attempts = 1`, then a direct `FaceStore::check_rate_limit` assertion that the table is untouched.
- `crates/facelock-cli/src/ipc_client.rs`: `require_root_scripted` never-prompts structural test + root-pass test; `add_access_denied_hint` root-required vs. group-membership hint tests.
- `crates/facelock-cli/tests/cli_smoke.rs`: ten new black-box subprocess tests (`status`, `devices`, `preview`, `test`, `audit`, `bench`, `config --edit`, `list`, `remove`, `clear`) — each spawns the real `facelock` binary non-root with stdin closed and asserts it refuses with "Root required" *before* emitting any command-specific output (C6 contract). Skips gracefully (not a failure) if the test runner happens to be root.

## Gates

```
just check          → PASS (cargo test/clippy/fmt-check/audit all green; 216 facelock-cli unit tests, 15 cli_smoke integration tests, 57 facelock-daemon unit tests, 20 daemon_integration tests, all passing)
just test-arch-pam        → 22/22 PASS
just test-arch-layout     → 21/21 PASS (is-enrolled's unprivileged group-member behavior unaffected)
```

## Cross-PR notes

- `list.rs`'s D-Bus branch previously relied on a bare `AccessDenied` (fixed generically by the hint change); it now proactively prompts like every other command, for consistency — not strictly required by DEC-6's letter but a clear UX improvement with no correctness downside.
- `status.rs`/`test_cmd.rs` have pre-existing messaging bugs (documented in the Aug-2026 architecture review, e.g. `test_cmd.rs`'s "No face models enrolled" wording when it can't read the store) that are out of scope here — flagged for the next PR.
- `Cargo.lock` picked up a handful of dropped `async-io`/`async-process`-family entries that were no longer reachable by the dependency graph (pure pruning, no version bumps of anything in use) — a byproduct of the first build in this worktree, not an intentional dependency change.

## Docs to reconcile (not touched here — book/ and man/ are out of my ownership for this PR)

- `man/facelock.1`: `test`, `status`, `devices`, `preview`, `bench`, `config --edit`, `audit` entries should note the new root requirement and (for `audit`) the no-prompt behavior.
- `book/src/cli-reference.md`: same set of commands.
- `book/src/troubleshooting.md`, `docs/troubleshooting.md`, `book/src/security.md`, `docs/security.md`: all still say "join the facelock group" for AccessDenied-style errors in places that are now root-only denials; worth a pass once this lands.

---
base is integration/wave-1; retarget to main after #107-#111 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
