### PR TITLE
refactor(status): Health facts + renderer — unknown is not false (N4, F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invoking user can be determined), so daemon commands like `facelock
   preview`/`test` work after setup without a manual `usermod`. A log-out/log-in
   reminder is printed.
+- **`facelock status` reports whether the PAM oneshot fallback is usable**: a
+  new "Oneshot fallback" section says whether root-invoked PAM could
+  authenticate via `/usr/bin/facelock auth` with the daemon unreachable — the
+  binary, both configured model files, and the database must be present — and
+  names whichever prerequisite is missing.
+- **`facelock status` explains the camera**: when the configured (or
+  auto-detected) device can be interrogated, the report shows its
+  evidence-based IR classification and any camera-quirks entries that will
+  shape how it is opened, so "why does this camera behave that way" is
+  answerable from the report. Auto-detect additionally names the device it
+  would select right now.
+- **`facelock status` flags a stale `is-enrolled` marker**: running as root it
+  compares the target user's marker against the database and prints a
+  diagnostic when they disagree (or when the marker is unreadable), pointing
+  at `sudo facelock setup` to reconcile. `is-enrolled` itself is unchanged.
 
 ### Changed
 
+- **`facelock status` says "cannot determine" instead of guessing**: a section
+  whose probe failed — an unreadable database, a config that did not parse —
+  now reports exactly that, and a daemon that is unreachable can never render
+  as "no faces enrolled". Previously a broken config silently dropped several
+  sections from the report; every section now always renders, as its value or
+  as honestly unknown. Internally the command is a pure renderer over a
+  `Health` fact model, so the report — including the exact bytes the container
+  tests grep — is pinned by unit tests.
 - **State directory and log permissions tightened — no paths moved, no data
   migration**. The database stays at `/var/lib/facelock/facelock.db` and the
   models at `/var/lib/facelock/models`; what changes are modes and ownership:

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -331,7 +331,10 @@ Shows device path, name, driver, formats, resolutions, and IR status.
 
 ## facelock status
 
