### PR TITLE
refactor(camera): CameraCaps — capabilities live on the camera, not in parameters (D8)

### DIFF
--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -89,7 +89,9 @@ fn open_camera(config: &Config) -> Result<Camera<'static>> {
             .with_context(|| format!("Camera device {path} not accessible"))?;
         info!(device = %path, ir = is_ir_camera(&device_info), "Camera validated");
     }
-    Camera::open(&config.device, None)
+    // An empty quirks DB: the bench deliberately opens without quirk
+    // overrides, exactly as its old `quirk: None` call did.
+    Camera::open(&config.device, &facelock_camera::QuirksDb::default())
         .with_context(|| format!("Failed to open camera ({path_display})"))
 }
 

--- a/crates/facelock-camera/src/caps.rs
+++ b/crates/facelock-camera/src/caps.rs
@@ -1,0 +1,195 @@
+//! Camera capability interrogation (gap D8).
+//!
+//! [`ResolvedCamera::interrogate`] is the ONE place [`CameraCaps`] are
+//! computed: construction is the only moment that knows the device's own
+//! format enumeration, its quirks match, and its sysfs identity all at once.
+//! Everything downstream asks the camera (`CameraSource::capabilities`)
+//! instead of threading `device_is_ir` / `DeviceFingerprint` as loose
+//! parameters.
+
+use facelock_core::config::DeviceConfig;
+use facelock_core::error::Result;
+use facelock_core::types::CameraCaps;
+
+use crate::capture::Camera;
+use crate::device::{self, DeviceInfo};
+use crate::ir_emitter::EmitterXuInfo;
+use crate::quirks::{Quirk, QuirksDb, device_fingerprint};
+
+/// A resolved-but-not-yet-opened camera device: its identity, its matched
+/// quirk, and the capabilities derived from interrogation.
+///
+/// Splitting resolution from opening lets pre-flight gates (`pre_check`'s
+/// `require_ir`) consult `caps` before any camera stream — or its indicator
+/// LED — is touched, while the eventually-opened [`Camera`] carries the very
+/// same caps.
+#[derive(Debug, Clone)]
+pub struct ResolvedCamera {
+    pub info: DeviceInfo,
+    /// The quirks-DB entry matched for this device, if any. Its overrides
+    /// (format preference, rotation, warmup) are applied at open time.
+    pub quirk: Option<Quirk>,
+    pub caps: CameraCaps,
+}
+
+impl ResolvedCamera {
+    /// Resolve the configured device (or auto-detect one) and interrogate it.
+    pub fn resolve(config: &DeviceConfig, quirks: &QuirksDb) -> Result<Self> {
+        let info = match config.path.as_deref() {
+            Some(path) => device::validate_device(path)?,
+            None => device::auto_detect_device()?,
+        };
+        Ok(Self::interrogate(info, quirks))
+    }
+
+    /// Interrogate an already-validated device into its capabilities.
+    ///
+    /// - `is_ir` adopts the evidence-derived, sibling-aware classification
+    ///   (`ir_source_resolved`, #98): queried mono-only formats or a
+    ///   corroborated quirk — never the free-text device name.
+    /// - `fingerprint` reads sysfs identity; all-`None` when unreadable.
+    /// - `has_emitter` and `applied_quirks` reflect the quirks match.
+    pub fn interrogate(info: DeviceInfo, quirks: &QuirksDb) -> Self {
+        let quirk = quirks.find_match(&info).cloned();
+        let caps = CameraCaps {
+            is_ir: device::is_ir_camera_resolved(&info, Some(quirks)),
+            has_emitter: quirk
+                .as_ref()
+                .is_some_and(|q| EmitterXuInfo::from_quirk(q).is_some()),
+            formats: info.formats.clone(),
+            fingerprint: device_fingerprint(&info.path),
+            applied_quirks: quirk.as_ref().map(quirk_id).into_iter().collect(),
+        };
+        Self { info, quirk, caps }
+    }
+
+    /// Open the camera stream; the returned [`Camera`] carries these caps.
+    /// The resolved device path takes precedence over `config.path`.
+    pub fn open(self, config: &DeviceConfig) -> Result<Camera<'static>> {
+        let mut config = config.clone();
+        config.path = Some(self.info.path.clone());
+        Camera::open_resolved(&config, self.quirk.as_ref(), self.caps)
+    }
+}
+
+/// Human-readable identifier for a quirks-DB entry, for
+/// `CameraCaps::applied_quirks` diagnostics. The quirks files carry no stable
+/// ids, so this is derived from the match fields plus the entry's notes.
+pub fn quirk_id(quirk: &Quirk) -> String {
+    let base = match (&quirk.vendor_id, &quirk.product_id, &quirk.name_pattern) {
+        (Some(vid), Some(pid), _) => format!("{vid}:{pid}"),
+        (_, _, Some(pattern)) => format!("name:{pattern}"),
+        _ => "unidentified-quirk".to_string(),
+    };
+    match quirk.notes.as_deref() {
+        Some(notes) if !notes.is_empty() => format!("{base} ({notes})"),
+        _ => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facelock_core::types::{DeviceFingerprint, FormatInfo};
+
+    fn device_with(name: &str, fourccs: &[&str]) -> DeviceInfo {
+        DeviceInfo {
+            path: "/dev/nonexistent_test_video".into(),
+            name: name.into(),
+            driver: "uvcvideo".into(),
+            capabilities: vec![],
+            formats: fourccs
+                .iter()
+                .map(|f| FormatInfo {
+                    fourcc: (*f).into(),
+                    description: "test".into(),
+                    sizes: vec![(640, 480)],
+                })
+                .collect(),
+        }
+    }
+
+    fn quirk(name_pattern: &str) -> Quirk {
+        Quirk {
+            vendor_id: None,
+            product_id: None,
+            name_pattern: Some(name_pattern.into()),
+            force_ir: None,
+            emitter_xu_guid: None,
+            emitter_xu_selector: None,
+            warmup_frames: None,
+            format_preference: None,
+            rotation: None,
+            notes: None,
+        }
+    }
+
+    #[test]
+    fn mono_only_device_interrogates_to_ir_caps() {
+        // C2's evidence rule, now living in the seam: a device that
+        // enumerates ONLY mono/IR-typical formats is IR — the name plays no
+        // part in it.
+        let resolved =
+            ResolvedCamera::interrogate(device_with("USB Camera", &["GREY"]), &QuirksDb::default());
+        assert!(resolved.caps.is_ir);
+        assert!(resolved.caps.applied_quirks.is_empty());
+        assert!(!resolved.caps.has_emitter);
+        assert_eq!(resolved.caps.formats.len(), 1);
+        assert_eq!(resolved.caps.formats[0].fourcc, "GREY");
+        // Fake path → no sysfs identity → all-None fingerprint, not an error.
+        assert_eq!(resolved.caps.fingerprint, DeviceFingerprint::default());
+    }
+
+    #[test]
+    fn crafted_ir_name_with_color_formats_is_not_ir_caps() {
+        // #98 regression, pinned at the caps seam: a v4l2loopback device can
+        // set CARD_LABEL to anything; a color-only "Fake IR Camera" must not
+        // interrogate into is_ir caps.
+        let resolved = ResolvedCamera::interrogate(
+            device_with("Fake IR Camera", &["YUYV", "MJPG"]),
+            &QuirksDb::default(),
+        );
+        assert!(!resolved.caps.is_ir);
+    }
+
+    #[test]
+    fn matched_quirk_populates_applied_quirks_and_emitter() {
+        let mut db = QuirksDb::default();
+        let mut q = quirk("(?i)test.*module");
+        q.emitter_xu_guid = Some("04".into());
+        q.emitter_xu_selector = Some(1);
+        q.notes = Some("test emitter module".into());
+        db.push_quirk_for_test(q);
+
+        // GREY-only: the quirk match is corroborated by the device's own
+        // format evidence, and the emitter declaration carries over.
+        let resolved = ResolvedCamera::interrogate(device_with("Test IR Module", &["GREY"]), &db);
+        assert!(resolved.caps.is_ir);
+        assert!(resolved.caps.has_emitter);
+        assert_eq!(
+            resolved.caps.applied_quirks,
+            vec!["name:(?i)test.*module (test emitter module)".to_string()]
+        );
+        assert!(resolved.quirk.is_some());
+    }
+
+    #[test]
+    fn quirk_without_emitter_fields_declares_no_emitter() {
+        let mut db = QuirksDb::default();
+        db.push_quirk_for_test(quirk("(?i)plain.*cam"));
+
+        let resolved = ResolvedCamera::interrogate(device_with("Plain Cam", &["YUYV"]), &db);
+        assert!(!resolved.caps.has_emitter);
+        assert_eq!(resolved.caps.applied_quirks.len(), 1);
+    }
+
+    #[test]
+    fn quirk_id_prefers_usb_identity_over_name_pattern() {
+        let mut q = quirk("(?i)brio");
+        q.vendor_id = Some("046d".into());
+        q.product_id = Some("085e".into());
+        q.notes = Some("Logitech BRIO".into());
+        assert_eq!(quirk_id(&q), "046d:085e (Logitech BRIO)");
+        assert_eq!(quirk_id(&quirk("(?i)brio")), "name:(?i)brio");
+    }
+}

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -18,7 +18,8 @@ const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 use crate::ir_emitter;
 use crate::ir_emitter::EmitterXuInfo;
 use crate::preprocess;
-use crate::quirks::Quirk;
+use crate::quirks::{Quirk, QuirksDb};
+use facelock_core::types::CameraCaps;
 
 /// A V4L2 camera for frame capture.
 pub struct Camera<'a> {
@@ -33,17 +34,34 @@ pub struct Camera<'a> {
     ir_emitter_active: bool,
     /// Emitter XU info, stored for disable on drop when the quirk ref is gone.
     emitter_xu_info: Option<EmitterXuInfo>,
+    /// Capabilities computed at construction — see `crate::caps` (gap D8).
+    caps: CameraCaps,
 }
 
 impl<'a> Camera<'a> {
-    /// Open a camera device with the given configuration.
-    /// If `config.path` is `None`, auto-detects the best available camera.
+    /// Resolve, interrogate and open a camera in one step. If `config.path`
+    /// is `None`, auto-detects the best available camera. The matched quirk
+    /// and the capabilities both come from the resolution — callers that need
+    /// the caps *before* opening (pre-flight gates) use
+    /// [`crate::caps::ResolvedCamera`] directly and open from that.
+    pub fn open(config: &DeviceConfig, quirks: &QuirksDb) -> Result<Camera<'static>> {
+        crate::caps::ResolvedCamera::resolve(config, quirks)?.open(config)
+    }
+
+    /// Open a camera device with the given configuration and pre-computed
+    /// capabilities (from [`crate::caps::ResolvedCamera`] — the one place
+    /// caps are derived, so an arbitrary caller cannot assert caps a device
+    /// never demonstrated).
     ///
     /// When a `quirk` is provided, its overrides take precedence:
     /// - `format_preference` is prepended to the format priority list.
     /// - `warmup_frames` replaces `config.warmup_frames`.
     /// - `rotation` replaces `config.rotation`.
