### PR TITLE
fix(pam): build zbus with the feature set that actually compiles standalone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,32 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+      # Build the PAM module ALONE — not via --workspace. `cargo build --workspace`
+      # unifies features across crates, so facelock-cli/facelock-polkit (which both
+      # request zbus ["tokio","blocking-api"]) silently repair an incoherent zbus
+      # feature set in pam-facelock. That masks a real breakage: zbus's `blocking`
+      # module is gated by `blocking-api`, NOT by the `blocking` feature, and with
+      # default-features off you must also pick a runtime (`tokio` or `async-io`).
+      # A standalone build is the only thing that proves the PAM crate compiles on
+      # its own. Keep in sync with `just check-pam-standalone`.
+      - name: Build pam-facelock in isolation
+        run: cargo build -p pam-facelock
+
+      # The whole point of PR #107 is to keep the PAM module's dependency surface
+      # small, so forbid the async-io runtime backend: async-io/async-signal/polling
+      # plus the async-executor/async-fs/async-lock trio that only the async-io zbus
+      # backend pulls. We deliberately do NOT forbid signal-hook-registry: the
+      # correct tokio backend pulls it transitively via tokio's "process" feature,
+      # so listing it here would reject the very fix that shrinks the surface. If you
+      # think you need to add signal-hook-registry back, you have probably
+      # reintroduced the async-io backend — check for async-io first.
+      # Keep in sync with `just check-pam-standalone`.
       - name: Verify pam-facelock dependency surface
         run: |
           cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u > /tmp/pam-deps
           echo "pam-facelock crate count: $(wc -l < /tmp/pam-deps)"
-          if grep -Eq '^(async-io|async-signal|signal-hook-registry|polling)$' /tmp/pam-deps; then
-            echo "forbidden async crates in pam-facelock"
+          if grep -Eq '^(async-io|async-signal|async-executor|async-fs|async-lock|polling)$' /tmp/pam-deps; then
+            echo "forbidden async-io backend crates in pam-facelock (expected the tokio backend)"
             exit 1
           fi
           echo "pam-facelock dependency guard passed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,18 +180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,12 +189,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -386,19 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -2445,17 +2414,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"
