### PR TITLE
test: pin config-template, D-Bus wire, and log-filter conformance (E2/E3/E9)

### DIFF
--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -329,8 +329,12 @@
 # notify_on_success = true
 
 # Show notification on failed face match.
-# Default: false (failure is already visible — you get a password prompt)
-# notify_on_failure = false
+# Default: false (failure is already visible — you get a password prompt).
+# Set explicitly here, unlike the options above: this key's per-field parser
+# default disagrees with the type's overall default when the [notification]
+# header is present but the key itself is omitted, so a fresh install must
+# ship the value to get the documented behavior.
+notify_on_failure = false
 
 
 # ── Audit ─────────────────────────────────────────────────────────

--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -25,6 +25,26 @@ const WARM_ITERATIONS: u32 = 10;
 /// Number of snapshots for enrollment benchmark.
 const ENROLLMENT_SNAPSHOTS: u32 = 5;
 
+/// Fallback `EnvFilter` directive used when `RUST_LOG` is unset (gap E9).
+///
+/// This crate's `[[bin]]` target and its Cargo.toml package name both are
+/// `facelock-bench` (target `facelock_bench`), so it does not have the
+/// facelock-cli's `facelock` vs `facelock_cli` naming mismatch. It also has
+/// no lib target to share a constant with facelock-cli's `logging` module
+/// across the crate boundary (see gap D6) and this crate's file ownership
+/// for this change does not extend into facelock-core, so this is an
+/// independently pinned analog rather than a truly shared constant — see
+/// `crates/facelock-cli/src/logging.rs` for the sibling definition.
+const DEFAULT_LOG_FILTER: &str = "facelock_bench=info";
+
+/// The `EnvFilter` this binary's tracing-subscriber init must use: honors
+/// `RUST_LOG` when set and valid, otherwise falls back to
+/// [`DEFAULT_LOG_FILTER`].
+fn default_env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| DEFAULT_LOG_FILTER.into())
+}
+
 #[derive(Parser)]
 #[command(
     name = "facelock-bench",
@@ -54,7 +74,9 @@ enum Command {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(default_env_filter())
+        .init();
 
     let cli = Cli::parse();
 
@@ -780,6 +802,90 @@ mod tests {
         assert_eq!(pass_fail(100, 200), "PASS");
         assert_eq!(pass_fail(200, 200), "PASS");
         assert_eq!(pass_fail(201, 200), "FAIL");
+    }
+
+    // --- E9: logging default (see DEFAULT_LOG_FILTER's doc comment) ---
+
+    #[test]
+    fn default_log_filter_pinned() {
+        assert_eq!(DEFAULT_LOG_FILTER, "facelock_bench=info");
+    }
+
+    #[test]
+    fn no_init_site_outside_the_constant_bypasses_default_env_filter() {
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut visited_files = 0usize;
+        let mut found_bypass = false;
+        let mut main_uses_helper = false;
+
+        visit_rs_files(&src_dir, &mut |path, contents| {
+            visited_files += 1;
+            // Skip the line range that is default_env_filter()'s own body —
+            // it is the one legitimate place the bypass pattern may appear —
+            // and stop at the `#[cfg(test)] mod tests` boundary: this is a
+            // single-file crate, so this very test's own source (which
+            // necessarily contains the bypass pattern as a string literal to
+            // search for) lives below that boundary and would otherwise
+            // trip its own check.
+            let mut in_definition_body = false;
+            for (line_no, line) in contents.lines().enumerate() {
+                if line.trim_start().starts_with("mod tests") {
+                    break;
+                }
+                if line.contains("fn default_env_filter") {
+                    in_definition_body = true;
+                    continue;
+                }
+                if in_definition_body {
+                    if line.trim_start() == "}" {
+                        in_definition_body = false;
+                    }
+                    continue;
+                }
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if line.contains("EnvFilter::try_from_default_env(")
+                    || line.contains("EnvFilter::from_default_env(")
+                {
+                    found_bypass = true;
+                    panic!(
+                        "{}:{}: builds an EnvFilter directly instead of calling \
+                         default_env_filter()",
+                        path.display(),
+                        line_no + 1
+                    );
+                }
+            }
+            if path.file_name().and_then(|n| n.to_str()) == Some("main.rs")
+                && contents.contains(".with_env_filter(default_env_filter())")
+            {
+                main_uses_helper = true;
+            }
+        });
+
+        assert!(!found_bypass);
+        assert!(visited_files >= 1);
+        assert!(
+            main_uses_helper,
+            "expected main.rs's tracing_subscriber init to call default_env_filter()"
+        );
+    }
+
+    fn visit_rs_files(dir: &std::path::Path, f: &mut dyn FnMut(&std::path::Path, &str)) {
+        let entries = std::fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+        for entry in entries {
+            let entry = entry.expect("dir entry read failed");
+            let path = entry.path();
+            if path.is_dir() {
+                visit_rs_files(&path, f);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                let contents = std::fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+                f(&path, &contents);
+            }
+        }
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -30,15 +30,9 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     };
 
     tracing_subscriber::fmt()
-        .with_env_filter(
-            // `facelock`, not `facelock_cli`: the crate builds as a bin target
-            // named `facelock`, so that is the target its own events carry.
-            // Filtering on `facelock_cli` matched nothing and silently dropped
-            // every diagnostic this command emits — including the reason an
-            // auth attempt failed. `daemon.rs` already gets this right.
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "facelock=info,facelock_daemon=info".into()),
-        )
+        // See crate::logging's module doc for why this must not build its
+        // own fallback filter by hand.
+        .with_env_filter(crate::logging::default_env_filter())
         .with_target(false)
         .with_writer(std::io::stderr)
         .init();

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -1222,12 +1222,11 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
 pub fn run(config_path: Option<String>) -> anyhow::Result<()> {
     crate::ipc_client::require_root("sudo facelock daemon")?;
 
-    // Init tracing (daemon uses its own tracing setup with target=true)
+    // Init tracing (daemon uses its own tracing setup with target=true).
+    // See crate::logging's module doc for why this must not build its own
+    // fallback filter by hand.
     tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "facelock_daemon=info,facelock=info".into()),
