### PR TITLE
refactor(notify): Notifier seam + unified notification defaults (D9)

### DIFF
--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -13,6 +13,7 @@ use facelock_core::dbus_interface::{
     AuthResult, BUS_NAME, DeviceInfo, ModelInfo, OBJECT_PATH, PreviewFaceInfo,
 };
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
+use facelock_core::notify::{Notifier, NotifierFactory, NotifyEvent, notify_desktop_if_enabled};
 use facelock_daemon::handler::Handler;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
@@ -623,6 +624,10 @@ struct FacelockService {
     capture_slot: Arc<CaptureSlot>,
     /// Per-connection polkit frame-authorization cache (PreviewDetectFrame).
     preview_authz: Arc<PreviewAuthzCache>,
+    /// Builds per-user notifiers for auth outcomes. Injected from `main` so
+    /// the server never names the delivery implementation (D9) — a
+    /// prerequisite for moving this server out of facelock-cli.
+    notifier_factory: NotifierFactory,
 }
 
 impl FacelockService {
@@ -702,6 +707,7 @@ impl FacelockService {
         self.clear_camera_owner();
         let capture_guard = self.capture_slot.try_acquire("Authenticate")?;
         let handler = self.handler.clone();
+        let notifier_factory = self.notifier_factory.clone();
         let user = user.to_string();
         let signal_user = user.clone();
         let result = tokio::task::spawn_blocking(move || {
@@ -723,17 +729,7 @@ impl FacelockService {
             match response {
                 DaemonResponse::AuthResult(result) => {
                     // Send desktop notification (fire-and-forget, runs as root → setpriv)
-                    let event = if result.matched {
-                        crate::notifications::NotifyEvent::Success {
-                            label: result.label.clone(),
-                            similarity: result.similarity,
-                        }
-                    } else {
-                        crate::notifications::NotifyEvent::Failure {
-                            reason: "no match".into(),
-                        }
-                    };
-                    crate::notifications::notify_if_enabled_for_user(&notify_config, &event, &user);
+                    notify_auth_outcome(&notify_config, notifier_factory(&user).as_ref(), &result);
 
                     Ok(AuthResult {
                         matched: result.matched,
@@ -1136,6 +1132,30 @@ type CameraFactory = Box<dyn Fn(&Config) -> Result<Camera<'static>, String> + Se
 
 /// Build a new handler from config. Used at startup and for live config reload.
 /// Returns the handler and idle_timeout_secs from the loaded config.
+/// Map an auth outcome to its desktop notification and deliver it through
+/// the injected notifier, honoring the notification config.
+///
+/// Pure decision + injected delivery: the tests below assert emit/no-emit
+/// with a recording notifier; production passes the per-user desktop
+/// notifier built by the injected [`NotifierFactory`].
+fn notify_auth_outcome(
+    config: &facelock_core::config::NotificationConfig,
+    notifier: &dyn Notifier,
+    result: &facelock_core::types::MatchResult,
+) {
+    let event = if result.matched {
+        NotifyEvent::Success {
+            label: result.label.clone(),
+            similarity: result.similarity,
+        }
+    } else {
+        NotifyEvent::Failure {
+            reason: "no match".into(),
+        }
+    };
+    notify_desktop_if_enabled(config, notifier, &event);
+}
+
 fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), String> {
     // Deliberate re-read (D7): this is the daemon's config lifecycle — one
     // parse at startup, one per mtime-triggered reload (maybe_reload_handler).
@@ -1285,7 +1305,7 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
     Ok((handler, idle_timeout_secs))
 }
 
-pub fn run(config_path: Option<String>) -> anyhow::Result<()> {
+pub fn run(config_path: Option<String>, notifier_factory: NotifierFactory) -> anyhow::Result<()> {
     crate::ipc_client::require_root("sudo facelock daemon")?;
 
     // Init tracing (daemon uses its own tracing setup with target=true)
@@ -1318,7 +1338,12 @@ pub fn run(config_path: Option<String>) -> anyhow::Result<()> {
         .enable_all()
         .build()?;
 
-    rt.block_on(run_dbus_server(handler, idle_timeout_secs, config_mtime))
+    rt.block_on(run_dbus_server(
+        handler,
+        idle_timeout_secs,
+        config_mtime,
+        notifier_factory,
+    ))
 }
 
 /// Bitmask (low 32-bit word, caps 0-31) of the capabilities the daemon keeps
@@ -1422,6 +1447,7 @@ async fn run_dbus_server(
     handler: Arc<Mutex<ProductionHandler>>,
     idle_timeout_secs: u64,
     startup_config_mtime: Option<std::time::SystemTime>,
+    notifier_factory: NotifierFactory,
 ) -> anyhow::Result<()> {
     let last_activity = Arc::new(AtomicU64::new(now_secs()));
     let preview_authz = Arc::new(PreviewAuthzCache::default());
@@ -1432,6 +1458,7 @@ async fn run_dbus_server(
         camera_owner_uid: Arc::new(Mutex::new(None)),
         capture_slot: Arc::new(CaptureSlot::default()),
         preview_authz: preview_authz.clone(),
+        notifier_factory,
     };
 
     let _connection = zbus::connection::Builder::system()?
@@ -1606,6 +1633,70 @@ mod tests {
         assert_eq!(result.model_id, -2);
         assert_eq!(result.label, "rate limited");
         assert_eq!(result.similarity, 0.0);
+    }
+
+    use facelock_core::config::{NotificationConfig, NotificationMode};
+    use facelock_core::types::MatchResult;
+    use facelock_test_support::RecordingNotifier;
+
+    fn match_result(matched: bool) -> MatchResult {
+        MatchResult {
+            matched,
+            model_id: matched.then_some(1),
+            label: matched.then(|| "front".to_string()),
+            similarity: 0.42,
+            failure_reason: None,
+        }
+    }
+
+    fn desktop_config() -> NotificationConfig {
+        NotificationConfig {
+            mode: NotificationMode::Both,
+            notify_prompt: true,
+            notify_on_success: true,
+            notify_on_failure: true,
+        }
+    }
+
+    /// D9: a failed auth emits a Failure notification through the injected
+    /// notifier when the config enables desktop failure notifications.
+    #[test]
+    fn failed_auth_emits_failure_notification_when_enabled() {
+        let recorder = RecordingNotifier::new();
+        notify_auth_outcome(&desktop_config(), &recorder, &match_result(false));
+        assert_eq!(
+            recorder.events(),
+            vec![NotifyEvent::Failure {
+                reason: "no match".into()
+            }]
+        );
+    }
+
+    /// D9: under the default config (terminal-only mode, and
+    /// notify_on_failure = false) the same failed auth emits nothing.
+    #[test]
+    fn failed_auth_emits_nothing_under_default_config() {
+        let recorder = RecordingNotifier::new();
+        notify_auth_outcome(
+            &NotificationConfig::default(),
+            &recorder,
+            &match_result(false),
+        );
+        assert_eq!(recorder.events(), vec![]);
+    }
+
+    /// A successful auth carries the label and similarity into the event.
+    #[test]
+    fn successful_auth_emits_success_event_with_match_data() {
+        let recorder = RecordingNotifier::new();
+        notify_auth_outcome(&desktop_config(), &recorder, &match_result(true));
+        assert_eq!(
+            recorder.events(),
+            vec![NotifyEvent::Success {
+                label: Some("front".into()),
+                similarity: 0.42
+            }]
+        );
     }
 
     // --- Authorization matrix (N13) ---

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -3,8 +3,10 @@ use std::time::Instant;
 use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
+use facelock_core::notify::{NotifyEvent, notify_desktop_if_enabled};
+
 use crate::ipc_client;
-use crate::notifications::{NotifyEvent, notify_if_enabled};
+use crate::notifications::DesktopNotifier;
 
 pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // N11 (issue #96): `facelock test` is root-only regardless of transport
@@ -39,6 +41,7 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
 
     let user = ipc_client::resolve_user(user.as_deref());
     let notif_config = &config.notification;
+    let notifier = DesktopNotifier::for_current_session();
 
     // Check if user has enrolled models before attempting auth. Three-way
     // discrimination (C7, issue #105): a store that opens with zero models
@@ -99,7 +102,7 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     println!("Testing face recognition for user '{user}'...");
     println!("Look at the camera.");
 
-    notify_if_enabled(notif_config, &NotifyEvent::Scanning);
+    notify_desktop_if_enabled(notif_config, &notifier, &NotifyEvent::Scanning);
 
     if ipc_client::should_use_direct(config) {
         let start = Instant::now();
@@ -111,8 +114,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     result.similarity,
                     elapsed.as_secs_f64()
                 );
-                notify_if_enabled(
+                notify_desktop_if_enabled(
                     notif_config,
+                    &notifier,
                     &NotifyEvent::Success {
                         label: result.label.clone(),
                         similarity: result.similarity,
@@ -131,8 +135,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                         result.similarity,
                         elapsed.as_secs_f64()
                     );
-                    notify_if_enabled(
+                    notify_desktop_if_enabled(
                         notif_config,
+                        &notifier,
                         &NotifyEvent::Failure {
                             reason: "face matched but liveness variance not satisfied".to_string(),
                         },
@@ -143,8 +148,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                         result.similarity,
                         elapsed.as_secs_f64()
                     );
-                    notify_if_enabled(
+                    notify_desktop_if_enabled(
                         notif_config,
+                        &notifier,
                         &NotifyEvent::Failure {
                             reason: format!("no match (best similarity: {:.2})", result.similarity),
                         },
@@ -152,8 +158,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                 }
             }
             Err(e) => {
-                notify_if_enabled(
+                notify_desktop_if_enabled(
                     notif_config,
+                    &notifier,
                     &NotifyEvent::Failure {
                         reason: e.to_string(),
                     },
@@ -180,8 +187,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     result.similarity,
                     elapsed.as_secs_f64()
                 );
-                notify_if_enabled(
+                notify_desktop_if_enabled(
                     notif_config,
+                    &notifier,
                     &NotifyEvent::Success {
                         label: result.label.clone(),
                         similarity: result.similarity,
@@ -200,8 +208,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     result.similarity,
                     elapsed.as_secs_f64()
                 );
-                notify_if_enabled(
+                notify_desktop_if_enabled(
                     notif_config,
+                    &notifier,
                     &NotifyEvent::Failure {
                         reason: "face matched but liveness variance not satisfied".to_string(),
                     },
@@ -212,8 +221,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     result.similarity,
                     elapsed.as_secs_f64()
                 );
-                notify_if_enabled(
+                notify_desktop_if_enabled(
                     notif_config,
+                    &notifier,
                     &NotifyEvent::Failure {
                         reason: format!("no match (best similarity: {:.2})", result.similarity),
                     },
@@ -221,8 +231,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
             }
         }
         other => {
-            notify_if_enabled(
+            notify_desktop_if_enabled(
                 notif_config,
+                &notifier,
                 &NotifyEvent::Failure {
                     reason: "unexpected daemon response".to_string(),
                 },

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -230,7 +230,7 @@ fn main() -> anyhow::Result<()> {
             if let Some(ref path) = config {
                 facelock_core::paths::set_process_config_override(PathBuf::from(path));
             }
-            commands::daemon::run(config)
+            commands::daemon::run(config, notifications::daemon_notifier_factory())
         }
         Commands::Auth { user, config } => {
             if let Some(ref path) = config {

--- a/crates/facelock-cli/src/notifications.rs
+++ b/crates/facelock-cli/src/notifications.rs
@@ -1,51 +1,42 @@
-use facelock_core::config::NotificationConfig;
+//! Desktop and terminal [`Notifier`] implementations (D9).
+//!
+//! The vocabulary ([`NotifyEvent`]) and the seam ([`Notifier`]) live in
+//! `facelock_core::notify`; this module owns rendering and delivery. The
+//! privilege-drop mechanics in [`send_as_user`] were hard-won against the
+//! daemon's systemd hardening — wrap them, don't rewrite them.
+
+use facelock_core::notify::{Notifier, NotifierFactory, NotifyEvent};
 use tracing::debug;
 
-/// Events that can trigger desktop notifications.
-#[derive(Debug, Clone, PartialEq)]
-pub enum NotifyEvent {
-    /// Face scanning has started.
-    Scanning,
-    /// Face recognition succeeded.
-    Success {
-        label: Option<String>,
-        similarity: f32,
-    },
-    /// Face recognition failed.
-    Failure { reason: String },
+/// Body text for the notification.
+fn body(event: &NotifyEvent) -> String {
+    match event {
+        NotifyEvent::Scanning => "Scanning face...".to_string(),
+        NotifyEvent::Success { label, similarity } => {
+            if let Some(label) = label {
+                format!("Welcome, {label}")
+            } else {
+                format!("Face recognized ({similarity:.2})")
+            }
+        }
+        NotifyEvent::Failure { reason } => format!("Face auth failed: {reason}"),
+    }
 }
 
-impl NotifyEvent {
-    /// Body text for the notification.
-    pub fn body(&self) -> String {
-        match self {
-            NotifyEvent::Scanning => "Scanning face...".to_string(),
-            NotifyEvent::Success { label, similarity } => {
-                if let Some(label) = label {
-                    format!("Welcome, {label}")
-                } else {
-                    format!("Face recognized ({similarity:.2})")
-                }
-            }
-            NotifyEvent::Failure { reason } => format!("Face auth failed: {reason}"),
-        }
+/// Freedesktop icon name for the notification.
+fn icon(event: &NotifyEvent) -> &'static str {
+    match event {
+        NotifyEvent::Scanning => "camera-web",
+        NotifyEvent::Success { .. } => "security-high",
+        NotifyEvent::Failure { .. } => "security-low",
     }
+}
 
-    /// Freedesktop icon name for the notification.
-    pub fn icon(&self) -> &str {
-        match self {
-            NotifyEvent::Scanning => "camera-web",
-            NotifyEvent::Success { .. } => "security-high",
-            NotifyEvent::Failure { .. } => "security-low",
-        }
-    }
-
-    /// Timeout in milliseconds for the notification.
-    pub fn timeout_ms(&self) -> i32 {
-        match self {
-            NotifyEvent::Scanning => 2000,
-            NotifyEvent::Success { .. } | NotifyEvent::Failure { .. } => 3000,
-        }
+/// Timeout in milliseconds for the notification.
+fn timeout_ms(event: &NotifyEvent) -> i32 {
+    match event {
+        NotifyEvent::Scanning => 2000,
+        NotifyEvent::Success { .. } | NotifyEvent::Failure { .. } => 3000,
     }
 }
 
@@ -75,12 +66,12 @@ fn send_notification_dbus(event: &NotifyEvent) -> anyhow::Result<()> {
         &(
             "Facelock",                                                        // app_name
             0u32,                                                              // replaces_id
-            event.icon(),                                                      // app_icon
+            icon(event),                                                       // app_icon
             "Facelock",                                                        // summary
-            event.body(),                                                      // body
+            body(event),                                                       // body
             Vec::<String>::new(),                                              // actions
             std::collections::HashMap::<String, zbus::zvariant::Value>::new(), // hints
-            event.timeout_ms(),                                                // expire_timeout
+            timeout_ms(event),                                                 // expire_timeout
         ),
     )?;
 
@@ -95,7 +86,7 @@ fn send_notification_dbus(event: &NotifyEvent) -> anyhow::Result<()> {
 /// When running as root (via sudo), D-Bus rejects connections from UID 0 to the
 /// user's session bus. We handle this by resolving the original user's session bus
 /// address and connecting directly, after dropping privileges with setpriv.
-pub fn send_notification(event: &NotifyEvent) {
+fn send_notification(event: &NotifyEvent) {
     debug!(?event, "sending desktop notification");
 
     if nix::unistd::Uid::current().is_root() {
@@ -141,15 +132,15 @@ fn send_as_user(user: &str, event: &NotifyEvent) {
     let uid = user_info.uid.as_raw();
     let gid = user_info.gid.as_raw();
     let bus_addr = format!("unix:path=/run/user/{uid}/bus");
-    let timeout = event.timeout_ms().to_string();
+    let timeout = timeout_ms(event).to_string();
 
     // Build the notify-send command string
     let notify_cmd = format!(
         "DBUS_SESSION_BUS_ADDRESS='{}' notify-send --app-name Facelock -i '{}' -t {} Facelock '{}'",
         bus_addr,
-        event.icon(),
+        icon(event),
         timeout,
-        event.body().replace('\'', "'\\''"),
+        body(event).replace('\'', "'\\''"),
     );
 
     // Try setpriv first: it switches real+effective uid/gid and supplementary
@@ -200,33 +191,59 @@ fn send_as_user(user: &str, event: &NotifyEvent) {
     }
 }
 
-/// Check whether a desktop notification should be sent for the given event.
-pub fn should_notify_desktop(config: &NotificationConfig, event: &NotifyEvent) -> bool {
-    if !config.desktop() {
-        return false;
+/// Desktop popup delivery. Pure delivery — config filtering happens at the
+/// decision site via [`facelock_core::notify::notify_desktop_if_enabled`].
+pub struct DesktopNotifier {
+    /// `None`: notify the invoking user's session ([`send_notification`] —
+    /// session bus directly, or setpriv via SUDO_USER/DOAS_USER when root).
+    /// `Some(user)`: notify that user's session ([`send_as_user`] — the
+    /// daemon path, which runs as root with no SUDO_USER).
+    target_user: Option<String>,
+}
+
+impl DesktopNotifier {
+    /// Notify the session of whoever invoked this process.
+    pub fn for_current_session() -> Self {
+        Self { target_user: None }
     }
-    match event {
-        NotifyEvent::Scanning => config.notify_prompt,
-        NotifyEvent::Success { .. } => config.notify_on_success,
-        NotifyEvent::Failure { .. } => config.notify_on_failure,
+
+    /// Notify a specific user's session. Used by the daemon.
+    pub fn for_user(user: impl Into<String>) -> Self {
+        Self {
+            target_user: Some(user.into()),
+        }
     }
 }
 
-/// Conditionally send a desktop notification based on config.
-pub fn notify_if_enabled(config: &NotificationConfig, event: &NotifyEvent) {
-    if should_notify_desktop(config, event) {
-        send_notification(event);
+impl Notifier for DesktopNotifier {
+    fn notify(&self, event: &NotifyEvent) {
+        match &self.target_user {
+            Some(user) => send_as_user(user, event),
+            None => send_notification(event),
+        }
     }
 }
 
-/// Conditionally send a desktop notification to a specific user's session.
-/// Used by the daemon, which runs as root without SUDO_USER/DOAS_USER.
-pub fn notify_if_enabled_for_user(config: &NotificationConfig, event: &NotifyEvent, user: &str) {
-    if !should_notify_desktop(config, event) {
-        debug!(?event, "notification filtered by config");
-        return;
+/// Renders events as plain lines on stdout.
+///
+/// Terminal text in the auth path is the PAM conversation, which pam_facelock
+/// owns; no CLI command routes through this yet — it exists so terminal
+/// delivery has a seam-shaped home when the daemon server moves out of this
+/// crate (H7) and for the i18n message-type work (D10).
+#[allow(dead_code)] // exercised by unit tests; production wiring arrives with H7/D10
+pub struct TerminalNotifier;
+
+impl Notifier for TerminalNotifier {
+    fn notify(&self, event: &NotifyEvent) {
+        println!("{}", body(event));
     }
-    send_as_user(user, event);
+}
+
+/// The production [`NotifierFactory`] for the daemon: per-request, per-user
+/// desktop delivery. Injected into `commands::daemon::run` from `main` so the
+/// server code never names this module.
+pub fn daemon_notifier_factory() -> NotifierFactory {
+    std::sync::Arc::new(|user: &str| Box::new(DesktopNotifier::for_user(user)))
 }
 
 #[cfg(test)]
@@ -234,11 +251,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn scanning_event_fields() {
+    fn scanning_event_rendering() {
         let event = NotifyEvent::Scanning;
-        assert_eq!(event.body(), "Scanning face...");
-        assert_eq!(event.icon(), "camera-web");
-        assert_eq!(event.timeout_ms(), 2000);
+        assert_eq!(body(&event), "Scanning face...");
+        assert_eq!(icon(&event), "camera-web");
+        assert_eq!(timeout_ms(&event), 2000);
     }
 
     #[test]
@@ -247,9 +264,9 @@ mod tests {
             label: Some("Alice".to_string()),
             similarity: 0.87,
         };
-        assert_eq!(event.body(), "Welcome, Alice");
-        assert_eq!(event.icon(), "security-high");
-        assert_eq!(event.timeout_ms(), 3000);
+        assert_eq!(body(&event), "Welcome, Alice");
+        assert_eq!(icon(&event), "security-high");
+        assert_eq!(timeout_ms(&event), 3000);
     }
 
     #[test]
@@ -258,155 +275,25 @@ mod tests {
             label: None,
             similarity: 0.87,
         };
-        assert_eq!(event.body(), "Face recognized (0.87)");
+        assert_eq!(body(&event), "Face recognized (0.87)");
     }
 
     #[test]
-    fn failure_event_fields() {
+    fn failure_event_rendering() {
         let event = NotifyEvent::Failure {
             reason: "no match".to_string(),
         };
-        assert_eq!(event.body(), "Face auth failed: no match");
-        assert_eq!(event.icon(), "security-low");
-        assert_eq!(event.timeout_ms(), 3000);
+        assert_eq!(body(&event), "Face auth failed: no match");
+        assert_eq!(icon(&event), "security-low");
+        assert_eq!(timeout_ms(&event), 3000);
     }
 
-    use facelock_core::config::NotificationMode;
-
+    /// The factory hands out per-user desktop notifiers targeting the given
+    /// session — pin the plumbing without touching a real bus.
     #[test]
-    fn mode_off_blocks_all() {
-        let config = NotificationConfig {
-            mode: NotificationMode::Off,
-            ..Default::default()
-        };
-        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
-        assert!(!should_notify_desktop(
-            &config,
-            &NotifyEvent::Success {
-                label: None,
-                similarity: 0.9
-            }
-        ));
-    }
-
-    #[test]
-    fn mode_terminal_blocks_desktop() {
-        let config = NotificationConfig {
-            mode: NotificationMode::Terminal,
-            ..Default::default()
-        };
-        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
-        assert!(config.terminal());
-        assert!(!config.desktop());
-    }
-
-    #[test]
-    fn mode_desktop_enables_desktop() {
-        let config = NotificationConfig {
-            mode: NotificationMode::Desktop,
-            ..Default::default()
-        };
-        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
-        assert!(!config.terminal());
-        assert!(config.desktop());
-    }
-
-    /// Helper: config with desktop notifications fully enabled
-    fn desktop_config() -> NotificationConfig {
-        NotificationConfig {
-            mode: NotificationMode::Both,
-            notify_prompt: true,
-            notify_on_success: true,
-            notify_on_failure: true,
-        }
-    }
-
-    #[test]
-    fn default_is_terminal_only() {
-        let config = NotificationConfig::default();
-        assert!(config.terminal());
-        assert!(!config.desktop());
-        assert!(!config.notify_on_failure);
-    }
-
-    #[test]
-    fn mode_both_enables_all() {
-        let config = desktop_config();
-        assert!(config.terminal());
-        assert!(config.desktop());
-        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
-        assert!(should_notify_desktop(
-            &config,
-            &NotifyEvent::Success {
-                label: None,
-                similarity: 0.5
-            }
-        ));
-        assert!(should_notify_desktop(
-            &config,
-            &NotifyEvent::Failure {
-                reason: "err".into()
-            }
-        ));
-    }
-
-    #[test]
-    fn notify_prompt_controls_scanning() {
-        let config = NotificationConfig {
-            notify_prompt: false,
-            ..desktop_config()
-        };
-        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
-        // Success/failure still enabled
-        assert!(should_notify_desktop(
-            &config,
-            &NotifyEvent::Success {
-                label: None,
-                similarity: 0.9
-            }
-        ));
-    }
-
-    #[test]
-    fn notify_on_success_controls_success() {
-        let config = NotificationConfig {
-            notify_on_success: false,
-            ..desktop_config()
-        };
-        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
-        assert!(!should_notify_desktop(
-            &config,
-            &NotifyEvent::Success {
-                label: None,
-                similarity: 0.9
-            }
-        ));
-        assert!(should_notify_desktop(
-            &config,
-            &NotifyEvent::Failure {
-                reason: "no match".into()
-            }
-        ));
-    }
-
-    #[test]
-    fn notify_on_failure_controls_failure() {
-        let config = NotificationConfig {
-            notify_on_failure: false,
-            ..desktop_config()
-        };
-        assert!(should_notify_desktop(
-            &config,
-            &NotifyEvent::Success {
-                label: Some("Bob".into()),
-                similarity: 0.8
-            }
-        ));
-        assert!(!should_notify_desktop(
-            &config,
-            &NotifyEvent::Failure {
-                reason: "timeout".into()
-            }
-        ));
+    fn factory_targets_the_requested_user() {
+        let notifier = DesktopNotifier::for_user("alice");
+        assert_eq!(notifier.target_user.as_deref(), Some("alice"));
+        assert!(DesktopNotifier::for_current_session().target_user.is_none());
     }
 }

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -347,8 +347,13 @@ pub struct NotificationConfig {
     /// Show notification on successful face match
     #[serde(default = "default_true")]
     pub notify_on_success: bool,
-    /// Show notification on failed face match
-    #[serde(default = "default_true")]
+    /// Show notification on failed face match.
+    /// Default: false — a failed match is already visible (you get a password
+    /// prompt). Must agree with `Default for NotificationConfig` below, or the
+    /// effective value flips depending on whether `[notification]` appears in
+    /// the file (the shipped template has the section header active with every
+    /// key commented, which is exactly the shape that triggers the drift).
+    #[serde(default)]
     pub notify_on_failure: bool,
 }
 
@@ -789,6 +794,25 @@ path = "/dev/video0"
         assert_eq!(config.device.max_height, 480);
         assert_eq!(config.recognition.threshold, 0.80);
         assert!(config.security.require_ir);
+    }
+
+    /// D9 drift pin: a `[notification]` section present with every key
+    /// omitted must parse identically to no section at all. The two paths are
+    /// different code (serde field defaults vs `Default for
+    /// NotificationConfig`), and `notify_on_failure` had already drifted
+    /// between them (serde said `true`, `Default` and the shipped template
+    /// said `false`).
+    #[test]
+    fn notification_section_present_with_keys_omitted_equals_default() {
+        let present = Config::parse("[notification]\n").unwrap().notification;
+        let absent = Config::parse("").unwrap().notification;
+        let default = NotificationConfig::default();
+        for parsed in [&present, &absent] {
+            assert_eq!(parsed.mode, default.mode);
+            assert_eq!(parsed.notify_prompt, default.notify_prompt);
+            assert_eq!(parsed.notify_on_success, default.notify_on_success);
+            assert_eq!(parsed.notify_on_failure, default.notify_on_failure);
+        }
     }
 
     #[test]

--- a/crates/facelock-core/src/lib.rs
+++ b/crates/facelock-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod dbus_interface;
 pub mod error;
 pub mod fs_security;
 pub mod ipc;
+pub mod notify;
 pub mod paths;
 pub mod traits;
 pub mod types;

--- a/crates/facelock-core/src/notify.rs
+++ b/crates/facelock-core/src/notify.rs
@@ -1,0 +1,228 @@
+//! Notification vocabulary and delivery seam (D9).
+//!
+//! [`NotifyEvent`] is the shared vocabulary for "tell a human something
+//! happened"; [`Notifier`] is the delivery seam. Events carry data only —
+//! rendering (body text, icon, timeout) belongs to the implementation, which
+//! is also where the i18n boundary will eventually sit (the sink decides
+//! presentation).
+//!
+//! Implementations live where their delivery mechanics live: the desktop and
+//! terminal notifiers are in `facelock-cli` (`notifications.rs`), next to the
+//! hard-won `setpriv` privilege-drop machinery. This module stays free of new
+//! dependencies so that any crate — including the daemon D-Bus server after
+//! its planned move out of `facelock-cli` — can reach the seam.
+//!
+//! The PAM module (`pam-facelock`) cannot depend on this crate; its
+//! `PamNotificationConfig` mirrors the `[notification]` schema and gates its
+//! terminal conversation text on the same flags (`notify_prompt` ↔
+//! [`NotifyEvent::Scanning`], `notify_on_success` ↔
+//! [`NotifyEvent::Success`]). Keep the vocabularies in lockstep by hand.
+
+use crate::config::NotificationConfig;
+
+/// Something that happened which a human may want to hear about.
+///
+/// Variants enumerate what the code actually sends today; carry the data and
+/// let the [`Notifier`] implementation render it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NotifyEvent {
+    /// Face scanning has started.
+    Scanning,
+    /// Face recognition succeeded.
+    Success {
+        label: Option<String>,
+        similarity: f32,
+    },
+    /// Face recognition failed.
+    Failure { reason: String },
+}
+
+/// Delivery seam: something that can tell a human about a [`NotifyEvent`].
+///
+/// Delivery is fire-and-forget by contract — implementations must never
+/// block or fail the auth flow (log and move on).
+pub trait Notifier {
+    fn notify(&self, event: &NotifyEvent);
+}
+
+/// A [`Notifier`] that discards every event. For tests and for contexts
+/// where notifications are structurally impossible.
+pub struct NullNotifier;
+
+impl Notifier for NullNotifier {
+    fn notify(&self, _event: &NotifyEvent) {}
+}
+
+/// Builds a [`Notifier`] targeting a specific user's session.
+///
+/// The daemon needs this indirection: it runs as root with no
+/// `SUDO_USER`, and learns the target user per request — so it is handed a
+/// factory at startup instead of a single notifier, keeping the delivery
+/// implementation (and its `setpriv` mechanics) out of the server code.
+pub type NotifierFactory = std::sync::Arc<dyn Fn(&str) -> Box<dyn Notifier> + Send + Sync>;
+
+/// Whether a desktop notification should be sent for `event` under `config`.
+pub fn should_notify_desktop(config: &NotificationConfig, event: &NotifyEvent) -> bool {
+    if !config.desktop() {
+        return false;
+    }
+    match event {
+        NotifyEvent::Scanning => config.notify_prompt,
+        NotifyEvent::Success { .. } => config.notify_on_success,
+        NotifyEvent::Failure { .. } => config.notify_on_failure,
+    }
+}
+
+/// Deliver `event` through `notifier` iff the desktop channel is enabled for
+/// it; otherwise log at debug level and do nothing.
+pub fn notify_desktop_if_enabled(
+    config: &NotificationConfig,
+    notifier: &dyn Notifier,
+    event: &NotifyEvent,
+) {
+    if should_notify_desktop(config, event) {
+        notifier.notify(event);
+    } else {
+        tracing::debug!(?event, "notification filtered by config");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::NotificationMode;
+
+    /// Minimal in-crate recorder (facelock-test-support has the shared
+    /// `RecordingNotifier`, but depending on it from here would be a
+    /// dev-dependency cycle).
+    #[derive(Default)]
+    struct Recorder(std::sync::Mutex<Vec<NotifyEvent>>);
+
+    impl Notifier for Recorder {
+        fn notify(&self, event: &NotifyEvent) {
+            self.0.lock().unwrap().push(event.clone());
+        }
+    }
+
+    /// Helper: config with desktop notifications fully enabled
+    fn desktop_config() -> NotificationConfig {
+        NotificationConfig {
+            mode: NotificationMode::Both,
+            notify_prompt: true,
+            notify_on_success: true,
+            notify_on_failure: true,
+        }
+    }
+
+    fn success() -> NotifyEvent {
+        NotifyEvent::Success {
+            label: None,
+            similarity: 0.9,
+        }
+    }
+
+    fn failure() -> NotifyEvent {
+        NotifyEvent::Failure {
+            reason: "no match".into(),
+        }
+    }
+
+    #[test]
+    fn mode_off_blocks_all() {
+        let config = NotificationConfig {
+            mode: NotificationMode::Off,
+            ..desktop_config()
+        };
+        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
+        assert!(!should_notify_desktop(&config, &success()));
+        assert!(!should_notify_desktop(&config, &failure()));
+    }
+
+    #[test]
+    fn mode_terminal_blocks_desktop() {
+        let config = NotificationConfig {
+            mode: NotificationMode::Terminal,
+            ..desktop_config()
+        };
+        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
+        assert!(config.terminal());
+        assert!(!config.desktop());
+    }
+
+    #[test]
+    fn mode_desktop_enables_desktop() {
+        let config = NotificationConfig {
+            mode: NotificationMode::Desktop,
+            ..desktop_config()
+        };
+        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
+        assert!(!config.terminal());
+        assert!(config.desktop());
+    }
+
+    #[test]
+    fn default_is_terminal_only() {
+        let config = NotificationConfig::default();
+        assert!(config.terminal());
+        assert!(!config.desktop());
+        assert!(!config.notify_on_failure);
+    }
+
+    #[test]
+    fn mode_both_enables_all() {
+        let config = desktop_config();
+        assert!(config.terminal());
+        assert!(config.desktop());
+        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
+        assert!(should_notify_desktop(&config, &success()));
+        assert!(should_notify_desktop(&config, &failure()));
+    }
+
+    #[test]
+    fn notify_prompt_controls_scanning() {
+        let config = NotificationConfig {
+            notify_prompt: false,
+            ..desktop_config()
+        };
+        assert!(!should_notify_desktop(&config, &NotifyEvent::Scanning));
+        // Success/failure still enabled
+        assert!(should_notify_desktop(&config, &success()));
+    }
+
+    #[test]
+    fn notify_on_success_controls_success() {
+        let config = NotificationConfig {
+            notify_on_success: false,
+            ..desktop_config()
+        };
+        assert!(should_notify_desktop(&config, &NotifyEvent::Scanning));
+        assert!(!should_notify_desktop(&config, &success()));
+        assert!(should_notify_desktop(&config, &failure()));
+    }
+
+    #[test]
+    fn notify_on_failure_controls_failure() {
+        let config = NotificationConfig {
+            notify_on_failure: false,
+            ..desktop_config()
+        };
+        assert!(should_notify_desktop(&config, &success()));
+        assert!(!should_notify_desktop(&config, &failure()));
+    }
+
+    #[test]
+    fn filtered_dispatch_delivers_iff_enabled() {
+        let recorder = Recorder::default();
+        notify_desktop_if_enabled(&desktop_config(), &recorder, &failure());
+        assert_eq!(recorder.0.lock().unwrap().as_slice(), &[failure()]);
+
+        let recorder = Recorder::default();
+        notify_desktop_if_enabled(&NotificationConfig::default(), &recorder, &failure());
+        assert!(recorder.0.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn null_notifier_accepts_events() {
+        NullNotifier.notify(&NotifyEvent::Scanning);
+    }
+}

--- a/crates/facelock-test-support/src/lib.rs
+++ b/crates/facelock-test-support/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod fixtures;
 pub mod mock_camera;
 pub mod mock_face_engine;
+pub mod recording_notifier;
 
 pub use mock_camera::MockCamera;
 pub use mock_face_engine::MockFaceEngine;
+pub use recording_notifier::RecordingNotifier;

--- a/crates/facelock-test-support/src/recording_notifier.rs
+++ b/crates/facelock-test-support/src/recording_notifier.rs
@@ -1,0 +1,50 @@
+use std::sync::Mutex;
+
+use facelock_core::notify::{Notifier, NotifyEvent};
+
+/// A [`Notifier`] that records every event it is asked to deliver, so tests
+/// can assert that a notification was (or was not) emitted.
+#[derive(Default)]
+pub struct RecordingNotifier {
+    events: Mutex<Vec<NotifyEvent>>,
+}
+
+impl RecordingNotifier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of everything delivered so far, in order.
+    pub fn events(&self) -> Vec<NotifyEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl Notifier for RecordingNotifier {
+    fn notify(&self, event: &NotifyEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_events_in_order() {
+        let notifier = RecordingNotifier::new();
+        notifier.notify(&NotifyEvent::Scanning);
+        notifier.notify(&NotifyEvent::Failure {
+            reason: "no match".into(),
+        });
+        assert_eq!(
+            notifier.events(),
+            vec![
+                NotifyEvent::Scanning,
+                NotifyEvent::Failure {
+                    reason: "no match".into()
+                }
+            ]
+        );
+    }
+}

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -109,17 +109,30 @@ impl Default for PamSecurityConfig {
     }
 }
 
-#[derive(Default, Deserialize, PartialEq)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)] // Variants used via deserialization
 enum PamNotificationMode {
     Off,
+    /// Default must agree with `PamNotificationConfig::default()` below and
+    /// with facelock-core's `NotificationMode` (Terminal). This enum-level
+    /// default is what a present `[notification]` section with `mode` omitted
+    /// produces; the struct `Default` is what an absent section produces.
+    /// The two had drifted (`Both` here, `Terminal` there) — benign only
+    /// because `terminal()` treats Both and Terminal identically.
+    #[default]
     Terminal,
     Desktop,
-    #[default]
     Both,
 }
 
+/// Private mirror of the `[notification]` table in facelock-core's
+/// `NotificationConfig` — the canonical schema. The dependency ceiling
+/// (libc/toml/serde/zbus only) forbids sharing the types; keep field names
+/// and defaults in lockstep by hand. The flags gate the same event
+/// vocabulary as `facelock_core::notify::NotifyEvent`: `notify_prompt` ↔
+/// Scanning, `notify_on_success` ↔ Success. (This module renders them as
+/// PAM conversation text; desktop delivery is the daemon's job.)
 #[derive(Deserialize)]
 struct PamNotificationConfig {
     #[serde(default)]
@@ -1098,6 +1111,44 @@ timeout_secs = 10
         assert!(!config.security.disabled);
         assert!(config.security.abort_if_ssh);
         assert_eq!(config.recognition.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    /// D9 drift pin: a `[notification]` section present with every key
+    /// omitted (serde field defaults) must parse identically to no section
+    /// at all (`PamNotificationConfig::default()`). The mode enum's
+    /// `#[default]` had drifted to `Both` while the struct default said
+    /// `Terminal` — undetected because `terminal()` treats both identically.
+    #[test]
+    fn notification_section_present_with_keys_omitted_equals_absent() {
+        let present: PamConfig = toml::from_str("[notification]\n").unwrap();
+        let absent: PamConfig = toml::from_str("").unwrap();
+        let default = PamNotificationConfig::default();
+        for config in [&present.notification, &absent.notification] {
+            assert_eq!(config.mode, default.mode);
+            assert_eq!(config.notify_prompt, default.notify_prompt);
+            assert_eq!(config.notify_on_success, default.notify_on_success);
+        }
+    }
+
+    /// Conformance with the canonical schema, in the only form the
+    /// dependency ceiling allows: parse the same shipped template
+    /// facelock-core ships and require the effective notification settings
+    /// to equal our defaults. The template has an active `[notification]`
+    /// header with every key commented — exactly the shape that exposed the
+    /// default drift — and any future template default that this crate does
+    /// not mirror will fail here visibly.
+    #[test]
+    fn shipped_template_notification_settings_equal_defaults() {
+        let template = include_str!("../../../config/facelock.toml");
+        let config: PamConfig = toml::from_str(template).unwrap();
+        let default = PamNotificationConfig::default();
+        assert_eq!(config.notification.mode, default.mode);
+        assert_eq!(config.notification.notify_prompt, default.notify_prompt);
+        assert_eq!(
+            config.notification.notify_on_success,
+            default.notify_on_success
+        );
+        assert!(config.notification.terminal());
     }
 
     #[test]


### PR DESCRIPTION
Wave 3, PR H4 — Notifications domain ([domain-object-map §6](../blob/main/.omc/plans/domain-object-map.md), gap **D9**). Base: `refactor/camera-caps` (H3).

## NotifyEvent vocabulary shipped

```rust
pub enum NotifyEvent {
    Scanning,
    Success { label: Option<String>, similarity: f32 },
    Failure { reason: String },
}
pub trait Notifier { fn notify(&self, event: &NotifyEvent); }
```

Enumerated from what the code actually sends today — these three, nothing else. **The map's mention of "enroll progress" events found no basis in code**: no enroll path sends any notification, so no enroll variants shipped (adding them would be new behavior, not refactor). Events carry data only; rendering (`body`/`icon`/`timeout_ms`) happens at the implementation, which is also where the D10 i18n boundary will want it.

## Trait placement

`facelock-core/src/notify.rs`: `NotifyEvent`, `Notifier`, `NullNotifier`, `NotifierFactory`, and the desktop-channel config policy (`should_notify_desktop` / `notify_desktop_if_enabled` — core already owns `NotificationConfig`). Zero new dependencies, and reachable from wherever H7 moves the D-Bus server. Implementations stay in `facelock-cli/src/notifications.rs` next to the setpriv machinery: `DesktopNotifier` (`for_current_session()` = session bus / SUDO_USER path; `for_user()` = daemon path), `TerminalNotifier` (renders bodies to stdout; unit-tested but not production-wired — terminal text in the auth path is the PAM conversation, which pam_facelock owns; carries `#[allow(dead_code)]` until H7/D10 wire it). `RecordingNotifier` lives in facelock-test-support.

The daemon learns its target user per request, so it is injected with a `NotifierFactory` (`Arc<dyn Fn(&str) -> Box<dyn Notifier>>`) rather than a single notifier — built by `notifications::daemon_notifier_factory()` and passed by `main` into `commands::daemon::run()`.

## Drift fix 1 — core `notify_on_failure` (with history findings)

`NotificationConfig::default()` says `false`; the field said `#[serde(default = "default_true")]`. **History: both sides shipped in the initial commit (`04ec3ef`) already disagreeing** — this was never a regression, just an undetected birth defect. Intent is unambiguous: the struct `Default`, the shipped template ("Default: false (failure is already visible — you get a password prompt)"), and `docs/configuration.md:118` all say `false`. Fixed the serde side to `#[serde(default)]`.

Swept the rest of `NotificationConfig`: `mode`, `notify_prompt`, `notify_on_success` were already consistent. Pinned: `config.rs` test `notification_section_present_with_keys_omitted_equals_default` (present-section/keys-omitted ≡ absent-section, field by field).

Sanctioned behavior change, for the record: a user who set `mode = "desktop"|"both"` but omitted `notify_on_failure` stops getting failure popups — which is what every piece of documentation always promised. The shipped template's active-header/commented-keys shape previously produced `true` here; note the template pin in the sibling PR #114 is *not* in this branch's base, and this PR deliberately doesn't touch the template.

## Drift fix 2 — PAM `PamNotificationMode`

Enum derived `#[default] Both`; struct `Default` says `Terminal`; benign only because the sole accessor `terminal()` treats both identically. Moved `#[default]` to `Terminal` (agreeing with the struct and with core's canonical `NotificationMode`). Ceiling respected — no facelock-core dep; alignment is a cross-referencing comment on `PamNotificationConfig` naming the canonical schema and the NotifyEvent mapping (`notify_prompt` ↔ Scanning, `notify_on_success` ↔ Success), plus two tests:

- `notification_section_present_with_keys_omitted_equals_absent` — same pin as core's, field by field.
- `shipped_template_notification_settings_equal_defaults` — `include_str!`s the same `config/facelock.toml` core ships and requires PAM's effective notification settings to equal its defaults. The template's active `[notification]` header with all keys commented is exactly the drift-triggering shape, so this is a live conformance check, not a tautology.

## Call sites converted

- `commands/daemon.rs` — **zero mentions of `crate::notifications` remain** (the D9 blocker metric). `FacelockService` holds the injected `notifier_factory`; the outcome→event decision is the pure `notify_auth_outcome()`.
- `commands/test_cmd.rs` — all 9 sites now `notify_desktop_if_enabled(config, &notifier, &event)` over a `DesktopNotifier::for_current_session()`.
- `main.rs` — injects `daemon_notifier_factory()` into `daemon::run()`.

Assertability evidence (`commands::daemon::tests`, via `RecordingNotifier`):
- `failed_auth_emits_failure_notification_when_enabled` — Failure event recorded;
- `failed_auth_emits_nothing_under_default_config` — same outcome, default (terminal-only) config, zero events;
- `successful_auth_emits_success_event_with_match_data` — label + similarity carried through.

## Delivery mechanics are verbatim (diff-level)

`original_user`, `send_notification_dbus`, `send_notification`, `send_as_user` moved behind the trait with bodies unchanged. Because `NotifyEvent` moved to core, its inherent render methods became module-local free functions; the **entire** diff of `send_as_user` (the setpriv path) is three call-syntax swaps:

```diff
-    let timeout = event.timeout_ms().to_string();
+    let timeout = timeout_ms(event).to_string();
-        event.icon(),
+        icon(event),
-        event.body().replace('\'', "'\\''"),
+        body(event).replace('\'', "'\\''"),
```

Same `setpriv --reuid … --regid … --init-groups --ambient-caps -all` invocation, same `runuser` fallback, same session-bus targeting, same filter-then-deliver order and debug logging. One unification: the CLI-path filter (`notify_if_enabled`) now emits the same debug-level "filtered by config" log the daemon path always had.

## Gates

- `just check` — clean (workspace tests, `clippy -D warnings`, `fmt --check`, audit with only the 2 pre-existing allowed yanked-crate warnings).
- `just test-arch-pam` — 22/22.
- `just test-arch-layout` — 21/21.

## Cross-PR notes (H7 especially)

- **H7**: `commands::daemon::run(config_path, notifier_factory)` — when the server moves out of facelock-cli, take `notify_auth_outcome` with it, keep receiving the factory from facelock-cli's `main`, and everything it needs is already in `facelock_core::notify`. The struct field is `FacelockService.notifier_factory`.
- **#114 (template pin)**: no conflict — this PR touches no template/packaging files; PAM's conformance test tolerates the active `notify_on_failure = false` line (unknown key to PAM, default-equal value to core).
- **D10 (i18n)**: rendering is now three free functions in one module — the future message-type seam has a single place to land.

## Docs to reconcile

None required: `docs/configuration.md`, `book/src/configuration.md`, and the template already document `notify_on_failure = false`; the code now agrees. Man pages don't state notification defaults.

## Plan errata

- Map §6's NotifyEvent sketch lists "enroll progress" — no such notification exists in code; vocabulary shipped without it (see above).
- `pam-facelock/src/lib.rs:939`'s comment attributes desktop notifications to "the daemon's auth_attempted D-Bus signal" — the daemon actually sends them directly via setpriv; the signal is a separate broadcast. Pre-existing comment inaccuracy, left for H7's sweep.
- `cargo test -p pam-facelock` alone fails to compile zbus (feature unification only provides zbus's tokio feature when facelock-cli is in the graph). Pre-existing; workspace-level tests (the `just check` gate) are unaffected.
- daemon.rs's capability-mask comments still say the drop exists for "`runuser`/`su`" while the code prefers setpriv — pre-existing wording, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