-Check system status -- config, daemon, camera, models.
+Check system status -- config, daemon, oneshot fallback, camera, models,
+encryption, enrollment, security posture, notifications, PAM wiring. Requires
+root. A check that cannot be performed (unreadable database, broken config) is
+reported as "cannot determine" -- never as a guessed value.
 
 ```bash
 facelock status

--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -22,8 +22,9 @@
 //!   fallback). It shares test vectors, not code.
 //! - **`is-enrolled`** is dispatched in `main` before any config parse and
 //!   must never probe the bus; `hyprlock` and `config` touch no backend.
-//! - **`status`** renders its own probes for now — H8 (Health) will consume
-//!   the [`DaemonReachability`] fact this module records.
+//! - **`status`** consumes facts, not transport: its daemon probe is
+//!   [`probe_daemon`] here in the seam (H8), so `ipc_client` stays
+//!   single-sited.
 //! - Maintenance commands (`bench`, `encrypt`, `tpm`, `audit`, `auth`,
 //!   `daemon`) are direct-by-nature and never select.
 
@@ -65,8 +66,9 @@ impl BackendKind {
 
 /// What the one probe observed, recorded beside the resolved-config facts
 /// (D7) with the same provenance discipline: `NotProbed` is a distinct value,
-/// never a guessed `Unreachable`. H8 (Health) lifts this into its `Fact`
-/// model; until then it is logged at selection.
+/// never a guessed `Unreachable`. `status` reports the same discipline
+/// through [`DaemonPing`], which additionally carries the failure detail a
+/// report wants and a human does not need at selection time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonReachability {
     /// `mode = "oneshot"`: the bus is deliberately never asked.
@@ -315,6 +317,54 @@ impl<'a> Backend<'a> {
     }
 }
 
+/// What `status`'s deliberate daemon probe found (H8).
+///
+/// Distinct from [`DaemonReachability`] on purpose. Selection's probe
+/// (`name_has_owner`) must never activate the daemon, because selection runs
+/// on every backend-using command. `status` exists to diagnose, so its probe
+/// is the full `Ping` round-trip — allowed to trigger D-Bus activation,
+/// because "responding" in a health report means *the daemon the next auth
+/// would get answered a method call*, not merely that the name has an owner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonPing {
+    /// `daemon.mode = "oneshot"`: the bus is deliberately never asked; there
+    /// is no daemon to report on.
+    NotConfigured,
+    /// A `Ping` method call completed.
+    Responding,
+    /// The round-trip failed; `error` is the transport's own account.
+    NotResponding { error: String },
+}
+
+/// `status`'s daemon probe. Lives in the seam so `ipc_client::ping` stays
+/// single-sited (D1) — the health model consumes the fact, not the transport.
+pub fn probe_daemon(mode: &DaemonMode) -> Resolved<DaemonPing> {
+    probe_daemon_with(mode, ipc_client::ping)
+}
+
+/// The probe rule, split from the transport so it is testable without a bus
+/// (same shape as [`classify`]).
+fn probe_daemon_with(
+    mode: &DaemonMode,
+    ping: impl FnOnce() -> anyhow::Result<()>,
+) -> Resolved<DaemonPing> {
+    match mode {
+        DaemonMode::Oneshot => Resolved {
+            value: DaemonPing::NotConfigured,
+            provenance: Provenance::Claimed,
+        },
+        DaemonMode::Daemon => Resolved {
+            value: match ping() {
+                Ok(()) => DaemonPing::Responding,
+                Err(e) => DaemonPing::NotResponding {
+                    error: e.to_string(),
+                },
+            },
+            provenance: Provenance::Probed,
+        },
+    }
+}
+
 /// The selection rule, split from the probe so it is testable without a bus.
 fn classify(
     mode: &DaemonMode,
@@ -415,6 +465,40 @@ mod tests {
         let (kind, fact) = classify(&DaemonMode::Daemon, || false);
         assert_eq!(kind, BackendKind::DirectByFallback);
         assert_eq!(fact.value, DaemonReachability::Unreachable);
+        assert_eq!(fact.provenance, Provenance::Probed);
+    }
+
+    // -----------------------------------------------------------------------
+    // status's daemon probe (H8): mode x ping outcome -> DaemonPing fact.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn oneshot_daemon_probe_never_pings() {
+        let fact = probe_daemon_with(&DaemonMode::Oneshot, || {
+            panic!("oneshot must never ping the daemon")
+        });
+        assert_eq!(fact.value, DaemonPing::NotConfigured);
+        assert_eq!(fact.provenance, Provenance::Claimed);
+    }
+
+    #[test]
+    fn daemon_probe_reports_a_completed_round_trip() {
+        let fact = probe_daemon_with(&DaemonMode::Daemon, || Ok(()));
+        assert_eq!(fact.value, DaemonPing::Responding);
+        assert_eq!(fact.provenance, Provenance::Probed);
+    }
+
+    #[test]
+    fn daemon_probe_carries_the_failure_detail() {
+        let fact = probe_daemon_with(&DaemonMode::Daemon, || {
+            Err(anyhow::anyhow!("D-Bus Ping call failed"))
+        });
+        assert_eq!(
+            fact.value,
+            DaemonPing::NotResponding {
+                error: "D-Bus Ping call failed".into()
+            }
+        );
         assert_eq!(fact.provenance, Provenance::Probed);
     }
 
@@ -620,7 +704,7 @@ mod tests {
             ("clear_models", backend_only),
             ("send_enroll", backend_only),
             ("list_devices", backend_only),
-            ("ping", &["commands/status.rs"]), // its own probe until H8
+            ("ping", backend_only), // status's probe routes through probe_daemon (H8)
             ("preview_detect_frame", preview),
             ("release_camera", preview),
         ];

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -1,423 +1,994 @@
-use std::path::Path;
+//! `facelock status` — a renderer over [`Health`] (map §5).
+//!
+//! The command is two halves with nothing hidden between them:
+//! [`Health::probe`] gathers every fact (root, real system), and [`render`]
+//! turns a `Health` into the report, pure and byte-deterministic. Every
+//! judgment this file used to make inline — "is that an error or an empty
+//! list?" — now arrives pre-decided as a [`Fact`], and the renderer's one
+//! obligation is N4's: an unknown fact renders as *unknown*, never as a
+//! guessed value. "The daemon is unreachable" must never read as "no faces
+//! enrolled".
+//!
+//! Output contract: the container integration tests grep
+//! `[ok] responding` from this report, and the English fallback of every
+//! message here is byte-identical to the historical inline strings (D10).
+//! There is no `status --json`; if one appears, it renders from the same
+//! `Health` value without gettext (machine-facing exclusion, D2).
 
-use facelock_core::Config;
-use facelock_core::config::EncryptionMethod;
-
+use crate::backend::DaemonPing;
+use crate::health::{
+    CameraHealth, ConfigOutcome, EncryptionHealth, EnrollmentHealth, Health, InterrogatedCamera,
+    KeyMaterial, MarkerDiagnostic, NotificationHealth, OneshotFallback, PamWiring, SecurityHealth,
+};
 use crate::ipc_client;
+use crate::message::UserMessage;
+use crate::resolved::{EpStatus, ExecutionProviderFact, Fact, ModelFiles};
 
 pub fn run(loaded: crate::resolved::ConfigLoad) -> anyhow::Result<()> {
-    // DEC-6/N4: every D-Bus method `status` calls (`Ping`, and `ListModels`
-    // via `check_enrolled`) is root-only now, and its direct-mode reads hit
-    // the same 0600 root:root database. Check before the first line of
-    // output (C6).
+    // DEC-6/N4: everything this report reads is root's — the daemon's
+    // root-only methods, the 0600 database, other users' markers. Check
+    // before the first line of output (C6).
     ipc_client::require_root("sudo facelock status")?;
 
-    println!("facelock system status\n");
-
-    // 1. Config — renders the process's one parse outcome (D7); a broken
-    // config file is a finding to report, not an exit.
-    check_config(&loaded);
-    let config = loaded.config();
-
-    // 2. Daemon
-    check_daemon(config);
-
-    // 3. Camera
-    check_camera(config);
-
-    // 4. Models
-    check_models(config);
-
-    // 5. Inference
-    check_inference(config);
-
-    // 6. Encryption
-    check_encryption(config);
-
-    // 7. Enrolled faces
-    check_enrolled(config);
-
-    // 8. Security
-    check_security(config);
-
-    // 9. Notifications
-    check_notifications(config);
-
-    // 10. PAM
-    check_pam();
-
+    let health = Health::probe(&loaded);
+    print!("{}", render(&health));
     Ok(())
 }
 
-fn check_config(loaded: &crate::resolved::ConfigLoad) {
-    print_status_item("Config file", &loaded.path.display().to_string());
+/// The report, as a string. Pure: no probing, no I/O, no branching on the
+/// live system — a synthetic [`Health`] renders in a unit test with zero
+/// root, camera, or bus.
+pub fn render(health: &Health) -> String {
+    let mut out = String::new();
+    out.push_str(&UserMessage::StatusHeader.localized());
+    out.push_str("\n\n");
 
-    match &loaded.result {
-        Ok(config) => {
-            print_result(true, "valid");
-            print_detail(
-                "device.path",
-                config.device.path.as_deref().unwrap_or("(auto-detect)"),
-            );
-        }
-        Err(facelock_core::config::ConfigError::NotFound(_)) => {
-            print_result(false, "not found");
-        }
-        Err(e) => {
-            print_result(false, &format!("invalid: {e}"));
-        }
-    }
+    render_config(&mut out, health);
+    render_daemon(&mut out, &health.daemon);
+    render_fallback(&mut out, &health.oneshot_fallback);
+    render_camera(&mut out, &health.camera);
+    render_models(&mut out, &health.models);
+    render_execution_provider(&mut out, &health.execution_provider);
+    render_encryption(&mut out, &health.encryption);
+    render_enrolled(&mut out, &health.user, &health.enrolled);
+    render_security(&mut out, &health.security);
+    render_notifications(&mut out, &health.notifications);
+    render_pam(&mut out, &health.pam);
+    out
 }
 
-fn check_daemon(config: Option<&Config>) {
-    let Some(config) = config else {
-        print_status_item("Daemon", "");
-        print_result(false, "config not loaded, cannot check daemon");
-        return;
-    };
+// ---------------------------------------------------------------------------
+// Report skeleton. The prefixes are structure, not prose: `[ok]`/`[!!]` are
+// grepped by the container tests and stay untranslated by construction.
+// ---------------------------------------------------------------------------
 
-    print_status_item("Daemon", "org.facelock.Daemon (D-Bus system bus)");
-
-    if config.daemon.mode == facelock_core::config::DaemonMode::Oneshot {
-        print_result(true, "oneshot mode (no daemon)");
-        return;
-    }
-
-    // Try to ping — this may trigger D-Bus activation if the daemon
-    // isn't running yet but activation is configured.
-    match ipc_client::ping() {
-        Ok(()) => {
-            print_result(true, "responding");
-        }
-        Err(e) => {
-            print_result(false, &format!("not responding: {e}"));
-        }
-    }
-}
-
-fn check_camera(config: Option<&Config>) {
-    let Some(config) = config else {
-        print_status_item("Camera", "");
-        print_result(false, "config not available");
-        return;
-    };
-
-    match crate::resolved::CameraPresence::probe(config).value {
-        crate::resolved::CameraPresence::Configured { path, present } => {
-            print_status_item("Camera device", &path);
-            print_result(
-                present,
-                if present {
-                    "device exists"
-                } else {
-                    "device not found"
-                },
-            );
-        }
-        crate::resolved::CameraPresence::AutoDetect => {
-            print_status_item("Camera device", "(auto-detect)");
-            print_result(true, "auto-detect enabled");
-        }
-    }
-}
-
-fn check_models(config: Option<&Config>) {
-    let Some(config) = config else {
-        print_status_item("Models", "");
-        print_result(false, "config not available");
-        return;
-    };
-
-    // The configured model files (not just defaults), through the shared
-    // probe (D7).
-    let models = crate::resolved::ModelFiles::probe(config).value;
-    print_status_item("Model directory", &models.dir.display().to_string());
-
-    if !models.dir_present {
-        print_result(false, "directory not found");
-        return;
-    }
-
-    for (purpose, file) in [
-        ("detector", &models.detector),
-        ("embedder", &models.embedder),
-    ] {
-        let filename = file.path.file_name().unwrap_or_default().to_string_lossy();
-        print_detail(
-            &format!("{purpose} ({filename})"),
-            if file.present { "present" } else { "MISSING" },
-        );
-    }
-
-    if models.all_present() {
-        print_result(true, "all configured models present");
+fn item(out: &mut String, label: &UserMessage, value: &str) {
+    let label = label.localized();
+    if value.is_empty() {
+        out.push_str(&format!("  {label}:\n"));
     } else {
-        print_result(false, "some models missing (run 'facelock setup')");
+        out.push_str(&format!("  {label}: {value}\n"));
     }
 }
 
-fn check_inference(config: Option<&Config>) {
-    let Some(config) = config else {
-        return;
-    };
+fn result(out: &mut String, ok: bool, msg: &UserMessage) {
+    let indicator = if ok { "[ok]" } else { "[!!]" };
+    out.push_str(&format!("    {indicator} {}\n", msg.localized()));
+}
 
-    // Resolved against the installed ONNX Runtime (D7): the old check listed
-    // .so paths — a copy of the provider module's search list that could
-    // drift, and one that said nothing about whether the *configured*
-    // provider is actually compiled into that runtime.
-    let ep = crate::resolved::ExecutionProviderFact::probe(config).value;
-    let label = match ep.configured.as_str() {
-        "cpu" => "CPU",
-        "cuda" => "CUDA (NVIDIA GPU)",
-        "rocm" => "ROCm (AMD GPU)",
-        "openvino" => "OpenVINO (Intel)",
-        other => other,
-    };
-    print_status_item("Execution provider", label);
+fn detail(out: &mut String, key: &str, value: &str) {
+    out.push_str(&format!("    - {key}: {value}\n"));
+}
 
-    match &ep.status {
-        crate::resolved::EpStatus::Available => {
-            print_result(true, "supported by the installed ONNX Runtime");
-        }
-        crate::resolved::EpStatus::NotBuiltIn => {
-            print_result(
-                false,
-                "not built into the installed ONNX Runtime — inference will fall back to CPU",
-            );
-        }
-        crate::resolved::EpStatus::UnknownName => {
-            print_result(
-                false,
-                "unknown execution provider (valid: cpu, cuda, rocm, openvino)",
-            );
-        }
-        crate::resolved::EpStatus::Unqueryable(e) => {
-            print_result(false, &format!("ONNX Runtime not loadable: {e}"));
-        }
+/// The N4 rule in one place: a fact that could not be determined renders as
+/// exactly that.
+fn unknown(out: &mut String, why: &str) {
+    result(out, false, &UserMessage::StatusUnknown { why: why.into() });
+}
+
+fn yes_no(value: bool) -> String {
+    if value {
+        UserMessage::StatusYes.localized()
+    } else {
+        UserMessage::StatusNo.localized()
     }
 }
 
-fn check_encryption(config: Option<&Config>) {
-    let Some(config) = config else {
-        return;
-    };
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
 
-    let method_str = match config.encryption.method {
-        EncryptionMethod::Tpm => "AES-256-GCM (TPM-sealed key)",
-        EncryptionMethod::Keyfile => "AES-256-GCM (keyfile)",
-        EncryptionMethod::None => "none",
-    };
-    print_status_item("Encryption", method_str);
+fn render_config(out: &mut String, health: &Health) {
+    item(
+        out,
+        &UserMessage::StatusLabelConfigFile,
+        &health.config.path,
+    );
+    match &health.config.outcome {
+        ConfigOutcome::Valid { device_path } => {
+            result(out, true, &UserMessage::StatusConfigValid);
+            detail(
+                out,
+                "device.path",
+                device_path.as_deref().unwrap_or("(auto-detect)"),
+            );
+        }
+        ConfigOutcome::NotFound => result(out, false, &UserMessage::StatusConfigNotFound),
+        ConfigOutcome::Invalid { error } => result(
+            out,
+            false,
+            &UserMessage::StatusConfigInvalid {
+                error: error.clone(),
+            },
+        ),
+    }
+}
 
-    match config.encryption.method {
-        EncryptionMethod::Tpm => {
-            let sealed_exists = Path::new(&config.encryption.sealed_key_path).exists();
-            let device_path = config
-                .tpm
-                .tcti
-                .strip_prefix("device:")
-                .unwrap_or(&config.tpm.tcti);
-            let device_exists = Path::new(device_path).exists();
-            if sealed_exists && device_exists {
-                print_result(
-                    true,
-                    &format!("sealed key: {}", config.encryption.sealed_key_path),
-                );
-            } else if !sealed_exists {
-                print_result(
-                    false,
-                    &format!("sealed key missing: {}", config.encryption.sealed_key_path),
-                );
+fn render_daemon(out: &mut String, daemon: &Fact<DaemonPing>) {
+    // The bus name is a static fact about the design, valid even when the
+    // config (and so the mode) is unknown.
+    item(
+        out,
+        &UserMessage::StatusLabelDaemon,
+        "org.facelock.Daemon (D-Bus system bus)",
+    );
+    match daemon {
+        Fact::Unknown { why } => unknown(out, why),
+        Fact::Known(ping) => match &ping.value {
+            DaemonPing::NotConfigured => result(out, true, &UserMessage::StatusDaemonOneshot),
+            DaemonPing::Responding => result(out, true, &UserMessage::StatusDaemonResponding),
+            DaemonPing::NotResponding { error } => result(
+                out,
+                false,
+                &UserMessage::StatusDaemonNotResponding {
+                    error: error.clone(),
+                },
+            ),
+        },
+    }
+}
+
+fn render_fallback(out: &mut String, fallback: &Fact<OneshotFallback>) {
+    match fallback {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelOneshotFallback, "");
+            unknown(out, why);
+        }
+        Fact::Known(resolved) => {
+            let fallback = &resolved.value;
+            item(
+                out,
+                &UserMessage::StatusLabelOneshotFallback,
+                &fallback.auth_bin,
+            );
+            if fallback.usable() {
+                result(out, true, &UserMessage::StatusFallbackUsable);
             } else {
-                print_result(false, &format!("TPM device missing: {}", device_path));
-            }
-        }
-        EncryptionMethod::Keyfile => {
-            let key_exists = Path::new(&config.encryption.key_path).exists();
-            if key_exists {
-                print_result(true, &format!("key file: {}", config.encryption.key_path));
-            } else {
-                print_result(
-                    false,
-                    &format!("key file missing: {}", config.encryption.key_path),
-                );
-            }
-        }
-        EncryptionMethod::None => {
-            print_result(
-                false,
-                "embeddings stored as plaintext (run 'facelock setup' to enable encryption)",
-            );
-        }
-    }
-
-    // Show DB encryption stats if readable
-    if let Ok(store) = facelock_store::FaceStore::open_readonly(Path::new(&config.storage.db_path))
-    {
-        if let Ok((sealed, unsealed)) = store.count_sealed() {
-            if sealed + unsealed > 0 {
-                print_detail("encrypted", &sealed.to_string());
-                print_detail("plaintext", &unsealed.to_string());
+                let missing = UserMessage::StatusMissing.localized();
+                for (key, present) in [
+                    ("binary", fallback.auth_bin_present),
+                    ("models", fallback.models_present),
+                    ("database", fallback.database_present),
+                ] {
+                    if !present {
+                        detail(out, key, &missing);
+                    }
+                }
+                result(out, false, &UserMessage::StatusFallbackNotUsable);
             }
         }
     }
 }
 
-fn check_enrolled(config: Option<&Config>) {
-    let Some(config) = config else {
-        return;
-    };
-
-    // One user-resolution implementation (C5, issue #105): the local
-    // SUDO_USER→USER chain this replaces omitted DOAS_USER and the getpwuid
-    // fallback, so `doas facelock status` reported root's enrollment.
-    let user = crate::ipc_client::resolve_user(None);
-
-    print_status_item("Enrolled faces", &user);
-
-    match facelock_store::FaceStore::open_readonly(Path::new(&config.storage.db_path)) {
-        Ok(store) => match store.list_models(&user) {
-            Ok(models) if models.is_empty() => {
-                print_result(false, "no faces enrolled (run 'facelock enroll')");
-            }
-            Ok(models) => {
-                print_result(true, &format!("{} model(s)", models.len()));
-                for m in &models {
-                    print_detail(&format!("#{}", m.id), &m.label);
+fn render_camera(out: &mut String, camera: &Fact<CameraHealth>) {
+    match camera {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelCameraDevice, "");
+            unknown(out, why);
+        }
+        Fact::Known(resolved) => match &resolved.value {
+            CameraHealth::Configured {
+                path,
+                present,
+                interrogated,
+            } => {
+                item(out, &UserMessage::StatusLabelCameraDevice, path);
+                if *present {
+                    result(out, true, &UserMessage::StatusCameraDeviceExists);
+                } else {
+                    result(out, false, &UserMessage::StatusCameraDeviceNotFound);
+                }
+                if let Some(camera) = interrogated {
+                    camera_details(out, camera);
                 }
             }
-            Err(e) => {
-                print_result(false, &format!("error reading models: {e}"));
+            CameraHealth::AutoDetect { resolved } => {
+                item(out, &UserMessage::StatusLabelCameraDevice, "(auto-detect)");
+                result(out, true, &UserMessage::StatusCameraAutoDetect);
+                if let Some(camera) = resolved {
+                    detail(out, "device", &format!("{} ({})", camera.path, camera.name));
+                    camera_details(out, camera);
+                }
             }
         },
-        Err(_) => {
-            print_detail("database", "not accessible (may need root)");
+    }
+}
+
+/// The D8 payoff: "why did this camera behave oddly" is answerable from
+/// `status` — the interrogated IR classification and any quirks-DB entries
+/// that will shape how the device is opened.
+fn camera_details(out: &mut String, camera: &InterrogatedCamera) {
+    detail(out, "ir", &yes_no(camera.is_ir));
+    if !camera.applied_quirks.is_empty() {
+        detail(out, "quirks", &camera.applied_quirks.join(", "));
+    }
+}
+
+fn render_models(out: &mut String, models: &Fact<ModelFiles>) {
+    match models {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelModelDirectory, "");
+            unknown(out, why);
         }
-    }
-}
-
-fn check_security(config: Option<&Config>) {
-    let Some(config) = config else {
-        return;
-    };
-
-    print_status_item("Security", "");
-    if config.security.disabled {
-        print_result(false, "ALL SECURITY CHECKS DISABLED");
-        return;
-    }
-    print_detail(
-        "require_ir",
-        if config.security.require_ir {
-            "yes"
-        } else {
-            "no"
-        },
-    );
-    print_detail(
-        "liveness (frame variance)",
-        if config.security.require_frame_variance {
-            "yes"
-        } else {
-            "no"
-        },
-    );
-    print_detail(
-        "liveness (landmark movement)",
-        if config.security.require_landmark_liveness {
-            "yes"
-        } else {
-            "no"
-        },
-    );
-    print_detail(
-        "min_auth_frames",
-        &config.security.min_auth_frames.to_string(),
-    );
-}
-
-fn check_notifications(config: Option<&Config>) {
-    let Some(config) = config else {
-        return;
-    };
-
-    let mode_str = match config.notification.mode {
-        facelock_core::config::NotificationMode::Off => "off",
-        facelock_core::config::NotificationMode::Terminal => "terminal",
-        facelock_core::config::NotificationMode::Desktop => "desktop",
-        facelock_core::config::NotificationMode::Both => "terminal + desktop",
-    };
-    print_status_item("Notifications", mode_str);
-    if config.notification.mode != facelock_core::config::NotificationMode::Off {
-        print_detail(
-            "prompt",
-            if config.notification.notify_prompt {
-                "yes"
+        Fact::Known(resolved) => {
+            let models = &resolved.value;
+            item(
+                out,
+                &UserMessage::StatusLabelModelDirectory,
+                &models.dir.display().to_string(),
+            );
+            if !models.dir_present {
+                result(out, false, &UserMessage::StatusModelsDirNotFound);
+                return;
+            }
+            for (purpose, file) in [
+                ("detector", &models.detector),
+                ("embedder", &models.embedder),
+            ] {
+                let filename = file.path.file_name().unwrap_or_default().to_string_lossy();
+                let presence = if file.present {
+                    UserMessage::StatusPresent
+                } else {
+                    UserMessage::StatusMissing
+                };
+                detail(
+                    out,
+                    &format!("{purpose} ({filename})"),
+                    &presence.localized(),
+                );
+            }
+            if models.all_present() {
+                result(out, true, &UserMessage::StatusModelsAllPresent);
             } else {
-                "no"
-            },
-        );
-        print_detail(
-            "on success",
-            if config.notification.notify_on_success {
-                "yes"
-            } else {
-                "no"
-            },
-        );
-        print_detail(
-            "on failure",
-            if config.notification.notify_on_failure {
-                "yes"
-            } else {
-                "no"
-            },
-        );
-    }
-}
-
-fn check_pam() {
-    let pam_path = "/lib/security/pam_facelock.so";
-    print_status_item("PAM module", pam_path);
-
-    if Path::new(pam_path).exists() {
-        print_result(true, "installed");
-    } else {
-        // Also check /usr/lib path
-        let alt_path = "/usr/lib/security/pam_facelock.so";
-        if Path::new(alt_path).exists() {
-            print_result(true, &format!("installed at {alt_path}"));
-        } else {
-            print_result(false, "not installed");
-        }
-    }
-
-    // Check if sudo is configured
-    let sudo_pam = "/etc/pam.d/sudo";
-    if Path::new(sudo_pam).exists() {
-        if let Ok(content) = std::fs::read_to_string(sudo_pam) {
-            if content.contains("pam_facelock") {
-                print_detail("sudo PAM", "configured");
-            } else {
-                print_detail("sudo PAM", "not configured for facelock");
+                result(out, false, &UserMessage::StatusModelsSomeMissing);
             }
         }
     }
 }
 
-fn print_status_item(label: &str, value: &str) {
-    if value.is_empty() {
-        println!("  {label}:");
-    } else {
-        println!("  {label}: {value}");
+fn render_execution_provider(out: &mut String, ep: &Fact<ExecutionProviderFact>) {
+    match ep {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelExecutionProvider, "");
+            unknown(out, why);
+        }
+        Fact::Known(resolved) => {
+            let ep = &resolved.value;
+            let label = match ep.configured.as_str() {
+                "cpu" => "CPU",
+                "cuda" => "CUDA (NVIDIA GPU)",
+                "rocm" => "ROCm (AMD GPU)",
+                "openvino" => "OpenVINO (Intel)",
+                other => other,
+            };
+            item(out, &UserMessage::StatusLabelExecutionProvider, label);
+            match &ep.status {
+                EpStatus::Available => result(out, true, &UserMessage::StatusEpSupported),
+                EpStatus::NotBuiltIn => result(out, false, &UserMessage::StatusEpNotBuiltIn),
+                EpStatus::UnknownName => result(out, false, &UserMessage::StatusEpUnknownName),
+                EpStatus::Unqueryable(error) => result(
+                    out,
+                    false,
+                    &UserMessage::StatusEpUnqueryable {
+                        error: error.clone(),
+                    },
+                ),
+            }
+        }
     }
 }
 
-fn print_result(ok: bool, message: &str) {
-    let indicator = if ok { "[ok]" } else { "[!!]" };
-    println!("    {indicator} {message}");
+fn render_encryption(out: &mut String, encryption: &Fact<EncryptionHealth>) {
+    match encryption {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelEncryption, "");
+            unknown(out, why);
+        }
+        Fact::Known(resolved) => {
+            use facelock_core::config::EncryptionMethod;
+            let encryption = &resolved.value;
+            let method = match encryption.method {
+                EncryptionMethod::Tpm => "AES-256-GCM (TPM-sealed key)",
+                EncryptionMethod::Keyfile => "AES-256-GCM (keyfile)",
+                EncryptionMethod::None => "none",
+            };
+            item(out, &UserMessage::StatusLabelEncryption, method);
+            match &encryption.material {
+                KeyMaterial::Tpm {
+                    sealed_key_path,
+                    sealed_key_present,
+                    device_path,
+                    device_present,
+                } => {
+                    if *sealed_key_present && *device_present {
+                        result(
+                            out,
+                            true,
+                            &UserMessage::StatusSealedKey {
+                                path: sealed_key_path.clone(),
+                            },
+                        );
+                    } else if !sealed_key_present {
+                        result(
+                            out,
+                            false,
+                            &UserMessage::StatusSealedKeyMissing {
+                                path: sealed_key_path.clone(),
+                            },
+                        );
+                    } else {
+                        result(
+                            out,
+                            false,
+                            &UserMessage::StatusTpmDeviceMissing {
+                                path: device_path.clone(),
+                            },
+                        );
+                    }
+                }
+                KeyMaterial::Keyfile { key_path, present } => {
+                    if *present {
+                        result(
+                            out,
+                            true,
+                            &UserMessage::StatusKeyFile {
+                                path: key_path.clone(),
+                            },
+                        );
+                    } else {
+                        result(
+                            out,
+                            false,
+                            &UserMessage::StatusKeyFileMissing {
+                                path: key_path.clone(),
+                            },
+                        );
+                    }
+                }
+                KeyMaterial::None => {
+                    result(out, false, &UserMessage::StatusPlaintextEmbeddings);
+                }
+            }
+            if let Some((sealed, plaintext)) = encryption.sealed_counts {
+                if sealed + plaintext > 0 {
+                    detail(out, "encrypted", &sealed.to_string());
+                    detail(out, "plaintext", &plaintext.to_string());
+                }
+            }
+        }
+    }
 }
 
-fn print_detail(key: &str, value: &str) {
-    println!("    - {key}: {value}");
+fn render_enrolled(out: &mut String, user: &str, enrolled: &Fact<EnrollmentHealth>) {
+    item(out, &UserMessage::StatusLabelEnrolledFaces, user);
+    match enrolled {
+        // The money case. An unreadable store renders as *cannot determine*
+        // — never as "no faces enrolled" (N4).
+        Fact::Unknown { why } => unknown(out, why),
+        Fact::Known(resolved) => {
+            let enrolled = &resolved.value;
+            if enrolled.models.is_empty() {
+                result(out, false, &UserMessage::StatusNoFacesEnrolled);
+            } else {
+                result(
+                    out,
+                    true,
+                    &UserMessage::StatusModelCount {
+                        count: enrolled.models.len(),
+                    },
+                );
+                for model in &enrolled.models {
+                    detail(out, &format!("#{}", model.id), &model.label);
+                }
+            }
+            match &enrolled.marker {
+                MarkerDiagnostic::Consistent => {}
+                MarkerDiagnostic::Mismatch { marker, store } => detail(
+                    out,
+                    "marker",
+                    &UserMessage::StatusMarkerMismatch {
+                        marker: *marker,
+                        store: *store,
+                    }
+                    .localized(),
+                ),
+                MarkerDiagnostic::Unreadable { why } => detail(
+                    out,
+                    "marker",
+                    &UserMessage::StatusMarkerUnreadable { why: why.clone() }.localized(),
+                ),
+            }
+        }
+    }
+}
+
+fn render_security(out: &mut String, security: &Fact<SecurityHealth>) {
+    item(out, &UserMessage::StatusLabelSecurity, "");
+    match security {
+        Fact::Unknown { why } => unknown(out, why),
+        Fact::Known(resolved) => {
+            let security = &resolved.value;
+            if security.disabled {
+                result(out, false, &UserMessage::StatusSecurityDisabled);
+                return;
+            }
+            detail(out, "require_ir", &yes_no(security.require_ir));
+            detail(
+                out,
+                "liveness (frame variance)",
+                &yes_no(security.require_frame_variance),
+            );
+            detail(
+                out,
+                "liveness (landmark movement)",
+                &yes_no(security.require_landmark_liveness),
+            );
+            detail(
+                out,
+                "min_auth_frames",
+                &security.min_auth_frames.to_string(),
+            );
+        }
+    }
+}
+
+fn render_notifications(out: &mut String, notifications: &Fact<NotificationHealth>) {
+    match notifications {
+        Fact::Unknown { why } => {
+            item(out, &UserMessage::StatusLabelNotifications, "");
+            unknown(out, why);
+        }
+        Fact::Known(resolved) => {
+            use facelock_core::config::NotificationMode;
+            let notifications = &resolved.value;
+            let mode = match notifications.mode {
+                NotificationMode::Off => UserMessage::StatusNotifyOff,
+                NotificationMode::Terminal => UserMessage::StatusNotifyTerminal,
+                NotificationMode::Desktop => UserMessage::StatusNotifyDesktop,
+                NotificationMode::Both => UserMessage::StatusNotifyBoth,
+            };
+            item(
+                out,
+                &UserMessage::StatusLabelNotifications,
+                &mode.localized(),
+            );
+            if notifications.mode != NotificationMode::Off {
+                detail(out, "prompt", &yes_no(notifications.notify_prompt));
+                detail(out, "on success", &yes_no(notifications.notify_on_success));
+                detail(out, "on failure", &yes_no(notifications.notify_on_failure));
+            }
+        }
+    }
+}
+
+fn render_pam(out: &mut String, pam: &PamWiring) {
+    item(out, &UserMessage::StatusLabelPamModule, &pam.module_path);
+    match &pam.installed_at {
+        Some(path) if *path == pam.module_path => {
+            result(out, true, &UserMessage::StatusPamInstalled)
+        }
+        Some(path) => result(
+            out,
+            true,
+            &UserMessage::StatusPamInstalledAt { path: path.clone() },
+        ),
+        None => result(out, false, &UserMessage::StatusPamNotInstalled),
+    }
+    if let Some(configured) = pam.sudo_configured {
+        let value = if configured {
+            UserMessage::StatusPamSudoConfigured
+        } else {
+            UserMessage::StatusPamSudoNotConfigured
+        };
+        detail(out, "sudo PAM", &value.localized());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    use facelock_core::config::NotificationMode;
+
+    use crate::health::{ConfigHealth, ModelSummary};
+    use crate::resolved::ProbedFile;
+
+    fn model_files(dir: &str, detector_present: bool, embedder_present: bool) -> ModelFiles {
+        let dir = PathBuf::from(dir);
+        ModelFiles {
+            detector: ProbedFile {
+                path: dir.join("det.onnx"),
+                present: detector_present,
+            },
+            embedder: ProbedFile {
+                path: dir.join("emb.onnx"),
+                present: embedder_present,
+            },
+            dir_present: true,
+            dir,
+        }
+    }
+
+    /// A fully healthy system, built literally — no root, camera, or bus.
+    fn healthy() -> Health {
+        Health {
+            config: ConfigHealth {
+                path: "/etc/facelock/config.toml".into(),
+                outcome: ConfigOutcome::Valid {
+                    device_path: Some("/dev/video2".into()),
+                },
+            },
+            daemon: Fact::probed(DaemonPing::Responding),
+            oneshot_fallback: Fact::probed(OneshotFallback {
+                auth_bin: "/usr/bin/facelock".into(),
+                auth_bin_present: true,
+                models_present: true,
+                database_present: true,
+            }),
+            camera: Fact::probed(CameraHealth::Configured {
+                path: "/dev/video2".into(),
+                present: true,
+                interrogated: Some(InterrogatedCamera {
+                    path: "/dev/video2".into(),
+                    name: "Integrated IR Camera".into(),
+                    is_ir: true,
+                    applied_quirks: vec![],
+                }),
+            }),
+            models: Fact::probed(model_files("/usr/share/facelock/models", true, true)),
+            execution_provider: Fact::probed(ExecutionProviderFact {
+                configured: "cpu".into(),
+                status: EpStatus::Available,
+            }),
+            encryption: Fact::probed(EncryptionHealth {
+                method: facelock_core::config::EncryptionMethod::Tpm,
+                material: KeyMaterial::Tpm {
+                    sealed_key_path: "/etc/facelock/sealed.key".into(),
+                    sealed_key_present: true,
+                    device_path: "/dev/tpmrm0".into(),
+                    device_present: true,
+                },
+                sealed_counts: Some((2, 0)),
+            }),
+            user: "alice".into(),
+            enrolled: Fact::probed(EnrollmentHealth {
+                models: vec![
+                    ModelSummary {
+                        id: 1,
+                        label: "front".into(),
+                    },
+                    ModelSummary {
+                        id: 2,
+                        label: "side".into(),
+                    },
+                ],
+                marker: MarkerDiagnostic::Consistent,
+            }),
+            security: Fact::claimed(SecurityHealth {
+                disabled: false,
+                require_ir: true,
+                require_frame_variance: true,
+                require_landmark_liveness: false,
+                min_auth_frames: 3,
+            }),
+            notifications: Fact::claimed(NotificationHealth {
+                mode: NotificationMode::Both,
+                notify_prompt: true,
+                notify_on_success: true,
+                notify_on_failure: false,
+            }),
+            pam: PamWiring {
+                module_path: "/lib/security/pam_facelock.so".into(),
+                installed_at: Some("/lib/security/pam_facelock.so".into()),
+                sudo_configured: Some(true),
+            },
+        }
+    }
+
+    /// The whole healthy report, byte for byte. This is the renderer's
+    /// contract with the container tests and the docs — most importantly the
+    /// grepped `    [ok] responding` line.
+    #[test]
+    fn healthy_report_renders_byte_exact() {
+        let expected = "\
+facelock system status
+
+  Config file: /etc/facelock/config.toml
+    [ok] valid
+    - device.path: /dev/video2
+  Daemon: org.facelock.Daemon (D-Bus system bus)
+    [ok] responding
+  Oneshot fallback: /usr/bin/facelock
+    [ok] usable (root-invoked PAM can authenticate via 'facelock auth' without the daemon)
+  Camera device: /dev/video2
+    [ok] device exists
+    - ir: yes
+  Model directory: /usr/share/facelock/models
+    - detector (det.onnx): present
+    - embedder (emb.onnx): present
+    [ok] all configured models present
+  Execution provider: CPU
+    [ok] supported by the installed ONNX Runtime
+  Encryption: AES-256-GCM (TPM-sealed key)
+    [ok] sealed key: /etc/facelock/sealed.key
+    - encrypted: 2
+    - plaintext: 0
+  Enrolled faces: alice
+    [ok] 2 model(s)
+    - #1: front
+    - #2: side
+  Security:
+    - require_ir: yes
+    - liveness (frame variance): yes
+    - liveness (landmark movement): no
+    - min_auth_frames: 3
+  Notifications: terminal + desktop
+    - prompt: yes
+    - on success: yes
+    - on failure: no
+  PAM module: /lib/security/pam_facelock.so
+    [ok] installed
+    - sudo PAM: configured
+";
+        assert_eq!(render(&healthy()), expected);
+    }
+
+    /// N4, the money case: a daemon that is unreachable and a store that
+    /// could not be read render as exactly that — the report must never
+    /// claim "no faces enrolled" for a user it could not check.
+    #[test]
+    fn unreachable_daemon_and_unknown_store_never_render_as_not_enrolled() {
+        let mut health = healthy();
+        health.daemon = Fact::probed(DaemonPing::NotResponding {
+            error: "D-Bus Ping call failed".into(),
+        });
+        health.enrolled = Fact::unknown("database not accessible: disk I/O error");
+
+        let report = render(&health);
+        assert!(
+            report.contains("    [!!] not responding: D-Bus Ping call failed\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    [!!] cannot determine: database not accessible: disk I/O error\n"),
+            "{report}"
+        );
+        assert!(
+            !report.contains("no faces enrolled"),
+            "unknown must not collapse into 'not enrolled':\n{report}"
+        );
+        assert!(
+            !report.contains("model(s)"),
+            "unknown must not collapse into a model count:\n{report}"
+        );
+    }
+
+    /// The converse pin: a *known* empty enrollment (provably absent store,
+    /// C7) is the one state allowed to say "no faces enrolled".
+    #[test]
+    fn known_empty_enrollment_renders_no_faces_enrolled() {
+        let mut health = healthy();
+        health.enrolled = Fact::probed(EnrollmentHealth {
+            models: vec![],
+            marker: MarkerDiagnostic::Consistent,
+        });
+        let report = render(&health);
+        assert!(
+            report.contains("    [!!] no faces enrolled (run 'facelock enroll')\n"),
+            "{report}"
+        );
+    }
+
+    /// A config that did not parse leaves every dependent section honestly
+    /// unknown — no section goes silent, none guesses.
+    #[test]
+    fn broken_config_renders_every_dependent_section_as_unknown() {
+        let health = Health {
+            config: ConfigHealth {
+                path: "/etc/facelock/config.toml".into(),
+                outcome: ConfigOutcome::Invalid {
+                    error: "expected `]` at line 1".into(),
+                },
+            },
+            daemon: Fact::unknown("config not available"),
+            oneshot_fallback: Fact::unknown("config not available"),
+            camera: Fact::unknown("config not available"),
+            models: Fact::unknown("config not available"),
+            execution_provider: Fact::unknown("config not available"),
+            encryption: Fact::unknown("config not available"),
+            user: "alice".into(),
+            enrolled: Fact::unknown("config not available"),
+            security: Fact::unknown("config not available"),
+            notifications: Fact::unknown("config not available"),
+            pam: PamWiring {
+                module_path: "/lib/security/pam_facelock.so".into(),
+                installed_at: None,
+                sudo_configured: None,
+            },
+        };
+
+        let report = render(&health);
+        assert!(
+            report.contains("    [!!] invalid: expected `]` at line 1\n"),
+            "{report}"
+        );
+        assert_eq!(
+            report
+                .matches("    [!!] cannot determine: config not available\n")
+                .count(),
+            9,
+            "all nine config-dependent sections must render as unknown:\n{report}"
+        );
+        // PAM wiring is config-independent and still answers.
+        assert!(report.contains("    [!!] not installed\n"), "{report}");
+    }
+
+    /// D8/H3: applied quirks are rendered, so "why does this camera behave
+    /// that way" is answerable from status.
+    #[test]
+    fn applied_quirks_render_as_a_camera_detail() {
+        let mut health = healthy();
+        health.camera = Fact::probed(CameraHealth::Configured {
+            path: "/dev/video2".into(),
+            present: true,
+            interrogated: Some(InterrogatedCamera {
+                path: "/dev/video2".into(),
+                name: "Logitech BRIO".into(),
+                is_ir: true,
+                applied_quirks: vec!["046d:085e (Logitech BRIO)".into(), "name:(?i)brio".into()],
+            }),
+        });
+        let report = render(&health);
+        assert!(
+            report.contains("    - quirks: 046d:085e (Logitech BRIO), name:(?i)brio\n"),
+            "{report}"
+        );
+        assert!(report.contains("    - ir: yes\n"), "{report}");
+    }
+
+    #[test]
+    fn auto_detect_renders_the_device_it_would_select() {
+        let mut health = healthy();
+        health.camera = Fact::probed(CameraHealth::AutoDetect {
+            resolved: Some(InterrogatedCamera {
+                path: "/dev/video0".into(),
+                name: "Integrated IR Camera".into(),
+                is_ir: true,
+                applied_quirks: vec![],
+            }),
+        });
+        let report = render(&health);
+        assert!(
+            report.contains("  Camera device: (auto-detect)\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    [ok] auto-detect enabled\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    - device: /dev/video0 (Integrated IR Camera)\n"),
+            "{report}"
+        );
+    }
+
+    /// F7: the oneshot fallback line, both verdicts, with the missing
+    /// prerequisites named.
+    #[test]
+    fn oneshot_fallback_renders_usable_and_names_whats_missing() {
+        let report = render(&healthy());
+        assert!(
+            report.contains(
+                "    [ok] usable (root-invoked PAM can authenticate via 'facelock auth' without the daemon)\n"
+            ),
+            "{report}"
+        );
+
+        let mut health = healthy();
+        health.oneshot_fallback = Fact::probed(OneshotFallback {
+            auth_bin: "/usr/bin/facelock".into(),
+            auth_bin_present: true,
+            models_present: false,
+            database_present: false,
+        });
+        let report = render(&health);
+        assert!(report.contains("    - models: MISSING\n"), "{report}");
+        assert!(report.contains("    - database: MISSING\n"), "{report}");
+        assert!(!report.contains("    - binary: MISSING\n"), "{report}");
+        assert!(
+            report.contains(
+                "    [!!] not usable (PAM would fall through to the next auth method if the daemon is unreachable)\n"
+            ),
+            "{report}"
+        );
+    }
+
+    /// The EP fact renders one verdict per status, resolved against the
+    /// installed ONNX Runtime (H2's fact, this renderer's words).
+    #[test]
+    fn execution_provider_renders_each_status() {
+        let cases = [
+            (
+                EpStatus::Available,
+                "    [ok] supported by the installed ONNX Runtime\n",
+            ),
+            (
+                EpStatus::NotBuiltIn,
+                "    [!!] not built into the installed ONNX Runtime — inference will fall back to CPU\n",
+            ),
+            (
+                EpStatus::UnknownName,
+                "    [!!] unknown execution provider (valid: cpu, cuda, rocm, openvino)\n",
+            ),
+            (
+                EpStatus::Unqueryable("no dylib".into()),
+                "    [!!] ONNX Runtime not loadable: no dylib\n",
+            ),
+        ];
+        for (status, expected) in cases {
+            let mut health = healthy();
+            health.execution_provider = Fact::probed(ExecutionProviderFact {
+                configured: "cuda".into(),
+                status,
+            });
+            let report = render(&health);
+            assert!(
+                report.contains(expected),
+                "missing {expected:?} in:\n{report}"
+            );
+            assert!(
+                report.contains("  Execution provider: CUDA (NVIDIA GPU)\n"),
+                "{report}"
+            );
+        }
+    }
+
+    #[test]
+    fn oneshot_mode_renders_no_daemon_as_ok() {
+        let mut health = healthy();
+        health.daemon = Fact::claimed(DaemonPing::NotConfigured);
+        let report = render(&health);
+        assert!(
+            report.contains("    [ok] oneshot mode (no daemon)\n"),
+            "{report}"
+        );
+    }
+
+    /// DEC-7: the marker diagnostic renders only when it has something to
+    /// say, and says it as a detail — the store stays the authority.
+    #[test]
+    fn stale_marker_renders_as_a_diagnostic_detail() {
+        let consistent = render(&healthy());
+        assert!(!consistent.contains("- marker:"), "{consistent}");
+
+        let mut health = healthy();
+        health.enrolled = Fact::probed(EnrollmentHealth {
+            models: vec![ModelSummary {
+                id: 1,
+                label: "front".into(),
+            }],
+            marker: MarkerDiagnostic::Mismatch {
+                marker: 3,
+                store: 1,
+            },
+        });
+        let report = render(&health);
+        assert!(
+            report.contains(
+                "    - marker: out of date (marker says 3, database has 1) — run 'sudo facelock setup' to reconcile\n"
+            ),
+            "{report}"
+        );
+
+        let mut health = healthy();
+        health.enrolled = Fact::probed(EnrollmentHealth {
+            models: vec![],
+            marker: MarkerDiagnostic::Unreadable {
+                why: "malformed marker".into(),
+            },
+        });
+        let report = render(&health);
+        assert!(
+            report.contains("    - marker: unreadable: malformed marker\n"),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn plaintext_encryption_renders_the_warning() {
+        let mut health = healthy();
+        health.encryption = Fact::probed(EncryptionHealth {
+            method: facelock_core::config::EncryptionMethod::None,
+            material: KeyMaterial::None,
+            sealed_counts: Some((0, 2)),
+        });
+        let report = render(&health);
+        assert!(report.contains("  Encryption: none\n"), "{report}");
+        assert!(
+            report.contains(
+                "    [!!] embeddings stored as plaintext (run 'facelock setup' to enable encryption)\n"
+            ),
+            "{report}"
+        );
+        assert!(report.contains("    - encrypted: 0\n"), "{report}");
+        assert!(report.contains("    - plaintext: 2\n"), "{report}");
+    }
+
+    #[test]
+    fn disabled_security_renders_the_alarm_and_no_knobs() {
+        let mut health = healthy();
+        health.security = Fact::claimed(SecurityHealth {
+            disabled: true,
+            require_ir: true,
+            require_frame_variance: true,
+            require_landmark_liveness: true,
+            min_auth_frames: 3,
+        });
+        let report = render(&health);
+        assert!(
+            report.contains("    [!!] ALL SECURITY CHECKS DISABLED\n"),
+            "{report}"
+        );
+        assert!(!report.contains("require_ir"), "{report}");
+    }
+
+    #[test]
+    fn pam_module_at_the_alternate_path_names_it() {
+        let mut health = healthy();
+        health.pam = PamWiring {
+            module_path: "/lib/security/pam_facelock.so".into(),
+            installed_at: Some("/usr/lib/security/pam_facelock.so".into()),
+            sudo_configured: Some(false),
+        };
+        let report = render(&health);
+        assert!(
+            report.contains("    [ok] installed at /usr/lib/security/pam_facelock.so\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    - sudo PAM: not configured for facelock\n"),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn missing_models_render_per_file_and_point_at_setup() {
+        let mut health = healthy();
+        health.models = Fact::probed(model_files("/usr/share/facelock/models", true, false));
+        let report = render(&health);
+        assert!(
+            report.contains("    - detector (det.onnx): present\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    - embedder (emb.onnx): MISSING\n"),
+            "{report}"
+        );
+        assert!(
+            report.contains("    [!!] some models missing (run 'facelock setup')\n"),
+            "{report}"
+        );
+    }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -58,7 +58,7 @@ pub fn open_store_existing(config: &Config) -> Result<FaceStore, StoreError> {
 /// (`is_ir`, fingerprint, formats, applied quirks) that used to be threaded
 /// around as loose values — pre-flight gates read `resolved.caps`, and the
 /// camera opened from it carries the very same caps.
-fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCamera> {
+pub(crate) fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedCamera> {
     let quirks = QuirksDb::load();
     let device_info = match config.device.path.as_deref() {
         Some(path) => validate_device(path)

--- a/crates/facelock-cli/src/health.rs
+++ b/crates/facelock-cli/src/health.rs
@@ -1,0 +1,826 @@
+//! The Health domain (map §5): what is knowable about the system, gathered
+//! into one value.
+//!
+//! [`Health`] is everything `facelock status` reports, as plain data: each
+//! section is a [`Fact`] populated by an isolated probe, and the report
+//! itself is a pure renderer over the struct (`commands::status`). The split
+//! is what makes the report testable — a `Health` can be constructed in a
+//! test with zero root, camera, or bus — and what enforces N4's surviving
+//! rule: *"the daemon is unreachable" and "the database could not be read"
+//! are distinct values from "this user has no models"*, so the renderer
+//! cannot collapse unknown into false.
+//!
+//! Privilege model (DEC-6/DEC-7): binary. `is-enrolled` is Tier 0 — one fact,
+//! its own 0600 marker, no bus, no store, no camera — and **never comes
+//! here**; its isolation is the contract (see `commands/is_enrolled.rs`).
+//! `status` is Tier 2 — root, everything — which is why these probes may read
+//! the 0600 database and other users' markers directly. The two commands
+//! share the enrollment *fact* (the store count vs the marker), not code: the
+//! marker comparison below is `status`'s diagnostic for the marker
+//! `is-enrolled` answers from.
+
+use std::path::{Path, PathBuf};
+
+use facelock_core::Config;
+use facelock_core::config::{EncryptionMethod, NotificationMode};
+use facelock_store::{FaceStore, StoreError};
+
+use crate::backend::{self, DaemonPing};
+use crate::commands::enrollment_marker::{self, MarkerState};
+use crate::resolved::{
+    CameraPresence, ConfigLoad, ExecutionProviderFact, Fact, ModelFiles, Resolved,
+};
+
+/// The oneshot auth binary the PAM module spawns when the daemon path fails.
+/// Mirrors `AUTH_BIN` in `pam-facelock` (hardcoded there by N9; a config key
+/// naming the binary PAM executes as root would be an escalation knob).
+pub const AUTH_BIN: &str = "/usr/bin/facelock";
+
+/// Where the PAM module may be installed; the first entry is the primary
+/// path named in the report's item line.
+pub const PAM_MODULE_PATHS: [&str; 2] = [
+    "/lib/security/pam_facelock.so",
+    "/usr/lib/security/pam_facelock.so",
+];
+
+/// The `why` shared by every fact that cannot be probed without a parsed
+/// config.
+const CONFIG_NOT_AVAILABLE: &str = "config not available";
+
+/// Everything `status` reports, as data. Constructed by [`Health::probe`] on
+/// the real system (root), or literally in tests.
+#[derive(Debug, Clone)]
+pub struct Health {
+    /// The config parse outcome is always known — running the parse *is* the
+    /// probe — so this is not a [`Fact`].
+    pub config: ConfigHealth,
+    pub daemon: Fact<DaemonPing>,
+    pub oneshot_fallback: Fact<OneshotFallback>,
+    pub camera: Fact<CameraHealth>,
+    pub models: Fact<ModelFiles>,
+    pub execution_provider: Fact<ExecutionProviderFact>,
+    pub encryption: Fact<EncryptionHealth>,
+    /// The user whose enrollment the report describes (`--user` semantics of
+    /// `resolve_user`: SUDO_USER/DOAS_USER aware, so `sudo facelock status`
+    /// reports on the invoking human, not root).
+    pub user: String,
+    pub enrolled: Fact<EnrollmentHealth>,
+    pub security: Fact<SecurityHealth>,
+    pub notifications: Fact<NotificationHealth>,
+    /// Config-independent: probed even when the config did not parse.
+    pub pam: PamWiring,
+}
+
+impl Health {
+    /// Probe the live system. Root path: reads the database, other users'
+    /// markers, the ONNX runtime, and pings the daemon (activating — see
+    /// [`backend::probe_daemon`]).
+    pub fn probe(loaded: &ConfigLoad) -> Health {
+        let user = crate::ipc_client::resolve_user(None);
+        let config_health = ConfigHealth::from_load(loaded);
+
+        let Some(config) = loaded.config() else {
+            return Health {
+                config: config_health,
+                daemon: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                oneshot_fallback: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                camera: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                models: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                execution_provider: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                encryption: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                user,
+                enrolled: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                security: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                notifications: Fact::unknown(CONFIG_NOT_AVAILABLE),
+                pam: probe_pam(),
+            };
+        };
+
+        let models: Fact<ModelFiles> = ModelFiles::probe(config).into();
+        let fallback = probe_oneshot_fallback_at(
+            Path::new(AUTH_BIN),
+            Path::new(&config.storage.db_path),
+            models.known().is_some_and(|m| m.all_present()),
+        );
+        Health {
+            config: config_health,
+            daemon: backend::probe_daemon(&config.daemon.mode).into(),
+            oneshot_fallback: Fact::probed(fallback),
+            camera: probe_camera(config).into(),
+            execution_provider: ExecutionProviderFact::probe(config).into(),
+            encryption: Fact::probed(probe_encryption(config)),
+            enrolled: probe_enrolled(config, &user),
+            security: Fact::claimed(SecurityHealth::from_config(config)),
+            notifications: Fact::claimed(NotificationHealth::from_config(config)),
+            pam: probe_pam(),
+            models,
+            user,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct ConfigHealth {
+    pub path: String,
+    pub outcome: ConfigOutcome,
+}
+
+#[derive(Debug, Clone)]
+pub enum ConfigOutcome {
+    Valid {
+        /// `device.path`, `None` for auto-detect — surfaced beside "valid"
+        /// because it is the setting people misconfigure most.
+        device_path: Option<String>,
+    },
+    NotFound,
+    Invalid {
+        error: String,
+    },
+}
+
+impl ConfigHealth {
+    pub fn from_load(loaded: &ConfigLoad) -> Self {
+        let outcome = match &loaded.result {
+            Ok(config) => ConfigOutcome::Valid {
+                device_path: config.device.path.clone(),
+            },
+            Err(facelock_core::config::ConfigError::NotFound(_)) => ConfigOutcome::NotFound,
+            Err(e) => ConfigOutcome::Invalid {
+                error: e.to_string(),
+            },
+        };
+        ConfigHealth {
+            path: loaded.path.display().to_string(),
+            outcome,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Oneshot fallback (F7)
+// ---------------------------------------------------------------------------
+
+/// F7: whether PAM's oneshot fallback would work if the daemon were
+/// unreachable at auth time.
+///
+/// "Usable" means precisely: `pam_facelock`, root-invoked (DEC-2), could
+/// spawn [`AUTH_BIN`] and complete an authentication locally — which needs
+/// the binary at its hardcoded path, both configured model files, and the
+/// database. Whether *this user* would then match is the Enrolled section's
+/// answer, not this one; a missing enrollment fails one user, a missing
+/// binary fails the mechanism.
+#[derive(Debug, Clone)]
+pub struct OneshotFallback {
+    pub auth_bin: String,
+    pub auth_bin_present: bool,
+    pub models_present: bool,
+    pub database_present: bool,
+}
+
+impl OneshotFallback {
+    pub fn usable(&self) -> bool {
+        self.auth_bin_present && self.models_present && self.database_present
+    }
+}
+
+fn probe_oneshot_fallback_at(
+    auth_bin: &Path,
+    db_path: &Path,
+    models_present: bool,
+) -> OneshotFallback {
+    OneshotFallback {
+        auth_bin: auth_bin.display().to_string(),
+        auth_bin_present: auth_bin.is_file(),
+        models_present,
+        database_present: db_path.is_file(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Camera
+// ---------------------------------------------------------------------------
+
+/// The camera section: presence (H2's [`CameraPresence`]) plus, when a device
+/// is reachable, the interrogated capabilities — including `applied_quirks`,
+/// so "why did this camera behave oddly" is answerable from `status` (D8).
+#[derive(Debug, Clone)]
+pub enum CameraHealth {
+    /// No path configured. `resolved` is what auto-detection would pick
+    /// right now, when it finds something.
+    AutoDetect {
+        resolved: Option<InterrogatedCamera>,
+    },
+    Configured {
+        path: String,
+        present: bool,
+        /// `None` when the node is absent or interrogation failed.
+        interrogated: Option<InterrogatedCamera>,
+    },
+}
+
+/// The slice of `ResolvedCamera` the report renders — plain data, so a
+/// synthetic `Health` needs no camera crate machinery.
+#[derive(Debug, Clone)]
+pub struct InterrogatedCamera {
+    pub path: String,
+    pub name: String,
+    pub is_ir: bool,
+    pub applied_quirks: Vec<String>,
+}
+
+impl From<&facelock_camera::ResolvedCamera> for InterrogatedCamera {
+    fn from(resolved: &facelock_camera::ResolvedCamera) -> Self {
+        InterrogatedCamera {
+            path: resolved.info.path.clone(),
+            name: resolved.info.name.clone(),
+            is_ir: resolved.caps.is_ir,
+            applied_quirks: resolved.caps.applied_quirks.clone(),
+        }
+    }
+}
+
+fn probe_camera(config: &Config) -> Resolved<CameraHealth> {
+    // Presence via the shared probe (D7); interrogation via the camera
+    // domain's one implementation (D8) — never re-derived here.
+    match CameraPresence::probe(config).value {
+        CameraPresence::AutoDetect => {
+            let resolved = crate::direct::resolve_camera_device(config)
+                .ok()
+                .map(|r| InterrogatedCamera::from(&r));
+            match resolved {
+                // Nothing detected right now: the config's claim is all we
+                // have.
+                None => Resolved {
+                    value: CameraHealth::AutoDetect { resolved: None },
+                    provenance: crate::resolved::Provenance::Claimed,
+                },
+                some => Resolved {
+                    value: CameraHealth::AutoDetect { resolved: some },
+                    provenance: crate::resolved::Provenance::Probed,
+                },
+            }
+        }
+        CameraPresence::Configured { path, present } => {
+            let interrogated = if present {
+                crate::direct::resolve_camera_device(config)
+                    .ok()
+                    .map(|r| InterrogatedCamera::from(&r))
+            } else {
+                None
+            };
+            Resolved {
+                value: CameraHealth::Configured {
+                    path,
+                    present,
+                    interrogated,
+                },
+                provenance: crate::resolved::Provenance::Probed,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encryption
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct EncryptionHealth {
+    pub method: EncryptionMethod,
+    pub material: KeyMaterial,
+    /// `(sealed, plaintext)` embedding counts, when the database was
+    /// readable. `None` is "could not count", not zero.
+    pub sealed_counts: Option<(u32, u32)>,
+}
+
+#[derive(Debug, Clone)]
+pub enum KeyMaterial {
+    Tpm {
+        sealed_key_path: String,
+        sealed_key_present: bool,
+        device_path: String,
+        device_present: bool,
+    },
+    Keyfile {
+        key_path: String,
+        present: bool,
+    },
+    None,
+}
+
+fn probe_encryption(config: &Config) -> EncryptionHealth {
+    let material = match config.encryption.method {
+        EncryptionMethod::Tpm => {
+            let device_path = config
+                .tpm
+                .tcti
+                .strip_prefix("device:")
+                .unwrap_or(&config.tpm.tcti)
+                .to_string();
+            KeyMaterial::Tpm {
+                sealed_key_present: Path::new(&config.encryption.sealed_key_path).exists(),
+                sealed_key_path: config.encryption.sealed_key_path.clone(),
+                device_present: Path::new(&device_path).exists(),
+                device_path,
+            }
+        }
+        EncryptionMethod::Keyfile => KeyMaterial::Keyfile {
+            present: Path::new(&config.encryption.key_path).exists(),
+            key_path: config.encryption.key_path.clone(),
+        },
+        EncryptionMethod::None => KeyMaterial::None,
+    };
+
+    let sealed_counts = FaceStore::open_readonly(Path::new(&config.storage.db_path))
+        .ok()
+        .and_then(|store| store.count_sealed().ok());
+
+    EncryptionHealth {
+        method: config.encryption.method.clone(),
+        material,
+        sealed_counts,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Enrollment (DEC-7: one fact, two renderers)
+// ---------------------------------------------------------------------------
+
+/// The target user's enrollment as the authoritative store reports it, plus
+/// the marker diagnostic — `status` may read the store (root) and may note a
+/// stale marker; `is-enrolled` reads only the marker and never comes here.
+#[derive(Debug, Clone)]
+pub struct EnrollmentHealth {
+    pub models: Vec<ModelSummary>,
+    pub marker: MarkerDiagnostic,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelSummary {
+    pub id: u32,
+    pub label: String,
+}
+
+/// Does the `is-enrolled` marker agree with the database?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkerDiagnostic {
+    Consistent,
+    /// The marker and the store disagree (an absent marker counts as 0) —
+    /// `is-enrolled` is answering with stale data until a reconcile.
+    Mismatch {
+        marker: u32,
+        store: u32,
+    },
+    Unreadable {
+        why: String,
+    },
+}
+
+/// The comparison rule, split from filesystem access for tests.
+fn marker_diagnostic(marker: MarkerState, store_count: u32) -> MarkerDiagnostic {
+    match marker {
+        MarkerState::Enrolled(m) if m.models == store_count => MarkerDiagnostic::Consistent,
+        MarkerState::Enrolled(m) => MarkerDiagnostic::Mismatch {
+            marker: m.models,
+            store: store_count,
+        },
+        MarkerState::Absent if store_count == 0 => MarkerDiagnostic::Consistent,
+        MarkerState::Absent => MarkerDiagnostic::Mismatch {
+            marker: 0,
+            store: store_count,
+        },
+        MarkerState::Unreadable(why) => MarkerDiagnostic::Unreadable { why },
+    }
+}
+
+/// The N4 discipline lives here: a store that cannot be read yields
+/// [`Fact::Unknown`], never an empty model list. Only a provably absent
+/// database ([`StoreError::Absent`], C7) is a *known* "nothing enrolled".
+fn probe_enrolled(config: &Config, user: &str) -> Fact<EnrollmentHealth> {
+    let store_count = match FaceStore::open_readonly(Path::new(&config.storage.db_path)) {
+        Ok(store) => match store.list_models(user) {
+            Ok(models) => Ok(models),
+            Err(e) => Err(format!("error reading models: {e}")),
+        },
+        Err(StoreError::Absent { .. }) => Ok(Vec::new()),
+        Err(e) => Err(format!("database not accessible: {e}")),
+    };
+
+    match store_count {
+        Err(why) => Fact::unknown(why),
+        Ok(models) => {
+            let marker =
+                enrollment_marker::read_marker_in(&enrollment_marker::marker_dir(config), user);
+            Fact::probed(EnrollmentHealth {
+                marker: marker_diagnostic(marker, models.len() as u32),
+                models: models
+                    .into_iter()
+                    .map(|m| ModelSummary {
+                        id: m.id,
+                        label: m.label,
+                    })
+                    .collect(),
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Security / notification posture (claims: rendered from config, unverified)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct SecurityHealth {
+    pub disabled: bool,
+    pub require_ir: bool,
+    pub require_frame_variance: bool,
+    pub require_landmark_liveness: bool,
+    pub min_auth_frames: u32,
+}
+
+impl SecurityHealth {
+    pub fn from_config(config: &Config) -> Self {
+        SecurityHealth {
+            disabled: config.security.disabled,
+            require_ir: config.security.require_ir,
+            require_frame_variance: config.security.require_frame_variance,
+            require_landmark_liveness: config.security.require_landmark_liveness,
+            min_auth_frames: config.security.min_auth_frames,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationHealth {
+    pub mode: NotificationMode,
+    pub notify_prompt: bool,
+    pub notify_on_success: bool,
+    pub notify_on_failure: bool,
+}
+
+impl NotificationHealth {
+    pub fn from_config(config: &Config) -> Self {
+        NotificationHealth {
+            mode: config.notification.mode.clone(),
+            notify_prompt: config.notification.notify_prompt,
+            notify_on_success: config.notification.notify_on_success,
+            notify_on_failure: config.notification.notify_on_failure,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PAM wiring
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct PamWiring {
+    /// The primary path, named in the report's item line.
+    pub module_path: String,
+    /// Where the module was actually found, if anywhere.
+    pub installed_at: Option<String>,
+    /// Whether `/etc/pam.d/sudo` names `pam_facelock`; `None` when there is
+    /// no readable sudo service file to inspect.
+    pub sudo_configured: Option<bool>,
+}
+
+fn probe_pam() -> PamWiring {
+    let paths: Vec<PathBuf> = PAM_MODULE_PATHS.iter().map(PathBuf::from).collect();
+    probe_pam_at(&paths, Path::new("/etc/pam.d/sudo"))
+}
+
+fn probe_pam_at(module_paths: &[PathBuf], sudo_pam: &Path) -> PamWiring {
+    PamWiring {
+        module_path: module_paths
+            .first()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default(),
+        installed_at: module_paths
+            .iter()
+            .find(|p| p.exists())
+            .map(|p| p.display().to_string()),
+        sudo_configured: std::fs::read_to_string(sudo_pam)
+            .ok()
+            .map(|content| content.contains("pam_facelock")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    use crate::commands::enrollment_marker::Marker;
+
+    fn config_with(toml: &str) -> Config {
+        Config::parse(toml).expect("test config parses")
+    }
+
+    // -----------------------------------------------------------------------
+    // Enrollment: unknown is not false (N4)
+    // -----------------------------------------------------------------------
+
+    /// The money probe: an unreadable database is `Unknown`, never a known
+    /// empty enrollment.
+    #[test]
+    fn unreadable_database_probes_to_unknown_not_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        fs::write(&db_path, b"this is not a sqlite database").unwrap();
+        let config = config_with(&format!("[storage]\ndb_path = \"{}\"\n", db_path.display()));
+
+        // SQLite defers content validation past open, so the corruption may
+        // surface at either step; both must land in Unknown, never in a
+        // known-empty enrollment.
+        match probe_enrolled(&config, "alice") {
+            Fact::Unknown { why } => {
+                assert!(why.contains("database"), "{why}")
+            }
+            Fact::Known(known) => panic!("must not claim a known answer: {:?}", known.value),
+        }
+    }
+
+    /// C7: a provably absent database is a *known* empty enrollment — and the
+    /// probe must not create it.
+    #[test]
+    fn absent_database_probes_to_known_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let config = config_with(&format!("[storage]\ndb_path = \"{}\"\n", db_path.display()));
+
+        let fact = probe_enrolled(&config, "alice");
+        let enrolled = fact.known().expect("absent store is a known answer");
+        assert!(enrolled.models.is_empty());
+        assert_eq!(enrolled.marker, MarkerDiagnostic::Consistent);
+        assert!(!db_path.exists(), "the probe must not create the database");
+    }
+
+    /// The full root-path probe against a real store, marker included.
+    #[test]
+    fn enrolled_probe_reads_store_and_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "embedder-a")
+                .unwrap();
+            store
+                .add_model("alice", "side", &[0.4f32; 512], "embedder-a")
+                .unwrap();
+        }
+        let config = config_with(&format!("[storage]\ndb_path = \"{}\"\n", db_path.display()));
+        // The marker dir derives from db_path, so it lands in the tempdir.
+        enrollment_marker::write_marker_in(
+            &enrollment_marker::marker_dir(&config),
+            "alice",
+            2,
+            None,
+        )
+        .unwrap();
+
+        let fact = probe_enrolled(&config, "alice");
+        let enrolled = fact.known().expect("readable store is a known answer");
+        assert_eq!(enrolled.models.len(), 2);
+        assert_eq!(enrolled.models[0].label, "front");
+        assert_eq!(enrolled.marker, MarkerDiagnostic::Consistent);
+
+        // A user with no rows: known-empty, and their absent marker agrees.
+        let fact = probe_enrolled(&config, "bob");
+        let enrolled = fact.known().unwrap();
+        assert!(enrolled.models.is_empty());
+        assert_eq!(enrolled.marker, MarkerDiagnostic::Consistent);
+    }
+
+    // -----------------------------------------------------------------------
+    // Marker diagnostic (DEC-7): the comparison rule
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn marker_agreement_is_consistent() {
+        let marker = MarkerState::Enrolled(Marker {
+            models: 2,
+            updated: "2026-08-14T00:00:00Z".into(),
+        });
+        assert_eq!(marker_diagnostic(marker, 2), MarkerDiagnostic::Consistent);
+        assert_eq!(
+            marker_diagnostic(MarkerState::Absent, 0),
+            MarkerDiagnostic::Consistent
+        );
+    }
+
+    #[test]
+    fn marker_disagreement_is_a_mismatch_in_both_directions() {
+        let stale_high = MarkerState::Enrolled(Marker {
+            models: 3,
+            updated: "2026-08-14T00:00:00Z".into(),
+        });
+        assert_eq!(
+            marker_diagnostic(stale_high, 1),
+            MarkerDiagnostic::Mismatch {
+                marker: 3,
+                store: 1
+            }
+        );
+        // Enrolled in the store but no marker: is-enrolled is answering
+        // "no" to an enrolled user.
+        assert_eq!(
+            marker_diagnostic(MarkerState::Absent, 2),
+            MarkerDiagnostic::Mismatch {
+                marker: 0,
+                store: 2
+            }
+        );
+    }
+
+    #[test]
+    fn broken_marker_reports_unreadable() {
+        assert_eq!(
+            marker_diagnostic(MarkerState::Unreadable("bad json".into()), 1),
+            MarkerDiagnostic::Unreadable {
+                why: "bad json".into()
+            }
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Oneshot fallback (F7)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn fallback_is_usable_only_with_binary_models_and_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("facelock");
+        let db = dir.path().join("facelock.db");
+        fs::write(&bin, b"#!").unwrap();
+        fs::write(&db, b"db").unwrap();
+
+        let fallback = probe_oneshot_fallback_at(&bin, &db, true);
+        assert!(fallback.auth_bin_present);
+        assert!(fallback.database_present);
+        assert!(fallback.usable());
+
+        let no_models = probe_oneshot_fallback_at(&bin, &db, false);
+        assert!(!no_models.usable());
+
+        let no_bin = probe_oneshot_fallback_at(&dir.path().join("missing"), &db, true);
+        assert!(!no_bin.auth_bin_present);
+        assert!(!no_bin.usable());
+
+        let no_db = probe_oneshot_fallback_at(&bin, &dir.path().join("missing.db"), true);
+        assert!(!no_db.database_present);
+        assert!(!no_db.usable());
+    }
+
+    // -----------------------------------------------------------------------
+    // Encryption
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn keyfile_probe_reports_key_presence_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("facelock.key");
+        let db_path = dir.path().join("facelock.db");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "e")
+                .unwrap();
+        }
+        let config = config_with(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n\n[storage]\ndb_path = \"{}\"\n",
+            key.display(),
+            db_path.display()
+        ));
+
+        let health = probe_encryption(&config);
+        assert_eq!(health.method, EncryptionMethod::Keyfile);
+        match &health.material {
+            KeyMaterial::Keyfile { present, key_path } => {
+                assert!(!present);
+                assert_eq!(*key_path, key.display().to_string());
+            }
+            other => panic!("expected keyfile material, got {other:?}"),
+        }
+        // One plaintext embedding, zero sealed.
+        assert_eq!(health.sealed_counts, Some((0, 1)));
+
+        fs::write(&key, b"k").unwrap();
+        let health = probe_encryption(&config);
+        assert!(matches!(
+            health.material,
+            KeyMaterial::Keyfile { present: true, .. }
+        ));
+    }
+
+    #[test]
+    fn tpm_probe_reports_sealed_key_and_device_separately() {
+        let dir = tempfile::tempdir().unwrap();
+        let sealed = dir.path().join("sealed.key");
+        let device = dir.path().join("tpmrm0");
+        fs::write(&device, b"").unwrap();
+        let config = config_with(&format!(
+            "[encryption]\nmethod = \"tpm\"\nsealed_key_path = \"{}\"\n\n[tpm]\ntcti = \"device:{}\"\n",
+            sealed.display(),
+            device.display()
+        ));
+
+        let health = probe_encryption(&config);
+        match &health.material {
+            KeyMaterial::Tpm {
+                sealed_key_present,
+                device_present,
+                device_path,
+                ..
+            } => {
+                assert!(!sealed_key_present);
+                assert!(device_present, "tcti device: prefix must be stripped");
+                assert_eq!(*device_path, device.display().to_string());
+            }
+            other => panic!("expected TPM material, got {other:?}"),
+        }
+        // No database: counts are unknown, not zero.
+        assert_eq!(health.sealed_counts, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // PAM wiring
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pam_probe_finds_the_module_at_either_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let primary = dir.path().join("lib/security/pam_facelock.so");
+        let alt = dir.path().join("usr/lib/security/pam_facelock.so");
+        let paths = vec![primary.clone(), alt.clone()];
+        let sudo = dir.path().join("pam.d/sudo");
+
+        let wiring = probe_pam_at(&paths, &sudo);
+        assert_eq!(wiring.module_path, primary.display().to_string());
+        assert_eq!(wiring.installed_at, None);
+        assert_eq!(wiring.sudo_configured, None, "no sudo file: nothing to say");
+
+        fs::create_dir_all(alt.parent().unwrap()).unwrap();
+        fs::write(&alt, b"elf").unwrap();
+        let wiring = probe_pam_at(&paths, &sudo);
+        assert_eq!(wiring.installed_at, Some(alt.display().to_string()));
+
+        fs::create_dir_all(primary.parent().unwrap()).unwrap();
+        fs::write(&primary, b"elf").unwrap();
+        let wiring = probe_pam_at(&paths, &sudo);
+        assert_eq!(
+            wiring.installed_at,
+            Some(primary.display().to_string()),
+            "the primary path wins when both exist"
+        );
+
+        fs::create_dir_all(sudo.parent().unwrap()).unwrap();
+        fs::write(&sudo, b"auth sufficient pam_facelock.so\n").unwrap();
+        let wiring = probe_pam_at(&paths, &sudo);
+        assert_eq!(wiring.sudo_configured, Some(true));
+
+        fs::write(&sudo, b"auth include system-auth\n").unwrap();
+        let wiring = probe_pam_at(&paths, &sudo);
+        assert_eq!(wiring.sudo_configured, Some(false));
+    }
+
+    // -----------------------------------------------------------------------
+    // Config outcome
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn config_health_carries_the_parse_outcome() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let missing = ConfigHealth::from_load(&ConfigLoad {
+            path: path.clone(),
+            result: Config::load_from(&path),
+        });
+        assert!(matches!(missing.outcome, ConfigOutcome::NotFound));
+
+        fs::write(&path, "[device\n").unwrap();
+        let broken = ConfigHealth::from_load(&ConfigLoad {
+            path: path.clone(),
+            result: Config::load_from(&path),
+        });
+        assert!(matches!(broken.outcome, ConfigOutcome::Invalid { .. }));
+
+        fs::write(&path, "[device]\npath = \"/dev/video2\"\n").unwrap();
+        let valid = ConfigHealth::from_load(&ConfigLoad {
+            path: path.clone(),
+            result: Config::load_from(&path),
+        });
+        match valid.outcome {
+            ConfigOutcome::Valid { device_path } => {
+                assert_eq!(device_path.as_deref(), Some("/dev/video2"))
+            }
+            other => panic!("expected valid, got {other:?}"),
+        }
+    }
+}

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 mod commands;
 pub mod direct;
+pub mod health;
 mod ipc_client;
 pub mod message;
 pub mod notifications;

--- a/crates/facelock-cli/src/message.rs
+++ b/crates/facelock-cli/src/message.rs
@@ -254,6 +254,95 @@ pub enum UserMessage {
         user: String,
     },
 
+    // -- status report (H8): the report's prose. The skeleton (item lines,
+    //    [ok]/[!!] markers, `- key:` details) stays structural in the
+    //    renderer; config-key-shaped detail keys (require_ir, device.path,
+    //    quirks, ...) are vocabulary, not prose, and stay literal. --
+    StatusHeader,
+    StatusLabelConfigFile,
+    StatusLabelDaemon,
+    StatusLabelOneshotFallback,
+    StatusLabelCameraDevice,
+    StatusLabelModelDirectory,
+    StatusLabelExecutionProvider,
+    StatusLabelEncryption,
+    StatusLabelEnrolledFaces,
+    StatusLabelSecurity,
+    StatusLabelNotifications,
+    StatusLabelPamModule,
+    /// The unknown-is-not-false rendering (N4): the answer could not be
+    /// determined, and no value is guessed in its place.
+    StatusUnknown {
+        why: String,
+    },
+    StatusConfigValid,
+    StatusConfigNotFound,
+    StatusConfigInvalid {
+        error: String,
+    },
+    StatusDaemonOneshot,
+    StatusDaemonResponding,
+    StatusDaemonNotResponding {
+        error: String,
+    },
+    StatusFallbackUsable,
+    StatusFallbackNotUsable,
+    StatusCameraDeviceExists,
+    StatusCameraDeviceNotFound,
+    StatusCameraAutoDetect,
+    StatusModelsDirNotFound,
+    StatusModelsAllPresent,
+    StatusModelsSomeMissing,
+    StatusPresent,
+    StatusMissing,
+    StatusEpSupported,
+    StatusEpNotBuiltIn,
+    StatusEpUnknownName,
+    StatusEpUnqueryable {
+        error: String,
+    },
+    StatusSealedKey {
+        path: String,
+    },
+    StatusSealedKeyMissing {
+        path: String,
+    },
+    StatusTpmDeviceMissing {
+        path: String,
+    },
+    StatusKeyFile {
+        path: String,
+    },
+    StatusKeyFileMissing {
+        path: String,
+    },
+    StatusPlaintextEmbeddings,
+    StatusNoFacesEnrolled,
+    StatusModelCount {
+        count: usize,
+    },
+    StatusMarkerMismatch {
+        marker: u32,
+        store: u32,
+    },
+    StatusMarkerUnreadable {
+        why: String,
+    },
+    StatusSecurityDisabled,
+    StatusYes,
+    StatusNo,
+    StatusNotifyOff,
+    StatusNotifyTerminal,
+    StatusNotifyDesktop,
+    StatusNotifyBoth,
+    StatusPamInstalled,
+    StatusPamInstalledAt {
+        path: String,
+    },
+    StatusPamNotInstalled,
+    StatusPamSudoConfigured,
+    StatusPamSudoNotConfigured,
+
     // -- desktop/terminal notification bodies (H4's NotifyEvent, rendered) --
     NotifyScanning,
     NotifyWelcome {
@@ -685,6 +774,108 @@ impl UserMessage {
                 translate("All face models removed for user '{user}'."),
                 &[("user", user.clone())],
             ),
+
+            StatusHeader => translate("facelock system status"),
+            StatusLabelConfigFile => translate("Config file"),
+            StatusLabelDaemon => translate("Daemon"),
+            StatusLabelOneshotFallback => translate("Oneshot fallback"),
+            StatusLabelCameraDevice => translate("Camera device"),
+            StatusLabelModelDirectory => translate("Model directory"),
+            StatusLabelExecutionProvider => translate("Execution provider"),
+            StatusLabelEncryption => translate("Encryption"),
+            StatusLabelEnrolledFaces => translate("Enrolled faces"),
+            StatusLabelSecurity => translate("Security"),
+            StatusLabelNotifications => translate("Notifications"),
+            StatusLabelPamModule => translate("PAM module"),
+            StatusUnknown { why } => fill(
+                translate("cannot determine: {why}"),
+                &[("why", why.clone())],
+            ),
+            StatusConfigValid => translate("valid"),
+            StatusConfigNotFound => translate("not found"),
+            StatusConfigInvalid { error } => {
+                fill(translate("invalid: {error}"), &[("error", error.clone())])
+            }
+            StatusDaemonOneshot => translate("oneshot mode (no daemon)"),
+            StatusDaemonResponding => translate("responding"),
+            StatusDaemonNotResponding { error } => fill(
+                translate("not responding: {error}"),
+                &[("error", error.clone())],
+            ),
+            StatusFallbackUsable => translate(
+                "usable (root-invoked PAM can authenticate via 'facelock auth' without the daemon)",
+            ),
+            StatusFallbackNotUsable => translate(
+                "not usable (PAM would fall through to the next auth method if the daemon is unreachable)",
+            ),
+            StatusCameraDeviceExists => translate("device exists"),
+            StatusCameraDeviceNotFound => translate("device not found"),
+            StatusCameraAutoDetect => translate("auto-detect enabled"),
+            StatusModelsDirNotFound => translate("directory not found"),
+            StatusModelsAllPresent => translate("all configured models present"),
+            StatusModelsSomeMissing => translate("some models missing (run 'facelock setup')"),
+            StatusPresent => translate("present"),
+            StatusMissing => translate("MISSING"),
+            StatusEpSupported => translate("supported by the installed ONNX Runtime"),
+            StatusEpNotBuiltIn => translate(
+                "not built into the installed ONNX Runtime — inference will fall back to CPU",
+            ),
+            StatusEpUnknownName => {
+                translate("unknown execution provider (valid: cpu, cuda, rocm, openvino)")
+            }
+            StatusEpUnqueryable { error } => fill(
+                translate("ONNX Runtime not loadable: {error}"),
+                &[("error", error.clone())],
+            ),
+            StatusSealedKey { path } => {
+                fill(translate("sealed key: {path}"), &[("path", path.clone())])
+            }
+            StatusSealedKeyMissing { path } => fill(
+                translate("sealed key missing: {path}"),
+                &[("path", path.clone())],
+            ),
+            StatusTpmDeviceMissing { path } => fill(
+                translate("TPM device missing: {path}"),
+                &[("path", path.clone())],
+            ),
+            StatusKeyFile { path } => {
+                fill(translate("key file: {path}"), &[("path", path.clone())])
+            }
+            StatusKeyFileMissing { path } => fill(
+                translate("key file missing: {path}"),
+                &[("path", path.clone())],
+            ),
+            StatusPlaintextEmbeddings => translate(
+                "embeddings stored as plaintext (run 'facelock setup' to enable encryption)",
+            ),
+            StatusNoFacesEnrolled => translate("no faces enrolled (run 'facelock enroll')"),
+            StatusModelCount { count } => fill(
+                translate("{count} model(s)"),
+                &[("count", count.to_string())],
+            ),
+            StatusMarkerMismatch { marker, store } => fill(
+                translate(
+                    "out of date (marker says {marker}, database has {store}) — run 'sudo facelock setup' to reconcile",
+                ),
+                &[("marker", marker.to_string()), ("store", store.to_string())],
+            ),
+            StatusMarkerUnreadable { why } => {
+                fill(translate("unreadable: {why}"), &[("why", why.clone())])
+            }
+            StatusSecurityDisabled => translate("ALL SECURITY CHECKS DISABLED"),
+            StatusYes => translate("yes"),
+            StatusNo => translate("no"),
+            StatusNotifyOff => translate("off"),
+            StatusNotifyTerminal => translate("terminal"),
+            StatusNotifyDesktop => translate("desktop"),
+            StatusNotifyBoth => translate("terminal + desktop"),
+            StatusPamInstalled => translate("installed"),
+            StatusPamInstalledAt { path } => {
+                fill(translate("installed at {path}"), &[("path", path.clone())])
+            }
+            StatusPamNotInstalled => translate("not installed"),
+            StatusPamSudoConfigured => translate("configured"),
+            StatusPamSudoNotConfigured => translate("not configured for facelock"),
 
             NotifyScanning => translate("Scanning face..."),
             NotifyWelcome { label } => {
@@ -1479,6 +1670,64 @@ mod tests {
                 user: s("u"),
             },
             AllModelsRemoved { user: s("u") },
+            StatusHeader,
+            StatusLabelConfigFile,
+            StatusLabelDaemon,
+            StatusLabelOneshotFallback,
+            StatusLabelCameraDevice,
+            StatusLabelModelDirectory,
+            StatusLabelExecutionProvider,
+            StatusLabelEncryption,
+            StatusLabelEnrolledFaces,
+            StatusLabelSecurity,
+            StatusLabelNotifications,
+            StatusLabelPamModule,
+            StatusUnknown { why: s("w") },
+            StatusConfigValid,
+            StatusConfigNotFound,
+            StatusConfigInvalid { error: s("e") },
+            StatusDaemonOneshot,
+            StatusDaemonResponding,
+            StatusDaemonNotResponding { error: s("e") },
+            StatusFallbackUsable,
+            StatusFallbackNotUsable,
+            StatusCameraDeviceExists,
+            StatusCameraDeviceNotFound,
+            StatusCameraAutoDetect,
+            StatusModelsDirNotFound,
+            StatusModelsAllPresent,
+            StatusModelsSomeMissing,
+            StatusPresent,
+            StatusMissing,
+            StatusEpSupported,
+            StatusEpNotBuiltIn,
+            StatusEpUnknownName,
+            StatusEpUnqueryable { error: s("e") },
+            StatusSealedKey { path: s("/p") },
+            StatusSealedKeyMissing { path: s("/p") },
+            StatusTpmDeviceMissing { path: s("/p") },
+            StatusKeyFile { path: s("/p") },
+            StatusKeyFileMissing { path: s("/p") },
+            StatusPlaintextEmbeddings,
+            StatusNoFacesEnrolled,
+            StatusModelCount { count: 2 },
+            StatusMarkerMismatch {
+                marker: 3,
+                store: 2,
+            },
+            StatusMarkerUnreadable { why: s("w") },
+            StatusSecurityDisabled,
+            StatusYes,
+            StatusNo,
+            StatusNotifyOff,
+            StatusNotifyTerminal,
+            StatusNotifyDesktop,
+            StatusNotifyBoth,
+            StatusPamInstalled,
+            StatusPamInstalledAt { path: s("/p") },
+            StatusPamNotInstalled,
+            StatusPamSudoConfigured,
+            StatusPamSudoNotConfigured,
             NotifyScanning,
             NotifyWelcome { label: s("l") },
             NotifyRecognized { similarity: 0.5 },

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -86,10 +86,7 @@ impl ConfigLoad {
 
 /// How a resolved fact was determined.
 ///
-/// Deliberately minimal: H8 (Health) will grow this into a richer `Fact`
-/// type carrying *unknown-is-not-false* across privilege and reachability;
-/// until then, a provenance tag per fact is all resolution promises. The
-/// daemon-reachability fact sits beside the existing ones the same way
+/// The daemon-reachability fact sits beside the existing ones the same way
 /// (`crate::backend::DaemonReachability` — Backend owns that probe, not
 /// this module).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,6 +104,66 @@ pub enum Provenance {
 pub struct Resolved<T> {
     pub value: T,
     pub provenance: Provenance,
+}
+
+/// A fact as `status` reports it: known — with the [`Provenance`] every
+/// resolved fact already carries — or honestly unknown (H8).
+///
+/// This is the grown form of [`Resolved`]: the same value-plus-provenance
+/// when the answer exists, plus the arm [`Resolved`] cannot express — *the
+/// probe could not determine the answer*. The domain map (§5) sketched
+/// `Unavailable { needs: Privilege }`; DEC-6 collapsed the privilege tiers
+/// (`status` is root, `is-enrolled` never comes here), so what is left of N4
+/// is probe failure — an unreadable database, a config that did not parse —
+/// and the honest payload is the reason, not a privilege level.
+///
+/// The discipline it enforces sits in the renderer: an [`Fact::Unknown`]
+/// value must never render as a guessed answer. "The database could not be
+/// read" is a distinct value from "this user has no models".
+#[derive(Debug, Clone)]
+pub enum Fact<T> {
+    Known(Resolved<T>),
+    /// Not an error and NOT a false answer: the probe could not determine
+    /// the value. `why` says what stood in the way.
+    Unknown {
+        why: String,
+    },
+}
+
+impl<T> Fact<T> {
+    /// A fact verified against the live system.
+    pub fn probed(value: T) -> Self {
+        Fact::Known(Resolved {
+            value,
+            provenance: Provenance::Probed,
+        })
+    }
+
+    /// A fact taken from configuration without verification.
+    pub fn claimed(value: T) -> Self {
+        Fact::Known(Resolved {
+            value,
+            provenance: Provenance::Claimed,
+        })
+    }
+
+    pub fn unknown(why: impl Into<String>) -> Self {
+        Fact::Unknown { why: why.into() }
+    }
+
+    /// The value, when it is known.
+    pub fn known(&self) -> Option<&T> {
+        match self {
+            Fact::Known(resolved) => Some(&resolved.value),
+            Fact::Unknown { .. } => None,
+        }
+    }
+}
+
+impl<T> From<Resolved<T>> for Fact<T> {
+    fn from(resolved: Resolved<T>) -> Self {
+        Fact::Known(resolved)
+    }
 }
 
 /// One file the config names, and whether it is on disk.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,7 +118,10 @@ Shows device path, name, driver, formats, resolutions, and IR status.
 
 ## facelock status
 
-Check system status — config, daemon, camera, models.
+Check system status — config, daemon, oneshot fallback, camera, models,
+encryption, enrollment, security posture, notifications, PAM wiring. Requires
+root. A check that cannot be performed (unreadable database, broken config) is
+reported as "cannot determine" — never as a guessed value.
 
 ```bash
 facelock status

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -218,7 +218,12 @@ Open config file in editor.
 .TP
 .B status
 Check system status including daemon connectivity, enrolled faces, camera