-    pub fn open(config: &DeviceConfig, quirk: Option<&Quirk>) -> Result<Camera<'static>> {
+    pub(crate) fn open_resolved(
+        config: &DeviceConfig,
+        quirk: Option<&Quirk>,
+        caps: CameraCaps,
+    ) -> Result<Camera<'static>> {
         let device_path = match config.path {
             Some(ref p) => p.clone(),
             None => {
@@ -56,10 +74,10 @@ impl<'a> Camera<'a> {
             .map_err(|e| FacelockError::Camera(format!("failed to open {device_path}: {e}")))?;
 
         // Verify VIDEO_CAPTURE capability
-        let caps = dev.query_caps().map_err(|e| {
+        let v4l_caps = dev.query_caps().map_err(|e| {
             FacelockError::Camera(format!("failed to query caps for {device_path}: {e}"))
         })?;
-        if !caps
+        if !v4l_caps
             .capabilities
             .contains(v4l::capability::Flags::VIDEO_CAPTURE)
         {
@@ -171,7 +189,13 @@ impl<'a> Camera<'a> {
             device_path,
             ir_emitter_active,
             emitter_xu_info,
+            caps,
         })
+    }
+
+    /// Capabilities computed at construction. See [`CameraCaps`].
+    pub fn capabilities(&self) -> &CameraCaps {
+        &self.caps
     }
 
     /// Return the negotiated pixel format string (e.g. "MJPG", "YUYV", "GREY").
@@ -284,8 +308,17 @@ impl<'a> Camera<'a> {
 
     /// Check if a frame is too dark using default thresholds.
     pub fn is_dark(frame: &Frame) -> bool {
-        is_dark_with_config(frame, 0.6, 10)
+        is_dark(frame)
     }
+}
+
+/// Check if a frame is too dark using default thresholds.
+///
+/// A free function, not a `CameraSource` method: darkness is a property of a
+/// frame, and hanging it off the trait was what made the trait non-object-safe
+/// (`where Self: Sized`).
+pub fn is_dark(frame: &Frame) -> bool {
+    is_dark_with_config(frame, 0.6, 10)
 }
 
 /// Check if a frame is too dark to process.
@@ -325,16 +358,16 @@ impl Drop for Camera<'_> {
 }
 
 impl CameraSource for Camera<'_> {
+    fn capabilities(&self) -> &CameraCaps {
+        Camera::capabilities(self)
+    }
+
     fn capture(&mut self) -> Result<Frame> {
         Camera::capture(self)
     }
 
     fn capture_rgb_only(&mut self) -> Result<Frame> {
         Camera::capture_rgb_only(self)
-    }
-
-    fn is_dark(frame: &Frame) -> bool {
-        Camera::is_dark(frame)
     }
 }
 
@@ -455,7 +488,7 @@ mod tests {
             ir_emitter: false,
             camera_release_secs: 5,
         };
-        let mut cam = Camera::open(&config, None).expect("failed to open camera");
+        let mut cam = Camera::open(&config, &QuirksDb::load()).expect("failed to open camera");
         let frame = cam.capture().expect("failed to capture frame");
         assert!(frame.width > 0);
         assert!(frame.height > 0);

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -14,13 +14,10 @@ pub struct DeviceInfo {
     pub formats: Vec<FormatInfo>,
 }
 
-/// A supported pixel format with its available sizes.
-#[derive(Debug, Clone)]
-pub struct FormatInfo {
-    pub fourcc: String,
-    pub description: String,
-    pub sizes: Vec<(u32, u32)>,
-}
+/// A supported pixel format with its available sizes. Defined in
+/// `facelock-core` so `CameraCaps` can carry it; re-exported here where the
+/// enumeration actually happens.
+pub use facelock_core::types::FormatInfo;
 
 /// List all V4L2 video capture devices.
 /// Returns an empty vec if no devices are found (does not error).

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -1,10 +1,12 @@
+pub mod caps;
 pub mod capture;
 pub mod device;
 pub mod ir_emitter;
 pub mod preprocess;
 pub mod quirks;
 
-pub use capture::{Camera, is_dark_with_config};
+pub use caps::{ResolvedCamera, quirk_id};
+pub use capture::{Camera, is_dark, is_dark_with_config};
 pub use device::{
     DeviceInfo, FormatInfo, IrSource, auto_detect_device, classify_ir_sources, ir_source,
     ir_source_resolved, ir_source_with_quirks, is_ir_camera, is_ir_camera_resolved,

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -5,9 +5,10 @@
 use std::path::Path;
 
 use facelock_camera::quirks::QuirksDb;
-use facelock_camera::{Camera, auto_detect_device, is_ir_camera_resolved, validate_device};
+use facelock_camera::{Camera, ResolvedCamera, auto_detect_device, validate_device};
 use facelock_core::config::Config;
 use facelock_core::ipc::DaemonResponse;
+use facelock_core::types::CameraCaps;
 use facelock_core::types::MatchResult;
 use facelock_daemon::audit::{self, AuditEntry, AuditSource};
 use facelock_daemon::auth;
@@ -58,25 +59,24 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         }
     }
 
-    // Resolve the live device before the pre-flight gates so `pre_check` sees
-    // the real IR classification, exactly like the daemon does at startup.
+    // Resolve and interrogate the live device before the pre-flight gates so
+    // `pre_check` sees the real caps (IR classification, fingerprint),
+    // exactly like the daemon does at startup. Tolerant of a device that
+    // cannot be queried: non-IR caps with whatever identity sysfs still
+    // offers, so `require_ir` rejects rather than a hard error here.
     let device_path = config.device.path.clone().unwrap();
     let quirks = QuirksDb::load();
-    let device_info = validate_device(&device_path);
-    // Sibling-aware classification: on multi-node USB cameras (e.g. BRIO) only
-    // the actual IR sensor node counts as IR, not every node of the device.
-    let device_is_ir = device_info
+    let resolved = match validate_device(&device_path) {
+        Ok(info) => Some(ResolvedCamera::interrogate(info, &quirks)),
+        Err(_) => None,
+    };
+    let caps = resolved
         .as_ref()
-        .map(|dev| is_ir_camera_resolved(dev, Some(&quirks)))
-        .unwrap_or(false);
-
-    // Device coupling (Plan 02): fingerprint the live camera so the compare loop
-    // can skip templates enrolled on a different camera.
-    let live_fingerprint = facelock_camera::device_fingerprint(&device_path);
-
-    let device_quirk = device_info
-        .ok()
-        .and_then(|info| quirks.find_match(&info).cloned());
+        .map(|r| r.caps.clone())
+        .unwrap_or_else(|| CameraCaps {
+            fingerprint: facelock_camera::device_fingerprint(&device_path),
+            ..Default::default()
+        });
 
     // Best-effort mode fixing before the store is opened: this is the PAM
     // path, the one entry point guaranteed to run on an oneshot-mode install
@@ -110,7 +110,7 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         &store,
         &user,
         &rate_limiter,
-        device_is_ir,
+        &caps,
         AuditSource::Oneshot,
     ) {
         // Every pre-flight rejection exits 2 ("error"), which the PAM module
@@ -123,7 +123,20 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         return 2;
     }
 
