### PR TITLE
refactor(cli): add a library target so the domain layer is testable and shareable (D6)

### DIFF
--- a/crates/facelock-cli/Cargo.toml
+++ b/crates/facelock-cli/Cargo.toml
@@ -5,6 +5,15 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+# The domain layer (backend selection, health/status renderer, message seam,
+# resolved-config, logging default, state layout, transport client) lives in
+# this library so it can be integration-tested from `tests/` and shared, rather
+# than being sealed inside a bin-only crate (gap D6). `src/main.rs` is the thin
+# `facelock` binary: clap wiring plus dispatch into this library.
+[lib]
+name = "facelock_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "facelock"
 path = "src/main.rs"

--- a/crates/facelock-cli/src/lib.rs
+++ b/crates/facelock-cli/src/lib.rs
@@ -1,0 +1,24 @@
+//! The `facelock` CLI as a library.
+//!
+//! Everything the `facelock` binary does apart from clap wiring and top-level
+//! dispatch lives here so it can be integration-tested from `tests/` and shared
+//! (gap D6). The binary (`src/main.rs`) is a thin `main` that parses the
+//! command line and calls into these modules.
+//!
+//! The public surface is the domain layer, not an API contract: these modules
+//! are `pub` so an out-of-process test — or a sibling crate — can construct a
+//! [`health::Health`] and render it, drive [`backend::Backend`] selection, or
+//! exercise the [`message`] seam without spawning the binary and scraping
+//! stdout. The clap `Cli`/`Commands` types and the `main` dispatch stay
+//! bin-private in `main.rs`; nothing outside the binary needs them.
+
+pub mod backend;
+pub mod commands;
+pub mod direct;
+pub mod health;
+pub mod ipc_client;
+pub mod logging;
+pub mod message;
+pub mod notifications;
+pub mod resolved;
+pub mod state_layout;

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1,24 +1,19 @@
-pub mod backend;
-mod commands;
-pub mod direct;
-pub mod health;
-mod ipc_client;
-mod logging;
-pub mod message;
-pub mod notifications;
-pub mod resolved;
-pub mod state_layout;
+//! The `facelock` binary: clap wiring plus top-level dispatch into the
+//! `facelock_cli` library. The domain layer (backend, health, message,
+//! resolved, logging, …) lives in `lib.rs` so it stays testable and shareable
+//! (gap D6); this file keeps only the `Cli`/`Commands` types and `main`.
 
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use commands::TpmCommand;
-use commands::bench::BenchCommand;
-use commands::hyprlock::HyprlockCommand;
-use commands::setup::{
+use facelock_cli::commands::TpmCommand;
+use facelock_cli::commands::bench::BenchCommand;
+use facelock_cli::commands::hyprlock::HyprlockCommand;
+use facelock_cli::commands::setup::{
     EncryptionChoice, ExecutionProviderChoice, ModelPreset, SetupArgs, resolve_setup_plan,
 };
+use facelock_cli::{commands, logging, message, notifications, resolved};
 
 #[derive(Parser)]
 #[command(name = "facelock", about = "Linux face authentication", version)]

--- a/crates/facelock-cli/tests/health_render.rs
+++ b/crates/facelock-cli/tests/health_render.rs
@@ -1,0 +1,88 @@
+//! Out-of-process test for the CLI domain layer (gap D6, cross-cutting C1).
+//!
+//! This file compiles against the `facelock_cli` *library* target. Before that
+//! target existed, `facelock-cli` was bin-only, so the only way to reach the
+//! `status` renderer from outside was to spawn the `facelock` binary and scrape
+//! stdout — which cannot produce a `Health` whose facts are *unknown*: that
+//! state only arises from a broken/absent config or an unreadable store on the
+//! live system, exactly what a black-box test cannot stage. Here the renderer
+//! is a plain function over a synthetic `Health`, so the N4 rule it exists to
+//! enforce — "unknown is not false" — is pinned as a property of the public API
+//! with no root, filesystem, camera, or bus.
+
+use facelock_cli::backend::DaemonPing;
+use facelock_cli::commands::status;
+use facelock_cli::health::{ConfigHealth, ConfigOutcome, Health, PamWiring};
+use facelock_cli::resolved::Fact;
+
+/// A `Health` whose every probe-backed fact is `Unknown` — the shape
+/// `Health::probe` returns when the config does not parse, reconstructed here
+/// without touching the system.
+fn health_all_unknown() -> Health {
+    let why = "config not available";
+    Health {
+        config: ConfigHealth {
+            path: "/etc/facelock/config.toml".to_string(),
+            outcome: ConfigOutcome::NotFound,
+        },
+        daemon: Fact::unknown(why),
+        oneshot_fallback: Fact::unknown(why),
+        camera: Fact::unknown(why),
+        models: Fact::unknown(why),
+        execution_provider: Fact::unknown(why),
+        encryption: Fact::unknown(why),
+        user: "alice".to_string(),
+        enrolled: Fact::unknown(why),
+        security: Fact::unknown(why),
+        notifications: Fact::unknown(why),
+        pam: PamWiring {
+            module_path: "/lib/security/pam_facelock.so".to_string(),
+            installed_at: None,
+            sudo_configured: None,
+        },
+    }
+}
+
+#[test]
+fn unknown_daemon_fact_renders_as_undetermined_never_as_a_verdict() {
+    let report = status::render(&health_all_unknown());
+
+    // The reason an undetermined fact could not be established is surfaced
+    // verbatim...
+    assert!(
+        report.contains("cannot determine: config not available"),
+        "unknown facts must render their reason, got:\n{report}"
+    );
+    // ...and an undetermined daemon must never be rendered as either known
+    // verdict ("responding" / "not responding"). N4: unknown is not false.
+    assert!(
+        !report.contains("responding"),
+        "an Unknown daemon fact must not collapse to a responding/not-responding \
+         verdict, got:\n{report}"
+    );
+}
+
+#[test]
+fn unknown_and_known_failure_render_differently() {
+    // Same renderer, same section: flipping the daemon fact from Unknown to a
+    // probed failure must change the rendered verdict. A bin-only crate could
+    // assert this only against a live daemon; here it is a pure comparison over
+    // two synthetic inputs.
+    let unknown = status::render(&health_all_unknown());
+
+    let mut degraded = health_all_unknown();
+    degraded.daemon = Fact::probed(DaemonPing::NotResponding {
+        error: "connection refused".to_string(),
+    });
+    let degraded = status::render(&degraded);
+
+    assert!(!unknown.contains("connection refused"));
+    assert!(
+        degraded.contains("not responding: connection refused"),
+        "a probed failure must render its transport error, got:\n{degraded}"
+    );
+    assert_ne!(
+        unknown, degraded,
+        "unknown and known-false must not render identically (N4)"
+    );
+}


### PR DESCRIPTION
## What & why

`facelock-cli` shipped ~2,600 lines of new domain machinery
(`backend`/`health`/`message`/`resolved`/`logging`/`state_layout` plus
`commands/`) into a crate with **no `[lib]` target**. Consequences in the
integrated tree:

- none of that layer could be integration-tested — only `#[cfg(test)]`-tested
  from inside;
- it could not be shared, which already forced **#114** to duplicate a logging
  constant into `facelock-bench`;
- **#119**'s stated intent that "the message seam moves with the daemon server"
  could not happen once **#121** moved the server into `facelock-daemon`.

So gap **D6** was only half-closed: #121 made the D-Bus authz layer
integration-testable (`facelock-daemon/tests/server_authz.rs`), but the
CLI-side seam layer stayed unreachable. This PR gives `facelock-cli` a library
target so the domain layer is testable and shareable — **a target + visibility
change, not a redesign**.

## The module split

A `facelock-cli` package now builds two crates from the same `src/`:

- **`[lib] name = "facelock_cli"` (`src/lib.rs`)** owns the whole module tree.
  It declares the domain modules `pub`.
- **`[[bin]] name = "facelock"` (`src/main.rs`)** is the thin binary: the clap
  `Cli`/`Commands` types and the top-level `main` dispatch, which now
  `use facelock_cli::{commands, logging, message, notifications, resolved}`
  instead of declaring the modules itself.

Rationale for the boundary: **clap wiring and dispatch are the only genuinely
bin-private things** — nothing outside the binary constructs a `Cli` or drives
the `match command` tree. Everything else is domain logic whose entire value is
being reachable from a test or a sibling crate, so it lives in the lib.

Crucially, **dispatch stayed in `main`.** I did not extract a `lib::run()`.
That keeps this a pure target+visibility change: no code moved between modules,
and the `logging::default_env_filter()` call site that the source-scan pin
tests key on (`main.rs`, `commands/auth.rs`, `commands/daemon.rs`) is exactly
where it was — so the three walkers in `resolved.rs`/`backend.rs`/`logging.rs`
needed **no edits** and still pass unchanged.

### What became public and why

`pub mod backend, commands, direct, health, ipc_client, logging, message,
notifications, resolved, state_layout`.

Of these, only three widened visibility (the rest were already `pub mod` in the
bin, where `pub` was inert): `commands`, `ipc_client`, and `logging` moved from
crate-private to `pub`. `commands` must be reachable because `main` dispatches
into it; `ipc_client`/`logging` are made `pub` so no `pub` item in an already-
public module leaks a less-visible type (`private_interfaces`) under
`clippy -D warnings`. The surface is the domain layer, not a committed API — it
exists so tests and sibling crates can reach in.

## The new integration test (proof)

`crates/facelock-cli/tests/health_render.rs` compiles against the **library**
and calls the public `commands::status::render` on a **synthetic `Health`** —
no spawned binary, no root, no bus, no camera. This test could not exist
before: a `Health` whose facts are `Unknown` only arises from a broken/absent
config or an unreadable store on the live system, which a stdout-scraping
black-box test cannot stage. It pins the **N4** rule the Health domain exists
to enforce — *unknown is not false*:

- an undetermined daemon fact renders as `cannot determine: …`, never as the
  known-false `not responding` verdict;
- flipping the same fact to a probed failure changes the rendered output, so
  the renderer provably never collapses unknown into false.

## `DEFAULT_LOG_FILTER` disposition — left as-is (deliberately)

The two constants **are not the same value**, so there is nothing to
deduplicate:

- `facelock-cli` → `"facelock=info,facelock_daemon=info"` (its bin target is
  `facelock`);
- `facelock-bench` → `"facelock_bench=info"` (its bin target is
  `facelock_bench`).

Each filter names its **own** binary's tracing target — that is the entire
point of gap **E9** (a filter naming the wrong target silently drops every
diagnostic). Making `facelock-bench` depend on `facelock-cli` to share the
constant would give it the *wrong* value and reintroduce E9, besides putting a
heavy dependency on a lean crate. Moving the constant to `facelock-core` is
also wrong: the only shareable element is the ~3-line `default_env_filter()`
helper, whose natural home would drag `tracing-subscriber` into `facelock-core`
— which the dependency table forbids and which E8 explicitly wants *out* of the
library crates. The library now does expose `logging::DEFAULT_LOG_FILTER` /
`logging::default_env_filter` for any crate that legitimately wants the CLI's
exact filter; `facelock-bench` specifically must not, because it needs its own
target name. Left as-is.

## Pin-test walker unification — left as-is (with reason)

The three source-scan walkers are near-twins in `resolved.rs`/`backend.rs`
(`source_files()` returning `Vec<(PathBuf, String)>`, comment-stripping match
counters) but `logging.rs`'s is a **different shape**: a callback-style
`visit_rs_files(&mut dyn FnMut)` that intentionally does **not** strip comments
(it scans raw `contents` for `EnvFilter::try_from_default_env(`). Folding all
three into one `#[cfg(test)]` helper would either change `logging.rs`'s
detection semantics or force the helper to carry two shapes — neither is the
"trivial" unification the task scoped, and both touch pins that gate the
container layout tier. Not worth the risk in this PR; noted for a follow-up.

## What surprised me in the bin→lib conversion

- **Nothing had to move.** Every `crate::` reference inside the modules pointed
  at another domain module (`crate::ipc_client`, `crate::resolved`, …), so once
  all modules moved to the lib together, every path still resolved — no `crate::`
  rewrites, no orphaned references to `main`-level items (there were none:
  `Cli`/`Commands` are used only by dispatch).
- **The pin walkers key on `CARGO_MANIFEST_DIR/src`**, which still contains
  `main.rs` + all modules + the new `lib.rs`, so they kept working; the new
  `tests/` file is outside `src/` and is not scanned.
- **No doc-tests appeared.** The only fenced blocks in doc comments are
  ` ```text ` (state-layout / marker diagrams), which Rust does not compile, so
  making the modules public added zero doc-tests to compile or mark.
- **No `private_interfaces` leaks** surfaced once `commands`/`ipc_client`/
  `logging` were made `pub`; `clippy --workspace -- -D warnings` is clean.

## Verification

- `just check` — green (clippy `-D warnings` clean; fmt clean; audit: only the
  two pre-existing `core2`/`uds_windows` yanked-crate *allowed* warnings).
- `just test-arch-pam` — **22/22**.
- `just test-arch-layout` — **21/21** (is-enrolled isolation + dispatch-before-
  config-parse preserved).

## Scope I deliberately did **not** touch

- No `lib::run()` extraction (dispatch stays in `main` — keeps this
  target+visibility only, and keeps the pins stable).
- No `DEFAULT_LOG_FILTER` dedup and no walker unification (reasons above).
- `pam-facelock` untouched; no D-Bus wire change; no auth-semantics change.

**Review finding:** cross-cutting **C1** — the remediation placed the CLI
domain layer in a bin-only crate, half-closing **D6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