-availability, and model integrity.
+availability, and model integrity. Also reports whether the PAM module's
+oneshot fallback could authenticate with the daemon unreachable, and whether
+the target user's
+.B is\-enrolled
+marker agrees with the database. Requires root. A check that cannot be
+performed is reported as such; the report never substitutes a guessed value.
 .TP
 .B devices
 List available camera devices.

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 01:07-0700\n"
+"POT-Creation-Date: 2026-08-14 02:18-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,102 +17,102 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/facelock-cli/src/message.rs:515
+#: crates/facelock-cli/src/message.rs:604
 msgid "no config file at {path} — run 'sudo facelock setup' to create one"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:519
+#: crates/facelock-cli/src/message.rs:608
 msgid "invalid config at {path}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:524
+#: crates/facelock-cli/src/message.rs:613
 msgid ""
 "Root required.\n"
 "  Run: {hint}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:527
+#: crates/facelock-cli/src/message.rs:616
 msgid "Root required. Re-run with sudo? [Y/n] "
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:529
+#: crates/facelock-cli/src/message.rs:618
 msgid ""
 "Access denied: this operation requires root.\n"
 "  Re-run with sudo, or as root."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:532
+#: crates/facelock-cli/src/message.rs:621
 msgid ""
 "Access denied. If you are not in the 'facelock' group, add yourself:\n"
 "  sudo usermod -aG facelock $USER\n"
 "then log out and back in (or re-run: sudo facelock setup). Note: some operations require root regardless of group membership."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:535