-    let mut camera = match Camera::open(&config.device, device_quirk.as_ref()) {
+    // Quirk override takes precedence over the config's warmup value.
+    let warmup = resolved
+        .as_ref()
+        .and_then(|r| r.quirk.as_ref())
+        .and_then(|q| q.warmup_frames)
+        .unwrap_or(config.device.warmup_frames);
+    let camera = match resolved {
+        // The camera carries the caps the pre-flight gates just checked.
+        Some(resolved) => resolved.open(&config.device),
+        // Unqueryable at resolution time: attempt a fresh resolve-and-open so
+        // the failure surfaces as the camera error it is.
+        None => Camera::open(&config.device, &quirks),
+    };
+    let mut camera = match camera {
         Ok(c) => c,
         Err(e) => {
             error!("camera: {e}");
@@ -132,9 +145,6 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     };
 
     // Discard warmup frames for AGC/AE stabilization.
-    let warmup = device_quirk
-        .and_then(|q| q.warmup_frames)
-        .unwrap_or(config.device.warmup_frames);
     for _ in 0..warmup {
         let _ = camera.capture();
     }
@@ -169,8 +179,6 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         &models,
         &config,
         &user,
-        device_is_ir,
-        &live_fingerprint,
         AuditSource::Oneshot,
     );
     let duration_ms = start.elapsed().as_millis() as u64;
@@ -292,6 +300,15 @@ path = "{audit_path}"
         RateLimiter::new(rl.max_attempts, rl.window_secs)
     }
 
+    /// Caps of an IR-classified device (what these tests used to express as a
+    /// bare `device_is_ir: true`).
+    fn ir_caps() -> facelock_core::types::CameraCaps {
+        facelock_core::types::CameraCaps {
+            is_ir: true,
+            ..Default::default()
+        }
+    }
+
     /// #95 symptom (a): a rate-limited oneshot attempt used to be rejected
     /// with no audit record. Unified on `pre_check_audited`, the rejection
     /// must produce the same `rate_limited` entry the daemon path writes,
@@ -315,7 +332,7 @@ path = "{audit_path}"
             &store,
             "alice",
             &limiter,
-            true,
+            &ir_caps(),
             AuditSource::Oneshot,
         )
         .expect("rate-limited user must short-circuit");
@@ -346,7 +363,7 @@ path = "{audit_path}"
             &store,
             "nobody",
             &rate_limiter(&config),
-            true,
+            &ir_caps(),
             AuditSource::Oneshot,
         )
         .expect("un-enrolled user must short-circuit");
@@ -373,7 +390,7 @@ path = "{audit_path}"
             &store,
             "nobody",
             &rate_limiter(&config),
-            true,
+            &ir_caps(),
             AuditSource::Oneshot,
         )
         .expect("un-enrolled user must short-circuit");
@@ -405,7 +422,7 @@ path = "{audit_path}"
             &store,
             "alice",
             &rate_limiter(&config),
-            true,
+            &ir_caps(),
             AuditSource::Oneshot,
         );
         assert!(resp.is_none(), "gates must pass, got {resp:?}");

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -5,7 +5,9 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
 
 use facelock_camera::quirks::QuirksDb;
