### PR TITLE
docs(security): describe the shipped IR classification model, with its honest residual

### DIFF
--- a/book/src/contracts.md
+++ b/book/src/contracts.md
@@ -93,7 +93,7 @@ TOML format. All keys optional -- camera auto-detected, sensible defaults for ev
 When `device.path` is omitted:
 1. Enumerate `/dev/video0` through `/dev/video63`
 2. Filter to VIDEO_CAPTURE devices
-3. Prefer IR cameras (name contains "ir"/"infrared", or supports GREY/Y16 format)
+3. Classify IR from queried evidence: a node whose formats are mono-only/IR-typical (GREY/Y8/Y10/Y12/Y16, no color format mixed in), or a quirks `force_ir` match (authoritative by USB vendor:product ID; a name-only match only when corroborated by a real USB identity or the node's own mono-format evidence). The device name is never used to classify a node — only as an auto-detection tiebreak among nodes that already qualify
 4. Fall back to first available device
 
 ## Database Schema

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -33,12 +33,23 @@
    ```bash
    facelock devices
    ```
-2. IR detection looks for keywords like "ir" or "infrared" in the device name and checks for grayscale formats (GREY, Y16). Some cameras do not advertise IR in their name.
-3. If you are certain your camera is IR, check its V4L2 capabilities:
+2. IR detection is derived from the pixel formats the camera reports, **not** its name. A node classifies as IR only when it enumerates *exclusively* IR-typical mono formats (GREY, Y8, Y10, Y12, Y16) with no color format (YUYV/MJPG) mixed in, or when a hardware quirk matches it. The device name is never used to classify a camera as IR (it is only a tiebreak during auto-detection), so a genuine IR camera whose single node also advertises a color format will **not** auto-classify.
+3. Inspect the formats your camera actually reports:
    ```bash
    v4l2-ctl -d /dev/video2 --list-formats-ext
    ```
-4. As a workaround, you can set `security.require_ir = false` -- but understand this weakens spoofing resistance. Only do this for testing.
+   If your IR sensor is a separate `/dev/video*` node that reports only a mono format (e.g. GREY or Y16), point `device.path` at that node (or let auto-detect find it). If IR and color share one node (a mixed format set), it will not classify by evidence alone — use a quirk (next step).
+4. For a genuine IR camera that format evidence alone does not catch, add a quirk in `/etc/facelock/quirks.d/` keyed by **USB vendor:product ID** (find yours with `lsusb`), which is the authoritative override:
+   ```toml
+   [[quirk]]
+   vendor_id = "046d"
+   product_id = "085e"
+   force_ir = true
+   format_preference = "GREY"   # the IR node's native format, for multi-node cameras
+   notes = "My IR camera"
+   ```
+   Prefer a USB-ID quirk over a `name_pattern` one: a name-only `force_ir` is trusted only when corroborated by the device's own mono-format evidence or a real USB identity, so it will not, by itself, force a color-only device to IR.
+5. As a last resort you can set `security.require_ir = false` -- but understand this weakens spoofing resistance. Only do this for testing.
 
 ## Auth too slow
 

--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -6,7 +6,9 @@
 #
 # Fields:
 #   vendor_id / product_id  - USB IDs (hex string, e.g. "8086")
-#   name_pattern            - regex matched against device name (fallback)
+#   name_pattern            - glob-like pattern matched against the WHOLE device
+#                             name (fallback). NOT regex: only (?i) and .* are
+#                             supported, and the pattern is anchored (#99).
 #   force_ir                - treat this device as an IR camera regardless of format detection
 #   emitter_xu_guid         - UVC Extension Unit GUID for IR emitter control
 #   emitter_xu_selector     - UVC XU control selector for emitter toggle

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -140,7 +140,16 @@ fn has_mono_only_formats(device: &DeviceInfo) -> bool {
 /// `CameraCaps.is_ir` (gap D8) should be derived from. Populated strictly
 /// from queried V4L2 data (the capture formats the device actually
 /// enumerates), NEVER from the free-text device/card name, which is
-/// attacker-controlled on virtual devices such as v4l2loopback (#98).
+/// trivially attacker-controlled on virtual devices such as v4l2loopback (#98).
+///
+/// Format evidence is stronger than the name, but it is NOT unforgeable:
+/// deriving IR-ness from the enumerated formats raises the attacker's cost from
+/// "set a `CARD_LABEL` string" to "also negotiate a mono-only pixel format", yet
+/// a root-loaded `v4l2loopback` device or a programmable USB gadget can still
+/// present a mono-only (GREY/Y16/…) format set and thus classify as IR. The
+/// backstops against a fabricated IR device are the liveness / frame-variance
+/// checks and the privilege required to create such a device — not this signal
+/// alone. See `docs/security.md` §A ("Honest residual").
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct IrEvidence {
     /// The device enumerates ONLY IR-typical mono capture formats — see

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -13,7 +13,11 @@ pub struct Quirk {
     /// USB product ID (hex string, e.g. "0b07")
     #[serde(default)]
     pub product_id: Option<String>,
-    /// Regex pattern to match against device name (fallback when IDs unavailable)
+    /// Glob-like pattern matched against the device name, a fallback when USB
+    /// IDs are unavailable. NOT a full regex: only a leading `(?i)` (case
+    /// insensitive) and `.*` (wildcard) are supported, and the pattern is
+    /// anchored — it must describe the WHOLE name, not a substring (#99). See
+    /// [`name_matches`].
     #[serde(default)]
     pub name_pattern: Option<String>,
     /// Force this device to be treated as an IR camera
@@ -46,8 +50,17 @@ struct QuirksFile {
     quirk: Vec<Quirk>,
 }
 
-/// Provenance of a [`QuirksDb`] match — how strongly the match is
-/// corroborated by evidence the device cannot forge.
+/// Provenance of a [`QuirksDb`] match — how the quirk matched, which bounds
+/// how far it can be trusted for a security-relevant decision like `force_ir`.
+///
+/// Neither kind is truly unforgeable; they differ only in the *cost* of
+/// forgery. A [`QuirkMatchKind::UsbId`] match rests on the sysfs USB identity,
+/// which a software-only virtual device (v4l2loopback) cannot present — though
+/// a programmable USB gadget could still advertise a chosen VID:PID. A
+/// [`QuirkMatchKind::NameOnly`] match rests only on the free-text device name,
+/// which is trivially attacker-controlled on virtual devices. This is why
+/// `force_ir` treats them differently (see
+/// [`crate::device::ir_source_with_quirks`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QuirkMatchKind {
     /// Matched by USB vendor:product ID, read from sysfs. Not spoofable by

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,9 +35,7 @@
 
 ### IR Cameras (recommended)
 
-IR cameras provide anti-spoofing protection. Facelock auto-detects IR cameras by:
-- Device name containing "ir" or "infrared"
-- Supporting GREY or Y16 pixel formats
+IR cameras provide anti-spoofing protection. Facelock auto-detects IR cameras from the pixel formats they report — a node that enumerates *only* IR-typical mono formats (GREY, Y8, Y10, Y12, Y16) with no color format (YUYV/MJPG) mixed in — or from a hardware quirk that matches the device. The device name is never used to classify a camera as IR.
 
 Known working:
 - Logitech BRIO (IR mode)

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -346,13 +346,19 @@ session and replays `PolicyPCR` — so a changed bound PCR makes unseal **fail**
 When `device.path` is omitted:
 1. Enumerate `/dev/video0` through `/dev/video63`
 2. Filter to VIDEO_CAPTURE devices
-3. Classify every node's IR provenance (quirks `force_ir` authoritative; name
-   token / format-corroboration heuristic otherwise), with node-level
-   disambiguation for multi-node USB devices: when several nodes share one
-   quirk-matched VID:PID and at least one has an IR-like format (GREY/Y16 or
-   the quirk's `format_preference`), only the format-bearing node(s) are IR
+3. Classify every node's IR provenance from queried evidence: a quirks
+   `force_ir` match (authoritative by USB vendor:product ID; a name-only match
+   only when corroborated by a real USB identity or the node's own mono-format
+   evidence), otherwise a node whose queried formats are mono-only/IR-typical
+   (GREY/Y8/Y10/Y12/Y16, with no color format mixed in). The device name never
+   classifies a node on its own. Node-level disambiguation for multi-node USB
+   devices: when several nodes share one quirk-matched VID:PID and at least one
+   has an IR-like format (GREY/Y16 or the quirk's `format_preference`), only the
+   format-bearing node(s) are IR
 4. Prefer a quirks-confirmed IR node with a native IR format, then any
-   quirks-confirmed IR node, then a name-token IR node
+   quirks-confirmed IR node, then an evidence-classified IR node (breaking ties
+   toward one whose name also carries an `ir`/`infrared` token — a hint only,
+   never a promotion of a node that lacks format evidence)
 5. Fall back to first available device
 
 ## Database Schema
@@ -564,11 +570,16 @@ treats a decline as a fall-through to another agent or as an outright denial.
 | Minimum auth frames (= variance window size) | `security.min_auth_frames` | 3 |
 | Frame variance default const | `DEFAULT_FRAME_VARIANCE_MAX_SIMILARITY` | 0.985 |
 
-IR classification requires a whole `ir`/`infrared` name token or a quirks `force_ir`
-entry; a GREY/Y16 format alone is not treated as IR. A `force_ir` quirk is
-device-level ("this USB device has an IR sensor"): when the device exposes multiple
-capture nodes and at least one has an IR-like format, only the format-bearing
-node(s) classify IR (see `docs/security.md` §A). Frame variance is passive
+IR classification is derived from queried device evidence: a node is IR when its
+enumerated pixel formats are mono-only/IR-typical (GREY/Y8/Y10/Y12/Y16, with no
+color format mixed in), or when a quirks `force_ir` entry matches (authoritative
+by USB vendor:product ID; a name-only match requires corroborating format
+evidence or a real USB identity). The free-text device name never classifies a
+device on its own, and a GREY/Y16 format offered *alongside* a color format is
+not treated as IR. A `force_ir` quirk is device-level ("this USB device has an
+IR sensor"): when the device exposes multiple capture nodes and at least one has
+an IR-like format, only the format-bearing node(s) classify IR (see
+`docs/security.md` §A). Frame variance is passive
 anti-photo only (does not stop video replay); it is evaluated over a sliding window
 of the most recent `min_auth_frames` matched frames (see `docs/security.md` §B), with
 a 0.985 cutoff rejecting truly static input (≳0.999) with margin; the

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,17 +41,22 @@ require_ir = true  # Refuse to authenticate on RGB-only cameras
 Implementation (`facelock-camera/src/device.rs`, `ir_source_with_quirks`):
 
 ```rust
-// IR classification is honest about its evidence, surfaced as IrSource:
-//   Quirk  – hardware quirks DB force_ir = true (authoritative, both directions)
-//   Format – native IR format (GREY/Y16) CORROBORATED by an IR name token
-//   Name   – an "ir"/"infrared" name *token* (tokenized, not substring)
-//   None   – not IR
+// IR classification is DERIVED from queried device evidence, surfaced as IrSource:
+//   Quirk  – hardware quirks DB force_ir, corroborated (authoritative, both directions)
+//   Format – the device's OWN queried capture formats are mono-only/IR-typical
+//            (GREY/Y8/Y10/Y12/Y16, with NO color format mixed in)
+//   None   – not classified as IR
 //
-// Per-node precedence:
-// 1. quirks DB force_ir is authoritative;
-// 2. a native GREY/Y16 format counts ONLY when corroborated by a name token;
-// 3. a name token alone is sufficient;
-// 4. otherwise not-IR.
+// The free-text device name is NEVER, by itself, sufficient to classify a
+// device as IR (#98): a crafted CARD_LABEL ("Fake IR Camera") on a
+// v4l2loopback node exposing only YUYV/MJPG does not classify as IR. Per-node:
+// 1. a quirks DB force_ir match is authoritative — by USB vendor:product ID
+//    unconditionally; by device NAME ONLY when corroborated by a real USB
+//    identity or the device's own mono-format evidence (#98 Task 3);
+// 2. otherwise IR-ness is derived SOLELY from the device's own queried
+//    formats: a mono-ONLY format set is IR, any set with a color format is not;
+// 3. the device name is consulted only as an auto-detection tiebreak hint,
+//    among nodes that ALREADY qualify by evidence — never to classify a node.
 pub fn ir_source_with_quirks(device, quirks) -> IrSource { ... }
 
 // Node-level disambiguation for multi-node USB devices: force_ir means "this
@@ -77,11 +82,15 @@ if config.security.require_ir && !device_is_ir {
 
 **Rationale**: Phone screens and printed photos do not emit infrared light correctly. An IR camera sees a flat, textureless surface where a real face would have depth and skin texture in IR. This single check eliminates the vast majority of spoofing attacks.
 
-**Why mere GREY/Y16 availability is not enough (H1)**: many ordinary RGB UVC webcams *enumerate* a GREY format alongside YUYV/MJPG. The previous heuristic (`contains("ir")` OR any GREY/Y16 format) misclassified those as IR, silently defeating `require_ir = true`. It also matched the substring "ir" inside unrelated names ("Sirius", "AIR-Cam"). The classifier now requires a whole `ir`/`infrared` **token** or a **quirks `force_ir`** entry, and treats a GREY/Y16 format as IR **only when corroborated** by one of those. This is why `require_ir` is now load-bearing rather than trivially bypassable.
+**Why the name alone is not enough, and what IS the evidence (H1, #98/#99)**: IR classification is derived **solely from queried device evidence** — the pixel formats the device actually enumerates — never from its free-text name. A node qualifies as IR only when it enumerates *exclusively* IR-typical mono formats (GREY/Y8/Y10/Y12/Y16) with **no color format mixed in**. Many ordinary RGB UVC webcams enumerate a GREY format *alongside* YUYV/MJPG; those do **not** qualify (this is what the old "H1" concern was about, now resolved by the mono-**only** requirement rather than by name corroboration). The previous heuristic (`contains("ir")` OR any GREY/Y16 format) misclassified plain webcams as IR and matched the substring "ir" inside unrelated names ("Sirius", "AIR-Cam"), silently defeating `require_ir = true`. Now a crafted `CARD_LABEL` on a color-only v4l2loopback device does not classify as IR no matter what it is named (#98), and the quirk `name_pattern` matcher is **anchored** (it matches the whole device name, not a substring) so it no longer fires on the "ir" inside those unrelated names (#99). The name is used only as a tiebreak hint when auto-detection chooses among nodes that *already* qualify by evidence, and as one corroboration path for a name-only `force_ir` quirk — never as a standalone classification signal. This is why `require_ir` is now load-bearing rather than trivially bypassable.
+
+**Quirk `force_ir` corroboration (#98 Task 3)**: a quirks `force_ir = true` entry that matched by **USB vendor:product ID** is authoritative on its own — a software-only virtual device (v4l2loopback) has no real USB node, so it can never win a USB-ID match. A `force_ir = true` entry that matched only by device **name**, however, requires corroboration before it is trusted: either the device has a real (even if DB-unlisted) USB identity, or its own queried formats independently support IR. Without either, a crafted name that happens to match a shipped pattern falls through to the evidence-only heuristic instead of being trusted. (`force_ir = false` remains authoritative unconditionally — the conservative "not IR" direction is always honored.)
+
+**Honest residual — format evidence is not unforgeable**: deriving IR-ness from queried formats raises the attacker's cost from "set a free-text `CARD_LABEL` string" to "also negotiate a mono-**only** pixel format", and removes the old path where a bare name token (or a name-only quirk) could escalate a device to IR. It does **not** make the evidence unforgeable. A `v4l2loopback` device (loading the module requires **root**) or a programmable USB gadget can present a mono-only (GREY/Y16/…) format set and **will** classify as IR — the format check cannot distinguish a genuine IR sensor from a device that merely advertises IR-typical formats. The remaining backstops against a fabricated IR device are the **liveness / frame-variance checks** (§B) and the **privilege required to create such a device** in the first place (root to load `v4l2loopback`, or physical access to attach USB-gadget hardware). `require_ir` is one layer of a layered defense, not a standalone attestation of a real IR sensor.
 
 **Why `force_ir` is device-level, not node-level (hardware-verified regression)**: on a real Logitech BRIO, treating every quirk-matched node as IR made *both* `/dev/video0` (the RGB sensor) and `/dev/video2` (the IR sensor) classify IR — so setup stopped auto-selecting and auto-detect captured from the RGB sensor (white LED) instead of the IR sensor. The sibling-format disambiguation above restores per-node honesty: exactly one BRIO node is `[IR]`, and auto-detection prefers the format-corroborated IR node.
 
-**Limitation**: classification is still heuristic without a hardware allow-list. Some genuine IR cameras report neither an IR name token nor a known quirk; add a quirks `force_ir` entry (`/etc/facelock/quirks.d/`) for such hardware (and set `format_preference` to the IR node's native format, e.g. `"GREY"`, when the camera exposes multiple capture nodes). The `facelock devices` command displays whether each camera is detected as IR. Device *identity* pinning (rather than capability heuristics) is implemented as its robust successor — see §1.D Device Coupling (Plan 02).
+**Limitation**: classification is capability-based, not a hardware allow-list. A genuine IR camera that exposes its IR and color streams on a *single* V4L2 node (so its format set is not mono-only) and is not covered by a shipped quirk will not auto-classify as IR. Add a quirks `force_ir` entry keyed by **USB vendor:product ID** (`/etc/facelock/quirks.d/`) for such hardware — a VID:PID match is authoritative — and set `format_preference` to the IR node's native format (e.g. `"GREY"`) when the camera exposes multiple capture nodes. Prefer a USB-ID quirk over a name-only one: a name-only `force_ir` is trusted only when corroborated by the device's own mono-format evidence or a real USB identity, so it is not a reliable override on its own. The `facelock devices` command displays whether each camera is detected as IR. Device *identity* pinning (rather than capability heuristics) is implemented as its robust successor — see §1.D Device Coupling (Plan 02).
 
 #### B. Frame Variance Check (Required)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,12 +33,23 @@
    ```bash
    facelock devices
    ```
-2. IR detection looks for keywords like "ir" or "infrared" in the device name and checks for grayscale formats (GREY, Y16). Some cameras do not advertise IR in their name.
-3. If you are certain your camera is IR, check its V4L2 capabilities:
+2. IR detection is derived from the pixel formats the camera reports, **not** its name. A node classifies as IR only when it enumerates *exclusively* IR-typical mono formats (GREY, Y8, Y10, Y12, Y16) with no color format (YUYV/MJPG) mixed in, or when a hardware quirk matches it. The device name is never used to classify a camera as IR (it is only a tiebreak during auto-detection), so a genuine IR camera whose single node also advertises a color format will **not** auto-classify.
+3. Inspect the formats your camera actually reports:
    ```bash
    v4l2-ctl -d /dev/video2 --list-formats-ext
    ```
-4. As a workaround, you can set `security.require_ir = false` -- but understand this weakens spoofing resistance. Only do this for testing.
+   If your IR sensor is a separate `/dev/video*` node that reports only a mono format (e.g. GREY or Y16), point `device.path` at that node (or let auto-detect find it). If IR and color share one node (a mixed format set), it will not classify by evidence alone — use a quirk (next step).
+4. For a genuine IR camera that format evidence alone does not catch, add a quirk in `/etc/facelock/quirks.d/` keyed by **USB vendor:product ID** (find yours with `lsusb`), which is the authoritative override:
+   ```toml
+   [[quirk]]
+   vendor_id = "046d"
+   product_id = "085e"
+   force_ir = true
+   format_preference = "GREY"   # the IR node's native format, for multi-node cameras
+   notes = "My IR camera"
+   ```
+   Prefer a USB-ID quirk over a `name_pattern` one: a name-only `force_ir` is trusted only when corroborated by the device's own mono-format evidence or a real USB identity, so it will not, by itself, force a color-only device to IR.
+5. As a last resort you can set `security.require_ir = false` -- but understand this weakens spoofing resistance. Only do this for testing.
 
 ## Auth too slow
 


### PR DESCRIPTION
## Summary

PR #110 (issues #98/#99) inverted how IR cameras are classified — IR-ness is now **derived from queried device evidence** (mono-only pixel formats: GREY/Y8/Y10/Y12/Y16), never concluded from the self-asserted device name; quirk `name_pattern`s now **full-match (anchored)** instead of substring-matching; and a name-only quirk asserting `force_ir` now requires **corroboration** (a real USB identity or the node's own mono-format evidence). The documentation still taught the **old, inverted model**. Because `CLAUDE.md` mandates reading `docs/security.md` before any auth-related work, those stale docs were a live vector for a future contributor to reintroduce the very bug (#98) that #110 closed.

This PR reconciles documentation and code **comments** with the shipped behavior. **No behavior changes** — docs and comments only.

**Review finding:** addresses REV-110's **High** documentation-defect finding on PR #110.

## What was wrong, per site (before → after)

**`docs/security.md` §A**
- `:44-54` (IrSource code-comment block): described the removed `IrSource::Name` variant and an inverted precedence ("a native GREY/Y16 format counts ONLY when corroborated by a name token; a name token alone is sufficient"). → Rewritten to the evidence-derived model: `IrSource` is `Quirk | Format | None`; Format = the device's own queried formats are mono-**only**/IR-typical; the name never classifies, only tiebreaks.
- `:80` (H1 rationale): said the classifier "now requires a whole `ir`/`infrared` token or a quirks `force_ir` entry, and treats a GREY/Y16 format as IR **only when corroborated** by one of those" — backwards. → Rewritten: IR is derived solely from queried formats (mono-only, no color mixed in); the name is not a classification signal; folds in the #99 anchoring fix.
- Added **"Quirk `force_ir` corroboration (#98 Task 3)"** paragraph and the required **"Honest residual — format evidence is not unforgeable"** paragraph (see below).
- `:84` (Limitation): said "some genuine IR cameras report neither an IR name token nor a known quirk; add a quirks `force_ir` entry" — the name-token path no longer exists. → Rewritten around the single-node mixed-format case, recommending a **USB-ID** quirk (authoritative).

**`docs/contracts.md`** (contract register preserved)
- `:349-355` (auto-detect algorithm): "quirks `force_ir` authoritative; name token / format-corroboration heuristic otherwise … then a name-token IR node". → Corrected to evidence-derived classification with the USB-ID/name-only corroboration distinction; step 4 tiebreak is a hint only.
- `:567-568` (normative anti-spoofing statement): "IR classification requires a whole `ir`/`infrared` name token or a quirks `force_ir` entry; a GREY/Y16 format alone is not treated as IR" — both clauses now false. → "IR is derived from queried evidence: mono-only formats, or a `force_ir` match (USB-ID authoritative; name-only needs corroboration); a GREY/Y16 offered *alongside* a color format is not IR."

**`docs/troubleshooting.md` `:36`** (where a user debugging a `require_ir` failure actually lands)
- "IR detection looks for keywords like 'ir' or 'infrared' in the device name and checks for grayscale formats." → Rewrote steps 2–5: classification is format-derived (mono-**only**), the name never classifies; concrete remedy for a genuine unrecognized IR camera — point `device.path` at a mono-only node, or add a **USB-ID** `force_ir` quirk (authoritative), preferred over a name-only quirk.

**`book/src/troubleshooting.md` / `book/src/contracts.md`** — the two in-scope stale book pages, brought in line with their `docs/` counterparts (no general book resync).

## Additional stale sites found beyond the listed set

- **`docs/compatibility.md:38-40`** — "Facelock auto-detects IR cameras by: device name containing 'ir' or 'infrared' / supporting GREY or Y16 pixel formats." Same inverted model; fixed (it is a `docs/` page and teaches classification directly).
- **`crates/facelock-camera/src/quirks.rs:16`** and **`config/quirks.d/00-defaults.toml:9`** — the two "regex" mislabels called out in the task; both corrected to describe the glob-like anchored matcher (only `(?i)` and `.*`, full-name match), so a contributor does not write a real regex.
- **Overclaiming in-code comments corrected** (documentation in all but location):
  - `quirks.rs` `QuirkMatchKind` doc — dropped "evidence the device cannot forge"; neither kind is unforgeable, they differ only in the cost of forgery.
  - `device.rs` `IrEvidence` doc — states plainly that queried mono-format evidence is stronger than the name but still forgeable (root-loaded v4l2loopback or a USB gadget); backstops are liveness/frame-variance and the privilege to create such a device.

**Stale site found but intentionally left (out of scope):** `book/src/compatibility.md:38-40` mirrors the fixed `docs/compatibility.md` and is still stale, but the task scoped book edits to `troubleshooting.md` + `contracts.md` only (no general book resync). Flagging it for the separate book-resync package.

## The honest residual (required, and why it belongs in security.md)

`security.md` is the file `CLAUDE.md` sends contributors to before auth work, so it must not leave the impression that format evidence is unforgeable. Deriving IR-ness from queried formats raises the attacker's cost from "set a `CARD_LABEL` string" to "also negotiate a mono-**only** format", and removes the quirk-escalation path — but a `v4l2loopback` device (loading it requires root) or a programmable USB gadget **can** present a mono-only format set and will classify as IR. The remaining backstops against a fabricated IR device are the **liveness / frame-variance checks** and the **privilege required to create such a device**. The doc now states this plainly, and the previously overclaiming code comments are corrected to match.

## Anything in #110's drafted wording the code did NOT support

Nothing. Every technical claim in #110's body was verified against `crates/facelock-camera/src/{device,quirks,caps}.rs` and holds: `IrSource` is `Quirk | Format | None` (no `Name`); mono set is GREY/Y8/Y10/Y12/Y16; `derive_ir_from_evidence` = `mono_only_formats`; a mono-set *mixed* with any color format is not IR (`has_mono_only_formats`); name-only `force_ir` requires `usb_ids.is_some() || derive_ir_from_evidence(...)`; `name_matches` is anchored and supports only `(?i)`/`.*`; the auto-detect name tiebreak (`has_ir_name_token`) fires only among nodes that already qualify by evidence. The shipped quirk patterns in `config/quirks.d/00-defaults.toml` match #110's table. I did not copy any prose the code doesn't support.

## Gates

`just check` (test + lint + fmt-check + audit) — **exit 0**.
- `cargo test --workspace` — all crates pass (facelock-camera 68 passed / 4 ignored, including every IR-classification test; workspace green).
- `cargo clippy --workspace -- -D warnings` — clean (compiled files with the comment edits build clean).
- `cargo fmt --all -- --check` — clean (no output).
- `cargo audit` — only the 2 pre-existing allowed yanked-crate warnings (`core2`, `uds_windows`).

Container tiers (`just test-arch-*`) **skipped** — another agent may hold the podman image; these are doc/comment-only changes with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