+#: crates/facelock-cli/src/message.rs:624
 msgid "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:539
+#: crates/facelock-cli/src/message.rs:628
 msgid ""
 "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\n"
 "Start it with: sudo systemctl start facelock-daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:542
+#: crates/facelock-cli/src/message.rs:631
 msgid ""
 "Graphical preview requires the daemon. In oneshot mode, use --text-only.\n"
 "Falling back to text-only mode.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:545
+#: crates/facelock-cli/src/message.rs:634
 msgid ""
 "Graphical preview requires the daemon, which is configured but not reachable.\n"
 "Falling back to text-only mode. Start the daemon with: sudo systemctl start facelock-daemon\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:548
+#: crates/facelock-cli/src/message.rs:637
 msgid "Setup has not been completed."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:549
+#: crates/facelock-cli/src/message.rs:638
 msgid "Run setup now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:550
+#: crates/facelock-cli/src/message.rs:639
 msgid "Setup did not complete successfully."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:551
+#: crates/facelock-cli/src/message.rs:640
 msgid "Run 'sudo facelock setup' when ready."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:553
+#: crates/facelock-cli/src/message.rs:642
 msgid ""
 "WARNING: encryption.method = \"none\" and security.allow_plaintext = true.\n"
 "Your face template will be stored UNENCRYPTED (plaintext biometric data at rest)."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:557