-use facelock_camera::{Camera, auto_detect_device, is_ir_camera_resolved, validate_device};
+use facelock_camera::{
+    Camera, ResolvedCamera, auto_detect_device, is_ir_camera_resolved, validate_device,
+};
 use facelock_core::config::Config;
 use facelock_core::dbus_interface::{
     AuthResult, BUS_NAME, DeviceInfo, ModelInfo, OBJECT_PATH, PreviewFaceInfo,
@@ -1161,19 +1163,35 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
 
     let device_path = config.device.path.clone().unwrap();
 
-    let device_is_ir = match validate_device(&device_path) {
+    // Resolve and interrogate the device once, up front. The resulting caps
+    // gate `pre_check` before any camera is opened, and every camera the
+    // factory opens carries the same interrogation. Tolerant of a device
+    // that cannot be queried: the daemon still starts (auth keeps falling
+    // through to password), with non-IR caps and whatever identity sysfs
+    // still offers.
+    let resolved = match validate_device(&device_path) {
         Ok(info) => {
-            // Sibling-aware: on multi-node USB cameras only the IR sensor
-            // node counts as IR, not every node sharing the quirk's VID:PID.
-            let is_ir = is_ir_camera_resolved(&info, Some(&quirks));
-            info!(device = %device_path, ir = is_ir, name = %info.name, "camera device");
-            is_ir
+            let resolved = ResolvedCamera::interrogate(info, &quirks);
+            info!(
+                device = %device_path,
+                ir = resolved.caps.is_ir,
+                name = %resolved.info.name,
+                "camera device"
+            );
+            Some(resolved)
         }
         Err(e) => {
             warn!("failed to query device {device_path}: {e}");
-            false
+            None
         }
     };
+    let device_caps = resolved
+        .as_ref()
+        .map(|r| r.caps.clone())
+        .unwrap_or_else(|| facelock_core::types::CameraCaps {
+            fingerprint: facelock_camera::device_fingerprint(&device_path),
+            ..Default::default()
+        });
 
     // Explicit resolution before construction (D7): name what is missing or
     // misconfigured up front — the engine's load error is opaque about
@@ -1225,34 +1243,41 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
         config.security.rate_limit.window_secs,
     );
 
-    let device_quirk = validate_device(&device_path)
-        .ok()
-        .and_then(|info| quirks.find_match(&info).cloned());
-
-    let quirk_for_factory = device_quirk.clone();
-    let camera_factory: CameraFactory = Box::new(move |config: &Config| {
-        Camera::open(&config.device, quirk_for_factory.as_ref()).map_err(|e| e.to_string())
-    });
-
-    // Device coupling (Plan 02): fingerprint the resolved camera once so enroll
-    // can record it and auth can require it. Advisory only (model-granularity,
-    // spoofable) — see facelock_core::types::DeviceFingerprint.
-    let device_fingerprint = facelock_camera::device_fingerprint(&device_path);
+    // Device coupling (Plan 02): the interrogated fingerprint rides on the
+    // caps, so enroll can record it and auth can require it. Advisory only
+    // (model-granularity, spoofable) — see facelock_core::types::DeviceFingerprint.
     info!(
         device = %device_path,
-        device_id = %device_fingerprint.canonical(),
+        device_id = %device_caps.fingerprint.canonical(),
         "camera device fingerprint"
     );
 
     let idle_timeout_secs = config.daemon.idle_timeout_secs;
-    let warmup_override = device_quirk.and_then(|q| q.warmup_frames);
+    let warmup_override = resolved
+        .as_ref()
+        .and_then(|r| r.quirk.as_ref())
+        .and_then(|q| q.warmup_frames);
+    let camera_factory: CameraFactory = match resolved {
+        // Reuse the startup interrogation for every (re)open, exactly as the
+        // startup-captured quirk used to be reused.
+        Some(resolved) => Box::new(move |config: &Config| {
+            resolved
+                .clone()
+                .open(&config.device)
+                .map_err(|e| e.to_string())
+        }),
+        // Unqueryable at startup: retry a fresh resolve-and-open per request
+        // so a later-appearing device surfaces its own open error (or works).
+        None => Box::new(move |config: &Config| {
+            Camera::open(&config.device, &QuirksDb::load()).map_err(|e| e.to_string())
+        }),
+    };
     let handler = Handler::new(
         config,
         engine,
         store,
         rate_limiter,
-        device_is_ir,
-        device_fingerprint,
+        device_caps,
         Some(camera_factory),
         warmup_override,
     )?;

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -7,10 +7,7 @@ use std::path::Path;
 
 use anyhow::{Context, bail};
 use facelock_camera::quirks::QuirksDb;
-use facelock_camera::{
-    Camera, DeviceInfo, auto_detect_device, is_ir_camera_resolved, list_devices, validate_device,
-};
-use facelock_core::config::DeviceConfig;
+use facelock_camera::{Camera, ResolvedCamera, auto_detect_device, list_devices, validate_device};
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::traits::{CameraSource, FaceProcessor};
@@ -55,39 +52,12 @@ pub fn open_store_existing(config: &Config) -> Result<FaceStore, StoreError> {
     FaceStore::open_existing(Path::new(&config.storage.db_path))
 }
 
-#[derive(Clone)]
-struct ResolvedCameraDevice {
-    device: DeviceConfig,
-    device_quirk: Option<facelock_camera::quirks::Quirk>,
-    device_is_ir: bool,
-    device_fingerprint: facelock_core::types::DeviceFingerprint,
-}
-
-struct OpenedCamera {
-    camera: Camera<'static>,
-    device_is_ir: bool,
-    device_fingerprint: facelock_core::types::DeviceFingerprint,
-}
-
-fn build_resolved_camera_device(
-    config: &Config,
-    device_info: DeviceInfo,
-    quirks: &QuirksDb,
-) -> ResolvedCameraDevice {
-    let mut device = config.device.clone();
-    device.path = Some(device_info.path.clone());
-
-    ResolvedCameraDevice {
-        device_fingerprint: facelock_camera::device_fingerprint(&device_info.path),
-        device_quirk: quirks.find_match(&device_info).cloned(),
-        // Sibling-aware: on multi-node USB cameras only the IR sensor node
-        // counts as IR, not every node sharing the quirk's VID:PID.
-        device_is_ir: is_ir_camera_resolved(&device_info, Some(quirks)),
-        device,
-    }
-}
-
-fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCameraDevice> {
+/// Resolve and interrogate the configured (or auto-detected) camera device
+/// without opening it. The returned [`ResolvedCamera`] carries the caps
+/// (`is_ir`, fingerprint, formats, applied quirks) that used to be threaded
+/// around as loose values — pre-flight gates read `resolved.caps`, and the
+/// camera opened from it carries the very same caps.
+fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCamera> {
     let quirks = QuirksDb::load();
     let device_info = match config.device.path.as_deref() {
         Some(path) => validate_device(path)
@@ -97,20 +67,24 @@ fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCameraDevice
         }
     };
 
-    Ok(build_resolved_camera_device(config, device_info, &quirks))
+    Ok(ResolvedCamera::interrogate(device_info, &quirks))
 }
 
-fn open_camera_context(config: &Config) -> anyhow::Result<OpenedCamera> {
-    let resolved = resolve_camera_device(config)?;
-    let mut camera = Camera::open(&resolved.device, resolved.device_quirk.as_ref())
-        .context("failed to open camera")?;
-
+/// Open an already-resolved camera and discard warmup frames.
+fn open_resolved_camera(
+    config: &Config,
+    resolved: ResolvedCamera,
+) -> anyhow::Result<Camera<'static>> {
     // Discard warmup frames for AGC/AE stabilization.
     // Quirk override takes precedence over config value.
     let warmup = resolved
-        .device_quirk
+        .quirk
+        .as_ref()
         .and_then(|q| q.warmup_frames)
-        .unwrap_or(resolved.device.warmup_frames);
+        .unwrap_or(config.device.warmup_frames);
+    let mut camera = resolved
+        .open(&config.device)
+        .context("failed to open camera")?;
     if warmup > 0 {
         debug!(warmup, "discarding warmup frames");
         for _ in 0..warmup {
@@ -118,16 +92,12 @@ fn open_camera_context(config: &Config) -> anyhow::Result<OpenedCamera> {
         }
     }
 
-    Ok(OpenedCamera {
-        camera,
-        device_is_ir: resolved.device_is_ir,
-        device_fingerprint: resolved.device_fingerprint,
-    })
+    Ok(camera)
 }
 
 /// Open camera with quirks support and warmup frame discarding.
 pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
-    Ok(open_camera_context(config)?.camera)
+    open_resolved_camera(config, resolve_camera_device(config)?)
 }
 
 pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
@@ -150,12 +120,11 @@ pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
 pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> {
     let store = open_store(config)?;
 
-    // Cheap device classification only (no camera I/O), so a pre-check
-    // rejection never touches the camera. `open_camera_context` below
-    // re-resolves the same device once opening actually proceeds.
-    let device_is_ir = resolve_camera_device(config)
-        .context("failed to resolve camera device")?
-        .device_is_ir;
+    // Cheap device resolution only (no camera I/O), so a pre-check rejection
+    // never touches the camera. The same resolution is opened below once auth
+    // actually proceeds, so the caps the gates saw are the caps the camera
+    // carries.
+    let resolved = resolve_camera_device(config).context("failed to resolve camera device")?;
 
     let rl = &config.security.rate_limit;
     let rate_limiter = RateLimiter::new(rl.max_attempts, rl.window_secs);
@@ -165,7 +134,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         &store,
         user,
         &rate_limiter,
-        device_is_ir,
+        &resolved.caps,
         AuditSource::Test,
         PreCheckContext::test(),
     ) {
@@ -185,11 +154,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         };
     }
 
-    let OpenedCamera {
-        mut camera,
-        device_is_ir,
-        device_fingerprint,
-    } = open_camera_context(config)?;
+    let mut camera = open_resolved_camera(config, resolved)?;
     let mut engine = load_engine(config)?;
 
     // Load embeddings with encryption support, matching the daemon handler path.
@@ -210,8 +175,6 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         &models,
         config,
         user,
-        device_is_ir,
-        &device_fingerprint,
         AuditSource::Test,
     );
 
@@ -226,7 +189,6 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
 /// embeddings (#100). `authenticate_with_embeddings` copies the compare set
 /// and zeroizes only its own copies, so without this the plaintext templates
 /// passed in would outlive authentication in the caller's memory.
-#[allow(clippy::too_many_arguments)]
 pub fn authenticate_and_wipe<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
     engine: &mut E,
