### PR TITLE
refactor(store): store-local StoreError — failure class as a type (D2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` 
 | facelock-core | serde, toml, thiserror, tracing, subtle, zeroize, zvariant |
 | facelock-camera | facelock-core, v4l, image, tracing |
 | facelock-face | facelock-core, ort, ndarray, image, sha2 |
-| facelock-store | facelock-core, rusqlite (bundled), bytemuck |
+| facelock-store | facelock-core, rusqlite (bundled), bytemuck, thiserror |
 | facelock-daemon | facelock-core, facelock-camera, facelock-face, facelock-store, facelock-tpm, signal-hook, nix |
 | facelock-cli | facelock-core + all above, clap, reqwest, zbus, tokio, dialoguer |
 | facelock-bench | facelock-core, facelock-camera, facelock-face, facelock-store, clap, anyhow, tracing |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "facelock-core",
  "rusqlite",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
+use facelock_store::StoreError;
 
 use crate::ipc_client;
 
@@ -37,7 +38,10 @@ pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
     }
 
     if ipc_client::should_use_direct(&config) {
-        let store = crate::direct::open_store(&config)?;
+        // `open_store_existing`: has_models above just proved the database is
+        // there. If it vanished since, deleting has nothing to do — erroring
+        // beats re-creating an empty database in its place.
+        let store = crate::direct::open_store_existing(&config)?;
         let count = store
             .clear_user(&user)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -66,9 +70,15 @@ pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
 
 /// Direct-transport half of the pre-prompt check: a store that cannot be
 /// opened or queried is an error, never "no models" and never "assume yes and
-/// prompt anyway".
+/// prompt anyway". [`StoreError::Absent`] alone reads as "no models" — a
+/// fresh install has provably nothing to delete, and the probe must not
+/// create the database it is about to report empty.
 fn direct_user_has_models(config: &Config, user: &str) -> anyhow::Result<bool> {
-    let store = crate::direct::open_store(config)?;
+    let store = match crate::direct::open_store_existing(config) {
+        Ok(store) => store,
+        Err(StoreError::Absent { .. }) => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
     store
         .has_models(user)
         .map_err(|e| anyhow::anyhow!("storage error: {e}"))
@@ -144,6 +154,21 @@ mod tests {
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
 
         assert!(direct_user_has_models(&config_with_db(&db_path), "alice").is_err());
+    }
+
+    /// The `Absent` variant reads as "no models" without creating anything:
+    /// before the typed error, this probe ran as root and left an empty
+    /// database at the path as a side effect of finding nothing to delete.
+    #[test]
+    fn direct_absent_store_reads_as_no_models_without_creating() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+
+        assert!(!direct_user_has_models(&config_with_db(&db_path), "alice").unwrap());
+        assert!(
+            !db_path.exists(),
+            "the pre-prompt probe must not create the database it reports empty"
+        );
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -4,6 +4,7 @@ use chrono::Local;
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use facelock_core::types::FaceModelInfo;
+use facelock_store::StoreError;
 
 use crate::ipc_client;
 
@@ -79,14 +80,7 @@ pub fn run(
     {
         let config_embedder = &config.recognition.embedder_model;
         let has_stale = if ipc_client::should_use_direct(&config) {
-            let store = crate::direct::open_store(&config)?;
-            let has_any = store
-                .has_models(&user)
-                .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
-            let has_matching = store
-                .has_models_for_embedder(&user, config_embedder)
-                .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
-            has_any && !has_matching
+            direct_has_stale_embedder(&config, &user, config_embedder)?
         } else {
             let request = DaemonRequest::ListModels { user: user.clone() };
             match ipc_client::send_request(&request)? {
@@ -153,7 +147,13 @@ pub fn run(
 /// read as "this user has no models".
 fn list_user_models(user: &str, config: &Config) -> anyhow::Result<Vec<FaceModelInfo>> {
     if ipc_client::should_use_direct(config) {
-        let store = crate::direct::open_store(config)?;
+        let store = match crate::direct::open_store_existing(config) {
+            Ok(store) => store,
+            // Fresh install: no models yet. Picking the first free label must
+            // not create the database enrollment itself is about to create.
+            Err(StoreError::Absent { .. }) => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
         store
             .list_models(user)
             .map_err(|e| anyhow::anyhow!("storage error: {e}"))
@@ -166,6 +166,25 @@ fn list_user_models(user: &str, config: &Config) -> anyhow::Result<Vec<FaceModel
             other => anyhow::bail!("unexpected response from daemon: {other:?}"),
         }
     }
+}
+
+/// Direct-transport half of the stale-embedder warning. [`StoreError::Absent`]
+/// reads as "no models, nothing stale" without creating the database; any
+/// other failure class propagates (C4) — the enrollment ahead needs the very
+/// store this check just failed to read.
+fn direct_has_stale_embedder(config: &Config, user: &str, embedder: &str) -> anyhow::Result<bool> {
+    let store = match crate::direct::open_store_existing(config) {
+        Ok(store) => store,
+        Err(StoreError::Absent { .. }) => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    let has_any = store
+        .has_models(user)
+        .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
+    let has_matching = store
+        .has_models_for_embedder(user, embedder)
+        .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
+    Ok(has_any && !has_matching)
 }
 
 /// Generate the next available label like "2026-03-15-1", "2026-03-15-2", etc.
@@ -208,6 +227,38 @@ mod tests {
         let mut config = Config::parse("[daemon]\nmode = \"oneshot\"\n").expect("config parses");
         config.storage.db_path = db_path.to_string_lossy().into_owned();
         config
+    }
+
+    /// `Absent` vs everything else at the pre-enrollment reads: a fresh
+    /// install reads as "no models, nothing stale" and the probes create
+    /// nothing — enrollment proper is what brings the database into being.
+    #[test]
+    fn absent_store_reads_as_no_models_without_creating() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let config = oneshot_config_with_db(&db_path);
+
+        assert!(!direct_has_stale_embedder(&config, "alice", "embedder").unwrap());
+        assert_eq!(
+            next_label("2026-08-13", "alice", &config).unwrap(),
+            "2026-08-13-1"
+        );
+        assert!(
+            !db_path.exists(),
+            "pre-enrollment reads must not create the database"
+        );
+    }
+
+    /// The counterpart: an unreadable (present) store is NOT `Absent` — the
+    /// stale-embedder check propagates it instead of skipping the warning.
+    #[test]
+    fn stale_embedder_check_propagates_unreadable_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
+
+        let config = oneshot_config_with_db(&db_path);
+        assert!(direct_has_stale_embedder(&config, "alice", "embedder").is_err());
     }
 
     /// C4: a store failure while picking the next label propagates — it must

--- a/crates/facelock-cli/src/commands/is_enrolled.rs
+++ b/crates/facelock-cli/src/commands/is_enrolled.rs
@@ -46,7 +46,7 @@
 //! first, which *activates* the system daemon. Nothing in this module may call
 //! [`crate::ipc_client::send_request`],
 //! [`crate::ipc_client::should_use_direct`] (it probes the system bus), or
-//! [`crate::direct::open_store`].
+//! [`crate::direct::open_store`] or [`crate::direct::open_store_existing`].
 //!
 //! The only syscalls on the hot path are: read `/etc/facelock/config.toml` (for
 //! the state directory), and read one marker file.

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1163,13 +1163,16 @@ fn handle_orphan_models_before_keygen(
     // Fail closed on both reads (C2, issue #105): a database that cannot be
     // opened, or a query that fails on an open one, does NOT mean "nothing to
     // protect" — it means facelock cannot tell, and minting a key on "cannot
-    // tell" is what orphans real templates.
-    let store = match crate::direct::open_store(config) {
+    // tell" is what orphans real templates. `Absent` is the one failure class
+    // that authorizes proceeding: no database file means there are no
+    // templates to orphan, and the probe must not create one to prove it.
+    let store = match crate::direct::open_store_existing(config) {
         Ok(s) => s,
+        Err(facelock_store::StoreError::Absent { .. }) => return Ok(()),
         Err(e) => bail!(
             "refusing to generate a new encryption key: the face database could \
              not be read, so facelock cannot tell whether existing templates \
-             would be orphaned ({e:#}). Fix access to {} and re-run, or clear \
+             would be orphaned ({e}). Fix access to {} and re-run, or clear \
              models first with: sudo facelock clear",
             config.storage.db_path
         ),
@@ -1303,6 +1306,24 @@ mod orphan_guard_tests {
 
         handle_orphan_models_before_keygen(&config_with_db(&db_path), None)
             .expect("a fresh store with zero models must not block keygen");
+    }
+
+    /// (c′) The `Absent` variant is what encodes case (c): the guard proceeds
+    /// on a missing database *because there is provably nothing to orphan* —
+    /// and, unlike the create-based probe it replaces, leaves no empty
+    /// database behind. Together with (a) this pins Absent ≠ Denied/Corrupt:
+    /// one authorizes keygen, the other refuses it.
+    #[test]
+    fn absent_database_proceeds_without_creating_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+
+        handle_orphan_models_before_keygen(&config_with_db(&db_path), None)
+            .expect("an absent database means nothing to orphan");
+        assert!(
+            !db_path.exists(),
+            "the orphan probe must not create the database it reports absent"
+        );
     }
 
     /// (d) Models present, non-interactive: the existing orphaned-models bail

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -67,7 +67,10 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     {
         let config_embedder = &config.recognition.embedder_model;
         let has_matching = if ipc_client::should_use_direct(&config) {
-            let store = crate::direct::open_store(&config)?;
+            // `open_store_existing`: the store answered has_models one query
+            // ago, so it exists; if it vanished since, that is an error, not
+            // a cue to create an empty one and warn about a stale embedder.
+            let store = crate::direct::open_store_existing(&config)?;
             store
                 .has_models_for_embedder(&user, config_embedder)
                 .map_err(|e| anyhow::anyhow!("storage error: {e}"))?
@@ -229,11 +232,11 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
 }
 
 /// Direct-transport "does this user have enrolled models?" with the C7
-/// three-way discrimination:
+/// three-way discrimination, now carried by [`StoreError`]'s variants:
 ///
-/// - store opens, zero models  → `Ok(false)` ("no models enrolled" is true)
-/// - store absent (fresh)      → `Ok(false)` (created empty; same message)
-/// - store present, unreadable → `Err`, never "no models"
+/// - store opens, zero models      → `Ok(false)` ("no models enrolled" is true)
+/// - `StoreError::Absent` (fresh)  → `Ok(false)` (no database created; same message)
+/// - any other failure class       → `Err`, never "no models"
 ///
 /// For the error, the per-user enrollment marker is consulted **for the
 /// message only** — it is readable in exactly the cases the database is not,
@@ -241,9 +244,10 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
 /// to be enrolled; the database is the problem"). The marker can be stale,
 /// hence "appear to"; it never influences the decision, only the wording.
 fn direct_user_has_models(config: &Config, user: &str) -> anyhow::Result<bool> {
-    let store = match crate::direct::open_store(config) {
+    let store = match crate::direct::open_store_existing(config) {
         Ok(store) => store,
-        Err(e) => return Err(unreadable_store_error(config, user, &e)),
+        Err(facelock_store::StoreError::Absent { .. }) => return Ok(false),
+        Err(e) => return Err(unreadable_store_error(config, user, &anyhow::Error::new(e))),
     };
     match store.has_models(user) {
         Ok(v) => Ok(v),
@@ -293,7 +297,8 @@ mod tests {
         let db_path = dir.path().join("facelock.db");
         let config = config_with_db(&db_path);
 
-        // Absent (fresh): created empty on first touch.
+        // Absent (fresh): the StoreError::Absent variant, read as "not
+        // enrolled" without creating anything.
         assert!(!direct_user_has_models(&config, "alice").unwrap());
 
         // Open store, models for someone else only.
@@ -305,6 +310,21 @@ mod tests {
         }
         assert!(!direct_user_has_models(&config, "alice").unwrap());
         assert!(direct_user_has_models(&config, "bob").unwrap());
+    }
+
+    /// The `Absent` arm answers "not enrolled" as a *value*: the probe must
+    /// not manufacture the empty database the create-based `open_store` used
+    /// to leave behind.
+    #[test]
+    fn absent_store_probe_creates_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+
+        assert!(!direct_user_has_models(&config_with_db(&db_path), "alice").unwrap());
+        assert!(
+            !db_path.exists(),
+            "probing enrollment must not create the database it reports absent"
+        );
     }
 
     /// C7 branch 3: a present-but-unreadable store is an error and must not

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -19,7 +19,7 @@ use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::{PreCheckContext, pre_check_audited_with_context};
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
-use facelock_store::FaceStore;
+use facelock_store::{FaceStore, StoreError};
 use tracing::debug;
 
 /// Open the face database, applying the state-directory layout first.
@@ -40,6 +40,19 @@ pub fn open_store(config: &Config) -> anyhow::Result<FaceStore> {
     // `create`: first-time `enroll` legitimately brings the database into
     // being here.
     FaceStore::create(Path::new(&config.storage.db_path)).context("failed to open database")
+}
+
+/// Like [`open_store`], but never creates: [`StoreError::Absent`] comes back
+/// as a value instead of an empty database materializing at the path.
+///
+/// This is the constructor for guards and reporters — the call shapes that
+/// need "fresh install" and "cannot read" to be different answers. The typed
+/// error is the point: callers match `Absent` to proceed on "nothing
+/// enrolled" and treat every other class as "cannot tell", without sniffing
+/// message strings.
+pub fn open_store_existing(config: &Config) -> Result<FaceStore, StoreError> {
+    crate::state_layout::ensure_state_layout_best_effort(config);
+    FaceStore::open_existing(Path::new(&config.storage.db_path))
 }
 
 #[derive(Clone)]

--- a/crates/facelock-store/Cargo.toml
+++ b/crates/facelock-store/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 facelock-core = { path = "../facelock-core" }
 rusqlite = { version = "0.40", features = ["bundled"] }
 bytemuck = { version = "1", features = ["derive"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -4,18 +4,18 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::params;
 
-use facelock_core::error::{FacelockError, Result};
 use facelock_core::fs_security::ensure_mode;
 use facelock_core::types::{FaceEmbedding, FaceModelInfo};
 
+use crate::error::{Result, StoreError};
 use crate::migrations::run_migrations;
 
+#[derive(Debug)]
 pub struct FaceStore {
     conn: rusqlite::Connection,
-}
-
-fn map_err(e: rusqlite::Error) -> FacelockError {
-    FacelockError::Storage(e.to_string())
+    /// Where this store lives, kept so post-open failures can name the
+    /// database they failed on. `:memory:` for [`FaceStore::open_memory`].
+    path: PathBuf,
 }
 
 impl FaceStore {
@@ -29,10 +29,11 @@ impl FaceStore {
     /// a store of biometric templates. A missing database must be an error the
     /// caller sees.
     ///
-    /// Errors when the file is missing, unreadable, or not a SQLite database.
-    /// The error type does not yet distinguish those cases — use
-    /// [`FaceStore::database_exists`] first when the caller needs to tell
-    /// "fresh install" apart from "cannot read".
+    /// The error says why: [`StoreError::Absent`] for a missing file (a
+    /// fresh install a caller may legitimately proceed on),
+    /// [`StoreError::Denied`]/[`StoreError::Corrupt`]/[`StoreError::Busy`]
+    /// when the file is there but cannot be used — cases that must never be
+    /// read as "nothing enrolled".
     ///
     /// **Migrations do run.** Not creating and not migrating are separate
     /// concerns: a database that is *present* but on an older schema still has
@@ -41,14 +42,13 @@ impl FaceStore {
     /// under [`FaceStore::create`].
     pub fn open_existing(db_path: &Path) -> Result<Self> {
         // The flags below are what actually guarantee no file is created; this
-        // check only exists so the common case reports "no database" instead of
-        // SQLite's undifferentiated "unable to open database file".
-        if !Self::database_exists(db_path) {
-            return Err(FacelockError::Storage(format!(
-                "no database at {}",
-                db_path.display()
-            )));
-        }
+        // stat exists to classify the common failures precisely. ENOENT is the
+        // only evidence for `Absent`: a stat the filesystem *refuses* (e.g. an
+        // unsearchable parent directory) is `Denied`, because a bare
+        // `is_file()` there would report a possibly-present database as
+        // absent — which a destructive guard would read as "nothing to
+        // protect".
+        Self::stat_existing(db_path)?;
 
         let conn = rusqlite::Connection::open_with_flags(
             db_path,
@@ -56,11 +56,28 @@ impl FaceStore {
             // `file:` URI with query parameters.
             rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
-        .map_err(|e| {
-            FacelockError::Storage(format!("failed to open {}: {e}", db_path.display()))
-        })?;
+        .map_err(|e| StoreError::classify(db_path, e))?;
 
         Self::init(conn, db_path)
+    }
+
+    /// Classify what is at `db_path` before a no-create open: absent, a
+    /// non-file, or unstatable. `Ok(())` means a regular file is present.
+    fn stat_existing(db_path: &Path) -> Result<()> {
+        match std::fs::metadata(db_path) {
+            Ok(m) if m.is_file() => Ok(()),
+            Ok(_) => Err(StoreError::Corrupt {
+                path: db_path.to_path_buf(),
+                detail: "path exists but is not a regular file".into(),
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(StoreError::Absent {
+                path: db_path.to_path_buf(),
+            }),
+            Err(e) => Err(StoreError::Denied {
+                path: db_path.to_path_buf(),
+                detail: format!("cannot stat: {e}"),
+            }),
+        }
     }
 
     /// Create the database if absent, then open it read-write.
@@ -70,8 +87,11 @@ impl FaceStore {
     /// should use [`FaceStore::open_existing`] — see its docs for why creating
     /// as a side effect of reading strands a user's templates.
     pub fn create(db_path: &Path) -> Result<Self> {
-        // `Connection::open` implies SQLITE_OPEN_CREATE.
-        let conn = rusqlite::Connection::open(db_path).map_err(map_err)?;
+        // `Connection::open` implies SQLITE_OPEN_CREATE, so `Absent` cannot
+        // come back from this constructor — an uncreatable path (missing or
+        // unwritable parent) surfaces as `Denied`.
+        let conn =
+            rusqlite::Connection::open(db_path).map_err(|e| StoreError::classify(db_path, e))?;
         Self::init(conn, db_path)
     }
 
@@ -90,10 +110,10 @@ impl FaceStore {
 
     /// Whether a database file is present at this path.
     ///
-    /// A cheap `stat`, no connection opened and no schema inspected — enough to
-    /// tell "fresh install" from "cannot read" before calling
-    /// [`FaceStore::open_existing`], which cannot express that difference in
-    /// its error type today.
+    /// A cheap `stat`, no connection opened and no schema inspected. Note it
+    /// cannot distinguish "absent" from "unstatable": for any decision that
+    /// treats those differently, call [`FaceStore::open_existing`] and match
+    /// on [`StoreError::Absent`] vs [`StoreError::Denied`] instead.
     pub fn database_exists(db_path: &Path) -> bool {
         db_path.is_file()
     }
@@ -103,10 +123,13 @@ impl FaceStore {
     /// used to obtain `conn` differ between them.
     fn init(conn: rusqlite::Connection, db_path: &Path) -> Result<Self> {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-            .map_err(map_err)?;
+            .map_err(|e| StoreError::classify(db_path, e))?;
         run_migrations(&conn)?;
         secure_database_files(db_path)?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            path: db_path.to_path_buf(),
+        })
     }
 
     /// Open database in read-only mode for authentication queries.
@@ -116,23 +139,39 @@ impl FaceStore {
     /// so never brings a database into existence; it differs in giving up write
     /// access entirely, which is why it also cannot migrate.
     pub fn open_readonly(db_path: &Path) -> Result<Self> {
+        // Same stat classification as `open_existing`: a missing file is
+        // `Absent`, not an undifferentiated open failure.
+        Self::stat_existing(db_path)?;
         let conn = rusqlite::Connection::open_with_flags(
             db_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )
-        .map_err(map_err)?;
+        .map_err(|e| StoreError::classify(db_path, e))?;
         conn.execute_batch("PRAGMA foreign_keys=ON;")
-            .map_err(map_err)?;
-        Ok(Self { conn })
+            .map_err(|e| StoreError::classify(db_path, e))?;
+        Ok(Self {
+            conn,
+            path: db_path.to_path_buf(),
+        })
     }
 
     /// Open an in-memory database for testing.
     pub fn open_memory() -> Result<Self> {
-        let conn = rusqlite::Connection::open_in_memory().map_err(map_err)?;
+        let path = Path::new(":memory:");
+        let conn =
+            rusqlite::Connection::open_in_memory().map_err(|e| StoreError::classify(path, e))?;
         conn.execute_batch("PRAGMA foreign_keys=ON;")
-            .map_err(map_err)?;
+            .map_err(|e| StoreError::classify(path, e))?;
         run_migrations(&conn)?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Classify a rusqlite failure from this store's connection.
+    fn err(&self, e: rusqlite::Error) -> StoreError {
+        StoreError::classify(&self.path, e)
     }
 
     /// Add a face model with its embedding. Returns the new model ID.
@@ -159,7 +198,7 @@ impl FaceStore {
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        let tx = self.conn.unchecked_transaction().map_err(map_err)?;
+        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
 
         // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
         // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
@@ -173,7 +212,7 @@ impl FaceStore {
             "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![user, label, created_at, embedder_model, device_id],
         )
-        .map_err(map_err)?;
+        .map_err(|e| self.err(e))?;
 
         let model_id = tx.last_insert_rowid() as u32;
 
@@ -182,9 +221,9 @@ impl FaceStore {
             "INSERT INTO face_embeddings (model_id, embedding) VALUES (?1, ?2)",
             params![model_id, bytes],
         )
-        .map_err(map_err)?;
+        .map_err(|e| self.err(e))?;
 
-        tx.commit().map_err(map_err)?;
+        tx.commit().map_err(|e| self.err(e))?;
         Ok(model_id)
     }
 
@@ -197,7 +236,7 @@ impl FaceStore {
                 "INSERT INTO face_embeddings (model_id, embedding) VALUES (?1, ?2)",
                 params![model_id, bytes],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(())
     }
 
@@ -210,7 +249,7 @@ impl FaceStore {
                 "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (?1, ?2, ?3)",
                 params![model_id, data, sealed_int],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(())
     }
 
@@ -223,7 +262,7 @@ impl FaceStore {
                 "DELETE FROM face_models WHERE user = ?1 AND label = ?2",
                 params![user, label],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(affected > 0)
     }
 
@@ -237,7 +276,7 @@ impl FaceStore {
                  JOIN face_embeddings fe ON fe.model_id = fm.id
                  WHERE fm.user = ?1",
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map(params![user], |row| {
@@ -245,17 +284,22 @@ impl FaceStore {
                 let blob: Vec<u8> = row.get(1)?;
                 Ok((id, blob))
             })
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            let (id, blob) = row.map_err(map_err)?;
+            let (id, blob) = row.map_err(|e| self.err(e))?;
             if blob.len() != 512 * 4 {
-                return Err(FacelockError::Storage(format!(
-                    "invalid embedding blob size: expected {} bytes, got {}",
-                    512 * 4,
-                    blob.len()
-                )));
+                // Wrong-size template data is a corrupt store, not a failed
+                // query: the row exists but cannot mean what it must.
+                return Err(StoreError::Corrupt {
+                    path: self.path.clone(),
+                    detail: format!(
+                        "invalid embedding blob size: expected {} bytes, got {}",
+                        512 * 4,
+                        blob.len()
+                    ),
+                });
             }
             let floats: &[f32] = bytemuck::cast_slice(&blob);
             let mut embedding = [0f32; 512];
@@ -270,7 +314,7 @@ impl FaceStore {
         let mut stmt = self
             .conn
             .prepare("SELECT id, user, label, created_at, embedder_model, device_id FROM face_models WHERE user = ?1")
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map(params![user], |row| {
@@ -285,11 +329,11 @@ impl FaceStore {
                     device_id: row.get::<_, Option<String>>(5)?,
                 })
             })
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            results.push(row.map_err(map_err)?);
+            results.push(row.map_err(|e| self.err(e))?);
         }
         Ok(results)
     }
@@ -302,15 +346,15 @@ impl FaceStore {
         let mut stmt = self
             .conn
             .prepare("SELECT DISTINCT user FROM face_models ORDER BY user")
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map([], |row| row.get::<_, String>(0))
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            results.push(row.map_err(map_err)?);
+            results.push(row.map_err(|e| self.err(e))?);
         }
         Ok(results)
     }
@@ -324,7 +368,7 @@ impl FaceStore {
                 "DELETE FROM face_models WHERE id = ?1 AND user = ?2",
                 params![model_id, user],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(affected > 0)
     }
 
@@ -333,7 +377,7 @@ impl FaceStore {
         let affected = self
             .conn
             .execute("DELETE FROM face_models WHERE user = ?1", params![user])
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(affected as u32)
     }
 
@@ -351,7 +395,7 @@ impl FaceStore {
                  JOIN face_embeddings fe ON fe.model_id = fm.id
                  WHERE fm.user = ?1",
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map(params![user], |row| {
@@ -360,11 +404,11 @@ impl FaceStore {
                 let sealed: bool = row.get::<_, i64>(2)? != 0;
                 Ok((id, blob, sealed))
             })
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            results.push(row.map_err(map_err)?);
+            results.push(row.map_err(|e| self.err(e))?);
         }
         Ok(results)
     }
@@ -388,7 +432,7 @@ impl FaceStore {
                  JOIN face_embeddings fe ON fe.model_id = fm.id
                  WHERE fm.user = ?1",
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map(params![user], |row| {
@@ -398,11 +442,11 @@ impl FaceStore {
                 let device_id: Option<String> = row.get(3)?;
                 Ok((id, blob, sealed, device_id))
             })
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            results.push(row.map_err(map_err)?);
+            results.push(row.map_err(|e| self.err(e))?);
         }
         Ok(results)
     }
@@ -433,7 +477,7 @@ impl FaceStore {
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        let tx = self.conn.unchecked_transaction().map_err(map_err)?;
+        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
 
         // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
         // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
@@ -447,7 +491,7 @@ impl FaceStore {
             "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![user, label, created_at, embedder_model, device_id],
         )
-        .map_err(map_err)?;
+        .map_err(|e| self.err(e))?;
 
         let model_id = tx.last_insert_rowid() as u32;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
@@ -456,9 +500,9 @@ impl FaceStore {
             "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (?1, ?2, ?3)",
             params![model_id, data, sealed_int],
         )
-        .map_err(map_err)?;
+        .map_err(|e| self.err(e))?;
 
-        tx.commit().map_err(map_err)?;
+        tx.commit().map_err(|e| self.err(e))?;
         Ok(model_id)
     }
 
@@ -476,12 +520,13 @@ impl FaceStore {
                 "UPDATE face_embeddings SET embedding = ?1, sealed = ?2 WHERE id = ?3",
                 params![data, sealed_int, embedding_id],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         if affected == 0 {
-            return Err(FacelockError::Storage(format!(
-                "embedding ID {embedding_id} not found"
-            )));
+            return Err(StoreError::Query {
+                path: self.path.clone(),
+                detail: format!("embedding ID {embedding_id} not found"),
+            });
         }
         Ok(())
     }
@@ -496,7 +541,7 @@ impl FaceStore {
                 [],
                 |row| row.get(0),
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         let unsealed: u32 = self
             .conn
             .query_row(
@@ -504,7 +549,7 @@ impl FaceStore {
                 [],
                 |row| row.get(0),
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok((sealed, unsealed))
     }
 
@@ -519,7 +564,7 @@ impl FaceStore {
                  FROM face_embeddings fe
                  JOIN face_models fm ON fm.id = fe.model_id",
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let rows = stmt
             .query_map([], |row| {
@@ -529,11 +574,11 @@ impl FaceStore {
                 let sealed: bool = row.get::<_, i64>(3)? != 0;
                 Ok((id, user, blob, sealed))
             })
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
 
         let mut results = Vec::new();
         for row in rows {
-            results.push(row.map_err(map_err)?);
+            results.push(row.map_err(|e| self.err(e))?);
         }
         Ok(results)
     }
@@ -550,7 +595,7 @@ impl FaceStore {
                 "INSERT INTO rate_limit (user, attempt_time) VALUES (?1, ?2)",
                 params![user, now],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(())
     }
 
@@ -576,7 +621,7 @@ impl FaceStore {
                 params![user, cutoff],
                 |row| row.get(0),
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(count < max_attempts)
     }
 
@@ -593,7 +638,7 @@ impl FaceStore {
                 "DELETE FROM rate_limit WHERE attempt_time <= ?1",
                 params![cutoff],
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(())
     }
 
@@ -608,7 +653,7 @@ impl FaceStore {
         match result {
             Ok(model) => Ok(Some(model)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(map_err(e)),
+            Err(e) => Err(self.err(e)),
         }
     }
 
@@ -621,7 +666,7 @@ impl FaceStore {
                 params![user, embedder_model],
                 |row| row.get(0),
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(count > 0)
     }
 
@@ -634,7 +679,7 @@ impl FaceStore {
                 params![user],
                 |row| row.get(0),
             )
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(count > 0)
     }
 
@@ -643,7 +688,7 @@ impl FaceStore {
         let count: u32 = self
             .conn
             .query_row("SELECT COUNT(*) FROM face_models", [], |row| row.get(0))
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(count > 0)
     }
 
@@ -652,7 +697,7 @@ impl FaceStore {
         let affected = self
             .conn
             .execute("DELETE FROM face_models", [])
-            .map_err(map_err)?;
+            .map_err(|e| self.err(e))?;
         Ok(affected as u32)
     }
 }
@@ -663,11 +708,9 @@ fn secure_database_files(db_path: &Path) -> Result<()> {
         sqlite_sidecar_path(db_path, "-wal"),
         sqlite_sidecar_path(db_path, "-shm"),
     ] {
-        ensure_mode(&path, 0o600).map_err(|e| {
-            FacelockError::Storage(format!(
-                "failed to secure database file {}: {e}",
-                path.display()
-            ))
+        ensure_mode(&path, 0o600).map_err(|e| StoreError::Denied {
+            detail: format!("failed to secure database file: {e}"),
+            path: path.clone(),
         })?;
     }
 
@@ -1327,6 +1370,117 @@ mod tests {
         let dir = tmp.path().join("subdir");
         std::fs::create_dir(&dir).unwrap();
         assert!(!FaceStore::database_exists(&dir));
+    }
+
+    /// Whether the test process would bypass the permission checks some of
+    /// the `Denied` tests rely on (root ignores file modes).
+    #[cfg(unix)]
+    fn running_as_root() -> bool {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata("/proc/self")
+            .map(|m| m.uid() == 0)
+            .unwrap_or(false)
+    }
+
+    /// The failure classes as they arise from a real filesystem: a missing
+    /// file is `Absent` — a *state*, carrying the path a caller may then
+    /// legitimately create at — never an undifferentiated error.
+    #[test]
+    fn missing_file_is_absent_with_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("facelock.db");
+
+        match FaceStore::open_existing(&missing).unwrap_err() {
+            StoreError::Absent { path } => assert_eq!(path, missing),
+            other => panic!("a missing database must classify as Absent, got {other:?}"),
+        }
+        match FaceStore::open_readonly(&missing).unwrap_err() {
+            StoreError::Absent { path } => assert_eq!(path, missing),
+            other => panic!("open_readonly must agree on Absent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn garbage_file_is_corrupt_not_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("facelock.db");
+        std::fs::write(&db, b"this is not a sqlite database").unwrap();
+
+        let err = FaceStore::open_existing(&db).unwrap_err();
+        assert!(matches!(err, StoreError::Corrupt { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn directory_at_path_is_corrupt_not_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("subdir");
+        std::fs::create_dir(&dir).unwrap();
+
+        let err = FaceStore::open_existing(&dir).unwrap_err();
+        assert!(matches!(err, StoreError::Corrupt { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn locked_database_is_busy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("facelock.db");
+
+        // A rollback-journal database (NOT the WAL mode FaceStore sets up),
+        // so BEGIN EXCLUSIVE really excludes readers.
+        let holder = rusqlite::Connection::open(&db).unwrap();
+        holder
+            .execute_batch("CREATE TABLE t(x); BEGIN EXCLUSIVE;")
+            .unwrap();
+
+        let err = FaceStore::open_existing(&db).unwrap_err();
+        assert!(matches!(err, StoreError::Busy { .. }), "got {err:?}");
+        drop(holder);
+    }
+
+    /// The distinction the type exists for: a database facelock cannot even
+    /// stat must read as `Denied` — "cannot tell" — never as `Absent`, which
+    /// a destructive guard is entitled to treat as "nothing to protect".
+    #[cfg(unix)]
+    #[test]
+    fn unstatable_path_is_denied_not_absent() {
+        use std::os::unix::fs::PermissionsExt;
+        if running_as_root() {
+            return; // root bypasses the permission bits this test relies on
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("locked");
+        std::fs::create_dir(&parent).unwrap();
+        let db = parent.join("facelock.db");
+        drop(FaceStore::create(&db).unwrap());
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0)).unwrap();
+
+        let result = FaceStore::open_existing(&db);
+        // Restore before asserting so the tempdir can clean up on failure.
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, StoreError::Denied { .. }),
+            "an unstatable database must be Denied, never Absent: {err:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_file_is_denied_not_absent() {
+        use std::os::unix::fs::PermissionsExt;
+        if running_as_root() {
+            return; // root bypasses the permission bits this test relies on
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("facelock.db");
+        drop(FaceStore::create(&db).unwrap());
+        std::fs::set_permissions(&db, std::fs::Permissions::from_mode(0)).unwrap();
+
+        let err = FaceStore::open_existing(&db).unwrap_err();
+        assert!(matches!(err, StoreError::Denied { .. }), "got {err:?}");
     }
 
     #[test]

--- a/crates/facelock-store/src/error.rs
+++ b/crates/facelock-store/src/error.rs
@@ -1,0 +1,177 @@
+use std::path::{Path, PathBuf};
+
+/// Result alias for this crate's own API.
+///
+/// `facelock-store` deliberately does not use `facelock_core::error::Result`
+/// for its public surface: the store owns the truth about *why* it failed, and
+/// keeping the error type local means new failure classes never require
+/// editing a crate everything depends on. Callers that still funnel into
+/// `FacelockError` get the `From` impl below.
+pub type Result<T, E = StoreError> = std::result::Result<T, E>;
+
+/// Why the store could not answer.
+///
+/// The variants are the failure classes callers actually branch on — a guard
+/// asking "may I destroy data?" treats [`StoreError::Absent`] (nothing to
+/// lose) very differently from [`StoreError::Denied`] (cannot tell), and
+/// collapsing them into one string is what historically made destructive
+/// paths fail open. Every variant carries the database path and enough detail
+/// to render a precise message on its own.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// No database file exists at the path. A fresh install, not a fault:
+    /// "absent" is a state a caller may legitimately proceed on. Never
+    /// returned by [`crate::FaceStore::create`].
+    #[error("no database at {path}")]
+    Absent { path: PathBuf },
+
+    /// The path or file exists but cannot be accessed: permissions, a
+    /// read-only filesystem, an unstatable parent directory. Unlike
+    /// [`StoreError::Absent`], nothing can be concluded about what the
+    /// database contains.
+    #[error("cannot access database {path}: {detail}")]
+    Denied { path: PathBuf, detail: String },
+
+    /// Locked by another connection. Transient; retrying can succeed.
+    #[error("database {path} is locked by another process: {detail}")]
+    Busy { path: PathBuf, detail: String },
+
+    /// Present but not usable as a database: not SQLite at all, or its
+    /// internal structure is broken.
+    #[error("database {path} is corrupt or not a database: {detail}")]
+    Corrupt { path: PathBuf, detail: String },
+
+    /// The schema could not be brought forward to the current version.
+    #[error("database {path} schema migration failed: {detail}")]
+    Migration { path: PathBuf, detail: String },
+
+    /// Any other failed operation on an open database — the residual class
+    /// for failures no caller policy distinguishes.
+    #[error("database {path}: {detail}")]
+    Query { path: PathBuf, detail: String },
+}
+
+impl StoreError {
+    /// Classify a rusqlite failure by its SQLite result code.
+    ///
+    /// The codes rusqlite surfaces already distinguish exactly what callers
+    /// need: `SQLITE_NOTADB`/`CORRUPT` ⇒ corrupt, `SQLITE_BUSY`/`LOCKED` ⇒
+    /// locked, `SQLITE_CANTOPEN`/`PERM`/`READONLY` ⇒ inaccessible. `CANTOPEN`
+    /// maps to `Denied` rather than `Absent` on purpose: by the time SQLite
+    /// reports it the file's existence was already checked, so a `CANTOPEN`
+    /// (including the stat-then-open race) reads as "cannot tell", the
+    /// fail-closed direction for guards.
+    pub(crate) fn classify(path: &Path, e: rusqlite::Error) -> Self {
+        use rusqlite::ErrorCode;
+
+        let code = match &e {
+            rusqlite::Error::SqliteFailure(err, _) => Some(err.code),
+            _ => None,
+        };
+        let path = path.to_path_buf();
+        let detail = e.to_string();
+        match code {
+            Some(ErrorCode::NotADatabase) | Some(ErrorCode::DatabaseCorrupt) => {
+                Self::Corrupt { path, detail }
+            }
+            Some(ErrorCode::DatabaseBusy) | Some(ErrorCode::DatabaseLocked) => {
+                Self::Busy { path, detail }
+            }
+            Some(ErrorCode::CannotOpen)
+            | Some(ErrorCode::PermissionDenied)
+            | Some(ErrorCode::ReadOnly) => Self::Denied { path, detail },
+            _ => Self::Query { path, detail },
+        }
+    }
+}
+
+/// Compatibility path into the core error type. Preserves the full rendered
+/// message, so callers that only display the error lose nothing — but the
+/// class is erased, so code that needs to *branch* on failure class must take
+/// `StoreError` before this conversion happens.
+impl From<StoreError> for facelock_core::error::FacelockError {
+    fn from(e: StoreError) -> Self {
+        facelock_core::error::FacelockError::Storage(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sqlite_error(code: std::os::raw::c_int) -> rusqlite::Error {
+        rusqlite::Error::SqliteFailure(rusqlite::ffi::Error::new(code), Some("detail".into()))
+    }
+
+    #[test]
+    fn classify_maps_sqlite_codes_to_failure_classes() {
+        let path = Path::new("/var/lib/facelock/facelock.db");
+        let cases: &[(std::os::raw::c_int, fn(&StoreError) -> bool)] = &[
+            (rusqlite::ffi::SQLITE_NOTADB, |e| {
+                matches!(e, StoreError::Corrupt { .. })
+            }),
+            (rusqlite::ffi::SQLITE_CORRUPT, |e| {
+                matches!(e, StoreError::Corrupt { .. })
+            }),
+            (rusqlite::ffi::SQLITE_BUSY, |e| {
+                matches!(e, StoreError::Busy { .. })
+            }),
+            (rusqlite::ffi::SQLITE_LOCKED, |e| {
+                matches!(e, StoreError::Busy { .. })
+            }),
+            (rusqlite::ffi::SQLITE_CANTOPEN, |e| {
+                matches!(e, StoreError::Denied { .. })
+            }),
+            (rusqlite::ffi::SQLITE_PERM, |e| {
+                matches!(e, StoreError::Denied { .. })
+            }),
+            (rusqlite::ffi::SQLITE_READONLY, |e| {
+                matches!(e, StoreError::Denied { .. })
+            }),
+            (rusqlite::ffi::SQLITE_CONSTRAINT, |e| {
+                matches!(e, StoreError::Query { .. })
+            }),
+            (rusqlite::ffi::SQLITE_IOERR, |e| {
+                matches!(e, StoreError::Query { .. })
+            }),
+        ];
+        for (code, is_expected) in cases {
+            let classified = StoreError::classify(path, sqlite_error(*code));
+            assert!(
+                is_expected(&classified),
+                "SQLite code {code} classified as {classified:?}"
+            );
+        }
+    }
+
+    /// Extended codes (e.g. `SQLITE_READONLY_CANTINIT`, `SQLITE_CANTOPEN_*`)
+    /// carry their primary code in rusqlite's `ErrorCode`, so the mapping
+    /// above covers them without enumerating each one.
+    #[test]
+    fn classify_handles_extended_codes_via_primary() {
+        let path = Path::new("/tmp/x.db");
+        let e = StoreError::classify(path, sqlite_error(rusqlite::ffi::SQLITE_CANTOPEN_ISDIR));
+        assert!(matches!(e, StoreError::Denied { .. }), "got {e:?}");
+    }
+
+    #[test]
+    fn classify_preserves_path_and_detail_in_message() {
+        let path = Path::new("/var/lib/facelock/facelock.db");
+        let e = StoreError::classify(path, sqlite_error(rusqlite::ffi::SQLITE_BUSY));
+        let msg = e.to_string();
+        assert!(msg.contains("/var/lib/facelock/facelock.db"), "{msg}");
+        assert!(msg.contains("detail"), "{msg}");
+    }
+
+    /// The compatibility conversion may erase the class, never the message.
+    #[test]
+    fn from_store_error_preserves_full_message() {
+        let e = StoreError::Denied {
+            path: PathBuf::from("/var/lib/facelock/facelock.db"),
+            detail: "permission denied".into(),
+        };
+        let rendered = e.to_string();
+        let core: facelock_core::error::FacelockError = e.into();
+        assert!(core.to_string().contains(&rendered), "{core}");
+    }
+}

--- a/crates/facelock-store/src/lib.rs
+++ b/crates/facelock-store/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod db;
+pub mod error;
 pub mod migrations;
 
 pub use db::FaceStore;
+pub use error::{Result, StoreError};

--- a/crates/facelock-store/src/migrations.rs
+++ b/crates/facelock-store/src/migrations.rs
@@ -1,4 +1,21 @@
-use facelock_core::error::{FacelockError, Result};
+use std::path::PathBuf;
+
+use crate::error::{Result, StoreError};
+
+/// Any failure while bringing the schema forward is a
+/// [`StoreError::Migration`]: whatever the underlying SQLite code, the
+/// database is on a schema this build cannot use, and no caller policy
+/// distinguishes further.
+fn migration_err(conn: &rusqlite::Connection, e: rusqlite::Error) -> StoreError {
+    let path = match conn.path() {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => PathBuf::from(":memory:"),
+    };
+    StoreError::Migration {
+        path,
+        detail: e.to_string(),
+    }
+}
 
 pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
     // V1: initial schema
@@ -15,7 +32,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_face_models_user ON face_models(user);
     ",
     )
-    .map_err(|e| FacelockError::Storage(e.to_string()))?;
+    .map_err(|e| migration_err(conn, e))?;
 
     // Check current schema version
     let version: i64 = conn
@@ -24,7 +41,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             [],
             |row| row.get(0),
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
 
     if version < 2 {
         // V2: face_embeddings allows multiple embeddings per model (no UNIQUE on model_id)
@@ -41,7 +58,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             INSERT OR REPLACE INTO schema_version (version) VALUES (2);
         ",
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
     }
 
     if version < 3 {
@@ -52,7 +69,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             INSERT OR REPLACE INTO schema_version (version) VALUES (3);
         ",
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
     }
 
     if version < 4 {
@@ -69,7 +86,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             INSERT OR REPLACE INTO schema_version (version) VALUES (4);
         ",
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
     }
 
     if version < 5 {
@@ -81,7 +98,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             INSERT OR REPLACE INTO schema_version (version) VALUES (5);
         ",
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
     }
 
     if version < 6 {
@@ -95,7 +112,7 @@ pub fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
             INSERT OR REPLACE INTO schema_version (version) VALUES (6);
         ",
         )
-        .map_err(|e| FacelockError::Storage(e.to_string()))?;
+        .map_err(|e| migration_err(conn, e))?;
     }
 
     Ok(())


### PR DESCRIPTION
Wave 3, PR H1 — the Store domain (gap D2, closing the type half of D3). Base: `integration/wave-2`.

## What this is

`facelock-store` could not say *why* it failed: every failure was collapsed at one line (`db.rs:17-19`, `fn map_err(e) -> FacelockError { FacelockError::Storage(e.to_string()) }`) into a stringly core-crate variant that is matched on zero times anywhere. Wave 2 (#113) fixed the *policies* behaviorally — guards fail closed, reporters propagate — but had to encode them with booleans, message strings, and a create-based open that could never observe "absent" (it papered over absence by materializing an empty database). This PR gives those policies the type they need so they can't regress. **Representational, not behavioral**: no auth-semantics change, no D-Bus wire change, `pam-facelock` untouched (it never links the store).

## The variant set

`StoreError` lives **in `facelock-store`** (`crates/facelock-store/src/error.rs`) — the store adds failure classes without editing the crate everything depends on. The crate's public API now returns `Result<T, StoreError>`; it no longer uses `facelock_core::error::Result`.

| Variant | Maps from | Meaning |
|---|---|---|
| `Absent { path }` | `ENOENT` on the pre-open stat (`open_existing` / `open_readonly`) | A fresh install — a *state* a caller may legitimately proceed on. Never returned by `create`. |
| `Denied { path, detail }` | `SQLITE_CANTOPEN`, `SQLITE_PERM`, `SQLITE_READONLY` (extended codes incl. `READONLY_CANTINIT` fold into their primary); any non-ENOENT stat error; a failed `chmod 600` on db/WAL/SHM | Present but inaccessible — "cannot tell", nothing may be concluded about contents |
| `Busy { path, detail }` | `SQLITE_BUSY`, `SQLITE_LOCKED` | Locked by another connection; transient |
| `Corrupt { path, detail }` | `SQLITE_NOTADB`, `SQLITE_CORRUPT`; a non-regular-file at the path; wrong-size template blobs | Present but not usable as a database |
| `Migration { path, detail }` | any failure inside `run_migrations` | Schema can't be brought forward |
| `Query { path, detail }` | everything else (constraints, I/O errors, not-found rows) | Residual class no caller policy distinguishes |

One `classify()` replaces `map_err`. A deliberate refinement over a bare `is_file()` check: **only ENOENT is evidence for `Absent`** — an unstatable path (e.g. unsearchable parent dir) is `Denied`, because a guard reading "cannot stat" as "absent" would be a fail-open. `SQLITE_CANTOPEN` also maps to `Denied`, not `Absent`: by the time SQLite reports it, existence was already checked, so it covers the stat-then-open race in the fail-closed direction.

`From<StoreError> for FacelockError` preserves the full rendered message, so **zero call sites needed edits to compile** — the workspace built unmodified after the retype. `database_exists` stays (its doc now points callers who need absent-vs-unstatable at the variants).

## Per-call-site policy (variant → behavior)

New `direct::open_store_existing(config) -> Result<FaceStore, StoreError>` (same layout hook as `open_store`, never creates) serves the sites below. `open_store` (create-based) remains for the flows that legitimately create: `direct::enroll`, direct/oneshot auth (the SQLite-backed rate limiter must be able to bring its storage into being — per #113, switching auth to `open_existing` would change auth-path behavior).

| Site | Shape | `Absent` | `Denied`/`Corrupt`/`Busy`/`Migration`/`Query` |
|---|---|---|---|
| `setup.rs` pre-keygen orphan guard (C2) | guard | **proceed** — no database file ⇒ provably nothing to orphan (and the probe no longer creates an empty DB to find that out) | **bail** — "refusing to generate a new encryption key…" (unchanged wording) |
| `test_cmd.rs` `direct_user_has_models` (C7) | reporter | "no models enrolled" (truthful, nothing created) | marker-aware error ("you appear to have N enrolled model(s), but…"), never "no models" |
| `test_cmd.rs` stale-embedder recheck | reporter | store proved present one query ago ⇒ unreachable; if it vanished mid-command, error instead of re-creating | propagate |
| `clear.rs` `direct_user_has_models` (C4) | reporter | "no models enrolled", exit 0 — without the old root-created empty DB side effect | propagate (never assume-yes, never "no models") |
| `clear.rs` delete path | actor | error (DB vanished after the probe) instead of re-creating an empty DB to delete from | propagate |
| `enroll.rs` `direct_has_stale_embedder` + `list_user_models`/`next_label` (C4) | reporters | "no models / first label" — enrollment *proper* remains the flow that creates the DB | propagate |
| `handler.rs` `handle_authenticate` (C3) | reporter | n/a (daemon holds an open store) | unchanged propagation; wire message loses the old `storage error: storage error: …` double prefix and now names class+path |

Behavioral deltas, all edge-case side effects and all in the safe direction (stated per the task's D3 requirement): (1) read-shaped probes no longer create an empty database at the path; (2) the orphan guard on a *missing parent directory* now proceeds (nothing can exist to orphan) where it previously bailed on the incidental create failure — with an unreadable/unstatable path it still bails.

## Proof the #113 pins hold

All pass with **assertions untouched**: `orphan_guard_tests::{unreadable_database_aborts_before_keygen, failing_models_query_on_open_store_aborts_before_keygen, zero_models_proceeds, models_present_non_interactive_bails_with_orphan_message}`, `test_cmd::tests::{absent_store_and_zero_models_read_as_not_enrolled, unreadable_store_is_an_error_not_no_models, unreadable_store_error_reports_marker_count, unreadable_store_for_other_user_degrades_to_plain_error}`, `clear::tests::*` (7), `enroll::tests::{next_label_propagates_store_failure, next_label_counts_existing_labels}`, and the C3 counter-unchanged test `authenticate_storage_failure_is_error_and_charges_no_rate_limit`. One justified non-assertion edit: a code comment inside `absent_store_and_zero_models_read_as_not_enrolled` said "created empty on first touch" — that side effect is deliberately gone, so the comment now describes the `Absent` value; the assertions are byte-identical.

New tests: store-level classification (`classify` code table incl. extended codes; `missing_file_is_absent_with_path`, `garbage_file_is_corrupt_not_absent`, `directory_at_path_is_corrupt_not_absent`, `locked_database_is_busy`, `unstatable_path_is_denied_not_absent`, `unreadable_file_is_denied_not_absent` — the last two skip under root, which bypasses permission bits); policy-level Absent ≠ Denied at the guard (`absent_database_proceeds_without_creating_one`) and reporters (`absent_store_probe_creates_nothing`, `direct_absent_store_reads_as_no_models_without_creating`, `absent_store_reads_as_no_models_without_creating`, `stale_embedder_check_propagates_unreadable_store`).

## Churn

13 files, +605/−123. Of that, `facelock-store` itself is +449/−97 (mostly tests and docs); the call-site commit is +156/−26 across 6 files. Compile-compatibility churn outside the store: **zero lines** (the `From` impl absorbed it).

## Gates

`just check` (test, clippy `-D warnings`, fmt-check, audit) — exit 0. Container tiers deliberately **not** run here (shared podman tag; orchestrator runs them centrally before this leaves draft).

## Cross-PR notes

- The conformance-tests agent (facelock-core / pam-facelock / EnvFilter sites): nothing here touches those files. If a conformance test asserts on store-failure *message text* over D-Bus, note the daemon's storage error messages changed shape: `storage error: <class-specific message incl. path>` instead of `storage error: storage error: <detail>`.
- P2-3 (`EnrollmentReport` / `DestructiveGuard` wrapper types) intentionally not built here — this PR provides the `StoreError` they consume; the guard/reporter split currently lives as per-site matches.
- `direct.rs` now has two store constructors; the future `FacelockBackend` trait (P2-5) should absorb both.

## Docs to reconcile

- `AGENTS.md` dependency table updated in-PR (`facelock-store` + thiserror); `CLAUDE.md` is a symlink, covered.
- `docs/contracts.md` / `book/src/contracts.md`: no store error contract is documented there today; nothing to update (binary names, paths, config keys, schema, auth semantics unchanged).
- `is_enrolled.rs` module doc extended to also forbid the new `open_store_existing` on the lock-screen hot path.

## Plan errata found

- `domain-object-map.md` §3 cites `maintenance.rs:36-39` as precedent — that file was deleted in Wave 1; the reasoning now lives in `FaceStore::open_existing`'s doc comment.
- The map's `Migration(..)`/`Query(..)` tuple sketch became struct variants carrying `path` — every variant can render a precise message without caller context.
- `architecture-remediation.md` §P2-2 says "keep `impl From<StoreError> for FacelockError` so nothing downstream breaks" — confirmed accurate; it was sufficient for the entire workspace.
- §P2-1's claim that `status`/`tpm` want `open_existing`: they use `open_readonly`, which now also returns `Absent`/`Denied`/… (same stat classification), so the claim is satisfied without changing those call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