+#: crates/facelock-cli/src/message.rs:646
 msgid ""
 "Face recognition models not found in {dir}.\n"
 "Run `sudo facelock setup` to download them."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:563
+#: crates/facelock-cli/src/message.rs:652
 msgid ""
 "Note: existing models don't use the configured embedder '{embedder}'.\n"
 "Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:568
+#: crates/facelock-cli/src/message.rs:657
 msgid "Enrolling face for user '{user}' with label '{label}'..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:572
+#: crates/facelock-cli/src/message.rs:661
 msgid "Look at the camera. Slowly turn your head left and right."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:580
+#: crates/facelock-cli/src/message.rs:669
 msgid ""
 "\n"
 "Face enrolled successfully!\n"
@@ -121,113 +121,333 @@ msgid ""
 "  Label: {label}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:590
+#: crates/facelock-cli/src/message.rs:679
 msgid ""
 "\n"
 "Warning: user '{user}' has {count} face models. Consider removing old ones with 'facelock remove'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:595
+#: crates/facelock-cli/src/message.rs:684
 msgid "Face recognition models not found."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:596
+#: crates/facelock-cli/src/message.rs:685
 msgid "Download models now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:597
+#: crates/facelock-cli/src/message.rs:686
 msgid "Models still not found after setup."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:598