@@ -234,20 +196,10 @@ pub fn authenticate_and_wipe<C: CameraSource, E: FaceProcessor>(
     models: &[facelock_core::types::FaceModelInfo],
     config: &Config,
     user: &str,
-    device_is_ir: bool,
-    live_fingerprint: &facelock_core::types::DeviceFingerprint,
     source: AuditSource,
 ) -> DaemonResponse {
     let response = facelock_daemon::auth::authenticate_with_embeddings(
-        camera,
-        engine,
-        stored,
-        models,
-        config,
-        user,
-        device_is_ir,
-        live_fingerprint,
-        source,
+        camera, engine, stored, models, config, user, source,
     );
     zeroize_stored_embeddings(stored);
     response
@@ -375,9 +327,10 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
         .map_err(|m| anyhow::anyhow!(m))?;
 
     let store = open_store(config)?;
-    let opened = open_camera_context(config)?;
-    let device_id = opened.device_fingerprint.canonical_for_storage();
-    let mut camera = opened.camera;
+    let mut camera = open_camera(config)?;
+    // The enrolling camera's own identity — asked of the camera that records
+    // the template.
+    let device_id = camera.capabilities().fingerprint.canonical_for_storage();
     let mut engine = load_engine(config)?;
 
     // Initialize sealer if encryption is configured
@@ -459,20 +412,10 @@ pub fn list_devices_direct() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use facelock_camera::FormatInfo;
+    use facelock_camera::{DeviceInfo, FormatInfo};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn test_config() -> Config {
-        Config::parse(
-            r#"
-[device]
-warmup_frames = 2
-"#,
-        )
-        .unwrap()
-    }
 
     fn make_device(path: &str, name: &str, fourcc: &str) -> DeviceInfo {
         DeviceInfo {
@@ -501,7 +444,6 @@ warmup_frames = 2
 
     #[test]
     fn auto_detected_device_inherits_quirk_state() {
-        let config = test_config();
         let device = make_device("/dev/video2", "BRIO IR", "GREY");
         let dir = write_quirks_dir(
             r#"
@@ -514,12 +456,13 @@ warmup_frames = 9
         let mut quirks = QuirksDb::default();
         quirks.load_dir(&dir);
 
-        let resolved = build_resolved_camera_device(&config, device, &quirks);
+        let resolved = ResolvedCamera::interrogate(device, &quirks);
 
-        assert_eq!(resolved.device.path.as_deref(), Some("/dev/video2"));
-        assert!(resolved.device_is_ir);
+        assert_eq!(resolved.info.path, "/dev/video2");
+        assert!(resolved.caps.is_ir);
+        assert_eq!(resolved.caps.applied_quirks.len(), 1);
         assert_eq!(
-            resolved.device_quirk.as_ref().and_then(|q| q.warmup_frames),
+            resolved.quirk.as_ref().and_then(|q| q.warmup_frames),
             Some(9)
         );
 
@@ -528,16 +471,17 @@ warmup_frames = 9
 
     #[test]
     fn unmatched_device_keeps_default_warmup_and_non_ir_state() {
-        let config = test_config();
         let device = make_device("/dev/video3", "USB Camera", "MJPG");
         let quirks = QuirksDb::default();
 
-        let resolved = build_resolved_camera_device(&config, device, &quirks);
+        let resolved = ResolvedCamera::interrogate(device, &quirks);
 
-        assert_eq!(resolved.device.path.as_deref(), Some("/dev/video3"));
-        assert_eq!(resolved.device.warmup_frames, 2);
-        assert!(!resolved.device_is_ir);
-        assert!(resolved.device_quirk.is_none());
+        assert_eq!(resolved.info.path, "/dev/video3");
+        assert!(!resolved.caps.is_ir);
+        // No quirk match: `open_resolved_camera` falls back to the config's
+        // own warmup_frames.
+        assert!(resolved.quirk.is_none());
+        assert!(resolved.caps.applied_quirks.is_empty());
     }
 
     // --- N8: encrypted-store loading in the direct path ---
@@ -648,13 +592,9 @@ abort_if_lid_closed = false
             embedder_model: String::new(),
             device_id: None,
         }];
-        let fingerprint = facelock_core::types::DeviceFingerprint {
-            vid: None,
-            pid: None,
-            serial: None,
-            by_path: None,
-        };
 
+        // The mock's default caps are non-IR with an all-None fingerprint —
+        // the same facts the removed loose parameters used to carry.
         let response = authenticate_and_wipe(
             &mut camera,
             &mut engine,
@@ -662,8 +602,6 @@ abort_if_lid_closed = false
             &models,
             &config,
             "alice",
-            false,
-            &fingerprint,
             AuditSource::Test,
         );
 

--- a/crates/facelock-core/src/traits.rs
+++ b/crates/facelock-core/src/traits.rs
@@ -1,18 +1,21 @@
 use crate::error::Result;
-use crate::types::{Detection, FaceEmbedding, Frame};
+use crate::types::{CameraCaps, Detection, FaceEmbedding, Frame};
 
 /// Abstraction over camera frame capture.
+///
+/// Object-safe: capabilities are computed once at construction and asked of
+/// the camera, never threaded alongside it as loose parameters (gap D8).
+/// Frame darkness is a property of a frame, not a camera — see the free
+/// function `facelock_camera::is_dark`.
 pub trait CameraSource {
+    /// Capabilities of the underlying device, computed at construction.
+    fn capabilities(&self) -> &CameraCaps;
+
     /// Capture a frame with full preprocessing (RGB + grayscale + CLAHE).
     fn capture(&mut self) -> Result<Frame>;
 
     /// Capture a frame with RGB only (no grayscale/CLAHE).
     fn capture_rgb_only(&mut self) -> Result<Frame>;
-
-    /// Check if a frame is too dark.
-    fn is_dark(frame: &Frame) -> bool
-    where
-        Self: Sized;
 }
 
 /// Abstraction over face detection + embedding extraction.

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -146,6 +146,41 @@ impl DeviceFingerprint {
     }
 }
 
+/// A supported capture pixel format with its available frame sizes, as
+/// enumerated by the device itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatInfo {
+    pub fourcc: String,
+    pub description: String,
+    pub sizes: Vec<(u32, u32)>,
+}
+
+/// Capabilities of a camera device, computed once at construction from device
+/// interrogation (format enumeration, quirks match, sysfs identity) and
+/// carried by the camera itself — so nothing downstream has to thread
+/// `device_is_ir` or a fingerprint as loose parameters (gap D8).
+#[derive(Debug, Clone, Default)]
+pub struct CameraCaps {
+    /// Whether this device is an IR camera, **derived** from queried device
+    /// evidence (mono-only format enumeration, corroborated quirks) — never
+    /// from the free-text device name, which is attacker-controlled on
+    /// virtual devices (#98). `security.require_ir` gates on this field.
+    pub is_ir: bool,
+    /// The quirks DB declares a controllable IR emitter (XU GUID + selector)
+    /// for this device. Declared, not probed: whether the ioctl actually
+    /// works is only known when the emitter is enabled at capture time.
+    pub has_emitter: bool,
+    /// The capture formats the device enumerates.
+    pub formats: Vec<FormatInfo>,
+    /// Hardware identity used for device coupling. All fields are `None`
+    /// when the device exposes no readable USB identity — "unknown" is a
+    /// value inside [`DeviceFingerprint`], not an `Option` around it.
+    pub fingerprint: DeviceFingerprint,
+    /// Human-readable identifiers of the quirks applied to this device, for
+    /// diagnostics ("why did this camera behave oddly").
+    pub applied_quirks: Vec<String>,
+}
+
 /// Granularity at which a live camera must match a template's enrolling camera.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -8,7 +8,7 @@ use facelock_core::fs_security::{ensure_dir, ensure_private_dir, write_file};
 use facelock_core::ipc::DaemonResponse;
 use facelock_core::traits::{CameraSource, FaceProcessor};
 use facelock_core::types::{
-    AuthFailureReason, DeviceFingerprint, FaceEmbedding, Frame, FrameVarianceWindow, MatchResult,
+    AuthFailureReason, CameraCaps, FaceEmbedding, Frame, FrameVarianceWindow, MatchResult,
     best_match, device_allowed_model_ids, zeroize_stored_embeddings,
 };
 use facelock_store::FaceStore;
@@ -56,19 +56,24 @@ impl PreCheckContext {
 
 /// Run pre-flight checks that don't need the camera, fully enforced.
 /// Returns Some(response) to short-circuit, or None to proceed with auth.
+///
+/// `caps` are the *resolved* device's capabilities ([`CameraCaps`]), computed
+/// without opening a camera stream — the `require_ir` gate must run before
+/// any camera (and its indicator LED) is touched, so this is the one boundary
+/// where caps arrive as a parameter instead of being asked of an open camera.
 pub fn pre_check(
     config: &Config,
     store: &FaceStore,
     user: &str,
     rate_limiter: &RateLimiter,
-    device_is_ir: bool,
+    caps: &CameraCaps,
 ) -> Option<DaemonResponse> {
     pre_check_with_context(
         config,
         store,
         user,
         rate_limiter,
-        device_is_ir,
+        caps,
         PreCheckContext::enforced(),
     )
 }
@@ -80,7 +85,7 @@ pub fn pre_check_with_context(
     store: &FaceStore,
     user: &str,
     rate_limiter: &RateLimiter,
-    device_is_ir: bool,
+    caps: &CameraCaps,
     ctx: PreCheckContext,
 ) -> Option<DaemonResponse> {
     if config.security.disabled {
@@ -145,7 +150,7 @@ pub fn pre_check_with_context(
         }
     }
 
-    if config.security.require_ir && !device_is_ir {
+    if config.security.require_ir && !caps.is_ir {
         warn!(user, "IR camera required but device is not IR");
         return Some(DaemonResponse::Error {
             message: "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).".into(),
@@ -165,7 +170,7 @@ pub fn pre_check_audited(
     store: &FaceStore,
     user: &str,
     rate_limiter: &RateLimiter,
-    device_is_ir: bool,
+    caps: &CameraCaps,
     source: AuditSource,
 ) -> Option<DaemonResponse> {
     pre_check_audited_with_context(
@@ -173,7 +178,7 @@ pub fn pre_check_audited(
         store,
         user,
         rate_limiter,
-        device_is_ir,
+        caps,
         source,
         PreCheckContext::enforced(),
     )
@@ -185,11 +190,11 @@ pub fn pre_check_audited_with_context(
     store: &FaceStore,
     user: &str,
     rate_limiter: &RateLimiter,
-    device_is_ir: bool,
+    caps: &CameraCaps,
     source: AuditSource,
     ctx: PreCheckContext,
 ) -> Option<DaemonResponse> {
-    let resp = pre_check_with_context(config, store, user, rate_limiter, device_is_ir, ctx)?;
+    let resp = pre_check_with_context(config, store, user, rate_limiter, caps, ctx)?;
     let (result, error) = match &resp {
         DaemonResponse::Error { message } if message.contains("rate limited") => {
             ("rate_limited".to_string(), Some(message.clone()))
@@ -231,7 +236,11 @@ pub fn pre_check_audited_with_context(
 /// only `Test` (direct-mode `facelock test`) skips `pre_check`, so a `success`
 /// stamped `test` is a recognition result rather than an approved
 /// authentication.
-#[allow(clippy::too_many_arguments)]
+///
+/// The device's IR-ness (gating the IR texture liveness check) and its
+/// fingerprint (restricting the compare set to templates enrolled on this
+/// camera) are asked of `camera.capabilities()` — the camera in use, not a
+/// parameter a caller could get out of sync with it (gap D8).
 pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
     engine: &mut E,
@@ -239,23 +248,11 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     models: &[facelock_core::types::FaceModelInfo],
     config: &Config,
     user: &str,
-    device_is_ir: bool,
-    live_fingerprint: &DeviceFingerprint,
     source: AuditSource,
 ) -> DaemonResponse {
     let mut stored = stored.to_vec();
     let models = models.to_vec();
-    authenticate_inner(
-        camera,
-        engine,
-        &mut stored,
-        &models,
-        config,
-        user,
-        device_is_ir,
-        live_fingerprint,
-        source,
-    )
+    authenticate_inner(camera, engine, &mut stored, &models, config, user, source)
 }
 
 /// Save a snapshot of the last captured frame to disk.
@@ -299,7 +296,6 @@ fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, 
     debug!(path = %path.display(), "saved auth snapshot");
 }
 
-#[allow(clippy::too_many_arguments)]
 fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
     engine: &mut E,
@@ -307,10 +303,10 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     models: &[facelock_core::types::FaceModelInfo],
     config: &Config,
     user: &str,
-    device_is_ir: bool,
-    live_fingerprint: &DeviceFingerprint,
     source: AuditSource,
 ) -> DaemonResponse {
+    let device_is_ir = camera.capabilities().is_ir;
+    let live_fingerprint = camera.capabilities().fingerprint.clone();
     let start = Instant::now();
     let save_snapshots = config.snapshots.mode != facelock_core::config::SnapshotMode::Off;
     let label_for =
@@ -322,7 +318,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     // — the outcome degrades to "no match" → password, never a success and never
     // a lockout. Fail SOFT by construction.
     let policy = config.security.device_binding_policy();
-    let allowed = device_allowed_model_ids(models, live_fingerprint, &policy);
+    let allowed = device_allowed_model_ids(models, &live_fingerprint, &policy);
     let mut compare_set: Vec<(u32, FaceEmbedding)> = stored
         .iter()
         .filter(|(id, _)| allowed.contains(id))
@@ -747,6 +743,15 @@ mod tests {
         config
     }
 
+    /// Caps of an IR-classified device (what these tests used to express as a
+    /// bare `device_is_ir: true`).
+    fn ir_caps() -> CameraCaps {
+        CameraCaps {
+            is_ir: true,
+            ..Default::default()
+        }
+    }
+
     fn store_with_enrolled_user(user: &str) -> FaceStore {
         let store = FaceStore::open_memory().unwrap();
         store
@@ -796,7 +801,7 @@ mod tests {
             &store,
             "alice",
             &rate_limiter,
-            true,
+            &ir_caps(),
             PreCheckContext::test(),
         );
         unsafe {
@@ -829,7 +834,7 @@ mod tests {
             &store,
             "alice",
             &rate_limiter,
-            true,
+            &ir_caps(),
             PreCheckContext::enforced(),
         );
         unsafe {
@@ -861,7 +866,7 @@ mod tests {
 
         let old_conn = std::env::var("SSH_CONNECTION").ok();
         unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 1 5.6.7.8 22") };
-        let resp = pre_check(&config, &store, "alice", &rate_limiter, true);
+        let resp = pre_check(&config, &store, "alice", &rate_limiter, &ir_caps());
         unsafe {
             match old_conn {
                 Some(v) => std::env::set_var("SSH_CONNECTION", v),

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -25,10 +25,11 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     pub engine: E,
     pub store: FaceStore,
     pub rate_limiter: RateLimiter,
-    pub device_is_ir: bool,
-    /// Live camera fingerprint used to couple templates to their enrolling
-    /// camera (Plan 02). Computed once at handler build from the resolved device.
-    pub device_fingerprint: facelock_core::types::DeviceFingerprint,
+    /// Capabilities of the resolved (not necessarily open) camera device,
+    /// computed once at handler build. `pre_check` gates `require_ir` on
+    /// `device_caps.is_ir` *before* any camera is opened; once a camera is
+    /// open, its own `capabilities()` are authoritative.
+    pub device_caps: facelock_core::types::CameraCaps,
     pub shutdown_requested: bool,
     camera: Option<C>,
     camera_factory: Option<CameraFactory<C>>,
@@ -52,8 +53,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         engine: E,
         store: FaceStore,
         rate_limiter: RateLimiter,
-        device_is_ir: bool,
-        device_fingerprint: facelock_core::types::DeviceFingerprint,
+        device_caps: facelock_core::types::CameraCaps,
         camera_factory: Option<CameraFactory<C>>,
         warmup_frames_override: Option<u32>,
     ) -> Result<Self, String> {
@@ -157,8 +157,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             engine,
             store,
             rate_limiter,
-            device_is_ir,
-            device_fingerprint,
+            device_caps,
             shutdown_requested: false,
             camera: None,
             camera_factory,
@@ -368,7 +367,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 }
 
                 let mut camera = self.camera.take().unwrap();
-                let device_id = self.device_fingerprint.canonical_for_storage();
+                // The enrolling camera's own identity — asked of the camera
+                // actually recording the template, not a handler-level copy.
+                let device_id = camera.capabilities().fingerprint.canonical_for_storage();
                 let result = enroll::enroll(
                     &mut camera,
                     &mut self.engine,
@@ -520,7 +521,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &self.store,
             &user,
             &self.rate_limiter,
-            self.device_is_ir,
+            &self.device_caps,
             AuditSource::Daemon,
         ) {
             return resp;
@@ -560,8 +561,6 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &models,
             &self.config,
             &user,
-            self.device_is_ir,
-            &self.device_fingerprint,
             AuditSource::Daemon,
         );
         // `authenticate_with_embeddings` works on an internal copy;

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -83,6 +83,19 @@ fn mock_camera_wraps_around() {
     assert_eq!(frame.width, 64);
 }
 
+/// D8 compile-time pin: `CameraSource` is object-safe. The old trait carried
+/// `fn is_dark(..) where Self: Sized`, which made `dyn CameraSource`
+/// unusable; darkness is a free function now and capabilities live on the
+/// camera, so a boxed camera works.
+#[test]
+fn camera_source_is_object_safe() {
+    use facelock_core::traits::CameraSource;
+    let mut cam: Box<dyn CameraSource> = Box::new(MockCamera::bright(64, 64, 1));
+    let frame = cam.capture().unwrap();
+    assert_eq!(frame.width, 64);
+    assert!(!cam.capabilities().is_ir);
+}
+
 #[test]
 fn mock_face_engine_one_face() {
     use facelock_core::traits::FaceProcessor;
@@ -184,6 +197,8 @@ fn device_mismatch_never_reaches_success() {
         device_id: Some("aaaa:bbbb:".into()),
     }];
 
+    // The live camera's identity now rides on its caps — the auth loop asks
+    // the camera rather than taking a fingerprint parameter (D8).
     let mismatch = DeviceFingerprint {
         vid: Some("cccc".into()),
         pid: Some("dddd".into()),
@@ -191,7 +206,10 @@ fn device_mismatch_never_reaches_success() {
         by_path: None,
     };
     let mut engine = MockFaceEngine::one_face(emb);
-    let mut cam = MockCamera::bright(64, 64, 10);
+    let mut cam = MockCamera::bright(64, 64, 10).with_caps(facelock_core::types::CameraCaps {
+        fingerprint: mismatch,
+        ..Default::default()
+    });
     let resp = authenticate_with_embeddings(
         &mut cam,
         &mut engine,
@@ -199,8 +217,6 @@ fn device_mismatch_never_reaches_success() {
         &models,
         &config,
         "u",
-        false,
-        &mismatch,
         AuditSource::Daemon,
     );
     match resp {
@@ -221,7 +237,10 @@ fn device_mismatch_never_reaches_success() {
         by_path: None,
     };
     let mut engine2 = MockFaceEngine::one_face(emb);
-    let mut cam2 = MockCamera::bright(64, 64, 10);
+    let mut cam2 = MockCamera::bright(64, 64, 10).with_caps(facelock_core::types::CameraCaps {
+        fingerprint: matching,
+        ..Default::default()
+    });
     let resp2 = authenticate_with_embeddings(
         &mut cam2,
         &mut engine2,
@@ -229,8 +248,6 @@ fn device_mismatch_never_reaches_success() {
         &models,
         &config,
         "u",
-        false,
-        &matching,
         AuditSource::Daemon,
     );
     match resp2 {
@@ -272,7 +289,10 @@ fn legacy_null_device_id_still_authenticates() {
         by_path: None,
     };
     let mut engine = MockFaceEngine::one_face(emb);
-    let mut cam = MockCamera::bright(64, 64, 10);
+    let mut cam = MockCamera::bright(64, 64, 10).with_caps(facelock_core::types::CameraCaps {
+        fingerprint: live,
+        ..Default::default()
+    });
     let resp = authenticate_with_embeddings(
         &mut cam,
         &mut engine,
@@ -280,8 +300,6 @@ fn legacy_null_device_id_still_authenticates() {
         &models,
         &config,
         "u",
-        false,
-        &live,
         AuditSource::Daemon,
     );
     match resp {
@@ -326,8 +344,7 @@ fn warmup_frames_discarded_on_camera_open() {
         engine,
         store,
         rate_limiter,
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory),
         None,
     )
@@ -370,8 +387,7 @@ fn warmup_frames_zero_skips_discard() {
         engine,
         store,
         rate_limiter,
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory),
         None,
     )
@@ -429,8 +445,6 @@ fn static_matching_frames_report_variance_reason() {
         &models,
         &config,
         "testuser",
-        false,
-        &facelock_core::types::DeviceFingerprint::default(),
         AuditSource::Daemon,
     );
 
@@ -482,8 +496,6 @@ fn still_then_moving_frames_recover_and_authenticate() {
         &models,
         &config,
         "testuser",
-        false,
-        &facelock_core::types::DeviceFingerprint::default(),
         AuditSource::Daemon,
     );
 
@@ -533,8 +545,6 @@ fn failed_auth_writes_audit_entry() {
         &[],
         &config,
         "testuser",
-        false,
-        &facelock_core::types::DeviceFingerprint::default(),
         AuditSource::Daemon,
     );
     assert!(
@@ -554,8 +564,6 @@ fn failed_auth_writes_audit_entry() {
         &[],
         &config,
         "testuser",
-        false,
-        &facelock_core::types::DeviceFingerprint::default(),
         AuditSource::Test,
     );
 
@@ -629,8 +637,7 @@ fn keyfile_sealer_init_failure_fails_enroll_closed_no_plaintext() {
         engine,
         store,
         rate_limiter,
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory),
         None,
     )
@@ -700,8 +707,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
             config.security.rate_limit.max_attempts,
             config.security.rate_limit.window_secs,
         ),
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory1),
         None,
     )
@@ -727,8 +733,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
             config.security.rate_limit.max_attempts,
             config.security.rate_limit.window_secs,
         ),
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory2),
         None,
     )
@@ -785,8 +790,7 @@ fn exempted_authenticate_does_not_consume_rate_limit_budget() {
             config.security.rate_limit.max_attempts,
             config.security.rate_limit.window_secs,
         ),
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory),
         None,
     )
@@ -875,8 +879,7 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
             config.security.rate_limit.max_attempts,
             config.security.rate_limit.window_secs,
         ),
-        false,
-        facelock_core::types::DeviceFingerprint::default(),
+        facelock_core::types::CameraCaps::default(),
         Some(factory),
         None,
     )

--- a/crates/facelock-test-support/src/mock_camera.rs
+++ b/crates/facelock-test-support/src/mock_camera.rs
@@ -1,6 +1,6 @@
 use facelock_core::error::Result;
 use facelock_core::traits::CameraSource;
-use facelock_core::types::Frame;
+use facelock_core::types::{CameraCaps, Frame};
 
 use crate::fixtures;
 
@@ -10,6 +10,7 @@ pub struct MockCamera {
     index: usize,
     #[allow(dead_code)]
     dark_threshold: f32,
+    caps: CameraCaps,
 }
 
 impl MockCamera {
@@ -22,6 +23,7 @@ impl MockCamera {
             frames,
             index: 0,
             dark_threshold: 0.4,
+            caps: CameraCaps::default(),
         }
     }
 
@@ -34,6 +36,7 @@ impl MockCamera {
             frames,
             index: 0,
             dark_threshold: 0.4,
+            caps: CameraCaps::default(),
         }
     }
 
@@ -43,16 +46,39 @@ impl MockCamera {
             frames,
             index: 0,
             dark_threshold: 0.4,
+            caps: CameraCaps::default(),
         }
+    }
+
+    /// Attach capabilities (defaults to `CameraCaps::default()`: non-IR, no
+    /// identity) — for IR-gating and device-coupling tests.
+    pub fn with_caps(mut self, caps: CameraCaps) -> Self {
+        self.caps = caps;
+        self
     }
 
     /// How many frames have been captured.
     pub fn captures(&self) -> usize {
         self.index
     }
+
+    /// Mock darkness check (fixed thresholds), kept as an inherent method now
+    /// that `is_dark` is no longer part of `CameraSource`.
+    pub fn is_dark(frame: &Frame) -> bool {
+        if frame.gray.is_empty() {
+            return true;
+        }
+        let dark_count = frame.gray.iter().filter(|&&p| p < 10).count();
+        let ratio = dark_count as f32 / frame.gray.len() as f32;
+        ratio > 0.4
+    }
 }
 
 impl CameraSource for MockCamera {
+    fn capabilities(&self) -> &CameraCaps {
+        &self.caps
+    }
+
     fn capture(&mut self) -> Result<Frame> {
         if self.index >= self.frames.len() {
             // Wrap around to allow repeated captures
@@ -67,14 +93,5 @@ impl CameraSource for MockCamera {
         let mut frame = self.capture()?;
         frame.gray = Vec::new();
         Ok(frame)
-    }
-
-    fn is_dark(frame: &Frame) -> bool {
-        if frame.gray.is_empty() {
-            return true;
-        }
-        let dark_count = frame.gray.iter().filter(|&&p| p < 10).count();
-        let ratio = dark_count as f32 / frame.gray.len() as f32;
-        ratio > 0.4
     }
 }


### PR DESCRIPTION
Closes gap **D8** (camera seam): capabilities are asked of the camera, not threaded as loose parameters. Zero behavior change; pure seam refactor on top of `refactor/config-resolved` (Wave-3 chain).

## Shipped shapes

```rust
// facelock-core/src/types.rs:163 (FormatInfo moved to core at types.rs:152)
pub struct CameraCaps {
    pub is_ir: bool,                 // DERIVED via C2's evidence path, never the name (#98)
    pub has_emitter: bool,           // quirk-declared XU emitter (declared, not probed)
    pub formats: Vec<FormatInfo>,
    pub fingerprint: DeviceFingerprint,  // "unknown" = all-None inside the type, not Option
    pub applied_quirks: Vec<String>,     // human-readable quirk ids; H8's status can render it
}

// facelock-core/src/traits.rs:10 — object-safe now
pub trait CameraSource {
    fn capabilities(&self) -> &CameraCaps;
    fn capture(&mut self) -> Result<Frame>;
    fn capture_rgb_only(&mut self) -> Result<Frame>;
}
// facelock-camera/src/capture.rs:320
pub fn is_dark(frame: &Frame) -> bool   // free function — `where Self: Sized` gone

// facelock-camera/src/caps.rs:27 — construction is the one place that knows everything
pub struct ResolvedCamera { pub info: DeviceInfo, pub quirk: Option<Quirk>, pub caps: CameraCaps }
impl ResolvedCamera {
    pub fn resolve(config, quirks) -> Result<Self>;   // caps.rs:37 validate-or-autodetect + interrogate
    pub fn interrogate(info, quirks) -> Self;         // caps.rs:52 THE caps derivation
    pub fn open(self, config) -> Result<Camera>;      // caps.rs:68 camera carries these caps
}
```

Shape adaptations vs. the map's sketch, judged and justified:
- **`FormatInfo`** moved to `facelock-core` (camera re-exports at the old path, `device.rs:21`) — the caps struct in core has to carry it. The D-Bus wire type `IpcFormatInfo` is untouched.
- **`QuirkId` is a `String`**, not a new type: the quirks files carry no stable ids, so `quirk_id()` (`caps.rs:78`) derives `"vid:pid (notes)"` / `"name:<pattern> (notes)"` from the match fields. A newtype would add ceremony around a value with no invariant.
- **`fingerprint` is not `Option`**: `DeviceFingerprint` already models "no readable identity" as all-`None` fields (`types.rs` doc); wrapping it would create two ways to say unknown.
- **`has_emitter` is quirk-declared** (`EmitterXuInfo::from_quirk(...).is_some()`), not probed — `has_controllable_emitter()` does a live ioctl (`ir_emitter.rs:162`), and interrogation must stay side-effect-free and valid on unopened devices.

`Camera::open(config, &QuirksDb)` (`capture.rs:47`) = resolve → interrogate → open; `Camera` stores its caps (`capture.rs:197`). The only way to construct a `Camera` with caps is through the interrogation path (`open_resolved` is `pub(crate)`, `capture.rs:60`), so a caller cannot assert caps a device never demonstrated.

## Threading removal, per call site

| Site | Before | After | Pinned by |
|---|---|---|---|
| `facelock-daemon/src/auth.rs` auth loop | `authenticate_with_embeddings(.., device_is_ir, live_fingerprint, ..)` | params gone; `camera.capabilities()` read at `auth.rs:308-309` (IR-texture gate + device-coupling compare set) | coupling tests `daemon_integration.rs:209,240,292` (fingerprints now on mock caps), variance/audit tests :425-575 |
| `facelock-daemon/src/auth.rs` pre_check family | `device_is_ir: bool` | `caps: &CameraCaps` (`auth.rs:69,88,173,193`); `require_ir` reads `caps.is_ir` at exactly one place, `auth.rs:153` | `pre_check_*` tests in `auth.rs` + oneshot gate tests in `commands/auth.rs` (#95 pins) |
| `facelock-daemon/src/handler.rs` | fields `device_is_ir` + `device_fingerprint` | one field `device_caps` (`handler.rs:32`); `Handler::new` takes `CameraCaps` (`handler.rs:51`); enroll records the enrolling camera's own `capabilities().fingerprint` (`handler.rs:372`) | all 7 handler integration tests (warmup, rate-limit persist/exempt, C3 storage-failure, keyfile fail-closed) |
| `facelock-cli/src/direct.rs` | local `ResolvedCameraDevice`/`OpenedCamera` carrying is_ir + fingerprint | `resolve_camera_device -> ResolvedCamera` (`direct.rs:60`), `open_resolved_camera` (`direct.rs:74`); `test` pre-checks on `&resolved.caps` then opens **that same resolution**; enroll device_id from `camera.capabilities()` (`direct.rs:333`) | `direct.rs` tests (quirk-state, zeroize-wipe), container tier-3 |
| `facelock-cli/src/commands/auth.rs` (oneshot) | validate + `is_ir_camera_resolved` + `device_fingerprint` + quirk, each threaded separately | one tolerant resolution (`auth.rs:69-79`); pre_check on `&caps`; open from the same resolution (`auth.rs:134`) | oneshot #95 gate tests; `test-arch-pam` |
| `facelock-cli/src/commands/daemon.rs` build_handler | is_ir (+ a **second** `validate_device` call for the quirk) + fingerprint + warmup, all loose | one `ResolvedCamera` (`daemon.rs:1172`); `device_caps` to Handler (`daemon.rs:1188`); factory reuses the startup interrogation per reopen (`daemon.rs:1260`) exactly as it reused the startup quirk | daemon integration + `test-arch-pam` (daemon flow) |
| `facelock-bench/src/main.rs` | `Camera::open(.., None)` | `Camera::open(.., &QuirksDb::default())` — empty DB ≡ old "no quirk applied" | bench unit tests |
| preview (`commands/preview/text_only.rs`) | via `direct::open_camera` | unchanged API — camera now carries caps | preview covered by existing CLI tests |
| test-support | `MockCamera` had trait `is_dark` | implements widened trait; `with_caps()` builder; `is_dark` inherent | object-safety test `daemon_integration.rs:91` |

## pre_check boundary decision

`pre_check` **keeps a parameter, but it is `&CameraCaps` instead of a bare bool**. Rationale: the `require_ir` gate must run before any camera stream (or its indicator LED) is touched — the daemon pre-checks before `acquire_camera`, oneshot/`test` before `Camera` open — so at this one boundary caps legitimately come from the *unopened* resolution (`ResolvedCamera::resolve`/`interrogate`). Passing the caps view (a) makes the gate read `caps.is_ir` at one place for all three paths (`auth.rs:153`), and (b) means the value handed to the gate is the same object the opened camera will carry, not a bool recomputed by each caller. Signature evolution declared at: `handler.rs:518` (daemon), `commands/auth.rs:108` (oneshot), `direct.rs:132` (`facelock test`), plus the test call sites listed above. Zero behavior change at each: the bool the gate used to receive was computed by the identical classification (`is_ir_camera_resolved`) at each site.

## Invariants evidence

- **`require_ir` not weakened**: default untouched; the gate text/placement unchanged (`auth.rs:153-158`); C2's classification rules are *adopted*, not modified — `interrogate` calls `is_ir_camera_resolved` (`caps.rs:56`), and all of C2's device.rs classification tests pass unchanged (68 camera tests green).
- **Caps cannot be self-asserted in production**: only `ResolvedCamera` construction produces a `Camera`'s caps (`open_resolved` is `pub(crate)`); `CameraCaps.is_ir` is derived from queried evidence per #98.
- **No D-Bus wire change**: `IpcDeviceInfo`/`IpcFormatInfo` and all method signatures untouched (`git diff` has no `facelock-core/src/ipc.rs`, `dbus_interface.rs`, or `dbus/` hunks).
- **pam-facelock untouched**, is-enrolled untouched (probe-free stays probe-free).
- **Object safety**: compile-time pin `daemon_integration.rs:91` holds a `Box<dyn CameraSource>`.
- **New caps tests** (`caps.rs` tests): mono-only fake device → `is_ir: true` caps; crafted "Fake IR Camera" color device → `is_ir: false`; matched quirk populates `applied_quirks` + `has_emitter`; fingerprint tolerates missing sysfs.

### Noted micro-divergences (declared, unreachable-in-practice)
1. Daemon/oneshot fallback when the device cannot be **queried at startup but reappears later**: the retry open now resolves fresh (daemon: `QuirksDb::load()` per attempt, `daemon.rs:1266-1269`; oneshot: `Camera::open(.., &quirks)`), so a reappeared device gets honest caps (previously: opened quirk-less with the stale `device_is_ir=false` threading). Strictly more-correct gating; `pre_check` still uses the startup caps exactly as it used the startup bool.
2. `facelock test` (direct.rs) used to resolve the device twice (once for the pre-check bool, again inside open); it now resolves once and opens that resolution. Same observable behavior (no camera I/O before pre_check, same classification), fewer sysfs sweeps.

## Gates

- `just check` (test + clippy `-D warnings` + fmt + audit): **exit 0**. Workspace: 671 tests passing, 0 failed (camera 68, daemon 57 + 22 integration, cli 249 + 15 smoke, core 97, store 49+11, tpm 29, pam 26, bench 8, polkit 8, face 27).
- `just test-arch-pam`: 22/22 (tail in PR comment / report).
- `just test-arch-layout`: 21/21.

## Churn

14 files, +544 / −273 (includes the new `caps.rs` with its tests). No new dependencies; crate boundaries per AGENTS.md unchanged.

## Cross-PR notes

- **H8 (status/health)**: `CameraCaps.applied_quirks` is ready to render in `facelock status`; H2's `resolved.rs` `CameraPresence` stays presence-only — if status wants full caps, feed it `ResolvedCamera::interrogate` output rather than duplicating interrogation.
- **H2**: `CameraPresence` untouched as instructed.
- **Enroll signature** (`facelock-daemon/src/enroll.rs`) still takes `device_id: Option<&str>` — both callers now derive it from `camera.capabilities()`; folding it into enroll itself (reading the camera) is a candidate follow-up, skipped here to keep enroll's tests untouched.
- Display/list paths (`handler.rs` ListDevices, `direct.rs::list_devices_direct`, setup.rs) still use `classify_ir_sources` over *all* nodes — that is enumeration, not a per-camera capability; no change intended.

## Docs to reconcile

- `docs/security.md:71` — the illustrative pre_check snippet reads `!device_is_ir`; the shipped check is `config.security.require_ir && !caps.is_ir`. One-line snippet touch-up (docs not in this PR's ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
