### PR TITLE
refactor(backend): BackendKind selection + one fork per operation (D1, N10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -1,0 +1,732 @@
+//! Backend selection and the transport seam (D1).
+//!
+//! Every user-facing operation is answered either by the daemon over D-Bus or
+//! by direct (in-process) store/camera access. That used to be a boolean
+//! (`should_use_direct`) consulted independently at 13 call sites, each with
+//! its own failure policy and its own fresh bus probe — real TOCTOU windows
+//! (`clear` probed, prompted for an unbounded time, then probed again) and an
+//! activation asymmetry (`name_has_owner` does not start the daemon, but a
+//! `send_request` on the "wrong" branch would, silently flipping a later
+//! operation from direct to daemon mode — issue #89 validation fallout).
+//!
+//! Now selection is made **once per invocation**, at the top of each
+//! backend-using command, with **at most one** deliberate, non-activating bus
+//! probe. The outcome is a [`BackendKind`], not a boolean, because "direct"
+//! means two different things that deserve different messages and log levels;
+//! and every operation that used to fork per call site forks in exactly one
+//! method here.
+//!
+//! What stays outside this seam, on the merits:
+//! - **PAM** performs one operation and needs things the CLI must not have
+//!   (pinned-peer verification, a hard deadline, an env-cleared subprocess
+//!   fallback). It shares test vectors, not code.
+//! - **`is-enrolled`** is dispatched in `main` before any config parse and
+//!   must never probe the bus; `hyprlock` and `config` touch no backend.
+//! - **`status`** renders its own probes for now — H8 (Health) will consume
+//!   the [`DaemonReachability`] fact this module records.
+//! - Maintenance commands (`bench`, `encrypt`, `tpm`, `audit`, `auth`,
+//!   `daemon`) are direct-by-nature and never select.
+
+use anyhow::bail;
+use zbus::blocking::Connection;
+
+use facelock_core::Config;
+use facelock_core::config::DaemonMode;
+use facelock_core::dbus_interface::BUS_NAME;
+use facelock_core::ipc::{DaemonRequest, DaemonResponse, IpcDeviceInfo};
+use facelock_core::types::{FaceModelInfo, MatchResult};
+use facelock_store::StoreError;
+
+use crate::message::{Terminal, UserMessage};
+use crate::resolved::{Provenance, Resolved};
+use crate::{direct, ipc_client};
+
+/// Which implementation answers this invocation's questions — and, for the
+/// direct answers, *why* it is direct. The distinction carries the failure
+/// policy: an expected configuration is not a degraded state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendKind {
+    /// `daemon.mode = "daemon"` and the bus name has an owner.
+    Daemon,
+    /// `daemon.mode = "oneshot"` — direct access is the configuration.
+    /// Expected; no warning.
+    DirectByConfig,
+    /// `daemon.mode = "daemon"` but the bus name has no owner — degraded.
+    /// WARNed once, at selection.
+    DirectByFallback,
+}
+
+impl BackendKind {
+    pub fn is_direct(self) -> bool {
+        !matches!(self, BackendKind::Daemon)
+    }
+}
+
+/// What the one probe observed, recorded beside the resolved-config facts
+/// (D7) with the same provenance discipline: `NotProbed` is a distinct value,
+/// never a guessed `Unreachable`. H8 (Health) lifts this into its `Fact`
+/// model; until then it is logged at selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonReachability {
+    /// `mode = "oneshot"`: the bus is deliberately never asked.
+    NotProbed,
+    Reachable,
+    Unreachable,
+}
+
+/// What a backend cannot do, stated once at selection instead of discovered
+/// at the failure site.
+///
+/// Deliberately not carried here: `facelock test`'s remaining posture
+/// asymmetries. Both transports now run the same `pre_check` gates (N11), so
+/// the old `enforces_auth_gates` flag would state a falsehood; what still
+/// differs — the direct path skips the SSH/lid *physical-presence* aborts via
+/// `PreCheckContext::test` and stamps `AuditSource::Test` instead of
+/// `AuditSource::Daemon` — is documented at [`Backend::recognize`], because no
+/// caller branches on it.
+pub struct BackendCaps {
+    /// Streaming JPEG preview frames come from the daemon; a direct backend
+    /// has only the local text preview.
+    pub graphical_preview: bool,
+    /// Per-device format/resolution detail is a V4L2 interrogation; the D-Bus
+    /// `DeviceInfo` type does not carry it.
+    pub device_formats: bool,
+}
+
+/// The transport seam. Holds the selection made by [`Backend::select`]; every
+/// method forks on it in exactly one place, with one failure policy per
+/// operation: daemon replies and store failures propagate — they never fold
+/// into "no models" (C4) — and on direct reads a provably absent database is
+/// a benign answer that must not materialize one (C7).
+pub struct Backend<'a> {
+    kind: BackendKind,
+    config: &'a Config,
+}
+
+impl<'a> Backend<'a> {
+    /// Select the backend for this invocation. Called once, at the top of
+    /// each backend-using command; probes the bus at most once (never for
+    /// `mode = "oneshot"`), non-activating by construction.
+    pub fn select(config: &'a Config) -> Backend<'a> {
+        let (kind, reachability) = classify(&config.daemon.mode, daemon_bus_reachable);
+        let (level, notice) = announcement(kind);
+        // The one machine-facing record of the selection and the probed
+        // reachability fact. `tracing::event!` needs a const level, hence the
+        // match.
+        match level {
+            tracing::Level::WARN => tracing::warn!(
+                target: "facelock::backend",
+                ?kind,
+                ?reachability,
+                "backend selected"
+            ),
+            _ => tracing::debug!(
+                target: "facelock::backend",
+                ?kind,
+                ?reachability,
+                "backend selected"
+            ),
+        }
+        if let Some(msg) = notice {
+            Terminal.error(&msg);
+        }
+        Backend { kind, config }
+    }
+
+    pub fn kind(&self) -> BackendKind {
+        self.kind
+    }
+
+    pub fn caps(&self) -> BackendCaps {
+        match self.kind {
+            BackendKind::Daemon => BackendCaps {
+                graphical_preview: true,
+                device_formats: false,
+            },
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => BackendCaps {
+                graphical_preview: false,
+                device_formats: true,
+            },
+        }
+    }
+
+    /// Does `user` have any enrolled models?
+    pub fn has_models(&self, user: &str) -> anyhow::Result<bool> {
+        match self.kind {
+            BackendKind::Daemon => Ok(!self.daemon_list_models(user)?.is_empty()),
+            _ => self.direct_read(false, |store| {
+                store
+                    .has_models(user)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
+        }
+    }
+
+    /// Does `user` have models produced by `embedder`?
+    pub fn has_models_for_embedder(&self, user: &str, embedder: &str) -> anyhow::Result<bool> {
+        match self.kind {
+            BackendKind::Daemon => Ok(self
+                .daemon_list_models(user)?
+                .iter()
+                .any(|model| model.embedder_model == embedder)),
+            _ => self.direct_read(false, |store| {
+                store
+                    .has_models_for_embedder(user, embedder)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
+        }
+    }
+
+    /// All of `user`'s models.
+    pub fn list_models(&self, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
+        match self.kind {
+            BackendKind::Daemon => self.daemon_list_models(user),
+            _ => self.direct_read(Vec::new(), |store| {
+                store
+                    .list_models(user)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
+        }
+    }
+
+    /// Remove one model. `Some(removed)` when this backend can tell whether
+    /// the model existed; `None` on the daemon path, whose wire reply does not
+    /// carry it (a P1-3 wire change deferred to keep this PR wire-stable).
+    pub fn remove_model(&self, user: &str, model_id: u32) -> anyhow::Result<Option<bool>> {
+        match self.kind {
+            BackendKind::Daemon => {
+                removed_reply(ipc_client::send_request(&DaemonRequest::RemoveModel {
+                    user: user.to_string(),
+                    model_id,
+                }))?;
+                Ok(None)
+            }
+            // An absent store provably holds nothing to remove: report "not
+            // found" without materializing a database (the per-site version
+            // used the creating opener here).
+            _ => self.direct_read(Some(false), |store| {
+                store
+                    .remove_model(user, model_id)
+                    .map(Some)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }),
+        }
+    }
+
+    /// Remove all of `user`'s models. `Some(count)` when this backend can
+    /// count them; `None` on the daemon path (same wire limitation as
+    /// [`Backend::remove_model`]).
+    pub fn clear_models(&self, user: &str) -> anyhow::Result<Option<usize>> {
+        match self.kind {
+            BackendKind::Daemon => {
+                removed_reply(ipc_client::send_request(&DaemonRequest::ClearModels {
+                    user: user.to_string(),
+                }))?;
+                Ok(None)
+            }
+            _ => {
+                // No `Absent` shortcut: callers check `has_models` first, so
+                // a vanished database is an error — erroring beats
+                // re-creating an empty database in its place.
+                let store = direct::open_store_existing(self.config)?;
+                let count = store.clear_user(user).map_err(|e| anyhow::anyhow!("{e}"))?;
+                Ok(Some(count as usize))
+            }
+        }
+    }
+
+    /// Enroll a face for `user`, returning `(model_id, embedding_count)`.
+    /// The daemon call runs on a dedicated connection whose timeout is
+    /// derived from the daemon's own enrollment deadline (issue #89).
+    pub fn enroll(&self, user: &str, label: &str) -> anyhow::Result<(u32, u32)> {
+        match self.kind {
+            BackendKind::Daemon => match ipc_client::send_enroll(user, label, self.config)? {
+                DaemonResponse::Enrolled {
+                    model_id,
+                    embedding_count,
+                } => Ok((model_id, embedding_count)),
+                other => bail!("unexpected response from daemon: {other:?}"),
+            },
+            _ => direct::enroll(self.config, user, label),
+        }
+    }
+
+    /// Recognition only — backs `facelock test` (root-only, N11). NEVER the
+    /// PAM/auth path.
+    ///
+    /// Both transports run the same `pre_check` gates. The surviving posture
+    /// difference: the direct path skips the SSH/lid physical-presence aborts
+    /// (`PreCheckContext::test` — they exist to stop an attacker's shortcuts,
+    /// not a root operator testing over SSH) and audits as `Test`, while the
+    /// daemon path enforces them and audits as `Daemon`. Neither path charges
+    /// the rate limit for a failed test: direct never records failures, and
+    /// the daemon exempts root callers.
+    pub fn recognize(&self, user: &str) -> anyhow::Result<MatchResult> {
+        match self.kind {
+            BackendKind::Daemon => {
+                match ipc_client::send_request(&DaemonRequest::Authenticate {
+                    user: user.to_string(),
+                })? {
+                    DaemonResponse::AuthResult(result) => Ok(result),
+                    // `suppress_unknown` short-circuit: same "no result"
+                    // shape the direct path reports.
+                    DaemonResponse::Suppressed => Ok(MatchResult {
+                        matched: false,
+                        model_id: None,
+                        label: None,
+                        similarity: 0.0,
+                        failure_reason: None,
+                    }),
+                    DaemonResponse::Error { message } => bail!("daemon error: {message}"),
+                    other => bail!("unexpected response from daemon: {other:?}"),
+                }
+            }
+            _ => direct::authenticate(self.config, user),
+        }
+    }
+
+    /// Enumerate camera devices. Formats are present only when
+    /// [`BackendCaps::device_formats`] says so.
+    pub fn list_devices(&self) -> anyhow::Result<Vec<IpcDeviceInfo>> {
+        match self.kind {
+            BackendKind::Daemon => {
+                // Only blame a missing daemon when the request wasn't
+                // refused: an AccessDenied already carries its own hint as
+                // the headline.
+                let response =
+                    ipc_client::send_request(&DaemonRequest::ListDevices).map_err(|e| {
+                        if ipc_client::is_access_denied(&e) {
+                            e
+                        } else {
+                            e.context("failed to query daemon — is facelock-daemon running?")
+                        }
+                    })?;
+                match response {
+                    DaemonResponse::Devices(devices) => Ok(devices),
+                    DaemonResponse::Error { message } => bail!("daemon error: {message}"),
+                    _ => bail!("unexpected response from daemon"),
+                }
+            }
+            _ => direct::list_devices_info(),
+        }
+    }
+
+    /// Interpret the daemon's `ListModels` reply. One failure policy (C4):
+    /// transport failures and error replies propagate — they must never read
+    /// as "no models enrolled".
+    fn daemon_list_models(&self, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
+        models_reply(ipc_client::send_request(&DaemonRequest::ListModels {
+            user: user.to_string(),
+        }))
+    }
+
+    /// Direct-transport read with the C7 discrimination carried by
+    /// [`StoreError`]: [`StoreError::Absent`] (fresh install) answers
+    /// `absent_value` without creating the database the probe would otherwise
+    /// materialize; every other failure class propagates.
+    fn direct_read<T>(
+        &self,
+        absent_value: T,
+        read: impl FnOnce(&facelock_store::FaceStore) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let store = match direct::open_store_existing(self.config) {
+            Ok(store) => store,
+            Err(StoreError::Absent { .. }) => return Ok(absent_value),
+            Err(e) => return Err(e.into()),
+        };
+        read(&store)
+    }
+}
+
+/// The selection rule, split from the probe so it is testable without a bus.
+fn classify(
+    mode: &DaemonMode,
+    probe: impl FnOnce() -> bool,
+) -> (BackendKind, Resolved<DaemonReachability>) {
+    match mode {
+        DaemonMode::Oneshot => (
+            BackendKind::DirectByConfig,
+            Resolved {
+                value: DaemonReachability::NotProbed,
+                provenance: Provenance::Claimed,
+            },
+        ),
+        DaemonMode::Daemon => {
+            if probe() {
+                (
+                    BackendKind::Daemon,
+                    Resolved {
+                        value: DaemonReachability::Reachable,
+                        provenance: Provenance::Probed,
+                    },
+                )
+            } else {
+                (
+                    BackendKind::DirectByFallback,
+                    Resolved {
+                        value: DaemonReachability::Unreachable,
+                        provenance: Provenance::Probed,
+                    },
+                )
+            }
+        }
+    }
+}
+
+/// What selection says, per kind: the log level for the machine line, and
+/// the user-facing stderr message, if any. Three kinds, three treatments —
+/// an expected configuration is silent, a degraded fallback warns once.
+fn announcement(kind: BackendKind) -> (tracing::Level, Option<UserMessage>) {
+    match kind {
+        BackendKind::Daemon => (tracing::Level::DEBUG, None),
+        BackendKind::DirectByConfig => (tracing::Level::DEBUG, None),
+        BackendKind::DirectByFallback => (
+            tracing::Level::WARN,
+            Some(UserMessage::DaemonUnreachableFallback),
+        ),
+    }
+}
+
+/// The one deliberate bus probe. `name_has_owner` asks the bus about the
+/// daemon's name without triggering D-Bus activation — the asymmetry that
+/// made per-site probing hazardous (`send_request` on a freshly booted
+/// system would *start* the daemon). Any failure to ask reads as
+/// unreachable.
+fn daemon_bus_reachable() -> bool {
+    let Ok(conn) = Connection::system() else {
+        return false;
+    };
+    let Ok(proxy) = zbus::blocking::fdo::DBusProxy::new(&conn) else {
+        return false;
+    };
+    let Ok(name) = BUS_NAME.try_into() else {
+        return false;
+    };
+    proxy.name_has_owner(name).unwrap_or(false)
+}
+
+/// Interpret a daemon reply that should be `Models`. Failure policy: C4.
+fn models_reply(response: anyhow::Result<DaemonResponse>) -> anyhow::Result<Vec<FaceModelInfo>> {
+    match response? {
+        DaemonResponse::Models(models) => Ok(models),
+        DaemonResponse::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+/// Interpret a daemon reply that should be `Removed`.
+fn removed_reply(response: anyhow::Result<DaemonResponse>) -> anyhow::Result<()> {
+    match response? {
+        DaemonResponse::Removed => Ok(()),
+        DaemonResponse::Error { message } => bail!("daemon error: {message}"),
+        other => bail!("unexpected response from daemon: {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // -----------------------------------------------------------------------
+    // Selection: config mode x reachability -> kind, message, log level.
+    // The probe is a closure, so no test touches a bus.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn oneshot_config_selects_direct_without_probing() {
+        let (kind, fact) = classify(&DaemonMode::Oneshot, || {
+            panic!("oneshot must never probe the bus")
+        });
+        assert_eq!(kind, BackendKind::DirectByConfig);
+        assert_eq!(fact.value, DaemonReachability::NotProbed);
+        assert_eq!(fact.provenance, Provenance::Claimed);
+    }
+
+    #[test]
+    fn daemon_mode_with_owner_selects_daemon() {
+        let (kind, fact) = classify(&DaemonMode::Daemon, || true);
+        assert_eq!(kind, BackendKind::Daemon);
+        assert_eq!(fact.value, DaemonReachability::Reachable);
+        assert_eq!(fact.provenance, Provenance::Probed);
+    }
+
+    #[test]
+    fn daemon_mode_without_owner_is_fallback_not_config() {
+        let (kind, fact) = classify(&DaemonMode::Daemon, || false);
+        assert_eq!(kind, BackendKind::DirectByFallback);
+        assert_eq!(fact.value, DaemonReachability::Unreachable);
+        assert_eq!(fact.provenance, Provenance::Probed);
+    }
+
+    /// Three kinds, three treatments: normal operation and an expected
+    /// configuration stay quiet at DEBUG; only the degraded fallback WARNs
+    /// and tells the human.
+    #[test]
+    fn announcement_levels_and_messages() {
+        let (level, msg) = announcement(BackendKind::Daemon);
+        assert_eq!(level, tracing::Level::DEBUG);
+        assert_eq!(msg, None);
+
+        let (level, msg) = announcement(BackendKind::DirectByConfig);
+        assert_eq!(level, tracing::Level::DEBUG);
+        assert_eq!(msg, None);
+
+        let (level, msg) = announcement(BackendKind::DirectByFallback);
+        assert_eq!(level, tracing::Level::WARN);
+        assert_eq!(msg, Some(UserMessage::DaemonUnreachableFallback));
+    }
+
+    #[test]
+    fn caps_state_the_transport_differences_up_front() {
+        let config = oneshot_config("/nonexistent/facelock.db");
+        let backend = Backend::select(&config);
+        assert!(backend.kind().is_direct());
+        let caps = backend.caps();
+        assert!(!caps.graphical_preview);
+        assert!(caps.device_formats);
+
+        // The daemon caps are the mirror image (constructed directly — no
+        // bus in unit tests).
+        let daemon = Backend {
+            kind: BackendKind::Daemon,
+            config: &config,
+        };
+        assert!(!daemon.kind().is_direct());
+        let caps = daemon.caps();
+        assert!(caps.graphical_preview);
+        assert!(!caps.device_formats);
+    }
+
+    // -----------------------------------------------------------------------
+    // Daemon reply interpretation (C4 pins, moved here with the fork: these
+    // lived in clear.rs as daemon_user_has_models tests).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn daemon_transport_failure_propagates() {
+        let err = models_reply(Err(anyhow::anyhow!("D-Bus timeout"))).unwrap_err();
+        assert!(format!("{err:#}").contains("D-Bus timeout"));
+    }
+
+    #[test]
+    fn daemon_error_reply_propagates() {
+        let err = models_reply(Ok(DaemonResponse::Error {
+            message: "storage error: disk I/O error".into(),
+        }))
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("storage error"));
+    }
+
+    #[test]
+    fn daemon_unexpected_reply_propagates() {
+        let err = models_reply(Ok(DaemonResponse::Ok)).unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+
+        let err = removed_reply(Ok(DaemonResponse::Ok)).unwrap_err();
+        assert!(format!("{err:#}").contains("unexpected response"));
+    }
+
+    #[test]
+    fn daemon_model_lists_map_to_bool() {
+        assert!(
+            models_reply(Ok(DaemonResponse::Models(vec![])))
+                .unwrap()
+                .is_empty()
+        );
+        let model = FaceModelInfo {
+            id: 1,
+            user: "alice".into(),
+            label: "front".into(),
+            created_at: 0,
+            embedder_model: String::new(),
+            device_id: None,
+        };
+        assert_eq!(
+            models_reply(Ok(DaemonResponse::Models(vec![model])))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Direct reads: the C4/C7 failure policy, uniform across operations.
+    // `mode = "oneshot"` pins DirectByConfig without touching D-Bus.
+    // -----------------------------------------------------------------------
+
+    fn oneshot_config(db_path: &str) -> Config {
+        let mut config = Config::parse("[daemon]\nmode = \"oneshot\"\n").expect("config parses");
+        config.storage.db_path = db_path.to_string();
+        config
+    }
+
+    fn oneshot_config_at(db_path: &Path) -> Config {
+        oneshot_config(&db_path.to_string_lossy())
+    }
+
+    /// C4/C7, direct: a fresh (absent) store answers benign reads as values
+    /// — and the probe must not create the database it reports empty.
+    #[test]
+    fn absent_store_reads_are_benign_and_create_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let config = oneshot_config_at(&db_path);
+        let backend = Backend::select(&config);
+
+        assert!(!backend.has_models("alice").unwrap());
+        assert!(
+            !backend
+                .has_models_for_embedder("alice", "embedder")
+                .unwrap()
+        );
+        assert!(backend.list_models("alice").unwrap().is_empty());
+        assert_eq!(backend.remove_model("alice", 3).unwrap(), Some(false));
+        assert!(
+            !db_path.exists(),
+            "benign reads must not create the database they report empty"
+        );
+    }
+
+    /// C4, direct: an unreadable (present) store is an error on every read —
+    /// never "no models", never "assume yes".
+    #[test]
+    fn unreadable_store_propagates_on_every_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
+        let config = oneshot_config_at(&db_path);
+        let backend = Backend::select(&config);
+
+        assert!(backend.has_models("alice").is_err());
+        assert!(backend.has_models_for_embedder("alice", "e").is_err());
+        assert!(backend.list_models("alice").is_err());
+        assert!(backend.remove_model("alice", 1).is_err());
+        assert!(backend.clear_models("alice").is_err());
+    }
+
+    /// The direct fork, end to end against a real store: one representative
+    /// per-operation behavioral pin.
+    #[test]
+    fn direct_operations_answer_from_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "embedder-a")
+                .unwrap();
+            store
+                .add_model("alice", "side", &[0.4f32; 512], "embedder-b")
+                .unwrap();
+        }
+        let config = oneshot_config_at(&db_path);
+        let backend = Backend::select(&config);
+
+        assert!(backend.has_models("alice").unwrap());
+        assert!(!backend.has_models("bob").unwrap());
+        assert!(
+            backend
+                .has_models_for_embedder("alice", "embedder-a")
+                .unwrap()
+        );
+        assert!(
+            !backend
+                .has_models_for_embedder("alice", "embedder-c")
+                .unwrap()
+        );
+        assert_eq!(backend.list_models("alice").unwrap().len(), 2);
+
+        let removed = backend.remove_model("alice", 1).unwrap();
+        assert_eq!(removed, Some(true));
+        assert_eq!(backend.remove_model("alice", 99).unwrap(), Some(false));
+
+        assert_eq!(backend.clear_models("alice").unwrap(), Some(1));
+        assert!(!backend.has_models("alice").unwrap());
+    }
+
+    // -----------------------------------------------------------------------
+    // Structural pins (source scan, same discipline as resolved.rs): the
+    // boolean fork stays deleted, and the daemon transport entry points stay
+    // single-sited.
+    // -----------------------------------------------------------------------
+
+    fn source_files() -> Vec<(std::path::PathBuf, String)> {
+        fn walk(dir: &Path, out: &mut Vec<(std::path::PathBuf, String)>) {
+            for entry in std::fs::read_dir(dir).unwrap().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let content = std::fs::read_to_string(&path).unwrap();
+                    out.push((path, content));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(&Path::new(env!("CARGO_MANIFEST_DIR")).join("src"), &mut out);
+        out
+    }
+
+    fn code_contains(content: &str, needle: &str) -> bool {
+        content
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .any(|l| l.contains(needle))
+    }
+
+    /// The 13-site boolean fork (`should_use_direct`) is gone and must stay
+    /// gone: transport is selected once, here.
+    #[test]
+    fn the_boolean_fork_stays_deleted() {
+        // Assembled at runtime so this test's own literal doesn't count.
+        let needle = format!("should_use_{}", "direct");
+        for (path, content) in source_files() {
+            assert!(
+                !code_contains(&content, &needle),
+                "{}: `{needle}` reappeared — transport is selected once via \
+                 backend::Backend::select, not per call site (D1)",
+                path.display()
+            );
+        }
+    }
+
+    /// Daemon transport entry points appear only at the allowed sites. A new
+    /// `send_request` call site outside the seam is a per-site fork trying to
+    /// come back.
+    #[test]
+    fn daemon_transport_entry_points_are_single_sited() {
+        let allowed_send_request = [
+            "ipc_client.rs",                       // the definition
+            "backend.rs",                          // the seam (this module)
+            "commands/status.rs",                  // its own Ping probe until H8
+            "commands/preview/text_only.rs",       // daemon frame loop
+            "commands/preview/wayland_preview.rs", // daemon frame loop
+            "resolved.rs",                         // token literal in its own pin test
+        ];
+        let allowed_send_enroll = ["ipc_client.rs", "backend.rs"];
+
+        for (path, content) in source_files() {
+            let rel = path
+                .to_string_lossy()
+                .split("/src/")
+                .last()
+                .unwrap()
+                .to_string();
+            if code_contains(&content, "send_request(") {
+                assert!(
+                    allowed_send_request.iter().any(|a| rel == *a),
+                    "{rel}: send_request( outside the backend seam — route the \
+                     operation through backend::Backend (D1)"
+                );
+            }
+            if code_contains(&content, "send_enroll(") {
+                assert!(
+                    allowed_send_enroll.iter().any(|a| rel == *a),
+                    "{rel}: send_enroll( outside the backend seam — route \
+                     enrollment through backend::Backend::enroll (D1)"
+                );
+            }
+        }
+    }
+}

--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -1,7 +1,6 @@
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
-use facelock_store::StoreError;
 
+use crate::backend::Backend;
 use crate::ipc_client;
 use crate::message::{Terminal, UserMessage};
 
@@ -12,17 +11,16 @@ pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<(
 
     let user = ipc_client::resolve_user(user.as_deref());
 
+    // One selection for the whole command (D1): the old code probed the bus
+    // here and again after the unbounded confirmation prompt below, so the
+    // transport could flip between the check and the deletion.
+    let backend = Backend::select(config);
+
     // Check if user has any models before prompting. One failure policy (C4,
-    // issue #105): a failed check propagates. The old D-Bus branch folded any
-    // failure into "no models enrolled" and exited 0 having deleted nothing,
-    // while the direct branch on the identical failure proceeded to delete.
-    let has_models = if ipc_client::should_use_direct(config) {
-        direct_user_has_models(config, &user)?
-    } else {
-        let request = DaemonRequest::ListModels { user: user.clone() };
-        daemon_user_has_models(ipc_client::send_request(&request))?
-    };
-    if !has_models {
+    // issue #105), now owned by the backend seam: a failed check propagates —
+    // never "no models enrolled", never "assume yes and prompt anyway" — and
+    // a provably absent database reads as "no models" without being created.
+    if !backend.has_models(&user)? {
         Terminal.info(&UserMessage::NoModelsEnrolled { user: user.clone() });
         return Ok(());
     }
@@ -35,156 +33,17 @@ pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<(
         }
     }
 
-    if ipc_client::should_use_direct(config) {
-        // `open_store_existing`: has_models above just proved the database is
-        // there. If it vanished since, deleting has nothing to do — erroring
-        // beats re-creating an empty database in its place.
-        let store = crate::direct::open_store_existing(config)?;
-        let count = store
-            .clear_user(&user)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        Terminal.info(&UserMessage::ClearedModels {
-            count: count as usize,
+    match backend.clear_models(&user)? {
+        // The direct backend counted what it deleted; the daemon reply
+        // cannot carry a count (wire-stable), so the message differs.
+        Some(count) => Terminal.info(&UserMessage::ClearedModels {
+            count,
             user: user.clone(),
-        });
-        // The user has no models by construction, so drop the marker outright.
-        super::enrollment_marker::forget(config, &user);
-        return Ok(());
+        }),
+        None => Terminal.info(&UserMessage::AllModelsRemoved { user: user.clone() }),
     }
 
-    let request = DaemonRequest::ClearModels { user: user.clone() };
-
-    let response = ipc_client::send_request(&request)?;
-
-    match response {
-        DaemonResponse::Removed => {
-            Terminal.info(&UserMessage::AllModelsRemoved { user: user.clone() });
-            super::enrollment_marker::forget(config, &user);
-        }
-        other => {
-            anyhow::bail!("unexpected response from daemon: {other:?}");
-        }
-    }
-
+    // The user has no models by construction, so drop the marker outright.
+    super::enrollment_marker::forget(config, &user);
     Ok(())
-}
-
-/// Direct-transport half of the pre-prompt check: a store that cannot be
-/// opened or queried is an error, never "no models" and never "assume yes and
-/// prompt anyway". [`StoreError::Absent`] alone reads as "no models" — a
-/// fresh install has provably nothing to delete, and the probe must not
-/// create the database it is about to report empty.
-fn direct_user_has_models(config: &Config, user: &str) -> anyhow::Result<bool> {
-    let store = match crate::direct::open_store_existing(config) {
-        Ok(store) => store,
-        Err(StoreError::Absent { .. }) => return Ok(false),
-        Err(e) => return Err(e.into()),
-    };
-    store
-        .has_models(user)
-        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-}
-
-/// Interpret the daemon's `ListModels` reply as "does the user have models".
-/// Transport failures and error replies propagate (C4) — they must never read
-/// as "no models enrolled".
-fn daemon_user_has_models(response: anyhow::Result<DaemonResponse>) -> anyhow::Result<bool> {
-    match response? {
-        DaemonResponse::Models(m) => Ok(!m.is_empty()),
-        DaemonResponse::Error { message } => anyhow::bail!("daemon error: {message}"),
-        other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::Path;
-
-    fn config_with_db(db_path: &Path) -> Config {
-        let mut config = Config::parse("").expect("defaults parse");
-        config.storage.db_path = db_path.to_string_lossy().into_owned();
-        config
-    }
-
-    /// C4, D-Bus transport: a transport failure must propagate, not read as
-    /// "no models enrolled" (which printed success and deleted nothing).
-    #[test]
-    fn daemon_transport_failure_propagates() {
-        let err = daemon_user_has_models(Err(anyhow::anyhow!("D-Bus timeout"))).unwrap_err();
-        assert!(format!("{err:#}").contains("D-Bus timeout"));
-    }
-
-    /// C4, D-Bus transport: an explicit daemon error reply is an error too.
-    #[test]
-    fn daemon_error_reply_propagates() {
-        let err = daemon_user_has_models(Ok(DaemonResponse::Error {
-            message: "storage error: disk I/O error".into(),
-        }))
-        .unwrap_err();
-        assert!(format!("{err:#}").contains("storage error"));
-    }
-
-    #[test]
-    fn daemon_unexpected_reply_propagates() {
-        let err = daemon_user_has_models(Ok(DaemonResponse::Ok)).unwrap_err();
-        assert!(format!("{err:#}").contains("unexpected response"));
-    }
-
-    #[test]
-    fn daemon_model_lists_map_to_bool() {
-        assert!(!daemon_user_has_models(Ok(DaemonResponse::Models(vec![]))).unwrap());
-        let model = facelock_core::types::FaceModelInfo {
-            id: 1,
-            user: "alice".into(),
-            label: "front".into(),
-            created_at: 0,
-            embedder_model: String::new(),
-            device_id: None,
-        };
-        assert!(daemon_user_has_models(Ok(DaemonResponse::Models(vec![model]))).unwrap());
-    }
-
-    /// C4, direct transport: an unreadable store must propagate as an error,
-    /// not assume-yes (the old behavior prompted the user for a deletion that
-    /// was doomed to fail).
-    #[test]
-    fn direct_unreadable_store_propagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("facelock.db");
-        std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
-
-        assert!(direct_user_has_models(&config_with_db(&db_path), "alice").is_err());
-    }
-
-    /// The `Absent` variant reads as "no models" without creating anything:
-    /// before the typed error, this probe ran as root and left an empty
-    /// database at the path as a side effect of finding nothing to delete.
-    #[test]
-    fn direct_absent_store_reads_as_no_models_without_creating() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("facelock.db");
-
-        assert!(!direct_user_has_models(&config_with_db(&db_path), "alice").unwrap());
-        assert!(
-            !db_path.exists(),
-            "the pre-prompt probe must not create the database it reports empty"
-        );
-    }
-
-    #[test]
-    fn direct_healthy_store_maps_to_bool() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("facelock.db");
-        {
-            let store = facelock_store::FaceStore::create(&db_path).unwrap();
-            store
-                .add_model("alice", "front", &[0.5f32; 512], "embedder")
-                .unwrap();
-        }
-
-        let config = config_with_db(&db_path);
-        assert!(direct_user_has_models(&config, "alice").unwrap());
-        assert!(!direct_user_has_models(&config, "bob").unwrap());
-    }
 }

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -1,67 +1,54 @@
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
+use crate::backend::Backend;
 use crate::ipc_client;
 
 pub fn run(config: &Config) -> anyhow::Result<()> {
     // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
     ipc_client::require_root("sudo facelock devices")?;
 
-    if ipc_client::should_use_direct(config) {
-        return crate::direct::list_devices_direct();
+    // One selection, one enumeration (D1); both transports render here. The
+    // renderers used to live twice — this one and a direct copy that printed
+    // its own loop.
+    let backend = Backend::select(config);
+    let devices = backend.list_devices()?;
+
+    if devices.is_empty() {
+        println!("No video devices found.");
+        println!("Check that your camera is connected and the v4l2 module is loaded.");
+        return Ok(());
     }
 
-    // Only blame a missing daemon when the request wasn't refused: an
-    // AccessDenied already carries the group-membership hint as its headline.
-    let response = ipc_client::send_request(&DaemonRequest::ListDevices).map_err(|e| {
-        if ipc_client::is_access_denied(&e) {
-            e
-        } else {
-            e.context("failed to query daemon — is facelock-daemon running?")
-        }
-    })?;
+    // Format detail is a direct-only capability (the D-Bus DeviceInfo does
+    // not carry it) — stated by the caps instead of silently printing
+    // nothing.
+    let show_formats = backend.caps().device_formats;
 
-    match response {
-        DaemonResponse::Devices(devices) => {
-            if devices.is_empty() {
-                println!("No video devices found.");
-                println!("Check that your camera is connected and the v4l2 module is loaded.");
-                return Ok(());
-            }
+    println!("Available video devices:\n");
+    for dev in &devices {
+        let ir_tag = if dev.is_ir { " [IR]" } else { "" };
+        println!("  {}{ir_tag}", dev.path);
+        println!("    Name:    {}", dev.name);
+        println!("    Driver:  {}", dev.driver);
 
-            println!("Available video devices:\n");
-            for dev in &devices {
-                let ir_tag = if dev.is_ir { " [IR]" } else { "" };
-                println!("  {}{ir_tag}", dev.path);
-                println!("    Name:    {}", dev.name);
-                println!("    Driver:  {}", dev.driver);
-
-                if !dev.formats.is_empty() {
-                    println!("    Formats:");
-                    for fmt in &dev.formats {
-                        let sizes: Vec<String> =
-                            fmt.sizes.iter().map(|(w, h)| format!("{w}x{h}")).collect();
-                        println!(
-                            "      {} ({}) — {}",
-                            fmt.fourcc.trim(),
-                            fmt.description,
-                            if sizes.is_empty() {
-                                "no sizes reported".to_string()
-                            } else {
-                                sizes.join(", ")
-                            }
-                        );
+        if show_formats && !dev.formats.is_empty() {
+            println!("    Formats:");
+            for fmt in &dev.formats {
+                let sizes: Vec<String> =
+                    fmt.sizes.iter().map(|(w, h)| format!("{w}x{h}")).collect();
+                println!(
+                    "      {} ({}) — {}",
+                    fmt.fourcc.trim(),
+                    fmt.description,
+                    if sizes.is_empty() {
+                        "no sizes reported".to_string()
+                    } else {
+                        sizes.join(", ")
                     }
-                }
-                println!();
+                );
             }
         }
-        DaemonResponse::Error { message } => {
-            anyhow::bail!("daemon error: {message}");
-        }
-        _ => {
-            anyhow::bail!("unexpected response from daemon");
-        }
+        println!();
     }
 
     Ok(())
@@ -69,5 +56,6 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    // Device listing requires hardware or a running daemon.
+    // Device listing requires hardware or a running daemon; the transport
+    // fork and its failure policy are pinned in `crate::backend`.
 }

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -1,10 +1,8 @@
 use chrono::Local;
 
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
-use facelock_core::types::FaceModelInfo;
-use facelock_store::StoreError;
 
+use crate::backend::Backend;
 use crate::ipc_client;
 use crate::message::{Terminal, UserMessage, fail};
 
@@ -61,35 +59,33 @@ pub fn run(
 
     let user = ipc_client::resolve_user(user.as_deref());
 
+    // One selection for the whole enrollment (D1). The probe is
+    // `name_has_owner`, which never triggers D-Bus activation — the old
+    // per-site convention this replaces existed because an unconditional
+    // D-Bus call here would *activate* the daemon and silently flip the
+    // subsequent enrollment from direct to daemon mode (issue #89 validation
+    // fallout). Now the transport cannot change between the label scan and
+    // the enrollment.
+    let backend = Backend::select(config);
+
     let label = match label {
         Some(label) => label,
         None => {
             let date = Local::now().format("%Y-%m-%d").to_string();
-            next_label(&date, &user, config)?
+            next_label(&date, &user, &backend)?
         }
     };
 
     // Warn if existing models use a different embedder than currently
-    // configured. One failure policy (C4, issue #105): a store or daemon
-    // failure propagates instead of silently skipping the warning — the
-    // enrollment ahead needs the very store this check just failed to read.
+    // configured. One failure policy (C4, issue #105), owned by the seam: a
+    // store or daemon failure propagates instead of silently skipping the
+    // warning — the enrollment ahead needs the very store this check just
+    // failed to read. A provably absent store reads as "no models, nothing
+    // stale" without being created.
     {
         let config_embedder = &config.recognition.embedder_model;
-        let has_stale = if ipc_client::should_use_direct(config) {
-            direct_has_stale_embedder(config, &user, config_embedder)?
-        } else {
-            let request = DaemonRequest::ListModels { user: user.clone() };
-            match ipc_client::send_request(&request)? {
-                DaemonResponse::Models(m) => {
-                    !m.is_empty()
-                        && !m
-                            .iter()
-                            .any(|model| model.embedder_model == *config_embedder)
-                }
-                DaemonResponse::Error { message } => anyhow::bail!("daemon error: {message}"),
-                other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-            }
-        };
+        let has_stale = backend.has_models(&user)?
+            && !backend.has_models_for_embedder(&user, config_embedder)?;
         if has_stale {
             Terminal.info(&UserMessage::StaleEmbedderNote {
                 embedder: config_embedder.clone(),
@@ -103,93 +99,27 @@ pub fn run(
     });
     Terminal.info(&UserMessage::EnrollLookAtCamera);
 
-    if ipc_client::should_use_direct(config) {
-        ipc_client::require_root("sudo facelock enroll")?;
-        let (model_id, embedding_count) = crate::direct::enroll(config, &user, &label)?;
-        Terminal.info(&UserMessage::EnrollComplete {
-            model_id,
-            count: embedding_count,
-            label: label.clone(),
-        });
-        super::enrollment_marker::refresh(config, &user);
-        check_model_count(&user, config);
-        return Ok(());
-    }
+    let (model_id, embedding_count) = backend.enroll(&user, &label)?;
 
-    // Dedicated call with a timeout derived from the daemon's enrollment
-    // deadline — the shared 15s proxy would abort mid-enrollment (issue #89).
-    // send_enroll yields Enrolled or an error, so there is no other arm.
-    let response = ipc_client::send_enroll(&user, &label, config)?;
-
-    if let DaemonResponse::Enrolled {
+    Terminal.info(&UserMessage::EnrollComplete {
         model_id,
-        embedding_count,
-    } = response
-    {
-        Terminal.info(&UserMessage::EnrollComplete {
-            model_id,
-            count: embedding_count,
-            label: label.clone(),
-        });
-        super::enrollment_marker::refresh(config, &user);
-        check_model_count(&user, config);
-    }
+        count: embedding_count,
+        label: label.clone(),
+    });
+    super::enrollment_marker::refresh(&backend, config, &user);
+    check_model_count(&user, &backend);
 
     Ok(())
 }
 
-/// List a user's models, honoring direct mode. Unlike a bare `send_request`,
-/// this never touches D-Bus in direct mode — an unconditional D-Bus call here
-/// would *activate* the system daemon and silently flip the subsequent
-/// enrollment from direct to daemon mode (issue #89 validation fallout).
-///
-/// One failure policy (C4, issue #105): failures propagate; they must not
-/// read as "this user has no models".
-fn list_user_models(user: &str, config: &Config) -> anyhow::Result<Vec<FaceModelInfo>> {
-    if ipc_client::should_use_direct(config) {
-        let store = match crate::direct::open_store_existing(config) {
-            Ok(store) => store,
-            // Fresh install: no models yet. Picking the first free label must
-            // not create the database enrollment itself is about to create.
-            Err(StoreError::Absent { .. }) => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
-        };
-        store
-            .list_models(user)
-            .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-    } else {
-        match ipc_client::send_request(&DaemonRequest::ListModels {
-            user: user.to_string(),
-        })? {
-            DaemonResponse::Models(models) => Ok(models),
-            DaemonResponse::Error { message } => anyhow::bail!("daemon error: {message}"),
-            other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-        }
-    }
-}
-
-/// Direct-transport half of the stale-embedder warning. [`StoreError::Absent`]
-/// reads as "no models, nothing stale" without creating the database; any
-/// other failure class propagates (C4) — the enrollment ahead needs the very
-/// store this check just failed to read.
-fn direct_has_stale_embedder(config: &Config, user: &str, embedder: &str) -> anyhow::Result<bool> {
-    let store = match crate::direct::open_store_existing(config) {
-        Ok(store) => store,
-        Err(StoreError::Absent { .. }) => return Ok(false),
-        Err(e) => return Err(e.into()),
-    };
-    let has_any = store
-        .has_models(user)
-        .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
-    let has_matching = store
-        .has_models_for_embedder(user, embedder)
-        .map_err(|e| anyhow::anyhow!("storage error: {e}"))?;
-    Ok(has_any && !has_matching)
-}
-
 /// Generate the next available label like "2026-03-15-1", "2026-03-15-2", etc.
-fn next_label(date_prefix: &str, user: &str, config: &Config) -> anyhow::Result<String> {
-    let max_suffix = list_user_models(user, config)?
+///
+/// One failure policy (C4, issue #105): a store failure while picking the
+/// label propagates via the seam; it must not silently fall back to a "-1"
+/// suffix.
+fn next_label(date_prefix: &str, user: &str, backend: &Backend) -> anyhow::Result<String> {
+    let max_suffix = backend
+        .list_models(user)?
         .iter()
         .filter_map(|m| {
             m.label
@@ -203,11 +133,11 @@ fn next_label(date_prefix: &str, user: &str, config: &Config) -> anyhow::Result<
     Ok(format!("{date_prefix}-{}", max_suffix + 1))
 }
 
-fn check_model_count(user: &str, config: &Config) {
+fn check_model_count(user: &str, backend: &Backend) {
     // Post-success advisory only: the enrollment already committed, so a
     // failed count here must not turn a successful enrollment into a
     // reported failure.
-    if let Ok(models) = list_user_models(user, config) {
+    if let Ok(models) = backend.list_models(user) {
         if models.len() > 5 {
             Terminal.info(&UserMessage::TooManyModels {
                 user: user.to_string(),
@@ -222,7 +152,8 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    /// `mode = "oneshot"` pins `should_use_direct` without touching D-Bus.
+    /// `mode = "oneshot"` pins a DirectByConfig selection without touching
+    /// D-Bus.
     fn oneshot_config_with_db(db_path: &Path) -> Config {
         let mut config = Config::parse("[daemon]\nmode = \"oneshot\"\n").expect("config parses");
         config.storage.db_path = db_path.to_string_lossy().into_owned();
@@ -237,10 +168,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("facelock.db");
         let config = oneshot_config_with_db(&db_path);
+        let backend = Backend::select(&config);
 
-        assert!(!direct_has_stale_embedder(&config, "alice", "embedder").unwrap());
+        let has_stale = backend.has_models("alice").unwrap()
+            && !backend
+                .has_models_for_embedder("alice", "embedder")
+                .unwrap();
+        assert!(!has_stale);
         assert_eq!(
-            next_label("2026-08-13", "alice", &config).unwrap(),
+            next_label("2026-08-13", "alice", &backend).unwrap(),
             "2026-08-13-1"
         );
         assert!(
@@ -258,7 +194,8 @@ mod tests {
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
 
         let config = oneshot_config_with_db(&db_path);
-        assert!(direct_has_stale_embedder(&config, "alice", "embedder").is_err());
+        let backend = Backend::select(&config);
+        assert!(backend.has_models("alice").is_err());
     }
 
     /// C4: a store failure while picking the next label propagates — it must
@@ -270,7 +207,8 @@ mod tests {
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
 
         let config = oneshot_config_with_db(&db_path);
-        assert!(next_label("2026-08-13", "alice", &config).is_err());
+        let backend = Backend::select(&config);
+        assert!(next_label("2026-08-13", "alice", &backend).is_err());
     }
 
     #[test]
@@ -289,17 +227,18 @@ mod tests {
         }
 
         let config = oneshot_config_with_db(&db_path);
+        let backend = Backend::select(&config);
         assert_eq!(
-            next_label("2026-08-13", "alice", &config).unwrap(),
+            next_label("2026-08-13", "alice", &backend).unwrap(),
             "2026-08-13-3"
         );
         // A fresh prefix (or user) starts at -1.
         assert_eq!(
-            next_label("2026-08-14", "alice", &config).unwrap(),
+            next_label("2026-08-14", "alice", &backend).unwrap(),
             "2026-08-14-1"
         );
         assert_eq!(
-            next_label("2026-08-13", "bob", &config).unwrap(),
+            next_label("2026-08-13", "bob", &backend).unwrap(),
             "2026-08-13-1"
         );
     }

--- a/crates/facelock-cli/src/commands/enrollment_marker.rs
+++ b/crates/facelock-cli/src/commands/enrollment_marker.rs
@@ -38,9 +38,6 @@ use serde::{Deserialize, Serialize};
 
 use facelock_core::Config;
 use facelock_core::fs_security::{ensure_private_dir, write_file};
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
-
-use crate::ipc_client;
 
 /// Fallback marker directory when the configured DB path yields no parent.
 pub const DEFAULT_MARKER_DIR: &str = "/var/lib/facelock/enrolled";
@@ -271,10 +268,10 @@ pub fn set_marker_in(
 /// Best-effort by contract: a marker is only a UI hint, so a failure here is
 /// logged and swallowed rather than failing the enroll/remove that triggered it.
 ///
-/// Uses whichever transport the calling command is already using — it may talk
-/// to the daemon. **Never call this from `is-enrolled`.**
-pub fn refresh(config: &Config, user: &str) {
-    let Some(models) = count_models(config, user) else {
+/// Uses the backend the calling command already selected — it may talk to the
+/// daemon. **Never call this from `is-enrolled`.**
+pub fn refresh(backend: &crate::backend::Backend, config: &Config, user: &str) {
+    let Some(models) = count_models(backend, user) else {
         tracing::warn!(
             user,
             "could not read model count; enrollment marker not updated"
@@ -306,25 +303,12 @@ pub fn forget(config: &Config, user: &str) {
     }
 }
 
-/// Count a user's stored models, honoring direct vs daemon mode.
+/// Count a user's stored models through the caller's selected backend.
 ///
 /// Returns `None` when the count could not be determined — the caller then
 /// leaves the existing marker alone rather than guessing.
-fn count_models(config: &Config, user: &str) -> Option<u32> {
-    if ipc_client::should_use_direct(config) {
-        crate::direct::open_store(config)
-            .ok()?
-            .list_models(user)
-            .ok()
-            .map(|m| m.len() as u32)
-    } else {
-        match ipc_client::send_request(&DaemonRequest::ListModels {
-            user: user.to_string(),
-        }) {
-            Ok(DaemonResponse::Models(models)) => Some(models.len() as u32),
-            _ => None,
-        }
-    }
+fn count_models(backend: &crate::backend::Backend, user: &str) -> Option<u32> {
+    backend.list_models(user).ok().map(|m| m.len() as u32)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/facelock-cli/src/commands/is_enrolled.rs
+++ b/crates/facelock-cli/src/commands/is_enrolled.rs
@@ -45,7 +45,7 @@
 //! why `list --json` cannot be reused: `commands::list` tries daemon IPC
 //! first, which *activates* the system daemon. Nothing in this module may call
 //! [`crate::ipc_client::send_request`],
-//! [`crate::ipc_client::should_use_direct`] (it probes the system bus), or
+//! [`crate::backend::Backend::select`] (it probes the system bus), or
 //! [`crate::direct::open_store`] or [`crate::direct::open_store_existing`].
 //!
 //! The only syscalls on the hot path are: read `/etc/facelock/config.toml` (for
@@ -208,7 +208,7 @@ mod tests {
 
     /// `is-enrolled` must answer from the marker alone: no database, no D-Bus.
     /// The database path here does not exist, and
-    /// `should_use_direct`/`send_request` are never on this call path.
+    /// `Backend::select`/`send_request` are never on this call path.
     #[test]
     fn answers_without_a_database() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -1,22 +1,25 @@
 use chrono::{Local, TimeZone};
 
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 use facelock_core::types::FaceModelInfo;
 
+use crate::backend::Backend;
 use crate::ipc_client;
 
 pub fn run(config: &Config, user: Option<String>, json: bool) -> anyhow::Result<()> {
     // DEC-6/N4: `ListModels` is root-only now (was facelock-group). The
-    // direct-mode fallback in `fetch_models` already required root when the
-    // 0600 root:root database wasn't readable; checking up front here gives
-    // the same interactive escalation prompt on the D-Bus path too, instead
-    // of a bare AccessDenied.
+    // direct fallback needs read access to the 0600 root:root database;
+    // checking up front here gives the same interactive escalation prompt on
+    // the D-Bus path too, instead of a bare AccessDenied.
     ipc_client::require_root("sudo facelock list")?;
 
     let user = ipc_client::resolve_user(user.as_deref());
 
-    let models = fetch_models(config, &user)?;
+    // One selection, one list operation (D1). The seam's direct read opens
+    // the existing store — a fresh install lists as empty without an empty
+    // database materializing at the path as a side effect.
+    let backend = Backend::select(config);
+    let models = backend.list_models(&user)?;
 
     if json {
         print_json(&models);
@@ -25,24 +28,6 @@ pub fn run(config: &Config, user: Option<String>, json: bool) -> anyhow::Result<
     }
 
     Ok(())
-}
-
-fn fetch_models(config: &Config, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
-    // Try D-Bus first — `run` already required root above.
-    if !ipc_client::should_use_direct(config) {
-        let request = DaemonRequest::ListModels {
-            user: user.to_string(),
-        };
-        let response = ipc_client::send_request(&request)?;
-        return match response {
-            DaemonResponse::Models(models) => Ok(models),
-            other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-        };
-    }
-
-    // Direct mode: needs read access to the 0600 root:root database.
-    let store = crate::direct::open_store(config)?;
-    store.list_models(user).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 fn print_table(user: &str, models: &[FaceModelInfo]) {

--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -6,7 +6,9 @@ mod wayland_preview;
 
 use facelock_core::Config;
 
+use crate::backend::{Backend, BackendKind};
 use crate::ipc_client;
+use crate::message::{Terminal, UserMessage};
 
 pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Result<()> {
     // DEC-6/N13: `PreviewDetectFrame` is root-only now — it was the last
@@ -19,12 +21,16 @@ pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Re
     // to *root*, so the preview never recognized the actual user.
     let user = ipc_client::resolve_user(user.as_deref());
 
-    if ipc_client::should_use_direct(config) {
+    let backend = Backend::select(config);
+
+    if !backend.caps().graphical_preview {
+        // A direct backend has only the local text preview — a capability
+        // stated by the selection, not discovered at a failure site. Why it
+        // is unavailable depends on the kind: a stopped daemon is a degraded
+        // state, not a configuration choice (the old single message blamed
+        // "oneshot mode" for both).
         if !text_only {
-            eprintln!(
-                "Graphical preview requires the daemon. In oneshot mode, use --text-only.\n\
-                 Falling back to text-only mode.\n"
-            );
+            Terminal.error(&graphical_unavailable_message(backend.kind()));
         }
         return text_only::run_direct(config, &user);
     }
@@ -34,6 +40,15 @@ pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Re
     }
 
     run_graphical(&user)
+}
+
+/// Why graphical preview is unavailable on a direct backend, accurately per
+/// kind.
+fn graphical_unavailable_message(kind: BackendKind) -> UserMessage {
+    match kind {
+        BackendKind::DirectByFallback => UserMessage::PreviewGraphicalDaemonUnreachable,
+        _ => UserMessage::PreviewGraphicalNeedsDaemonOneshot,
+    }
 }
 
 #[cfg(feature = "wayland")]
@@ -62,6 +77,24 @@ fn run_graphical(user: &str) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// The misattribution pin (D1): a *stopped* daemon must render the
+    /// degraded fallback message, never the "configured off" oneshot wording
+    /// — the old single message told users with a crashed daemon that they
+    /// had chosen oneshot mode.
+    #[test]
+    fn stopped_daemon_is_not_blamed_on_configuration() {
+        assert_eq!(
+            graphical_unavailable_message(BackendKind::DirectByFallback),
+            UserMessage::PreviewGraphicalDaemonUnreachable
+        );
+        assert_eq!(
+            graphical_unavailable_message(BackendKind::DirectByConfig),
+            UserMessage::PreviewGraphicalNeedsDaemonOneshot
+        );
+    }
+
     /// C5 (issue #105): preview resolves its user through the one shared
     /// resolver, whose precedence honors SUDO_USER — the deleted local
     /// implementation used getpwuid only, so `sudo facelock preview`

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -1,6 +1,6 @@
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
+use crate::backend::Backend;
 use crate::ipc_client;
 use crate::message::{Terminal, UserMessage};
 
@@ -13,6 +13,9 @@ pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> a
 
     let user = ipc_client::resolve_user(user.as_deref());
 
+    // One selection for the whole command (D1), before the unbounded prompt.
+    let backend = Backend::select(config);
+
     if !yes {
         let confirmed = Terminal.confirm(&UserMessage::ConfirmRemoveModel {
             model_id,
@@ -24,51 +27,20 @@ pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> a
         }
     }
 
-    if ipc_client::should_use_direct(config) {
-        let store = crate::direct::open_store(config)?;
-        let removed = store
-            .remove_model(&user, model_id)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        if removed {
-            Terminal.info(&UserMessage::RemovedModel {
-                model_id,
-                user: user.clone(),
-            });
-        } else {
-            Terminal.info(&UserMessage::ModelNotFound {
-                model_id,
-                user: user.clone(),
-            });
-        }
-        // Recompute from the list we already have open rather than decrementing:
-        // same cost, and it cannot drift from the database.
-        let remaining = store.list_models(&user).ok().map(|m| m.len() as u32);
-        drop(store);
-        if let Some(remaining) = remaining {
-            super::enrollment_marker::set(config, &user, remaining);
-        }
-        return Ok(());
+    match backend.remove_model(&user, model_id)? {
+        Some(false) => Terminal.info(&UserMessage::ModelNotFound {
+            model_id,
+            user: user.clone(),
+        }),
+        // `None`: the daemon reply cannot say whether the model existed
+        // (wire-stable), so a completed request reports as removed — as the
+        // daemon path always has.
+        Some(true) | None => Terminal.info(&UserMessage::RemovedModel {
+            model_id,
+            user: user.clone(),
+        }),
     }
 
-    let request = DaemonRequest::RemoveModel {
-        user: user.clone(),
-        model_id,
-    };
-
-    let response = ipc_client::send_request(&request)?;
-
-    match response {
-        DaemonResponse::Removed => {
-            Terminal.info(&UserMessage::RemovedModel {
-                model_id,
-                user: user.clone(),
-            });
-            super::enrollment_marker::refresh(config, &user);
-        }
-        other => {
-            anyhow::bail!("unexpected response from daemon: {other:?}");
-        }
-    }
-
+    super::enrollment_marker::refresh(&backend, config, &user);
     Ok(())
 }

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -1,10 +1,10 @@
 use std::time::Instant;
 
 use facelock_core::Config;
-use facelock_core::ipc::{DaemonRequest, DaemonResponse};
 
 use facelock_core::notify::{NotifyEvent, notify_desktop_if_enabled};
 
+use crate::backend::{Backend, BackendKind};
 use crate::ipc_client;
 use crate::message::{Terminal, UserMessage, fail};
 use crate::notifications::DesktopNotifier;
@@ -44,23 +44,16 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     let notif_config = &config.notification;
     let notifier = DesktopNotifier::for_current_session();
 
+    // One selection for the whole test (D1) — after the setup offer above,
+    // which may have just installed and started the daemon.
+    let backend = Backend::select(config);
+
     // Check if user has enrolled models before attempting auth. Three-way
-    // discrimination (C7, issue #105): a store that opens with zero models
-    // and a store that doesn't exist yet both mean "not enrolled" — but a
-    // store that is present and cannot be read is an error, and must never be
-    // reported as "no models enrolled".
-    let has_models = if ipc_client::should_use_direct(config) {
-        direct_user_has_models(config, &user)?
-    } else {
-        // Propagate a failed query instead of folding it into "no models
-        // enrolled" — an AccessDenied here carries its own actionable hint.
-        let request = DaemonRequest::ListModels { user: user.clone() };
-        match ipc_client::send_request(&request)? {
-            DaemonResponse::Models(m) => !m.is_empty(),
-            DaemonResponse::Error { message } => anyhow::bail!("daemon error: {message}"),
-            other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-        }
-    };
+    // discrimination (C7, issue #105), owned by the backend seam: a store
+    // that opens with zero models and a store that doesn't exist yet both
+    // mean "not enrolled" — but a store that is present and cannot be read
+    // is an error, and must never be reported as "no models enrolled".
+    let has_models = enrolled_check(&backend, config, &user)?;
     if !has_models {
         Terminal.info(&UserMessage::NoModelsEnrolled { user: user.clone() });
         Terminal.info(&UserMessage::RunEnrollFirst);
@@ -73,25 +66,7 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // branches used to guess in opposite directions).
     {
         let config_embedder = &config.recognition.embedder_model;
-        let has_matching = if ipc_client::should_use_direct(config) {
-            // `open_store_existing`: the store answered has_models one query
-            // ago, so it exists; if it vanished since, that is an error, not
-            // a cue to create an empty one and warn about a stale embedder.
-            let store = crate::direct::open_store_existing(config)?;
-            store
-                .has_models_for_embedder(&user, config_embedder)
-                .map_err(|e| anyhow::anyhow!("storage error: {e}"))?
-        } else {
-            let request = DaemonRequest::ListModels { user: user.clone() };
-            match ipc_client::send_request(&request)? {
-                DaemonResponse::Models(m) => m
-                    .iter()
-                    .any(|model| model.embedder_model == *config_embedder),
-                DaemonResponse::Error { message } => anyhow::bail!("daemon error: {message}"),
-                other => anyhow::bail!("unexpected response from daemon: {other:?}"),
-            }
-        };
-        if !has_matching {
+        if !backend.has_models_for_embedder(&user, config_embedder)? {
             Terminal.info(&UserMessage::NoMatchingEmbedder {
                 embedder: config_embedder.clone(),
             });
@@ -105,77 +80,30 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
 
     notify_desktop_if_enabled(notif_config, &notifier, &NotifyEvent::Scanning);
 
-    if ipc_client::should_use_direct(config) {
-        let start = Instant::now();
-        match crate::direct::authenticate(config, &user) {
-            Ok(result) if result.matched => {
-                let elapsed = start.elapsed();
-                Terminal.info(&UserMessage::TestMatched {
-                    similarity: result.similarity,
-                    seconds: elapsed.as_secs_f64(),
-                });
-                notify_desktop_if_enabled(
-                    notif_config,
-                    &notifier,
-                    &NotifyEvent::Success {
-                        label: result.label.clone(),
-                        similarity: result.similarity,
-                    },
-                );
-            }
-            Ok(result) => {
-                let elapsed = start.elapsed();
-                if result.failure_reason
-                    == Some(facelock_core::types::AuthFailureReason::VarianceNotSatisfied)
-                {
-                    Terminal.info(&UserMessage::TestVarianceBlocked {
-                        similarity: result.similarity,
-                        seconds: elapsed.as_secs_f64(),
-                    });
-                    notify_desktop_if_enabled(
-                        notif_config,
-                        &notifier,
-                        &NotifyEvent::Failure {
-                            reason: "face matched but liveness variance not satisfied".to_string(),
-                        },
-                    );
-                } else {
-                    Terminal.info(&UserMessage::TestNoMatch {
-                        similarity: result.similarity,
-                        seconds: elapsed.as_secs_f64(),
-                    });
-                    notify_desktop_if_enabled(
-                        notif_config,
-                        &notifier,
-                        &NotifyEvent::Failure {
-                            reason: format!("no match (best similarity: {:.2})", result.similarity),
-                        },
-                    );
-                }
-            }
-            Err(e) => {
-                notify_desktop_if_enabled(
-                    notif_config,
-                    &notifier,
-                    &NotifyEvent::Failure {
-                        reason: e.to_string(),
-                    },
-                );
-                return Err(e);
-            }
-        }
-        return Ok(());
-    }
-
-    let request = DaemonRequest::Authenticate { user: user.clone() };
-
     let start = Instant::now();
-    let response = ipc_client::send_request(&request)?;
+    let result = match backend.recognize(&user) {
+        Ok(result) => result,
+        Err(e) => {
+            // One failure policy for both transports: the error's own text is
+            // the notification body, and the error propagates.
+            notify_desktop_if_enabled(
+                notif_config,
+                &notifier,
+                &NotifyEvent::Failure {
+                    reason: e.to_string(),
+                },
+            );
+            return Err(e);
+        }
+    };
     let elapsed = start.elapsed();
 
-    match response {
-        DaemonResponse::AuthResult(result) => {
-            if result.matched {
+    if result.matched {
+        // Presentation, not transport: the two renderings predate the seam
+        // and are kept byte-stable. The direct line has always omitted the
+        // model id/label.
+        match backend.kind() {
+            BackendKind::Daemon => {
                 let model_id = result.model_id.unwrap_or(0);
                 let label = result.label.as_deref().unwrap_or("unknown");
                 Terminal.info(&UserMessage::TestMatchedModel {
@@ -184,86 +112,84 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
                     similarity: result.similarity,
                     seconds: elapsed.as_secs_f64(),
                 });
-                notify_desktop_if_enabled(
-                    notif_config,
-                    &notifier,
-                    &NotifyEvent::Success {
-                        label: result.label.clone(),
-                        similarity: result.similarity,
-                    },
-                );
-            } else if config.security.require_frame_variance
-                && result.similarity >= config.recognition.threshold
-            {
-                // The D-Bus AuthResult contract carries no failure reason, but
-                // matched=false with similarity above the recognition threshold
-                // means a liveness gate (frame variance) blocked the attempt.
-                Terminal.info(&UserMessage::TestVarianceBlocked {
+            }
+            _ => {
+                Terminal.info(&UserMessage::TestMatched {
                     similarity: result.similarity,
                     seconds: elapsed.as_secs_f64(),
                 });
-                notify_desktop_if_enabled(
-                    notif_config,
-                    &notifier,
-                    &NotifyEvent::Failure {
-                        reason: "face matched but liveness variance not satisfied".to_string(),
-                    },
-                );
-            } else {
-                Terminal.info(&UserMessage::TestNoMatch {
-                    similarity: result.similarity,
-                    seconds: elapsed.as_secs_f64(),
-                });
-                notify_desktop_if_enabled(
-                    notif_config,
-                    &notifier,
-                    &NotifyEvent::Failure {
-                        reason: format!("no match (best similarity: {:.2})", result.similarity),
-                    },
-                );
             }
         }
-        other => {
-            notify_desktop_if_enabled(
-                notif_config,
-                &notifier,
-                &NotifyEvent::Failure {
-                    reason: "unexpected daemon response".to_string(),
-                },
-            );
-            anyhow::bail!("unexpected response from daemon: {other:?}");
+        notify_desktop_if_enabled(
+            notif_config,
+            &notifier,
+            &NotifyEvent::Success {
+                label: result.label.clone(),
+                similarity: result.similarity,
+            },
+        );
+        return Ok(());
+    }
+
+    // Not matched: name the liveness gate when it was the blocker. The direct
+    // result carries the reason; the D-Bus AuthResult contract does not, so
+    // the daemon side infers it — matched=false with similarity above the
+    // recognition threshold means frame variance blocked the attempt.
+    let variance_blocked = match backend.kind() {
+        BackendKind::Daemon => {
+            config.security.require_frame_variance
+                && result.similarity >= config.recognition.threshold
         }
+        _ => {
+            result.failure_reason
+                == Some(facelock_core::types::AuthFailureReason::VarianceNotSatisfied)
+        }
+    };
+
+    if variance_blocked {
+        Terminal.info(&UserMessage::TestVarianceBlocked {
+            similarity: result.similarity,
+            seconds: elapsed.as_secs_f64(),
+        });
+        notify_desktop_if_enabled(
+            notif_config,
+            &notifier,
+            &NotifyEvent::Failure {
+                reason: "face matched but liveness variance not satisfied".to_string(),
+            },
+        );
+    } else {
+        Terminal.info(&UserMessage::TestNoMatch {
+            similarity: result.similarity,
+            seconds: elapsed.as_secs_f64(),
+        });
+        notify_desktop_if_enabled(
+            notif_config,
+            &notifier,
+            &NotifyEvent::Failure {
+                reason: format!("no match (best similarity: {:.2})", result.similarity),
+            },
+        );
     }
 
     Ok(())
 }
 
-/// Direct-transport "does this user have enrolled models?" with the C7
-/// three-way discrimination, now carried by [`StoreError`]'s variants:
-///
-/// - store opens, zero models      → `Ok(false)` ("no models enrolled" is true)
-/// - `StoreError::Absent` (fresh)  → `Ok(false)` (no database created; same message)
-/// - any other failure class       → `Err`, never "no models"
-///
-/// For the error, the per-user enrollment marker is consulted **for the
-/// message only** — it is readable in exactly the cases the database is not,
-/// and lets the error say what the user actually wants to know ("you appear
-/// to be enrolled; the database is the problem"). The marker can be stale,
-/// hence "appear to"; it never influences the decision, only the wording.
-fn direct_user_has_models(config: &Config, user: &str) -> anyhow::Result<bool> {
-    let store = match crate::direct::open_store_existing(config) {
-        Ok(store) => store,
-        Err(facelock_store::StoreError::Absent { .. }) => return Ok(false),
-        Err(e) => return Err(unreadable_store_error(config, user, &anyhow::Error::new(e))),
-    };
-    match store.has_models(user) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(unreadable_store_error(
-            config,
-            user,
-            &anyhow::anyhow!("storage error: {e}"),
-        )),
-    }
+/// The C7 enrolled check, with the direct transport's store failures reworded
+/// for the human running `test`: the per-user enrollment marker is consulted
+/// **for the message only** — it is readable in exactly the cases the
+/// database is not, and lets the error say what the user actually wants to
+/// know ("you appear to be enrolled; the database is the problem"). Daemon
+/// errors pass through untouched: they are not store reads, and an
+/// AccessDenied already carries its own actionable hint.
+fn enrolled_check(backend: &Backend, config: &Config, user: &str) -> anyhow::Result<bool> {
+    backend.has_models(user).map_err(|e| {
+        if backend.kind().is_direct() {
+            unreadable_store_error(config, user, &e)
+        } else {
+            e
+        }
+    })
 }
 
 /// Build the "store present but unreadable" error (C7). With a readable
@@ -290,8 +216,10 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    /// `mode = "oneshot"` pins a DirectByConfig selection without touching
+    /// D-Bus.
     fn config_with_db(db_path: &Path) -> Config {
-        let mut config = Config::parse("").expect("defaults parse");
+        let mut config = Config::parse("[daemon]\nmode = \"oneshot\"\n").expect("config parses");
         config.storage.db_path = db_path.to_string_lossy().into_owned();
         config
     }
@@ -303,10 +231,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("facelock.db");
         let config = config_with_db(&db_path);
+        let backend = Backend::select(&config);
 
         // Absent (fresh): the StoreError::Absent variant, read as "not
         // enrolled" without creating anything.
-        assert!(!direct_user_has_models(&config, "alice").unwrap());
+        assert!(!enrolled_check(&backend, &config, "alice").unwrap());
 
         // Open store, models for someone else only.
         {
@@ -315,8 +244,8 @@ mod tests {
                 .add_model("bob", "front", &[0.5f32; 512], "embedder")
                 .unwrap();
         }
-        assert!(!direct_user_has_models(&config, "alice").unwrap());
-        assert!(direct_user_has_models(&config, "bob").unwrap());
+        assert!(!enrolled_check(&backend, &config, "alice").unwrap());
+        assert!(enrolled_check(&backend, &config, "bob").unwrap());
     }
 
     /// The `Absent` arm answers "not enrolled" as a *value*: the probe must
@@ -326,8 +255,10 @@ mod tests {
     fn absent_store_probe_creates_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("facelock.db");
+        let config = config_with_db(&db_path);
+        let backend = Backend::select(&config);
 
-        assert!(!direct_user_has_models(&config_with_db(&db_path), "alice").unwrap());
+        assert!(!enrolled_check(&backend, &config, "alice").unwrap());
         assert!(
             !db_path.exists(),
             "probing enrollment must not create the database it reports absent"
@@ -342,8 +273,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("facelock.db");
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
+        let config = config_with_db(&db_path);
+        let backend = Backend::select(&config);
 
-        let err = direct_user_has_models(&config_with_db(&db_path), "alice").unwrap_err();
+        let err = enrolled_check(&backend, &config, "alice").unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("can't be read"),
@@ -364,10 +297,11 @@ mod tests {
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
 
         let config = config_with_db(&db_path);
+        let backend = Backend::select(&config);
         let marker_base = super::super::enrollment_marker::marker_dir(&config);
         super::super::enrollment_marker::write_marker_in(&marker_base, "alice", 3, None).unwrap();
 
-        let err = direct_user_has_models(&config, "alice").unwrap_err();
+        let err = enrolled_check(&backend, &config, "alice").unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             msg.contains("appear to have 3 enrolled model(s)"),
@@ -386,10 +320,11 @@ mod tests {
         std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
 
         let config = config_with_db(&db_path);
+        let backend = Backend::select(&config);
         let marker_base = super::super::enrollment_marker::marker_dir(&config);
         super::super::enrollment_marker::write_marker_in(&marker_base, "alice", 3, None).unwrap();
 
-        let err = direct_user_has_models(&config, "someone-else").unwrap_err();
+        let err = enrolled_check(&backend, &config, "someone-else").unwrap_err();
         let msg = format!("{err:#}");
         assert!(!msg.contains("appear to have"), "{msg}");
         assert!(msg.contains("can't be read"), "{msg}");

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -327,52 +327,37 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
     }
 }
 
-/// Direct device listing (no daemon needed).
-pub fn list_devices_direct() -> anyhow::Result<()> {
+/// Direct device enumeration (no daemon needed), in the transport shape the
+/// backend seam hands to the renderer.
+///
+/// The quirks DB is consulted so the reported `is_ir` matches the
+/// authoritative decision the auth path makes (e.g. a quirks `force_ir`
+/// camera), with node-level disambiguation for multi-node USB devices.
+/// Formats survive here — the D-Bus `DeviceInfo` type does not carry them
+/// (`BackendCaps::device_formats`).
+pub fn list_devices_info() -> anyhow::Result<Vec<facelock_core::ipc::IpcDeviceInfo>> {
     let devices = list_devices().context("failed to enumerate devices")?;
-
-    if devices.is_empty() {
-        println!("No video devices found.");
-        return Ok(());
-    }
-
-    // Consult the quirks DB so the displayed [IR] tag matches the authoritative
-    // decision the auth path makes (e.g. a quirks `force_ir` camera), with
-    // node-level disambiguation for multi-node USB devices.
     let quirks = facelock_camera::QuirksDb::load();
     let sources = facelock_camera::classify_ir_sources(&devices, Some(&quirks));
-    println!("Available video devices:\n");
-    for (dev, source) in devices.iter().zip(&sources) {
-        let ir_tag = if *source != facelock_camera::IrSource::None {
-            " [IR]"
-        } else {
-            ""
-        };
-        println!("  {}{ir_tag}", dev.path);
-        println!("    Name:    {}", dev.name);
-        println!("    Driver:  {}", dev.driver);
-
-        if !dev.formats.is_empty() {
-            println!("    Formats:");
-            for fmt in &dev.formats {
-                let sizes: Vec<String> =
-                    fmt.sizes.iter().map(|(w, h)| format!("{w}x{h}")).collect();
-                println!(
-                    "      {} ({}) — {}",
-                    fmt.fourcc.trim(),
-                    fmt.description,
-                    if sizes.is_empty() {
-                        "no sizes reported".to_string()
-                    } else {
-                        sizes.join(", ")
-                    }
-                );
-            }
-        }
-        println!();
-    }
-
-    Ok(())
+    Ok(devices
+        .iter()
+        .zip(&sources)
+        .map(|(dev, source)| facelock_core::ipc::IpcDeviceInfo {
+            path: dev.path.clone(),
+            name: dev.name.clone(),
+            driver: dev.driver.clone(),
+            is_ir: *source != facelock_camera::IrSource::None,
+            formats: dev
+                .formats
+                .iter()
+                .map(|f| facelock_core::ipc::IpcFormatInfo {
+                    fourcc: f.fourcc.clone(),
+                    description: f.description.clone(),
+                    sizes: f.sizes.clone(),
+                })
+                .collect(),
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -247,10 +247,10 @@ fn init_software_sealer(config: &Config) -> anyhow::Result<Option<facelock_tpm::
 }
 
 /// Load user embeddings, decrypting software-encrypted or TPM-sealed blobs as
-/// needed. Mirrors `Handler::load_user_embeddings` from the daemon path,
-/// including directly TPM-sealed rows (version byte 0x01/0x03) written when
-/// `tpm.seal_database` is enabled — previously those failed here, which broke
-/// `bench`, `preview --text-only`, `test` and oneshot on sealed stores (B3).
+/// needed. The per-row decrypt is the daemon handler's own implementation
+/// (`facelock_daemon::embeddings`, N10) — a local copy previously lived here
+/// and drifted (B3: it predated `tpm.seal_database` rows, which broke `bench`,
+/// `preview --text-only`, `test` and oneshot on sealed stores).
 pub fn load_user_embeddings(
     store: &FaceStore,
     config: &Config,
@@ -261,62 +261,28 @@ pub fn load_user_embeddings(
     // Fast path: nothing is configured that could have written encrypted rows.
     // `seal_database` forces the raw path even without a software sealer, so a
     // TPM-sealed blob is never misread as a raw embedding.
-    if software_sealer.is_none() && !config.tpm.seal_database {
+    if !facelock_daemon::embeddings::needs_raw_rows(config, software_sealer.is_some()) {
         return store
             .get_user_embeddings(user)
             .context("storage error loading embeddings");
     }
 
-    // Slow path: load raw blobs (with device ids for opt-in AAD) and decrypt
+    // Slow path: load raw blobs (with device ids for opt-in AAD) and decrypt.
+    // The TPM connection is lazy — only made when a TPM-sealed row is present.
     let raw_rows = store
         .get_user_embeddings_raw_with_device(user)
         .context("storage error loading raw embeddings")?;
 
-    // Connect to the TPM lazily, only when a TPM-sealed row is present.
-    let mut tpm_sealer: Option<facelock_tpm::TpmSealer> = None;
-
-    let mut results = Vec::with_capacity(raw_rows.len());
-    for (id, blob, sealed, device_id) in &raw_rows {
-        let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
-            let sealer = software_sealer.as_ref().with_context(|| {
-                format!("embedding {id} is software-encrypted but no key is configured")
-            })?;
-            let aad = config.security.device_aad(device_id.as_deref());
-            sealer
-                .unseal_embedding_with_aad(blob, aad.as_deref())
-                .with_context(|| format!("software decryption failed for embedding {id}"))?
-        } else if *sealed {
-            // TPM-sealed (version byte 0x01/0x03), matching the daemon at
-            // `Handler::load_user_embeddings`. Without the `tpm` feature the
-            // passthrough sealer reports a clear "compile with tpm" error
-            // instead of misreading the blob.
-            let sealer = match tpm_sealer.as_mut() {
-                Some(s) => s,
-                None => {
-                    let s = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                        .context("TPM initialization failed")?;
-                    tpm_sealer.insert(s)
-                }
-            };
-            sealer
-                .unseal_embedding(blob)
-                .with_context(|| format!("TPM unseal failed for embedding {id}"))?
-        } else {
-            // Plaintext raw embedding
-            anyhow::ensure!(
-                blob.len() == 512 * 4,
-                "invalid raw embedding size for id {id}: expected {} bytes, got {}",
-                512 * 4,
-                blob.len()
-            );
-            let floats: &[f32] = bytemuck::cast_slice(blob);
-            let mut emb = [0f32; 512];
-            emb.copy_from_slice(floats);
-            emb
-        };
-        results.push((*id, embedding));
-    }
-    Ok(results)
+    facelock_daemon::embeddings::decrypt_user_embeddings(
+        &raw_rows,
+        config,
+        software_sealer.as_ref(),
+        facelock_daemon::embeddings::TpmAccess::Lazy {
+            tcti: &config.tpm.tcti,
+            sealer: None,
+        },
+    )
+    .map_err(|message| anyhow::anyhow!(message))
 }
 
 /// Direct enrollment — returns (model_id, embedding_count).

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, bail};
 use nix::unistd::Uid;
-use zbus::blocking::Connection;
 use zbus::blocking::Proxy;
 
 use facelock_core::dbus_interface::*;
@@ -67,29 +66,6 @@ pub fn require_root_scripted(hint: &str) -> anyhow::Result<()> {
             hint: hint.to_string(),
         },
     ))
-}
-
-/// Check whether we should use direct (daemonless) mode.
-/// Returns true if config says "oneshot" OR if the D-Bus service isn't available.
-/// When falling back from daemon mode, logs a warning.
-pub fn should_use_direct(config: &facelock_core::Config) -> bool {
-    if config.daemon.mode == facelock_core::DaemonMode::Oneshot {
-        return true;
-    }
-    // Daemon mode -- check if D-Bus service is available
-    match Connection::system() {
-        Ok(conn) => {
-            let proxy = zbus::blocking::fdo::DBusProxy::new(&conn);
-            match proxy {
-                Ok(p) => match BUS_NAME.try_into() {
-                    Ok(name) => !p.name_has_owner(name).unwrap_or(false),
-                    Err(_) => true,
-                },
-                Err(_) => true,
-            }
-        }
-        Err(_) => true,
-    }
 }
 
 /// Process-wide daemon proxy, built once and reused for every request.

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1,3 +1,4 @@
+pub mod backend;
 mod commands;
 pub mod direct;
 mod ipc_client;

--- a/crates/facelock-cli/src/message.rs
+++ b/crates/facelock-cli/src/message.rs
@@ -161,6 +161,11 @@ pub enum UserMessage {
     AccessDeniedGroupHint,
     EnrollTimedOutClientSide,
 
+    // -- backend selection (D1) --
+    DaemonUnreachableFallback,
+    PreviewGraphicalNeedsDaemonOneshot,
+    PreviewGraphicalDaemonUnreachable,
+
     // -- enroll --
     SetupNotCompleted,
     ConfirmRunSetupNow,
@@ -528,6 +533,16 @@ impl UserMessage {
             ),
             EnrollTimedOutClientSide => translate(
                 "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying",
+            ),
+
+            DaemonUnreachableFallback => translate(
+                "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\nStart it with: sudo systemctl start facelock-daemon",
+            ),
+            PreviewGraphicalNeedsDaemonOneshot => translate(
+                "Graphical preview requires the daemon. In oneshot mode, use --text-only.\nFalling back to text-only mode.\n",
+            ),
+            PreviewGraphicalDaemonUnreachable => translate(
+                "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the daemon with: sudo systemctl start facelock-daemon\n",
             ),
 
             SetupNotCompleted => translate("Setup has not been completed."),
@@ -1393,6 +1408,9 @@ mod tests {
             AccessDeniedRootHint,
             AccessDeniedGroupHint,
             EnrollTimedOutClientSide,
+            DaemonUnreachableFallback,
+            PreviewGraphicalNeedsDaemonOneshot,
+            PreviewGraphicalDaemonUnreachable,
             SetupNotCompleted,
             ConfirmRunSetupNow,
             SetupDidNotComplete,

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -88,9 +88,10 @@ impl ConfigLoad {
 ///
 /// Deliberately minimal: H8 (Health) will grow this into a richer `Fact`
 /// type carrying *unknown-is-not-false* across privilege and reachability;
-/// until then, a provenance tag per fact is all resolution promises. A
-/// daemon-reachability fact slots in beside the existing ones the same way
-/// (H6 — Backend owns that probe, not this module).
+/// until then, a provenance tag per fact is all resolution promises. The
+/// daemon-reachability fact sits beside the existing ones the same way
+/// (`crate::backend::DaemonReachability` — Backend owns that probe, not
+/// this module).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Provenance {
     /// Verified against the live system by this process (file stat, ORT
@@ -537,7 +538,8 @@ mod tests {
             "ResolvedConfig",
             "resolved::",
             "send_request(",
-            "should_use_direct(",
+            "Backend::select(",
+            "backend::",
             "open_store",
             "Camera",
         ];

--- a/crates/facelock-daemon/Cargo.toml
+++ b/crates/facelock-daemon/Cargo.toml
@@ -31,3 +31,4 @@ tpm = ["facelock-tpm/tpm"]
 facelock-test-support = { path = "../facelock-test-support" }
 # Raw SQL access for schema-level failure injection in integration tests.
 rusqlite = { version = "0.40", features = ["bundled"] }
+tempfile = "3"

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -1,0 +1,229 @@
+//! The one embedding-decrypt implementation (N10).
+//!
+//! The daemon handler and the CLI's direct path both load a user's stored
+//! templates and decrypt software-encrypted (version byte 0x02) or TPM-sealed
+//! (0x01/0x03) rows. The per-row logic used to live twice — `Handler` and
+//! `facelock-cli`'s `direct::load_user_embeddings` — and drifted once already
+//! (B3: the direct copy predated `seal_database` handling). This module is
+//! that loop, once.
+//!
+//! What stays with the callers, deliberately:
+//! - the fast path (`get_user_embeddings` when nothing could have written an
+//!   encrypted row) and the raw-row fetch, because they belong to each
+//!   caller's store-access policy;
+//! - sealer *initialization* policy — the daemon fails enroll closed on a
+//!   broken keyfile while auth continues, the direct path propagates — which
+//!   is a real posture difference, not duplication.
+//!
+//! Errors are plain strings: the handler wraps them in
+//! `DaemonResponse::Error`, the direct path in `anyhow`. They are
+//! machine-facing (they cross D-Bus and land in logs) and must not localize.
+
+use facelock_core::config::Config;
+use facelock_core::types::FaceEmbedding;
+
+/// How the decrypt loop reaches a TPM sealer when a TPM-sealed row appears.
+///
+/// The two callers hold the sealer differently and that difference is worth
+/// keeping: the daemon initializes once at startup (a failure there is warned
+/// once and every sealed row afterwards reports it), while the one-shot direct
+/// path connects lazily so unsealed stores never pay a TPM round-trip.
+pub enum TpmAccess<'a> {
+    /// A long-lived sealer initialized at handler construction. `None` means
+    /// `tpm.seal_database` is configured but initialization failed at startup.
+    Held(Option<&'a mut facelock_tpm::TpmSealer>),
+    /// Connect on the first sealed row, using the configured TCTI. Without
+    /// the `tpm` feature the passthrough sealer connects trivially and each
+    /// unseal reports a clear "compile with tpm" error instead of misreading
+    /// the blob.
+    Lazy {
+        tcti: &'a str,
+        sealer: Option<facelock_tpm::TpmSealer>,
+    },
+}
+
+impl TpmAccess<'_> {
+    fn sealer(&mut self) -> Result<&mut facelock_tpm::TpmSealer, String> {
+        match self {
+            TpmAccess::Held(Some(sealer)) => Ok(sealer),
+            TpmAccess::Held(None) => {
+                Err("TPM-sealed embeddings exist but TPM is not available".into())
+            }
+            TpmAccess::Lazy { tcti, sealer } => {
+                if sealer.is_none() {
+                    let connected = facelock_tpm::TpmSealer::new(tcti)
+                        .map_err(|e| format!("TPM initialization failed: {e}"))?;
+                    *sealer = Some(connected);
+                }
+                Ok(sealer.as_mut().expect("just connected"))
+            }
+        }
+    }
+}
+
+/// True when the store must be read through the raw-row path: either a
+/// software sealer is active, or `tpm.seal_database` says TPM-sealed rows may
+/// exist. The `seal_database` half matters even when the sealer failed to
+/// initialize (or TPM support is not compiled in): the fast path would hand
+/// sealed blobs to callers as if they were raw embeddings, which at best
+/// reports a misleading "corrupt store" and at worst misreads a template (the
+/// B3 class — the handler previously made exactly this mistake).
+pub fn needs_raw_rows(config: &Config, software_sealer_active: bool) -> bool {
+    software_sealer_active || config.tpm.seal_database
+}
+
+/// Decrypt raw `(id, blob, sealed, device_id)` rows into embeddings.
+///
+/// Per row: software-encrypted blobs unseal with the configured key and this
+/// template's own device-derived AAD (opt-in, matching enroll); TPM-sealed
+/// blobs unseal through `tpm`; plaintext rows are size-checked and cast. The
+/// first failing row fails the whole load — a partial compare set would
+/// silently narrow authentication.
+pub fn decrypt_user_embeddings(
+    raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
+    config: &Config,
+    software_sealer: Option<&facelock_tpm::SoftwareSealer>,
+    mut tpm: TpmAccess<'_>,
+) -> Result<Vec<(u32, FaceEmbedding)>, String> {
+    let mut results = Vec::with_capacity(raw_rows.len());
+    for (id, blob, sealed, device_id) in raw_rows {
+        let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
+            // Software-encrypted (version byte 0x02)
+            let sealer = software_sealer.ok_or_else(|| {
+                format!("embedding {id} is software-encrypted but no key is configured")
+            })?;
+            let aad = config.security.device_aad(device_id.as_deref());
+            sealer
+                .unseal_embedding_with_aad(blob, aad.as_deref())
+                .map_err(|e| format!("software decryption failed for embedding {id}: {e}"))?
+        } else if *sealed {
+            // TPM-sealed (version byte 0x01/0x03)
+            tpm.sealer()?
+                .unseal_embedding(blob)
+                .map_err(|e| format!("TPM unseal failed for embedding {id}: {e}"))?
+        } else {
+            // Plaintext raw embedding
+            if blob.len() != 512 * 4 {
+                return Err(format!(
+                    "invalid raw embedding size for id {id}: expected {} bytes, got {}",
+                    512 * 4,
+                    blob.len()
+                ));
+            }
+            let floats: &[f32] = bytemuck::cast_slice(blob);
+            let mut emb = [0f32; 512];
+            emb.copy_from_slice(floats);
+            emb
+        };
+        results.push((*id, embedding));
+    }
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plaintext_row(id: u32, value: f32) -> (u32, Vec<u8>, bool, Option<String>) {
+        let emb: FaceEmbedding = [value; 512];
+        (id, bytemuck::cast_slice(&emb).to_vec(), false, None)
+    }
+
+    #[test]
+    fn plaintext_rows_round_trip() {
+        let config = Config::parse("").unwrap();
+        let rows = vec![plaintext_row(1, 0.25), plaintext_row(2, 0.75)];
+        let out = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], (1, [0.25; 512]));
+        assert_eq!(out[1], (2, [0.75; 512]));
+    }
+
+    #[test]
+    fn wrong_size_plaintext_row_fails_the_load() {
+        let config = Config::parse("").unwrap();
+        let rows = vec![(7u32, vec![0u8; 100], false, None)];
+        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        assert!(err.contains("invalid raw embedding size for id 7"), "{err}");
+    }
+
+    #[test]
+    fn software_row_without_key_names_the_row() {
+        let config = Config::parse("").unwrap();
+        // Version byte 0x02 marks software encryption.
+        let mut blob = vec![0x02u8];
+        blob.extend_from_slice(&[0u8; 64]);
+        let rows = vec![(3u32, blob, true, None)];
+        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        assert_eq!(
+            err,
+            "embedding 3 is software-encrypted but no key is configured"
+        );
+    }
+
+    #[test]
+    fn software_rows_decrypt_with_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let sealer = facelock_tpm::SoftwareSealer::from_key_file(&key_path).unwrap();
+
+        let emb: FaceEmbedding = [0.5; 512];
+        let blob = sealer.seal_embedding(&emb).unwrap();
+        let rows = vec![(4u32, blob, true, None)];
+
+        let config = Config::parse("").unwrap();
+        let out =
+            decrypt_user_embeddings(&rows, &config, Some(&sealer), TpmAccess::Held(None)).unwrap();
+        assert_eq!(out, vec![(4, emb)]);
+    }
+
+    /// The daemon's held-sealer failure mode: seal_database configured but
+    /// TPM init failed at startup — every sealed row reports it.
+    #[test]
+    fn tpm_row_with_no_held_sealer_reports_unavailable() {
+        let config = Config::parse("").unwrap();
+        let mut blob = vec![0x01u8];
+        blob.extend_from_slice(&[0u8; 64]);
+        let rows = vec![(5u32, blob, true, None)];
+        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        assert_eq!(err, "TPM-sealed embeddings exist but TPM is not available");
+    }
+
+    /// The direct path's lazy connection (B3 pin, relocated with the loop):
+    /// without the `tpm` feature the passthrough sealer connects and reports
+    /// a clear per-row error instead of misreading the blob.
+    #[cfg(not(feature = "tpm"))]
+    #[test]
+    fn tpm_row_via_lazy_passthrough_errors_clearly() {
+        let config = Config::parse("").unwrap();
+        let mut blob = vec![0x01u8];
+        blob.extend_from_slice(&[0u8; 64]);
+        let rows = vec![(6u32, blob, true, None)];
+        let err = decrypt_user_embeddings(
+            &rows,
+            &config,
+            None,
+            TpmAccess::Lazy {
+                tcti: "device",
+                sealer: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("TPM unseal failed for embedding 6"), "{err}");
+        assert!(err.contains("without TPM support"), "{err}");
+    }
+
+    /// `needs_raw_rows` forces the slow path whenever sealed rows may exist,
+    /// even with no working sealer — the fast path must never hand a sealed
+    /// blob to a caller as a raw embedding.
+    #[test]
+    fn seal_database_forces_raw_rows_without_a_sealer() {
+        let sealed = Config::parse("[tpm]\nseal_database = true\n").unwrap();
+        assert!(needs_raw_rows(&sealed, false));
+
+        let plain = Config::parse("").unwrap();
+        assert!(!needs_raw_rows(&plain, false));
+        assert!(needs_raw_rows(&plain, true));
+    }
+}

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -37,7 +37,9 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     jpeg_buf: Vec<u8>,
     /// Quirk-overridden warmup frames (takes precedence over config if `Some`).
     warmup_frames_override: Option<u32>,
-    #[cfg(feature = "tpm")]
+    /// Held TPM sealer for `tpm.seal_database` stores. Without the `tpm`
+    /// feature this is the passthrough sealer, whose per-row unseal reports a
+    /// clear "compile with tpm" error instead of misreading sealed blobs.
     tpm_sealer: Option<facelock_tpm::TpmSealer>,
     software_sealer: Option<facelock_tpm::SoftwareSealer>,
     /// Why the software sealer could not be initialized for a configured
@@ -57,7 +59,6 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         camera_factory: Option<CameraFactory<C>>,
         warmup_frames_override: Option<u32>,
     ) -> Result<Self, String> {
-        #[cfg(feature = "tpm")]
         let tpm_sealer = if config.tpm.seal_database {
             match facelock_tpm::TpmSealer::new(&config.tpm.tcti) {
                 Ok(sealer) => {
@@ -164,7 +165,6 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             camera_last_used: Instant::now(),
             jpeg_buf: Vec::with_capacity(JPEG_BUF_CAPACITY),
             warmup_frames_override,
-            #[cfg(feature = "tpm")]
             tpm_sealer,
             software_sealer,
             sealer_init_error,
@@ -219,18 +219,15 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         }
     }
 
-    /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs.
-    /// Falls back to the standard `get_user_embeddings` path when no encryption is active.
+    /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs
+    /// through the shared per-row implementation (`crate::embeddings`, N10).
+    /// Falls back to the standard `get_user_embeddings` path when nothing could
+    /// have written an encrypted row.
     fn load_user_embeddings(
         &mut self,
         user: &str,
     ) -> Result<Vec<(u32, facelock_core::types::FaceEmbedding)>, DaemonResponse> {
-        // Check if any encryption is configured that requires raw blob handling
-        let needs_raw = self.software_sealer.is_some();
-        #[cfg(feature = "tpm")]
-        let needs_raw = needs_raw || self.tpm_sealer.is_some();
-
-        if !needs_raw {
+        if !crate::embeddings::needs_raw_rows(&self.config, self.software_sealer.is_some()) {
             // Fast path: no encryption, use standard method (no overhead)
             return self
                 .store
@@ -249,70 +246,13 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 message: format!("storage error: {e}"),
             })?;
 
-        let mut results = Vec::with_capacity(raw_rows.len());
-        for (id, blob, sealed, device_id) in &raw_rows {
-            let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
-                // Software-encrypted (version byte 0x02)
-                let sealer =
-                    self.software_sealer
-                        .as_ref()
-                        .ok_or_else(|| DaemonResponse::Error {
-                            message: format!(
-                                "embedding {id} is software-encrypted but no key is configured"
-                            ),
-                        })?;
-                // Hard device binding (opt-in): derive AAD from this template's
-                // own device id. `None` when disabled — matching enroll.
-                let aad = self.config.security.device_aad(device_id.as_deref());
-                sealer
-                    .unseal_embedding_with_aad(blob, aad.as_deref())
-                    .map_err(|e| DaemonResponse::Error {
-                        message: format!("software decryption failed for embedding {id}: {e}"),
-                    })?
-            } else if *sealed {
-                // TPM-sealed (version byte 0x01)
-                #[cfg(feature = "tpm")]
-                {
-                    let sealer = self
-                        .tpm_sealer
-                        .as_mut()
-                        .ok_or_else(|| DaemonResponse::Error {
-                            message: "TPM-sealed embeddings exist but TPM is not available".into(),
-                        })?;
-                    sealer
-                        .unseal_embedding(blob)
-                        .map_err(|e| DaemonResponse::Error {
-                            message: format!("TPM unseal failed for embedding {id}: {e}"),
-                        })?
-                }
-                #[cfg(not(feature = "tpm"))]
-                {
-                    return Err(DaemonResponse::Error {
-                        message: format!(
-                            "embedding {id} is TPM-sealed but TPM support is not compiled in"
-                        ),
-                    });
-                }
-            } else {
-                // Plaintext raw embedding
-                if blob.len() != 512 * 4 {
-                    return Err(DaemonResponse::Error {
-                        message: format!(
-                            "invalid raw embedding size for id {id}: expected {} bytes, got {}",
-                            512 * 4,
-                            blob.len()
-                        ),
-                    });
-                }
-                let floats: &[f32] = bytemuck::cast_slice(blob);
-                let mut emb = [0f32; 512];
-                emb.copy_from_slice(floats);
-                emb
-            };
-
-            results.push((*id, embedding));
-        }
-        Ok(results)
+        crate::embeddings::decrypt_user_embeddings(
+            &raw_rows,
+            &self.config,
+            self.software_sealer.as_ref(),
+            crate::embeddings::TpmAccess::Held(self.tpm_sealer.as_mut()),
+        )
+        .map_err(|message| DaemonResponse::Error { message })
     }
 
     pub fn handle(&mut self, request: DaemonRequest) -> DaemonResponse {

--- a/crates/facelock-daemon/src/lib.rs
+++ b/crates/facelock-daemon/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod auth;
+pub mod embeddings;
 pub mod enroll;
 pub mod handler;
 pub mod liveness;

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 00:41-0700\n"
+"POT-Creation-Date: 2026-08-14 01:07-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,84 +17,102 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/facelock-cli/src/message.rs:510
+#: crates/facelock-cli/src/message.rs:515
 msgid "no config file at {path} — run 'sudo facelock setup' to create one"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:514
+#: crates/facelock-cli/src/message.rs:519
 msgid "invalid config at {path}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:519
+#: crates/facelock-cli/src/message.rs:524
 msgid ""
 "Root required.\n"
 "  Run: {hint}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:522
+#: crates/facelock-cli/src/message.rs:527
 msgid "Root required. Re-run with sudo? [Y/n] "
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:524
+#: crates/facelock-cli/src/message.rs:529
 msgid ""
 "Access denied: this operation requires root.\n"
 "  Re-run with sudo, or as root."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:527
+#: crates/facelock-cli/src/message.rs:532
 msgid ""
 "Access denied. If you are not in the 'facelock' group, add yourself:\n"
 "  sudo usermod -aG facelock $USER\n"
 "then log out and back in (or re-run: sudo facelock setup). Note: some operations require root regardless of group membership."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:530
+#: crates/facelock-cli/src/message.rs:535
 msgid "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:533
+#: crates/facelock-cli/src/message.rs:539
+msgid ""
+"Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\n"
+"Start it with: sudo systemctl start facelock-daemon"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:542
+msgid ""
+"Graphical preview requires the daemon. In oneshot mode, use --text-only.\n"
+"Falling back to text-only mode.\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:545
+msgid ""
+"Graphical preview requires the daemon, which is configured but not reachable.\n"
+"Falling back to text-only mode. Start the daemon with: sudo systemctl start facelock-daemon\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:548
 msgid "Setup has not been completed."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:534
+#: crates/facelock-cli/src/message.rs:549
 msgid "Run setup now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:535
+#: crates/facelock-cli/src/message.rs:550
 msgid "Setup did not complete successfully."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:536
+#: crates/facelock-cli/src/message.rs:551
 msgid "Run 'sudo facelock setup' when ready."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:538
+#: crates/facelock-cli/src/message.rs:553
 msgid ""
 "WARNING: encryption.method = \"none\" and security.allow_plaintext = true.\n"
 "Your face template will be stored UNENCRYPTED (plaintext biometric data at rest)."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:542
+#: crates/facelock-cli/src/message.rs:557
 msgid ""
 "Face recognition models not found in {dir}.\n"
 "Run `sudo facelock setup` to download them."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:548
+#: crates/facelock-cli/src/message.rs:563
 msgid ""
 "Note: existing models don't use the configured embedder '{embedder}'.\n"
 "Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:553
+#: crates/facelock-cli/src/message.rs:568
 msgid "Enrolling face for user '{user}' with label '{label}'..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:557
+#: crates/facelock-cli/src/message.rs:572
 msgid "Look at the camera. Slowly turn your head left and right."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:565
+#: crates/facelock-cli/src/message.rs:580
 msgid ""
 "\n"
 "Face enrolled successfully!\n"
@@ -103,113 +121,113 @@ msgid ""
 "  Label: {label}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:575
+#: crates/facelock-cli/src/message.rs:590
 msgid ""
 "\n"
 "Warning: user '{user}' has {count} face models. Consider removing old ones with 'facelock remove'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:580
+#: crates/facelock-cli/src/message.rs:595
 msgid "Face recognition models not found."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:581
+#: crates/facelock-cli/src/message.rs:596
 msgid "Download models now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:582
+#: crates/facelock-cli/src/message.rs:597
 msgid "Models still not found after setup."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:583
+#: crates/facelock-cli/src/message.rs:598
 msgid "Models required. Run `facelock setup` to download them."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:585
+#: crates/facelock-cli/src/message.rs:600
 msgid "No face models enrolled for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:588
+#: crates/facelock-cli/src/message.rs:603
 msgid "Run 'facelock enroll' to enroll a face first."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:590
+#: crates/facelock-cli/src/message.rs:605
 msgid "Warning: no enrolled models use the configured embedder '{embedder}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:593
+#: crates/facelock-cli/src/message.rs:608
 msgid "Re-enroll with 'facelock enroll' to use the current model."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:595
+#: crates/facelock-cli/src/message.rs:610
 msgid "Testing face recognition for user '{user}'..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:598
+#: crates/facelock-cli/src/message.rs:613
 msgid "Look at the camera."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:603
+#: crates/facelock-cli/src/message.rs:618
 msgid "Matched (similarity: {similarity}) in {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:616
+#: crates/facelock-cli/src/message.rs:631
 msgid "Matched model #{model_id} '{label}' (similarity: {similarity}) in {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:630
+#: crates/facelock-cli/src/message.rs:645
 msgid "Face matched (best: {similarity}) but the liveness variance check was not satisfied after {seconds}s — try moving slightly, or tune security.frame_variance_max_similarity"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:641
+#: crates/facelock-cli/src/message.rs:656
 msgid "No match (best: {similarity}) after {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:649
+#: crates/facelock-cli/src/message.rs:664
 msgid "Remove face model #{model_id} for user '{user}'?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:652
+#: crates/facelock-cli/src/message.rs:667
 msgid "Cancelled."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:654
+#: crates/facelock-cli/src/message.rs:669
 msgid "Removed face model #{model_id} for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:658
+#: crates/facelock-cli/src/message.rs:673
 msgid "Model #{model_id} not found for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:662
+#: crates/facelock-cli/src/message.rs:677
 msgid "Remove ALL face models for user '{user}'?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:666
+#: crates/facelock-cli/src/message.rs:681
 msgid "Removed {count} face model(s) for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:670
+#: crates/facelock-cli/src/message.rs:685
 msgid "All face models removed for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:674
+#: crates/facelock-cli/src/message.rs:689
 msgid "Scanning face..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:676
+#: crates/facelock-cli/src/message.rs:691
 msgid "Welcome, {label}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:679
+#: crates/facelock-cli/src/message.rs:694
 msgid "Face recognized ({similarity})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:683
+#: crates/facelock-cli/src/message.rs:698
 msgid "Face auth failed: {reason}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:689
+#: crates/facelock-cli/src/message.rs:704
 msgid ""
 "\n"
 "  Facelock v{version}\n"
@@ -224,320 +242,320 @@ msgid ""
 "    - Daemon and PAM configuration\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:693
+#: crates/facelock-cli/src/message.rs:708
 msgid ""
 "\n"
 "--- Step 1: Camera Selection ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:694
+#: crates/facelock-cli/src/message.rs:709
 msgid ""
 "\n"
 "--- Step 2: Model Quality ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:695
+#: crates/facelock-cli/src/message.rs:710
 msgid ""
 "\n"
 "--- Step 3: Inference Device ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:696
+#: crates/facelock-cli/src/message.rs:711
 msgid ""
 "\n"
 "--- Step 4: Model Download ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:697
+#: crates/facelock-cli/src/message.rs:712
 msgid ""
 "\n"
 "--- Step 5: Embedding Encryption ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:698
+#: crates/facelock-cli/src/message.rs:713
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:700
+#: crates/facelock-cli/src/message.rs:715
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:702
+#: crates/facelock-cli/src/message.rs:717
 msgid ""
 "\n"
 "--- Step 7: Test Recognition ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:704
+#: crates/facelock-cli/src/message.rs:719
 msgid ""
 "\n"
 "--- Step 7: Test Recognition (skipped, no face enrolled) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:706
+#: crates/facelock-cli/src/message.rs:721
 msgid ""
 "\n"
 "--- Step 8: Daemon Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:707
+#: crates/facelock-cli/src/message.rs:722
 msgid ""
 "\n"
 "--- Step 9: PAM Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:708
+#: crates/facelock-cli/src/message.rs:723
 msgid ""
 "\n"
 "--- Setup Complete ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:712
+#: crates/facelock-cli/src/message.rs:727
 msgid ""
 "  Camera detection failed: {error}\n"
 "  You can configure the camera later in the config file.\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:718
+#: crates/facelock-cli/src/message.rs:733
 msgid ""
 "  Model quality selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:724
+#: crates/facelock-cli/src/message.rs:739
 msgid ""
 "  Inference device selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:730
+#: crates/facelock-cli/src/message.rs:745
 msgid ""
 "  Model download failed: {error}\n"
 "  You can retry later with: sudo facelock setup --non-interactive"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:736
+#: crates/facelock-cli/src/message.rs:751
 msgid ""
 "  Encryption setup failed: {error}\n"
 "  You can configure encryption later with: sudo facelock encrypt --generate-key"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:742
+#: crates/facelock-cli/src/message.rs:757
 msgid ""
 "  Enrollment failed: {error}\n"
 "  You can enroll later with: facelock enroll"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:747
+#: crates/facelock-cli/src/message.rs:762
 msgid ""
 "  Test failed: {error}\n"
 "  You can test later with: facelock test"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:752
+#: crates/facelock-cli/src/message.rs:767
 msgid ""
 "  Systemd setup failed: {error}\n"
 "  You can enable it later with: sudo facelock setup --systemd"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:758
+#: crates/facelock-cli/src/message.rs:773
 msgid ""
 "  Group setup failed: {error}\n"
 "  Add manually: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:764
+#: crates/facelock-cli/src/message.rs:779
 msgid ""
 "  PAM setup failed: {error}\n"
 "  You can configure PAM later with: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:770
+#: crates/facelock-cli/src/message.rs:785
 msgid ""
 "  No video devices found.\n"
 "  Check that your camera is connected and the v4l2 module is loaded."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:773
+#: crates/facelock-cli/src/message.rs:788
 msgid "  Auto-selected IR camera: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:777
+#: crates/facelock-cli/src/message.rs:792
 msgid "  Auto-selected IR camera: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:781
+#: crates/facelock-cli/src/message.rs:796
 msgid "  Selected: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:785
+#: crates/facelock-cli/src/message.rs:800
 msgid "  Selected: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:788
+#: crates/facelock-cli/src/message.rs:803
 msgid "Select camera device"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:790
+#: crates/facelock-cli/src/message.rs:805
 msgid "--camera=auto found no video devices; check that the camera is connected and the v4l2 module is loaded"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:794
+#: crates/facelock-cli/src/message.rs:809
 msgid ""
 "--camera=auto found no IR-capable camera among the detected devices:\n"
 "{listed}\n"
 "  Pass an explicit device path, e.g. --camera={example}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:800
+#: crates/facelock-cli/src/message.rs:815
 msgid ""
 "--camera=auto found {count} IR-capable cameras:\n"
 "{listed}\n"
 "  Pass an explicit device path to choose one."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:806
+#: crates/facelock-cli/src/message.rs:821
 msgid "camera device {path} does not exist; pass a valid /dev/video* path or --camera=auto"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:811
+#: crates/facelock-cli/src/message.rs:826
 msgid "Select model quality"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:812
+#: crates/facelock-cli/src/message.rs:827
 msgid "Select inference device"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:815
+#: crates/facelock-cli/src/message.rs:830
 msgid "  [ok] {name} ({purpose})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:818
+#: crates/facelock-cli/src/message.rs:833
 msgid "  All models are already present and verified."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:819
+#: crates/facelock-cli/src/message.rs:834
 msgid "  Models to download:"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:825
+#: crates/facelock-cli/src/message.rs:840
 msgid "    - {name} (~{size_mb}MB) - {purpose}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:833
+#: crates/facelock-cli/src/message.rs:848
 msgid "  Total download size: ~{mb}MB"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:836
+#: crates/facelock-cli/src/message.rs:851
 msgid "Download required models?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:837
+#: crates/facelock-cli/src/message.rs:852
 msgid "  Skipping model download."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:839
+#: crates/facelock-cli/src/message.rs:854
 msgid "  Downloading {name}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:843
+#: crates/facelock-cli/src/message.rs:858
 msgid "  [ok] {name} downloaded and verified"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:847
+#: crates/facelock-cli/src/message.rs:862
 msgid "Would you like to enroll a face now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:848
+#: crates/facelock-cli/src/message.rs:863
 msgid "  Skipping face enrollment."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:849
+#: crates/facelock-cli/src/message.rs:864
 msgid "Would you like to test recognition?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:850
+#: crates/facelock-cli/src/message.rs:865
 msgid "  Skipping recognition test."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:851
+#: crates/facelock-cli/src/message.rs:866
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:853
+#: crates/facelock-cli/src/message.rs:868
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:856
+#: crates/facelock-cli/src/message.rs:871
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:859
+#: crates/facelock-cli/src/message.rs:874
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:862
+#: crates/facelock-cli/src/message.rs:877
 msgid "  Answered on the command line; applied once setup finishes."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:865
+#: crates/facelock-cli/src/message.rs:880
 msgid "  Creating 'facelock' system group..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:867
+#: crates/facelock-cli/src/message.rs:882
 msgid ""
 "  Note: running daemon commands (preview/test) as a normal user requires\n"
 "  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:870
+#: crates/facelock-cli/src/message.rs:885
 msgid "  User '{user}' is already in the 'facelock' group."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:875
+#: crates/facelock-cli/src/message.rs:890
 msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:880
+#: crates/facelock-cli/src/message.rs:895
 msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:885
+#: crates/facelock-cli/src/message.rs:900
 msgid ""
 "  Added '{user}' to the 'facelock' group.\n"
 "  NOTE: log out and back in for the new group membership to take effect."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:892
+#: crates/facelock-cli/src/message.rs:907
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:898
+#: crates/facelock-cli/src/message.rs:913
 msgid ""
 "  PAM module not found at {path}.\n"
 "  Install it first, then run: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:903
+#: crates/facelock-cli/src/message.rs:918
 msgid "  Configuring PAM for {service}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:907
+#: crates/facelock-cli/src/message.rs:922
 msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:912
+#: crates/facelock-cli/src/message.rs:927
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -548,35 +566,35 @@ msgid ""
 "  to confirm each file individually.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:917
+#: crates/facelock-cli/src/message.rs:932
 msgid "Select services to enable face authentication for"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:920
+#: crates/facelock-cli/src/message.rs:935
 msgid "  Failed to configure {service}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:923
+#: crates/facelock-cli/src/message.rs:938
 msgid "  No PAM services selected."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:925
+#: crates/facelock-cli/src/message.rs:940
 msgid "PAM service file not found: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:929
+#: crates/facelock-cli/src/message.rs:944
 msgid "PAM line already present in {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:932
+#: crates/facelock-cli/src/message.rs:947
 msgid "inserted before the first 'auth' line"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:934
+#: crates/facelock-cli/src/message.rs:949
 msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:943
+#: crates/facelock-cli/src/message.rs:958
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -586,19 +604,19 @@ msgid ""
 "(To configure manually instead, add the line above to each service yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:952
+#: crates/facelock-cli/src/message.rs:967
 msgid "Proceed?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:954
+#: crates/facelock-cli/src/message.rs:969
 msgid "Skipped {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:957
+#: crates/facelock-cli/src/message.rs:972
 msgid "Backed up {path} -> {backup}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:966
+#: crates/facelock-cli/src/message.rs:981
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
@@ -607,99 +625,99 @@ msgid ""
 "  # or: sudo facelock setup --pam --remove --service {service}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:975
+#: crates/facelock-cli/src/message.rs:990
 msgid "Removed facelock PAM line from {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:979
+#: crates/facelock-cli/src/message.rs:994
 msgid "No facelock PAM line found in {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:983
+#: crates/facelock-cli/src/message.rs:998
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:988
+#: crates/facelock-cli/src/message.rs:1003
 msgid "  Camera:     {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:992
+#: crates/facelock-cli/src/message.rs:1007
 msgid "  Models:     {dir} ({quality})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:996
+#: crates/facelock-cli/src/message.rs:1011
 msgid "  Inference:  {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1000
+#: crates/facelock-cli/src/message.rs:1015
 msgid "  Database:   {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1004
+#: crates/facelock-cli/src/message.rs:1019
 msgid "  Encryption: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1008
+#: crates/facelock-cli/src/message.rs:1023
 msgid "  Daemon:   {status}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1011
+#: crates/facelock-cli/src/message.rs:1026
 msgid "not configured (--no-systemd)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1012
+#: crates/facelock-cli/src/message.rs:1027
 msgid "configured from the command line"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1013
+#: crates/facelock-cli/src/message.rs:1028
 msgid "enabled (D-Bus activation)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1014
+#: crates/facelock-cli/src/message.rs:1029
 msgid "not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1016
+#: crates/facelock-cli/src/message.rs:1031
 msgid "  PAM:      {services}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1019
+#: crates/facelock-cli/src/message.rs:1034
 msgid "  PAM:      not configured (--no-pam)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1020
+#: crates/facelock-cli/src/message.rs:1035
 msgid "  PAM:      not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1021
+#: crates/facelock-cli/src/message.rs:1036
 msgid "  Face:     enrolled"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1023
+#: crates/facelock-cli/src/message.rs:1038
 msgid "  Face:     not enrolled (--no-enroll; run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1025
+#: crates/facelock-cli/src/message.rs:1040
 msgid "  Face:     not enrolled (run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1027
+#: crates/facelock-cli/src/message.rs:1042
 msgid "facelock setup: preparing system...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1029
+#: crates/facelock-cli/src/message.rs:1044
 msgid "Checking {count} model(s)...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1032
+#: crates/facelock-cli/src/message.rs:1047
 msgid ""
 "\n"
 "Setup complete."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1034
+#: crates/facelock-cli/src/message.rs:1049
 msgid ""
 "\n"
 "Setup complete. Run `facelock enroll` to register your face."


### PR DESCRIPTION
Wave 3, PR H6 — the Backend domain (gaps D1, N10, D3/D4 remnants): one question, one implementation, one failure policy. Based on `feat/i18n-seam` (full Wave-3 chain: H1 StoreError, H2 ConfigLoad/ResolvedConfig, H3 CameraCaps, H4 Notifier, H5 message seam).

## The seam

`crates/facelock-cli/src/backend.rs` (new): `Backend::select(config)` runs **once at the top of each backend-using command** — at most one deliberate, non-activating bus probe (`name_has_owner`, backend.rs:395) — and every operation that used to fork transport per call site forks in exactly one `Backend` method. A struct with per-op methods rather than a `Box<dyn>` trait: two implementations, crate-private, no object-safety or lifetime tax; the seam property (callers cannot reach around it) is held by the structural pins below.

- `BackendKind` (backend.rs:48), selection rule `classify` (backend.rs:342) — pure, probe injected, unit-tested without a bus
- `BackendCaps` (backend.rs:87) — capability facts stated at selection
- `DaemonReachability` (backend.rs:70) — the probe outcome recorded beside H2's resolved-config facts using `Resolved`/`Provenance` **as-is** (per H2's handoff note); `NotProbed` is a distinct value, never a guessed `Unreachable`

## BackendKind: three messages, three levels

| Kind | When | Log level | User-facing text |
|---|---|---|---|
| `Daemon` | mode=daemon, bus name owned | debug | none |
| `DirectByConfig` | mode=oneshot | debug | none — expected, not degraded |
| `DirectByFallback` | mode=daemon, no owner | **warn** | one stderr notice via the H5 seam (`DaemonUnreachableFallback`) |

The known misattribution is fixed: preview with a **stopped** daemon now renders `PreviewGraphicalDaemonUnreachable` instead of blaming "oneshot mode" as a configuration choice (was preview/mod.rs:22-30; the old message survives byte-identically for the genuine oneshot case). Pinned: `stopped_daemon_is_not_blamed_on_configuration` (preview/mod.rs).

## Per-site fork table (recount: 13 sites, plan said 12)

| Old fork site | Operation | Now |
|---|---|---|
| clear.rs:19 | has-models pre-prompt | `Backend::has_models` |
| clear.rs:38 | clear all | `Backend::clear_models` |
| enroll.rs:78 | stale-embedder check | `has_models` + `has_models_for_embedder` |
| enroll.rs:106 (via 149 helper) | list models (label scan) | `Backend::list_models` |
| enroll.rs:149 | enroll | `Backend::enroll` |
| devices.rs:10 | device listing | `Backend::list_devices` (one renderer; direct printing copy deleted) |
| preview/mod.rs:22 | preview routing | `caps().graphical_preview` + kind-accurate message |
| list.rs:32 | list models | `Backend::list_models` |
| remove.rs:27 | remove model | `Backend::remove_model` |
| test_cmd.rs:52 | has-models (C7) | `Backend::has_models` (+ marker-enriched wording kept in `enrolled_check`) |
| test_cmd.rs:76 | embedder match | `Backend::has_models_for_embedder` |
| test_cmd.rs:108 | test auth | `Backend::recognize` |
| enrollment_marker.rs:314 | marker recount | `Backend::list_models` via `refresh(&backend, ..)` |

After: **0** `should_use_direct` occurrences (the function is deleted); pinned by `the_boolean_fork_stays_deleted` and `daemon_transport_entry_points_are_single_sited` (backend.rs tests; `send_request`/`send_enroll` allowlist: the seam, ipc_client's definition, status.rs until H8, the preview frame loops). The is-enrolled probe-free pin in resolved.rs now names `Backend::select(`/`backend::` as forbidden tokens.

## D3 remnant: failure policy uniform per kind

Selection failure policy is decided once: `DirectByFallback` is chosen at selection and never re-probed — a daemon dying mid-invocation is an error, not a silent per-site re-fallback. Direct reads share one policy (`Backend::direct_read`): `StoreError::Absent` answers a benign value **without creating the database**; every other class propagates — never "no models" (C4/C7). This closes two residual creation side effects: `facelock list` and the marker recount no longer materialize an empty DB on a fresh install, and `remove` reports "not found" without creating one.

## N10: honest numbers

Re-measured on the base (the cited duplication had been rewritten twice since the plan):
- Still duplicated: the per-row decrypt loop (software-AAD unseal / TPM unseal / plaintext size-check+cast) — ~45 lines each in `Handler::load_user_embeddings` (handler.rs:224-316, 93 lines total) and `direct::load_user_embeddings` (direct.rs:249-320, 67 lines total), plus the fast-path condition.
- **Not** duplicated, left per-caller on purpose: sealer *initialization* policy (daemon fails enroll closed on a broken keyfile while auth continues; direct propagates) and the raw-row fetch/error-type wrapping.

Consolidated exactly the loop: `facelock_daemon::embeddings::decrypt_user_embeddings` (embeddings.rs:82) + `TpmAccess` (embeddings.rs:31, Held vs Lazy — the daemon holds a startup-initialized sealer, the one-shot path connects lazily) + `needs_raw_rows` (embeddings.rs:71). Both loaders are now fetch-and-delegate (handler.rs:226, direct.rs:254).

En-passant fix the unification forced: the handler previously took the **fast path** when `tpm.seal_database` was set but TPM init failed (or the `tpm` feature was absent), handing sealed blobs to `get_user_embeddings` → a misleading "corrupt store" error. Both callers now share the B3-correct condition; the handler's cfg-gated `tpm_sealer` field became an unconditional `Option<TpmSealer>` (passthrough reports a clear per-row "compile with tpm" error). No change for correctly-working setups; no pre_check/auth-semantics change; no wire change.

Pins that stayed green across both former call paths: direct.rs `load_user_embeddings_decrypts_software_sealed_rows`, `tpm_sealed_rows_error_clearly_without_tpm_support` (B3), `seal_database_slow_path_still_loads_plaintext_rows`; daemon integration suite (22 tests) incl. `keyfile_sealer_init_failure_fails_enroll_closed_no_plaintext`. New unit coverage in embeddings.rs (7 tests).

## D4 disposition

Closed, no code: `LAYOUT_IN_PROGRESS`/`StateReady` (and any thread-local re-entrancy guard) no longer exist anywhere in the tree — state_layout.rs was rewritten in Wave 1 (now 563 lines) and the cycle the guard protected against went with DEC-3's relocation removal.

## `enforces_auth_gates` decision

**Dropped** — it would state a falsehood: both transports run the same `pre_check` since Wave-2 N11. The surviving `facelock test` asymmetries are real but narrow — the direct path skips the SSH/lid physical-presence aborts (`PreCheckContext::test`) and audits as `Test` vs `Daemon`; neither path charges the rate limit for a failed test — and no caller branches on them, so they are documented at `Backend::recognize` (backend.rs) instead of carried as a boolean nobody reads. `BackendCaps` keeps the two facts callers actually consume: `graphical_preview` (daemon-only) and `device_formats` (direct-only; the D-Bus `DeviceInfo` carries none — wire unchanged).

## Behavioral deltas (beyond the spec'd messaging)

- `DirectByFallback` prints one stderr warning per invocation (was silent).
- Fresh-install direct reads no longer create the database (`list`, `remove`, marker recount).
- `devices` (direct, none found) gains the "Check that your camera is connected…" hint line the daemon path already printed; rendering otherwise byte-identical.
- `test` daemon path: an `Error` reply now surfaces as `daemon error: <msg>` (was `unexpected response from daemon: Error {..}`) and `Suppressed` renders as no-match (was "unexpected"); the desktop notification carries the error text — the direct path's existing policy.
- `test` renderings stay per-path byte-stable (daemon shows model id/label, direct does not) — presentation predating the seam, keyed on `kind()` with a comment; transport itself is single-sited in `recognize`.
- enroll's redundant in-branch `require_root` re-check removed (root already enforced at the top).
- Daemon corner: `seal_database` + failed TPM init now yields a clear per-row TPM error instead of a misleading "corrupt store" (see N10).

## Invariants held

PAM untouched and outside the trait; `DaemonRequest`↔dbus double translation untouched (H7's input type); is-enrolled/hyprlock/config never select or probe (pins updated, dispatch order unchanged); no D-Bus wire change; the PAM-matched protocol strings ("rate limited", "IR camera required") flow byte-identical (live in facelock-daemon/src/auth.rs, untouched); H5 discipline: the three new messages are human/stderr-only, machine sinks (`machine()`, D-Bus errors, audit) never localize.

## Cross-PR notes

- **H7 (daemon extraction):** the seam's daemon arms are now the only CLI consumers of `send_request`/`send_enroll` besides status.rs (Ping) and the preview frame loops — all named in the structural pin's allowlist. When the D-Bus server moves out and `DaemonRequest` becomes a handler input type, only backend.rs + those allowlisted files need touching; the pin will flag any strays.
- **H8 (Health):** `DaemonReachability` + `Resolved`/`Provenance` is the reachability fact ready to lift into `Fact<T>`; status.rs still runs its own Ping probe (deliberately left — H8's rewrite should consume `classify`'s fact and delete status.rs from the send_request allowlist).
- **i18n:** 3 new msgids regenerated into `po/facelock.pot` (`just pot`); translation catalogs need the usual update pass.

## Docs to reconcile

- `book/src/troubleshooting.md` / `docs/troubleshooting.md`: document the new one-line fallback warning ("daemon.mode = \"daemon\" but the facelock daemon is unreachable…") as the signature of a stopped daemon, and the corrected preview wording.
- `book/src/cli-reference.md`: `facelock devices` formats note (format detail requires direct camera access; the daemon listing has none) and the fresh-install `list` no-DB-creation behavior.
- No `docs/contracts.md` change needed: no binary/path/config/schema/wire/auth-semantics change.

## Gates

`just check` (test + clippy -D warnings + fmt-check + audit):
```
cargo clippy --workspace -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.96s
cargo fmt --all -- --check
cargo audit --deny unmaintained --deny unsound
    Scanning Cargo.lock for vulnerabilities (481 crate dependencies)
warning: 2 allowed warnings found   # pre-existing yanked-crate allowlist (core2, uds_windows)
```

`just test-arch-pam`:
```
TEST: Peer-UID harness: fake non-root daemon replies matched=true ... PASS
TEST: Peer-UID: non-root daemon owner yields no PAM_SUCCESS ... PASS

=== Results: 22 passed, 0 failed ===
```

`just test-arch-layout`:
```
TEST: is-enrolled exits 0 for an enrolled group member ... PASS
TEST: is-enrolled exits 1 for a user outside the group ... PASS
TEST: is-enrolled --json reports the model count ... PASS

=== Results: 21 passed, 0 failed ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