+#: crates/facelock-cli/src/message.rs:687
 msgid "Models required. Run `facelock setup` to download them."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:600
+#: crates/facelock-cli/src/message.rs:689
 msgid "No face models enrolled for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:603
+#: crates/facelock-cli/src/message.rs:692
 msgid "Run 'facelock enroll' to enroll a face first."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:605
+#: crates/facelock-cli/src/message.rs:694
 msgid "Warning: no enrolled models use the configured embedder '{embedder}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:608
+#: crates/facelock-cli/src/message.rs:697
 msgid "Re-enroll with 'facelock enroll' to use the current model."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:610
+#: crates/facelock-cli/src/message.rs:699
 msgid "Testing face recognition for user '{user}'..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:613
+#: crates/facelock-cli/src/message.rs:702
 msgid "Look at the camera."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:618
+#: crates/facelock-cli/src/message.rs:707
 msgid "Matched (similarity: {similarity}) in {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:631
+#: crates/facelock-cli/src/message.rs:720
 msgid "Matched model #{model_id} '{label}' (similarity: {similarity}) in {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:645
+#: crates/facelock-cli/src/message.rs:734
 msgid "Face matched (best: {similarity}) but the liveness variance check was not satisfied after {seconds}s — try moving slightly, or tune security.frame_variance_max_similarity"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:656