@@ -4598,7 +4556,6 @@ dependencies = [
  "async-broadcast",
  "async-recursion",
  "async-trait",
- "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/crates/pam-facelock/Cargo.toml
+++ b/crates/pam-facelock/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 libc = "0.2"
 toml = { workspace = true }
 serde = { workspace = true }
-zbus = { version = "5", default-features = false, features = ["blocking"] }
+zbus = { version = "5", default-features = false, features = ["tokio", "blocking-api"] }

--- a/justfile
+++ b/justfile
@@ -36,8 +36,28 @@ fmt:
 audit:
     cargo audit --deny unmaintained --deny unsound
 
-# Run all checks (test + lint + format + audit)
-check: test lint fmt-check audit
+# Verify the PAM module compiles on its OWN and stays off the async-io backend.
+# `cargo build --workspace` unifies zbus features with facelock-cli/-polkit, so it
+# hides an incoherent feature set in pam-facelock; only a standalone build catches
+# it. The dep guard then forbids the async-io runtime backend (async-io/async-signal/
+# polling + the async-executor/async-fs/async-lock trio) while allowing
+# signal-hook-registry, which the correct tokio backend legitimately pulls via
+# tokio's "process" feature. Keep in sync with .github/workflows/ci.yml
+# ("Build pam-facelock in isolation" + "Verify pam-facelock dependency surface").
+check-pam-standalone:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build -p pam-facelock
+    cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u > /tmp/pam-deps
+    echo "pam-facelock crate count: $(wc -l < /tmp/pam-deps)"
+    if grep -Eq '^(async-io|async-signal|async-executor|async-fs|async-lock|polling)$' /tmp/pam-deps; then
+        echo "forbidden async-io backend crates in pam-facelock (expected the tokio backend)" >&2
+        exit 1
+    fi
+    echo "pam-facelock dependency guard passed"
+
+# Run all checks (test + lint + format + audit + PAM standalone surface)
+check: test lint fmt-check audit check-pam-standalone
 
 # Build the PAM test container image (uses host-built release binaries).
 # Keep in sync with .github/workflows/ci.yml, which builds this same image


### PR DESCRIPTION
## What

Fixes the merge-blocker from REV-107's principal-architect review: `cargo build -p pam-facelock` did not compile on its own.

## Reproduction

```
$ cargo build -p pam-facelock
error: Either "async-io" (default) or "tokio" must be enabled
error[E0433]: cannot find module or crate `async_lock` ...
error[E0433]: cannot find module or crate `async_process` ...
error: could not compile `zbus` (lib) due to 21 previous errors
```

`crates/pam-facelock/Cargo.toml` declared:

```toml
zbus = { version = "5", default-features = false, features = ["blocking"] }
```

In zbus 5 the `zbus::blocking` module the PAM code uses (`zbus::blocking::Connection`, `::Proxy`, `::fdo::DBusProxy`, `::connection::Builder`) is gated by **`blocking-api`**, not `blocking`. `blocking` is only a sub-item of the async-io bundle that turns on an unrelated thread-pool crate. With `default-features = false` and no runtime selected, the feature set is incoherent and zbus cannot compile.

## Why it hid

`cargo build --workspace` unifies features across crates. `facelock-cli` and `facelock-polkit` both request `zbus = { ..., features = ["tokio", "blocking-api"] }` for the same zbus, so the workspace build silently repaired pam-facelock's set. `cargo tree` also resolved fine (58 crates) — graph resolution succeeds; it is not a compile check. Only a standalone `cargo build -p pam-facelock` exposed it.

This means the memory note claiming "pam solo-test breakage is pre-existing" was **wrong**. `main` declares `zbus = { version = "5", features = ["blocking"] }` (defaults *on*), which builds standalone via the async-io backend. This PR's commit `54a2935 fix(pam): build zbus without default features (C1)` added `default-features = false` and is what introduced the breakage.

## The fix

```toml
zbus = { version = "5", default-features = false, features = ["tokio", "blocking-api"] }
```

Matches `facelock-cli` and `facelock-polkit` exactly. pam-facelock now builds and tests in isolation (29 tests pass). The async-io thread-pool crates (`async-channel`, `async-task`, `blocking`, `piper`) drop out of `Cargo.lock`.

## Guard re-tuning (measured)

The CI guard forbade `async-io|async-signal|signal-hook-registry|polling`. The correct tokio backend pulls **`signal-hook-registry`** transitively via tokio's `process` feature, so the old guard would have rejected this very fix (it was calibrated against the broken tree).

Measured post-fix dependency set (`cargo tree -p pam-facelock --edges normal --prefix none`):
- **Added** by tokio backend: `bytes`, `errno`, `mio`, `signal-hook-registry`, `socket2`, `tokio`
- **Removed** async-io backend: `async-channel`, `async-task`, `atomic-waker`, `blocking`, `concurrent-queue`, `crossbeam-utils`, `piper`

New guard forbids the async-io runtime backend directly — `async-io`, `async-signal`, `polling`, plus `async-executor`, `async-fs`, `async-lock` — and drops `signal-hook-registry`. Verified: the new regex matches nothing in the fixed tree and still catches 5 markers in `main`'s async-io tree.

## Isolation build in CI

Added a `Build pam-facelock in isolation` step (`cargo build -p pam-facelock`, not `--workspace`) next to the guard, so this class of bug can no longer hide behind feature unification. Mirrored locally as `just check-pam-standalone`, wired into `just check`.

## Crate-count story (C1 goal holds)

| Tree | Crates | Compiles standalone? |
|------|--------|----------------------|
| pre-#107 baseline (`main`, async-io backend) | 68 | yes |
| #107 as-shipped (`default-features=false, ["blocking"]`) | 58 (resolves) | **no** |
| this fix (`["tokio","blocking-api"]`) | **57** | yes |

The fix is one crate smaller than the number #107 claimed (58) and 11 smaller than the 68-crate baseline — C1's dependency-shrink goal is preserved and slightly improved.

## Review finding

Fixes REV-107's merge-blocker: pam-facelock failing to build standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