-        )
+        .with_env_filter(crate::logging::default_env_filter())
         .with_target(true)
         .init();
 

--- a/crates/facelock-cli/src/logging.rs
+++ b/crates/facelock-cli/src/logging.rs
@@ -1,0 +1,121 @@
+//! Shared tracing/`EnvFilter` default for the `facelock` binary (gap E9).
+//!
+//! `RUST_LOG` filters by target, and this binary's own diagnostic events
+//! carry the target `facelock` — the `[[bin]] name` in Cargo.toml — not
+//! `facelock_cli`, the crate directory's name. That mismatch has silently
+//! dropped every diagnostic at an init site three times historically (see
+//! `commands/auth.rs`'s prior fix and CHANGELOG). Every
+//! `tracing_subscriber::fmt()` init site in this crate must build its
+//! fallback filter through [`default_env_filter`] rather than hand-rolling
+//! an `EnvFilter::try_from_default_env().unwrap_or_else(...)` string —
+//! `logging_conformance_test` in this module enforces that no other site in
+//! `src/` bypasses it.
+
+/// Fallback `EnvFilter` directive string used when `RUST_LOG` is unset.
+/// Enables `info` level on `facelock` (this crate's bin target) and
+/// `facelock_daemon` (the library every auth-path command pulls in) — the
+/// two targets that carry the diagnostics operators care about by default.
+pub const DEFAULT_LOG_FILTER: &str = "facelock=info,facelock_daemon=info";
+
+/// The `EnvFilter` every tracing-subscriber init site in this crate must use:
+/// honors `RUST_LOG` when set and valid, otherwise falls back to
+/// [`DEFAULT_LOG_FILTER`].
+pub fn default_env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| DEFAULT_LOG_FILTER.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_log_filter_targets_the_bin_name_not_the_crate_directory_name() {
+        // The crate directory is `facelock-cli` (which underscores to
+        // `facelock_cli`), but the `[[bin]]` target — and therefore every
+        // tracing event's target in this binary — is `facelock`.
+        // `facelock_cli=...` matches nothing and silently drops every event.
+        assert!(DEFAULT_LOG_FILTER.contains("facelock="));
+        assert!(!DEFAULT_LOG_FILTER.contains("facelock_cli"));
+        assert!(DEFAULT_LOG_FILTER.contains("facelock_daemon="));
+    }
+
+    #[test]
+    fn default_log_filter_pinned() {
+        assert_eq!(DEFAULT_LOG_FILTER, "facelock=info,facelock_daemon=info");
+    }
+
+    /// Walks this crate's `src/` tree at test time and asserts that (a) the
+    /// raw bypass pattern `EnvFilter::try_from_default_env(` /
+    /// `EnvFilter::from_default_env(` appears nowhere outside this file, and
+    /// (b) every file that previously hand-rolled a fallback filter now
+    /// calls `default_env_filter()`.
+    ///
+    /// Honest scope: this is a textual scan, not a borrow-checked guarantee
+    /// — a call site could still be added and shadowed under a different
+    /// name, or the bypass strings could be split across lines/macros to
+    /// dodge the substring match. It catches the actual historical failure
+    /// mode (copy-pasting the old `EnvFilter::try_from_default_env()...`
+    /// block into a new command) and regressions at the three known sites;
+    /// it is not a guarantee that *no* site anywhere can ever bypass it.
+    #[test]
+    fn no_init_site_outside_this_module_bypasses_default_env_filter() {
+        let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut visited_files = 0usize;
+        let mut sites_using_helper = Vec::new();
+
+        visit_rs_files(&src_dir, &mut |path, contents| {
+            visited_files += 1;
+            let is_this_file = path.file_name().and_then(|n| n.to_str()) == Some("logging.rs");
+            if !is_this_file {
+                assert!(
+                    !contents.contains("EnvFilter::try_from_default_env(")
+                        && !contents.contains("EnvFilter::from_default_env("),
+                    "{} builds an EnvFilter directly instead of calling \
+                     logging::default_env_filter() — see logging.rs's module \
+                     doc comment",
+                    path.display()
+                );
+            }
+            if contents.contains("logging::default_env_filter()") {
+                sites_using_helper.push(path.to_path_buf());
+            }
+        });
+
+        assert!(
+            visited_files >= 4,
+            "expected to scan at least main.rs, logging.rs, commands/auth.rs, \
+             commands/daemon.rs; only found {visited_files} — did the src \
+             layout change under this test's feet?"
+        );
+
+        // The three call sites this gap originally named. If a command gets
+        // its own tracing init in the future, add it here too.
+        for expected_substr in ["main.rs", "auth.rs", "daemon.rs"] {
+            assert!(
+                sites_using_helper
+                    .iter()
+                    .any(|p| p.to_string_lossy().contains(expected_substr)),
+                "expected a call to logging::default_env_filter() in a path \
+                 containing {expected_substr:?}, found calls only in {sites_using_helper:?}"
+            );
+        }
+    }
+
+    fn visit_rs_files(dir: &Path, f: &mut dyn FnMut(&Path, &str)) {
+        let entries = std::fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+        for entry in entries {
+            let entry = entry.expect("dir entry read failed");
+            let path = entry.path();
+            if path.is_dir() {
+                visit_rs_files(&path, f);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                let contents = std::fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+                f(&path, &contents);
+            }
+        }
+    }
+}

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1,13 +1,13 @@
 mod commands;
 pub mod direct;
 mod ipc_client;
