### PR TITLE
refactor(config): parse once, resolve explicitly (D7)

### DIFF
--- a/crates/facelock-cli/src/commands/audit.rs
+++ b/crates/facelock-cli/src/commands/audit.rs
@@ -9,7 +9,6 @@ pub fn run(config: &Config, tail: bool, lines: usize) -> Result<()> {
     // hard-errors rather than offering the usual sudo re-exec prompt.
     crate::ipc_client::require_root_scripted("sudo facelock audit")?;
 
-
     if !config.audit.enabled {
         println!("Audit logging is not enabled.");
         println!("Enable it in config:");

--- a/crates/facelock-cli/src/commands/audit.rs
+++ b/crates/facelock-cli/src/commands/audit.rs
@@ -4,12 +4,11 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use facelock_core::config::Config;
 
-pub fn run(tail: bool, lines: usize) -> Result<()> {
+pub fn run(config: &Config, tail: bool, lines: usize) -> Result<()> {
     // DEC-6: `audit` is typically invoked scripted/non-interactively, so it
     // hard-errors rather than offering the usual sudo re-exec prompt.
     crate::ipc_client::require_root_scripted("sudo facelock audit")?;
 
-    let config = Config::load()?;
 
     if !config.audit.enabled {
         println!("Audit logging is not enabled.");

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -17,6 +17,8 @@ use facelock_store::FaceStore;
 use tracing::{debug, error, info};
 
 pub fn run(user: String, config_path: Option<String>) -> i32 {
+    // Deliberate parse (D7): `facelock auth` is its own one-shot process
+    // spawned by PAM, so this is its top-of-process read — not a re-read.
     let config = match config_path {
         Some(ref p) => Config::load_from(Path::new(p)),
         None => Config::load(),

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -206,7 +206,6 @@ fn cmd_warm_auth(config: &Config) -> Result<()> {
 }
 
 fn cmd_preview(config: &Config) -> Result<()> {
-
     println!("=== Preview Frame Benchmark ===");
     println!(
         "Measuring: frame capture + face detection ({} iterations)",
@@ -263,7 +262,6 @@ fn cmd_preview(config: &Config) -> Result<()> {
 }
 
 fn cmd_enrollment(config: &Config) -> Result<()> {
-
     println!("=== Enrollment Benchmark ===");
     println!(
         "Measuring: time to capture and embed {} snapshots",
@@ -310,7 +308,6 @@ fn cmd_enrollment(config: &Config) -> Result<()> {
 }
 
 fn cmd_model_load(config: &Config) -> Result<()> {
-
     println!("=== Model Load Benchmark ===");
     println!("Measuring: ONNX model load time (SCRFD + ArcFace)");
     println!();

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -46,28 +46,21 @@ pub enum BenchCommand {
     Report,
 }
 
-pub fn run(command: BenchCommand) -> Result<()> {
+pub fn run(config: &Config, command: BenchCommand) -> Result<()> {
     // DEC-6: `bench` is root by default (direct-mode access needs the 0600
     // root:root database regardless of subcommand, and auth benchmarks may
     // need TPM access besides). Supersedes the old TPM-only conditional check.
     crate::ipc_client::require_root("sudo facelock bench <subcommand>")?;
 
     match command {
-        BenchCommand::ColdAuth => cmd_cold_auth(),
-        BenchCommand::WarmAuth => cmd_warm_auth(),
-        BenchCommand::Preview => cmd_preview(),
-        BenchCommand::Enrollment => cmd_enrollment(),
-        BenchCommand::ModelLoad => cmd_model_load(),
-        BenchCommand::Calibrate => cmd_calibrate(),
-        BenchCommand::Report => cmd_report(),
+        BenchCommand::ColdAuth => cmd_cold_auth(config),
+        BenchCommand::WarmAuth => cmd_warm_auth(config),
+        BenchCommand::Preview => cmd_preview(config),
+        BenchCommand::Enrollment => cmd_enrollment(config),
+        BenchCommand::ModelLoad => cmd_model_load(config),
+        BenchCommand::Calibrate => cmd_calibrate(config),
+        BenchCommand::Report => cmd_report(config),
     }
-}
-
-/// Load config, returning a helpful error if it fails.
-fn load_config() -> Result<Config> {
-    Config::load().context(
-        "Failed to load config. Set FACELOCK_CONFIG env var or ensure /etc/facelock/config.toml exists.",
-    )
 }
 
 /// Resolve the model directory from config.
@@ -90,8 +83,7 @@ fn load_engine(config: &Config) -> Result<FaceEngine> {
 // Subcommand implementations
 // ---------------------------------------------------------------------------
 
-fn cmd_cold_auth() -> Result<()> {
-    let config = load_config()?;
+fn cmd_cold_auth(config: &Config) -> Result<()> {
     let user = current_user();
 
     println!("=== Cold Auth Benchmark ===");
@@ -101,16 +93,16 @@ fn cmd_cold_auth() -> Result<()> {
     let start = Instant::now();
 
     // Load models (cold)
-    let mut engine = load_engine(&config)?;
+    let mut engine = load_engine(config)?;
 
     // Open camera
-    let mut camera = open_camera(&config)?;
+    let mut camera = open_camera(config)?;
 
     // Open store
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
+    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -156,8 +148,7 @@ fn cmd_cold_auth() -> Result<()> {
     Ok(())
 }
 
-fn cmd_warm_auth() -> Result<()> {
-    let config = load_config()?;
+fn cmd_warm_auth(config: &Config) -> Result<()> {
     let user = current_user();
 
     println!("=== Warm Auth Benchmark ===");
@@ -168,12 +159,12 @@ fn cmd_warm_auth() -> Result<()> {
     println!();
 
     // Pre-load everything
-    let mut engine = load_engine(&config)?;
-    let mut camera = open_camera(&config)?;
+    let mut engine = load_engine(config)?;
+    let mut camera = open_camera(config)?;
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
+    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -214,8 +205,7 @@ fn cmd_warm_auth() -> Result<()> {
     Ok(())
 }
 
-fn cmd_preview() -> Result<()> {
-    let config = load_config()?;
+fn cmd_preview(config: &Config) -> Result<()> {
 
     println!("=== Preview Frame Benchmark ===");
     println!(
@@ -224,8 +214,8 @@ fn cmd_preview() -> Result<()> {
     );
     println!();
 
-    let mut engine = load_engine(&config)?;
-    let mut camera = open_camera(&config)?;
+    let mut engine = load_engine(config)?;
+    let mut camera = open_camera(config)?;
 
     // Warm up
     let _ = camera.capture();
@@ -272,8 +262,7 @@ fn cmd_preview() -> Result<()> {
     Ok(())
 }
 
-fn cmd_enrollment() -> Result<()> {
-    let config = load_config()?;
+fn cmd_enrollment(config: &Config) -> Result<()> {
 
     println!("=== Enrollment Benchmark ===");
     println!(
@@ -283,8 +272,8 @@ fn cmd_enrollment() -> Result<()> {
     println!("NOTE: embeddings are NOT stored (dry run)");
     println!();
 
-    let mut engine = load_engine(&config)?;
-    let mut camera = open_camera(&config)?;
+    let mut engine = load_engine(config)?;
+    let mut camera = open_camera(config)?;
 
     // Warm up
     let _ = camera.capture();
@@ -320,8 +309,7 @@ fn cmd_enrollment() -> Result<()> {
     Ok(())
 }
 
-fn cmd_model_load() -> Result<()> {
-    let config = load_config()?;
+fn cmd_model_load(config: &Config) -> Result<()> {
 
     println!("=== Model Load Benchmark ===");
     println!("Measuring: ONNX model load time (SCRFD + ArcFace)");
@@ -332,7 +320,7 @@ fn cmd_model_load() -> Result<()> {
 
     for i in 0..iterations {
         let start = Instant::now();
-        let _engine = load_engine(&config)?;
+        let _engine = load_engine(config)?;
         let elapsed_ms = start.elapsed().as_millis() as u64;
         times.push(elapsed_ms);
         info!(iteration = i + 1, elapsed_ms, "model load iteration");
@@ -352,20 +340,19 @@ fn cmd_model_load() -> Result<()> {
     Ok(())
 }
 
-fn cmd_calibrate() -> Result<()> {
-    let config = load_config()?;
+fn cmd_calibrate(config: &Config) -> Result<()> {
     let user = current_user();
 
     println!("=== Threshold Calibration ===");
     println!("Sweeping recognition.threshold from 0.20 to 0.80 (step 0.05)");
     println!();
 
-    let mut engine = load_engine(&config)?;
-    let mut camera = open_camera(&config)?;
+    let mut engine = load_engine(config)?;
+    let mut camera = open_camera(config)?;
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let enrolled = direct::load_user_embeddings(&store, &config, &user)?;
+    let enrolled = direct::load_user_embeddings(&store, config, &user)?;
     if enrolled.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -471,7 +458,7 @@ fn cmd_calibrate() -> Result<()> {
         let mut sweep_config = config.recognition.clone();
         sweep_config.detection_confidence = confidence;
 
-        match FaceEngine::load(&sweep_config, model_dir(&config)) {
+        match FaceEngine::load(&sweep_config, model_dir(config)) {
             Ok(mut sweep_engine) => match sweep_engine.process(&frame) {
                 Ok(faces) => {
                     println!("{:<12.2} {:<15}", confidence, faces.len());
@@ -491,8 +478,7 @@ fn cmd_calibrate() -> Result<()> {
     Ok(())
 }
 
-fn cmd_report() -> Result<()> {
-    let config = load_config()?;
+fn cmd_report(config: &Config) -> Result<()> {
     let user = current_user();
 
     // Gather system info
@@ -518,13 +504,13 @@ fn cmd_report() -> Result<()> {
     // Model load benchmark
     let model_load_ms = {
         let start = Instant::now();
-        let _engine = load_engine(&config)?;
+        let _engine = load_engine(config)?;
         start.elapsed().as_millis() as u64
     };
 
     // Open camera for subsequent benchmarks
-    let mut engine = load_engine(&config)?;
-    let mut camera = open_camera(&config)?;
+    let mut engine = load_engine(config)?;
+    let mut camera = open_camera(config)?;
 
     // Warm up
     let _ = camera.capture();
@@ -544,7 +530,7 @@ fn cmd_report() -> Result<()> {
     // Warm auth benchmark
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
-    let embeddings = direct::load_user_embeddings(&store, &config, &user)?;
+    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
     let has_enrolled = !embeddings.is_empty();
 
     let warm_auth_ms = if has_enrolled {
@@ -564,7 +550,7 @@ fn cmd_report() -> Result<()> {
     // Cold auth (approximate: model load + one auth)
     let cold_auth_ms = if has_enrolled {
         let start = Instant::now();
-        let mut cold_engine = load_engine(&config)?;
+        let mut cold_engine = load_engine(config)?;
         let frame = camera.capture().context("Failed to capture frame")?;
         let faces = cold_engine.process(&frame)?;
         let _matched = find_best_match(&faces, &embeddings, config.recognition.threshold);

--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
@@ -6,20 +5,19 @@ use facelock_store::StoreError;
 
 use crate::ipc_client;
 
-pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
+pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<()> {
     // ClearModels is root-only on the daemon side too, so demand root up front.
     // Otherwise the user gets prompted Y/N first and only then hits AccessDenied.
     ipc_client::require_root("sudo facelock clear")?;
 
-    let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
     // Check if user has any models before prompting. One failure policy (C4,
     // issue #105): a failed check propagates. The old D-Bus branch folded any
     // failure into "no models enrolled" and exited 0 having deleted nothing,
     // while the direct branch on the identical failure proceeded to delete.
-    let has_models = if ipc_client::should_use_direct(&config) {
-        direct_user_has_models(&config, &user)?
+    let has_models = if ipc_client::should_use_direct(config) {
+        direct_user_has_models(config, &user)?
     } else {
         let request = DaemonRequest::ListModels { user: user.clone() };
         daemon_user_has_models(ipc_client::send_request(&request))?
@@ -37,17 +35,17 @@ pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
         }
     }
 
-    if ipc_client::should_use_direct(&config) {
+    if ipc_client::should_use_direct(config) {
         // `open_store_existing`: has_models above just proved the database is
         // there. If it vanished since, deleting has nothing to do — erroring
         // beats re-creating an empty database in its place.
-        let store = crate::direct::open_store_existing(&config)?;
+        let store = crate::direct::open_store_existing(config)?;
         let count = store
             .clear_user(&user)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         println!("Removed {count} face model(s) for user '{user}'.");
         // The user has no models by construction, so drop the marker outright.
-        super::enrollment_marker::forget(&config, &user);
+        super::enrollment_marker::forget(config, &user);
         return Ok(());
     }
 
@@ -58,7 +56,7 @@ pub fn run(user: Option<String>, yes: bool) -> anyhow::Result<()> {
     match response {
         DaemonResponse::Removed => {
             println!("All face models removed for user '{user}'.");
-            super::enrollment_marker::forget(&config, &user);
+            super::enrollment_marker::forget(config, &user);
         }
         other => {
             anyhow::bail!("unexpected response from daemon: {other:?}");

--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -1,4 +1,3 @@
-
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use facelock_store::StoreError;

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -1175,6 +1175,43 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
         }
     };
 
+    // Explicit resolution before construction (D7): name what is missing or
+    // misconfigured up front — the engine's load error is opaque about
+    // missing model files, and ORT falls back to CPU silently when the
+    // configured provider isn't compiled into the installed runtime.
+    let models = crate::resolved::ModelFiles::probe(&config);
+    if !models.value.all_present() {
+        let missing: Vec<String> = models
+            .value
+            .missing()
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        return Err(format!(
+            "model files missing: {} — run 'sudo facelock setup' to download them",
+            missing.join(", ")
+        ));
+    }
+    let ep = crate::resolved::ExecutionProviderFact::probe(&config);
+    match &ep.value.status {
+        crate::resolved::EpStatus::Available => {
+            info!(provider = %ep.value.configured, "execution provider resolved");
+        }
+        crate::resolved::EpStatus::NotBuiltIn => {
+            warn!(
+                provider = %ep.value.configured,
+                "configured execution provider is not built into the installed \
+                 ONNX Runtime; inference will fall back to CPU"
+            );
+        }
+        crate::resolved::EpStatus::Unqueryable(e) => {
+            warn!("could not query ONNX Runtime for provider availability: {e}");
+        }
+        // The engine load below fails with the provider registry's error,
+        // which names the valid values.
+        crate::resolved::EpStatus::UnknownName => {}
+    }
+
     let engine = FaceEngine::load(&config.recognition, Path::new(&config.daemon.model_dir))
         .map_err(|e| format!("failed to load face engine: {e}"))?;
 

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -710,6 +710,10 @@ impl FacelockService {
             // without this a few `facelock test` runs would lock the user
             // out of real authentication. See `Handler::handle_authenticate`.
             let response = handler.handle_authenticate(user.clone(), !caller_is_root);
+            // Notification settings come from the handler's config — the
+            // freshest parse, since maybe_reload_handler ran at method entry.
+            // No mid-request file re-read (D7).
+            let notify_config = handler.config.notification.clone();
             drop(handler);
             // Capture finished — free the slot before slower follow-up work
             // (notifications) so the next auth isn't rejected needlessly.
@@ -727,9 +731,6 @@ impl FacelockService {
                             reason: "no match".into(),
                         }
                     };
-                    // Re-read notification config from disk so changes
-                    // take effect without daemon restart
-                    let notify_config = Config::load().map(|c| c.notification).unwrap_or_default();
                     crate::notifications::notify_if_enabled_for_user(&notify_config, &event, &user);
 
                     Ok(AuthResult {
@@ -1134,6 +1135,9 @@ type CameraFactory = Box<dyn Fn(&Config) -> Result<Camera<'static>, String> + Se
 /// Build a new handler from config. Used at startup and for live config reload.
 /// Returns the handler and idle_timeout_secs from the loaded config.
 fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), String> {
+    // Deliberate re-read (D7): this is the daemon's config lifecycle — one
+    // parse at startup, one per mtime-triggered reload (maybe_reload_handler).
+    // Everything downstream consumes the Config held by the handler.
     let config = match config_path {
         Some(p) => Config::load_from(Path::new(p)),
         None => Config::load(),

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -7,7 +7,6 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
     // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
     ipc_client::require_root("sudo facelock devices")?;
 
-
     if ipc_client::should_use_direct(config) {
         return crate::direct::list_devices_direct();
     }

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -1,16 +1,14 @@
-use anyhow::Context;
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use crate::ipc_client;
 
-pub fn run() -> anyhow::Result<()> {
+pub fn run(config: &Config) -> anyhow::Result<()> {
     // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
     ipc_client::require_root("sudo facelock devices")?;
 
-    let config = Config::load().context("failed to load config")?;
 
-    if ipc_client::should_use_direct(&config) {
+    if ipc_client::should_use_direct(config) {
         return crate::direct::list_devices_direct();
     }
 

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -36,9 +36,8 @@ fn obtain_sealer(config: &Config) -> Result<facelock_tpm::SoftwareSealer> {
     }
 }
 
-pub fn run_encrypt(generate_key: bool) -> Result<()> {
+pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock encrypt")?;
-    let config = Config::load()?;
 
     if generate_key {
         match config.encryption.method {
@@ -96,7 +95,7 @@ pub fn run_encrypt(generate_key: bool) -> Result<()> {
         println!("Proceeding to encrypt embeddings...");
     }
 
-    let sealer = obtain_sealer(&config).context("failed to obtain encryption sealer")?;
+    let sealer = obtain_sealer(config).context("failed to obtain encryption sealer")?;
 
     // `open_existing`, never `create`: nothing to encrypt or decrypt means a
     // missing database is an error to report, not a file to bring into being
@@ -144,9 +143,8 @@ pub fn run_encrypt(generate_key: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn run_decrypt() -> Result<()> {
+pub fn run_decrypt(config: &Config) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock decrypt")?;
-    let config = Config::load()?;
 
     // `open_existing`, never `create`: nothing to encrypt or decrypt means a
     // missing database is an error to report, not a file to bring into being
@@ -178,7 +176,7 @@ pub fn run_decrypt() -> Result<()> {
 
     // Decrypt software-encrypted embeddings
     if !sw_encrypted.is_empty() {
-        let sealer = obtain_sealer(&config).context("failed to obtain encryption sealer")?;
+        let sealer = obtain_sealer(config).context("failed to obtain encryption sealer")?;
 
         println!(
             "Decrypting {} software-encrypted embedding(s)...",

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -50,11 +50,12 @@ pub fn run(
         }
     }
 
-    // Check models exist
-    let model_dir = std::path::Path::new(&config.daemon.model_dir);
-    let detector = model_dir.join(&config.recognition.detector_model);
-    let embedder = model_dir.join(&config.recognition.embedder_model);
-    if !detector.exists() || !embedder.exists() {
+    // Models must exist before anything opens a camera. One probe through the
+    // shared fact (D7) instead of a per-command re-derivation.
+    if !crate::resolved::ModelFiles::probe(config)
+        .value
+        .all_present()
+    {
         anyhow::bail!(
             "Face recognition models not found in {}.\nRun `sudo facelock setup` to download them.",
             config.daemon.model_dir

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use chrono::Local;
 
 use facelock_core::Config;
@@ -9,6 +8,7 @@ use facelock_store::StoreError;
 use crate::ipc_client;
 
 pub fn run(
+    config: &Config,
     user: Option<String>,
     label: Option<String>,
     skip_setup_check: bool,
@@ -36,8 +36,6 @@ pub fn run(
     }
 
     ipc_client::require_root("sudo facelock enroll")?;
-
-    let config = Config::load().context("failed to load config")?;
 
     // Encryption posture (Plan 04): refuse plaintext enrollment unless opted in;
     // warn prominently when the opt-in is active.
@@ -69,7 +67,7 @@ pub fn run(
         Some(label) => label,
         None => {
             let date = Local::now().format("%Y-%m-%d").to_string();
-            next_label(&date, &user, &config)?
+            next_label(&date, &user, config)?
         }
     };
 
@@ -79,8 +77,8 @@ pub fn run(
     // enrollment ahead needs the very store this check just failed to read.
     {
         let config_embedder = &config.recognition.embedder_model;
-        let has_stale = if ipc_client::should_use_direct(&config) {
-            direct_has_stale_embedder(&config, &user, config_embedder)?
+        let has_stale = if ipc_client::should_use_direct(config) {
+            direct_has_stale_embedder(config, &user, config_embedder)?
         } else {
             let request = DaemonRequest::ListModels { user: user.clone() };
             match ipc_client::send_request(&request)? {
@@ -107,21 +105,21 @@ pub fn run(
     println!("Enrolling face for user '{user}' with label '{label}'...");
     println!("Look at the camera. Slowly turn your head left and right.");
 
-    if ipc_client::should_use_direct(&config) {
+    if ipc_client::should_use_direct(config) {
         ipc_client::require_root("sudo facelock enroll")?;
-        let (model_id, embedding_count) = crate::direct::enroll(&config, &user, &label)?;
+        let (model_id, embedding_count) = crate::direct::enroll(config, &user, &label)?;
         println!(
             "\nFace enrolled successfully!\n  Model ID: {model_id}\n  Embeddings: {embedding_count}\n  Label: {label}"
         );
-        super::enrollment_marker::refresh(&config, &user);
-        check_model_count(&user, &config);
+        super::enrollment_marker::refresh(config, &user);
+        check_model_count(&user, config);
         return Ok(());
     }
 
     // Dedicated call with a timeout derived from the daemon's enrollment
     // deadline — the shared 15s proxy would abort mid-enrollment (issue #89).
     // send_enroll yields Enrolled or an error, so there is no other arm.
-    let response = ipc_client::send_enroll(&user, &label, &config)?;
+    let response = ipc_client::send_enroll(&user, &label, config)?;
 
     if let DaemonResponse::Enrolled {
         model_id,
@@ -131,8 +129,8 @@ pub fn run(
         println!(
             "\nFace enrolled successfully!\n  Model ID: {model_id}\n  Embeddings: {embedding_count}\n  Label: {label}"
         );
-        super::enrollment_marker::refresh(&config, &user);
-        check_model_count(&user, &config);
+        super::enrollment_marker::refresh(config, &user);
+        check_model_count(&user, config);
     }
 
     Ok(())

--- a/crates/facelock-cli/src/commands/enrollment_marker.rs
+++ b/crates/facelock-cli/src/commands/enrollment_marker.rs
@@ -103,6 +103,9 @@ fn marker_dir_for_db(db_path: &Path) -> Option<PathBuf> {
 /// [`DEFAULT_MARKER_DIR`] when the config is missing or unreadable.
 ///
 /// Reads a file and nothing else — safe on the unprivileged `is-enrolled` path.
+///
+/// Deliberate load (D7): `is-enrolled` is dispatched before main's shared
+/// config parse precisely so it can tolerate a missing or broken config here.
 pub fn marker_dir_or_default() -> PathBuf {
     Config::load()
         .map(|config| marker_dir(&config))

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use chrono::{Local, TimeZone};
 
 use facelock_core::Config;
@@ -7,7 +6,7 @@ use facelock_core::types::FaceModelInfo;
 
 use crate::ipc_client;
 
-pub fn run(user: Option<String>, json: bool) -> anyhow::Result<()> {
+pub fn run(config: &Config, user: Option<String>, json: bool) -> anyhow::Result<()> {
     // DEC-6/N4: `ListModels` is root-only now (was facelock-group). The
     // direct-mode fallback in `fetch_models` already required root when the
     // 0600 root:root database wasn't readable; checking up front here gives
@@ -15,10 +14,9 @@ pub fn run(user: Option<String>, json: bool) -> anyhow::Result<()> {
     // of a bare AccessDenied.
     ipc_client::require_root("sudo facelock list")?;
 
-    let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
-    let models = fetch_models(&config, &user)?;
+    let models = fetch_models(config, &user)?;
 
     if json {
         print_json(&models);

--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -4,31 +4,29 @@ mod text_only;
 #[cfg(feature = "wayland")]
 mod wayland_preview;
 
-use anyhow::Context;
 use facelock_core::Config;
 
 use crate::ipc_client;
 
-pub fn run(text_only: bool, user: Option<String>) -> anyhow::Result<()> {
+pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Result<()> {
     // DEC-6/N13: `PreviewDetectFrame` is root-only now — it was the last
     // unprivileged consumer of a per-frame similarity score (the
     // hill-climbing oracle N12/N13 close by construction).
     ipc_client::require_root("sudo facelock preview")?;
 
-    let config = Config::load().context("failed to load config")?;
     // One user-resolution implementation (C5, issue #105). The local
     // getpwuid-only version this replaces resolved `sudo facelock preview`
     // to *root*, so the preview never recognized the actual user.
     let user = ipc_client::resolve_user(user.as_deref());
 
-    if ipc_client::should_use_direct(&config) {
+    if ipc_client::should_use_direct(config) {
         if !text_only {
             eprintln!(
                 "Graphical preview requires the daemon. In oneshot mode, use --text-only.\n\
                  Falling back to text-only mode.\n"
             );
         }
-        return text_only::run_direct(&config, &user);
+        return text_only::run_direct(config, &user);
     }
 
     if text_only {

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -1,18 +1,16 @@
-use anyhow::Context;
 
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use crate::ipc_client;
 
-pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()> {
+pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()> {
     // C6: root check must run before the confirmation prompt below — a group
     // member confirming a destructive action only to then hit AccessDenied
     // is exactly the bug this ordering fixes. RemoveModel is root-only on the
     // daemon side too, so this applies regardless of transport.
     ipc_client::require_root(&format!("sudo facelock remove {model_id}"))?;
 
-    let config = Config::load().context("failed to load config")?;
     let user = ipc_client::resolve_user(user.as_deref());
 
     if !yes {
@@ -24,8 +22,8 @@ pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()>
         }
     }
 
-    if ipc_client::should_use_direct(&config) {
-        let store = crate::direct::open_store(&config)?;
+    if ipc_client::should_use_direct(config) {
+        let store = crate::direct::open_store(config)?;
         let removed = store
             .remove_model(&user, model_id)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -39,7 +37,7 @@ pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()>
         let remaining = store.list_models(&user).ok().map(|m| m.len() as u32);
         drop(store);
         if let Some(remaining) = remaining {
-            super::enrollment_marker::set(&config, &user, remaining);
+            super::enrollment_marker::set(config, &user, remaining);
         }
         return Ok(());
     }
@@ -54,7 +52,7 @@ pub fn run(model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()>
     match response {
         DaemonResponse::Removed => {
             println!("Removed face model #{model_id} for user '{user}'.");
-            super::enrollment_marker::refresh(&config, &user);
+            super::enrollment_marker::refresh(config, &user);
         }
         other => {
             anyhow::bail!("unexpected response from daemon: {other:?}");

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -1,4 +1,3 @@
-
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -372,6 +372,8 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     println!();
 
     // -- Load or create config --
+    // Deliberate load (D7): setup bootstraps the config file — it may not
+    // exist yet, and the wizard edits it in place afterwards.
     let mut config = match Config::load() {
         Ok(c) => c,
         Err(e) => {
@@ -466,7 +468,7 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     let enroll_steps = enroll_steps_for(plan);
     let enrolled = if enroll_steps.enroll {
         println!("\n--- Step 6: Face Enrollment ---\n");
-        match wizard_face_enroll(&theme, enroll_steps.assume_yes) {
+        match wizard_face_enroll(&config, &theme, enroll_steps.assume_yes) {
             Ok(did_enroll) => did_enroll,
             Err(e) => {
                 println!("  Enrollment failed: {e}");
@@ -482,7 +484,7 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     // -- Step 7: Test recognition --
     if test_recognition_runs(enroll_steps, enrolled) {
         println!("\n--- Step 7: Test Recognition ---\n");
-        match wizard_test_recognition(&theme, plan.yes) {
+        match wizard_test_recognition(&config, &theme, plan.yes) {
             Ok(()) => {}
             Err(e) => {
                 println!("  Test failed: {e}");
@@ -1545,9 +1547,8 @@ fn detect_tpm(config: &Config) -> bool {
 /// Update only the encryption method in the config file (no key_path changes).
 /// Used by `facelock tpm seal-key` / `unseal-key` for migration.
 #[cfg_attr(not(feature = "tpm"), allow(dead_code))]
-pub fn update_config_encryption_method(method: &str) -> anyhow::Result<()> {
-    let config = Config::load().context("failed to load config")?;
-    update_config_encryption(&config, method)
+pub fn update_config_encryption_method(config: &Config, method: &str) -> anyhow::Result<()> {
+    update_config_encryption(config, method)
 }
 
 /// Update the config file on disk with the chosen encryption method.
@@ -1860,7 +1861,11 @@ fn confirm_step(theme: &ColorfulTheme, prompt: &str, assume_yes: bool) -> anyhow
         .interact()?)
 }
 
-fn wizard_face_enroll(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::Result<bool> {
+fn wizard_face_enroll(
+    config: &Config,
+    theme: &ColorfulTheme,
+    assume_yes: bool,
+) -> anyhow::Result<bool> {
     let proceed = confirm_step(theme, "Would you like to enroll a face now?", assume_yes)?;
 
     if !proceed {
@@ -1868,11 +1873,15 @@ fn wizard_face_enroll(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::Result
         return Ok(false);
     }
 
-    super::enroll::run(None, None, true)?;
+    super::enroll::run(config, None, None, true)?;
     Ok(true)
 }
 
-fn wizard_test_recognition(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::Result<()> {
+fn wizard_test_recognition(
+    config: &Config,
+    theme: &ColorfulTheme,
+    assume_yes: bool,
+) -> anyhow::Result<()> {
     let proceed = confirm_step(theme, "Would you like to test recognition?", assume_yes)?;
 
     if !proceed {
@@ -1880,7 +1889,7 @@ fn wizard_test_recognition(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::R
         return Ok(());
     }
 
-    super::test_cmd::run(None)?;
+    super::test_cmd::run(config, None)?;
     Ok(())
 }
 
@@ -2082,7 +2091,8 @@ fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
 fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     println!("facelock setup: preparing system...\n");
 
-    // Load config (or use defaults for paths)
+    // Load config (or use defaults for paths). Deliberate load (D7): setup
+    // bootstraps the config file, which may not exist yet.
     let mut config = match Config::load() {
         Ok(c) => c,
         Err(e) => {
@@ -2182,7 +2192,7 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     let enrolled = plan.enroll == Some(true);
     if enrolled {
         println!("\nEnrolling face...");
-        super::enroll::run(None, None, true)?;
+        super::enroll::run(&config, None, None, true)?;
     }
 
     // See the matching call in `run_wizard`.

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -107,17 +107,20 @@ fn check_camera(config: Option<&Config>) {
         return;
     };
 
-    let device_path = config.device.path.as_deref().unwrap_or("(auto-detect)");
-    print_status_item("Camera device", device_path);
-
-    match &config.device.path {
-        Some(p) if Path::new(p).exists() => {
-            print_result(true, "device exists");
+    match crate::resolved::CameraPresence::probe(config).value {
+        crate::resolved::CameraPresence::Configured { path, present } => {
+            print_status_item("Camera device", &path);
+            print_result(
+                present,
+                if present {
+                    "device exists"
+                } else {
+                    "device not found"
+                },
+            );
         }
-        Some(_) => {
-            print_result(false, "device not found");
-        }
-        None => {
+        crate::resolved::CameraPresence::AutoDetect => {
+            print_status_item("Camera device", "(auto-detect)");
             print_result(true, "auto-detect enabled");
         }
     }
@@ -130,32 +133,28 @@ fn check_models(config: Option<&Config>) {
         return;
     };
 
-    let model_dir = &config.daemon.model_dir;
-    print_status_item("Model directory", model_dir);
+    // The configured model files (not just defaults), through the shared
+    // probe (D7).
+    let models = crate::resolved::ModelFiles::probe(config).value;
+    print_status_item("Model directory", &models.dir.display().to_string());
 
-    if !Path::new(model_dir).exists() {
+    if !models.dir_present {
         print_result(false, "directory not found");
         return;
     }
 
-    // Check for the configured model files (not just defaults)
-    let models = [
-        ("detector", config.recognition.detector_model.as_str()),
-        ("embedder", config.recognition.embedder_model.as_str()),
-    ];
-
-    let mut all_present = true;
-    for (purpose, filename) in &models {
-        let path = Path::new(model_dir).join(filename);
-        if path.exists() {
-            print_detail(&format!("{purpose} ({filename})"), "present");
-        } else {
-            print_detail(&format!("{purpose} ({filename})"), "MISSING");
-            all_present = false;
-        }
+    for (purpose, file) in [
+        ("detector", &models.detector),
+        ("embedder", &models.embedder),
+    ] {
+        let filename = file.path.file_name().unwrap_or_default().to_string_lossy();
+        print_detail(
+            &format!("{purpose} ({filename})"),
+            if file.present { "present" } else { "MISSING" },
+        );
     }
 
-    if all_present {
+    if models.all_present() {
         print_result(true, "all configured models present");
     } else {
         print_result(false, "some models missing (run 'facelock setup')");
@@ -167,8 +166,12 @@ fn check_inference(config: Option<&Config>) {
         return;
     };
 
-    let provider = &config.recognition.execution_provider;
-    let label = match provider.as_str() {
+    // Resolved against the installed ONNX Runtime (D7): the old check listed
+    // .so paths — a copy of the provider module's search list that could
+    // drift, and one that said nothing about whether the *configured*
+    // provider is actually compiled into that runtime.
+    let ep = crate::resolved::ExecutionProviderFact::probe(config).value;
+    let label = match ep.configured.as_str() {
         "cpu" => "CPU",
         "cuda" => "CUDA (NVIDIA GPU)",
         "rocm" => "ROCm (AMD GPU)",
@@ -177,16 +180,25 @@ fn check_inference(config: Option<&Config>) {
     };
     print_status_item("Execution provider", label);
 
-    // Check that the ORT library is loadable
-    let ort_paths = [
-        "/usr/lib/libonnxruntime.so",
-        "/usr/lib64/libonnxruntime.so",
-        "/usr/lib/facelock/libonnxruntime.so",
-    ];
-    if let Some(path) = ort_paths.iter().find(|p| Path::new(p).exists()) {
-        print_result(true, &format!("ONNX Runtime found at {path}"));
-    } else {
-        print_result(false, "ONNX Runtime not found (install onnxruntime)");
+    match &ep.status {
+        crate::resolved::EpStatus::Available => {
+            print_result(true, "supported by the installed ONNX Runtime");
+        }
+        crate::resolved::EpStatus::NotBuiltIn => {
+            print_result(
+                false,
+                "not built into the installed ONNX Runtime — inference will fall back to CPU",
+            );
+        }
+        crate::resolved::EpStatus::UnknownName => {
+            print_result(
+                false,
+                "unknown execution provider (valid: cpu, cuda, rocm, openvino)",
+            );
+        }
+        crate::resolved::EpStatus::Unqueryable(e) => {
+            print_result(false, &format!("ONNX Runtime not loadable: {e}"));
+        }
     }
 }
 

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -6,7 +6,7 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use crate::ipc_client;
 
-pub fn run() -> anyhow::Result<()> {
+pub fn run(loaded: crate::resolved::ConfigLoad) -> anyhow::Result<()> {
     // DEC-6/N4: every D-Bus method `status` calls (`Ping`, and `ListModels`
     // via `check_enrolled`) is root-only now, and its direct-mode reads hit
     // the same 0600 root:root database. Check before the first line of
@@ -15,32 +15,34 @@ pub fn run() -> anyhow::Result<()> {
 
     println!("facelock system status\n");
 
-    // 1. Config
-    check_config();
+    // 1. Config — renders the process's one parse outcome (D7); a broken
+    // config file is a finding to report, not an exit.
+    check_config(&loaded);
+    let config = loaded.config();
 
     // 2. Daemon
-    let config = check_daemon();
+    check_daemon(config);
 
     // 3. Camera
-    check_camera(&config);
+    check_camera(config);
 
     // 4. Models
-    check_models(&config);
+    check_models(config);
 
     // 5. Inference
-    check_inference(&config);
+    check_inference(config);
 
     // 6. Encryption
-    check_encryption(&config);
+    check_encryption(config);
 
     // 7. Enrolled faces
-    check_enrolled(&config);
+    check_enrolled(config);
 
     // 8. Security
-    check_security(&config);
+    check_security(config);
 
     // 9. Notifications
-    check_notifications(&config);
+    check_notifications(config);
 
     // 10. PAM
     check_pam();
@@ -48,16 +50,10 @@ pub fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn check_config() {
-    let config_path = facelock_core::paths::config_path();
-    print_status_item("Config file", &config_path.display().to_string());
+fn check_config(loaded: &crate::resolved::ConfigLoad) {
+    print_status_item("Config file", &loaded.path.display().to_string());
 
-    if !config_path.exists() {
-        print_result(false, "not found");
-        return;
-    }
-
-    match Config::load_from(&config_path) {
+    match &loaded.result {
         Ok(config) => {
             print_result(true, "valid");
             print_detail(
@@ -65,27 +61,27 @@ fn check_config() {
                 config.device.path.as_deref().unwrap_or("(auto-detect)"),
             );
         }
+        Err(facelock_core::config::ConfigError::NotFound(_)) => {
+            print_result(false, "not found");
+        }
         Err(e) => {
             print_result(false, &format!("invalid: {e}"));
         }
     }
 }
 
-fn check_daemon() -> Option<Config> {
-    let config = match Config::load() {
-        Ok(c) => c,
-        Err(_) => {
-            print_status_item("Daemon", "");
-            print_result(false, "config not loaded, cannot check daemon");
-            return None;
-        }
+fn check_daemon(config: Option<&Config>) {
+    let Some(config) = config else {
+        print_status_item("Daemon", "");
+        print_result(false, "config not loaded, cannot check daemon");
+        return;
     };
 
     print_status_item("Daemon", "org.facelock.Daemon (D-Bus system bus)");
 
     if config.daemon.mode == facelock_core::config::DaemonMode::Oneshot {
         print_result(true, "oneshot mode (no daemon)");
-        return Some(config);
+        return;
     }
 
     // Try to ping — this may trigger D-Bus activation if the daemon
@@ -102,11 +98,9 @@ fn check_daemon() -> Option<Config> {
             print_result(false, &format!("not responding: {e}"));
         }
     }
-
-    Some(config)
 }
 
-fn check_camera(config: &Option<Config>) {
+fn check_camera(config: Option<&Config>) {
     let Some(config) = config else {
         print_status_item("Camera", "");
         print_result(false, "config not available");
@@ -129,7 +123,7 @@ fn check_camera(config: &Option<Config>) {
     }
 }
 
-fn check_models(config: &Option<Config>) {
+fn check_models(config: Option<&Config>) {
     let Some(config) = config else {
         print_status_item("Models", "");
         print_result(false, "config not available");
@@ -168,7 +162,7 @@ fn check_models(config: &Option<Config>) {
     }
 }
 
-fn check_inference(config: &Option<Config>) {
+fn check_inference(config: Option<&Config>) {
     let Some(config) = config else {
         return;
     };
@@ -196,7 +190,7 @@ fn check_inference(config: &Option<Config>) {
     }
 }
 
-fn check_encryption(config: &Option<Config>) {
+fn check_encryption(config: Option<&Config>) {
     let Some(config) = config else {
         return;
     };
@@ -262,7 +256,7 @@ fn check_encryption(config: &Option<Config>) {
     }
 }
 
-fn check_enrolled(config: &Option<Config>) {
+fn check_enrolled(config: Option<&Config>) {
     let Some(config) = config else {
         return;
     };
@@ -295,7 +289,7 @@ fn check_enrolled(config: &Option<Config>) {
     }
 }
 
-fn check_security(config: &Option<Config>) {
+fn check_security(config: Option<&Config>) {
     let Some(config) = config else {
         return;
     };
@@ -335,7 +329,7 @@ fn check_security(config: &Option<Config>) {
     );
 }
 
-fn check_notifications(config: &Option<Config>) {
+fn check_notifications(config: Option<&Config>) {
     let Some(config) = config else {
         return;
     };

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-use anyhow::Context;
 
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
@@ -8,7 +7,7 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use crate::ipc_client;
 use crate::notifications::{NotifyEvent, notify_if_enabled};
 
-pub fn run(user: Option<String>) -> anyhow::Result<()> {
+pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // N11 (issue #96): `facelock test` is root-only regardless of transport
     // (direct or daemon-mediated) — keeps similarity scores and full detail,
     // and lets both the daemon and direct paths safely exempt failed test
@@ -16,7 +15,6 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     // to the rate-limit table). Must run before any prompt or output (C6).
     ipc_client::require_root("sudo facelock test")?;
 
-    let config = Config::load().context("failed to load config")?;
 
     // Check models exist — offer to run setup if missing
     let model_dir = std::path::Path::new(&config.daemon.model_dir);
@@ -42,8 +40,8 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     // and a store that doesn't exist yet both mean "not enrolled" — but a
     // store that is present and cannot be read is an error, and must never be
     // reported as "no models enrolled".
-    let has_models = if ipc_client::should_use_direct(&config) {
-        direct_user_has_models(&config, &user)?
+    let has_models = if ipc_client::should_use_direct(config) {
+        direct_user_has_models(config, &user)?
     } else {
         // Propagate a failed query instead of folding it into "no models
         // enrolled" — an AccessDenied here carries its own actionable hint.
@@ -66,11 +64,11 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
     // branches used to guess in opposite directions).
     {
         let config_embedder = &config.recognition.embedder_model;
-        let has_matching = if ipc_client::should_use_direct(&config) {
+        let has_matching = if ipc_client::should_use_direct(config) {
             // `open_store_existing`: the store answered has_models one query
             // ago, so it exists; if it vanished since, that is an error, not
             // a cue to create an empty one and warn about a stale embedder.
-            let store = crate::direct::open_store_existing(&config)?;
+            let store = crate::direct::open_store_existing(config)?;
             store
                 .has_models_for_embedder(&user, config_embedder)
                 .map_err(|e| anyhow::anyhow!("storage error: {e}"))?
@@ -98,9 +96,9 @@ pub fn run(user: Option<String>) -> anyhow::Result<()> {
 
     notify_if_enabled(notif_config, &NotifyEvent::Scanning);
 
-    if ipc_client::should_use_direct(&config) {
+    if ipc_client::should_use_direct(config) {
         let start = Instant::now();
-        match crate::direct::authenticate(&config, &user) {
+        match crate::direct::authenticate(config, &user) {
             Ok(result) if result.matched => {
                 let elapsed = start.elapsed();
                 println!(

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
@@ -15,16 +14,22 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // to the rate-limit table). Must run before any prompt or output (C6).
     ipc_client::require_root("sudo facelock test")?;
 
-
     // Check models exist — offer to run setup if missing
-    let model_dir = std::path::Path::new(&config.daemon.model_dir);
-    let detector = model_dir.join(&config.recognition.detector_model);
-    let embedder = model_dir.join(&config.recognition.embedder_model);
-    if !detector.exists() || !embedder.exists() {
+    if !crate::resolved::ModelFiles::probe(config)
+        .value
+        .all_present()
+    {
         println!("Face recognition models not found.");
         if crate::ipc_client::confirm("Download models now?")? {
             crate::commands::setup::run(false)?;
-            if !detector.exists() || !embedder.exists() {
+            // Deliberate re-probe: setup just changed the disk. The judgment
+            // still uses the Config this process parsed, as it always has —
+            // setup may have rewritten the file, and picking that up would be
+            // a mid-command re-read.
+            if !crate::resolved::ModelFiles::probe(config)
+                .value
+                .all_present()
+            {
                 anyhow::bail!("Models still not found after setup.");
             }
         } else {

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -5,13 +5,13 @@ use facelock_core::config::Config;
 
 use crate::commands::TpmCommand;
 
-pub fn run(command: TpmCommand) -> Result<()> {
+pub fn run(config: &Config, command: TpmCommand) -> Result<()> {
     match command {
-        TpmCommand::Status => status(),
-        TpmCommand::SealKey => seal_key(),
-        TpmCommand::UnsealKey => unseal_key(),
-        TpmCommand::UnsealCheck => unseal_check(),
-        TpmCommand::PcrBaseline => pcr_baseline(),
+        TpmCommand::Status => status(config),
+        TpmCommand::SealKey => seal_key(config),
+        TpmCommand::UnsealKey => unseal_key(config),
+        TpmCommand::UnsealCheck => unseal_check(config),
+        TpmCommand::PcrBaseline => pcr_baseline(config),
     }
 }
 
@@ -21,10 +21,9 @@ pub fn run(command: TpmCommand) -> Result<()> {
 /// keys) without writing anything or mutating config. Returns an error (non-zero
 /// exit) when unseal fails — e.g. after a bound PCR changed. Used by operators to
 /// confirm whether `facelock reseal` is needed, and by the TPM E2E suite.
-fn unseal_check() -> Result<()> {
+fn unseal_check(config: &Config) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock tpm unseal-check")?;
 
-    let config = Config::load()?;
     if config.encryption.method != facelock_core::config::EncryptionMethod::Tpm {
         anyhow::bail!(
             "encryption.method is not \"tpm\" (current: {:?}); nothing to unseal.",
@@ -63,8 +62,7 @@ fn unseal_check() -> Result<()> {
     }
 }
 
-fn status() -> Result<()> {
-    let config = Config::load().context("failed to load config (try: sudo facelock tpm status)")?;
+fn status(config: &Config) -> Result<()> {
 
     // Extract device path from TCTI string (e.g., "device:/dev/tpmrm0" -> "/dev/tpmrm0")
     let device_path = config
@@ -130,12 +128,12 @@ fn status() -> Result<()> {
     Ok(())
 }
 
-fn seal_key() -> Result<()> {
+#[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
+fn seal_key(config: &Config) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock tpm seal-key")?;
 
     #[cfg(feature = "tpm")]
     {
-        let config = Config::load()?;
         let key_path = Path::new(&config.encryption.key_path);
         let sealed_path = Path::new(&config.encryption.sealed_key_path);
 
@@ -181,7 +179,7 @@ fn seal_key() -> Result<()> {
         key.zeroize();
 
         // Update config to use tpm method
-        super::setup::update_config_encryption_method("tpm")?;
+        super::setup::update_config_encryption_method(config, "tpm")?;
 
         println!(
             "Key sealed to {} (permissions: 0600).",
@@ -214,12 +212,12 @@ fn seal_key() -> Result<()> {
     }
 }
 
-fn unseal_key() -> Result<()> {
+#[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
+fn unseal_key(config: &Config) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock tpm unseal-key")?;
 
     #[cfg(feature = "tpm")]
     {
-        let config = Config::load()?;
         let key_path = Path::new(&config.encryption.key_path);
         let sealed_path = Path::new(&config.encryption.sealed_key_path);
 
@@ -255,7 +253,7 @@ fn unseal_key() -> Result<()> {
         }
 
         // Update config to use keyfile method
-        super::setup::update_config_encryption_method("keyfile")?;
+        super::setup::update_config_encryption_method(config, "keyfile")?;
 
         println!("Key written to {} (permissions: 0600).", key_path.display());
         println!("Config updated: encryption.method = \"keyfile\"");
@@ -281,10 +279,9 @@ fn unseal_key() -> Result<()> {
 /// the key against the new PCR state. The key is recovered from the existing
 /// sealed blob when PCRs are still valid, otherwise from the plaintext key backup
 /// at `encryption.key_path` if present.
-pub fn run_reseal() -> Result<()> {
+pub fn run_reseal(config: &Config) -> Result<()> {
     crate::ipc_client::require_root("sudo facelock reseal")?;
 
-    let config = Config::load()?;
     if config.encryption.method != facelock_core::config::EncryptionMethod::Tpm {
         anyhow::bail!(
             "`facelock reseal` only applies when encryption.method = \"tpm\" \
@@ -388,8 +385,7 @@ pub fn run_reseal() -> Result<()> {
     }
 }
 
-fn pcr_baseline() -> Result<()> {
-    let config = Config::load()?;
+fn pcr_baseline(config: &Config) -> Result<()> {
 
     println!("PCR Baseline (indices: {:?})", config.tpm.pcr_indices);
     println!("----------");

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -63,7 +63,6 @@ fn unseal_check(config: &Config) -> Result<()> {
 }
 
 fn status(config: &Config) -> Result<()> {
-
     // Extract device path from TCTI string (e.g., "device:/dev/tpmrm0" -> "/dev/tpmrm0")
     let device_path = config
         .tpm
@@ -386,7 +385,6 @@ pub fn run_reseal(config: &Config) -> Result<()> {
 }
 
 fn pcr_baseline(config: &Config) -> Result<()> {
-
     println!("PCR Baseline (indices: {:?})", config.tpm.pcr_indices);
     println!("----------");
 

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -2,6 +2,7 @@ mod commands;
 pub mod direct;
 mod ipc_client;
 pub mod notifications;
+pub mod resolved;
 pub mod state_layout;
 
 use std::path::PathBuf;
@@ -246,6 +247,25 @@ fn main() -> anyhow::Result<()> {
                 .init();
 
             match other {
+                // -- Dispatched before the shared config parse (D7). --
+                //
+                // `is-enrolled` runs unprivileged on lock screens and must stay
+                // in front of all config/resolution machinery: it tolerates a
+                // missing or broken config and probes nothing (see
+                // commands/is_enrolled.rs). `hyprlock` edits the user's own
+                // dotfiles, `config` operates on the config file itself, and
+                // `restart` only talks to systemd — none consume a parsed
+                // Config.
+                Commands::IsEnrolled { user, json, quiet } => {
+                    std::process::exit(commands::is_enrolled::run(user, json, quiet))
+                }
+                Commands::Hyprlock { command } => commands::hyprlock::run(command),
+                Commands::Config { edit } => commands::config::run(edit),
+                Commands::Restart => commands::config::restart(),
+
+                // Setup bootstraps the config file — creates the default when
+                // missing and edits it in place — so it owns its own load; see
+                // the commented sites in commands/setup.rs.
                 Commands::Setup {
                     non_interactive,
                     yes,
@@ -279,36 +299,58 @@ fn main() -> anyhow::Result<()> {
                     execution_provider,
                     encryption,
                 })),
-                Commands::IsEnrolled { user, json, quiet } => {
-                    std::process::exit(commands::is_enrolled::run(user, json, quiet))
+
+                other => {
+                    // The one parse for this process (D7): every remaining
+                    // command consumes this Config and none re-reads the file.
+                    let loaded = resolved::ConfigLoad::read();
+
+                    // `status` reports on the config file itself, so a load
+                    // failure is a finding to render, not an exit.
+                    if matches!(other, Commands::Status) {
+                        return commands::status::run(loaded);
+                    }
+                    let config = loaded.require()?;
+
+                    match other {
+                        Commands::Enroll {
+                            user,
+                            label,
+                            skip_setup_check,
+                        } => commands::enroll::run(&config, user, label, skip_setup_check),
+                        Commands::Remove {
+                            model_id,
+                            user,
+                            yes,
+                        } => commands::remove::run(&config, model_id, user, yes),
+                        Commands::Clear { user, yes } => commands::clear::run(&config, user, yes),
+                        Commands::List { user, json } => commands::list::run(&config, user, json),
+                        Commands::Test { user } => commands::test_cmd::run(&config, user),
+                        Commands::Preview { text_only, user } => {
+                            commands::preview::run(&config, text_only, user)
+                        }
+                        Commands::Devices => commands::devices::run(&config),
+                        Commands::Bench { command } => commands::bench::run(&config, command),
+                        Commands::Tpm { command } => commands::tpm::run(&config, command),
+                        Commands::Encrypt { generate_key } => {
+                            commands::encrypt::run_encrypt(&config, generate_key)
+                        }
+                        Commands::Decrypt => commands::encrypt::run_decrypt(&config),
+                        Commands::Reseal => commands::tpm::run_reseal(&config),
+                        Commands::Audit { follow, lines } => {
+                            commands::audit::run(&config, follow, lines)
+                        }
+                        // Already handled above
+                        Commands::Daemon { .. }
+                        | Commands::Auth { .. }
+                        | Commands::IsEnrolled { .. }
+                        | Commands::Hyprlock { .. }
+                        | Commands::Config { .. }
+                        | Commands::Restart
+                        | Commands::Setup { .. }
+                        | Commands::Status => unreachable!(),
+                    }
                 }
-                Commands::Enroll {
-                    user,
-                    label,
-                    skip_setup_check,
-                } => commands::enroll::run(user, label, skip_setup_check),
-                Commands::Remove {
-                    model_id,
-                    user,
-                    yes,
-                } => commands::remove::run(model_id, user, yes),
-                Commands::Clear { user, yes } => commands::clear::run(user, yes),
-                Commands::List { user, json } => commands::list::run(user, json),
-                Commands::Test { user } => commands::test_cmd::run(user),
-                Commands::Preview { text_only, user } => commands::preview::run(text_only, user),
-                Commands::Config { edit } => commands::config::run(edit),
-                Commands::Status => commands::status::run(),
-                Commands::Devices => commands::devices::run(),
-                Commands::Bench { command } => commands::bench::run(command),
-                Commands::Tpm { command } => commands::tpm::run(command),
-                Commands::Hyprlock { command } => commands::hyprlock::run(command),
-                Commands::Encrypt { generate_key } => commands::encrypt::run_encrypt(generate_key),
-                Commands::Decrypt => commands::encrypt::run_decrypt(),
-                Commands::Reseal => commands::tpm::run_reseal(),
-                Commands::Restart => commands::config::restart(),
-                Commands::Audit { follow, lines } => commands::audit::run(follow, lines),
-                // Already handled above
-                Commands::Daemon { .. } | Commands::Auth { .. } => unreachable!(),
             }
         }
     }

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -1,0 +1,230 @@
+//! Parsed vs resolved configuration (D7).
+//!
+//! Two different questions, two types:
+//!
+//! - [`ConfigLoad`] — **what the file says.** `main` performs the one read and
+//!   parse for the process and hands every command a `&Config`. Commands do
+//!   not re-read the file mid-flow; the deliberate exceptions each carry a
+//!   comment at their load site (`daemon` reloads on mtime change, `auth` is
+//!   its own one-shot process, `setup` bootstraps and edits the file,
+//!   `config` displays/edits the file itself, and `is-enrolled` tolerates a
+//!   missing config on its unprivileged path).
+//!
+//! # `is-enrolled` never comes here
+//!
+//! `is-enrolled` is dispatched in `main` *before* [`ConfigLoad::read`] runs
+//! and must never construct any resolution machinery: no bus, no camera, no
+//! store, no probes. See the module docs in `commands/is_enrolled.rs`; a
+//! source-level pin lives in this module's tests.
+
+use std::path::PathBuf;
+
+use facelock_core::Config;
+use facelock_core::config::ConfigError;
+
+/// The outcome of the process's single config read.
+///
+/// Carries the failure instead of unwrapping it so `status` can render a
+/// broken config file as a finding; every other command goes through
+/// [`ConfigLoad::require`], which is the one place load errors are worded.
+pub struct ConfigLoad {
+    /// The path that was read (after any `--config` override).
+    pub path: PathBuf,
+    pub result: Result<Config, ConfigError>,
+}
+
+impl ConfigLoad {
+    /// Read and parse the config file once, from the process's resolved path.
+    pub fn read() -> Self {
+        Self::read_from(facelock_core::paths::config_path())
+    }
+
+    fn read_from(path: PathBuf) -> Self {
+        let result = Config::load_from(&path);
+        ConfigLoad { path, result }
+    }
+
+    /// The parsed config, or the unified load error (D7 item 4): missing file
+    /// points at `facelock setup`; a broken file names the path and the parse
+    /// error. Every command that needs a config fails through here, so the
+    /// wording cannot drift per command.
+    pub fn require(self) -> anyhow::Result<Config> {
+        match self.result {
+            Ok(config) => Ok(config),
+            Err(ConfigError::NotFound(_)) => anyhow::bail!(
+                "no config file at {} — run 'sudo facelock setup' to create one",
+                self.path.display()
+            ),
+            Err(e) => anyhow::bail!("invalid config at {}: {e}", self.path.display()),
+        }
+    }
+
+    /// Borrow the config when it parsed; `None` otherwise. For renderers
+    /// (`status`) that degrade instead of failing.
+    pub fn config(&self) -> Option<&Config> {
+        self.result.as_ref().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    #[test]
+    fn require_on_missing_file_points_at_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let err = ConfigLoad::read_from(path.clone()).require().unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no config file"), "{msg}");
+        assert!(msg.contains("facelock setup"), "{msg}");
+        assert!(msg.contains(&path.display().to_string()), "{msg}");
+    }
+
+    #[test]
+    fn require_on_broken_file_names_path_and_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[device\npath=").unwrap();
+
+        let err = ConfigLoad::read_from(path.clone()).require().unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("invalid config"), "{msg}");
+        assert!(msg.contains(&path.display().to_string()), "{msg}");
+    }
+
+    /// The ownership contract: after the one read, the `Config` value is the
+    /// source of truth — commands hold `&Config` and keep working even if the
+    /// file disappears, because nothing on their path re-reads it.
+    #[test]
+    fn parsed_config_outlives_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[storage]\ndb_path = \"/srv/faces/facelock.db\"\n").unwrap();
+
+        let config = ConfigLoad::read_from(path.clone()).require().unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert_eq!(config.storage.db_path, "/srv/faces/facelock.db");
+        // A hypothetical re-read would now fail — which is exactly why
+        // commands must not perform one.
+        assert!(matches!(
+            ConfigLoad::read_from(path).result,
+            Err(ConfigError::NotFound(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Structural pins (source scan)
+    // -----------------------------------------------------------------------
+    //
+    // These read the crate's own sources at test time. They are blunt — a
+    // token count cannot prove call-graph properties — but they turn "parse
+    // once" and "is-enrolled probes nothing" from conventions into failures
+    // with a file name attached. Comment lines are ignored so prose may
+    // mention the tokens.
+
+    fn source_files() -> Vec<(PathBuf, String)> {
+        fn walk(dir: &std::path::Path, out: &mut Vec<(PathBuf, String)>) {
+            for entry in fs::read_dir(dir).unwrap().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let content = fs::read_to_string(&path).unwrap();
+                    out.push((path, content));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(
+            &std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+            &mut out,
+        );
+        out
+    }
+
+    fn count_code_occurrences(content: &str, needle: &str) -> usize {
+        content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .map(|l| l.matches(needle).count())
+            .sum()
+    }
+
+    /// Parse-once pin. `Config::load()` (the global-path read) is allowed only
+    /// at the sites below, each of which documents why it re-reads. Adding one
+    /// anywhere else re-introduces the 29-call-site sprawl D7 removed — route
+    /// the command through the `&Config` that `main` already parsed.
+    #[test]
+    fn config_load_call_sites_are_pinned() {
+        let allowed: &[(&str, usize)] = &[
+            // One-shot auth process: its own top-of-process parse.
+            ("commands/auth.rs", 1),
+            // Daemon startup + mtime-triggered reload both go through
+            // build_handler.
+            ("commands/daemon.rs", 1),
+            // is-enrolled's tolerant read: must answer even with no config.
+            ("commands/enrollment_marker.rs", 1),
+            // Bootstrap: load-or-create-default, in both wizard and
+            // non-interactive entry points (2 sites x 2 calls).
+            ("commands/setup.rs", 4),
+        ];
+
+        // Assembled at runtime so this test's own literals don't count.
+        let needle = format!("Config::load{}", "()");
+        for (path, content) in source_files() {
+            let rel = path
+                .to_string_lossy()
+                .split("/src/")
+                .last()
+                .unwrap()
+                .to_string();
+            let count = count_code_occurrences(&content, &needle);
+            let expected = allowed
+                .iter()
+                .find(|(p, _)| *p == rel)
+                .map(|(_, n)| *n)
+                .unwrap_or(0);
+            assert_eq!(
+                count, expected,
+                "{rel}: found {count} global-path config read(s) ({needle}), \
+                 expected {expected}. Commands receive &Config from main (see \
+                 resolved::ConfigLoad); a mid-command re-read is a D7 regression."
+            );
+        }
+    }
+
+    /// `is-enrolled` isolation pin: its module must not name the resolution
+    /// machinery or any transport/store entry point. This guarantees only that
+    /// the module itself stays clean — indirect calls would need a reviewer —
+    /// but every past regression started with one of these tokens appearing
+    /// here.
+    #[test]
+    fn is_enrolled_module_stays_probe_free() {
+        let forbidden = [
+            "ConfigLoad",
+            "ResolvedConfig",
+            "resolved::",
+            "send_request(",
+            "should_use_direct(",
+            "open_store",
+            "Camera",
+        ];
+        let (_, content) = source_files()
+            .into_iter()
+            .find(|(p, _)| p.ends_with("commands/is_enrolled.rs"))
+            .expect("is_enrolled.rs must exist");
+        for token in forbidden {
+            assert_eq!(
+                count_code_occurrences(&content, token),
+                0,
+                "is_enrolled.rs must not reference {token:?} — it is dispatched \
+                 before all resolution machinery and probes nothing (domain map §5)"
+            );
+        }
+    }
+}

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -10,6 +10,15 @@
 //!   `config` displays/edits the file itself, and `is-enrolled` tolerates a
 //!   missing config on its unprivileged path).
 //!
+//! - [`ResolvedConfig`] — **what is actually true.** A config value like
+//!   `execution_provider = "cuda"` or `device.path = "/dev/video2"` is a
+//!   *claim*; whether CUDA exists in the installed ONNX Runtime or the device
+//!   node is present is discovered by an explicit probe, once, instead of
+//!   being re-derived ad hoc at each use site. Each fact carries a
+//!   [`Provenance`] tag. Resolution is for the heavyweight paths only
+//!   (daemon startup, status, enroll, test); lighter commands probe just the
+//!   fact they consume.
+//!
 //! # `is-enrolled` never comes here
 //!
 //! `is-enrolled` is dispatched in `main` *before* [`ConfigLoad::read`] runs
@@ -17,10 +26,11 @@
 //! store, no probes. See the module docs in `commands/is_enrolled.rs`; a
 //! source-level pin lives in this module's tests.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use facelock_core::Config;
 use facelock_core::config::ConfigError;
+use facelock_face::ProviderKind;
 
 /// The outcome of the process's single config read.
 ///
@@ -63,6 +73,206 @@ impl ConfigLoad {
     /// (`status`) that degrade instead of failing.
     pub fn config(&self) -> Option<&Config> {
         self.result.as_ref().ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ResolvedConfig — what is actually true
+// ---------------------------------------------------------------------------
+
+/// How a resolved fact was determined.
+///
+/// Deliberately minimal: H8 (Health) will grow this into a richer `Fact`
+/// type carrying *unknown-is-not-false* across privilege and reachability;
+/// until then, a provenance tag per fact is all resolution promises. A
+/// daemon-reachability fact slots in beside the existing ones the same way
+/// (H6 — Backend owns that probe, not this module).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// Verified against the live system by this process (file stat, ORT
+    /// query).
+    Probed,
+    /// Taken from the config without verification — a claim, not a checked
+    /// fact.
+    Claimed,
+}
+
+/// A fact plus how it was established.
+#[derive(Debug, Clone)]
+pub struct Resolved<T> {
+    pub value: T,
+    pub provenance: Provenance,
+}
+
+/// One file the config names, and whether it is on disk.
+#[derive(Debug, Clone)]
+pub struct ProbedFile {
+    pub path: PathBuf,
+    pub present: bool,
+}
+
+impl ProbedFile {
+    fn probe(path: PathBuf) -> Self {
+        let present = path.is_file();
+        ProbedFile { path, present }
+    }
+}
+
+/// Presence of the configured detector/embedder ONNX files.
+///
+/// Presence only, by design: content integrity stays where it already lives —
+/// `FaceEngine` verifies SHA256 at load time, and setup's download flow
+/// checks hashes as part of its repair loop.
+#[derive(Debug, Clone)]
+pub struct ModelFiles {
+    pub dir: PathBuf,
+    pub dir_present: bool,
+    pub detector: ProbedFile,
+    pub embedder: ProbedFile,
+}
+
+impl ModelFiles {
+    pub fn probe(config: &Config) -> Resolved<ModelFiles> {
+        let dir = PathBuf::from(&config.daemon.model_dir);
+        let value = ModelFiles {
+            dir_present: dir.is_dir(),
+            detector: ProbedFile::probe(dir.join(&config.recognition.detector_model)),
+            embedder: ProbedFile::probe(dir.join(&config.recognition.embedder_model)),
+            dir,
+        };
+        Resolved {
+            value,
+            provenance: Provenance::Probed,
+        }
+    }
+
+    pub fn all_present(&self) -> bool {
+        self.detector.present && self.embedder.present
+    }
+
+    /// Paths of the configured model files that are not on disk.
+    pub fn missing(&self) -> Vec<&Path> {
+        [&self.detector, &self.embedder]
+            .into_iter()
+            .filter(|f| !f.present)
+            .map(|f| f.path.as_path())
+            .collect()
+    }
+}
+
+/// What the config claims about the camera, resolved as far as a presence
+/// check can take it.
+///
+/// Only "does the configured node exist" — which is what `status` and setup
+/// were each re-deriving. Full device interrogation (formats, IR
+/// classification, quirks, siblings) is the camera domain's job (D8,
+/// `direct::resolve_camera_device` and friends) and is *not* duplicated here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CameraPresence {
+    /// No path configured: detection happens at open time; nothing to probe
+    /// yet, so this fact stays a claim.
+    AutoDetect,
+    Configured {
+        path: String,
+        present: bool,
+    },
+}
+
+impl CameraPresence {
+    pub fn probe(config: &Config) -> Resolved<CameraPresence> {
+        match config.device.path.as_deref() {
+            None => Resolved {
+                value: CameraPresence::AutoDetect,
+                provenance: Provenance::Claimed,
+            },
+            Some(path) => Resolved {
+                value: CameraPresence::Configured {
+                    path: path.to_string(),
+                    present: Path::new(path).exists(),
+                },
+                provenance: Provenance::Probed,
+            },
+        }
+    }
+}
+
+/// The configured execution provider, resolved against the ONNX Runtime that
+/// is actually installed — availability is a property of the ORT *build*, not
+/// the hardware (see `facelock_face::detect_execution_provider`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionProviderFact {
+    pub configured: String,
+    pub status: EpStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EpStatus {
+    /// Not a name the provider registry knows; engine load will fail with the
+    /// registry's error naming the valid values.
+    UnknownName,
+    /// The installed ONNX Runtime can use it (CPU is available by
+    /// construction).
+    Available,
+    /// A valid name, but the installed ORT was not built with it — ORT falls
+    /// back to CPU silently at session creation, which is exactly the
+    /// misconfiguration this fact exists to surface.
+    NotBuiltIn,
+    /// The ONNX Runtime shared library could not be loaded or queried.
+    Unqueryable(String),
+}
+
+impl ExecutionProviderFact {
+    /// Probe the installed ONNX Runtime. Loads the ORT shared library unless
+    /// the configured provider is `cpu` (or unknown), so call this only on
+    /// paths that will load the engine anyway or exist to diagnose (status).
+    pub fn probe(config: &Config) -> Resolved<ExecutionProviderFact> {
+        let value = Self::status_of(&config.recognition.execution_provider, || {
+            facelock_face::detect_execution_provider().map(|d| d.available)
+        });
+        Resolved {
+            value,
+            provenance: Provenance::Probed,
+        }
+    }
+
+    /// The decision rule, split from the ORT query so it is testable without
+    /// a GPU-enabled runtime (same shape as `select_by_priority` upstream).
+    fn status_of(
+        configured: &str,
+        detect: impl FnOnce() -> Result<Vec<ProviderKind>, String>,
+    ) -> ExecutionProviderFact {
+        let status = match ProviderKind::parse(configured) {
+            None => EpStatus::UnknownName,
+            Some(ProviderKind::Cpu) => EpStatus::Available,
+            Some(kind) => match detect() {
+                Ok(available) if available.contains(&kind) => EpStatus::Available,
+                Ok(_) => EpStatus::NotBuiltIn,
+                Err(e) => EpStatus::Unqueryable(e),
+            },
+        };
+        ExecutionProviderFact {
+            configured: configured.to_string(),
+            status,
+        }
+    }
+}
+
+/// The full resolution pass, for the paths that consume every fact (daemon
+/// startup logging, `status`). Commands that need one fact probe it directly.
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    pub models: Resolved<ModelFiles>,
+    pub camera: Resolved<CameraPresence>,
+    pub execution_provider: Resolved<ExecutionProviderFact>,
+}
+
+impl ResolvedConfig {
+    pub fn resolve(config: &Config) -> Self {
+        ResolvedConfig {
+            models: ModelFiles::probe(config),
+            camera: CameraPresence::probe(config),
+            execution_provider: ExecutionProviderFact::probe(config),
+        }
     }
 }
 
@@ -115,6 +325,119 @@ mod tests {
             ConfigLoad::read_from(path).result,
             Err(ConfigError::NotFound(_))
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Facts
+    // -----------------------------------------------------------------------
+
+    fn config_with(toml: &str) -> Config {
+        Config::parse(toml).expect("test config parses")
+    }
+
+    #[test]
+    fn model_probe_reports_each_file_and_the_missing_set() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("det.onnx"), b"x").unwrap();
+
+        let config = config_with(&format!(
+            "[daemon]\nmodel_dir = \"{}\"\n\n[recognition]\n\
+             detector_model = \"det.onnx\"\nembedder_model = \"emb.onnx\"\n",
+            dir.path().display()
+        ));
+        let models = ModelFiles::probe(&config);
+
+        assert_eq!(models.provenance, Provenance::Probed);
+        assert!(models.value.dir_present);
+        assert!(models.value.detector.present);
+        assert!(!models.value.embedder.present);
+        assert!(!models.value.all_present());
+        assert_eq!(
+            models.value.missing(),
+            vec![dir.path().join("emb.onnx").as_path()]
+        );
+
+        fs::write(dir.path().join("emb.onnx"), b"x").unwrap();
+        let models = ModelFiles::probe(&config).value;
+        assert!(models.all_present());
+        assert!(models.missing().is_empty());
+    }
+
+    #[test]
+    fn model_probe_on_missing_directory_is_all_absent() {
+        let config = config_with("[daemon]\nmodel_dir = \"/nonexistent/facelock-test-models\"\n");
+        let models = ModelFiles::probe(&config).value;
+        assert!(!models.dir_present);
+        assert!(!models.all_present());
+        assert_eq!(models.missing().len(), 2);
+    }
+
+    #[test]
+    fn camera_probe_distinguishes_claim_from_probed_presence() {
+        // No path: a claim — detection is deferred to open time.
+        let auto = CameraPresence::probe(&config_with(""));
+        assert_eq!(auto.value, CameraPresence::AutoDetect);
+        assert_eq!(auto.provenance, Provenance::Claimed);
+
+        // Configured and present.
+        let dir = tempfile::tempdir().unwrap();
+        let node = dir.path().join("video9");
+        fs::write(&node, b"").unwrap();
+        let present = CameraPresence::probe(&config_with(&format!(
+            "[device]\npath = \"{}\"\n",
+            node.display()
+        )));
+        assert_eq!(present.provenance, Provenance::Probed);
+        assert_eq!(
+            present.value,
+            CameraPresence::Configured {
+                path: node.display().to_string(),
+                present: true
+            }
+        );
+
+        // Configured and absent.
+        let absent = CameraPresence::probe(&config_with(
+            "[device]\npath = \"/dev/facelock-no-such-video\"\n",
+        ));
+        assert_eq!(
+            absent.value,
+            CameraPresence::Configured {
+                path: "/dev/facelock-no-such-video".into(),
+                present: false
+            }
+        );
+    }
+
+    #[test]
+    fn ep_status_unknown_name_never_queries_ort() {
+        let fact = ExecutionProviderFact::status_of("tensorrt", || {
+            panic!("an unknown name must not trigger an ORT query")
+        });
+        assert_eq!(fact.status, EpStatus::UnknownName);
+    }
+
+    #[test]
+    fn ep_status_cpu_is_available_without_querying_ort() {
+        let fact =
+            ExecutionProviderFact::status_of("cpu", || panic!("cpu must not trigger an ORT query"));
+        assert_eq!(fact.status, EpStatus::Available);
+    }
+
+    #[test]
+    fn ep_status_gpu_resolves_against_the_ort_build() {
+        let cuda_in = ExecutionProviderFact::status_of("cuda", || Ok(vec![ProviderKind::Cuda]));
+        assert_eq!(cuda_in.status, EpStatus::Available);
+
+        let cuda_out = ExecutionProviderFact::status_of("cuda", || Ok(vec![]));
+        assert_eq!(cuda_out.status, EpStatus::NotBuiltIn);
+
+        let rocm_elsewhere =
+            ExecutionProviderFact::status_of("rocm", || Ok(vec![ProviderKind::Cuda]));
+        assert_eq!(rocm_elsewhere.status, EpStatus::NotBuiltIn);
+
+        let broken = ExecutionProviderFact::status_of("cuda", || Err("no dylib".into()));
+        assert_eq!(broken.status, EpStatus::Unqueryable("no dylib".into()));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Wave 3, PR H2 — the Config domain (gap D7): the parsed-vs-resolved split, per `domain-object-map.md` §1.

## Design

Two types in a new `crates/facelock-cli/src/resolved.rs`:

- **`ConfigLoad`** — *what the file says.* `main` performs the process's single read/parse and hands every command a `&Config`. Load-error rendering is unified in `ConfigLoad::require` (missing file → "run 'sudo facelock setup'"; broken file → path + parse error). `status` receives the whole `ConfigLoad` so a broken config is a finding it renders, not an exit.
- **`ResolvedConfig`** — *what is actually true.* Facts established by explicit probes, each tagged with a lightweight `Provenance` (`Probed`/`Claimed`) that H8's richer `Fact` type can adopt:
  - `ModelFiles` — configured detector/embedder presence (integrity stays with `FaceEngine`'s SHA256 check at load);
  - `CameraPresence` — configured device node exists; auto-detect stays a `Claimed` fact deferred to open time;
  - `ExecutionProviderFact` — is the configured EP compiled into the installed ONNX Runtime (`Available` / `NotBuiltIn` / `UnknownName` / `Unqueryable`); the decision rule is split from the ORT query so it tests without a GPU.

The `Config` type itself is untouched — the `#[serde(default)]` structure is the `%config(noreplace)` guarantee and stays as-is.

**Placement rationale:** `facelock-cli`, not `facelock-core`. The probes need `facelock-face` (ORT queries) — core cannot depend on it without inverting the crate DAG. The daemon's engine/store construction lives in `commands/daemon.rs` (in this crate), so daemon startup is covered; `facelock-daemon` (lib) receives already-built engine/store and needs no resolution machinery. The standalone `facelock-bench` binary keeps its own single top-of-process parse.

## Call-site accounting

At the branch point, facelock-cli had **27 `Config::load()` + 6 `Config::load_from` = 33 load expressions** in non-test code (the gap register's "29×" had drifted as Wave 2 landed — plan errata below).

After: **7 `Config::load()` + 6 `load_from` = 13**, every one deliberate and commented:

| Site | Count | Why it remains |
|---|---|---|
| `resolved.rs` (`ConfigLoad`) | 1 | **the** shared parse |
| `commands/daemon.rs` (`build_handler`) | 2 | daemon lifecycle: startup + mtime-triggered reload |
| `commands/auth.rs` | 2 | one-shot process spawned by PAM; its own top-of-process parse |
| `commands/setup.rs` | 4 | bootstrap: load-or-create-default (wizard + non-interactive entry points) |
| `commands/config.rs` | 3 | operates on the file itself (pre/post-edit validation) |
| `commands/enrollment_marker.rs` | 1 | `is-enrolled`'s tolerant read — must answer with no config |

Commands converted to take `&Config` from main: `enroll`, `remove`, `clear`, `list`, `test`, `preview`, `devices`, `bench` (7 subcommands), `tpm` (5 subcommands + `reseal`), `encrypt`, `decrypt`, `audit`; `status` takes `ConfigLoad`. `setup::update_config_encryption_method` now takes `&Config` instead of re-reading (it was a mid-flow re-read on the `tpm seal-key`/`unseal-key` paths).

Also removed: the daemon's **per-request** notification-config re-read in the D-Bus `Authenticate` handler — `maybe_reload_handler` already refreshes the handler's config at method entry, so the handler's held config is used instead.

## Probe sites: converted vs deliberately left

| Site | Disposition |
|---|---|
| `enroll.rs` inline detector/embedder `.exists()` pair | **converted** → `ModelFiles::probe` |
| `test_cmd.rs` same pair (×2, incl. post-setup re-check) | **converted**; the re-probe after setup is deliberate (setup changed the disk) and commented |
| `status.rs` `check_models` | **converted** → `ModelFiles` |
| `status.rs` `check_camera` | **converted** → `CameraPresence` |
| `status.rs` `check_inference` | **converted** → `ExecutionProviderFact`; the old check stat-ed a private copy of the provider module's `.so` search paths (drift hazard) and said nothing about the *configured* provider |
| `daemon.rs` `build_handler` | **converted**: names missing model files before the engine's opaque load error; warns when the configured EP will silently fall back to CPU |
| `direct.rs` `resolve_camera_device` / `build_resolved_camera_device` | **left** — the camera domain's rich resolution (D8 owns it) |
| `auth.rs` oneshot device validation | **left** — PAM auth path; no resolution machinery there |
| `setup.rs` `check_model` + SHA256 | **left** — the download/repair flow's subject matter is presence *and* hash |
| `setup.rs` `resolve_execution_provider_auto` | **left** — wizard *selection* of a provider, not verification of a claim |
| `setup.rs` `warn_provider_preflight` (`/dev/nvidiactl`) | **left** — driver-node hardware hint, not an ORT-build fact |
| `setup.rs` `detect_tpm`, `tpm.rs`/`encrypt.rs` key/device path checks | **left** — encryption-domain flows, coherent in place |
| `status.rs` store/PAM/encryption checks | **left** — H8 (Health) turns status into a renderer over `Health` |

## Invariants preserved

- **`is-enrolled` never probes.** It is dispatched in `main` *before* `ConfigLoad::read`, keeps its tolerant `marker_dir_or_default()` load, and touches no bus/camera/store. Two structural pins in `resolved.rs` tests: a source-scan that fails if `is_enrolled.rs` names any resolution/transport/store token, and a `Config::load()` allowlist that fails (naming the file) if any command regrows a mid-flow re-read. These pin the module text, not the call graph — the layout container tier pins the runtime behavior (21/21 below).
- `hyprlock` and `config` display stay probe-free and unprivileged (dispatched before the shared parse).
- The PAM schema in `pam-facelock` is untouched (dependency ceiling; #114's conformance test covers drift).
- `setup.rs` line-oriented config editing (`set_config_scalar`, ~:1029) untouched — ugly and correct.
- **No backend/reachability work**: no bus probing added; `Provenance` and `ResolvedConfig` are documented as the slot where H6 adds a reachability fact.
- No auth-semantics or D-Bus wire changes: interface signatures untouched; `config/facelock.toml` untouched; nothing the #114 sibling pins is touched.

## Behavior notes (deliberate, small)

1. Config load errors now surface **before** the interactive sudo-escalation prompt (main parses first). Previously e.g. `facelock list` prompted for sudo and then failed on the broken config as root.
2. `facelock enroll` on a system with **no config file at all** now errors with the unified "run 'sudo facelock setup'" message instead of reaching the interactive setup-gate prompt. With a config present but setup incomplete (the packaged-install case), the interactive gate is unchanged.
3. Daemon notification-config freshness now rides the mtime reload (was: raw re-read per request, which also caught same-second edits mtime comparison misses). Documented at the site.
4. `facelock status`'s inference line now reports whether the configured EP is built into the installed ORT (this loads the ORT dylib during `status` unless the EP is `cpu`/unknown; failures are contained and rendered).
5. Daemon startup with missing model files exits with the files named instead of the engine's load error.

## Churn

Two commits, `facelock-cli` only: 18 files, +459/−209 (parse-once) and 11 files, +432/−63 (facts). No other crate touched.

## Tests

- `ConfigLoad`: missing-file and broken-file rendering; parsed-config-outlives-the-file (ownership demonstration).
- Facts: `ModelFiles` probe with temp dirs (per-file presence, `missing()` set, absent dir); `CameraPresence` claim-vs-probed distinction; `ExecutionProviderFact` decision rule with injected detection (unknown name and `cpu` provably never query ORT; GPU against built-in list; unqueryable runtime).
- Structural pins as described under invariants.

## Gates

- `just check` — clean (exit 0; workspace tests, clippy `-D warnings`, fmt-check, cargo-audit with the 2 pre-existing allowed yanked-crate warnings).
- `just test-arch-pam` — 22/22.
- `just test-arch-layout` — 21/21 (pins `is-enrolled` runtime behavior).

## Cross-PR notes

- **H6 (Backend):** add the daemon-reachability fact beside the existing three in `ResolvedConfig`; `Provenance::Probed` fits it as-is. `should_use_direct` remains the (unowned) reachability logic this PR deliberately did not touch.
- **H8 (Health):** `Provenance` is the adoption point — replace `Resolved<T>` with `Fact<T>` carrying `Unavailable { needs }` and re-render `status` over `Health`. The three fact types here are already constructed without root/camera/bus (models/camera facts are plain stats; EP fact's query is injectable).
- **#114 (conformance):** no template or schema changes here; `notify_on_failure` drift remains pinned on the template side.
- **Template**: no `config/facelock.toml` deltas needed by this PR.
- The sibling branch's `logging.rs` / `DEFAULT_LOG_FILTER` is not in this base; no logging changes made here beyond the daemon's existing filter.

## Docs to reconcile

- `CHANGELOG.md`: no entry added (the Wave-3 chain has not been adding per-PR entries; reconcile once the wave merges). Suggested text: parse-once config ownership + resolved facts, and the daemon notification-config sourcing note (behavior note 3).
- `docs/troubleshooting.md` / `book`: `facelock status`'s inference line wording changed (now reports EP-vs-ORT-build instead of `.so` presence paths).
- `man/facelock.1`: no flag changes; no update required.

## Plan errata

- Gap register D7 says `Config::load()` is called **29×**; measured at this branch point: 27 (`Config::load()`) + 6 (`load_from`) = 33 expressions. The counts drifted as Wave 2 landed.
- `domain-object-map.md` §1 "setup.rs:1029" — confirmed; `set_config_scalar` sits at that region and is untouched.
- The daemon's config-reload-on-mtime is at `commands/daemon.rs` `maybe_reload_handler` (~:643) — confirmed as the deliberate re-read the brief predicted.
- **Not in the plan:** the daemon also re-read the config from disk *per authenticated request* (notification section, `Authenticate` handler ~:732). Fixed here; worth knowing it existed when reviewing daemon config-freshness assumptions.
- `test_cmd`'s post-setup model re-check judges by the pre-setup config (setup may rewrite `recognition.*_model`); pre-existing behavior, preserved and now commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
