### PR TITLE
feat(i18n): message seam — gettext at the sink boundary (D10)

### DIFF
--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -3,6 +3,7 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use facelock_store::StoreError;
 
 use crate::ipc_client;
+use crate::message::{Terminal, UserMessage};
 
 pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<()> {
     // ClearModels is root-only on the daemon side too, so demand root up front.
@@ -22,14 +23,14 @@ pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<(
         daemon_user_has_models(ipc_client::send_request(&request))?
     };
     if !has_models {
-        println!("No face models enrolled for user '{user}'.");
+        Terminal.info(&UserMessage::NoModelsEnrolled { user: user.clone() });
         return Ok(());
     }
 
     if !yes {
-        let confirmed = ipc_client::confirm(&format!("Remove ALL face models for user '{user}'?"))?;
+        let confirmed = Terminal.confirm(&UserMessage::ConfirmClearAll { user: user.clone() })?;
         if !confirmed {
-            println!("Cancelled.");
+            Terminal.info(&UserMessage::Cancelled);
             return Ok(());
         }
     }
@@ -42,7 +43,10 @@ pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<(
         let count = store
             .clear_user(&user)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
-        println!("Removed {count} face model(s) for user '{user}'.");
+        Terminal.info(&UserMessage::ClearedModels {
+            count: count as usize,
+            user: user.clone(),
+        });
         // The user has no models by construction, so drop the marker outright.
         super::enrollment_marker::forget(config, &user);
         return Ok(());
@@ -54,7 +58,7 @@ pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<(
 
     match response {
         DaemonResponse::Removed => {
-            println!("All face models removed for user '{user}'.");
+            Terminal.info(&UserMessage::AllModelsRemoved { user: user.clone() });
             super::enrollment_marker::forget(config, &user);
         }
         other => {

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -6,6 +6,7 @@ use facelock_core::types::FaceModelInfo;
 use facelock_store::StoreError;
 
 use crate::ipc_client;
+use crate::message::{Terminal, UserMessage, fail};
 
 pub fn run(
     config: &Config,
@@ -20,16 +21,16 @@ pub fn run(
         let marker = std::path::Path::new(super::setup::SETUP_COMPLETE_MARKER);
         if !marker.exists() {
             ipc_client::require_root("sudo facelock setup")?;
-            println!("Setup has not been completed.");
-            if ipc_client::confirm("Run setup now?")? {
+            Terminal.info(&UserMessage::SetupNotCompleted);
+            if Terminal.confirm(&UserMessage::ConfirmRunSetupNow)? {
                 super::setup::run(false)?;
                 if !marker.exists() {
-                    anyhow::bail!("Setup did not complete successfully.");
+                    return Err(fail(UserMessage::SetupDidNotComplete));
                 }
                 // Setup includes face enrollment (Step 4), so we're done
                 return Ok(());
             } else {
-                println!("Run 'sudo facelock setup' when ready.");
+                Terminal.info(&UserMessage::RunSetupWhenReady);
                 return Ok(());
             }
         }
@@ -41,10 +42,7 @@ pub fn run(
     // warn prominently when the opt-in is active.
     if config.encryption.method == facelock_core::config::EncryptionMethod::None {
         if config.security.allow_plaintext {
-            eprintln!(
-                "WARNING: encryption.method = \"none\" and security.allow_plaintext = true.\n\
-                 Your face template will be stored UNENCRYPTED (plaintext biometric data at rest)."
-            );
+            Terminal.error(&UserMessage::PlaintextEnrollWarning);
         } else if let Err(message) = config.ensure_enroll_encryption_allowed() {
             anyhow::bail!(message);
         }
@@ -56,10 +54,9 @@ pub fn run(
         .value
         .all_present()
     {
-        anyhow::bail!(
-            "Face recognition models not found in {}.\nRun `sudo facelock setup` to download them.",
-            config.daemon.model_dir
-        );
+        return Err(fail(UserMessage::ModelsMissing {
+            dir: config.daemon.model_dir.clone(),
+        }));
     }
 
     let user = ipc_client::resolve_user(user.as_deref());
@@ -94,24 +91,26 @@ pub fn run(
             }
         };
         if has_stale {
-            println!(
-                "Note: existing models don't use the configured embedder '{config_embedder}'."
-            );
-            println!(
-                "Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
-            );
+            Terminal.info(&UserMessage::StaleEmbedderNote {
+                embedder: config_embedder.clone(),
+            });
         }
     }
 
-    println!("Enrolling face for user '{user}' with label '{label}'...");
-    println!("Look at the camera. Slowly turn your head left and right.");
+    Terminal.info(&UserMessage::Enrolling {
+        user: user.clone(),
+        label: label.clone(),
+    });
+    Terminal.info(&UserMessage::EnrollLookAtCamera);
 
     if ipc_client::should_use_direct(config) {
         ipc_client::require_root("sudo facelock enroll")?;
         let (model_id, embedding_count) = crate::direct::enroll(config, &user, &label)?;
-        println!(
-            "\nFace enrolled successfully!\n  Model ID: {model_id}\n  Embeddings: {embedding_count}\n  Label: {label}"
-        );
+        Terminal.info(&UserMessage::EnrollComplete {
+            model_id,
+            count: embedding_count,
+            label: label.clone(),
+        });
         super::enrollment_marker::refresh(config, &user);
         check_model_count(&user, config);
         return Ok(());
@@ -127,9 +126,11 @@ pub fn run(
         embedding_count,
     } = response
     {
-        println!(
-            "\nFace enrolled successfully!\n  Model ID: {model_id}\n  Embeddings: {embedding_count}\n  Label: {label}"
-        );
+        Terminal.info(&UserMessage::EnrollComplete {
+            model_id,
+            count: embedding_count,
+            label: label.clone(),
+        });
         super::enrollment_marker::refresh(config, &user);
         check_model_count(&user, config);
     }
@@ -208,10 +209,10 @@ fn check_model_count(user: &str, config: &Config) {
     // reported failure.
     if let Ok(models) = list_user_models(user, config) {
         if models.len() > 5 {
-            println!(
-                "\nWarning: user '{user}' has {} face models. Consider removing old ones with 'facelock remove'.",
-                models.len()
-            );
+            Terminal.info(&UserMessage::TooManyModels {
+                user: user.to_string(),
+                count: models.len(),
+            });
         }
     }
 }

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -2,6 +2,7 @@ use facelock_core::Config;
 use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use crate::ipc_client;
+use crate::message::{Terminal, UserMessage};
 
 pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()> {
     // C6: root check must run before the confirmation prompt below — a group
@@ -13,10 +14,12 @@ pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> a
     let user = ipc_client::resolve_user(user.as_deref());
 
     if !yes {
-        let confirmed =
-            ipc_client::confirm(&format!("Remove face model #{model_id} for user '{user}'?"))?;
+        let confirmed = Terminal.confirm(&UserMessage::ConfirmRemoveModel {
+            model_id,
+            user: user.clone(),
+        })?;
         if !confirmed {
-            println!("Cancelled.");
+            Terminal.info(&UserMessage::Cancelled);
             return Ok(());
         }
     }
@@ -27,9 +30,15 @@ pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> a
             .remove_model(&user, model_id)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         if removed {
-            println!("Removed face model #{model_id} for user '{user}'.");
+            Terminal.info(&UserMessage::RemovedModel {
+                model_id,
+                user: user.clone(),
+            });
         } else {
-            println!("Model #{model_id} not found for user '{user}'.");
+            Terminal.info(&UserMessage::ModelNotFound {
+                model_id,
+                user: user.clone(),
+            });
         }
         // Recompute from the list we already have open rather than decrementing:
         // same cost, and it cannot drift from the database.
@@ -50,7 +59,10 @@ pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> a
 
     match response {
         DaemonResponse::Removed => {
-            println!("Removed face model #{model_id} for user '{user}'.");
+            Terminal.info(&UserMessage::RemovedModel {
+                model_id,
+                user: user.clone(),
+            });
             super::enrollment_marker::refresh(config, &user);
         }
         other => {

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -13,6 +13,8 @@ use facelock_core::fs_security::{
     create_truncate_file, ensure_mode, ensure_private_dir, write_file,
 };
 
+use crate::message::{Terminal, UserMessage, fail};
+
 /// Embedded systemd unit file.
 const SERVICE_UNIT: &str = include_str!("../../../../systemd/facelock-daemon.service");
 
@@ -358,18 +360,9 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     let theme = ColorfulTheme::default();
 
     // -- Welcome --
-    println!();
-    println!("  Facelock v{}", env!("CARGO_PKG_VERSION"));
-    println!("  Linux face authentication");
-    println!();
-    println!("  This wizard will walk you through initial setup:");
-    println!("    - Camera detection");
-    println!("    - Model quality and inference device");
-    println!("    - Model downloads");
-    println!("    - Embedding encryption (TPM or software)");
-    println!("    - Face enrollment");
-    println!("    - Daemon and PAM configuration");
-    println!();
+    Terminal.info(&UserMessage::SetupIntro {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    });
 
     // -- Load or create config --
     // Deliberate load (D7): setup bootstraps the config file — it may not
@@ -391,75 +384,76 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     // `--camera` answers the question and therefore replaces the prompt (plan
     // §1 rule 1). An explicit value that cannot be honoured is fatal: the user
     // asked for a specific device, so falling back would be silently wrong.
-    println!("\n--- Step 1: Camera Selection ---\n");
+    Terminal.info(&UserMessage::SetupStepCamera);
     match plan.camera.as_ref() {
         Some(choice) => apply_camera_choice(&mut config, choice)?,
         None => match wizard_camera_selection(&theme, &mut config) {
             Ok(()) => {}
             Err(e) => {
-                println!("  Camera detection failed: {e}");
-                println!("  You can configure the camera later in the config file.");
-                println!(
-                    "  Continuing with current setting: {}",
-                    config.device.path.as_deref().unwrap_or("/dev/video0")
-                );
+                Terminal.info(&UserMessage::CameraStepFailed {
+                    error: e.to_string(),
+                    current: config
+                        .device
+                        .path
+                        .as_deref()
+                        .unwrap_or("/dev/video0")
+                        .to_string(),
+                });
             }
         },
     }
 
     // -- Step 2: Model quality --
-    println!("\n--- Step 2: Model Quality ---\n");
+    Terminal.info(&UserMessage::SetupStepModelQuality);
     match plan.models {
         Some(preset) => apply_model_preset(&mut config, preset)?,
         None => match wizard_model_quality(&theme, &mut config) {
             Ok(()) => {}
             Err(e) => {
-                println!("  Model quality selection failed: {e}");
-                println!(
-                    "  Continuing with current setting: {}",
-                    config.recognition.detector_model
-                );
+                Terminal.info(&UserMessage::ModelQualityStepFailed {
+                    error: e.to_string(),
+                    current: config.recognition.detector_model.clone(),
+                });
             }
         },
     }
 
     // -- Step 3: Execution provider --
-    println!("\n--- Step 3: Inference Device ---\n");
+    Terminal.info(&UserMessage::SetupStepInferenceDevice);
     match plan.execution_provider {
         Some(choice) => apply_execution_provider(&mut config, choice)?,
         None => match wizard_execution_provider(&theme, &mut config) {
             Ok(()) => {}
             Err(e) => {
-                println!("  Inference device selection failed: {e}");
-                println!(
-                    "  Continuing with current setting: {}",
-                    config.recognition.execution_provider
-                );
+                Terminal.info(&UserMessage::InferenceStepFailed {
+                    error: e.to_string(),
+                    current: config.recognition.execution_provider.clone(),
+                });
             }
         },
     }
 
     // -- Step 4: Model download --
-    println!("\n--- Step 4: Model Download ---\n");
+    Terminal.info(&UserMessage::SetupStepModelDownload);
     match wizard_model_download(&theme, &config) {
         Ok(()) => {}
         Err(e) => {
-            println!("  Model download failed: {e}");
-            println!("  You can retry later with: sudo facelock setup --non-interactive");
+            Terminal.info(&UserMessage::ModelDownloadStepFailed {
+                error: e.to_string(),
+            });
         }
     }
 
     // -- Step 5: Encryption setup --
-    println!("\n--- Step 5: Embedding Encryption ---\n");
+    Terminal.info(&UserMessage::SetupStepEncryption);
     match plan.encryption {
         Some(choice) => apply_encryption_choice(&mut config, choice, Some(&theme))?,
         None => match wizard_encryption_setup(&theme, &mut config) {
             Ok(()) => {}
             Err(e) => {
-                println!("  Encryption setup failed: {e}");
-                println!(
-                    "  You can configure encryption later with: sudo facelock encrypt --generate-key"
-                );
+                Terminal.info(&UserMessage::EncryptionStepFailed {
+                    error: e.to_string(),
+                });
             }
         },
     }
@@ -467,52 +461,54 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     // -- Step 6: Face enrollment --
     let enroll_steps = enroll_steps_for(plan);
     let enrolled = if enroll_steps.enroll {
-        println!("\n--- Step 6: Face Enrollment ---\n");
+        Terminal.info(&UserMessage::SetupStepEnrollment);
         match wizard_face_enroll(&config, &theme, enroll_steps.assume_yes) {
             Ok(did_enroll) => did_enroll,
             Err(e) => {
-                println!("  Enrollment failed: {e}");
-                println!("  You can enroll later with: facelock enroll");
+                Terminal.info(&UserMessage::EnrollStepFailed {
+                    error: e.to_string(),
+                });
                 false
             }
         }
     } else {
-        println!("\n--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n");
+        Terminal.info(&UserMessage::SetupStepEnrollmentSkipped);
         false
     };
 
     // -- Step 7: Test recognition --
     if test_recognition_runs(enroll_steps, enrolled) {
-        println!("\n--- Step 7: Test Recognition ---\n");
+        Terminal.info(&UserMessage::SetupStepTest);
         match wizard_test_recognition(&config, &theme, plan.yes) {
             Ok(()) => {}
             Err(e) => {
-                println!("  Test failed: {e}");
-                println!("  You can test later with: facelock test");
+                Terminal.info(&UserMessage::TestStepFailed {
+                    error: e.to_string(),
+                });
             }
         }
     } else {
-        println!("\n--- Step 7: Test Recognition (skipped, no face enrolled) ---\n");
+        Terminal.info(&UserMessage::SetupStepTestSkipped);
     }
 
     // -- Step 8: Systemd setup --
-    println!("\n--- Step 8: Daemon Configuration ---\n");
+    Terminal.info(&UserMessage::SetupStepDaemon);
     let systemd_step = systemd_step_for(plan);
     let systemd_enabled = if systemd_step.wizard_may_install() {
         match wizard_systemd_setup(&theme, plan.yes) {
             Ok(enabled) => enabled,
             Err(e) => {
-                println!("  Systemd setup failed: {e}");
-                println!("  You can enable it later with: sudo facelock setup --systemd");
+                Terminal.info(&UserMessage::SystemdStepFailed {
+                    error: e.to_string(),
+                });
                 false
             }
         }
     } else {
         if systemd_step == SystemdStep::Skip {
-            println!("  Skipping daemon configuration (--no-systemd).");
-            println!("  No unit files are written and systemctl is not invoked.");
+            Terminal.info(&UserMessage::SystemdSkippedFlag);
         } else {
-            println!("  Answered on the command line; applied once setup finishes.");
+            Terminal.info(&UserMessage::SystemdDeferred);
         }
         false
     };
@@ -520,12 +516,13 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     // Group membership: without it, the first daemon command a normal user
     // runs after setup fails with a bare D-Bus AccessDenied (issue #89).
     if let Err(e) = setup_group_membership(Some(&theme)) {
-        println!("  Group setup failed: {e}");
-        println!("  Add manually: sudo usermod -aG facelock <user>");
+        Terminal.info(&UserMessage::GroupStepFailed {
+            error: e.to_string(),
+        });
     }
 
     // -- Step 9: PAM configuration --
-    println!("\n--- Step 9: PAM Configuration ---\n");
+    Terminal.info(&UserMessage::SetupStepPam);
     let pam_services = match pam_step_in(
         Path::new(PAM_DIR),
         plan,
@@ -534,8 +531,9 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     ) {
         Ok(services) => services,
         Err(e) => {
-            println!("  PAM setup failed: {e}");
-            println!("  You can configure PAM later with: sudo facelock setup --pam");
+            Terminal.info(&UserMessage::PamStepFailed {
+                error: e.to_string(),
+            });
             Vec::new()
         }
     };
@@ -547,7 +545,7 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     print_pam_extension_hint();
 
     // -- Summary --
-    println!("\n--- Setup Complete ---\n");
+    Terminal.info(&UserMessage::SetupCompleteHeader);
     let encryption_label = match config.encryption.method {
         facelock_core::config::EncryptionMethod::Tpm => "AES-256-GCM (TPM-sealed key)",
         facelock_core::config::EncryptionMethod::Keyfile => "AES-256-GCM (keyfile)",
@@ -561,42 +559,51 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
         ("scrfd_2.5g_bnkps.onnx", "glintr100.onnx") => "balanced (SCRFD 2.5G + ArcFace R100)",
         _ => "standard (SCRFD 2.5G + ArcFace R50)",
     };
-    println!(
-        "  Camera:     {}",
-        config.device.path.as_deref().unwrap_or("/dev/video0")
-    );
-    println!(
-        "  Models:     {} ({})",
-        config.daemon.model_dir, model_quality_label
-    );
-    println!(
-        "  Inference:  {}",
-        config.recognition.execution_provider.to_uppercase()
-    );
-    println!("  Database:   {}", config.storage.db_path);
-    println!("  Encryption: {}", encryption_label);
-    println!(
-        "  Daemon:   {}",
-        match systemd_step {
-            SystemdStep::Skip => "not configured (--no-systemd)",
-            SystemdStep::Deferred => "configured from the command line",
-            SystemdStep::Ask if systemd_enabled => "enabled (D-Bus activation)",
-            SystemdStep::Ask => "not configured",
+    Terminal.info(&UserMessage::SummaryCamera {
+        value: config
+            .device
+            .path
+            .as_deref()
+            .unwrap_or("/dev/video0")
+            .to_string(),
+    });
+    Terminal.info(&UserMessage::SummaryModels {
+        dir: config.daemon.model_dir.clone(),
+        quality: model_quality_label.to_string(),
+    });
+    Terminal.info(&UserMessage::SummaryInference {
+        value: config.recognition.execution_provider.to_uppercase(),
+    });
+    Terminal.info(&UserMessage::SummaryDatabase {
+        value: config.storage.db_path.clone(),
+    });
+    Terminal.info(&UserMessage::SummaryEncryption {
+        value: encryption_label.to_string(),
+    });
+    Terminal.info(&UserMessage::SummaryDaemon {
+        status: match systemd_step {
+            SystemdStep::Skip => UserMessage::DaemonStatusNotConfiguredNoSystemd,
+            SystemdStep::Deferred => UserMessage::DaemonStatusDeferred,
+            SystemdStep::Ask if systemd_enabled => UserMessage::DaemonStatusEnabled,
+            SystemdStep::Ask => UserMessage::DaemonStatusNotConfigured,
         }
-    );
+        .localized(),
+    });
     if !pam_services.is_empty() {
-        println!("  PAM:      {}", pam_services.join(", "));
+        Terminal.info(&UserMessage::SummaryPam {
+            services: pam_services.join(", "),
+        });
     } else if pam_step_for(plan) == PamStep::Skip {
-        println!("  PAM:      not configured (--no-pam)");
+        Terminal.info(&UserMessage::SummaryPamSkipped);
     } else {
-        println!("  PAM:      not configured");
+        Terminal.info(&UserMessage::SummaryPamNone);
     }
     if enrolled {
-        println!("  Face:     enrolled");
+        Terminal.info(&UserMessage::SummaryFaceEnrolled);
     } else if !enroll_steps.enroll {
-        println!("  Face:     not enrolled (--no-enroll; run `facelock enroll`)");
+        Terminal.info(&UserMessage::SummaryFaceNotEnrolledNoEnroll);
     } else {
-        println!("  Face:     not enrolled (run `facelock enroll`)");
+        Terminal.info(&UserMessage::SummaryFaceNotEnrolled);
     }
     println!();
 
@@ -625,8 +632,7 @@ fn wizard_camera_selection(theme: &ColorfulTheme, config: &mut Config) -> anyhow
     let devices = facelock_camera::list_devices().map_err(|e| anyhow::anyhow!("{e}"))?;
 
     if devices.is_empty() {
-        println!("  No video devices found.");
-        println!("  Check that your camera is connected and the v4l2 module is loaded.");
+        Terminal.info(&UserMessage::NoVideoDevices);
         return Ok(());
     }
 
@@ -654,7 +660,10 @@ fn wizard_camera_selection(theme: &ColorfulTheme, config: &mut Config) -> anyhow
     // If exactly one IR camera, auto-select it
     if ir_devices.len() == 1 {
         let dev = ir_devices[0];
-        println!("  Auto-selected IR camera: {} ({})", dev.path, dev.name);
+        Terminal.info(&UserMessage::AutoSelectedIrCamera {
+            path: dev.path.clone(),
+            name: dev.name.clone(),
+        });
         config.device.path = Some(dev.path.clone());
         return Ok(());
     }
@@ -680,14 +689,17 @@ fn wizard_camera_selection(theme: &ColorfulTheme, config: &mut Config) -> anyhow
         .unwrap_or(0);
 
     let selection = Select::with_theme(theme)
-        .with_prompt("Select camera device")
+        .with_prompt(UserMessage::PromptSelectCameraDevice.localized())
         .items(&display_items)
         .default(default_idx)
         .interact()?;
 
     let selected = &devices[selection];
     config.device.path = Some(selected.path.clone());
-    println!("  Selected: {} ({})", selected.path, selected.name);
+    Terminal.info(&UserMessage::SelectedCamera {
+        path: selected.path.clone(),
+        name: selected.name.clone(),
+    });
 
     Ok(())
 }
@@ -713,21 +725,17 @@ fn select_ir_camera(candidates: &[CameraCandidate]) -> anyhow::Result<String> {
 
     match ir.len() {
         1 => Ok(ir[0].path.clone()),
-        0 if candidates.is_empty() => bail!(
-            "--camera=auto found no video devices; check that the camera is connected \
-             and the v4l2 module is loaded"
-        ),
+        0 if candidates.is_empty() => Err(fail(UserMessage::AutoCameraNoDevices)),
         0 => {
             let listed = candidates
                 .iter()
                 .map(|c| format!("    {} - {}", c.path, c.name))
                 .collect::<Vec<_>>()
                 .join("\n");
-            bail!(
-                "--camera=auto found no IR-capable camera among the detected devices:\n{listed}\n  \
-                 Pass an explicit device path, e.g. --camera={}",
-                candidates[0].path
-            )
+            Err(fail(UserMessage::AutoCameraNoIr {
+                listed,
+                example: candidates[0].path.clone(),
+            }))
         }
         _ => {
             let listed = ir
@@ -735,11 +743,10 @@ fn select_ir_camera(candidates: &[CameraCandidate]) -> anyhow::Result<String> {
                 .map(|c| format!("    {} - {}", c.path, c.name))
                 .collect::<Vec<_>>()
                 .join("\n");
-            bail!(
-                "--camera=auto found {} IR-capable cameras:\n{listed}\n  \
-                 Pass an explicit device path to choose one.",
-                ir.len()
-            )
+            Err(fail(UserMessage::AutoCameraManyIr {
+                count: ir.len(),
+                listed,
+            }))
         }
     }
 }
@@ -772,17 +779,18 @@ fn apply_camera_choice(config: &mut Config, choice: &CameraChoice) -> anyhow::Re
     let path = match choice {
         CameraChoice::Auto => {
             let path = select_ir_camera(&enumerate_camera_candidates()?)?;
-            println!("  Auto-selected IR camera: {path}");
+            Terminal.info(&UserMessage::AutoSelectedIrCameraPath { path: path.clone() });
             path
         }
         CameraChoice::Path(path) => {
             if !Path::new(path).exists() {
-                bail!(
-                    "camera device {path} does not exist; \
-                     pass a valid /dev/video* path or --camera=auto"
-                );
+                return Err(fail(UserMessage::CameraDeviceMissing {
+                    path: path.clone(),
+                }));
             }
-            println!("  Selected: {path}");
+            Terminal.info(&UserMessage::SelectedValue {
+                value: path.clone(),
+            });
             path.clone()
         }
     };
@@ -883,7 +891,7 @@ fn wizard_model_quality(theme: &ColorfulTheme, config: &mut Config) -> anyhow::R
     .unwrap_or(0);
 
     let selection = Select::with_theme(theme)
-        .with_prompt("Select model quality")
+        .with_prompt(UserMessage::PromptSelectModelQuality.localized())
         .items(&MODEL_PRESET_OPTIONS[..])
         .default(default_idx)
         .interact()?;
@@ -908,7 +916,7 @@ fn wizard_execution_provider(theme: &ColorfulTheme, config: &mut Config) -> anyh
     ];
 
     let selection = Select::with_theme(theme)
-        .with_prompt("Select inference device")
+        .with_prompt(UserMessage::PromptSelectInferenceDevice.localized())
         .items(&options[..])
         .default(default_idx)
         .interact()?;
@@ -919,7 +927,9 @@ fn wizard_execution_provider(theme: &ColorfulTheme, config: &mut Config) -> anyh
     };
 
     config.recognition.execution_provider = provider.to_string();
-    println!("  Selected: {}", provider);
+    Terminal.info(&UserMessage::SelectedValue {
+        value: provider.to_string(),
+    });
     warn_provider_preflight(provider);
 
     update_config_provider(config)?;
@@ -993,7 +1003,9 @@ fn apply_execution_provider(
 ) -> anyhow::Result<()> {
     let provider = provider_name(choice)?;
     config.recognition.execution_provider = provider.clone();
-    println!("  Selected: {provider}");
+    Terminal.info(&UserMessage::SelectedValue {
+        value: provider.clone(),
+    });
     warn_provider_preflight(&provider);
 
     update_config_provider(config)?;
@@ -1112,40 +1124,48 @@ fn wizard_model_download(theme: &ColorfulTheme, config: &Config) -> anyhow::Resu
     }
 
     for entry in &already_present {
-        println!("  [ok] {} ({})", entry.name, entry.purpose);
+        Terminal.info(&UserMessage::ModelPresentOk {
+            name: entry.name.clone(),
+            purpose: entry.purpose.clone(),
+        });
     }
 
     if to_download.is_empty() {
-        println!("  All models are already present and verified.");
+        Terminal.info(&UserMessage::AllModelsPresent);
         return Ok(());
     }
 
     let total_mb: u64 = to_download.iter().map(|e| e.size_mb).sum();
-    println!("  Models to download:");
+    Terminal.info(&UserMessage::ModelsToDownloadHeader);
     for entry in &to_download {
-        println!(
-            "    - {} (~{}MB) - {}",
-            entry.name, entry.size_mb, entry.purpose
-        );
+        Terminal.info(&UserMessage::ModelToDownloadEntry {
+            name: entry.name.clone(),
+            size_mb: entry.size_mb,
+            purpose: entry.purpose.clone(),
+        });
     }
-    println!("  Total download size: ~{}MB", total_mb);
+    Terminal.info(&UserMessage::TotalDownloadSize { mb: total_mb });
 
     let proceed = Confirm::with_theme(theme)
-        .with_prompt("Download required models?")
+        .with_prompt(UserMessage::ConfirmDownloadRequiredModels.localized())
         .default(true)
         .interact()?;
 
     if !proceed {
-        println!("  Skipping model download.");
+        Terminal.info(&UserMessage::SkippingModelDownload);
         return Ok(());
     }
 
     for entry in &to_download {
         let model_path = model_dir.join(&entry.filename);
-        println!("  Downloading {}...", entry.name);
+        Terminal.info(&UserMessage::DownloadingModel {
+            name: entry.name.clone(),
+        });
         download_model(entry, &model_path)?;
         verify_after_download(&model_path, &entry.sha256, &entry.name)?;
-        println!("  [ok] {} downloaded and verified", entry.name);
+        Terminal.info(&UserMessage::ModelDownloaded {
+            name: entry.name.clone(),
+        });
     }
 
     Ok(())
@@ -1866,10 +1886,14 @@ fn wizard_face_enroll(
     theme: &ColorfulTheme,
     assume_yes: bool,
 ) -> anyhow::Result<bool> {
-    let proceed = confirm_step(theme, "Would you like to enroll a face now?", assume_yes)?;
+    let proceed = confirm_step(
+        theme,
+        &UserMessage::ConfirmEnrollNow.localized(),
+        assume_yes,
+    )?;
 
     if !proceed {
-        println!("  Skipping face enrollment.");
+        Terminal.info(&UserMessage::EnrollSkipped);
         return Ok(false);
     }
 
@@ -1882,10 +1906,14 @@ fn wizard_test_recognition(
     theme: &ColorfulTheme,
     assume_yes: bool,
 ) -> anyhow::Result<()> {
-    let proceed = confirm_step(theme, "Would you like to test recognition?", assume_yes)?;
+    let proceed = confirm_step(
+        theme,
+        &UserMessage::ConfirmTestRecognition.localized(),
+        assume_yes,
+    )?;
 
     if !proceed {
-        println!("  Skipping recognition test.");
+        Terminal.info(&UserMessage::TestSkipped);
         return Ok(());
     }
 
@@ -1895,19 +1923,18 @@ fn wizard_test_recognition(
 
 fn wizard_systemd_setup(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::Result<bool> {
     if !Path::new("/run/systemd/system").exists() {
-        println!("  systemd not detected. Skipping daemon configuration.");
-        println!("  Facelock will use oneshot mode for authentication.");
+        Terminal.info(&UserMessage::SystemdNotDetected);
         return Ok(false);
     }
 
     let proceed = confirm_step(
         theme,
-        "Enable daemon mode with D-Bus activation?",
+        &UserMessage::ConfirmDaemonMode.localized(),
         assume_yes,
     )?;
 
     if !proceed {
-        println!("  Skipping systemd setup. Facelock will use oneshot mode.");
+        Terminal.info(&UserMessage::SystemdDeclined);
         return Ok(false);
     }
 
@@ -1932,21 +1959,25 @@ fn pam_step_in(
 
     if !step.touches_pam_d() {
         if step == PamStep::Skip {
-            println!("  Skipping PAM configuration (--no-pam).");
-            println!("  No file under {} is read or modified.", base.display());
+            Terminal.info(&UserMessage::PamSkippedFlag {
+                dir: base.display().to_string(),
+            });
         }
         return Ok(Vec::new());
     }
 
     if !module_present {
-        println!("  PAM module not found at {PAM_MODULE_PATH}.");
-        println!("  Install it first, then run: sudo facelock setup --pam");
+        Terminal.info(&UserMessage::PamModuleMissing {
+            path: PAM_MODULE_PATH.to_string(),
+        });
         return Ok(Vec::new());
     }
 
     match step {
         PamStep::Install(service) => {
-            println!("  Configuring PAM for {service}...");
+            Terminal.info(&UserMessage::ConfiguringPamFor {
+                service: service.clone(),
+            });
             pam_install_in(base, &service, plan.yes, false)?;
             Ok(vec![service])
         }
@@ -1960,23 +1991,15 @@ fn wizard_pam_setup_in(base: &Path, theme: &ColorfulTheme) -> anyhow::Result<Vec
     let candidates = candidates_in(base);
 
     if candidates.is_empty() {
-        println!(
-            "  No supported PAM service files found in {}/.",
-            base.display()
-        );
+        Terminal.info(&UserMessage::NoPamCandidates {
+            dir: base.display().to_string(),
+        });
         return Ok(Vec::new());
     }
 
-    println!("  The following line will be added to each selected /etc/pam.d/<service>:");
-    println!();
-    println!("      {PAM_LINE}");
-    println!();
-    println!(
-        "  It is inserted above the first existing 'auth' line. A backup\n  \
-         (.facelock-backup) is saved before any change, and you'll be asked\n  \
-         to confirm each file individually."
-    );
-    println!();
+    Terminal.info(&UserMessage::PamLinePreview {
+        line: PAM_LINE.to_string(),
+    });
 
     let labels: Vec<&str> = candidates.iter().map(|c| c.description).collect();
     let defaults: Vec<bool> = candidates.iter().map(|c| c.default_enabled).collect();
@@ -1991,7 +2014,7 @@ fn wizard_pam_setup_in(base: &Path, theme: &ColorfulTheme) -> anyhow::Result<Vec
             .collect()
     } else {
         let selections = MultiSelect::with_theme(theme)
-            .with_prompt("Select services to enable face authentication for")
+            .with_prompt(UserMessage::PromptSelectPamServices.localized())
             .items(&labels)
             .defaults(&defaults)
             .interact()?;
@@ -2003,19 +2026,24 @@ fn wizard_pam_setup_in(base: &Path, theme: &ColorfulTheme) -> anyhow::Result<Vec
 
     let mut configured = Vec::new();
     for service in selected_services {
-        println!("  Configuring PAM for {service}...");
+        Terminal.info(&UserMessage::ConfiguringPamFor {
+            service: service.clone(),
+        });
         // `yes = true`: the multi-select above *is* the per-service consent, and
         // no candidate is in SENSITIVE_SERVICES.
         match pam_install_in(base, &service, true, false) {
             Ok(()) => configured.push(service),
             Err(e) => {
-                println!("  Failed to configure {service}: {e}");
+                Terminal.info(&UserMessage::PamConfigureFailed {
+                    service: service.clone(),
+                    error: e.to_string(),
+                });
             }
         }
     }
 
     if configured.is_empty() {
-        println!("  No PAM services selected.");
+        Terminal.info(&UserMessage::NoPamServicesSelected);
     }
 
     Ok(configured)
@@ -2089,7 +2117,7 @@ fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
 // ---------------------------------------------------------------------------
 
 fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
-    println!("facelock setup: preparing system...\n");
+    Terminal.info(&UserMessage::NonInteractivePreparing);
 
     // Load config (or use defaults for paths). Deliberate load (D7): setup
     // bootstraps the config file, which may not exist yet.
@@ -2139,7 +2167,9 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
         .filter(|m| m.filename == *configured_detector || m.filename == *configured_embedder)
         .collect();
 
-    println!("Checking {} model(s)...\n", needed.len());
+    Terminal.info(&UserMessage::CheckingModels {
+        count: needed.len(),
+    });
 
     for entry in &needed {
         let model_path = model_dir.join(&entry.filename);
@@ -2207,9 +2237,9 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     }
 
     if enrolled {
-        println!("\nSetup complete.");
+        Terminal.info(&UserMessage::SetupCompleteShort);
     } else {
-        println!("\nSetup complete. Run `facelock enroll` to register your face.");
+        Terminal.info(&UserMessage::SetupCompleteEnroll);
     }
     Ok(())
 }
@@ -2331,7 +2361,7 @@ fn setup_group_membership(theme: Option<&ColorfulTheme>) -> anyhow::Result<()> {
         .context("failed to look up facelock group")?
         .is_none()
     {
-        println!("  Creating 'facelock' system group...");
+        Terminal.info(&UserMessage::CreatingFacelockGroup);
         run_cmd("groupadd", &["-r", "facelock"])?;
     }
     let group = nix::unistd::Group::from_name("facelock")
@@ -2339,15 +2369,12 @@ fn setup_group_membership(theme: Option<&ColorfulTheme>) -> anyhow::Result<()> {
         .context("facelock group missing after creation")?;
 
     let Some(user) = invoking_user() else {
-        println!(
-            "  Note: running daemon commands (preview/test) as a normal user requires\n  \
-             membership in the 'facelock' group: sudo usermod -aG facelock <user>"
-        );
+        Terminal.info(&UserMessage::GroupMembershipNote);
         return Ok(());
     };
 
     if user_in_group(&user, &group) {
-        println!("  User '{user}' is already in the 'facelock' group.");
+        Terminal.info(&UserMessage::AlreadyInGroup { user: user.clone() });
         return Ok(());
     }
 
@@ -2356,22 +2383,18 @@ fn setup_group_membership(theme: Option<&ColorfulTheme>) -> anyhow::Result<()> {
         // the wizard's caller prints the error plus the manual usermod command,
         // so a broken stdin surfaces rather than silently skipping the add.
         let proceed = Confirm::with_theme(theme)
-            .with_prompt(format!(
-                "Add user '{user}' to the 'facelock' group? (required to run \
-                 facelock preview/test without sudo)"
-            ))
+            .with_prompt(UserMessage::ConfirmAddToGroup { user: user.clone() }.localized())
             .default(true)
             .interact()
             .context("group membership prompt failed")?;
         if !proceed {
-            println!("  Skipped. Add later with: sudo usermod -aG facelock {user}");
+            Terminal.info(&UserMessage::GroupAddSkipped { user: user.clone() });
             return Ok(());
         }
     }
 
     run_cmd("usermod", &["-aG", "facelock", &user])?;
-    println!("  Added '{user}' to the 'facelock' group.");
-    println!("  NOTE: log out and back in for the new group membership to take effect.");
+    Terminal.info(&UserMessage::AddedToGroup { user: user.clone() });
     Ok(())
 }
 
@@ -2830,7 +2853,9 @@ fn pam_install_in(base: &Path, service: &str, yes: bool, no_prompt: bool) -> any
 
     // Check idempotency — match on the module name, not exact spacing
     if content.lines().any(is_facelock_pam_line) {
-        println!("PAM line already present in {pam_path}. Nothing to do.");
+        Terminal.info(&UserMessage::PamLineAlreadyPresent {
+            path: pam_path.clone(),
+        });
         return Ok(());
     }
 
@@ -2839,37 +2864,42 @@ fn pam_install_in(base: &Path, service: &str, yes: bool, no_prompt: bool) -> any
 
     // Decide where the line will go BEFORE prompting, so the preview is accurate.
     let insertion_hint = if content.lines().any(|l| l.trim_start().starts_with("auth")) {
-        "inserted before the first 'auth' line"
+        UserMessage::PamInsertBeforeAuthHint
     } else {
-        "no 'auth' line found — inserted at the top of the file"
+        UserMessage::PamInsertAtTopHint
     };
 
-    println!();
-    println!("About to modify {pam_path}:");
-    println!("  + {PAM_LINE}    ({insertion_hint})");
-    println!("  Backup will be saved to: {backup_path}");
-    println!();
-    println!("(To configure manually instead, add the line above to each service yourself.)");
+    Terminal.info(&UserMessage::PamModifyPreview {
+        path: pam_path.clone(),
+        line: PAM_LINE.to_string(),
+        hint: insertion_hint.localized(),
+        backup: backup_path.clone(),
+    });
 
     let proceed = if yes || no_prompt || !std::io::stdin().is_terminal() {
         true
     } else {
         Confirm::new()
-            .with_prompt("Proceed?")
+            .with_prompt(UserMessage::ConfirmProceed.localized())
             .default(true)
             .interact()
             .context("failed to read confirmation")?
     };
 
     if !proceed {
-        println!("Skipped {pam_path}.");
+        Terminal.info(&UserMessage::PamSkippedFile {
+            path: pam_path.clone(),
+        });
         return Ok(());
     }
 
     // 4b. Create backup (always, before any modification)
     fs::copy(pam_file, &backup_path)
         .with_context(|| format!("failed to back up {pam_path} to {backup_path}"))?;
-    println!("Backed up {pam_path} -> {backup_path}");
+    Terminal.info(&UserMessage::PamBackedUp {
+        path: pam_path.clone(),
+        backup: backup_path.clone(),
+    });
 
     // 5. Prepend PAM line before first auth line
     let mut new_lines: Vec<String> = Vec::new();
@@ -2896,10 +2926,11 @@ fn pam_install_in(base: &Path, service: &str, yes: bool, no_prompt: bool) -> any
 
     fs::write(pam_file, &output).with_context(|| format!("failed to write {pam_path}"))?;
 
-    println!("Installed facelock PAM line into {pam_path}");
-    println!("\nTo rollback:");
-    println!("  sudo cp {backup_path} {pam_path}");
-    println!("  # or: sudo facelock setup --pam --remove --service {service}");
+    Terminal.info(&UserMessage::PamInstalled {
+        path: pam_path.clone(),
+        backup: backup_path.clone(),
+        service: service.to_string(),
+    });
 
     Ok(())
 }
@@ -2922,7 +2953,9 @@ fn pam_remove(service: &str) -> anyhow::Result<()> {
         .collect();
 
     if new_lines.len() == original_count {
-        println!("No facelock PAM line found in {pam_path}. Nothing to remove.");
+        Terminal.info(&UserMessage::PamNoLineFound {
+            path: pam_path.clone(),
+        });
     } else {
         let mut output = new_lines.join("\n");
         if content.ends_with('\n') {
@@ -2930,14 +2963,18 @@ fn pam_remove(service: &str) -> anyhow::Result<()> {
         }
 
         fs::write(pam_file, &output).with_context(|| format!("failed to write {pam_path}"))?;
-        println!("Removed facelock PAM line from {pam_path}");
+        Terminal.info(&UserMessage::PamRemoved {
+            path: pam_path.clone(),
+        });
     }
 
     // Offer backup restore
     let backup_path = format!("{pam_path}.facelock-backup");
     if Path::new(&backup_path).exists() {
-        println!("Backup exists at {backup_path}");
-        println!("To restore: sudo cp {backup_path} {pam_path}");
+        Terminal.info(&UserMessage::PamBackupExists {
+            path: pam_path.clone(),
+            backup: backup_path.clone(),
+        });
     }
 
     Ok(())

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -6,6 +6,7 @@ use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use facelock_core::notify::{NotifyEvent, notify_desktop_if_enabled};
 
 use crate::ipc_client;
+use crate::message::{Terminal, UserMessage, fail};
 use crate::notifications::DesktopNotifier;
 
 pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
@@ -21,8 +22,8 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
         .value
         .all_present()
     {
-        println!("Face recognition models not found.");
-        if crate::ipc_client::confirm("Download models now?")? {
+        Terminal.info(&UserMessage::ModelsNotFoundOfferSetup);
+        if Terminal.confirm(&UserMessage::ConfirmDownloadModels)? {
             crate::commands::setup::run(false)?;
             // Deliberate re-probe: setup just changed the disk. The judgment
             // still uses the Config this process parsed, as it always has —
@@ -32,10 +33,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                 .value
                 .all_present()
             {
-                anyhow::bail!("Models still not found after setup.");
+                return Err(fail(UserMessage::ModelsStillMissingAfterSetup));
             }
         } else {
-            anyhow::bail!("Models required. Run `facelock setup` to download them.");
+            return Err(fail(UserMessage::ModelsRequired));
         }
     }
 
@@ -61,8 +62,8 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
         }
     };
     if !has_models {
-        println!("No face models enrolled for user '{user}'.");
-        println!("Run 'facelock enroll' to enroll a face first.");
+        Terminal.info(&UserMessage::NoModelsEnrolled { user: user.clone() });
+        Terminal.info(&UserMessage::RunEnrollFirst);
         return Ok(());
     }
 
@@ -91,16 +92,16 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
             }
         };
         if !has_matching {
-            println!(
-                "Warning: no enrolled models use the configured embedder '{config_embedder}'."
-            );
-            println!("Re-enroll with 'facelock enroll' to use the current model.");
+            Terminal.info(&UserMessage::NoMatchingEmbedder {
+                embedder: config_embedder.clone(),
+            });
+            Terminal.info(&UserMessage::ReenrollHint);
             return Ok(());
         }
     }
 
-    println!("Testing face recognition for user '{user}'...");
-    println!("Look at the camera.");
+    Terminal.info(&UserMessage::TestingUser { user: user.clone() });
+    Terminal.info(&UserMessage::TestLookAtCamera);
 
     notify_desktop_if_enabled(notif_config, &notifier, &NotifyEvent::Scanning);
 
@@ -109,11 +110,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
         match crate::direct::authenticate(config, &user) {
             Ok(result) if result.matched => {
                 let elapsed = start.elapsed();
-                println!(
-                    "Matched (similarity: {:.2}) in {:.2}s",
-                    result.similarity,
-                    elapsed.as_secs_f64()
-                );
+                Terminal.info(&UserMessage::TestMatched {
+                    similarity: result.similarity,
+                    seconds: elapsed.as_secs_f64(),
+                });
                 notify_desktop_if_enabled(
                     notif_config,
                     &notifier,
@@ -128,13 +128,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                 if result.failure_reason
                     == Some(facelock_core::types::AuthFailureReason::VarianceNotSatisfied)
                 {
-                    println!(
-                        "Face matched (best: {:.2}) but the liveness variance check was not \
-                         satisfied after {:.1}s — try moving slightly, or tune \
-                         security.frame_variance_max_similarity",
-                        result.similarity,
-                        elapsed.as_secs_f64()
-                    );
+                    Terminal.info(&UserMessage::TestVarianceBlocked {
+                        similarity: result.similarity,
+                        seconds: elapsed.as_secs_f64(),
+                    });
                     notify_desktop_if_enabled(
                         notif_config,
                         &notifier,
@@ -143,11 +140,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                         },
                     );
                 } else {
-                    println!(
-                        "No match (best: {:.2}) after {:.1}s",
-                        result.similarity,
-                        elapsed.as_secs_f64()
-                    );
+                    Terminal.info(&UserMessage::TestNoMatch {
+                        similarity: result.similarity,
+                        seconds: elapsed.as_secs_f64(),
+                    });
                     notify_desktop_if_enabled(
                         notif_config,
                         &notifier,
@@ -182,11 +178,12 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
             if result.matched {
                 let model_id = result.model_id.unwrap_or(0);
                 let label = result.label.as_deref().unwrap_or("unknown");
-                println!(
-                    "Matched model #{model_id} '{label}' (similarity: {:.2}) in {:.2}s",
-                    result.similarity,
-                    elapsed.as_secs_f64()
-                );
+                Terminal.info(&UserMessage::TestMatchedModel {
+                    model_id,
+                    label: label.to_string(),
+                    similarity: result.similarity,
+                    seconds: elapsed.as_secs_f64(),
+                });
                 notify_desktop_if_enabled(
                     notif_config,
                     &notifier,
@@ -201,13 +198,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                 // The D-Bus AuthResult contract carries no failure reason, but
                 // matched=false with similarity above the recognition threshold
                 // means a liveness gate (frame variance) blocked the attempt.
-                println!(
-                    "Face matched (best: {:.2}) but the liveness variance check was not \
-                     satisfied after {:.1}s — try moving slightly, or tune \
-                     security.frame_variance_max_similarity",
-                    result.similarity,
-                    elapsed.as_secs_f64()
-                );
+                Terminal.info(&UserMessage::TestVarianceBlocked {
+                    similarity: result.similarity,
+                    seconds: elapsed.as_secs_f64(),
+                });
                 notify_desktop_if_enabled(
                     notif_config,
                     &notifier,
@@ -216,11 +210,10 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     },
                 );
             } else {
-                println!(
-                    "No match (best: {:.2}) after {:.1}s",
-                    result.similarity,
-                    elapsed.as_secs_f64()
-                );
+                Terminal.info(&UserMessage::TestNoMatch {
+                    similarity: result.similarity,
+                    seconds: elapsed.as_secs_f64(),
+                });
                 notify_desktop_if_enabled(
                     notif_config,
                     &notifier,

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -13,6 +13,8 @@ use facelock_core::types::{FaceModelInfo, MatchResult};
 /// If stdin is a TTY, prompts the user and re-execs. Otherwise bails
 /// with an actionable error message.
 pub fn require_root(hint: &str) -> anyhow::Result<()> {
+    use crate::message::{Terminal, UserMessage, fail};
+
     if Uid::current().is_root() {
         return Ok(());
     }
@@ -21,18 +23,22 @@ pub fn require_root(hint: &str) -> anyhow::Result<()> {
 
     // Non-interactive: just bail with instructions
     if !is_tty {
-        bail!("Root required.\n  Run: {hint}");
+        return Err(fail(UserMessage::RootRequired {
+            hint: hint.to_string(),
+        }));
     }
 
     // Interactive: offer to re-exec with sudo
-    eprint!("Root required. Re-run with sudo? [Y/n] ");
+    Terminal.prompt(&UserMessage::SudoReexecPrompt);
     let mut input = String::new();
     std::io::stdin()
         .read_line(&mut input)
         .context("failed to read input")?;
     let answer = input.trim().to_lowercase();
     if answer == "n" || answer == "no" {
-        bail!("Root required.\n  Run: {hint}");
+        return Err(fail(UserMessage::RootRequired {
+            hint: hint.to_string(),
+        }));
     }
 
     // Re-exec with sudo, preserving all arguments
@@ -56,7 +62,11 @@ pub fn require_root_scripted(hint: &str) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    bail!("Root required.\n  Run: {hint}");
+    Err(crate::message::fail(
+        crate::message::UserMessage::RootRequired {
+            hint: hint.to_string(),
+        },
+    ))
 }
 
 /// Check whether we should use direct (daemonless) mode.
@@ -144,10 +154,8 @@ pub fn send_enroll(
     // into a duplicate label.
     let result: (u32, u32) = proxy.call("Enroll", &(user, label)).map_err(|e| {
         if is_timeout_error(&e) {
-            anyhow::Error::new(e).context(
-                "enrollment timed out client-side; the daemon may have completed it — \
-                 run `facelock list` before retrying",
-            )
+            anyhow::Error::new(e)
+                .context(crate::message::UserMessage::EnrollTimedOutClientSide.localized())
         } else {
             anyhow::Error::new(e).context("D-Bus Enroll call failed")
         }
@@ -213,15 +221,11 @@ fn add_access_denied_hint(err: anyhow::Error) -> anyhow::Error {
     if !is_access_denied(&err) {
         return err;
     }
+    // Context strings render on stderr for a human, so they localize (D10).
     if is_root_required_denial(&err) {
-        err.context("Access denied: this operation requires root.\n  Re-run with sudo, or as root.")
+        err.context(crate::message::UserMessage::AccessDeniedRootHint.localized())
     } else {
-        err.context(
-            "Access denied. If you are not in the 'facelock' group, add yourself:\n  \
-             sudo usermod -aG facelock $USER\nthen log out and back in (or re-run: \
-             sudo facelock setup). Note: some operations require root regardless of \
-             group membership.",
-        )
+        err.context(crate::message::UserMessage::AccessDeniedGroupHint.localized())
     }
 }
 

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 pub mod direct;
 mod ipc_client;
+pub mod message;
 pub mod notifications;
 pub mod resolved;
 pub mod state_layout;
@@ -217,6 +218,10 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Localization first: user-facing text (D10) may render before any
+    // subcommand dispatch. Log/tracing output is unaffected by design (D2).
+    message::init();
+
     let cli = Cli::parse();
     let Cli { config, command } = cli;
 

--- a/crates/facelock-cli/src/message.rs
+++ b/crates/facelock-cli/src/message.rs
@@ -1,0 +1,1620 @@
+//! The Messages seam (D10): user-facing text as typed events.
+//!
+//! [`UserMessage`] is a vocabulary of things the CLI wants to tell a human —
+//! events carrying data, not strings. Rendering happens at the edge, per sink:
+//!
+//! - [`UserMessage::localized`] — gettext-translated text for a human
+//!   (terminal via [`Terminal`], desktop notification bodies, `anyhow` errors
+//!   whose `Display` lands on stderr via [`fail`]).
+//! - [`UserMessage::machine`] — a C-locale, locale-independent event line for
+//!   machine sinks (tracing today; `audit.jsonl` when a message ever needs to
+//!   be recorded as well as shown).
+//!
+//! This is how D2 ("logs stay English") holds *by construction*: a message
+//! routed through this type cannot reach a log sink in translated form,
+//! because the log rendering never consults gettext. The boundary is the
+//! sink, not the string — `bail!` text a human reads on stderr localizes,
+//! the same event written to audit/syslog/tracing does not.
+//!
+//! # Adding a message (the conversion pattern)
+//!
+//! 1. Add a variant carrying the data (not the formatted string):
+//!    `EnrollComplete { model_id: u32, count: u32, label: String }`.
+//! 2. Add one arm to [`UserMessage::localized`]. The English template is the
+//!    msgid: keep it on a **single source line** with explicit `\n` escapes
+//!    (no `\`-continuations, no raw strings) so `just pot` can extract it,
+//!    and use **named placeholders** (`{user}`) filled via [`fill`] so
+//!    translators can reorder them. Pre-format numbers that need precision
+//!    (`format!("{similarity:.2}")`) before filling — Rust formatting is
+//!    locale-independent, so numbers stay stable across locales.
+//! 3. Replace the `println!`/`eprintln!`/`bail!` site with
+//!    `Terminal.info(&msg)` / `Terminal.error(&msg)` / `return Err(fail(msg))`.
+//!
+//! The English fallback (no `.mo` installed, or the C locale) renders
+//! byte-identically to the string the call site used to print; container
+//! tests that grep CLI output rely on this.
+//!
+//! # What must NOT come through here
+//!
+//! Machine-facing output never localizes: `--json` output, `is-enrolled`'s
+//! stdout contract, `audit.jsonl`, syslog/tracing lines, and D-Bus error
+//! strings (PAM substring-matches those on the wire — see
+//! `pam_code_for_daemon_error` in `pam-facelock`). Route none of them
+//! through [`UserMessage::localized`].
+//!
+//! # Why this lives in `facelock-cli`
+//!
+//! The two decided constraints (domain map §7): gettext everywhere (D1, via
+//! the same ~20-line libc FFI the PAM module uses — `pam_facelock` keeps its
+//! own copy and its own text domain), and logs stay English (D2). No non-CLI
+//! crate renders user text today, and `facelock-core`'s dependency contract
+//! excludes libc — when the daemon D-Bus server moves out of this crate
+//! (H7), the seam moves with it or into core alongside that work.
+
+use std::ffi::{CStr, CString};
+
+use facelock_core::notify::NotifyEvent;
+
+// ---------------------------------------------------------------------------
+// Gettext (libc FFI) — the CLI's copy of pam-facelock's wrapper, domain
+// "facelock". Kept dependency-free on purpose: gettext ships in glibc.
+// ---------------------------------------------------------------------------
+
+/// Text domain for CLI translations (`/usr/share/locale/<lang>/LC_MESSAGES/facelock.mo`).
+const GETTEXT_DOMAIN: &CStr = c"facelock";
+
+unsafe extern "C" {
+    safe fn dgettext(
+        domainname: *const libc::c_char,
+        msgid: *const libc::c_char,
+    ) -> *const libc::c_char;
+    safe fn bindtextdomain(
+        domainname: *const libc::c_char,
+        dirname: *const libc::c_char,
+    ) -> *const libc::c_char;
+    safe fn bind_textdomain_codeset(
+        domainname: *const libc::c_char,
+        codeset: *const libc::c_char,
+    ) -> *const libc::c_char;
+    safe fn setlocale(category: libc::c_int, locale: *const libc::c_char) -> *const libc::c_char;
+}
+
+/// Initialize localization for this process. Call once, early in `main`.
+///
+/// Sets LC_MESSAGES (only) from the environment: translations follow the
+/// user's locale without letting LC_NUMERIC and friends leak into in-process
+/// C libraries (ONNX Runtime parses floats). Output charset is pinned to
+/// UTF-8 regardless of LC_CTYPE. `FACELOCK_LOCALEDIR` overrides the catalog
+/// directory — translations only, English fallback otherwise, so it grants
+/// nothing security-relevant.
+pub fn init() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        setlocale(libc::LC_MESSAGES, c"".as_ptr());
+        let dir =
+            std::env::var("FACELOCK_LOCALEDIR").unwrap_or_else(|_| "/usr/share/locale".to_string());
+        if let Ok(c_dir) = CString::new(dir) {
+            bindtextdomain(GETTEXT_DOMAIN.as_ptr(), c_dir.as_ptr());
+        }
+        bind_textdomain_codeset(GETTEXT_DOMAIN.as_ptr(), c"UTF-8".as_ptr());
+    });
+}
+
+/// Translate a msgid via gettext. Falls back to the original English string
+/// if no translation is available or if gettext fails.
+///
+/// This is the xgettext extraction keyword (`just pot` scans for
+/// `translate("...")`), so every call must pass a string literal.
+fn translate(msgid: &str) -> String {
+    let Ok(c_msgid) = CString::new(msgid) else {
+        return msgid.to_string();
+    };
+    let result = dgettext(GETTEXT_DOMAIN.as_ptr(), c_msgid.as_ptr());
+    if result.is_null() {
+        return msgid.to_string();
+    }
+    unsafe { CStr::from_ptr(result) }
+        .to_str()
+        .unwrap_or(msgid)
+        .to_string()
+}
+
+/// Substitute named placeholders (`{user}`) in a translated template.
+///
+/// Values are substituted in order; a value that itself contains a later
+/// placeholder token would be re-substituted, so keep placeholder names
+/// unlikely to occur in data (they are).
+fn fill(template: String, args: &[(&str, String)]) -> String {
+    let mut out = template;
+    for (name, value) in args {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The vocabulary
+// ---------------------------------------------------------------------------
+
+/// Something the CLI wants to tell a human. Data only — rendering is the
+/// sink's job ([`UserMessage::localized`] / [`UserMessage::machine`]).
+///
+/// Variant and field names are a stable contract: [`UserMessage::machine`]
+/// derives its event line from them.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UserMessage {
+    // -- config load (ConfigLoad::require, D7) --
+    NoConfigFile {
+        path: String,
+    },
+    InvalidConfig {
+        path: String,
+        error: String,
+    },
+
+    // -- privilege / access (ipc_client) --
+    RootRequired {
+        hint: String,
+    },
+    SudoReexecPrompt,
+    AccessDeniedRootHint,
+    AccessDeniedGroupHint,
+    EnrollTimedOutClientSide,
+
+    // -- enroll --
+    SetupNotCompleted,
+    ConfirmRunSetupNow,
+    SetupDidNotComplete,
+    RunSetupWhenReady,
+    PlaintextEnrollWarning,
+    ModelsMissing {
+        dir: String,
+    },
+    StaleEmbedderNote {
+        embedder: String,
+    },
+    Enrolling {
+        user: String,
+        label: String,
+    },
+    EnrollLookAtCamera,
+    EnrollComplete {
+        model_id: u32,
+        count: u32,
+        label: String,
+    },
+    TooManyModels {
+        user: String,
+        count: usize,
+    },
+
+    // -- test --
+    ModelsNotFoundOfferSetup,
+    ConfirmDownloadModels,
+    ModelsStillMissingAfterSetup,
+    ModelsRequired,
+    NoModelsEnrolled {
+        user: String,
+    },
+    RunEnrollFirst,
+    NoMatchingEmbedder {
+        embedder: String,
+    },
+    ReenrollHint,
+    TestingUser {
+        user: String,
+    },
+    TestLookAtCamera,
+    TestMatched {
+        similarity: f32,
+        seconds: f64,
+    },
+    TestMatchedModel {
+        model_id: u32,
+        label: String,
+        similarity: f32,
+        seconds: f64,
+    },
+    TestVarianceBlocked {
+        similarity: f32,
+        seconds: f64,
+    },
+    TestNoMatch {
+        similarity: f32,
+        seconds: f64,
+    },
+
+    // -- remove / clear --
+    ConfirmRemoveModel {
+        model_id: u32,
+        user: String,
+    },
+    Cancelled,
+    RemovedModel {
+        model_id: u32,
+        user: String,
+    },
+    ModelNotFound {
+        model_id: u32,
+        user: String,
+    },
+    ConfirmClearAll {
+        user: String,
+    },
+    ClearedModels {
+        count: usize,
+        user: String,
+    },
+    AllModelsRemoved {
+        user: String,
+    },
+
+    // -- desktop/terminal notification bodies (H4's NotifyEvent, rendered) --
+    NotifyScanning,
+    NotifyWelcome {
+        label: String,
+    },
+    NotifyRecognized {
+        similarity: f32,
+    },
+    NotifyAuthFailed {
+        reason: String,
+    },
+
+    // -- setup: wizard spine --
+    SetupIntro {
+        version: String,
+    },
+    SetupStepCamera,
+    SetupStepModelQuality,
+    SetupStepInferenceDevice,
+    SetupStepModelDownload,
+    SetupStepEncryption,
+    SetupStepEnrollment,
+    SetupStepEnrollmentSkipped,
+    SetupStepTest,
+    SetupStepTestSkipped,
+    SetupStepDaemon,
+    SetupStepPam,
+    SetupCompleteHeader,
+
+    // -- setup: step-level failures (error + retry hint, one event) --
+    CameraStepFailed {
+        error: String,
+        current: String,
+    },
+    ModelQualityStepFailed {
+        error: String,
+        current: String,
+    },
+    InferenceStepFailed {
+        error: String,
+        current: String,
+    },
+    ModelDownloadStepFailed {
+        error: String,
+    },
+    EncryptionStepFailed {
+        error: String,
+    },
+    EnrollStepFailed {
+        error: String,
+    },
+    TestStepFailed {
+        error: String,
+    },
+    SystemdStepFailed {
+        error: String,
+    },
+    GroupStepFailed {
+        error: String,
+    },
+    PamStepFailed {
+        error: String,
+    },
+
+    // -- setup: camera selection --
+    NoVideoDevices,
+    AutoSelectedIrCamera {
+        path: String,
+        name: String,
+    },
+    AutoSelectedIrCameraPath {
+        path: String,
+    },
+    SelectedCamera {
+        path: String,
+        name: String,
+    },
+    SelectedValue {
+        value: String,
+    },
+    PromptSelectCameraDevice,
+    AutoCameraNoDevices,
+    AutoCameraNoIr {
+        listed: String,
+        example: String,
+    },
+    AutoCameraManyIr {
+        count: usize,
+        listed: String,
+    },
+    CameraDeviceMissing {
+        path: String,
+    },
+
+    // -- setup: model quality / inference device --
+    PromptSelectModelQuality,
+    PromptSelectInferenceDevice,
+
+    // -- setup: model download --
+    ModelPresentOk {
+        name: String,
+        purpose: String,
+    },
+    AllModelsPresent,
+    ModelsToDownloadHeader,
+    ModelToDownloadEntry {
+        name: String,
+        size_mb: u64,
+        purpose: String,
+    },
+    TotalDownloadSize {
+        mb: u64,
+    },
+    ConfirmDownloadRequiredModels,
+    SkippingModelDownload,
+    DownloadingModel {
+        name: String,
+    },
+    ModelDownloaded {
+        name: String,
+    },
+
+    // -- setup: enrollment / test / systemd steps --
+    ConfirmEnrollNow,
+    EnrollSkipped,
+    ConfirmTestRecognition,
+    TestSkipped,
+    ConfirmDaemonMode,
+    SystemdNotDetected,
+    SystemdDeclined,
+    SystemdSkippedFlag,
+    SystemdDeferred,
+
+    // -- setup: group membership --
+    CreatingFacelockGroup,
+    GroupMembershipNote,
+    AlreadyInGroup {
+        user: String,
+    },
+    ConfirmAddToGroup {
+        user: String,
+    },
+    GroupAddSkipped {
+        user: String,
+    },
+    AddedToGroup {
+        user: String,
+    },
+
+    // -- setup: PAM step --
+    PamSkippedFlag {
+        dir: String,
+    },
+    PamModuleMissing {
+        path: String,
+    },
+    ConfiguringPamFor {
+        service: String,
+    },
+    NoPamCandidates {
+        dir: String,
+    },
+    PamLinePreview {
+        line: String,
+    },
+    PromptSelectPamServices,
+    PamConfigureFailed {
+        service: String,
+        error: String,
+    },
+    NoPamServicesSelected,
+    PamFileNotFound {
+        path: String,
+    },
+    PamLineAlreadyPresent {
+        path: String,
+    },
+    PamInsertBeforeAuthHint,
+    PamInsertAtTopHint,
+    PamModifyPreview {
+        path: String,
+        line: String,
+        hint: String,
+        backup: String,
+    },
+    ConfirmProceed,
+    PamSkippedFile {
+        path: String,
+    },
+    PamBackedUp {
+        path: String,
+        backup: String,
+    },
+    PamInstalled {
+        path: String,
+        backup: String,
+        service: String,
+    },
+    PamRemoved {
+        path: String,
+    },
+    PamNoLineFound {
+        path: String,
+    },
+    PamBackupExists {
+        path: String,
+        backup: String,
+    },
+
+    // -- setup: summary --
+    SummaryCamera {
+        value: String,
+    },
+    SummaryModels {
+        dir: String,
+        quality: String,
+    },
+    SummaryInference {
+        value: String,
+    },
+    SummaryDatabase {
+        value: String,
+    },
+    SummaryEncryption {
+        value: String,
+    },
+    SummaryDaemon {
+        status: String,
+    },
+    DaemonStatusNotConfiguredNoSystemd,
+    DaemonStatusDeferred,
+    DaemonStatusEnabled,
+    DaemonStatusNotConfigured,
+    SummaryPam {
+        services: String,
+    },
+    SummaryPamSkipped,
+    SummaryPamNone,
+    SummaryFaceEnrolled,
+    SummaryFaceNotEnrolledNoEnroll,
+    SummaryFaceNotEnrolled,
+
+    // -- setup: non-interactive --
+    NonInteractivePreparing,
+    CheckingModels {
+        count: usize,
+    },
+    SetupCompleteShort,
+    SetupCompleteEnroll,
+}
+
+impl UserMessage {
+    /// Render for a human: gettext at the edge, English fallback
+    /// byte-identical to the historical inline string.
+    pub fn localized(&self) -> String {
+        use UserMessage::*;
+        match self {
+            NoConfigFile { path } => fill(
+                translate("no config file at {path} — run 'sudo facelock setup' to create one"),
+                &[("path", path.clone())],
+            ),
+            InvalidConfig { path, error } => fill(
+                translate("invalid config at {path}: {error}"),
+                &[("path", path.clone()), ("error", error.clone())],
+            ),
+
+            RootRequired { hint } => fill(
+                translate("Root required.\n  Run: {hint}"),
+                &[("hint", hint.clone())],
+            ),
+            SudoReexecPrompt => translate("Root required. Re-run with sudo? [Y/n] "),
+            AccessDeniedRootHint => translate(
+                "Access denied: this operation requires root.\n  Re-run with sudo, or as root.",
+            ),
+            AccessDeniedGroupHint => translate(
+                "Access denied. If you are not in the 'facelock' group, add yourself:\n  sudo usermod -aG facelock $USER\nthen log out and back in (or re-run: sudo facelock setup). Note: some operations require root regardless of group membership.",
+            ),
+            EnrollTimedOutClientSide => translate(
+                "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying",
+            ),
+
+            SetupNotCompleted => translate("Setup has not been completed."),
+            ConfirmRunSetupNow => translate("Run setup now?"),
+            SetupDidNotComplete => translate("Setup did not complete successfully."),
+            RunSetupWhenReady => translate("Run 'sudo facelock setup' when ready."),
+            PlaintextEnrollWarning => translate(
+                "WARNING: encryption.method = \"none\" and security.allow_plaintext = true.\nYour face template will be stored UNENCRYPTED (plaintext biometric data at rest).",
+            ),
+            ModelsMissing { dir } => fill(
+                translate(
+                    "Face recognition models not found in {dir}.\nRun `sudo facelock setup` to download them.",
+                ),
+                &[("dir", dir.clone())],
+            ),
+            StaleEmbedderNote { embedder } => fill(
+                translate(
+                    "Note: existing models don't use the configured embedder '{embedder}'.\nOld enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n",
+                ),
+                &[("embedder", embedder.clone())],
+            ),
+            Enrolling { user, label } => fill(
+                translate("Enrolling face for user '{user}' with label '{label}'..."),
+                &[("user", user.clone()), ("label", label.clone())],
+            ),
+            EnrollLookAtCamera => {
+                translate("Look at the camera. Slowly turn your head left and right.")
+            }
+            EnrollComplete {
+                model_id,
+                count,
+                label,
+            } => fill(
+                translate(
+                    "\nFace enrolled successfully!\n  Model ID: {model_id}\n  Embeddings: {count}\n  Label: {label}",
+                ),
+                &[
+                    ("model_id", model_id.to_string()),
+                    ("count", count.to_string()),
+                    ("label", label.clone()),
+                ],
+            ),
+            TooManyModels { user, count } => fill(
+                translate(
+                    "\nWarning: user '{user}' has {count} face models. Consider removing old ones with 'facelock remove'.",
+                ),
+                &[("user", user.clone()), ("count", count.to_string())],
+            ),
+
+            ModelsNotFoundOfferSetup => translate("Face recognition models not found."),
+            ConfirmDownloadModels => translate("Download models now?"),
+            ModelsStillMissingAfterSetup => translate("Models still not found after setup."),
+            ModelsRequired => translate("Models required. Run `facelock setup` to download them."),
+            NoModelsEnrolled { user } => fill(
+                translate("No face models enrolled for user '{user}'."),
+                &[("user", user.clone())],
+            ),
+            RunEnrollFirst => translate("Run 'facelock enroll' to enroll a face first."),
+            NoMatchingEmbedder { embedder } => fill(
+                translate("Warning: no enrolled models use the configured embedder '{embedder}'."),
+                &[("embedder", embedder.clone())],
+            ),
+            ReenrollHint => translate("Re-enroll with 'facelock enroll' to use the current model."),
+            TestingUser { user } => fill(
+                translate("Testing face recognition for user '{user}'..."),
+                &[("user", user.clone())],
+            ),
+            TestLookAtCamera => translate("Look at the camera."),
+            TestMatched {
+                similarity,
+                seconds,
+            } => fill(
+                translate("Matched (similarity: {similarity}) in {seconds}s"),
+                &[
+                    ("similarity", format!("{similarity:.2}")),
+                    ("seconds", format!("{seconds:.2}")),
+                ],
+            ),
+            TestMatchedModel {
+                model_id,
+                label,
+                similarity,
+                seconds,
+            } => fill(
+                translate(
+                    "Matched model #{model_id} '{label}' (similarity: {similarity}) in {seconds}s",
+                ),
+                &[
+                    ("model_id", model_id.to_string()),
+                    ("label", label.clone()),
+                    ("similarity", format!("{similarity:.2}")),
+                    ("seconds", format!("{seconds:.2}")),
+                ],
+            ),
+            TestVarianceBlocked {
+                similarity,
+                seconds,
+            } => fill(
+                translate(
+                    "Face matched (best: {similarity}) but the liveness variance check was not satisfied after {seconds}s — try moving slightly, or tune security.frame_variance_max_similarity",
+                ),
+                &[
+                    ("similarity", format!("{similarity:.2}")),
+                    ("seconds", format!("{seconds:.1}")),
+                ],
+            ),
+            TestNoMatch {
+                similarity,
+                seconds,
+            } => fill(
+                translate("No match (best: {similarity}) after {seconds}s"),
+                &[
+                    ("similarity", format!("{similarity:.2}")),
+                    ("seconds", format!("{seconds:.1}")),
+                ],
+            ),
+
+            ConfirmRemoveModel { model_id, user } => fill(
+                translate("Remove face model #{model_id} for user '{user}'?"),
+                &[("model_id", model_id.to_string()), ("user", user.clone())],
+            ),
+            Cancelled => translate("Cancelled."),
+            RemovedModel { model_id, user } => fill(
+                translate("Removed face model #{model_id} for user '{user}'."),
+                &[("model_id", model_id.to_string()), ("user", user.clone())],
+            ),
+            ModelNotFound { model_id, user } => fill(
+                translate("Model #{model_id} not found for user '{user}'."),
+                &[("model_id", model_id.to_string()), ("user", user.clone())],
+            ),
+            ConfirmClearAll { user } => fill(
+                translate("Remove ALL face models for user '{user}'?"),
+                &[("user", user.clone())],
+            ),
+            ClearedModels { count, user } => fill(
+                translate("Removed {count} face model(s) for user '{user}'."),
+                &[("count", count.to_string()), ("user", user.clone())],
+            ),
+            AllModelsRemoved { user } => fill(
+                translate("All face models removed for user '{user}'."),
+                &[("user", user.clone())],
+            ),
+
+            NotifyScanning => translate("Scanning face..."),
+            NotifyWelcome { label } => {
+                fill(translate("Welcome, {label}"), &[("label", label.clone())])
+            }
+            NotifyRecognized { similarity } => fill(
+                translate("Face recognized ({similarity})"),
+                &[("similarity", format!("{similarity:.2}"))],
+            ),
+            NotifyAuthFailed { reason } => fill(
+                translate("Face auth failed: {reason}"),
+                &[("reason", reason.clone())],
+            ),
+
+            SetupIntro { version } => fill(
+                translate(
+                    "\n  Facelock v{version}\n  Linux face authentication\n\n  This wizard will walk you through initial setup:\n    - Camera detection\n    - Model quality and inference device\n    - Model downloads\n    - Embedding encryption (TPM or software)\n    - Face enrollment\n    - Daemon and PAM configuration\n",
+                ),
+                &[("version", version.clone())],
+            ),
+            SetupStepCamera => translate("\n--- Step 1: Camera Selection ---\n"),
+            SetupStepModelQuality => translate("\n--- Step 2: Model Quality ---\n"),
+            SetupStepInferenceDevice => translate("\n--- Step 3: Inference Device ---\n"),
+            SetupStepModelDownload => translate("\n--- Step 4: Model Download ---\n"),
+            SetupStepEncryption => translate("\n--- Step 5: Embedding Encryption ---\n"),
+            SetupStepEnrollment => translate("\n--- Step 6: Face Enrollment ---\n"),
+            SetupStepEnrollmentSkipped => {
+                translate("\n--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n")
+            }
+            SetupStepTest => translate("\n--- Step 7: Test Recognition ---\n"),
+            SetupStepTestSkipped => {
+                translate("\n--- Step 7: Test Recognition (skipped, no face enrolled) ---\n")
+            }
+            SetupStepDaemon => translate("\n--- Step 8: Daemon Configuration ---\n"),
+            SetupStepPam => translate("\n--- Step 9: PAM Configuration ---\n"),
+            SetupCompleteHeader => translate("\n--- Setup Complete ---\n"),
+
+            CameraStepFailed { error, current } => fill(
+                translate(
+                    "  Camera detection failed: {error}\n  You can configure the camera later in the config file.\n  Continuing with current setting: {current}",
+                ),
+                &[("error", error.clone()), ("current", current.clone())],
+            ),
+            ModelQualityStepFailed { error, current } => fill(
+                translate(
+                    "  Model quality selection failed: {error}\n  Continuing with current setting: {current}",
+                ),
+                &[("error", error.clone()), ("current", current.clone())],
+            ),
+            InferenceStepFailed { error, current } => fill(
+                translate(
+                    "  Inference device selection failed: {error}\n  Continuing with current setting: {current}",
+                ),
+                &[("error", error.clone()), ("current", current.clone())],
+            ),
+            ModelDownloadStepFailed { error } => fill(
+                translate(
+                    "  Model download failed: {error}\n  You can retry later with: sudo facelock setup --non-interactive",
+                ),
+                &[("error", error.clone())],
+            ),
+            EncryptionStepFailed { error } => fill(
+                translate(
+                    "  Encryption setup failed: {error}\n  You can configure encryption later with: sudo facelock encrypt --generate-key",
+                ),
+                &[("error", error.clone())],
+            ),
+            EnrollStepFailed { error } => fill(
+                translate(
+                    "  Enrollment failed: {error}\n  You can enroll later with: facelock enroll",
+                ),
+                &[("error", error.clone())],
+            ),
+            TestStepFailed { error } => fill(
+                translate("  Test failed: {error}\n  You can test later with: facelock test"),
+                &[("error", error.clone())],
+            ),
+            SystemdStepFailed { error } => fill(
+                translate(
+                    "  Systemd setup failed: {error}\n  You can enable it later with: sudo facelock setup --systemd",
+                ),
+                &[("error", error.clone())],
+            ),
+            GroupStepFailed { error } => fill(
+                translate(
+                    "  Group setup failed: {error}\n  Add manually: sudo usermod -aG facelock <user>",
+                ),
+                &[("error", error.clone())],
+            ),
+            PamStepFailed { error } => fill(
+                translate(
+                    "  PAM setup failed: {error}\n  You can configure PAM later with: sudo facelock setup --pam",
+                ),
+                &[("error", error.clone())],
+            ),
+
+            NoVideoDevices => translate(
+                "  No video devices found.\n  Check that your camera is connected and the v4l2 module is loaded.",
+            ),
+            AutoSelectedIrCamera { path, name } => fill(
+                translate("  Auto-selected IR camera: {path} ({name})"),
+                &[("path", path.clone()), ("name", name.clone())],
+            ),
+            AutoSelectedIrCameraPath { path } => fill(
+                translate("  Auto-selected IR camera: {path}"),
+                &[("path", path.clone())],
+            ),
+            SelectedCamera { path, name } => fill(
+                translate("  Selected: {path} ({name})"),
+                &[("path", path.clone()), ("name", name.clone())],
+            ),
+            SelectedValue { value } => fill(
+                translate("  Selected: {value}"),
+                &[("value", value.clone())],
+            ),
+            PromptSelectCameraDevice => translate("Select camera device"),
+            AutoCameraNoDevices => translate(
+                "--camera=auto found no video devices; check that the camera is connected and the v4l2 module is loaded",
+            ),
+            AutoCameraNoIr { listed, example } => fill(
+                translate(
+                    "--camera=auto found no IR-capable camera among the detected devices:\n{listed}\n  Pass an explicit device path, e.g. --camera={example}",
+                ),
+                &[("listed", listed.clone()), ("example", example.clone())],
+            ),
+            AutoCameraManyIr { count, listed } => fill(
+                translate(
+                    "--camera=auto found {count} IR-capable cameras:\n{listed}\n  Pass an explicit device path to choose one.",
+                ),
+                &[("count", count.to_string()), ("listed", listed.clone())],
+            ),
+            CameraDeviceMissing { path } => fill(
+                translate(
+                    "camera device {path} does not exist; pass a valid /dev/video* path or --camera=auto",
+                ),
+                &[("path", path.clone())],
+            ),
+
+            PromptSelectModelQuality => translate("Select model quality"),
+            PromptSelectInferenceDevice => translate("Select inference device"),
+
+            ModelPresentOk { name, purpose } => fill(
+                translate("  [ok] {name} ({purpose})"),
+                &[("name", name.clone()), ("purpose", purpose.clone())],
+            ),
+            AllModelsPresent => translate("  All models are already present and verified."),
+            ModelsToDownloadHeader => translate("  Models to download:"),
+            ModelToDownloadEntry {
+                name,
+                size_mb,
+                purpose,
+            } => fill(
+                translate("    - {name} (~{size_mb}MB) - {purpose}"),
+                &[
+                    ("name", name.clone()),
+                    ("size_mb", size_mb.to_string()),
+                    ("purpose", purpose.clone()),
+                ],
+            ),
+            TotalDownloadSize { mb } => fill(
+                translate("  Total download size: ~{mb}MB"),
+                &[("mb", mb.to_string())],
+            ),
+            ConfirmDownloadRequiredModels => translate("Download required models?"),
+            SkippingModelDownload => translate("  Skipping model download."),
+            DownloadingModel { name } => fill(
+                translate("  Downloading {name}..."),
+                &[("name", name.clone())],
+            ),
+            ModelDownloaded { name } => fill(
+                translate("  [ok] {name} downloaded and verified"),
+                &[("name", name.clone())],
+            ),
+
+            ConfirmEnrollNow => translate("Would you like to enroll a face now?"),
+            EnrollSkipped => translate("  Skipping face enrollment."),
+            ConfirmTestRecognition => translate("Would you like to test recognition?"),
+            TestSkipped => translate("  Skipping recognition test."),
+            ConfirmDaemonMode => translate("Enable daemon mode with D-Bus activation?"),
+            SystemdNotDetected => translate(
+                "  systemd not detected. Skipping daemon configuration.\n  Facelock will use oneshot mode for authentication.",
+            ),
+            SystemdDeclined => {
+                translate("  Skipping systemd setup. Facelock will use oneshot mode.")
+            }
+            SystemdSkippedFlag => translate(
+                "  Skipping daemon configuration (--no-systemd).\n  No unit files are written and systemctl is not invoked.",
+            ),
+            SystemdDeferred => {
+                translate("  Answered on the command line; applied once setup finishes.")
+            }
+
+            CreatingFacelockGroup => translate("  Creating 'facelock' system group..."),
+            GroupMembershipNote => translate(
+                "  Note: running daemon commands (preview/test) as a normal user requires\n  membership in the 'facelock' group: sudo usermod -aG facelock <user>",
+            ),
+            AlreadyInGroup { user } => fill(
+                translate("  User '{user}' is already in the 'facelock' group."),
+                &[("user", user.clone())],
+            ),
+            ConfirmAddToGroup { user } => fill(
+                translate(
+                    "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)",
+                ),
+                &[("user", user.clone())],
+            ),
+            GroupAddSkipped { user } => fill(
+                translate("  Skipped. Add later with: sudo usermod -aG facelock {user}"),
+                &[("user", user.clone())],
+            ),
+            AddedToGroup { user } => fill(
+                translate(
+                    "  Added '{user}' to the 'facelock' group.\n  NOTE: log out and back in for the new group membership to take effect.",
+                ),
+                &[("user", user.clone())],
+            ),
+
+            PamSkippedFlag { dir } => fill(
+                translate(
+                    "  Skipping PAM configuration (--no-pam).\n  No file under {dir} is read or modified.",
+                ),
+                &[("dir", dir.clone())],
+            ),
+            PamModuleMissing { path } => fill(
+                translate(
+                    "  PAM module not found at {path}.\n  Install it first, then run: sudo facelock setup --pam",
+                ),
+                &[("path", path.clone())],
+            ),
+            ConfiguringPamFor { service } => fill(
+                translate("  Configuring PAM for {service}..."),
+                &[("service", service.clone())],
+            ),
+            NoPamCandidates { dir } => fill(
+                translate("  No supported PAM service files found in {dir}/."),
+                &[("dir", dir.clone())],
+            ),
+            PamLinePreview { line } => fill(
+                translate(
+                    "  The following line will be added to each selected /etc/pam.d/<service>:\n\n      {line}\n\n  It is inserted above the first existing 'auth' line. A backup\n  (.facelock-backup) is saved before any change, and you'll be asked\n  to confirm each file individually.\n",
+                ),
+                &[("line", line.clone())],
+            ),
+            PromptSelectPamServices => {
+                translate("Select services to enable face authentication for")
+            }
+            PamConfigureFailed { service, error } => fill(
+                translate("  Failed to configure {service}: {error}"),
+                &[("service", service.clone()), ("error", error.clone())],
+            ),
+            NoPamServicesSelected => translate("  No PAM services selected."),
+            PamFileNotFound { path } => fill(
+                translate("PAM service file not found: {path}"),
+                &[("path", path.clone())],
+            ),
+            PamLineAlreadyPresent { path } => fill(
+                translate("PAM line already present in {path}. Nothing to do."),
+                &[("path", path.clone())],
+            ),
+            PamInsertBeforeAuthHint => translate("inserted before the first 'auth' line"),
+            PamInsertAtTopHint => {
+                translate("no 'auth' line found — inserted at the top of the file")
+            }
+            PamModifyPreview {
+                path,
+                line,
+                hint,
+                backup,
+            } => fill(
+                translate(
+                    "\nAbout to modify {path}:\n  + {line}    ({hint})\n  Backup will be saved to: {backup}\n\n(To configure manually instead, add the line above to each service yourself.)",
+                ),
+                &[
+                    ("path", path.clone()),
+                    ("line", line.clone()),
+                    ("hint", hint.clone()),
+                    ("backup", backup.clone()),
+                ],
+            ),
+            ConfirmProceed => translate("Proceed?"),
+            PamSkippedFile { path } => {
+                fill(translate("Skipped {path}."), &[("path", path.clone())])
+            }
+            PamBackedUp { path, backup } => fill(
+                translate("Backed up {path} -> {backup}"),
+                &[("path", path.clone()), ("backup", backup.clone())],
+            ),
+            PamInstalled {
+                path,
+                backup,
+                service,
+            } => fill(
+                translate(
+                    "Installed facelock PAM line into {path}\n\nTo rollback:\n  sudo cp {backup} {path}\n  # or: sudo facelock setup --pam --remove --service {service}",
+                ),
+                &[
+                    ("path", path.clone()),
+                    ("backup", backup.clone()),
+                    ("service", service.clone()),
+                ],
+            ),
+            PamRemoved { path } => fill(
+                translate("Removed facelock PAM line from {path}"),
+                &[("path", path.clone())],
+            ),
+            PamNoLineFound { path } => fill(
+                translate("No facelock PAM line found in {path}. Nothing to remove."),
+                &[("path", path.clone())],
+            ),
+            PamBackupExists { path, backup } => fill(
+                translate("Backup exists at {backup}\nTo restore: sudo cp {backup} {path}"),
+                &[("path", path.clone()), ("backup", backup.clone())],
+            ),
+
+            SummaryCamera { value } => fill(
+                translate("  Camera:     {value}"),
+                &[("value", value.clone())],
+            ),
+            SummaryModels { dir, quality } => fill(
+                translate("  Models:     {dir} ({quality})"),
+                &[("dir", dir.clone()), ("quality", quality.clone())],
+            ),
+            SummaryInference { value } => fill(
+                translate("  Inference:  {value}"),
+                &[("value", value.clone())],
+            ),
+            SummaryDatabase { value } => fill(
+                translate("  Database:   {value}"),
+                &[("value", value.clone())],
+            ),
+            SummaryEncryption { value } => fill(
+                translate("  Encryption: {value}"),
+                &[("value", value.clone())],
+            ),
+            SummaryDaemon { status } => fill(
+                translate("  Daemon:   {status}"),
+                &[("status", status.clone())],
+            ),
+            DaemonStatusNotConfiguredNoSystemd => translate("not configured (--no-systemd)"),
+            DaemonStatusDeferred => translate("configured from the command line"),
+            DaemonStatusEnabled => translate("enabled (D-Bus activation)"),
+            DaemonStatusNotConfigured => translate("not configured"),
+            SummaryPam { services } => fill(
+                translate("  PAM:      {services}"),
+                &[("services", services.clone())],
+            ),
+            SummaryPamSkipped => translate("  PAM:      not configured (--no-pam)"),
+            SummaryPamNone => translate("  PAM:      not configured"),
+            SummaryFaceEnrolled => translate("  Face:     enrolled"),
+            SummaryFaceNotEnrolledNoEnroll => {
+                translate("  Face:     not enrolled (--no-enroll; run `facelock enroll`)")
+            }
+            SummaryFaceNotEnrolled => translate("  Face:     not enrolled (run `facelock enroll`)"),
+
+            NonInteractivePreparing => translate("facelock setup: preparing system...\n"),
+            CheckingModels { count } => fill(
+                translate("Checking {count} model(s)...\n"),
+                &[("count", count.to_string())],
+            ),
+            SetupCompleteShort => translate("\nSetup complete."),
+            SetupCompleteEnroll => {
+                translate("\nSetup complete. Run `facelock enroll` to register your face.")
+            }
+        }
+    }
+
+    /// Render for a machine sink: the C-locale event line. Derived from the
+    /// variant's `Debug` form — variant and field names are the stable
+    /// vocabulary, values print locale-independently, and gettext is never
+    /// consulted, which is what makes D2 hold by construction.
+    pub fn machine(&self) -> String {
+        format!("{self:?}")
+    }
+}
+
+impl From<&NotifyEvent> for UserMessage {
+    fn from(event: &NotifyEvent) -> Self {
+        match event {
+            NotifyEvent::Scanning => UserMessage::NotifyScanning,
+            NotifyEvent::Success {
+                label: Some(label),
+                similarity: _,
+            } => UserMessage::NotifyWelcome {
+                label: label.clone(),
+            },
+            NotifyEvent::Success {
+                label: None,
+                similarity,
+            } => UserMessage::NotifyRecognized {
+                similarity: *similarity,
+            },
+            NotifyEvent::Failure { reason } => UserMessage::NotifyAuthFailed {
+                reason: reason.clone(),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sinks
+// ---------------------------------------------------------------------------
+
+/// The human sink on this terminal. Localized text to stdout/stderr; the
+/// same event goes to tracing at debug level in its machine rendering, so
+/// `RUST_LOG=facelock=debug` shows the stable C-locale event stream next to
+/// whatever the user saw.
+pub struct Terminal;
+
+impl Terminal {
+    /// Informational message to stdout.
+    pub fn info(&self, msg: &UserMessage) {
+        tracing::debug!(target: "facelock::message", "{}", msg.machine());
+        println!("{}", msg.localized());
+    }
+
+    /// Warning/error message to stderr (the process continues).
+    pub fn error(&self, msg: &UserMessage) {
+        tracing::debug!(target: "facelock::message", "{}", msg.machine());
+        eprintln!("{}", msg.localized());
+    }
+
+    /// Inline prompt to stderr — no trailing newline; the caller reads the
+    /// answer from stdin.
+    pub fn prompt(&self, msg: &UserMessage) {
+        tracing::debug!(target: "facelock::message", "{}", msg.machine());
+        eprint!("{}", msg.localized());
+    }
+
+    /// Localized y/N confirmation via the shared stdin reader.
+    pub fn confirm(&self, msg: &UserMessage) -> anyhow::Result<bool> {
+        tracing::debug!(target: "facelock::message", "{}", msg.machine());
+        crate::ipc_client::confirm(&msg.localized())
+    }
+}
+
+/// An error whose `Display` is destined for a human on stderr (the CLI's
+/// `anyhow` exit path) — so it localizes at birth. Never use this for errors
+/// that cross the D-Bus wire or land in audit/syslog.
+pub fn fail(msg: UserMessage) -> anyhow::Error {
+    tracing::debug!(target: "facelock::message", "{}", msg.machine());
+    anyhow::anyhow!("{}", msg.localized())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// In the test environment no facelock .mo is installed for the C locale,
+    /// so `localized()` is the English fallback — these pins are exactly the
+    /// bytes the historical inline strings produced (container tests grep
+    /// some of them).
+    #[test]
+    fn english_fallback_is_byte_identical() {
+        assert_eq!(
+            UserMessage::EnrollComplete {
+                model_id: 3,
+                count: 12,
+                label: "2026-08-14-1".into()
+            }
+            .localized(),
+            "\nFace enrolled successfully!\n  Model ID: 3\n  Embeddings: 12\n  Label: 2026-08-14-1"
+        );
+        assert_eq!(
+            UserMessage::TestNoMatch {
+                similarity: 0.5,
+                seconds: 1.234
+            }
+            .localized(),
+            "No match (best: 0.50) after 1.2s"
+        );
+        assert_eq!(
+            UserMessage::TestMatchedModel {
+                model_id: 7,
+                label: "front".into(),
+                similarity: 0.876,
+                seconds: 0.5
+            }
+            .localized(),
+            "Matched model #7 'front' (similarity: 0.88) in 0.50s"
+        );
+        assert_eq!(
+            UserMessage::NoConfigFile {
+                path: "/etc/facelock/config.toml".into()
+            }
+            .localized(),
+            "no config file at /etc/facelock/config.toml — run 'sudo facelock setup' to create one"
+        );
+        assert_eq!(
+            UserMessage::RootRequired {
+                hint: "sudo facelock enroll".into()
+            }
+            .localized(),
+            "Root required.\n  Run: sudo facelock enroll"
+        );
+        assert_eq!(
+            UserMessage::ClearedModels {
+                count: 2,
+                user: "alice".into()
+            }
+            .localized(),
+            "Removed 2 face model(s) for user 'alice'."
+        );
+    }
+
+    /// Every sample message renders with all placeholders substituted — a
+    /// leftover `{name}` means a template/argument mismatch.
+    #[test]
+    fn no_unfilled_placeholders() {
+        for msg in sample_messages() {
+            let rendered = msg.localized();
+            assert!(
+                !rendered.contains('{') && !rendered.contains('}'),
+                "unfilled placeholder in {msg:?}: {rendered:?}"
+            );
+        }
+    }
+
+    /// The machine rendering names the variant and its data, and never goes
+    /// through gettext — the D2 side of the seam.
+    #[test]
+    fn machine_rendering_is_the_debug_vocabulary() {
+        let msg = UserMessage::EnrollComplete {
+            model_id: 3,
+            count: 12,
+            label: "x".into(),
+        };
+        let line = msg.machine();
+        assert!(line.starts_with("EnrollComplete"), "{line}");
+        assert!(line.contains("model_id: 3"), "{line}");
+        assert!(line.contains("count: 12"), "{line}");
+    }
+
+    /// Unknown msgids fall back to the input string (no catalog installed).
+    #[test]
+    fn translate_falls_back_to_msgid() {
+        assert_eq!(
+            translate("facelock test msgid that no catalog contains"),
+            "facelock test msgid that no catalog contains"
+        );
+    }
+
+    #[test]
+    fn fill_substitutes_named_placeholders() {
+        assert_eq!(
+            fill(
+                "a {x} b {y} c {x}".to_string(),
+                &[("x", "1".to_string()), ("y", "2".to_string())]
+            ),
+            "a 1 b 2 c 1"
+        );
+    }
+
+    /// NotifyEvent -> UserMessage mapping mirrors H4's rendering rules:
+    /// a labeled success is a welcome, an unlabeled one shows similarity.
+    #[test]
+    fn notify_event_mapping() {
+        assert_eq!(
+            UserMessage::from(&NotifyEvent::Scanning),
+            UserMessage::NotifyScanning
+        );
+        assert_eq!(
+            UserMessage::from(&NotifyEvent::Success {
+                label: Some("Alice".into()),
+                similarity: 0.9
+            }),
+            UserMessage::NotifyWelcome {
+                label: "Alice".into()
+            }
+        );
+        assert_eq!(
+            UserMessage::from(&NotifyEvent::Success {
+                label: None,
+                similarity: 0.87
+            }),
+            UserMessage::NotifyRecognized { similarity: 0.87 }
+        );
+        assert_eq!(
+            UserMessage::from(&NotifyEvent::Failure {
+                reason: "no match".into()
+            }),
+            UserMessage::NotifyAuthFailed {
+                reason: "no match".into()
+            }
+        );
+    }
+
+    /// `fail` produces an error whose Display is the localized rendering.
+    #[test]
+    fn fail_renders_localized_display() {
+        let err = fail(UserMessage::ModelsRequired);
+        assert_eq!(
+            format!("{err}"),
+            "Models required. Run `facelock setup` to download them."
+        );
+    }
+
+    /// Real gettext lookup through a fixture catalog: build a minimal `.mo`
+    /// in a tempdir, point the domain at it, and check that `localized()`
+    /// translates while `machine()` does not — the D2 seam, exercised
+    /// end to end.
+    ///
+    /// Locale plumbing is process-global, so this test is written to be
+    /// harmless to concurrent tests: the fixture translates exactly one
+    /// msgid ("Run setup now?"), which no other test pins in English, and
+    /// everything is restored on exit. If the environment offers no usable
+    /// non-C locale (LANGUAGE is ignored under "C"), the lookup assertions
+    /// are skipped; the manual recipe in the module docs of `just pot`
+    /// covers that case.
+    #[test]
+    fn mo_catalog_lookup_translates_localized_but_not_machine() {
+        let dir = tempfile::tempdir().unwrap();
+        let mo_dir = dir.path().join("xx/LC_MESSAGES");
+        std::fs::create_dir_all(&mo_dir).unwrap();
+        std::fs::write(
+            mo_dir.join("facelock.mo"),
+            build_mo(&[("Run setup now?", "XX-RUN-SETUP-NOW")]),
+        )
+        .unwrap();
+
+        // A non-C locale for LC_MESSAGES, else glibc ignores LANGUAGE.
+        let original = setlocale(libc::LC_MESSAGES, std::ptr::null());
+        let original: CString = if original.is_null() {
+            c"C".to_owned()
+        } else {
+            unsafe { CStr::from_ptr(original) }.to_owned()
+        };
+        let usable = [c"en_US.UTF-8", c"en_US.utf8", c"C.UTF-8", c"C.utf8"]
+            .into_iter()
+            .find(|l| !setlocale(libc::LC_MESSAGES, l.as_ptr()).is_null());
+        if usable.is_none() {
+            eprintln!("skipping .mo lookup assertions: no usable non-C locale in this environment");
+            return;
+        }
+
+        // SAFETY: process-global env mutation in a test; restored below.
+        unsafe { std::env::set_var("LANGUAGE", "xx") };
+        let c_dir = CString::new(dir.path().to_str().unwrap()).unwrap();
+        // A fresh binding also invalidates glibc's per-domain catalog cache.
+        bindtextdomain(GETTEXT_DOMAIN.as_ptr(), c_dir.as_ptr());
+        bind_textdomain_codeset(GETTEXT_DOMAIN.as_ptr(), c"UTF-8".as_ptr());
+
+        let localized = UserMessage::ConfirmRunSetupNow.localized();
+        let machine = UserMessage::ConfirmRunSetupNow.machine();
+        let missing = translate("facelock msgid absent from the fixture catalog");
+
+        // Restore before asserting so a failure cannot leak state.
+        unsafe { std::env::remove_var("LANGUAGE") };
+        setlocale(libc::LC_MESSAGES, original.as_ptr());
+        bindtextdomain(GETTEXT_DOMAIN.as_ptr(), c"/usr/share/locale".as_ptr());
+
+        assert_eq!(localized, "XX-RUN-SETUP-NOW", "catalog hit must translate");
+        assert_eq!(machine, "ConfirmRunSetupNow", "machine rendering must not");
+        assert_eq!(
+            missing, "facelock msgid absent from the fixture catalog",
+            "catalog miss must fall back to the msgid"
+        );
+    }
+
+    /// Minimal GNU MO encoder: header entry plus the given pairs.
+    /// Entries must be sorted by msgid (binary-search format, no hash table).
+    fn build_mo(pairs: &[(&str, &str)]) -> Vec<u8> {
+        let mut entries: Vec<(Vec<u8>, Vec<u8>)> = vec![(
+            Vec::new(),
+            b"Content-Type: text/plain; charset=UTF-8\n".to_vec(),
+        )];
+        entries.extend(
+            pairs
+                .iter()
+                .map(|(id, s)| (id.as_bytes().to_vec(), s.as_bytes().to_vec())),
+        );
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let n = entries.len() as u32;
+        let orig_table = 28u32;
+        let trans_table = orig_table + 8 * n;
+        let mut data_off = trans_table + 8 * n;
+
+        // msgids first, then msgstrs, in table order.
+        let texts: Vec<&[u8]> = entries
+            .iter()
+            .map(|(id, _)| id.as_slice())
+            .chain(entries.iter().map(|(_, s)| s.as_slice()))
+            .collect();
+        let mut tables = Vec::new();
+        let mut data = Vec::new();
+        for text in texts {
+            tables.extend((text.len() as u32).to_le_bytes());
+            tables.extend(data_off.to_le_bytes());
+            data.extend(text);
+            data.push(0);
+            data_off += text.len() as u32 + 1;
+        }
+
+        let mut mo = Vec::new();
+        mo.extend(0x950412deu32.to_le_bytes()); // magic
+        mo.extend(0u32.to_le_bytes()); // revision
+        mo.extend(n.to_le_bytes());
+        mo.extend(orig_table.to_le_bytes());
+        mo.extend(trans_table.to_le_bytes());
+        mo.extend(0u32.to_le_bytes()); // hash size
+        mo.extend(0u32.to_le_bytes()); // hash offset
+        mo.extend(tables);
+        mo.extend(data);
+        mo
+    }
+
+    /// One constructed value per variant family, for the placeholder sweep.
+    fn sample_messages() -> Vec<UserMessage> {
+        use UserMessage::*;
+        let s = |v: &str| v.to_string();
+        vec![
+            NoConfigFile { path: s("/p") },
+            InvalidConfig {
+                path: s("/p"),
+                error: s("e"),
+            },
+            RootRequired { hint: s("h") },
+            SudoReexecPrompt,
+            AccessDeniedRootHint,
+            AccessDeniedGroupHint,
+            EnrollTimedOutClientSide,
+            SetupNotCompleted,
+            ConfirmRunSetupNow,
+            SetupDidNotComplete,
+            RunSetupWhenReady,
+            PlaintextEnrollWarning,
+            ModelsMissing { dir: s("/m") },
+            StaleEmbedderNote { embedder: s("e") },
+            Enrolling {
+                user: s("u"),
+                label: s("l"),
+            },
+            EnrollLookAtCamera,
+            EnrollComplete {
+                model_id: 1,
+                count: 2,
+                label: s("l"),
+            },
+            TooManyModels {
+                user: s("u"),
+                count: 6,
+            },
+            ModelsNotFoundOfferSetup,
+            ConfirmDownloadModels,
+            ModelsStillMissingAfterSetup,
+            ModelsRequired,
+            NoModelsEnrolled { user: s("u") },
+            RunEnrollFirst,
+            NoMatchingEmbedder { embedder: s("e") },
+            ReenrollHint,
+            TestingUser { user: s("u") },
+            TestLookAtCamera,
+            TestMatched {
+                similarity: 0.5,
+                seconds: 1.0,
+            },
+            TestMatchedModel {
+                model_id: 1,
+                label: s("l"),
+                similarity: 0.5,
+                seconds: 1.0,
+            },
+            TestVarianceBlocked {
+                similarity: 0.5,
+                seconds: 1.0,
+            },
+            TestNoMatch {
+                similarity: 0.5,
+                seconds: 1.0,
+            },
+            ConfirmRemoveModel {
+                model_id: 1,
+                user: s("u"),
+            },
+            Cancelled,
+            RemovedModel {
+                model_id: 1,
+                user: s("u"),
+            },
+            ModelNotFound {
+                model_id: 1,
+                user: s("u"),
+            },
+            ConfirmClearAll { user: s("u") },
+            ClearedModels {
+                count: 1,
+                user: s("u"),
+            },
+            AllModelsRemoved { user: s("u") },
+            NotifyScanning,
+            NotifyWelcome { label: s("l") },
+            NotifyRecognized { similarity: 0.5 },
+            NotifyAuthFailed { reason: s("r") },
+            SetupIntro { version: s("1.0") },
+            SetupStepCamera,
+            SetupStepModelQuality,
+            SetupStepInferenceDevice,
+            SetupStepModelDownload,
+            SetupStepEncryption,
+            SetupStepEnrollment,
+            SetupStepEnrollmentSkipped,
+            SetupStepTest,
+            SetupStepTestSkipped,
+            SetupStepDaemon,
+            SetupStepPam,
+            SetupCompleteHeader,
+            CameraStepFailed {
+                error: s("e"),
+                current: s("c"),
+            },
+            ModelQualityStepFailed {
+                error: s("e"),
+                current: s("c"),
+            },
+            InferenceStepFailed {
+                error: s("e"),
+                current: s("c"),
+            },
+            ModelDownloadStepFailed { error: s("e") },
+            EncryptionStepFailed { error: s("e") },
+            EnrollStepFailed { error: s("e") },
+            TestStepFailed { error: s("e") },
+            SystemdStepFailed { error: s("e") },
+            GroupStepFailed { error: s("e") },
+            PamStepFailed { error: s("e") },
+            NoVideoDevices,
+            AutoSelectedIrCamera {
+                path: s("/d"),
+                name: s("n"),
+            },
+            AutoSelectedIrCameraPath { path: s("/d") },
+            SelectedCamera {
+                path: s("/d"),
+                name: s("n"),
+            },
+            SelectedValue { value: s("v") },
+            PromptSelectCameraDevice,
+            AutoCameraNoDevices,
+            AutoCameraNoIr {
+                listed: s("l"),
+                example: s("/d"),
+            },
+            AutoCameraManyIr {
+                count: 2,
+                listed: s("l"),
+            },
+            CameraDeviceMissing { path: s("/d") },
+            PromptSelectModelQuality,
+            PromptSelectInferenceDevice,
+            ModelPresentOk {
+                name: s("n"),
+                purpose: s("p"),
+            },
+            AllModelsPresent,
+            ModelsToDownloadHeader,
+            ModelToDownloadEntry {
+                name: s("n"),
+                size_mb: 1,
+                purpose: s("p"),
+            },
+            TotalDownloadSize { mb: 1 },
+            ConfirmDownloadRequiredModels,
+            SkippingModelDownload,
+            DownloadingModel { name: s("n") },
+            ModelDownloaded { name: s("n") },
+            ConfirmEnrollNow,
+            EnrollSkipped,
+            ConfirmTestRecognition,
+            TestSkipped,
+            ConfirmDaemonMode,
+            SystemdNotDetected,
+            SystemdDeclined,
+            SystemdSkippedFlag,
+            SystemdDeferred,
+            CreatingFacelockGroup,
+            GroupMembershipNote,
+            AlreadyInGroup { user: s("u") },
+            ConfirmAddToGroup { user: s("u") },
+            GroupAddSkipped { user: s("u") },
+            AddedToGroup { user: s("u") },
+            PamSkippedFlag { dir: s("/d") },
+            PamModuleMissing { path: s("/p") },
+            ConfiguringPamFor { service: s("sudo") },
+            NoPamCandidates { dir: s("/d") },
+            PamLinePreview {
+                line: s("auth ..."),
+            },
+            PromptSelectPamServices,
+            PamConfigureFailed {
+                service: s("sudo"),
+                error: s("e"),
+            },
+            NoPamServicesSelected,
+            PamFileNotFound { path: s("/p") },
+            PamLineAlreadyPresent { path: s("/p") },
+            PamInsertBeforeAuthHint,
+            PamInsertAtTopHint,
+            PamModifyPreview {
+                path: s("/p"),
+                line: s("auth"),
+                hint: s("h"),
+                backup: s("/b"),
+            },
+            ConfirmProceed,
+            PamSkippedFile { path: s("/p") },
+            PamBackedUp {
+                path: s("/p"),
+                backup: s("/b"),
+            },
+            PamInstalled {
+                path: s("/p"),
+                backup: s("/b"),
+                service: s("sudo"),
+            },
+            PamRemoved { path: s("/p") },
+            PamNoLineFound { path: s("/p") },
+            PamBackupExists {
+                path: s("/p"),
+                backup: s("/b"),
+            },
+            SummaryCamera { value: s("v") },
+            SummaryModels {
+                dir: s("/d"),
+                quality: s("q"),
+            },
+            SummaryInference { value: s("v") },
+            SummaryDatabase { value: s("v") },
+            SummaryEncryption { value: s("v") },
+            SummaryDaemon { status: s("st") },
+            DaemonStatusNotConfiguredNoSystemd,
+            DaemonStatusDeferred,
+            DaemonStatusEnabled,
+            DaemonStatusNotConfigured,
+            SummaryPam {
+                services: s("sudo"),
+            },
+            SummaryPamSkipped,
+            SummaryPamNone,
+            SummaryFaceEnrolled,
+            SummaryFaceNotEnrolledNoEnroll,
+            SummaryFaceNotEnrolled,
+            NonInteractivePreparing,
+            CheckingModels { count: 2 },
+            SetupCompleteShort,
+            SetupCompleteEnroll,
+        ]
+    }
+}

--- a/crates/facelock-cli/src/message.rs
+++ b/crates/facelock-cli/src/message.rs
@@ -1205,10 +1205,10 @@ mod tests {
     /// Unknown msgids fall back to the input string (no catalog installed).
     #[test]
     fn translate_falls_back_to_msgid() {
-        assert_eq!(
-            translate("facelock test msgid that no catalog contains"),
-            "facelock test msgid that no catalog contains"
-        );
+        // Via a binding so xgettext (which extracts literal `translate("...")`
+        // calls) does not sweep this probe into the catalog.
+        let probe = "facelock test msgid that no catalog contains";
+        assert_eq!(translate(probe), probe);
     }
 
     #[test]
@@ -1313,7 +1313,9 @@ mod tests {
 
         let localized = UserMessage::ConfirmRunSetupNow.localized();
         let machine = UserMessage::ConfirmRunSetupNow.machine();
-        let missing = translate("facelock msgid absent from the fixture catalog");
+        // Binding keeps this probe msgid out of xgettext extraction.
+        let absent_probe = "facelock msgid absent from the fixture catalog";
+        let missing = translate(absent_probe);
 
         // Restore before asserting so a failure cannot leak state.
         unsafe { std::env::remove_var("LANGUAGE") };

--- a/crates/facelock-cli/src/notifications.rs
+++ b/crates/facelock-cli/src/notifications.rs
@@ -8,19 +8,14 @@
 use facelock_core::notify::{Notifier, NotifierFactory, NotifyEvent};
 use tracing::debug;
 
-/// Body text for the notification.
+use crate::message::UserMessage;
+
+/// Body text for the notification: user-facing, so it renders through the
+/// message seam (gettext at this edge, D10). The `reason` inside
+/// `NotifyEvent::Failure` is still free text composed upstream — making it
+/// structured is an H4 vocabulary follow-up.
 fn body(event: &NotifyEvent) -> String {
-    match event {
-        NotifyEvent::Scanning => "Scanning face...".to_string(),
-        NotifyEvent::Success { label, similarity } => {
-            if let Some(label) = label {
-                format!("Welcome, {label}")
-            } else {
-                format!("Face recognized ({similarity:.2})")
-            }
-        }
-        NotifyEvent::Failure { reason } => format!("Face auth failed: {reason}"),
-    }
+    UserMessage::from(event).localized()
 }
 
 /// Freedesktop icon name for the notification.

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -57,15 +57,19 @@ impl ConfigLoad {
     /// The parsed config, or the unified load error (D7 item 4): missing file
     /// points at `facelock setup`; a broken file names the path and the parse
     /// error. Every command that needs a config fails through here, so the
-    /// wording cannot drift per command.
+    /// wording cannot drift per command. The error's Display terminates on
+    /// stderr, so it renders through the message seam (D10).
     pub fn require(self) -> anyhow::Result<Config> {
+        use crate::message::{UserMessage, fail};
         match self.result {
             Ok(config) => Ok(config),
-            Err(ConfigError::NotFound(_)) => anyhow::bail!(
-                "no config file at {} — run 'sudo facelock setup' to create one",
-                self.path.display()
-            ),
-            Err(e) => anyhow::bail!("invalid config at {}: {e}", self.path.display()),
+            Err(ConfigError::NotFound(_)) => Err(fail(UserMessage::NoConfigFile {
+                path: self.path.display().to_string(),
+            })),
+            Err(e) => Err(fail(UserMessage::InvalidConfig {
+                path: self.path.display().to_string(),
+                error: e.to_string(),
+            })),
         }
     }
 

--- a/justfile
+++ b/justfile
@@ -174,6 +174,13 @@ install-files:
     install -dm755 /usr/share/facelock/quirks.d
     install -Dm644 config/quirks.d/*.toml /usr/share/facelock/quirks.d/
 
+    # Compiled translations (optional; produced by `just mo`, absent otherwise)
+    if [ -d target/locale ]; then
+        (cd target/locale && find . -name '*.mo' | while read -r mo; do
+            install -Dm644 "$mo" "/usr/share/locale/${mo#./}"
+        done)
+    fi
+
     # systemd unit
     install -Dm644 systemd/facelock-daemon.service /usr/lib/systemd/system/facelock-daemon.service
     if [ -f /etc/systemd/system/facelock-daemon.service ] && \
@@ -342,6 +349,9 @@ uninstall-files:
     rm -rf /usr/share/facelock
     rm -f /etc/facelock/config.toml.default
 
+    # Remove installed translation catalogs (ours only)
+    rm -f /usr/share/locale/*/LC_MESSAGES/facelock.mo /usr/share/locale/*/LC_MESSAGES/pam_facelock.mo
+
     systemctl daemon-reload 2>/dev/null || true
 
     echo ""
@@ -356,6 +366,66 @@ uninstall-files:
     echo "==> To remove the facelock group (after removing all members):"
     echo "==>   sudo gpasswd -d <username> facelock"
     echo "==>   sudo groupdel facelock"
+
+# ---------------------------------------------------------------------------
+# Localization (optional tooling)
+#
+# gettext is NOT required to build, test, or install facelock — English is
+# compiled in as the fallback. These recipes exist for translators and fail
+# with a clear message when the gettext tools are absent.
+# ---------------------------------------------------------------------------
+
+# Regenerate translation templates (po/*.pot) from source. The CLI catalog
+# extracts every `translate("...")` literal in the message seam
+# (crates/facelock-cli/src/message.rs — the one place CLI user-facing English
+# lives); the PAM catalog extracts `gettext("...")` from pam-facelock.
+# xgettext has no Rust mode, but --language=C tokenizes these files correctly
+# because the seam keeps msgids as single-line plain literals (see the
+# "Adding a message" pattern in message.rs).
+pot:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v xgettext >/dev/null; then
+        echo "error: xgettext not found — install the gettext package." >&2
+        echo "       (Translations are optional; building facelock does not need this.)" >&2
+        exit 1
+    fi
+    xgettext --language=C --keyword=translate --from-code=UTF-8 --no-wrap \
+        --package-name=facelock --copyright-holder="Facelock Contributors" \
+        -o po/facelock.pot crates/facelock-cli/src/message.rs
+    xgettext --language=C --keyword=gettext --from-code=UTF-8 --no-wrap \
+        --package-name=pam_facelock --copyright-holder="Facelock Contributors" \
+        -o po/pam_facelock.pot crates/pam-facelock/src/lib.rs
+    echo "Regenerated po/facelock.pot and po/pam_facelock.pot"
+
+# Compile translations po/<lang>/{facelock,pam_facelock}.po into
+# target/locale/<lang>/LC_MESSAGES/<domain>.mo. `just install` installs
+# target/locale/ under /usr/share/locale if present. To start a new
+# translation: mkdir -p po/de && msginit -i po/facelock.pot -o po/de/facelock.po -l de
+# To verify a translation manually without installing system-wide:
+#   FACELOCK_LOCALEDIR=$PWD/target/locale LANGUAGE=de facelock list
+mo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v msgfmt >/dev/null; then
+        echo "error: msgfmt not found — install the gettext package." >&2
+        echo "       (Translations are optional; building facelock does not need this.)" >&2
+        exit 1
+    fi
+    found=0
+    for po in po/*/*.po; do
+        [ -e "$po" ] || continue
+        found=1
+        lang=$(basename "$(dirname "$po")")
+        domain=$(basename "$po" .po)
+        out="target/locale/$lang/LC_MESSAGES/$domain.mo"
+        mkdir -p "$(dirname "$out")"
+        msgfmt --check -o "$out" "$po"
+        echo "  $po -> $out"
+    done
+    if [ "$found" = 0 ]; then
+        echo "no .po files under po/<lang>/ — nothing to compile"
+    fi
 
 # Bump version and prepare a release commit + tag
 # Usage: just release 0.2.0

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -1,12 +1,14 @@
-# Facelock CLI - translation template
-# Copyright (C) 2026 Facelock Contributors
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Facelock Contributors
 # This file is distributed under the same license as the facelock package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: facelock 0.1.0\n"
+"Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-12 00:00+0000\n"
+"POT-Creation-Date: 2026-08-14 00:41-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,55 +17,690 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Setup command
-msgid "Downloading face recognition models..."
+#: crates/facelock-cli/src/message.rs:510
+msgid "no config file at {path} — run 'sudo facelock setup' to create one"
 msgstr ""
 
-msgid "Setup complete."
+#: crates/facelock-cli/src/message.rs:514
+msgid "invalid config at {path}: {error}"
 msgstr ""
 
-#. Enrollment
-msgid "Look at the camera. Move your head slightly for different angles."
+#: crates/facelock-cli/src/message.rs:519
+msgid ""
+"Root required.\n"
+"  Run: {hint}"
 msgstr ""
 
-msgid "Enrollment complete: {} embeddings captured."
+#: crates/facelock-cli/src/message.rs:522
+msgid "Root required. Re-run with sudo? [Y/n] "
 msgstr ""
 
-msgid "Enrollment failed: not enough frames captured."
+#: crates/facelock-cli/src/message.rs:524
+msgid ""
+"Access denied: this operation requires root.\n"
+"  Re-run with sudo, or as root."
 msgstr ""
 
-#. Authentication
-msgid "Face recognized."
+#: crates/facelock-cli/src/message.rs:527
+msgid ""
+"Access denied. If you are not in the 'facelock' group, add yourself:\n"
+"  sudo usermod -aG facelock $USER\n"
+"then log out and back in (or re-run: sudo facelock setup). Note: some operations require root regardless of group membership."
 msgstr ""
 
-msgid "Face not recognized."
+#: crates/facelock-cli/src/message.rs:530
+msgid "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying"
 msgstr ""
 
-msgid "Authentication timed out."
+#: crates/facelock-cli/src/message.rs:533
+msgid "Setup has not been completed."
 msgstr ""
 
-#. Status
-msgid "Daemon status: running"
+#: crates/facelock-cli/src/message.rs:534
+msgid "Run setup now?"
 msgstr ""
 
-msgid "Daemon status: not running"
+#: crates/facelock-cli/src/message.rs:535
+msgid "Setup did not complete successfully."
 msgstr ""
 
-msgid "IR camera: detected"
+#: crates/facelock-cli/src/message.rs:536
+msgid "Run 'sudo facelock setup' when ready."
 msgstr ""
 
-msgid "IR camera: not detected"
+#: crates/facelock-cli/src/message.rs:538
+msgid ""
+"WARNING: encryption.method = \"none\" and security.allow_plaintext = true.\n"
+"Your face template will be stored UNENCRYPTED (plaintext biometric data at rest)."
 msgstr ""
 
-msgid "Enrolled models: {}"
+#: crates/facelock-cli/src/message.rs:542
+msgid ""
+"Face recognition models not found in {dir}.\n"
+"Run `sudo facelock setup` to download them."
 msgstr ""
 
-#. Errors
-msgid "No camera device found."
+#: crates/facelock-cli/src/message.rs:548
+msgid ""
+"Note: existing models don't use the configured embedder '{embedder}'.\n"
+"Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
 msgstr ""
 
-msgid "Failed to connect to daemon."
+#: crates/facelock-cli/src/message.rs:553
+msgid "Enrolling face for user '{user}' with label '{label}'..."
 msgstr ""
 
-msgid "Rate limited. Please wait."
+#: crates/facelock-cli/src/message.rs:557
+msgid "Look at the camera. Slowly turn your head left and right."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:565
+msgid ""
+"\n"
+"Face enrolled successfully!\n"
+"  Model ID: {model_id}\n"
+"  Embeddings: {count}\n"
+"  Label: {label}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:575
+msgid ""
+"\n"
+"Warning: user '{user}' has {count} face models. Consider removing old ones with 'facelock remove'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:580
+msgid "Face recognition models not found."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:581
+msgid "Download models now?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:582
+msgid "Models still not found after setup."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:583
+msgid "Models required. Run `facelock setup` to download them."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:585
+msgid "No face models enrolled for user '{user}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:588
+msgid "Run 'facelock enroll' to enroll a face first."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:590
+msgid "Warning: no enrolled models use the configured embedder '{embedder}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:593
+msgid "Re-enroll with 'facelock enroll' to use the current model."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:595
+msgid "Testing face recognition for user '{user}'..."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:598
+msgid "Look at the camera."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:603
+msgid "Matched (similarity: {similarity}) in {seconds}s"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:616
+msgid "Matched model #{model_id} '{label}' (similarity: {similarity}) in {seconds}s"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:630
+msgid "Face matched (best: {similarity}) but the liveness variance check was not satisfied after {seconds}s — try moving slightly, or tune security.frame_variance_max_similarity"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:641
+msgid "No match (best: {similarity}) after {seconds}s"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:649
+msgid "Remove face model #{model_id} for user '{user}'?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:652
+msgid "Cancelled."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:654
+msgid "Removed face model #{model_id} for user '{user}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:658
+msgid "Model #{model_id} not found for user '{user}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:662
+msgid "Remove ALL face models for user '{user}'?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:666
+msgid "Removed {count} face model(s) for user '{user}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:670
+msgid "All face models removed for user '{user}'."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:674
+msgid "Scanning face..."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:676
+msgid "Welcome, {label}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:679
+msgid "Face recognized ({similarity})"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:683
+msgid "Face auth failed: {reason}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:689
+msgid ""
+"\n"
+"  Facelock v{version}\n"
+"  Linux face authentication\n"
+"\n"
+"  This wizard will walk you through initial setup:\n"
+"    - Camera detection\n"
+"    - Model quality and inference device\n"
+"    - Model downloads\n"
+"    - Embedding encryption (TPM or software)\n"
+"    - Face enrollment\n"
+"    - Daemon and PAM configuration\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:693
+msgid ""
+"\n"
+"--- Step 1: Camera Selection ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:694
+msgid ""
+"\n"
+"--- Step 2: Model Quality ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:695
+msgid ""
+"\n"
+"--- Step 3: Inference Device ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:696
+msgid ""
+"\n"
+"--- Step 4: Model Download ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:697
+msgid ""
+"\n"
+"--- Step 5: Embedding Encryption ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:698
+msgid ""
+"\n"
+"--- Step 6: Face Enrollment ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:700
+msgid ""
+"\n"
+"--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:702
+msgid ""
+"\n"
+"--- Step 7: Test Recognition ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:704
+msgid ""
+"\n"
+"--- Step 7: Test Recognition (skipped, no face enrolled) ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:706
+msgid ""
+"\n"
+"--- Step 8: Daemon Configuration ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:707
+msgid ""
+"\n"
+"--- Step 9: PAM Configuration ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:708
+msgid ""
+"\n"
+"--- Setup Complete ---\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:712
+msgid ""
+"  Camera detection failed: {error}\n"
+"  You can configure the camera later in the config file.\n"
+"  Continuing with current setting: {current}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:718
+msgid ""
+"  Model quality selection failed: {error}\n"
+"  Continuing with current setting: {current}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:724
+msgid ""
+"  Inference device selection failed: {error}\n"
+"  Continuing with current setting: {current}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:730
+msgid ""
+"  Model download failed: {error}\n"
+"  You can retry later with: sudo facelock setup --non-interactive"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:736
+msgid ""
+"  Encryption setup failed: {error}\n"
+"  You can configure encryption later with: sudo facelock encrypt --generate-key"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:742
+msgid ""
+"  Enrollment failed: {error}\n"
+"  You can enroll later with: facelock enroll"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:747
+msgid ""
+"  Test failed: {error}\n"
+"  You can test later with: facelock test"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:752
+msgid ""
+"  Systemd setup failed: {error}\n"
+"  You can enable it later with: sudo facelock setup --systemd"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:758
+msgid ""
+"  Group setup failed: {error}\n"
+"  Add manually: sudo usermod -aG facelock <user>"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:764
+msgid ""
+"  PAM setup failed: {error}\n"
+"  You can configure PAM later with: sudo facelock setup --pam"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:770
+msgid ""
+"  No video devices found.\n"
+"  Check that your camera is connected and the v4l2 module is loaded."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:773
+msgid "  Auto-selected IR camera: {path} ({name})"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:777
+msgid "  Auto-selected IR camera: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:781
+msgid "  Selected: {path} ({name})"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:785
+msgid "  Selected: {value}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:788
+msgid "Select camera device"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:790
+msgid "--camera=auto found no video devices; check that the camera is connected and the v4l2 module is loaded"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:794
+msgid ""
+"--camera=auto found no IR-capable camera among the detected devices:\n"
+"{listed}\n"
+"  Pass an explicit device path, e.g. --camera={example}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:800
+msgid ""
+"--camera=auto found {count} IR-capable cameras:\n"
+"{listed}\n"
+"  Pass an explicit device path to choose one."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:806
+msgid "camera device {path} does not exist; pass a valid /dev/video* path or --camera=auto"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:811
+msgid "Select model quality"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:812
+msgid "Select inference device"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:815
+msgid "  [ok] {name} ({purpose})"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:818
+msgid "  All models are already present and verified."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:819
+msgid "  Models to download:"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:825
+msgid "    - {name} (~{size_mb}MB) - {purpose}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:833
+msgid "  Total download size: ~{mb}MB"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:836
+msgid "Download required models?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:837
+msgid "  Skipping model download."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:839
+msgid "  Downloading {name}..."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:843
+msgid "  [ok] {name} downloaded and verified"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:847
+msgid "Would you like to enroll a face now?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:848
+msgid "  Skipping face enrollment."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:849
+msgid "Would you like to test recognition?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:850
+msgid "  Skipping recognition test."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:851
+msgid "Enable daemon mode with D-Bus activation?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:853
+msgid ""
+"  systemd not detected. Skipping daemon configuration.\n"
+"  Facelock will use oneshot mode for authentication."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:856
+msgid "  Skipping systemd setup. Facelock will use oneshot mode."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:859
+msgid ""
+"  Skipping daemon configuration (--no-systemd).\n"
+"  No unit files are written and systemctl is not invoked."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:862
+msgid "  Answered on the command line; applied once setup finishes."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:865
+msgid "  Creating 'facelock' system group..."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:867
+msgid ""
+"  Note: running daemon commands (preview/test) as a normal user requires\n"
+"  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:870
+msgid "  User '{user}' is already in the 'facelock' group."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:875
+msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:880
+msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:885
+msgid ""
+"  Added '{user}' to the 'facelock' group.\n"
+"  NOTE: log out and back in for the new group membership to take effect."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:892
+msgid ""
+"  Skipping PAM configuration (--no-pam).\n"
+"  No file under {dir} is read or modified."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:898
+msgid ""
+"  PAM module not found at {path}.\n"
+"  Install it first, then run: sudo facelock setup --pam"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:903
+msgid "  Configuring PAM for {service}..."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:907
+msgid "  No supported PAM service files found in {dir}/."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:912
+msgid ""
+"  The following line will be added to each selected /etc/pam.d/<service>:\n"
+"\n"
+"      {line}\n"
+"\n"
+"  It is inserted above the first existing 'auth' line. A backup\n"
+"  (.facelock-backup) is saved before any change, and you'll be asked\n"
+"  to confirm each file individually.\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:917
+msgid "Select services to enable face authentication for"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:920
+msgid "  Failed to configure {service}: {error}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:923
+msgid "  No PAM services selected."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:925
+msgid "PAM service file not found: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:929
+msgid "PAM line already present in {path}. Nothing to do."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:932
+msgid "inserted before the first 'auth' line"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:934
+msgid "no 'auth' line found — inserted at the top of the file"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:943
+msgid ""
+"\n"
+"About to modify {path}:\n"
+"  + {line}    ({hint})\n"
+"  Backup will be saved to: {backup}\n"
+"\n"
+"(To configure manually instead, add the line above to each service yourself.)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:952
+msgid "Proceed?"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:954
+msgid "Skipped {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:957
+msgid "Backed up {path} -> {backup}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:966
+msgid ""
+"Installed facelock PAM line into {path}\n"
+"\n"
+"To rollback:\n"
+"  sudo cp {backup} {path}\n"
+"  # or: sudo facelock setup --pam --remove --service {service}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:975
+msgid "Removed facelock PAM line from {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:979
+msgid "No facelock PAM line found in {path}. Nothing to remove."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:983
+msgid ""
+"Backup exists at {backup}\n"
+"To restore: sudo cp {backup} {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:988
+msgid "  Camera:     {value}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:992
+msgid "  Models:     {dir} ({quality})"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:996
+msgid "  Inference:  {value}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1000
+msgid "  Database:   {value}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1004
+msgid "  Encryption: {value}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1008
+msgid "  Daemon:   {status}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1011
+msgid "not configured (--no-systemd)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1012
+msgid "configured from the command line"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1013
+msgid "enabled (D-Bus activation)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1014
+msgid "not configured"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1016
+msgid "  PAM:      {services}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1019
+msgid "  PAM:      not configured (--no-pam)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1020
+msgid "  PAM:      not configured"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1021
+msgid "  Face:     enrolled"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1023
+msgid "  Face:     not enrolled (--no-enroll; run `facelock enroll`)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1025
+msgid "  Face:     not enrolled (run `facelock enroll`)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1027
+msgid "facelock setup: preparing system...\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1029
+msgid "Checking {count} model(s)...\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1032
+msgid ""
+"\n"
+"Setup complete."
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:1034
+msgid ""
+"\n"
+"Setup complete. Run `facelock enroll` to register your face."
 msgstr ""

--- a/po/pam_facelock.pot
+++ b/po/pam_facelock.pot
@@ -1,66 +1,27 @@
-# Facelock PAM module - translation template
-# Copyright (C) 2026 Facelock Contributors
-# This file is distributed under the same license as the facelock package.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Facelock Contributors
+# This file is distributed under the same license as the pam_facelock package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pam_facelock 0.1.0\n"
+"Project-Id-Version: pam_facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-12 00:00+0000\n"
+"POT-Creation-Date: 2026-08-14 00:11-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/pam-facelock/src/lib.rs
-#. Shown when face scanning begins
+#: crates/pam-facelock/src/lib.rs:936
 msgid "Identifying face..."
 msgstr ""
 
-#: crates/pam-facelock/src/lib.rs
-#. Shown on successful face recognition
+#: crates/pam-facelock/src/lib.rs:946 crates/pam-facelock/src/lib.rs:958
+#: crates/pam-facelock/src/lib.rs:1000
 msgid "Face recognized."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when face recognition fails
-msgid "Face not recognized."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when face recognition times out
-msgid "Face recognition timed out."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when rate limited
-msgid "Too many attempts. Please wait."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when IR camera is required but not available
-msgid "IR camera required for face authentication."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when no faces are enrolled
-msgid "No faces enrolled."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when facelock is disabled
-msgid "Face authentication disabled."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when SSH session detected
-msgid "Face authentication skipped (SSH session)."
-msgstr ""
-
-#: crates/pam-facelock/src/lib.rs
-#. Shown when laptop lid is closed
-msgid "Face authentication skipped (lid closed)."
 msgstr ""


### PR DESCRIPTION
Implements the Messages domain (domain-object-map §7, gap D10) under the two decided constraints: **D1 — gettext everywhere** (libc FFI, no new dependencies) and **D2 — logs stay English**, with the boundary at the **sink**, not the string.

## The seam

`crates/facelock-cli/src/message.rs` — one module, three parts:

- **`UserMessage`** (~140 variants): a typed vocabulary of user-facing events carrying data, not strings — `EnrollComplete { model_id, count, label }`, not a formatted line.
- **Two renderers, one per sink class:**
  - `localized()` — gettext at the edge (domain `facelock`, `/usr/share/locale`, `FACELOCK_LOCALEDIR` override for testing). English fallback is **byte-identical** to the historical inline strings.
  - `machine()` — a C-locale event line derived from the variant's `Debug` form (`NoConfigFile { path: "/etc/..." }`). Never consults gettext.
- **Sinks:** `Terminal` (`info`/`error`/`prompt`/`confirm` — localized text to stdout/stderr, plus the machine line to `tracing::debug!` so `RUST_LOG=facelock=debug` shows the stable event stream beside what the user saw) and `fail()` (localized `anyhow` errors whose `Display` terminates on stderr).

The gettext wrapper is the same ~20-line libc FFI pattern `pam_facelock` uses; PAM keeps its own copy and its own text domain untouched (it cannot depend on anything here). The seam lives in `facelock-cli` rather than `facelock-core` because core's dependency contract excludes libc and no non-CLI crate renders user text today; when the daemon D-Bus server moves out of this crate (H7), the seam moves with it.

**D2 by construction:** a message routed through `UserMessage` cannot reach a log sink translated, because the machine rendering never touches gettext. Demonstrated live:

```
$ FACELOCK_LOCALEDIR=$PWD/target/locale LANGUAGE=xx RUST_LOG=facelock=debug facelock list --config /nonexistent.toml
DEBUG NoConfigFile { path: "/nonexistent.toml" }        <- trace: C locale
Error: XX-KEINE-KONFIG /nonexistent.toml                <- stderr: translated
```

`init()` sets **LC_MESSAGES only** (not LC_ALL), so LC_NUMERIC can never leak into in-process C libraries (ONNX Runtime parses floats), and pins the output charset to UTF-8.

## Conversion coverage (honest accounting)

Seam-routed rendering sites after this PR, per file:

| File | Seam-routed | Raw sites remaining | Remaining is |
|---|---|---|---|
| commands/setup.rs | 95 | 84 | deep sub-flows: TPM/encryption detail, orphan-model recovery, preset summaries, EP warnings, hyprlock handoff, PAM-extension hint, unit-install detail, helper bails |
| commands/test_cmd.rs | 16 | 5 | diagnostic bails (`daemon error:`, `unexpected response`), store-error wording |
| commands/enroll.rs | 12 | 5 | diagnostic bails |
| ipc_client.rs | 6 | 2 | `[y/N]` convention in `confirm()` (see residue), D-Bus call-context strings |
| commands/remove.rs | 5 | 1 | diagnostic bail |
| commands/clear.rs | 5 | 3 | diagnostic bails |
| resolved.rs | 2 | 0 | — (ConfigLoad::require fully converted) |
| notifications.rs | 1 | 1 | the `TerminalNotifier` println — it *is* the sink edge |
| main.rs | — | — | `message::init()` wired first |

**Unconverted this PR (the long tail, counted):** bench.rs 102, tpm.rs 49, hyprlock.rs 30, encrypt.rs 19, direct.rs 15, config.rs 13, devices.rs 11, list.rs 10 (partly `--json`-exempt), audit.rs 8 (renders machine records; stays English deliberately), status.rs 5, preview/* 9, state_layout.rs 1, auth.rs 1 (PAM-spawned; stderr goes to logs, not a human). Total raw sites went from ~566 to ~385; every conversion is mechanical per the pattern documented in `message.rs` module docs ("Adding a message").

What a non-developer sees running `setup` (full wizard spine: banner, all 9 step headers, prompts, selections, download flow, group membership, the PAM preview/confirm/backup/rollback block, summary, non-interactive outcomes), `enroll`, `test`, `remove`, `clear`, plus desktop/terminal notification bodies and the top-level config-load errors, is localizable.

## Machine-facing text that must NEVER localize (sink discipline)

- `--json` output anywhere (`list --json`, `is-enrolled --json`)
- `is-enrolled` stdout contract and exit codes (file untouched, structural pin still green)
- `audit.jsonl` and everything under `facelock audit`
- syslog and `tracing` output (daemon and oneshot)
- **D-Bus error message strings** — verified contract: PAM never shows daemon error text to users; `pam_code_for_daemon_error` (pam-facelock/src/lib.rs:864) substring-matches `"rate limited"` / `"IR camera required"` on the wire to pick PAM codes and syslog reasons. Those strings are wire protocol and stay English; PAM localizes its own presentation via its own gettext domain, untouched.
- anything container tests grep (`Matched model`, `No match`, …) — safe twice over: English fallback is byte-identical, and test containers run in the C locale.

## Toolchain (opt-in; gettext never required to build)

- `just pot` — regenerates both templates via `xgettext --language=C` keyed on the extraction keywords (`translate` for the CLI seam, `gettext` for PAM). xgettext has no Rust mode; C tokenization works because the seam keeps msgids as single-line plain literals (enforced by the documented pattern). Fails with a clear message if xgettext is absent.
- `just mo` — compiles `po/<lang>/{facelock,pam_facelock}.po` → `target/locale/<lang>/LC_MESSAGES/*.mo` (`msgfmt --check`); no `.po` files is a clean no-op.
- `just install` — ships `target/locale/` under `/usr/share/locale` **iff present**; `just uninstall` removes only our two domains. Nothing in build/test/CI invokes gettext tools.
- Manual verification recipe (also in the `mo` recipe comment): `msginit -i po/facelock.pot -o po/de/facelock.po -l de`, translate, `just mo`, then `FACELOCK_LOCALEDIR=$PWD/target/locale LANGUAGE=de facelock <cmd>`.

## .pot regeneration

- `po/facelock.pot`: **16 phantom entries** (strings existing nowhere in code) → **142 entries extracted from the seam**, every one backed by a `translate()` call with a source-location comment.
- `po/pam_facelock.pot`: 10 entries → **2** (`"Identifying face..."`, `"Face recognized."`). Plan errata: the domain map says PAM has 7 localized strings; the code wraps 4 call sites over 2 distinct msgids — the other 8 catalog entries were phantoms too.

## Tests

- Byte-identical English pins for representative messages (incl. container-grepped ones), a placeholder sweep across the whole vocabulary, NotifyEvent→UserMessage mapping, machine-rendering shape.
- Real catalog lookup: a minimal `.mo` built in-test (binary MO encoder), bound via `bindtextdomain` + `LANGUAGE` — asserts `localized()` translates, `machine()` does not, misses fall back; skips lookup assertions gracefully if the environment has no non-C locale.

## Residue / follow-ups

- `NotifyEvent::Failure { reason }` carries free text composed upstream — it interpolates untranslated inside a localized template. Structuring the reason is an H4 vocabulary follow-up.
- `ipc_client::confirm`'s `[y/N]` suffix and accepted answers (`y`/`yes`) stay English — answer parsing is a contract; localizing accepted answers needs a deliberate design (gettext's `rpmatch` pattern).
- The `Error:` prefix on fatal errors comes from `anyhow`'s termination path, and `Caused by:` chains stay English (deep error chains are long-tail by scope).
- Daemon-sent desktop notifications render in the daemon's locale (C under systemd → English), same as before this PR; per-recipient locale needs a user-locale lookup at notify time.
- dialoguer choice items (model preset names, PAM service descriptions) and summary sub-values (encryption/quality labels) are unconverted (counted above).
- Plural forms use the historical `model(s)` msgids (byte-identity constraint); moving to `ngettext` is mechanical later and PAM's ceiling allows it.

## Cross-PR notes

- **H4 (Notifier):** `NotifyEvent` untouched; its renderers (`body()`) now route through the seam. English rendering pinned by H4's existing tests, unchanged.
- **H2 (ConfigLoad):** `require()`'s two errors are seam events (`NoConfigFile`/`InvalidConfig`); H2's wording tests still pass on the byte-identical fallback.
- **H7 (daemon-server move):** the seam should migrate (to core or with the server) when the daemon leaves `facelock-cli`; `NotifierFactory` consumers get localization for free via `body()`.
- **Remediation §P3-2 (packaging conformance):** LC_MESSAGES install currently exists only in the justfile path; the six other packaging paths (deb/rpm/PKGBUILD/nix/openrc/tmpfiles) ship no catalogs yet — they need the same conditional install once translations exist.

## Docs to reconcile

- `docs/contracts.md`: note the two gettext domains (`facelock`, `pam_facelock`) as install artifacts and the D-Bus error strings as an English wire contract.
- `CONTRIBUTING.md` / `book`: a "translating facelock" section pointing at `just pot`/`just mo` and the message.rs pattern.
- `man/facelock.1`: `FACELOCK_LOCALEDIR` env var.

Gates: `just check` clean; `just test-arch-pam` 22/22; `just test-arch-layout` 21/21 (tails in the PR conversation below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