+#: crates/facelock-cli/src/message.rs:745
 msgid "No match (best: {similarity}) after {seconds}s"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:664
+#: crates/facelock-cli/src/message.rs:753
 msgid "Remove face model #{model_id} for user '{user}'?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:667
+#: crates/facelock-cli/src/message.rs:756
 msgid "Cancelled."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:669
+#: crates/facelock-cli/src/message.rs:758
 msgid "Removed face model #{model_id} for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:673
+#: crates/facelock-cli/src/message.rs:762
 msgid "Model #{model_id} not found for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:677
+#: crates/facelock-cli/src/message.rs:766
 msgid "Remove ALL face models for user '{user}'?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:681
+#: crates/facelock-cli/src/message.rs:770
 msgid "Removed {count} face model(s) for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:685
+#: crates/facelock-cli/src/message.rs:774
 msgid "All face models removed for user '{user}'."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:689
+#: crates/facelock-cli/src/message.rs:778
+msgid "facelock system status"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:779
+msgid "Config file"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:780
+msgid "Daemon"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:781
+msgid "Oneshot fallback"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:782
+msgid "Camera device"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:783
+msgid "Model directory"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:784
+msgid "Execution provider"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:785
+msgid "Encryption"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:786
+msgid "Enrolled faces"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:787
+msgid "Security"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:788
+msgid "Notifications"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:789
+msgid "PAM module"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:791
+msgid "cannot determine: {why}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:794
+msgid "valid"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:795
+msgid "not found"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:797
+msgid "invalid: {error}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:799
+msgid "oneshot mode (no daemon)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:800
+msgid "responding"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:802
+msgid "not responding: {error}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:806
+msgid "usable (root-invoked PAM can authenticate via 'facelock auth' without the daemon)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:809
+msgid "not usable (PAM would fall through to the next auth method if the daemon is unreachable)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:811
+msgid "device exists"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:812
+msgid "device not found"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:813
+msgid "auto-detect enabled"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:814
+msgid "directory not found"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:815
+msgid "all configured models present"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:816
+msgid "some models missing (run 'facelock setup')"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:817
+msgid "present"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:818
+msgid "MISSING"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:819
+msgid "supported by the installed ONNX Runtime"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:821
+msgid "not built into the installed ONNX Runtime — inference will fall back to CPU"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:824
+msgid "unknown execution provider (valid: cpu, cuda, rocm, openvino)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:827
+msgid "ONNX Runtime not loadable: {error}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:831
+msgid "sealed key: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:834
+msgid "sealed key missing: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:838
+msgid "TPM device missing: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:842
+msgid "key file: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:845
+msgid "key file missing: {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:849
+msgid "embeddings stored as plaintext (run 'facelock setup' to enable encryption)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:851
+msgid "no faces enrolled (run 'facelock enroll')"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:853
+msgid "{count} model(s)"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:858
+msgid "out of date (marker says {marker}, database has {store}) — run 'sudo facelock setup' to reconcile"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:863
+msgid "unreadable: {why}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:865
+msgid "ALL SECURITY CHECKS DISABLED"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:866
+msgid "yes"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:867
+msgid "no"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:868
+msgid "off"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:869
+msgid "terminal"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:870
+msgid "desktop"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:871
+msgid "terminal + desktop"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:872
+msgid "installed"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:874
+msgid "installed at {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:876
+msgid "not installed"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:877
+msgid "configured"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:878
+msgid "not configured for facelock"
+msgstr ""
+
+#: crates/facelock-cli/src/message.rs:880
 msgid "Scanning face..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:691
+#: crates/facelock-cli/src/message.rs:882
 msgid "Welcome, {label}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:694
+#: crates/facelock-cli/src/message.rs:885
 msgid "Face recognized ({similarity})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:698
+#: crates/facelock-cli/src/message.rs:889
 msgid "Face auth failed: {reason}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:704
+#: crates/facelock-cli/src/message.rs:895
 msgid ""
 "\n"
 "  Facelock v{version}\n"
@@ -242,320 +462,320 @@ msgid ""
 "    - Daemon and PAM configuration\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:708
+#: crates/facelock-cli/src/message.rs:899
 msgid ""
 "\n"
 "--- Step 1: Camera Selection ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:709
+#: crates/facelock-cli/src/message.rs:900
 msgid ""
 "\n"
 "--- Step 2: Model Quality ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:710
+#: crates/facelock-cli/src/message.rs:901
 msgid ""
 "\n"
 "--- Step 3: Inference Device ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:711
+#: crates/facelock-cli/src/message.rs:902
 msgid ""
 "\n"
 "--- Step 4: Model Download ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:712
+#: crates/facelock-cli/src/message.rs:903
 msgid ""
 "\n"
 "--- Step 5: Embedding Encryption ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:713
+#: crates/facelock-cli/src/message.rs:904
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:715
+#: crates/facelock-cli/src/message.rs:906
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:717
+#: crates/facelock-cli/src/message.rs:908
 msgid ""
 "\n"
 "--- Step 7: Test Recognition ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:719
+#: crates/facelock-cli/src/message.rs:910
 msgid ""
 "\n"
 "--- Step 7: Test Recognition (skipped, no face enrolled) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:721
+#: crates/facelock-cli/src/message.rs:912
 msgid ""
 "\n"
 "--- Step 8: Daemon Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:722
+#: crates/facelock-cli/src/message.rs:913
 msgid ""
 "\n"
 "--- Step 9: PAM Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:723
+#: crates/facelock-cli/src/message.rs:914
 msgid ""
 "\n"
 "--- Setup Complete ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:727
+#: crates/facelock-cli/src/message.rs:918
 msgid ""
 "  Camera detection failed: {error}\n"
 "  You can configure the camera later in the config file.\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:733
+#: crates/facelock-cli/src/message.rs:924
 msgid ""
 "  Model quality selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:739
+#: crates/facelock-cli/src/message.rs:930
 msgid ""
 "  Inference device selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:745
+#: crates/facelock-cli/src/message.rs:936
 msgid ""
 "  Model download failed: {error}\n"
 "  You can retry later with: sudo facelock setup --non-interactive"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:751
+#: crates/facelock-cli/src/message.rs:942
 msgid ""
 "  Encryption setup failed: {error}\n"
 "  You can configure encryption later with: sudo facelock encrypt --generate-key"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:757
+#: crates/facelock-cli/src/message.rs:948
 msgid ""
 "  Enrollment failed: {error}\n"
 "  You can enroll later with: facelock enroll"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:762
+#: crates/facelock-cli/src/message.rs:953
 msgid ""
 "  Test failed: {error}\n"
 "  You can test later with: facelock test"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:767
+#: crates/facelock-cli/src/message.rs:958
 msgid ""
 "  Systemd setup failed: {error}\n"
 "  You can enable it later with: sudo facelock setup --systemd"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:773
+#: crates/facelock-cli/src/message.rs:964
 msgid ""
 "  Group setup failed: {error}\n"
 "  Add manually: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:779
+#: crates/facelock-cli/src/message.rs:970
 msgid ""
 "  PAM setup failed: {error}\n"
 "  You can configure PAM later with: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:785
+#: crates/facelock-cli/src/message.rs:976
 msgid ""
 "  No video devices found.\n"
 "  Check that your camera is connected and the v4l2 module is loaded."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:788
+#: crates/facelock-cli/src/message.rs:979
 msgid "  Auto-selected IR camera: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:792
+#: crates/facelock-cli/src/message.rs:983
 msgid "  Auto-selected IR camera: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:796
+#: crates/facelock-cli/src/message.rs:987
 msgid "  Selected: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:800
+#: crates/facelock-cli/src/message.rs:991
 msgid "  Selected: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:803
+#: crates/facelock-cli/src/message.rs:994
 msgid "Select camera device"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:805
+#: crates/facelock-cli/src/message.rs:996
 msgid "--camera=auto found no video devices; check that the camera is connected and the v4l2 module is loaded"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:809
+#: crates/facelock-cli/src/message.rs:1000
 msgid ""
 "--camera=auto found no IR-capable camera among the detected devices:\n"
 "{listed}\n"
 "  Pass an explicit device path, e.g. --camera={example}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:815
+#: crates/facelock-cli/src/message.rs:1006
 msgid ""
 "--camera=auto found {count} IR-capable cameras:\n"
 "{listed}\n"
 "  Pass an explicit device path to choose one."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:821
+#: crates/facelock-cli/src/message.rs:1012
 msgid "camera device {path} does not exist; pass a valid /dev/video* path or --camera=auto"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:826
+#: crates/facelock-cli/src/message.rs:1017
 msgid "Select model quality"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:827
+#: crates/facelock-cli/src/message.rs:1018
 msgid "Select inference device"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:830
+#: crates/facelock-cli/src/message.rs:1021
 msgid "  [ok] {name} ({purpose})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:833
+#: crates/facelock-cli/src/message.rs:1024
 msgid "  All models are already present and verified."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:834
+#: crates/facelock-cli/src/message.rs:1025
 msgid "  Models to download:"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:840
+#: crates/facelock-cli/src/message.rs:1031
 msgid "    - {name} (~{size_mb}MB) - {purpose}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:848
+#: crates/facelock-cli/src/message.rs:1039
 msgid "  Total download size: ~{mb}MB"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:851
+#: crates/facelock-cli/src/message.rs:1042
 msgid "Download required models?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:852
+#: crates/facelock-cli/src/message.rs:1043
 msgid "  Skipping model download."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:854