+mod logging;
 pub mod notifications;
 pub mod state_layout;
 
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use tracing_subscriber::EnvFilter;
 
 use commands::TpmCommand;
 use commands::bench::BenchCommand;
@@ -241,7 +241,7 @@ fn main() -> anyhow::Result<()> {
         other => {
             // Default tracing init for all other commands
             tracing_subscriber::fmt()
-                .with_env_filter(EnvFilter::from_default_env())
+                .with_env_filter(logging::default_env_filter())
                 .with_target(false)
                 .init();
 

--- a/crates/facelock-core/tests/config_template_test.rs
+++ b/crates/facelock-core/tests/config_template_test.rs
@@ -1,0 +1,219 @@
+//! Conformance test for gap E2: the shipped config template must parse to
+//! exactly `Config::default()`, and every commented-out example value in it
+//! must round-trip to the same default it documents. The template is not
+//! just documentation — `%config(noreplace)` packaging ships this exact file
+//! as `/etc/facelock/config.toml` on every fresh install, so drift here is a
+//! drift in what a real installation actually does.
+//!
+//! `Config` derives neither `PartialEq` nor `Default` (and adding either is
+//! outside this crate's test-only edit scope for this change), so this test
+//! gets its "default" reference from `Config::parse("")` instead — every one
+//! of `Config`'s 11 fields is `#[serde(default)]`, so an empty TOML document
+//! parses to exactly what a `Config::default()` would produce if one
+//! existed — and compares via `Debug` formatting, which is derived
+//! everywhere `Config` nests.
+
+use facelock_core::config::Config;
+
+const TEMPLATE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../config/facelock.toml"
+));
+
+fn debug_eq(a: &Config, b: &Config) -> bool {
+    format!("{a:?}") == format!("{b:?}")
+}
+
+fn debug_diff(a: &Config, b: &Config) -> String {
+    format!("parsed:\n{a:#?}\n\ndefault:\n{b:#?}")
+}
+
+/// What `Config::default()` would produce, obtained without one: every field
+/// is `#[serde(default)]`, so an empty document is equivalent by construction.
+fn expected_default() -> Config {
+    Config::parse("").expect("an empty config document must always parse")
+}
+
+/// Three example lines in the template are deliberately **not** defaults:
+/// `device.path` shows syntax for an explicit camera path (the real default
+/// is "auto-detect", i.e. absent), and `recognition.detector_sha256` /
+/// `embedder_sha256` ship the placeholder `"..."`, which is not valid hex and
+/// must not be blindly uncommented. Skip these three by (section, key) while
+/// building the "uncomment every example" variant of the template.
+const NOT_DEFAULT_EXAMPLES: &[(&str, &str)] = &[
+    ("device", "path"),
+    ("recognition", "detector_sha256"),
+    ("recognition", "embedder_sha256"),
+];
+
+/// A line's `#`-stripped remainder is a candidate to uncomment only if it is
+/// exactly `[section.path]` or `key = value` with a bare, whitespace-free key
+/// AND a syntactically plausible TOML value — otherwise it is prose. This
+/// template has doc comments that legitimately contain `=` with a
+/// key-shaped left side, e.g. "encryption.method = \"none\". Default
+/// FALSE: ..." (bad value: trailing prose after the closing quote) or
+/// "pcr_binding = true is ENFORCED: ..." (bad value: trailing prose after
+/// `true`) — the value check is what rejects those.
+fn assignment_key(rest: &str) -> Option<&str> {
+    let (key, value) = rest.split_once('=')?;
+    let key = key.trim();
+    if key.is_empty() || key.split_whitespace().count() != 1 {
+        return None;
+    }
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+    {
+        return None;
+    }
+    if !looks_like_toml_value(value) {
+        return None;
+    }
+    Some(key)
+}
+
+/// Best-effort check that `value` is *just* a TOML scalar or array, with at
+/// most a trailing `# comment` — not a scalar followed by run-on prose. Good
+/// enough for this template's actual value shapes (quoted strings, bools,
+/// numbers, string arrays); not a general TOML value parser.
+fn looks_like_toml_value(raw_value: &str) -> bool {
+    let value = raw_value.trim();
+    if let Some(after_quote) = value.strip_prefix('"') {
+        return match after_quote.find('"') {
+            Some(idx) => {
+                let trailing = after_quote[idx + 1..].trim();
+                trailing.is_empty() || trailing.starts_with('#')
+            }
+            None => false,
+        };
+    }
+    let value = match value.split_once('#') {
+        Some((v, _)) => v.trim(),
+        None => value,
+    };
+    value == "true"
+        || value == "false"
+        || (value.starts_with('[') && value.ends_with(']'))
+        || value.parse::<f64>().is_ok()
+}
+
+/// Uncomment every commented-out example in the template except the
+/// deliberately-non-default placeholders in [`NOT_DEFAULT_EXAMPLES`],
+/// tracking the current `[section]` so keys reused across sections (e.g.
+/// `path` under both `[device]` and `[audit]`) are only skipped where
+/// documented as non-default.
+fn uncomment_all_examples(template: &str) -> String {
+    let mut current_section = String::new();
+    let mut out = String::with_capacity(template.len());
+    for line in template.lines() {
+        let trimmed = line.trim_start();
+        let indent = &line[..line.len() - trimmed.len()];
+        let Some(rest) = trimmed.strip_prefix('#') else {
+            // Already-active line (e.g. a bare `[section]` header) — track it too.
+            if let Some(section) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                current_section = section.to_string();
+            }
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+        let rest = rest.strip_prefix(' ').unwrap_or(rest);
+
+        if let Some(section) = rest.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            current_section = section.to_string();
+            out.push_str(indent);
+            out.push_str(rest);
+            out.push('\n');
+            continue;
+        }
+
+        if let Some(key) = assignment_key(rest) {
+            if NOT_DEFAULT_EXAMPLES.contains(&(current_section.as_str(), key)) {
+                out.push_str(line);
+            } else {
+                out.push_str(indent);
+                out.push_str(rest);
+            }
+            out.push('\n');
+            continue;
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn shipped_template_parses_to_config_default() {
+    // Byte-for-byte what a fresh install gets at /etc/facelock/config.toml.
+    let parsed = Config::parse(TEMPLATE).expect("shipped template must parse");
+    let default = expected_default();
+    assert!(
+        debug_eq(&parsed, &default),
+        "shipped config/facelock.toml drifted from Config::default():\n{}",
+        debug_diff(&parsed, &default)
+    );
+}
+
+#[test]
+fn every_documented_example_default_round_trips() {
+    let expanded = uncomment_all_examples(TEMPLATE);
+    let parsed = Config::parse(&expanded).unwrap_or_else(|e| {
+        panic!(
+            "uncommenting every documented example must still parse: {e}\n\n\
+             --- expanded template ---\n{expanded}"
+        )
+    });
+    let default = expected_default();
+    assert!(
+        debug_eq(&parsed, &default),
+        "a commented-out example in config/facelock.toml documents a value \
+         that is not actually Config::default() once uncommented:\n{}",
+        debug_diff(&parsed, &default)
+    );
+}
+
+#[test]
+fn security_pam_policy_is_documented_but_owned_by_pam_facelock_not_core() {
+    // `[security.pam_policy]` is real syntax (pam-facelock's own PamConfig
+    // parses it — see the `shipped_config_template_parses_as_pam_config`
+    // test in crates/pam-facelock/src/lib.rs) but facelock-core's `Config`
+    // has no such field. `every_documented_example_default_round_trips`
+    // above already proves core parses the section without error; this test
+    // pins that it has zero effect on core's parsed result, which is the
+    // load-bearing half of the contract (core must never reject a key that
+    // belongs to PAM's schema).
+    let with_pam_policy = r#"
+[security.pam_policy]
+allowed_services = ["sudo"]
+denied_services = ["sshd"]
+"#;
+    let parsed =
+        Config::parse(with_pam_policy).expect("unknown keys must be ignored, not rejected");
+    assert!(debug_eq(&parsed, &expected_default()));
+}
+
+#[test]
+fn placeholder_examples_are_intentionally_not_config_defaults() {
+    // Documents *why* the three (section, key) pairs above are excluded from
+    // every_documented_example_default_round_trips, as a live assertion
+    // rather than just a comment: if either fact stops being true, this test
+    // fails and the exclusion list needs to be revisited.
+    let default = expected_default();
+    assert!(
+        default.device.path.is_none(),
+        "device.path's real default is auto-detect (None); the template's \
+         `path = \"/dev/video2\"` is a syntax example, not the default"
+    );
+    assert!(
+        !is_sha256_hex("..."),
+        "recognition.{{detector,embedder}}_sha256 examples ship the literal \
+         placeholder \"...\", which Config::validate() rejects as not-hex — \
+         it must stay commented, never blindly uncommented"
+    );
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit())
+}

--- a/crates/facelock-core/tests/dbus_types_test.rs
+++ b/crates/facelock-core/tests/dbus_types_test.rs
@@ -1,20 +1,32 @@
+//! Conformance test for gap E3: pin the exact D-Bus wire signature of every
+//! type crossing the bus, plus the bus name/path/interface constants.
+//!
+//! D-Bus is the *only* auth path for user-run lockers (hyprlock, swaylock —
+//! they cannot read the `0600 root:root` key, see gap-register.md DEC-2), so
+//! an accidental wire-format change during the upgrade window (old client,
+//! new daemon or vice versa) is a face-auth outage, not just a test failure.
+//! The previous version of this file asserted `!sig.is_empty()`, which
+//! cannot fail for any struct — it caught zero regressions. Every assertion
+//! below is an exact string: if a field is added, removed, reordered, or
+//! retyped on any of these structs, this file must be touched deliberately.
+
 use facelock_core::dbus_interface::*;
 use zvariant::DynamicType;
 
 #[test]
-fn auth_result_has_dbus_signature() {
+fn auth_result_signature_is_pinned() {
     let val = AuthResult {
         matched: false,
         model_id: -1,
         label: String::new(),
         similarity: 0.0,
     };
-    let sig = val.signature();
-    assert!(!sig.to_string().is_empty());
+    // bool, i32, String, f64 -> b, i, s, d
+    assert_eq!(val.signature().to_string(), "(bisd)");
 }
 
 #[test]
-fn model_info_has_dbus_signature() {
+fn model_info_signature_is_pinned() {
     let val = ModelInfo {
         id: 0,
         user: String::new(),
@@ -23,12 +35,12 @@ fn model_info_has_dbus_signature() {
         embedder_model: String::new(),
         device_id: String::new(),
     };
-    let sig = val.signature();
-    assert!(!sig.to_string().is_empty());
+    // u32, String, String, u64, String, String -> u, s, s, t, s, s
+    assert_eq!(val.signature().to_string(), "(usstss)");
 }
 
 #[test]
-fn preview_face_info_has_dbus_signature() {
+fn preview_face_info_signature_is_pinned() {
     let val = PreviewFaceInfo {
         x: 0.0,
         y: 0.0,
@@ -38,20 +50,20 @@ fn preview_face_info_has_dbus_signature() {
         similarity: 0.0,
         recognized: false,
     };
-    let sig = val.signature();
-    assert!(!sig.to_string().is_empty());
+    // f64 x5, then bool -> d, d, d, d, d, d, b
+    assert_eq!(val.signature().to_string(), "(ddddddb)");
 }
 
 #[test]
-fn device_info_has_dbus_signature() {
+fn device_info_signature_is_pinned() {
     let val = DeviceInfo {
         path: String::new(),
         name: String::new(),
         driver: String::new(),
         is_ir: false,
     };
-    let sig = val.signature();
-    assert!(!sig.to_string().is_empty());
+    // String x3, bool -> s, s, s, b
+    assert_eq!(val.signature().to_string(), "(sssb)");
 }
 
 #[test]
@@ -59,4 +71,15 @@ fn constants_correct() {
     assert_eq!(BUS_NAME, "org.facelock.Daemon");
     assert_eq!(OBJECT_PATH, "/org/facelock/Daemon");
     assert_eq!(INTERFACE_NAME, "org.facelock.Daemon");
+}
+
+/// The three D-Bus identity constants are compared for byte-for-byte
+/// equality *to each other* in addition to their literal values above: the
+/// bus name and interface name happen to coincide today (a single-object,
+/// single-interface daemon), but nothing enforces that they must — pin both
+/// facts independently so a future divergence is a deliberate edit here, not
+/// a surprise at connection time.
+#[test]
+fn bus_name_and_interface_name_currently_coincide() {
+    assert_eq!(BUS_NAME, INTERFACE_NAME);
 }

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -1347,4 +1347,39 @@ auth_bin = "/usr/local/bin/evil"
         )));
         assert!(!is_timeout_zbus_error(&io_err));
     }
+
+    // --- E2: shared-schema conformance (domain-object-map.md §1) ---
+
+    /// The shipped config template is parsed by two independent, deliberately
+    /// unmerged schemas: facelock-core's `Config` (see
+    /// `crates/facelock-core/tests/config_template_test.rs`) and this
+    /// crate's private `PamConfig`, kept minimal by the PAM dependency
+    /// ceiling. This is PAM's half of that contract: if a future key drifts
+    /// so one side gains a key the other rejects (a `deny_unknown_fields`
+    /// creeping onto either schema, or a new required field with no
+    /// `#[serde(default)]`), this fails loudly in CI instead of surfacing as
+    /// a silent config parse error at `pam_sm_authenticate` time on a real
+    /// system.
+    #[test]
+    fn shipped_config_template_parses_as_pam_config() {
+        const TEMPLATE: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../config/facelock.toml"
+        ));
+        let config: PamConfig = toml::from_str(TEMPLATE)
+            .expect("PamConfig must parse the same shipped template facelock-core parses");
+
+        // Every key this template documents for PAM is shipped commented out
+        // (illustrating syntax, not overriding anything), so parsing it must
+        // be indistinguishable from parsing an empty document.
+        assert_eq!(config.daemon.mode, "daemon");
+        assert!(!config.security.disabled);
+        assert!(config.security.abort_if_ssh);
+        assert!(config.security.abort_if_lid_closed);
+        assert!(config.security.pam_policy.is_none());
+        assert_eq!(config.recognition.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert!(config.notification.terminal());
+        assert!(config.notification.notify_prompt);
+        assert!(config.notification.notify_on_success);
+    }
 }


### PR DESCRIPTION
## Summary

Three independent conformance tests, each replacing an assertion that either didn't exist or couldn't fail, per the [gap register](https://github.com/tyvsmith/facelock/blob/main/.omc/plans/gap-register.md) (this PR predates that file existing on `main`; see the orchestrating agent's task for context).

### E2 — config template ↔ `Config::default()`

`crates/facelock-core/tests/config_template_test.rs` parses the shipped `config/facelock.toml` (which ships byte-for-byte as `/etc/facelock/config.toml` on every install, per `%config(noreplace)`) and asserts it equals `Config::default()`. Since `Config` has neither `PartialEq` nor `Default` (and adding either touches non-test code in `facelock-core`, outside this PR's file ownership), the reference default comes from `Config::parse("")` — every field is `#[serde(default)]`, so an empty document is defaults by construction — and comparison goes through `Debug` formatting.

A second test uncomments every commented-out example value in the template (tracking `[section]` context so a key like `path` under both `[device]` and `[audit]` is handled per-section) and asserts that round-trips to the same default too. Three examples are deliberately excluded because they are illustrative, not defaults: `device.path` (shows syntax for an explicit camera path; the real default is auto-detect/`None`) and `recognition.detector_sha256`/`embedder_sha256` (ship the literal placeholder `"..."`, which `Config::validate()` rejects as not-hex). A fourth test makes that exclusion a live assertion instead of a silent skip.

**Drift found and fixed (template side):** `notification.notify_on_failure` had a real, live divergence. Its per-field serde default (`default_true`) disagrees with `NotificationConfig`'s manual `Default` impl (`false`) whenever the `[notification]` header is present but the key itself is omitted — which is exactly the shape of the shipped template (and of any minimal custom `[notification]` section a user writes, e.g. just `mode = "off"`). The doc comment already said "Default: false"; the field-level parser default silently produced `true`. **Fixed on the template side** by promoting `notify_on_failure = false` from a commented example to an active line, closing the gap for every fresh install without touching non-test code. **Not fixed:** the underlying field-level default in `crates/facelock-core/src/config.rs` (`notify_on_failure`'s `#[serde(default = "default_true")]` should be `default_false`/unadorned) is still live for any user config that specifies `[notification]` without this key — see "Docs to reconcile."

`[security.pam_policy]` is real syntax (documented in the template, parsed by `pam-facelock`'s own `PamConfig`) but has no corresponding field in `facelock-core::Config`. Confirmed by design, not drift: `pam_policy` is a PAM-only concern (allow/deny PAM service names), and `Config::parse` silently ignores unknown keys (no `deny_unknown_fields`), which is the correct behavior. Pinned as its own test.

Also added, per `domain-object-map.md` §1: a `#[cfg(test)]`-only test in `crates/pam-facelock/src/lib.rs` (`shipped_config_template_parses_as_pam_config`) that `include_str!`s the same shipped template through `PamConfig`, so a future key one schema accepts and the other rejects becomes a visible CI failure instead of a silent parse error on a real system.

### E3 — exact D-Bus signature strings

`crates/facelock-core/tests/dbus_types_test.rs` previously asserted `!sig.to_string().is_empty()` for every D-Bus type — true for any struct, so it caught zero regressions. Replaced with the exact zvariant signature for each type crossing the bus:

| Type | Signature |
|---|---|
| `AuthResult` | `(bisd)` |
| `ModelInfo` | `(usstss)` |
| `PreviewFaceInfo` | `(ddddddb)` |
| `DeviceInfo` | `(sssb)` |

Kept the `BUS_NAME`/`OBJECT_PATH`/`INTERFACE_NAME` constant pins and added one more: that `BUS_NAME` and `INTERFACE_NAME` currently coincide, pinned independently of their literal values. No signature was changed — only pinned as observed today, per the assignment's constraint.

### E9 — one shared `EnvFilter` default

Found three `tracing_subscriber` init sites in `facelock-cli` plus one in `facelock-bench`:
- `crates/facelock-cli/src/main.rs:244` — `EnvFilter::from_default_env()` with **no fallback at all** (a milder cousin of the historical bug: silently shows nothing without `RUST_LOG` set, rather than filtering on the wrong crate name).
- `crates/facelock-cli/src/commands/auth.rs:32-44` — already fixed in Wave 1 to `"facelock=info,facelock_daemon=info"`, with a comment explaining the `facelock` vs `facelock_cli` bug.
- `crates/facelock-cli/src/commands/daemon.rs:1226-1232` — already used the correct targets but as its own literal string (`"facelock_daemon=info,facelock=info"` — same targets, different order, no shared source of truth).
- `crates/facelock-bench/src/main.rs:57` — bare `tracing_subscriber::fmt::init()`, no explicit fallback.

Added `crates/facelock-cli/src/logging.rs`: `DEFAULT_LOG_FILTER = "facelock=info,facelock_daemon=info"` and `default_env_filter()`, used at all three `facelock-cli` sites. Its test module pins the constant's content and target names, and walks this crate's `src/` tree at test time to assert no other file builds an `EnvFilter` directly via `EnvFilter::try_from_default_env()`/`from_default_env()`, and that `main.rs`/`auth.rs`/`daemon.rs` each call the shared helper. **Honest scope, stated in the test's own comment:** this is a textual scan, not a borrow-checked guarantee — it catches the actual historical failure mode (copy-pasting the old hand-rolled block into a new command), not every conceivable bypass.

`facelock-bench` cannot import `facelock-cli`'s constant — `facelock-cli` is bin-only with no lib target (gap D6), and this PR's file ownership doesn't extend into `facelock-core`, the one crate both already depend on where a truly shared constant could live. Gave it an independently-pinned analog instead: `DEFAULT_LOG_FILTER = "facelock_bench=info"` (its bin target name already equals its crate name, so it never had the crate-vs-bin mismatch bug — this is purely about giving it an explicit, pinned fallback for consistency) plus the same style of scan test, adapted for its single-file layout (the scan stops at the `#[cfg(test)] mod tests` boundary so the test's own string literals don't trip its own check).

## Cross-PR notes

- No auth-semantics changes. No D-Bus signature changes (E3 pins today's wire format; nothing was retyped/reordered).
- `notify_on_failure`'s field-level default bug in `crates/facelock-core/src/config.rs` (see E2 above) is real and still live for user-written configs, just no longer live in the shipped template. Fixing it is a one-line change (`#[serde(default = "default_true")]` → `#[serde(default)]` or `default_false`) but touches non-test code in `facelock-core`, which was out of this PR's file ownership.
- `-p pam-facelock` fails to build standalone (`zbus` feature-resolution error: `default-features = false, features = ["blocking"]` alone doesn't pull in an async backend) — confirmed pre-existing on `integration/wave-2` before this branch's changes, unrelated to this PR. All tests here were verified via full-workspace `cargo test`/`just check`, where feature unification resolves it.
- The E9 fix surfaces (but does not act on) the D6 gap again: `facelock-cli` having no lib target blocks not just integration-testing the D-Bus authz layer, but also sharing a simple logging constant with `facelock-bench` without either duplicating it or reaching into `facelock-core`.

## Docs to reconcile

- `docs/contracts.md` (or wherever the D-Bus wire format is documented, if anywhere) should reference `dbus_types_test.rs` as the source of truth for current signatures.
- Fast follow-up: fix `notify_on_failure`'s field-level default in `crates/facelock-core/src/config.rs` (see above).
- Fast follow-up: once D6 (facelock-cli lib target) or a facelock-core edit is in scope, move `DEFAULT_LOG_FILTER`/`default_env_filter` to a single shared location for both `facelock-cli` and `facelock-bench`.

## Gate output

`just check` (test + lint + fmt-check + audit) passes clean on the full workspace. Tail:

```
cargo clippy --workspace -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
cargo fmt --all -- --check
cargo audit --deny unmaintained --deny unsound
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1216 security advisories (from /home/ty/.cargo/advisory-db)
    Scanning Cargo.lock for vulnerabilities (481 crate dependencies)
Crate:     core2       Version: 0.4.0   Warning: yanked   (pre-existing, unrelated)
Crate:     uds_windows  Version: 1.2.0   Warning: yanked   (pre-existing, unrelated)
warning: 2 allowed warnings found
```

Full-workspace `cargo test --workspace` shows every test binary green, including the new/changed ones:
```
tests/config_template_test.rs  ... 4 passed; 0 failed
tests/dbus_types_test.rs       ... 6 passed; 0 failed
facelock (bin, facelock-cli)   ... 236 passed; 0 failed   (includes 3 new logging:: tests)
facelock_bench (bin)           ... 10 passed; 0 failed    (includes 2 new logging tests)
pam_facelock (lib)             ... 27 passed; 0 failed    (includes shipped_config_template_parses_as_pam_config)
```

Not run here per instructions (shared podman image tag with concurrent agents): `just test-arch-pam`, `just test-arch-layout`. The orchestrator runs these centrally before the PR leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)