### PR TITLE
fix(security): always rate-limit Authenticate; give `facelock test` an explicit root-only method

### DIFF
--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -244,18 +244,19 @@ impl<'a> Backend<'a> {
     }
 
     /// Recognition only — backs `facelock test` (root-only, N11). NEVER the
-    /// PAM/auth path.
+    /// PAM/auth path: the daemon transport calls the root-only
+    /// `TestAuthenticate` method, not `Authenticate`.
     ///
-    /// Both transports run the same `pre_check` gates. The surviving posture
-    /// difference: the direct path skips the SSH/lid physical-presence aborts
+    /// The two transports now have the same posture: both run every
+    /// `pre_check` gate except the SSH/lid physical-presence aborts
     /// (`PreCheckContext::test` — they exist to stop an attacker's shortcuts,
-    /// not a root operator testing over SSH) and audits as `Test`, while the
-    /// daemon path enforces them and audits as `Daemon`. Neither path charges
-    /// the rate limit for a failed test: direct never records failures, and
-    /// the daemon exempts root callers.
+    /// not a root operator diagnosing over SSH), both audit as `Test`, and
+    /// neither charges the rate limit for a failed test — the direct path
+    /// because it never records failures, the daemon path because
+    /// `TestAuthenticate` is the entry point that does not.
     pub fn recognize(&self, user: &str) -> anyhow::Result<MatchResult> {
         match self.kind {
-            BackendKind::Daemon => match ipc_client::authenticate(user)? {
+            BackendKind::Daemon => match ipc_client::test_authenticate(user)? {
                 AuthOutcome::AuthResult(result) => Ok(result),
                 // `suppress_unknown` short-circuit: same "no result"
                 // shape the direct path reports.
@@ -698,7 +699,7 @@ mod tests {
             "commands/preview/wayland_preview.rs", // daemon frame loop
         ];
         let pins: &[(&str, &[&str])] = &[
-            ("authenticate", backend_only),
+            ("test_authenticate", backend_only),
             ("list_models", backend_only),
             ("remove_model", backend_only),
             ("clear_models", backend_only),
@@ -729,6 +730,28 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// The CLI must never call the daemon's `Authenticate` method. That
+    /// method is real authentication: it always charges the shared
+    /// rate-limit budget, and its only legitimate callers are the
+    /// authenticators (PAM, the polkit agent). `facelock test` is a
+    /// diagnostic and goes to the root-only `TestAuthenticate` instead —
+    /// keeping the two apart on the wire is what lets the daemon stop
+    /// guessing an attempt's purpose from the caller's UID, which is how a
+    /// failed face auth at a `sudo` prompt used to escape the limiter.
+    #[test]
+    fn the_cli_never_calls_the_real_authenticate_method() {
+        // Assembled at runtime so this test's own literal doesn't count.
+        let needle = format!("ipc_client::{}(", "authenticate");
+        for (path, content) in source_files() {
+            assert!(
+                !code_contains(&content, &needle),
+                "{}: `{needle}` is the always-charging real-auth method — \
+                 `facelock test` must call ipc_client::test_authenticate",
+                path.display()
+            );
         }
     }
 

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -12,9 +12,12 @@ use crate::notifications::DesktopNotifier;
 pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // N11 (issue #96): `facelock test` is root-only regardless of transport
     // (direct or daemon-mediated) — keeps similarity scores and full detail,
-    // and lets both the daemon and direct paths safely exempt failed test
-    // runs from rate-limit consumption (root already has unrestricted access
-    // to the rate-limit table). Must run before any prompt or output (C6).
+    // and is what makes it safe for both paths to exempt failed test runs
+    // from rate-limit consumption (root already has unrestricted access to
+    // the rate-limit table). On the daemon transport that exemption is the
+    // root-only `TestAuthenticate` method, asked for explicitly, rather than
+    // something the daemon infers from this process being root. Must run
+    // before any prompt or output (C6).
     ipc_client::require_root("sudo facelock test")?;
 
     // Check models exist — offer to run setup if missing

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -211,43 +211,58 @@ fn hinted<T>(result: anyhow::Result<T>) -> anyhow::Result<T> {
     result.map_err(add_access_denied_hint)
 }
 
-/// Call `Authenticate` and decode the in-band sentinels (see
-/// docs/contracts.md "Authenticate error encoding"): `model_id == -2` is a
-/// recoverable daemon error travelling as data (label carries the message,
-/// byte-identical — PAM string-matches "rate limited"), `-3` is the
-/// `suppress_unknown` short-circuit.
-pub fn authenticate(user: &str) -> anyhow::Result<AuthOutcome> {
+/// Call the daemon's root-only `TestAuthenticate` and decode the reply.
+///
+/// This is deliberately the CLI's *only* authentication transport. The
+/// always-charging `Authenticate` method belongs to the real authenticators
+/// — PAM, the polkit agent — and has no CLI caller: `facelock test` is a
+/// diagnostic, and routing it through `Authenticate` is what once let a
+/// failed face auth at a `sudo` prompt (setuid-root, UID 0 at the daemon)
+/// escape the rate limiter, because the daemon had to guess from the
+/// caller's privilege which of the two it was serving.
+pub fn test_authenticate(user: &str) -> anyhow::Result<AuthOutcome> {
     hinted((|| {
         let proxy = create_proxy()?;
         let result: AuthResult = proxy
-            .call("Authenticate", &(user,))
-            .context("D-Bus Authenticate call failed")?;
-        if !result.matched && result.model_id == -2 {
-            return Ok(AuthOutcome::Error {
-                message: result.label,
-            });
-        }
-        if !result.matched && result.model_id == -3 {
-            return Ok(AuthOutcome::Suppressed);
-        }
-        Ok(AuthOutcome::AuthResult(MatchResult {
-            matched: result.matched,
-            model_id: if result.model_id >= 0 {
-                Some(result.model_id as u32)
-            } else {
-                None
-            },
-            label: if result.label.is_empty() {
-                None
-            } else {
-                Some(result.label)
-            },
-            similarity: result.similarity as f32,
-            // Not part of the D-Bus AuthResult contract; derived client-side
-            // where needed (see test_cmd).
-            failure_reason: None,
-        }))
+            .call("TestAuthenticate", &(user,))
+            .context("D-Bus TestAuthenticate call failed")?;
+        Ok(decode_auth_result(result))
     })())
+}
+
+/// Decode the in-band sentinels of an `AuthResult` (see docs/contracts.md
+/// "Authenticate error encoding"): `model_id == -2` is a recoverable daemon
+/// error travelling as data (label carries the message, byte-identical —
+/// PAM string-matches "rate limited"), `-3` is the `suppress_unknown`
+/// short-circuit. Split from the transport so the sentinel decoding is
+/// testable without a bus, and so any future method replying with an
+/// `AuthResult` decodes it identically.
+fn decode_auth_result(result: AuthResult) -> AuthOutcome {
+    if !result.matched && result.model_id == -2 {
+        return AuthOutcome::Error {
+            message: result.label,
+        };
+    }
+    if !result.matched && result.model_id == -3 {
+        return AuthOutcome::Suppressed;
+    }
+    AuthOutcome::AuthResult(MatchResult {
+        matched: result.matched,
+        model_id: if result.model_id >= 0 {
+            Some(result.model_id as u32)
+        } else {
+            None
+        },
+        label: if result.label.is_empty() {
+            None
+        } else {
+            Some(result.label)
+        },
+        similarity: result.similarity as f32,
+        // Not part of the D-Bus AuthResult contract; derived client-side
+        // where needed (see test_cmd).
+        failure_reason: None,
+    })
 }
 
 pub fn list_models(user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
@@ -462,6 +477,58 @@ mod tests {
         if !Uid::current().is_root() {
             let err = require_root_scripted("sudo facelock audit").unwrap_err();
             assert!(format!("{err:#}").contains("Root required"));
+        }
+    }
+
+    fn reply(matched: bool, model_id: i32, label: &str) -> AuthResult {
+        AuthResult {
+            matched,
+            model_id,
+            label: label.to_string(),
+            similarity: 0.9,
+        }
+    }
+
+    /// The `-2` sentinel is a recoverable daemon decision carried as data,
+    /// and the message must survive byte-identical: PAM substring-matches
+    /// "rate limited" and "IR camera required" on the same encoding.
+    #[test]
+    fn recoverable_error_sentinel_decodes_with_the_message_intact() {
+        match decode_auth_result(reply(false, -2, "rate limited")) {
+            AuthOutcome::Error { message } => assert_eq!(message, "rate limited"),
+            other => panic!("expected a recoverable error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn suppressed_sentinel_decodes_to_suppressed() {
+        assert!(matches!(
+            decode_auth_result(reply(false, -3, "")),
+            AuthOutcome::Suppressed
+        ));
+    }
+
+    #[test]
+    fn no_match_decodes_without_a_model() {
+        match decode_auth_result(reply(false, -1, "")) {
+            AuthOutcome::AuthResult(result) => {
+                assert!(!result.matched);
+                assert_eq!(result.model_id, None);
+                assert_eq!(result.label, None);
+            }
+            other => panic!("expected an ordinary non-match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn match_decodes_with_its_model_and_label() {
+        match decode_auth_result(reply(true, 4, "front")) {
+            AuthOutcome::AuthResult(result) => {
+                assert!(result.matched);
+                assert_eq!(result.model_id, Some(4));
+                assert_eq!(result.label.as_deref(), Some("front"));
+            }
+            other => panic!("expected a match, got {other:?}"),
         }
     }
 

--- a/crates/facelock-core/tests/dbus_types_test.rs
+++ b/crates/facelock-core/tests/dbus_types_test.rs
@@ -11,7 +11,7 @@
 //! retyped on any of these structs, this file must be touched deliberately.
 
 use facelock_core::dbus_interface::*;
-use zvariant::DynamicType;
+use zvariant::{DynamicType, Type};
 
 #[test]
 fn auth_result_signature_is_pinned() {
@@ -23,6 +23,34 @@ fn auth_result_signature_is_pinned() {
     };
     // bool, i32, String, f64 -> b, i, s, d
     assert_eq!(val.signature().to_string(), "(bisd)");
+}
+
+/// `AuthResult` is the reply of **two** methods now: `Authenticate` (real
+/// authentication, always charges the rate limit) and the root-only
+/// `TestAuthenticate` (the diagnostic entry point behind `facelock test`,
+/// which charges nothing). They deliberately share one wire shape — a single
+/// `s` username in, one `AuthResult` out, with the same `-1`/`-2`/`-3`
+/// sentinels — so the in-band encoding cannot drift between them, and so the
+/// upgrade-window concern above applies once rather than twice.
+///
+/// The method *names* cannot be pinned from this crate: zbus derives them
+/// from the `#[interface]` function names in facelock-daemon, which pins the
+/// wire method set against its authorization matrix in
+/// `server::tests::interface_methods_and_the_authz_matrix_are_the_same_set`.
+/// What is pinned here is the shape a client must be able to encode and
+/// decode for either method.
+#[test]
+fn both_authentication_methods_share_the_pinned_wire_shape() {
+    // The argument list: one username, for both methods.
+    assert_eq!(<(String,) as Type>::SIGNATURE.to_string(), "(s)");
+
+    let reply = AuthResult {
+        matched: false,
+        model_id: -2,
+        label: "rate limited".into(),
+        similarity: 0.0,
+    };
+    assert_eq!(reply.signature().to_string(), "(bisd)");
 }
 
 #[test]

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -9,9 +9,65 @@ use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
 
 use crate::audit::AuditSource;
-use crate::auth::{self, AuthOutcome};
+use crate::auth::{self, AuthOutcome, PreCheckContext};
 use crate::enroll::{self, EnrollOutcome};
 use crate::rate_limit::RateLimiter;
+
+/// Why an authentication is being run.
+///
+/// This is the *declared purpose of the call*, never an inference from the
+/// caller's privilege. The daemon used to infer it — a root D-Bus caller was
+/// assumed to be root-only `facelock test` and had its failed attempts
+/// exempted from the rate limit — but "caller is root" is not a proxy for
+/// "this is a test run": `sudo` is setuid-root, and `login`, `su` and
+/// root-run display-manager greeters run their PAM stack as root too. Real
+/// failed authentications therefore reached the daemon as UID 0 and were
+/// never charged, leaving the documented 5-attempts/user/60s limit inert on
+/// the project's primary documented PAM target. The intent now travels with
+/// the request: the `Authenticate` D-Bus method is always
+/// [`AuthIntent::Authenticate`], and the root-only `TestAuthenticate` method
+/// is the only producer of [`AuthIntent::Test`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthIntent {
+    /// A real authentication — every PAM stack (sudo, login, screen
+    /// lockers), the polkit agent, `facelock auth`. Fully enforced, and a
+    /// failed attempt charges the shared rate-limit budget.
+    Authenticate,
+    /// A diagnostic run of root-only `facelock test` (N11, issue #96).
+    /// Skips only the SSH/lid physical-presence gates, and never charges the
+    /// budget — a handful of test runs must not lock the user out of real
+    /// authentication.
+    Test,
+}
+
+impl AuthIntent {
+    /// Does a failed attempt consume the shared (SQLite-backed) rate-limit
+    /// budget? Only real authentication does.
+    pub fn charges_rate_limit(self) -> bool {
+        matches!(self, AuthIntent::Authenticate)
+    }
+
+    /// Which of `pre_check`'s environment gates this intent may skip. Every
+    /// other gate — `disabled`, enrollment/`suppress_unknown`, the
+    /// rate-limit *check*, `require_ir` — applies to both intents.
+    pub fn pre_check_context(self) -> PreCheckContext {
+        match self {
+            AuthIntent::Authenticate => PreCheckContext::enforced(),
+            AuthIntent::Test => PreCheckContext::test(),
+        }
+    }
+
+    /// The audit `source` stamped on the entries this intent produces. The
+    /// field records the enforcement path, so a diagnostic run that skipped
+    /// the SSH/lid gates and charged nothing must not be logged as an
+    /// ordinary daemon authentication.
+    pub fn audit_source(self) -> AuditSource {
+        match self {
+            AuthIntent::Authenticate => AuditSource::Daemon,
+            AuthIntent::Test => AuditSource::Test,
+        }
+    }
+}
 
 /// The handler's input vocabulary — one variant per operation the daemon can
 /// perform. Internal to this crate (D5): the D-Bus server (`crate::server`)
@@ -362,7 +418,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 DaemonResponse::Ok
             }
 
-            DaemonRequest::Authenticate { user } => self.handle_authenticate(user, true),
+            DaemonRequest::Authenticate { user } => {
+                self.handle_authenticate(user, AuthIntent::Authenticate)
+            }
 
             DaemonRequest::Enroll { user, label } => {
                 // Refuse to enroll a plaintext template unless explicitly opted in.
@@ -524,35 +582,28 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         }
     }
 
-    /// Run an `Authenticate` request.
+    /// Run an authentication, enforced and audited according to `intent`.
     ///
-    /// `charge_failed_attempt` controls whether a non-matching result
-    /// consumes the shared (SQLite-backed) rate-limit budget for `user`.
-    /// `handle()` always passes `true`, preserving real-authentication
-    /// behavior exactly.
+    /// [`AuthIntent::Authenticate`] — every real authentication, whatever the
+    /// caller's privilege — runs every gate and charges the shared
+    /// (SQLite-backed) rate-limit budget on a failed attempt.
+    /// [`AuthIntent::Test`] is reached only from the root-only
+    /// `TestAuthenticate` D-Bus method: it skips the SSH/lid gates and
+    /// charges nothing.
     ///
-    /// The D-Bus layer (`commands/daemon.rs`) passes `false` when the caller
-    /// is root (N11, issue #96): `facelock test` is root-only and reaches
-    /// the daemon through this same `Authenticate` method, and a failed test
-    /// run must not lock the user out of real authentication. This costs
-    /// nothing security-wise — root already has unrestricted access to the
-    /// rate-limit table directly. `pre_check_audited`'s rate-limit *check*
-    /// (whether `user` is already over budget) is unaffected either way: an
-    /// already-limited user still sees "rate limited" here regardless of
-    /// `charge_failed_attempt`, because that decision is made before this
+    /// The rate-limit *check* (whether `user` is already over budget) is
+    /// unaffected by the intent: an already-limited user still sees "rate
+    /// limited" from `test`, because that decision is made before this
     /// function knows whether the attempt itself will fail.
-    pub fn handle_authenticate(
-        &mut self,
-        user: String,
-        charge_failed_attempt: bool,
-    ) -> DaemonResponse {
-        if let Some(resp) = auth::pre_check_audited(
+    pub fn handle_authenticate(&mut self, user: String, intent: AuthIntent) -> DaemonResponse {
+        if let Some(resp) = auth::pre_check_audited_with_context(
             &self.config,
             &self.store,
             &user,
             &self.rate_limiter,
             &self.device_caps,
-            AuditSource::Daemon,
+            intent.audit_source(),
+            intent.pre_check_context(),
         ) {
             return resp.into();
         }
@@ -591,17 +642,17 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &models,
             &self.config,
             &user,
-            AuditSource::Daemon,
+            intent.audit_source(),
         );
         // `authenticate_with_embeddings` works on an internal copy;
         // wipe the caller-side plaintext set too (#100).
         zeroize_stored_embeddings(&mut stored);
         self.camera = Some(camera);
         self.camera_last_used = Instant::now();
-        // Only failed auths count against the rate limit, and only when the
-        // caller hasn't been exempted (see doc comment above).
+        // Only failed auths count against the rate limit, and only for the
+        // real-authentication intent (see [`AuthIntent`]).
         if let AuthOutcome::AuthResult(ref mr) = result {
-            if !mr.matched && charge_failed_attempt {
+            if !mr.matched && intent.charges_rate_limit() {
                 if let Err(e) = self.rate_limiter.record_failure(&self.store, &user) {
                     warn!(user, error = %e, "failed to record auth failure");
                 }
@@ -654,5 +705,42 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one table that decides what an authentication costs and how it is
+    /// enforced. Real authentication charges the rate limit; the diagnostic
+    /// intent does not. Nothing here consults the caller's UID — that
+    /// inference is exactly what let a failed face auth at a `sudo` prompt
+    /// (setuid-root, so UID 0 at the daemon) escape the limiter.
+    #[test]
+    fn only_real_authentication_charges_the_rate_limit() {
+        assert!(AuthIntent::Authenticate.charges_rate_limit());
+        assert!(!AuthIntent::Test.charges_rate_limit());
+    }
+
+    /// The SSH/lid physical-presence gates are skippable for the diagnostic
+    /// intent only (N11); every other gate applies to both.
+    #[test]
+    fn only_the_test_intent_skips_the_ssh_and_lid_gates() {
+        let real = AuthIntent::Authenticate.pre_check_context();
+        assert!(!real.skip_ssh_gate);
+        assert!(!real.skip_lid_gate);
+
+        let test = AuthIntent::Test.pre_check_context();
+        assert!(test.skip_ssh_gate);
+        assert!(test.skip_lid_gate);
+    }
+
+    /// The audit `source` names the enforcement path that ran, so the two
+    /// intents must never share a stamp.
+    #[test]
+    fn each_intent_stamps_its_own_audit_source() {
+        assert_eq!(AuthIntent::Authenticate.audit_source(), AuditSource::Daemon);
+        assert_eq!(AuthIntent::Test.audit_source(), AuditSource::Test);
     }
 }

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -25,7 +25,7 @@ use nix::unistd::{Uid, User};
 use tracing::{error, info, warn};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
-use crate::handler::{DaemonRequest, DaemonResponse, Handler};
+use crate::handler::{AuthIntent, DaemonRequest, DaemonResponse, Handler};
 
 /// Production type alias for the handler with real Camera and FaceEngine.
 pub type ProductionHandler = Handler<Camera<'static>, FaceEngine>;
@@ -464,6 +464,7 @@ async fn resolve_caller_identity(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Method {
     Authenticate,
+    TestAuthenticate,
     Enroll,
     ListModels,
     RemoveModel,
@@ -478,8 +479,9 @@ enum Method {
 
 impl Method {
     #[cfg(test)]
-    const ALL: [Method; 11] = [
+    const ALL: [Method; 12] = [
         Method::Authenticate,
+        Method::TestAuthenticate,
         Method::Enroll,
         Method::ListModels,
         Method::RemoveModel,
@@ -495,6 +497,7 @@ impl Method {
     fn name(self) -> &'static str {
         match self {
             Method::Authenticate => "Authenticate",
+            Method::TestAuthenticate => "TestAuthenticate",
             Method::Enroll => "Enroll",
             Method::ListModels => "ListModels",
             Method::RemoveModel => "RemoveModel",
@@ -518,9 +521,15 @@ impl Method {
     /// an unprivileged caller: together with score redaction this closes the
     /// similarity hill-climbing oracle by construction. The catch-all arm
     /// makes any future method root-only until it is deliberately opened up.
+    ///
+    /// `TestAuthenticate` is listed explicitly rather than left to the
+    /// catch-all: it is the entry point that does *not* charge the rate
+    /// limit, so its root-only scope is the whole reason it is safe to
+    /// offer, not an incidental default.
     fn scope(self) -> Scope {
         match self {
             Method::Authenticate => Scope::UserScoped,
+            Method::TestAuthenticate => Scope::Root,
             _ => Scope::Root,
         }
     }
@@ -768,28 +777,71 @@ where
     // it from the message header in the `#[interface]` glue below.
     // ------------------------------------------------------------------
 
+    /// The real-authentication entry point: every PAM stack, every locker,
+    /// the polkit agent. A failed attempt ALWAYS charges the rate-limit
+    /// budget, whatever the caller's UID.
+    ///
+    /// It used to charge only non-root callers, on the theory that a root
+    /// caller must be root-only `facelock test` (N11). That inference was
+    /// wrong in the direction that matters: `sudo` is setuid-root, and
+    /// `login`, `su` and root-run greeters run their PAM stack as root too,
+    /// so real failed authentications arrived here as UID 0 and were never
+    /// charged. The diagnostic carve-out now lives in
+    /// [`FacelockService::test_authenticate_as`], where it is asked for
+    /// explicitly instead of inferred.
     pub async fn authenticate_as(
         &self,
         caller: CallerIdentity,
         user: &str,
     ) -> fdo::Result<AuthResult> {
+        self.run_authentication(caller, user, Method::Authenticate, AuthIntent::Authenticate)
+            .await
+    }
+
+    /// The root-only diagnostic entry point behind `facelock test` (N11,
+    /// issue #96). Same authentication, same reply shape, two deliberate
+    /// differences: a failed attempt charges no rate-limit budget, and the
+    /// SSH/lid physical-presence gates are skipped — an admin who is already
+    /// root may legitimately diagnose recognition over SSH or with the lid
+    /// closed on a docked laptop. Everything else (`disabled`, enrollment,
+    /// the rate-limit *check*, `require_ir`) still applies.
+    ///
+    /// Root-only is what makes that safe, and it is enforced by the same
+    /// table-driven [`authorize_method`] as every other privileged method.
+    pub async fn test_authenticate_as(
+        &self,
+        caller: CallerIdentity,
+        user: &str,
+    ) -> fdo::Result<AuthResult> {
+        self.run_authentication(caller, user, Method::TestAuthenticate, AuthIntent::Test)
+            .await
+    }
+
+    /// The body both authentication entry points share, so the diagnostic
+    /// method cannot drift from the real one: same authorization table, same
+    /// capture slot, same handler call, same in-band error encoding, same
+    /// notification, same redaction. Only `method` (which authorization
+    /// applies) and `intent` (what the attempt costs and which gates run)
+    /// differ.
+    async fn run_authentication(
+        &self,
+        caller: CallerIdentity,
+        user: &str,
+        method: Method,
+        intent: AuthIntent,
+    ) -> fdo::Result<AuthResult> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
-        authorize_method(&caller, Method::Authenticate, Some(user))?;
+        authorize_method(&caller, method, Some(user))?;
         let caller_is_root = caller.uid == 0;
         self.clear_camera_owner();
-        let capture_guard = self.capture_slot.try_acquire("Authenticate")?;
+        let capture_guard = self.capture_slot.try_acquire(method.name())?;
         let handler = self.handler.clone();
         let notifier_factory = self.notifier_factory.clone();
         let user = user.to_string();
         let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
-            // N11: a root caller (e.g. root-only `facelock test`) is exempt
-            // from rate-limit consumption on a failed attempt — root already
-            // has unrestricted access to the rate-limit table directly, and
-            // without this a few `facelock test` runs would lock the user
-            // out of real authentication. See `Handler::handle_authenticate`.
-            let response = handler.handle_authenticate(user.clone(), !caller_is_root);
+            let response = handler.handle_authenticate(user.clone(), intent);
             // Notification settings come from the handler's config — the
             // freshest parse, since maybe_reload_handler ran at method entry.
             // No mid-request file re-read (D7).
@@ -1158,6 +1210,30 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         // fails). The payload deliberately carries no similarity score — the
         // raw biometric score is a spoof-tuning oracle for anyone able to
         // receive the broadcast; `matched` + user is enough for consumers.
+        if let Ok(ref auth_result) = result {
+            let _ = Self::auth_attempted(&ctxt, user, auth_result.matched).await;
+        }
+
+        result
+    }
+
+    /// The root-only diagnostic counterpart of `Authenticate`, behind
+    /// `facelock test`. Identical wire shape (`s` in, `AuthResult` out,
+    /// same `-1`/`-2`/`-3` sentinels) — see
+    /// [`FacelockService::test_authenticate_as`] for the two behavioral
+    /// differences.
+    async fn test_authenticate(
+        &self,
+        #[zbus(header)] hdr: zbus::message::Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+        #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
+        user: &str,
+    ) -> fdo::Result<AuthResult> {
+        let caller = resolve_caller_identity(&hdr, connection).await?;
+        let result = self.test_authenticate_as(caller, user).await;
+
+        // Emitted for the same reason and with the same payload as
+        // `Authenticate`'s: a camera-backed attempt happened for `user`.
         if let Ok(ref auth_result) = result {
             let _ = Self::auth_attempted(&ctxt, user, auth_result.matched).await;
         }
@@ -1689,6 +1765,73 @@ mod tests {
     // Authenticate is the only user-scoped method; everything else is
     // root-only. These tests iterate Method::ALL so a new method cannot be
     // added without landing in the matrix.
+
+    /// The wire method set and the authorization matrix must be the same
+    /// set. `Method` is what [`authorize_method`] keys on, and zbus derives
+    /// the wire name from the `#[interface]` function name — nothing in the
+    /// type system ties the two together, so a method added to the interface
+    /// without a `Method` variant would be a wire method the matrix tests
+    /// above never see. Scanning the source is how the repo pins structural
+    /// facts a type cannot (same idiom as the CLI's backend-seam pins); the
+    /// live introspection XML is unavailable here because `#[interface]` is
+    /// implemented only for the production `Camera`/`FaceEngine` handler.
+    #[test]
+    fn interface_methods_and_the_authz_matrix_are_the_same_set() {
+        // Assembled at runtime so this literal doesn't match itself.
+        let marker = format!("#[{}(name = \"org.facelock.Daemon\")]", "interface");
+        let after_marker = include_str!("server.rs")
+            .split_once(&marker)
+            .expect("the #[interface] block")
+            .1;
+        // The impl ends at the first `}` in column 0; every brace inside it
+        // is indented.
+        let block = after_marker
+            .split_once("\n}\n")
+            .expect("the #[interface] block's closing brace")
+            .0;
+
+        let mut on_wire: Vec<String> = Vec::new();
+        let mut previous = "";
+        for line in block.lines() {
+            let line = line.trim();
+            // Signals are declared in the same block but are not methods.
+            if let Some(rest) = line.strip_prefix("async fn ") {
+                if !previous.contains("(signal)") {
+                    on_wire.push(rest.split('(').next().unwrap().to_string());
+                }
+            }
+            if !line.is_empty() {
+                previous = line;
+            }
+        }
+
+        let mut in_matrix: Vec<String> = Method::ALL.iter().map(|m| snake_case(m.name())).collect();
+        on_wire.sort();
+        in_matrix.sort();
+        assert_eq!(
+            on_wire, in_matrix,
+            "every #[interface] method needs a Method variant (and vice versa) — \
+             the authorization matrix is keyed on that enum"
+        );
+    }
+
+    /// `Method::name` is the wire name: it is what the denial messages and
+    /// the capture-slot contention errors quote, and what the scan above
+    /// compares against the interface block.
+    fn snake_case(name: &str) -> String {
+        let mut out = String::with_capacity(name.len() + 3);
+        for (i, ch) in name.char_indices() {
+            if ch.is_ascii_uppercase() {
+                if i > 0 {
+                    out.push('_');
+                }
+                out.push(ch.to_ascii_lowercase());
+            } else {
+                out.push(ch);
+            }
+        }
+        out
+    }
 
     #[test]
     fn authz_matrix_root_is_allowed_everywhere() {

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -5,7 +5,7 @@ use facelock_core::config::Config;
 use facelock_core::types::MatchResult;
 use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::AuthOutcome;
-use facelock_daemon::handler::{DaemonRequest, DaemonResponse};
+use facelock_daemon::handler::{AuthIntent, DaemonRequest, DaemonResponse};
 use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
 use facelock_test_support::{MockCamera, MockFaceEngine};
@@ -751,14 +751,16 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
     cleanup_db(&db_path);
 }
 
-/// N11 (issue #96): `facelock test` runs through the daemon's `Authenticate`
-/// method exactly like real auth, but is root-only and must never consume
-/// the shared rate-limit budget on failure — the D-Bus layer calls
-/// `Handler::handle_authenticate(user, false)` for a root caller instead of
-/// `handle(DaemonRequest::Authenticate { .. })`. A handful of failed test
-/// runs must not lock the user out of real authentication afterward.
+/// N11 (issue #96): `facelock test` must never consume the shared
+/// rate-limit budget on failure — a handful of failed test runs must not
+/// lock the user out of real authentication afterward.
+///
+/// This pins the handler half of that: `AuthIntent::Test` charges nothing.
+/// The intent is no longer inferred from the caller's privilege (which was
+/// the bug — `sudo`'s PAM stack is root too); it arrives from the root-only
+/// `TestAuthenticate` D-Bus method, which `tests/server_authz.rs` covers.
 #[test]
-fn exempted_authenticate_does_not_consume_rate_limit_budget() {
+fn test_intent_does_not_consume_rate_limit_budget() {
     use facelock_daemon::handler::Handler;
     use facelock_daemon::rate_limit::RateLimiter;
 
@@ -797,17 +799,16 @@ fn exempted_authenticate_does_not_consume_rate_limit_budget() {
     )
     .unwrap();
 
-    // Run more failed attempts than max_attempts (1), all exempted from
-    // charging. None may report "rate limited" — the budget starts and stays
-    // at zero recorded failures.
+    // Run more failed attempts than max_attempts (1). None may report "rate
+    // limited" — the budget starts and stays at zero recorded failures.
     for i in 0..3 {
-        let resp = handler.handle_authenticate("testuser".into(), false);
+        let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Test);
         assert!(
             matches!(
                 resp,
                 DaemonResponse::AuthResult(MatchResult { matched: false, .. })
             ),
-            "exempted attempt {i} should run the auth loop normally, not report rate-limited: {resp:?}"
+            "test attempt {i} should run the auth loop normally, not report rate-limited: {resp:?}"
         );
     }
 
@@ -816,7 +817,7 @@ fn exempted_authenticate_does_not_consume_rate_limit_budget() {
     let inspect_store = FaceStore::create(&db_path).unwrap();
     assert!(
         inspect_store.check_rate_limit("testuser", 1, 60).unwrap(),
-        "rate_limit table must be untouched by exempted (root/test) failures"
+        "rate_limit table must be untouched by diagnostic (test) failures"
     );
 
     cleanup_db(&db_path);
@@ -886,9 +887,9 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
     )
     .unwrap();
 
-    // charge_failed_attempt = true: this is the real-authentication path
-    // (`handle()` always charges); the exemption exists only for root `test`.
-    let resp = handler.handle_authenticate("testuser".into(), true);
+    // The real-authentication intent, which always charges; the diagnostic
+    // carve-out exists only for `facelock test`.
+    let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Authenticate);
     match resp {
         DaemonResponse::Error { ref message } => {
             assert!(

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -7,8 +7,8 @@
 //! per-method authorization (denials, the Authenticate self-scope, the
 //! root-only catch-all), the in-band `-2`/`-3` sentinel encoding with its
 //! byte-exact protocol strings, similarity redaction for non-root callers,
-//! the N11 root rate-limit exemption, and the rule that a denied caller
-//! never starts a polkit round-trip.
+//! which entry point charges the rate limit (N11), and the rule that a
+//! denied caller never starts a polkit round-trip.
 //!
 //! NOT covered here, deliberately: the zbus wiring — caller-identity
 //! resolution from message headers (`GetConnectionUnixUser`), signal
@@ -17,7 +17,9 @@
 //! (`just test-arch-pam`, `just test-arch-integration`) prove that layer
 //! against a real bus and PAM stack.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use facelock_core::config::Config;
 use facelock_core::notify::{Notifier, NullNotifier};
@@ -110,6 +112,46 @@ fn matching_service_for(user: &str) -> MockService {
     ))
 }
 
+/// A file-backed store, for the tests that must read the `rate_limit` table
+/// back through a *second* connection — the counter those tests are about is
+/// on disk, and an in-memory store is private to the handler holding it.
+fn temp_db_path(test_name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "facelock-authz-{test_name}-{}-{unique}.db",
+        std::process::id()
+    ))
+}
+
+fn cleanup_db(path: &Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+}
+
+/// A service whose store lives at `db_path` and holds one enrolled model for
+/// `user`, with an engine that never sees a face — so every attempt fails and
+/// the only question is what it costs. `max_attempts` sets the budget.
+fn failing_service_at(db_path: &Path, user: &str, max_attempts: u32) -> MockService {
+    let store = FaceStore::create(db_path).unwrap();
+    store
+        .add_model(
+            user,
+            "front",
+            &fixtures::known_embedding(1),
+            "test-embedder",
+        )
+        .unwrap();
+    service(handler_with(
+        test_config(max_attempts, 1),
+        MockFaceEngine::no_faces(),
+        store,
+    ))
+}
+
 fn caller(uid: u32, username: Option<&str>) -> CallerIdentity {
     CallerIdentity {
         uid,
@@ -150,6 +192,10 @@ async fn every_entry_point_except_authenticate_denies_non_root() {
     let svc = matching_service_for("alice");
     let a = alice();
 
+    assert_denied(
+        svc.test_authenticate_as(a.clone(), "alice").await,
+        "TestAuthenticate",
+    );
     assert_denied(svc.enroll_as(a.clone(), "alice", "front").await, "Enroll");
     assert_denied(svc.list_models_as(a.clone(), "alice").await, "ListModels");
     assert_denied(
@@ -183,6 +229,12 @@ async fn root_passes_authorization_on_every_entry_point() {
     let r = root();
 
     assert_eq!(svc.ping_as(r.clone()).await.unwrap(), "pong");
+    assert!(
+        svc.test_authenticate_as(r.clone(), "alice")
+            .await
+            .unwrap()
+            .matched
+    );
     assert_eq!(
         svc.list_models_as(r.clone(), "alice").await.unwrap().len(),
         1
@@ -324,45 +376,128 @@ async fn suppress_unknown_maps_to_the_minus_three_sentinel() {
     assert!(result.label.is_empty());
 }
 
-/// N11 wiring: the service exempts root callers from rate-limit consumption
-/// (`facelock test` reaches the daemon through Authenticate, and failed test
-/// runs must not lock the user out), while a user's own failed attempts
-/// still charge the shared budget.
+/// REGRESSION PIN: a ROOT caller's failed `Authenticate` charges the
+/// rate-limit budget.
+///
+/// The daemon used to exempt every root caller, on the theory that a root
+/// caller must be root-only `facelock test`. But `pam_facelock` runs inside
+/// the PAM stack of whatever program is authenticating, and `sudo` is
+/// setuid-root — as are `login`, `su`, and root-run display-manager
+/// greeters. PAM tries D-Bus first, so a real failed face authentication at
+/// a `sudo` prompt reached the daemon as UID 0 and was never charged: the
+/// documented 5-attempts/user/60s limit was inert on the project's primary
+/// documented PAM target, and an attacker presenting spoof material there
+/// had unlimited daemon-mediated attempts.
+///
+/// Asserted against the on-disk `rate_limit` table through a second
+/// connection, not just through the next reply, so this cannot pass on a
+/// coincidence of the in-band encoding.
 #[tokio::test]
-async fn root_failed_attempts_do_not_charge_the_rate_limit() {
-    let emb = fixtures::known_embedding(1);
-    let store = FaceStore::open_memory().unwrap();
-    store
-        .add_model("alice", "front", &emb, "test-embedder")
-        .unwrap();
+async fn root_failed_authenticate_charges_the_rate_limit() {
+    let db_path = temp_db_path("root-charges");
+    cleanup_db(&db_path);
+    // Budget of one failed attempt.
+    let svc = failing_service_at(&db_path, "alice", 1);
 
-    // Budget of one failed attempt; the engine never sees a face.
-    let svc = service(handler_with(
-        test_config(1, 1),
-        MockFaceEngine::no_faces(),
-        store,
-    ));
+    let first = svc.authenticate_as(root(), "alice").await.unwrap();
+    assert!(!first.matched);
+    assert_eq!(first.model_id, -1, "an ordinary non-match: {first:?}");
 
-    // Two consecutive failed ROOT attempts: neither is charged, so the
-    // second still runs the comparison instead of reporting "rate limited".
-    for attempt in 0..2 {
-        let result = svc.authenticate_as(root(), "alice").await.unwrap();
-        assert!(!result.matched);
-        assert_eq!(
-            result.model_id, -1,
-            "root attempt {attempt} must be an ordinary non-match, not a rate-limit rejection: {result:?}"
-        );
-    }
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        !inspect.check_rate_limit("alice", 1, 60).unwrap(),
+        "a root caller's failed Authenticate MUST consume budget — this is \
+         how a failed face auth at a sudo prompt gets counted"
+    );
 
-    // Alice's own failed attempt IS charged...
+    // And the charge is enforced: the next attempt is rejected in-band
+    // before the camera runs, root or not.
+    let limited = svc.authenticate_as(root(), "alice").await.unwrap();
+    assert_eq!(limited.model_id, -2);
+    assert_eq!(limited.label, "rate limited");
+
+    cleanup_db(&db_path);
+}
+
+/// The other half: a non-root user's own failed attempts are charged, as
+/// they always were.
+#[tokio::test]
+async fn user_failed_authenticate_charges_the_rate_limit() {
+    let db_path = temp_db_path("user-charges");
+    cleanup_db(&db_path);
+    let svc = failing_service_at(&db_path, "alice", 1);
+
     let charged = svc.authenticate_as(alice(), "alice").await.unwrap();
     assert!(!charged.matched);
     assert_eq!(charged.model_id, -1);
 
-    // ...so her next attempt is rejected in-band before the camera runs.
     let limited = svc.authenticate_as(alice(), "alice").await.unwrap();
     assert_eq!(limited.model_id, -2);
     assert_eq!(limited.label, "rate limited");
+
+    cleanup_db(&db_path);
+}
+
+/// N11, now explicit: the root-only `TestAuthenticate` method is the one
+/// entry point whose failures cost nothing. `facelock test` runs here, and a
+/// handful of failed test runs must not lock the user out of real
+/// authentication. The exemption is asked for by calling this method — it is
+/// no longer inferred from the caller being root.
+#[tokio::test]
+async fn test_authenticate_does_not_charge_the_rate_limit() {
+    let db_path = temp_db_path("test-charges-nothing");
+    cleanup_db(&db_path);
+    // Budget of one failed attempt — three failed test runs must not reach it.
+    let svc = failing_service_at(&db_path, "alice", 1);
+
+    for attempt in 0..3 {
+        let result = svc.test_authenticate_as(root(), "alice").await.unwrap();
+        assert!(!result.matched);
+        assert_eq!(
+            result.model_id, -1,
+            "test attempt {attempt} must be an ordinary non-match, not a \
+             rate-limit rejection: {result:?}"
+        );
+    }
+
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect.check_rate_limit("alice", 1, 60).unwrap(),
+        "the rate_limit table must be untouched by diagnostic runs"
+    );
+
+    // The *check* is not exempted: an already-limited user still sees it.
+    // (Charge through the real method, then test again.)
+    svc.authenticate_as(root(), "alice").await.unwrap();
+    let limited = svc.test_authenticate_as(root(), "alice").await.unwrap();
+    assert_eq!(limited.model_id, -2);
+    assert_eq!(
+        limited.label, "rate limited",
+        "an existing lockout must surface in `test`, not be masked by it"
+    );
+
+    cleanup_db(&db_path);
+}
+
+/// `TestAuthenticate` is root-only — that is what makes a
+/// budget-free authentication endpoint safe to expose at all. A non-root
+/// caller must be denied even for their own username, unlike `Authenticate`.
+#[tokio::test]
+async fn test_authenticate_denies_a_non_root_caller() {
+    let svc = matching_service_for("alice");
+
+    assert_denied(
+        svc.test_authenticate_as(alice(), "alice").await,
+        "TestAuthenticate (own user)",
+    );
+    assert_denied(
+        svc.test_authenticate_as(alice(), "bob").await,
+        "TestAuthenticate (cross-user)",
+    );
+
+    // Root runs the real comparison through it.
+    let as_root = svc.test_authenticate_as(root(), "alice").await.unwrap();
+    assert!(as_root.matched, "root must reach the comparison loop");
 }
 
 /// The root preview path end to end: frames and per-face metadata with the

--- a/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
+++ b/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
@@ -1,0 +1,108 @@
+//! The SSH physical-presence gate across the two authentication entry
+//! points, pinned through the real service (D6).
+//!
+//! `abort_if_ssh` exists to stop an *attacker* from authenticating a face
+//! session from a remote shell. It is not meant to stop an admin — already
+//! root, by construction, since `facelock test` requires it — from
+//! diagnosing recognition over SSH, which is why `PreCheckContext::test`
+//! exists (N11). Before `TestAuthenticate` there was nowhere on the daemon
+//! transport to apply that context: `test` arrived as an ordinary
+//! `Authenticate` call, indistinguishable from real auth, so the carve-out
+//! could only ever work in direct/oneshot mode. Now it applies on both.
+//!
+//! One test, alone in its own integration binary on purpose: it mutates
+//! `SSH_CONNECTION`, which is process-global state. Cargo gives each
+//! integration test file its own process, so owning this file means owning
+//! the environment — no lock to forget, and no sibling test that could
+//! observe the mutation.
+
+use std::sync::Arc;
+
+use facelock_core::config::Config;
+use facelock_core::notify::{Notifier, NullNotifier};
+use facelock_core::types::CameraCaps;
+use facelock_daemon::handler::Handler;
+use facelock_daemon::rate_limit::RateLimiter;
+use facelock_daemon::server::{CallerIdentity, FacelockService};
+use facelock_store::FaceStore;
+use facelock_test_support::fixtures;
+use facelock_test_support::{MockCamera, MockFaceEngine};
+
+#[tokio::test]
+async fn test_authenticate_skips_the_ssh_gate_that_authenticate_enforces() {
+    let config = Config::parse(
+        r#"
+[recognition]
+threshold = 0.45
+timeout_secs = 2
+
+[security]
+require_ir = false
+require_frame_variance = false
+require_landmark_liveness = false
+abort_if_ssh = true
+abort_if_lid_closed = false
+
+[encryption]
+method = "none"
+
+[audit]
+enabled = false
+"#,
+    )
+    .unwrap();
+
+    let emb = fixtures::known_embedding(1);
+    let store = FaceStore::open_memory().unwrap();
+    store
+        .add_model("alice", "front", &emb, "test-embedder")
+        .unwrap();
+    let rate_limiter = RateLimiter::new(
+        config.security.rate_limit.max_attempts,
+        config.security.rate_limit.window_secs,
+    );
+    let factory: Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync> =
+        Box::new(|_| Ok(MockCamera::bright(64, 64, 60)));
+    let handler = Handler::new(
+        config,
+        MockFaceEngine::one_face(emb),
+        store,
+        rate_limiter,
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+    let svc = FacelockService::new(
+        handler,
+        None,
+        None,
+        Arc::new(|_user: &str| Box::new(NullNotifier) as Box<dyn Notifier>),
+    );
+    let root = CallerIdentity {
+        uid: 0,
+        username: Some("root".into()),
+    };
+
+    let previous = std::env::var("SSH_CONNECTION").ok();
+    unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 5678 10.0.0.1 22") };
+
+    // Real authentication: the gate fires, in-band, before the camera runs.
+    let real = svc.authenticate_as(root.clone(), "alice").await.unwrap();
+    assert!(!real.matched);
+    assert_eq!(real.model_id, -2, "recoverable error sentinel: {real:?}");
+    assert_eq!(real.label, "SSH session detected");
+
+    // The diagnostic entry point runs the comparison anyway.
+    let diagnostic = svc.test_authenticate_as(root, "alice").await.unwrap();
+    assert!(
+        diagnostic.matched,
+        "TestAuthenticate must skip the SSH gate and reach the comparison \
+         loop, got: {diagnostic:?}"
+    );
+
+    match previous {
+        Some(value) => unsafe { std::env::set_var("SSH_CONNECTION", value) },
+        None => unsafe { std::env::remove_var("SSH_CONNECTION") },
+    }
+}

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -119,53 +119,52 @@ group) gets the group-membership hint. Telling a root-only rejection to
 
 `facelock test` is root-only (issue #96) and, being root, keeps full detail
 on both transports: on the daemon transport, `AuthResult.similarity` is
-redacted to non-root D-Bus callers only (`redact_similarity_unless_root` in
-`commands/daemon.rs`) — since `test` requires root, its `Authenticate` calls
-always get the real score. The direct transport never redacts.
+redacted to non-root D-Bus callers only (`redact_similarity_unless_root`) —
+since `test` requires root, it always gets the real score. The direct
+transport never redacts.
 
-It runs through the same pre-flight gates as real authentication —
-`security.disabled`, enrollment / `suppress_unknown`, the rate-limit check,
-and `require_ir` — via `facelock_daemon::auth::pre_check_audited*`, with one
-explicit, narrow exception: the `abort_if_ssh` / `abort_if_lid_closed` gates
-are skippable via `PreCheckContext::test()`. Those two gates exist to stop an
-*attacker*'s physical-access shortcuts, not to block an admin who is already
-root (by construction, since `test` requires root) and is deliberately
-diagnosing recognition over SSH or with the lid closed on a docked laptop.
-Every other gate stays enforced — this is a context flag threaded through
-`pre_check`, not a parallel copy of the gate logic (issue #95 was exactly
-that kind of drift).
+**`test` is a separate D-Bus method, not a privileged flavor of
+`Authenticate`.** On the daemon transport `facelock test` calls the
+root-only **`TestAuthenticate`** method; `Authenticate` is real
+authentication only. The daemon does not infer which it is serving from the
+caller's UID, and must not: `pam_facelock` runs inside the PAM stack of the
+authenticating program, and `sudo` is setuid-root — as are `login`, `su`,
+and root-run display-manager greeters — so a real failed face
+authentication at a `sudo` prompt reaches the daemon as UID 0. A design that
+exempted root callers from rate-limit consumption therefore left the limit
+inert on the primary documented PAM target. Intent travels with the method
+call instead (`AuthIntent` in `facelock_daemon::handler`).
 
-The override applies uniformly on the **direct** (daemonless) transport,
-where the pre-flight check runs in the same process that has the invoking
-session's actual `SSH_CONNECTION`/lid state. It does **not** apply
-separately on the **daemon** transport: `test` there is just another
-`Authenticate` D-Bus call, indistinguishable from real auth at that layer,
-so `abort_if_ssh` is evaluated against the long-running daemon process's own
-environment (never an SSH session) and is already inert there regardless;
-`abort_if_lid_closed` reads a system-wide hardware file and so still applies
-uniformly to every daemon-mediated `Authenticate` call, `test` included. In
-practice this means: diagnosing over SSH works on both transports (direct
-because it's overridden, daemon because the gate was already a no-op there);
-diagnosing with the lid closed only bypasses the gate in direct/oneshot mode.
+Both entry points run the same pre-flight gates — `security.disabled`,
+enrollment / `suppress_unknown`, the rate-limit check, and `require_ir` —
+via `facelock_daemon::auth::pre_check_audited*`. `TestAuthenticate` differs
+in exactly two documented ways:
 
-**Rate-limit consumption is exempted; the check is not.** A failed `test`
-attempt never consumes the shared (SQLite-backed) rate-limit budget:
-- Direct transport: `direct::authenticate` never calls
-  `RateLimiter::record_failure` — structurally, not conditionally.
-- Daemon transport: `test` reaches the daemon through the same
-  `Authenticate` D-Bus method as real auth. The D-Bus layer
-  (`commands/daemon.rs`) calls `Handler::handle_authenticate(user, charge)`
-  with `charge = !caller_is_root`; since `test` requires root, its D-Bus
-  calls are always exempted. Real end-user authentication (hyprlock, screen
-  lockers) runs as the *unprivileged user themselves*, so it is always
-  charged as before — this exemption only ever fires for a root caller.
+1. **The `abort_if_ssh` / `abort_if_lid_closed` gates are skipped**
+   (`PreCheckContext::test()`). Those two exist to stop an *attacker*'s
+   physical-access shortcuts, not to block an admin who is already root (by
+   construction, since `test` requires root) and is deliberately diagnosing
+   recognition over SSH or with the lid closed on a docked laptop. This is a
+   context flag threaded through `pre_check`, not a parallel copy of the gate
+   logic (issue #95 was exactly that kind of drift). It applies identically
+   on the direct transport, which calls `pre_check_audited_with_context`
+   directly — the two transports no longer diverge here, as they did while
+   `test` had no daemon-side method of its own to carry the context.
+2. **A failed attempt consumes no rate-limit budget.** The direct transport
+   gets this structurally (`direct::authenticate` never calls
+   `RateLimiter::record_failure`); the daemon transport gets it because
+   `TestAuthenticate` is the entry point that does not charge. Root-only is
+   what makes a budget-free authentication endpoint safe to offer at all —
+   root already owns the database and can clear the limiter directly, so
+   exempting *consumption* for it costs nothing.
 
-The rate-limit *check* (whether `user` is already over budget) is
-unaffected by any of the above and still runs on both transports: an
+`Authenticate` always charges a failed attempt, on every transport and for
+every caller including root.
+
+The rate-limit *check* (whether `user` is already over budget) is unaffected
+by any of the above and still runs on both methods and both transports: an
 already-limited user's `test` run reports "rate limited", exactly like real
-auth would. Root can already clear the limiter directly (it owns the
-database), so exempting *consumption* costs nothing security-wise, while
-still surfacing an existing lockout instead of masking it.
+auth would — surfacing an existing lockout instead of masking it.
 
 ## Operating Modes
 
@@ -281,7 +280,7 @@ binary; none of it touches the data itself.
 
 `audit.jsonl` is JSONL; each line carries `timestamp`, `user`, `result` (`success`, `failure`, `error`, `rate_limited`, `suppressed`) and, when known, `similarity`, `frame_count`, `duration_ms`, `device`, `model_label`, `error`.
 
-`source` names the code path that produced the entry — `daemon` (the `Authenticate` D-Bus method), `oneshot` (the `facelock auth` helper PAM spawns), or `test` (direct-mode `facelock test`, which runs the recognition loop in-process). It records the **enforcement path, not the caller's intent**: `facelock test` against a running daemon goes through `Authenticate` and is logged as `daemon`, because it runs the full `pre_check` gates (rate limiting, `require_ir`, SSH/lid abort) and its failures count against the rate limit. Only `test` skips those gates, so a `success` stamped `test` is a recognition result, not a policy-approved authentication. The field is absent on entries written before it existed.
+`source` names the code path that produced the entry — `daemon` (the `Authenticate` D-Bus method), `oneshot` (the `facelock auth` helper PAM spawns), or `test` (`facelock test`, on either transport: the daemon's `TestAuthenticate` method or the in-process direct loop). It records the **enforcement path, not the caller's identity**: `daemon` and `oneshot` are fully-enforced authentications whose failures count against the rate limit, while `test` skips the SSH/lid physical-presence gates and charges nothing. So a `success` stamped `test` is a recognition result, not a policy-approved authentication — and a real authentication is never stamped `test`, whatever privilege its caller holds. The field is absent on entries written before it existed.
 
 ## Config Schema
 
@@ -406,7 +405,7 @@ The daemon registers on the system bus via D-Bus activation.
 - **Interface**: `org.facelock.Daemon`
 
 ### Methods
-`Authenticate`, `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`, `Ping`, `Shutdown`
+`Authenticate`, `TestAuthenticate`, `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`, `Ping`, `Shutdown`
 
 Method authorization contract (updated under DEC-6/N13 — the CLI's
 root-by-default privilege map left no unprivileged consumer for most of
@@ -414,16 +413,23 @@ these, so tightening them to root-only closes the per-frame similarity
 hill-climbing oracle by construction rather than by redacting fields):
 - `Authenticate`: root or the matching Unix user. The one user-scoped method
   — screen lockers run their PAM stack as the user, so this is architecture,
-  not policy.
+  not policy. It is **real authentication**: a failed attempt always
+  consumes rate-limit budget, whatever the caller's UID.
+- `TestAuthenticate`: **root only.** Same arguments and same `AuthResult`
+  reply as `Authenticate`, and the same gates except that it skips the
+  SSH/lid physical-presence aborts and charges no rate-limit budget on
+  failure (see "facelock test Semantics" above). It exists so the daemon
+  never has to infer a caller's purpose from their privilege; root-only is
+  what makes a budget-free endpoint safe to expose.
 - Every other method — `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`,
   `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`,
   `Ping`, `Shutdown` — is root only. The bus policy
   (`dbus/org.facelock.Daemon.conf`) stays interface-scoped (grants send
-  access to root and the `facelock` group for the whole interface); the
-  per-method root/user-scoped decision is the in-daemon check on the caller
-  UID from `GetConnectionUnixUser`, keyed by a table-driven scope
-  (`authorize_method` in `commands/daemon.rs`) so a new method is root-only
-  by default until deliberately opened up.
+  access to root and the `facelock` group for the whole interface, so adding
+  a method needs no policy edit); the per-method root/user-scoped decision is
+  the in-daemon check on the caller UID from `GetConnectionUnixUser`, keyed
+  by a table-driven scope (`authorize_method` in `facelock_daemon::server`)
+  so a new method is root-only by default until deliberately opened up.
 
 Raw camera frames require privilege. `PreviewFrame` remains root-only.
 `PreviewDetectFrame` returns the `jpeg_data` frame bytes to root
@@ -459,21 +465,22 @@ Enrollment behavior is mode-independent: oneshot (`facelock enroll` in direct
 mode) and the daemon's `Enroll` method run the same capture loop, so the
 quality gate and the angle-diversity check apply in both.
 
-Capture concurrency: `Authenticate`, `Enroll`, `PreviewFrame`, and
-`PreviewDetectFrame` are serialized by an in-flight capture guard. While one
-capture is in progress, a concurrent call to any of these methods fails
-**immediately** with an `org.freedesktop.DBus.Error.Failed` error whose
-message contains `daemon busy` (no queuing on the internal handler lock).
+Capture concurrency: `Authenticate`, `TestAuthenticate`, `Enroll`,
+`PreviewFrame`, and `PreviewDetectFrame` are serialized by an in-flight
+capture guard. While one capture is in progress, a concurrent call to any of
+these methods fails **immediately** with an
+`org.freedesktop.DBus.Error.Failed` error whose message contains `daemon
+busy` (no queuing on the internal handler lock).
 Clients (PAM included) must treat this like any other daemon error — degrade
 to the next auth mechanism (password), never a lockout.
 
 ### Signals
-- `AuthAttempted(user: s, matched: b)` — emitted after each authentication
-  attempt. The payload intentionally carries **no similarity score** (the raw
-  biometric score is an information leak / spoof-tuning oracle). The system
-  bus policy (`dbus/org.facelock.Daemon.conf`) denies signal reception from
-  the daemon by default; only root and members of the `facelock` group may
-  receive it.
+- `AuthAttempted(user: s, matched: b)` — emitted after each camera-backed
+  attempt, from `Authenticate` and `TestAuthenticate` alike. The payload
+  intentionally carries **no similarity score** (the raw biometric score is
+  an information leak / spoof-tuning oracle). The system bus policy
+  (`dbus/org.facelock.Daemon.conf`) denies signal reception from the daemon
+  by default; only root and members of the `facelock` group may receive it.
 
 ### Response types
 `AuthResult`, `Enrolled`, `Models`, `Removed`, `Frame`, `DetectFrame`, `Devices`, `Ok`, `Error`
@@ -483,6 +490,8 @@ to the next auth mechanism (password), never a lockout.
 ### Authenticate error encoding
 
 `Authenticate` returns `AuthResult (matched: b, model_id: i, label: s, similarity: d)`.
+`TestAuthenticate` returns the same type with the same sentinels — one
+encoding, so the two cannot drift.
 Sentinel `model_id` values (only meaningful with `matched == false`):
 
 | model_id | Meaning |


### PR DESCRIPTION
## The vulnerability

`crates/facelock-daemon/src/server.rs` computed `let caller_is_root = caller.uid == 0;` and called
`handler.handle_authenticate(user, !caller_is_root)` — a root caller's failed authentication consumed
no rate-limit budget.

The intent (gap N11) was narrow: `facelock test` is root-only, and testing a few times shouldn't lock
you out of real auth. But **"caller is root" is not a proxy for "this is a test run"**:

- `pam_facelock` runs inside the PAM stack of the calling program. `sudo` is setuid-root; `login`,
  `su`, and root-run display-manager greeters run as root too. PAM tries D-Bus first, so a **real
  failed face authentication at a `sudo` prompt reached the daemon as caller UID 0 and was never
  charged.**
- Consequence: the documented core security rule (5 attempts/user/60s — `docs/security.md`,
  `docs/contracts.md`) was **inert on the project's primary documented PAM target**
  (`/etc/pam.d/sudo`). An attacker presenting spoof material at a sudo prompt had unlimited
  daemon-mediated attempts.
- Two independent signals that this was unintended: the oneshot fallback path *does* charge the same
  failure (`crates/facelock-cli/src/commands/auth.rs`), so whether an attempt counted depended purely
  on whether the daemon happened to be running; and `docs/contracts.md` justified the exemption with
  "Real end-user authentication (hyprlock, screen lockers) runs as the *unprivileged user
  themselves*, so it is always charged as before" — true for hyprlock, false for sudo/login.

Who is affected: anyone running the documented `auth sufficient pam_facelock.so` line in
`/etc/pam.d/sudo`, `/etc/pam.d/login`, `/etc/pam.d/su`, or a display-manager stack, with the daemon
running (the default `daemon.mode = "daemon"`). Screen lockers that run PAM as the user were always
charged correctly.

Root cause note: this shape came from the orchestrator's implementation instruction on PR #112, not
from the implementing agent's own design.

## The design: explicit beats inferred

Stop inferring intent from caller privilege. Make the test path a separate method.

1. **`Authenticate` always charges a failed attempt**, on every transport and for every caller
   including root. This restores the limiter on every PAM stack.
2. **New root-only `TestAuthenticate` D-Bus method** — same `s` argument, same `AuthResult` reply and
   the same `-1`/`-2`/`-3` sentinels. Two deliberate differences: it charges no rate-limit budget,
   and it applies `PreCheckContext::test()` (skips the SSH/lid physical-presence gates). Root-only is
   *why* a budget-free endpoint is safe to offer, so the scope is listed explicitly in the
   table-driven authorization rather than left to the `Scope::Root` catch-all.
3. **`AuthIntent`** (`facelock-daemon/src/handler.rs`) carries the purpose through the handler: what
   the attempt costs, which gates run, and which audit `source` it stamps. One table, one place.
4. `facelock test` calls the new method through the Backend seam. The direct/root path is unchanged
   and still never records failures structurally.

This also resolves the ssh/lid asymmetry PR #112 had to document as a wart: the daemon transport
previously had nowhere to apply the test context, so diagnosing with the lid closed only worked in
oneshot mode. Both transports now behave identically, and the daemon's diagnostic runs audit as
`test` instead of claiming the enforcement of an ordinary `daemon` authentication.

**PAM needs no change** — `crates/pam-facelock/src/lib.rs` calls `Authenticate`, which is now
correctly always-charging. The crate is untouched by this PR (`git diff --stat` confirms), as is
`is-enrolled`. The two protocol strings PAM substring-matches ("rate limited", "IR camera required")
still flow byte-identical through the same in-band encoding, pinned by the existing tests in
`tests/server_authz.rs`.

## Wire addition and every pin updated

- `dbus/org.facelock.Daemon.conf` — **no edit needed, verified**: the policy is interface-scoped
  (`send_interface="org.facelock.Daemon"` grants the whole interface to root and the `facelock`
  group); per-method decisions live in the daemon.
- `crates/facelock-core/tests/dbus_types_test.rs` — existing signature pins untouched; added a pin
  stating that `AuthResult` is now the reply of two methods and pinning the shared argument list.
  Method *names* cannot be pinned from core (zbus derives them from the `#[interface]` fn names), so
  the doc points at the daemon-side scan below.
- `crates/facelock-daemon/src/server.rs` — new `interface_methods_and_the_authz_matrix_are_the_same_set`
  scans the `#[interface]` block and requires it to match `Method::ALL` exactly. A wire method with
  no `Method` variant would be one the authorization matrix never sees. Falsified by removing the
  variant: the test fails.
- `crates/facelock-daemon/tests/server_authz.rs` — the matrix tests iterate `Method::ALL`, so
  `TestAuthenticate` is covered automatically (root allowed, non-root denied), plus explicit
  end-to-end denial tests.
- `crates/facelock-cli/src/backend.rs` — the single-sited transport pin now covers
  `test_authenticate`, and a new pin fails if any CLI source references `ipc_client::authenticate`
  (deleted: the CLI has no business calling the always-charging method).

## docs/contracts.md — the contradiction, fixed

The file contradicted itself about exactly this behavior. Both passages are reconciled with what
ships:

- "facelock test Semantics (N11)" (~:118) claimed consumption was exempted for root callers, with the
  hyprlock justification quoted above. Rewritten around the new method, including why UID is the
  wrong predicate.
- "Audit Log Entries" (~:284) claimed `test` against a running daemon "goes through `Authenticate`
  … and its failures count against the rate limit" — the opposite. Rewritten: `test` is the
  diagnostic path on either transport, `daemon`/`oneshot` are the enforced ones.
- Also updated in the same commit as the behavior: the method list, the authorization table, the
  capture-concurrency list, the `AuthAttempted` signal note, and the error-encoding section.

## Tests

Added:
- `root_failed_authenticate_charges_the_rate_limit` — **the regression pin.** Asserts the on-disk
  `rate_limit` table through a second connection, not just the next reply.
- `user_failed_authenticate_charges_the_rate_limit` — the unchanged half.
- `test_authenticate_does_not_charge_the_rate_limit` — three failed diagnostic runs against a budget
  of one, plus the proof that the rate-limit *check* is still not exempted.
- `test_authenticate_denies_a_non_root_caller` (own user and cross-user), and `TestAuthenticate` added
  to the sweep tests for both denial and root access.
- `tests/test_authenticate_ssh_gate.rs` — `Authenticate` returns "SSH session detected" while
  `TestAuthenticate` reaches the comparison loop. Alone in its own integration binary because it owns
  the process environment.
- `AuthIntent` table unit tests (charging / gates / audit source) and `decode_auth_result` sentinel
  tests.

Rewritten/deleted because the fix invalidates their premise:
- `daemon_integration.rs::exempted_authenticate_does_not_consume_rate_limit_budget` → renamed
  `test_intent_does_not_consume_rate_limit_budget`; it asserted the root-exemption premise via
  `handle_authenticate(user, false)`.
- `server_authz.rs::root_failed_attempts_do_not_charge_the_rate_limit` → **deleted**; it asserted the
  vulnerable behavior directly ("two consecutive failed ROOT attempts: neither is charged"). Replaced
  by the two charging pins above.

Both new structural pins were falsified before being kept (reintroduce the UID-0 exemption → the
regression pin fails; drop the enum variant → the matrix scan fails).

## Review finding

Addresses the High-severity finding raised independently by REV-112 and REV-BP: the N11 rate-limit
exemption keyed on caller UID disables the daemon's rate limiter for every root-run PAM stack,
including `sudo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