+#: crates/facelock-cli/src/message.rs:1045
 msgid "  Downloading {name}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:858
+#: crates/facelock-cli/src/message.rs:1049
 msgid "  [ok] {name} downloaded and verified"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:862
+#: crates/facelock-cli/src/message.rs:1053
 msgid "Would you like to enroll a face now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:863
+#: crates/facelock-cli/src/message.rs:1054
 msgid "  Skipping face enrollment."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:864
+#: crates/facelock-cli/src/message.rs:1055
 msgid "Would you like to test recognition?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:865
+#: crates/facelock-cli/src/message.rs:1056
 msgid "  Skipping recognition test."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:866
+#: crates/facelock-cli/src/message.rs:1057
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:868
+#: crates/facelock-cli/src/message.rs:1059
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:871
+#: crates/facelock-cli/src/message.rs:1062
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:874
+#: crates/facelock-cli/src/message.rs:1065
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:877
+#: crates/facelock-cli/src/message.rs:1068
 msgid "  Answered on the command line; applied once setup finishes."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:880
+#: crates/facelock-cli/src/message.rs:1071
 msgid "  Creating 'facelock' system group..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:882
+#: crates/facelock-cli/src/message.rs:1073
 msgid ""
 "  Note: running daemon commands (preview/test) as a normal user requires\n"
 "  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:885
+#: crates/facelock-cli/src/message.rs:1076
 msgid "  User '{user}' is already in the 'facelock' group."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:890
+#: crates/facelock-cli/src/message.rs:1081
 msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:895
+#: crates/facelock-cli/src/message.rs:1086
 msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:900
+#: crates/facelock-cli/src/message.rs:1091
 msgid ""
 "  Added '{user}' to the 'facelock' group.\n"
 "  NOTE: log out and back in for the new group membership to take effect."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:907
+#: crates/facelock-cli/src/message.rs:1098
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:913
+#: crates/facelock-cli/src/message.rs:1104
 msgid ""
 "  PAM module not found at {path}.\n"
 "  Install it first, then run: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:918
+#: crates/facelock-cli/src/message.rs:1109
 msgid "  Configuring PAM for {service}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:922
+#: crates/facelock-cli/src/message.rs:1113
 msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:927
+#: crates/facelock-cli/src/message.rs:1118
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -566,35 +786,35 @@ msgid ""
 "  to confirm each file individually.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:932
+#: crates/facelock-cli/src/message.rs:1123
 msgid "Select services to enable face authentication for"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:935
+#: crates/facelock-cli/src/message.rs:1126
 msgid "  Failed to configure {service}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:938
+#: crates/facelock-cli/src/message.rs:1129
 msgid "  No PAM services selected."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:940
+#: crates/facelock-cli/src/message.rs:1131
 msgid "PAM service file not found: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:944
+#: crates/facelock-cli/src/message.rs:1135
 msgid "PAM line already present in {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:947
+#: crates/facelock-cli/src/message.rs:1138
 msgid "inserted before the first 'auth' line"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:949
+#: crates/facelock-cli/src/message.rs:1140
 msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:958
+#: crates/facelock-cli/src/message.rs:1149
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -604,19 +824,19 @@ msgid ""
 "(To configure manually instead, add the line above to each service yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:967
+#: crates/facelock-cli/src/message.rs:1158
 msgid "Proceed?"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:969
+#: crates/facelock-cli/src/message.rs:1160
 msgid "Skipped {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:972
+#: crates/facelock-cli/src/message.rs:1163
 msgid "Backed up {path} -> {backup}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:981
+#: crates/facelock-cli/src/message.rs:1172
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
@@ -625,99 +845,99 @@ msgid ""
 "  # or: sudo facelock setup --pam --remove --service {service}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:990
+#: crates/facelock-cli/src/message.rs:1181
 msgid "Removed facelock PAM line from {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:994
+#: crates/facelock-cli/src/message.rs:1185
 msgid "No facelock PAM line found in {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:998
+#: crates/facelock-cli/src/message.rs:1189
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1003
+#: crates/facelock-cli/src/message.rs:1194
 msgid "  Camera:     {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1007
+#: crates/facelock-cli/src/message.rs:1198
 msgid "  Models:     {dir} ({quality})"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1011
+#: crates/facelock-cli/src/message.rs:1202
 msgid "  Inference:  {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1015
+#: crates/facelock-cli/src/message.rs:1206
 msgid "  Database:   {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1019
+#: crates/facelock-cli/src/message.rs:1210
 msgid "  Encryption: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1023
+#: crates/facelock-cli/src/message.rs:1214
 msgid "  Daemon:   {status}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1026
+#: crates/facelock-cli/src/message.rs:1217
 msgid "not configured (--no-systemd)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1027
+#: crates/facelock-cli/src/message.rs:1218
 msgid "configured from the command line"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1028
+#: crates/facelock-cli/src/message.rs:1219
 msgid "enabled (D-Bus activation)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1029
+#: crates/facelock-cli/src/message.rs:1220
 msgid "not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1031
+#: crates/facelock-cli/src/message.rs:1222
 msgid "  PAM:      {services}"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1034
+#: crates/facelock-cli/src/message.rs:1225
 msgid "  PAM:      not configured (--no-pam)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1035
+#: crates/facelock-cli/src/message.rs:1226
 msgid "  PAM:      not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1036
+#: crates/facelock-cli/src/message.rs:1227
 msgid "  Face:     enrolled"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1038
+#: crates/facelock-cli/src/message.rs:1229
 msgid "  Face:     not enrolled (--no-enroll; run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1040
+#: crates/facelock-cli/src/message.rs:1231
 msgid "  Face:     not enrolled (run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1042
+#: crates/facelock-cli/src/message.rs:1233
 msgid "facelock setup: preparing system...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1044
+#: crates/facelock-cli/src/message.rs:1235
 msgid "Checking {count} model(s)...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1047
+#: crates/facelock-cli/src/message.rs:1238
 msgid ""
 "\n"
 "Setup complete."
 msgstr ""
 
-#: crates/facelock-cli/src/message.rs:1049
+#: crates/facelock-cli/src/message.rs:1240
 msgid ""
 "\n"
 "Setup complete. Run `facelock enroll` to register your face."

--- a/po/pam_facelock.pot
+++ b/po/pam_facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 00:11-0700\n"
+"POT-Creation-Date: 2026-08-14 01:55-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "Identifying face..."
 msgstr ""
 
-#: crates/pam-facelock/src/lib.rs:946 crates/pam-facelock/src/lib.rs:958
-#: crates/pam-facelock/src/lib.rs:1000
+#: crates/pam-facelock/src/lib.rs:946 crates/pam-facelock/src/lib.rs:960
+#: crates/pam-facelock/src/lib.rs:1002
 msgid "Face recognized."
 msgstr ""


### PR DESCRIPTION
Wave 3, PR H8 — the Health domain (map §5, post-DEC-6/DEC-7; gap register N4's remnant, F7 reopened, DEC-7). `status` becomes a testable renderer over a `Health` fact model, and "unknown" stops collapsing into "false".

## Design: `Fact<T>` and `Health`

**`Fact<T>`** (`crates/facelock-cli/src/resolved.rs`) is the grown form of H2's `Resolved<T>` — adopted, not duplicated:

```rust
pub enum Fact<T> {
    Known(Resolved<T>),          // value + the Provenance every resolved fact already carries
    Unknown { why: String },     // the probe could not determine the answer
}
```

The map sketched `Unavailable { needs: Privilege }`. DEC-6 collapsed the privilege tiers — `status` is root, `is-enrolled` never touches this machinery — so what is left of N4 is *probe failure* (unreadable database, unparsed config), and the honest payload is the reason, not a privilege level. `From<Resolved<T>>` lets every H2 probe (`ModelFiles`, `CameraPresence`, `ExecutionProviderFact`) and H6's reachability discipline lift into a `Fact` unchanged.

**`Health`** (`crates/facelock-cli/src/health.rs`) is shaped from what `status` actually reports, not the map's six-field sketch:

| Field | Type | Probe |
|---|---|---|
| `config` | `ConfigHealth` (not a `Fact` — running the parse *is* the probe) | `ConfigHealth::from_load` |
| `daemon` | `Fact<DaemonPing>` | `backend::probe_daemon` (in the seam) |
| `oneshot_fallback` | `Fact<OneshotFallback>` (F7) | `probe_oneshot_fallback_at` |
| `camera` | `Fact<CameraHealth>` (presence + interrogated caps incl. `applied_quirks`) | `probe_camera` → `direct::resolve_camera_device` (H3's one implementation) |
| `models` | `Fact<ModelFiles>` (H2's type, unchanged) | `ModelFiles::probe` |
| `execution_provider` | `Fact<ExecutionProviderFact>` (H2's type) | `ExecutionProviderFact::probe` |
| `encryption` | `Fact<EncryptionHealth>` | `probe_encryption` |
| `user` + `enrolled` | `Fact<EnrollmentHealth>` (store + marker diagnostic, DEC-7) | `probe_enrolled` |
| `security`, `notifications` | `Fact<…>` (claims, `Provenance::Claimed`) | `from_config` |
| `pam` | `PamWiring` (config-independent, always probed) | `probe_pam_at` |

`Health` is plain owned data — constructible in a test with zero root, camera, or bus.

## Probe / renderer split

Before: `commands/status.rs` = 423 lines of interleaved probing and printing, 0 tests.
After:

- **Probes** — `health.rs` (511 code lines, 11 tests): each section an isolated fn, mockable ones parameterized by path/closure (`probe_pam_at`, `probe_oneshot_fallback_at`, `marker_diagnostic`, `probe_enrolled` against a tempdir store). The daemon probe is `backend::probe_daemon` / `probe_daemon_with` (`backend.rs`), so `ipc_client::ping` is now single-sited in the transport seam — `status.rs` is **removed from the transport-pin allowlist** (`backend.rs` test `daemon_transport_entry_points_are_single_sited`: `("ping", backend_only)`).
- **Renderer** — `commands/status.rs` `render(&Health) -> String` (505 code lines, 14 tests): pure, byte-deterministic, including a full-report golden test (`healthy_report_renders_byte_exact`).
- `run()` is now 8 lines: `require_root` → `Health::probe` → `print!(render(..))`.

`DaemonPing` is deliberately distinct from H6's `DaemonReachability`: selection's probe (`name_has_owner`) must never activate the daemon; `status`'s probe is the full `Ping` round-trip and may activate — "responding" in a health report means a method call completed on the daemon the next auth would get. Behavior is unchanged from the old `check_daemon`.

## The money pin (N4)

`unreachable_daemon_and_unknown_store_never_render_as_not_enrolled` (`commands/status.rs`): a `Health` with `daemon = NotResponding` and `enrolled = Unknown` renders `[!!] not responding: …` and `[!!] cannot determine: …`, and the report **must not contain** "no faces enrolled" or "model(s)". The converse pin: only a *known* empty enrollment (provably absent database, C7 — `StoreError::Absent`) renders "no faces enrolled".

## F7 semantics ("usable", precisely)

`status` now renders an **Oneshot fallback** section: *usable* means root-invoked `pam_facelock` (DEC-2/N9) could spawn `/usr/bin/facelock auth` and complete an authentication locally with the daemon unreachable — requiring (1) the binary at PAM's hardcoded `AUTH_BIN` path, (2) both configured model files, (3) the database. All three derive from facts already in `Health`. Per-user enrollment is deliberately *not* part of "usable" — a missing enrollment fails one user, a missing binary fails the mechanism — and stays the Enrolled section's answer. When not usable, the missing prerequisites are named (`- models: MISSING`).

## DEC-7: unify the fact, not the command

`status` (root) reads the store as the authority and *additionally* reads the target user's `is-enrolled` marker, rendering a diagnostic detail only on disagreement: `- marker: out of date (marker says 3, database has 1) — run 'sudo facelock setup' to reconcile` (also `unreadable:`). **`is-enrolled` is untouched** — zero diff in `commands/is_enrolled.rs`; the three layout-tier is-enrolled tests pass unmodified; the source-scan isolation pins in `resolved.rs` still hold.

## Pinned output (verified against the test scripts)

- `test/run-integration-tests.sh:66` greps `\[ok\] responding` from `facelock status` — preserved byte-for-byte and pinned by the golden renderer test.
- `test/run-layout-tests.sh` pins `is-enrolled` exit codes and `"models":2` JSON — command untouched.
- No other script greps status output (`run-container-tests.sh`, `run-tests.sh`, `run-oneshot-tests.sh`, `pkg-validate.sh` checked).
- All previously-reachable report lines render byte-identically in the C locale (golden test). There is **no `status --json`** today; the module doc records that if one appears it renders from the same `Health` without gettext (H5 machine-facing exclusion).

Deliberate output changes (none grepped anywhere): a broken config no longer silently drops sections — every section always renders, either its value or `[!!] cannot determine: <why>` (previously camera/models/daemon printed ad-hoc "config not available"-style lines and four sections vanished); the enrolled section's store-failure text is now the uniform `cannot determine:` form (was a `- database: not accessible (may need root)` detail — stale advice now that `status` is root-only); new lines: Oneshot fallback section, camera `ir:`/`quirks:`/`device:` details, `marker:` diagnostic.

## H5 message seam

All report prose routes through `UserMessage` (55 new `Status*` variants; English fallback byte-identical; `po/facelock.pot` regenerated via `just pot` — `pam_facelock.pot` picked up line-reference drift from the chain's own doc commit). The report skeleton (`  label:`, `[ok]`/`[!!]`, `- key:`) and config-key-shaped detail keys (`require_ir`, `device.path`, `quirks`, …) stay structural/literal by design — they are vocabulary, not prose.

## Testability

| | before | after |
|---|---|---|
| status probing+rendering code | 423 lines, **0 under test** | 505 (renderer) + 511 (probes) code lines |
| tests | 0 | 14 renderer + 11 probe + 3 seam-probe (`backend.rs`) |
| untested residue | everything | `run()` (8 lines), `Health::probe` assembly, `probe_camera` composition (its parts are H2/H3-tested) |

## Cross-PR notes

- Consumes H2 (`Resolved`/facts), H3 (`ResolvedCamera::interrogate`, `applied_quirks`), H5 (seam + byte-stability discipline), H6 (`classify` untouched; reachability discipline extended, transport allowlist updated), H7 (ping transport; server stays in `facelock-daemon`).
- `direct::resolve_camera_device` widened to `pub(crate)` so the camera probe reuses the one interrogation path instead of re-deriving.
- `resolved.rs`'s "H8 will grow this into Fact" forward-reference comments replaced by the real thing.

## Docs to reconcile (done here)

`CHANGELOG.md` (3 Added + 1 Changed entries), `man/facelock.1` (status: fallback report, marker diagnostic, root requirement — which Wave-2 introduced but the man page never recorded), `docs/cli.md` + `book/src/cli-reference.md` (status blurb). Plan errata below.

## Plan errata

- Map §5 says "415 untested lines"; it was 423 at this base.
- The map's `Health` sketch has a `store: Fact<StoreHealth>` field; in the real report the store surfaces through `enrolled` (readability) and `encryption.sealed_counts` / `oneshot_fallback.database_present` — a separate section would duplicate those, so it was folded rather than cargo-culted.
- `man/facelock.1` had never recorded the Wave-2 root requirement for `status` (fixed here in passing).

## Gates

- `just check` — clean (tests + clippy `-D warnings` + fmt + audit; audit's two pre-allowed yanked-crate warnings).
- `just test-arch-pam` — 22/22.
- `just test-arch-layout` — 21/21 (the three is-enrolled tests untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
