### PR TITLE
refactor(cli): one fact type, no unread provenance (review C2)

### DIFF
--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -40,7 +40,7 @@ use facelock_daemon::auth::AuthOutcome;
 use facelock_store::StoreError;
 
 use crate::message::{Terminal, UserMessage};
-use crate::resolved::{Provenance, Resolved};
+use crate::resolved::Fact;
 use crate::{direct, ipc_client};
 
 /// Which implementation answers this invocation's questions — and, for the
@@ -64,9 +64,9 @@ impl BackendKind {
     }
 }
 
-/// What the one probe observed, recorded beside the resolved-config facts
-/// (D7) with the same provenance discipline: `NotProbed` is a distinct value,
-/// never a guessed `Unreachable`. `status` reports the same discipline
+/// What the one probe observed, recorded as a [`Fact`] beside the config
+/// facts in `resolved` (D7) and with the same discipline: `NotProbed` is a
+/// distinct value, never a guessed `Unreachable`. `status` reports it
 /// through [`DaemonPing`], which additionally carries the failure detail a
 /// report wants and a human does not need at selection time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -339,7 +339,7 @@ pub enum DaemonPing {
 
 /// `status`'s daemon probe. Lives in the seam so `ipc_client::ping` stays
 /// single-sited (D1) — the health model consumes the fact, not the transport.
-pub fn probe_daemon(mode: &DaemonMode) -> Resolved<DaemonPing> {
+pub fn probe_daemon(mode: &DaemonMode) -> Fact<DaemonPing> {
     probe_daemon_with(mode, ipc_client::ping)
 }
 
@@ -348,21 +348,15 @@ pub fn probe_daemon(mode: &DaemonMode) -> Resolved<DaemonPing> {
 fn probe_daemon_with(
     mode: &DaemonMode,
     ping: impl FnOnce() -> anyhow::Result<()>,
-) -> Resolved<DaemonPing> {
+) -> Fact<DaemonPing> {
     match mode {
-        DaemonMode::Oneshot => Resolved {
-            value: DaemonPing::NotConfigured,
-            provenance: Provenance::Claimed,
-        },
-        DaemonMode::Daemon => Resolved {
-            value: match ping() {
-                Ok(()) => DaemonPing::Responding,
-                Err(e) => DaemonPing::NotResponding {
-                    error: e.to_string(),
-                },
+        DaemonMode::Oneshot => Fact::claimed(DaemonPing::NotConfigured),
+        DaemonMode::Daemon => Fact::probed(match ping() {
+            Ok(()) => DaemonPing::Responding,
+            Err(e) => DaemonPing::NotResponding {
+                error: e.to_string(),
             },
-            provenance: Provenance::Probed,
-        },
+        }),
     }
 }
 
@@ -370,31 +364,22 @@ fn probe_daemon_with(
 fn classify(
     mode: &DaemonMode,
     probe: impl FnOnce() -> bool,
-) -> (BackendKind, Resolved<DaemonReachability>) {
+) -> (BackendKind, Fact<DaemonReachability>) {
     match mode {
         DaemonMode::Oneshot => (
             BackendKind::DirectByConfig,
-            Resolved {
-                value: DaemonReachability::NotProbed,
-                provenance: Provenance::Claimed,
-            },
+            Fact::claimed(DaemonReachability::NotProbed),
         ),
         DaemonMode::Daemon => {
             if probe() {
                 (
                     BackendKind::Daemon,
-                    Resolved {
-                        value: DaemonReachability::Reachable,
-                        provenance: Provenance::Probed,
-                    },
+                    Fact::probed(DaemonReachability::Reachable),
                 )
             } else {
                 (
                     BackendKind::DirectByFallback,
-                    Resolved {
-                        value: DaemonReachability::Unreachable,
-                        provenance: Provenance::Probed,
-                    },
+                    Fact::probed(DaemonReachability::Unreachable),
                 )
             }
         }
@@ -449,24 +434,21 @@ mod tests {
             panic!("oneshot must never probe the bus")
         });
         assert_eq!(kind, BackendKind::DirectByConfig);
-        assert_eq!(fact.value, DaemonReachability::NotProbed);
-        assert_eq!(fact.provenance, Provenance::Claimed);
+        assert_eq!(fact, Fact::claimed(DaemonReachability::NotProbed));
     }
 
     #[test]
     fn daemon_mode_with_owner_selects_daemon() {
         let (kind, fact) = classify(&DaemonMode::Daemon, || true);
         assert_eq!(kind, BackendKind::Daemon);
-        assert_eq!(fact.value, DaemonReachability::Reachable);
-        assert_eq!(fact.provenance, Provenance::Probed);
+        assert_eq!(fact, Fact::probed(DaemonReachability::Reachable));
     }
 
     #[test]
     fn daemon_mode_without_owner_is_fallback_not_config() {
         let (kind, fact) = classify(&DaemonMode::Daemon, || false);
         assert_eq!(kind, BackendKind::DirectByFallback);
-        assert_eq!(fact.value, DaemonReachability::Unreachable);
-        assert_eq!(fact.provenance, Provenance::Probed);
+        assert_eq!(fact, Fact::probed(DaemonReachability::Unreachable));
     }
 
     // -----------------------------------------------------------------------
@@ -478,15 +460,13 @@ mod tests {
         let fact = probe_daemon_with(&DaemonMode::Oneshot, || {
             panic!("oneshot must never ping the daemon")
         });
-        assert_eq!(fact.value, DaemonPing::NotConfigured);
-        assert_eq!(fact.provenance, Provenance::Claimed);
+        assert_eq!(fact, Fact::claimed(DaemonPing::NotConfigured));
     }
 
     #[test]
     fn daemon_probe_reports_a_completed_round_trip() {
         let fact = probe_daemon_with(&DaemonMode::Daemon, || Ok(()));
-        assert_eq!(fact.value, DaemonPing::Responding);
-        assert_eq!(fact.provenance, Provenance::Probed);
+        assert_eq!(fact, Fact::probed(DaemonPing::Responding));
     }
 
     #[test]
@@ -495,12 +475,11 @@ mod tests {
             Err(anyhow::anyhow!("D-Bus Ping call failed"))
         });
         assert_eq!(
-            fact.value,
-            DaemonPing::NotResponding {
+            fact,
+            Fact::probed(DaemonPing::NotResponding {
                 error: "D-Bus Ping call failed".into()
-            }
+            })
         );
-        assert_eq!(fact.provenance, Provenance::Probed);
     }
 
     /// Three kinds, three treatments: normal operation and an expected

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -89,9 +89,8 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
     // missing model files, and ORT falls back to CPU silently when the
     // configured provider isn't compiled into the installed runtime.
     let models = crate::resolved::ModelFiles::probe(&config);
-    if !models.value.all_present() {
+    if !models.all_present() {
         let missing: Vec<String> = models
-            .value
             .missing()
             .iter()
             .map(|p| p.display().to_string())
@@ -102,13 +101,13 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
         ));
     }
     let ep = crate::resolved::ExecutionProviderFact::probe(&config);
-    match &ep.value.status {
+    match &ep.status {
         crate::resolved::EpStatus::Available => {
-            info!(provider = %ep.value.configured, "execution provider resolved");
+            info!(provider = %ep.configured, "execution provider resolved");
         }
         crate::resolved::EpStatus::NotBuiltIn => {
             warn!(
-                provider = %ep.value.configured,
+                provider = %ep.configured,
                 "configured execution provider is not built into the installed \
                  ONNX Runtime; inference will fall back to CPU"
             );

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -48,10 +48,7 @@ pub fn run(
 
     // Models must exist before anything opens a camera. One probe through the
     // shared fact (D7) instead of a per-command re-derivation.
-    if !crate::resolved::ModelFiles::probe(config)
-        .value
-        .all_present()
-    {
+    if !crate::resolved::ModelFiles::probe(config).all_present() {
         return Err(fail(UserMessage::ModelsMissing {
             dir: config.daemon.model_dir.clone(),
         }));

--- a/crates/facelock-cli/src/commands/status.rs
+++ b/crates/facelock-cli/src/commands/status.rs
@@ -134,7 +134,7 @@ fn render_daemon(out: &mut String, daemon: &Fact<DaemonPing>) {
     );
     match daemon {
         Fact::Unknown { why } => unknown(out, why),
-        Fact::Known(ping) => match &ping.value {
+        Fact::Probed(ping) | Fact::Claimed(ping) => match ping {
             DaemonPing::NotConfigured => result(out, true, &UserMessage::StatusDaemonOneshot),
             DaemonPing::Responding => result(out, true, &UserMessage::StatusDaemonResponding),
             DaemonPing::NotResponding { error } => result(
@@ -154,8 +154,7 @@ fn render_fallback(out: &mut String, fallback: &Fact<OneshotFallback>) {
             item(out, &UserMessage::StatusLabelOneshotFallback, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => {
-            let fallback = &resolved.value;
+        Fact::Probed(fallback) | Fact::Claimed(fallback) => {
             item(
                 out,
                 &UserMessage::StatusLabelOneshotFallback,
@@ -186,7 +185,7 @@ fn render_camera(out: &mut String, camera: &Fact<CameraHealth>) {
             item(out, &UserMessage::StatusLabelCameraDevice, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => match &resolved.value {
+        Fact::Probed(camera) | Fact::Claimed(camera) => match camera {
             CameraHealth::Configured {
                 path,
                 present,
@@ -230,8 +229,7 @@ fn render_models(out: &mut String, models: &Fact<ModelFiles>) {
             item(out, &UserMessage::StatusLabelModelDirectory, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => {
-            let models = &resolved.value;
+        Fact::Probed(models) | Fact::Claimed(models) => {
             item(
                 out,
                 &UserMessage::StatusLabelModelDirectory,
@@ -272,8 +270,7 @@ fn render_execution_provider(out: &mut String, ep: &Fact<ExecutionProviderFact>)
             item(out, &UserMessage::StatusLabelExecutionProvider, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => {
-            let ep = &resolved.value;
+        Fact::Probed(ep) | Fact::Claimed(ep) => {
             let label = match ep.configured.as_str() {
                 "cpu" => "CPU",
                 "cuda" => "CUDA (NVIDIA GPU)",
@@ -304,9 +301,8 @@ fn render_encryption(out: &mut String, encryption: &Fact<EncryptionHealth>) {
             item(out, &UserMessage::StatusLabelEncryption, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => {
+        Fact::Probed(encryption) | Fact::Claimed(encryption) => {
             use facelock_core::config::EncryptionMethod;
-            let encryption = &resolved.value;
             let method = match encryption.method {
                 EncryptionMethod::Tpm => "AES-256-GCM (TPM-sealed key)",
                 EncryptionMethod::Keyfile => "AES-256-GCM (keyfile)",
@@ -385,8 +381,7 @@ fn render_enrolled(out: &mut String, user: &str, enrolled: &Fact<EnrollmentHealt
         // The money case. An unreadable store renders as *cannot determine*
         // — never as "no faces enrolled" (N4).
         Fact::Unknown { why } => unknown(out, why),
-        Fact::Known(resolved) => {
-            let enrolled = &resolved.value;
+        Fact::Probed(enrolled) | Fact::Claimed(enrolled) => {
             if enrolled.models.is_empty() {
                 result(out, false, &UserMessage::StatusNoFacesEnrolled);
             } else {
@@ -426,8 +421,7 @@ fn render_security(out: &mut String, security: &Fact<SecurityHealth>) {
     item(out, &UserMessage::StatusLabelSecurity, "");
     match security {
         Fact::Unknown { why } => unknown(out, why),
-        Fact::Known(resolved) => {
-            let security = &resolved.value;
+        Fact::Probed(security) | Fact::Claimed(security) => {
             if security.disabled {
                 result(out, false, &UserMessage::StatusSecurityDisabled);
                 return;
@@ -458,9 +452,8 @@ fn render_notifications(out: &mut String, notifications: &Fact<NotificationHealt
             item(out, &UserMessage::StatusLabelNotifications, "");
             unknown(out, why);
         }
-        Fact::Known(resolved) => {
+        Fact::Probed(notifications) | Fact::Claimed(notifications) => {
             use facelock_core::config::NotificationMode;
-            let notifications = &resolved.value;
             let mode = match notifications.mode {
                 NotificationMode::Off => UserMessage::StatusNotifyOff,
                 NotificationMode::Terminal => UserMessage::StatusNotifyTerminal,

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -21,10 +21,7 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     ipc_client::require_root("sudo facelock test")?;
 
     // Check models exist — offer to run setup if missing
-    if !crate::resolved::ModelFiles::probe(config)
-        .value
-        .all_present()
-    {
+    if !crate::resolved::ModelFiles::probe(config).all_present() {
         Terminal.info(&UserMessage::ModelsNotFoundOfferSetup);
         if Terminal.confirm(&UserMessage::ConfirmDownloadModels)? {
             crate::commands::setup::run(false)?;
@@ -32,10 +29,7 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
             // still uses the Config this process parsed, as it always has —
             // setup may have rewritten the file, and picking that up would be
             // a mid-command re-read.
-            if !crate::resolved::ModelFiles::probe(config)
-                .value
-                .all_present()
-            {
+            if !crate::resolved::ModelFiles::probe(config).all_present() {
                 return Err(fail(UserMessage::ModelsStillMissingAfterSetup));
             }
         } else {

--- a/crates/facelock-cli/src/health.rs
+++ b/crates/facelock-cli/src/health.rs
@@ -27,9 +27,7 @@ use facelock_store::{FaceStore, StoreError};
 
 use crate::backend::{self, DaemonPing};
 use crate::commands::enrollment_marker::{self, MarkerState};
-use crate::resolved::{
-    CameraPresence, ConfigLoad, ExecutionProviderFact, Fact, ModelFiles, Resolved,
-};
+use crate::resolved::{CameraPresence, ConfigLoad, ExecutionProviderFact, Fact, ModelFiles};
 
 /// The oneshot auth binary the PAM module spawns when the daemon path fails.
 /// Mirrors `AUTH_BIN` in `pam-facelock` (hardcoded there by N9; a config key
@@ -96,24 +94,24 @@ impl Health {
             };
         };
 
-        let models: Fact<ModelFiles> = ModelFiles::probe(config).into();
+        let models = ModelFiles::probe(config);
         let fallback = probe_oneshot_fallback_at(
             Path::new(AUTH_BIN),
             Path::new(&config.storage.db_path),
-            models.known().is_some_and(|m| m.all_present()),
+            models.all_present(),
         );
         Health {
             config: config_health,
-            daemon: backend::probe_daemon(&config.daemon.mode).into(),
+            daemon: backend::probe_daemon(&config.daemon.mode),
             oneshot_fallback: Fact::probed(fallback),
-            camera: probe_camera(config).into(),
-            execution_provider: ExecutionProviderFact::probe(config).into(),
+            camera: probe_camera(config),
+            execution_provider: Fact::probed(ExecutionProviderFact::probe(config)),
             encryption: Fact::probed(probe_encryption(config)),
             enrolled: probe_enrolled(config, &user),
             security: Fact::claimed(SecurityHealth::from_config(config)),
             notifications: Fact::claimed(NotificationHealth::from_config(config)),
             pam: probe_pam(),
-            models,
+            models: Fact::probed(models),
             user,
         }
     }
@@ -243,10 +241,10 @@ impl From<&facelock_camera::ResolvedCamera> for InterrogatedCamera {
     }
 }
 
-fn probe_camera(config: &Config) -> Resolved<CameraHealth> {
+fn probe_camera(config: &Config) -> Fact<CameraHealth> {
     // Presence via the shared probe (D7); interrogation via the camera
     // domain's one implementation (D8) — never re-derived here.
-    match CameraPresence::probe(config).value {
+    match CameraPresence::probe(config) {
         CameraPresence::AutoDetect => {
             let resolved = crate::direct::resolve_camera_device(config)
                 .ok()
@@ -254,14 +252,8 @@ fn probe_camera(config: &Config) -> Resolved<CameraHealth> {
             match resolved {
                 // Nothing detected right now: the config's claim is all we
                 // have.
-                None => Resolved {
-                    value: CameraHealth::AutoDetect { resolved: None },
-                    provenance: crate::resolved::Provenance::Claimed,
-                },
-                some => Resolved {
-                    value: CameraHealth::AutoDetect { resolved: some },
-                    provenance: crate::resolved::Provenance::Probed,
-                },
+                None => Fact::claimed(CameraHealth::AutoDetect { resolved: None }),
+                some => Fact::probed(CameraHealth::AutoDetect { resolved: some }),
             }
         }
         CameraPresence::Configured { path, present } => {
@@ -272,14 +264,11 @@ fn probe_camera(config: &Config) -> Resolved<CameraHealth> {
             } else {
                 None
             };
-            Resolved {
-                value: CameraHealth::Configured {
-                    path,
-                    present,
-                    interrogated,
-                },
-                provenance: crate::resolved::Provenance::Probed,
-            }
+            Fact::probed(CameraHealth::Configured {
+                path,
+                present,
+                interrogated,
+            })
         }
     }
 }
@@ -541,7 +530,7 @@ mod tests {
             Fact::Unknown { why } => {
                 assert!(why.contains("database"), "{why}")
             }
-            Fact::Known(known) => panic!("must not claim a known answer: {:?}", known.value),
+            known => panic!("must not claim a known answer: {known:?}"),
         }
     }
 

--- a/crates/facelock-cli/src/health.rs
+++ b/crates/facelock-cli/src/health.rs
@@ -244,32 +244,34 @@ impl From<&facelock_camera::ResolvedCamera> for InterrogatedCamera {
 fn probe_camera(config: &Config) -> Fact<CameraHealth> {
     // Presence via the shared probe (D7); interrogation via the camera
     // domain's one implementation (D8) — never re-derived here.
-    match CameraPresence::probe(config) {
-        CameraPresence::AutoDetect => {
-            let resolved = crate::direct::resolve_camera_device(config)
-                .ok()
-                .map(|r| InterrogatedCamera::from(&r));
-            match resolved {
-                // Nothing detected right now: the config's claim is all we
-                // have.
-                None => Fact::claimed(CameraHealth::AutoDetect { resolved: None }),
-                some => Fact::probed(CameraHealth::AutoDetect { resolved: some }),
-            }
-        }
-        CameraPresence::Configured { path, present } => {
-            let interrogated = if present {
-                crate::direct::resolve_camera_device(config)
-                    .ok()
-                    .map(|r| InterrogatedCamera::from(&r))
-            } else {
-                None
-            };
-            Fact::probed(CameraHealth::Configured {
-                path,
-                present,
-                interrogated,
-            })
-        }
+    camera_fact(CameraPresence::probe(config), || {
+        crate::direct::resolve_camera_device(config)
+            .ok()
+            .map(|r| InterrogatedCamera::from(&r))
+    })
+}
+
+/// The camera rule, split from the device interrogation so it is testable
+/// without hardware (same shape as `backend::classify`).
+///
+/// Every arm is [`Fact::Probed`], including auto-detect finding nothing:
+/// detection *ran*, and its coming back empty is an observation about this
+/// machine, not an unverified reading of the config.
+fn camera_fact(
+    presence: CameraPresence,
+    interrogate: impl FnOnce() -> Option<InterrogatedCamera>,
+) -> Fact<CameraHealth> {
+    match presence {
+        CameraPresence::AutoDetect => Fact::probed(CameraHealth::AutoDetect {
+            resolved: interrogate(),
+        }),
+        CameraPresence::Configured { path, present } => Fact::probed(CameraHealth::Configured {
+            // An absent node has nothing to interrogate; don't open a device
+            // to confirm what the stat already answered.
+            interrogated: present.then(interrogate).flatten(),
+            path,
+            present,
+        }),
     }
 }
 
@@ -508,6 +510,47 @@ mod tests {
 
     fn config_with(toml: &str) -> Config {
         Config::parse(toml).expect("test config parses")
+    }
+
+    // -----------------------------------------------------------------------
+    // Camera: what was probed vs what was merely claimed
+    // -----------------------------------------------------------------------
+
+    /// Auto-detection running and finding nothing is a *probed* absence. It
+    /// used to be tagged `Claimed`, which said the opposite — that the config
+    /// had been taken at its word and nothing checked.
+    #[test]
+    fn auto_detect_finding_nothing_is_a_probed_absence() {
+        let fact = camera_fact(CameraPresence::AutoDetect, || None);
+        assert!(
+            matches!(
+                fact,
+                Fact::Probed(CameraHealth::AutoDetect { resolved: None })
+            ),
+            "expected a probed absence, got {fact:?}"
+        );
+    }
+
+    #[test]
+    fn an_absent_configured_node_is_never_interrogated() {
+        let fact = camera_fact(
+            CameraPresence::Configured {
+                path: "/dev/facelock-no-such-video".into(),
+                present: false,
+            },
+            || panic!("an absent node must not be opened"),
+        );
+        assert!(
+            matches!(
+                fact,
+                Fact::Probed(CameraHealth::Configured {
+                    present: false,
+                    interrogated: None,
+                    ..
+                })
+            ),
+            "{fact:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/facelock-cli/src/health.rs
+++ b/crates/facelock-cli/src/health.rs
@@ -94,11 +94,16 @@ impl Health {
             };
         };
 
+        // The model files are probed as a *value*, and the fallback's
+        // `models_present` is derived from it here, before it is lifted into
+        // a `Fact`. Deriving it from the lifted fact instead would fold an
+        // undetermined answer into `false` (N4) — see
+        // [`probe_oneshot_fallback_at`].
         let models = ModelFiles::probe(config);
         let fallback = probe_oneshot_fallback_at(
             Path::new(AUTH_BIN),
             Path::new(&config.storage.db_path),
-            models.all_present(),
+            &models,
         );
         Health {
             config: config_health,
@@ -185,15 +190,22 @@ impl OneshotFallback {
     }
 }
 
+/// Takes the [`ModelFiles`] **value**, not the [`Fact`] it is later lifted
+/// into. A `bool` argument let the caller write
+/// `models.known().is_some_and(|m| m.all_present())`, which answers a
+/// confident `false` for a fact nobody established — the report would then
+/// state "models: missing / fallback not usable" on the strength of a probe
+/// that did not run. Taking the value makes that call unrepresentable rather
+/// than merely unreachable.
 fn probe_oneshot_fallback_at(
     auth_bin: &Path,
     db_path: &Path,
-    models_present: bool,
+    models: &ModelFiles,
 ) -> OneshotFallback {
     OneshotFallback {
         auth_bin: auth_bin.display().to_string(),
         auth_bin_present: auth_bin.is_file(),
-        models_present,
+        models_present: models.all_present(),
         database_present: db_path.is_file(),
     }
 }
@@ -507,6 +519,7 @@ mod tests {
     use std::fs;
 
     use crate::commands::enrollment_marker::Marker;
+    use crate::resolved::ProbedFile;
 
     fn config_with(toml: &str) -> Config {
         Config::parse(toml).expect("test config parses")
@@ -684,6 +697,24 @@ mod tests {
     // Oneshot fallback (F7)
     // -----------------------------------------------------------------------
 
+    /// A `ModelFiles` for a directory that either holds both files or
+    /// neither — the only distinction the fallback derivation reads.
+    fn model_files(present: bool) -> ModelFiles {
+        let dir = PathBuf::from("/usr/share/facelock/models");
+        ModelFiles {
+            detector: ProbedFile {
+                path: dir.join("det.onnx"),
+                present,
+            },
+            embedder: ProbedFile {
+                path: dir.join("emb.onnx"),
+                present,
+            },
+            dir_present: true,
+            dir,
+        }
+    }
+
     #[test]
     fn fallback_is_usable_only_with_binary_models_and_database() {
         let dir = tempfile::tempdir().unwrap();
@@ -692,21 +723,63 @@ mod tests {
         fs::write(&bin, b"#!").unwrap();
         fs::write(&db, b"db").unwrap();
 
-        let fallback = probe_oneshot_fallback_at(&bin, &db, true);
+        let fallback = probe_oneshot_fallback_at(&bin, &db, &model_files(true));
         assert!(fallback.auth_bin_present);
         assert!(fallback.database_present);
+        assert!(fallback.models_present);
         assert!(fallback.usable());
 
-        let no_models = probe_oneshot_fallback_at(&bin, &db, false);
+        let no_models = probe_oneshot_fallback_at(&bin, &db, &model_files(false));
+        assert!(!no_models.models_present);
         assert!(!no_models.usable());
 
-        let no_bin = probe_oneshot_fallback_at(&dir.path().join("missing"), &db, true);
+        let no_bin =
+            probe_oneshot_fallback_at(&dir.path().join("missing"), &db, &model_files(true));
         assert!(!no_bin.auth_bin_present);
         assert!(!no_bin.usable());
 
-        let no_db = probe_oneshot_fallback_at(&bin, &dir.path().join("missing.db"), true);
+        let no_db =
+            probe_oneshot_fallback_at(&bin, &dir.path().join("missing.db"), &model_files(true));
         assert!(!no_db.database_present);
         assert!(!no_db.usable());
+    }
+
+    /// N4 at the derivation site. `models_present` must be read off the
+    /// `ModelFiles` *value*; the shape this replaced passed
+    /// `models.known().is_some_and(|m| m.all_present())`, and `Fact::known`
+    /// answers `None` for an unknown fact — so an undetermined model probe
+    /// would have rendered as a confident "models: missing / fallback not
+    /// usable", a guessed false answer from a fact nobody established. That
+    /// was unreachable only because `ModelFiles::probe` happens to be
+    /// infallible today, which is a property of the implementation and not of
+    /// the types. `probe_oneshot_fallback_at` now takes `&ModelFiles`, so the
+    /// old expression does not type-check; this pin fails if a `Fact` is ever
+    /// routed back through `known()` inside the constructor.
+    #[test]
+    fn probe_derives_the_fallback_from_the_model_value_not_a_fact() {
+        let source =
+            fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/health.rs"))
+                .unwrap();
+        let body = source
+            .split_once("pub fn probe(loaded: &ConfigLoad) -> Health {")
+            .expect("Health::probe must exist")
+            .1
+            .split_once("\n    }\n")
+            .expect("Health::probe must close at method indentation")
+            .0;
+        // Comment lines are ignored so the prose above may name the shape it
+        // forbids (same rule as the pins in `resolved`).
+        let code: String = body
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !code.contains("known()"),
+            "Health::probe must derive the fallback's models_present from the \
+             ModelFiles value, never from a Fact — an Unknown fact collapses \
+             to a confident false (N4). Body was:\n{body}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -10,14 +10,14 @@
 //!   `config` displays/edits the file itself, and `is-enrolled` tolerates a
 //!   missing config on its unprivileged path).
 //!
-//! - [`ResolvedConfig`] — **what is actually true.** A config value like
+//! - [`Fact`] — **what is actually true.** A config value like
 //!   `execution_provider = "cuda"` or `device.path = "/dev/video2"` is a
 //!   *claim*; whether CUDA exists in the installed ONNX Runtime or the device
-//!   node is present is discovered by an explicit probe, once, instead of
-//!   being re-derived ad hoc at each use site. Each fact carries a
-//!   [`Provenance`] tag. Resolution is for the heavyweight paths only
-//!   (daemon startup, status, enroll, test); lighter commands probe just the
-//!   fact they consume.
+//!   node is present is discovered by an explicit probe ([`ModelFiles`],
+//!   [`CameraPresence`], [`ExecutionProviderFact`]) instead of being
+//!   re-derived ad hoc at each use site. Each fact carries a [`Provenance`]
+//!   tag. Commands probe just the fact they consume; `status` gathers all of
+//!   them into `health::Health`.
 //!
 //! # `is-enrolled` never comes here
 //!
@@ -81,7 +81,7 @@ impl ConfigLoad {
 }
 
 // ---------------------------------------------------------------------------
-// ResolvedConfig — what is actually true
+// Facts — what is actually true
 // ---------------------------------------------------------------------------
 
 /// How a resolved fact was determined.
@@ -315,25 +315,6 @@ impl ExecutionProviderFact {
         ExecutionProviderFact {
             configured: configured.to_string(),
             status,
-        }
-    }
-}
-
-/// The full resolution pass, for the paths that consume every fact (daemon
-/// startup logging, `status`). Commands that need one fact probe it directly.
-#[derive(Debug, Clone)]
-pub struct ResolvedConfig {
-    pub models: Resolved<ModelFiles>,
-    pub camera: Resolved<CameraPresence>,
-    pub execution_provider: Resolved<ExecutionProviderFact>,
-}
-
-impl ResolvedConfig {
-    pub fn resolve(config: &Config) -> Self {
-        ResolvedConfig {
-            models: ModelFiles::probe(config),
-            camera: CameraPresence::probe(config),
-            execution_provider: ExecutionProviderFact::probe(config),
         }
     }
 }
@@ -592,7 +573,6 @@ mod tests {
     fn is_enrolled_module_stays_probe_free() {
         let forbidden = [
             "ConfigLoad",
-            "ResolvedConfig",
             "resolved::",
             "send_request(",
             "Backend::select(",

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -15,9 +15,10 @@
 //!   *claim*; whether CUDA exists in the installed ONNX Runtime or the device
 //!   node is present is discovered by an explicit probe ([`ModelFiles`],
 //!   [`CameraPresence`], [`ExecutionProviderFact`]) instead of being
-//!   re-derived ad hoc at each use site. Each fact carries a [`Provenance`]
-//!   tag. Commands probe just the fact they consume; `status` gathers all of
-//!   them into `health::Health`.
+//!   re-derived ad hoc at each use site. Each probe here is infallible and
+//!   returns its value plainly; commands call the one whose answer they
+//!   consume, and `status` gathers all of them into `health::Health`, where
+//!   each is lifted into a [`Fact`] — the type that can also say *unknown*.
 //!
 //! # `is-enrolled` never comes here
 //!
@@ -84,67 +85,52 @@ impl ConfigLoad {
 // Facts — what is actually true
 // ---------------------------------------------------------------------------
 
-/// How a resolved fact was determined.
+/// A fact as `status` reports it: known — with a note on whether it was
+/// verified — or honestly unknown (H8).
 ///
-/// The daemon-reachability fact sits beside the existing ones the same way
-/// (`crate::backend::DaemonReachability` — Backend owns that probe, not
-/// this module).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Provenance {
+/// One type, one level of nesting. The arm a plain value cannot express is
+/// [`Fact::Unknown`]: *the probe could not determine the answer*. The domain
+/// map (§5) sketched `Unavailable { needs: Privilege }`; DEC-6 collapsed the
+/// privilege tiers (`status` is root, `is-enrolled` never comes here), so what
+/// is left of N4 is probe failure — an unreadable database, a config that did
+/// not parse — and the honest payload is the reason, not a privilege level.
+///
+/// The discipline it enforces sits in the renderer: a [`Fact::Unknown`] value
+/// must never render as a guessed answer. "The database could not be read" is
+/// a distinct value from "this user has no models".
+///
+/// [`Probed`](Fact::Probed) vs [`Claimed`](Fact::Claimed) is a note, not a
+/// branch. No renderer distinguishes them and no control flow turns on them;
+/// the one machine-facing reader is `backend`'s `backend selected` trace,
+/// which prints the fact's `Debug`. It is a variant name rather than a
+/// separate `Provenance` field precisely so it stays free to carry and cannot
+/// grow back into a second level of nesting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Fact<T> {
     /// Verified against the live system by this process (file stat, ORT
-    /// query).
-    Probed,
+    /// query, D-Bus round trip).
+    Probed(T),
     /// Taken from the config without verification — a claim, not a checked
     /// fact.
-    Claimed,
-}
-
-/// A fact plus how it was established.
-#[derive(Debug, Clone)]
-pub struct Resolved<T> {
-    pub value: T,
-    pub provenance: Provenance,
-}
-
-/// A fact as `status` reports it: known — with the [`Provenance`] every
-/// resolved fact already carries — or honestly unknown (H8).
-///
-/// This is the grown form of [`Resolved`]: the same value-plus-provenance
-/// when the answer exists, plus the arm [`Resolved`] cannot express — *the
-/// probe could not determine the answer*. The domain map (§5) sketched
-/// `Unavailable { needs: Privilege }`; DEC-6 collapsed the privilege tiers
-/// (`status` is root, `is-enrolled` never comes here), so what is left of N4
-/// is probe failure — an unreadable database, a config that did not parse —
-/// and the honest payload is the reason, not a privilege level.
-///
-/// The discipline it enforces sits in the renderer: an [`Fact::Unknown`]
-/// value must never render as a guessed answer. "The database could not be
-/// read" is a distinct value from "this user has no models".
-#[derive(Debug, Clone)]
-pub enum Fact<T> {
-    Known(Resolved<T>),
+    Claimed(T),
     /// Not an error and NOT a false answer: the probe could not determine
     /// the value. `why` says what stood in the way.
-    Unknown {
-        why: String,
-    },
+    Unknown { why: String },
 }
 
 impl<T> Fact<T> {
     /// A fact verified against the live system.
+    ///
+    /// Spelled lower-case beside [`Fact::unknown`], which has to be a
+    /// function because its variant holds an owned `String`; construction
+    /// sites then read alike whichever arm they build.
     pub fn probed(value: T) -> Self {
-        Fact::Known(Resolved {
-            value,
-            provenance: Provenance::Probed,
-        })
+        Fact::Probed(value)
     }
 
     /// A fact taken from configuration without verification.
     pub fn claimed(value: T) -> Self {
-        Fact::Known(Resolved {
-            value,
-            provenance: Provenance::Claimed,
-        })
+        Fact::Claimed(value)
     }
 
     pub fn unknown(why: impl Into<String>) -> Self {
@@ -152,17 +138,17 @@ impl<T> Fact<T> {
     }
 
     /// The value, when it is known.
+    ///
+    /// Deliberately `Option`: callers that need an answer either handle the
+    /// `None` or say "unknown". Folding it into a `bool` with a default —
+    /// `fact.known().is_some_and(..)` — is how an unestablished fact turns
+    /// into a confident false, which is the one thing this type exists to
+    /// prevent.
     pub fn known(&self) -> Option<&T> {
         match self {
-            Fact::Known(resolved) => Some(&resolved.value),
+            Fact::Probed(value) | Fact::Claimed(value) => Some(value),
             Fact::Unknown { .. } => None,
         }
-    }
-}
-
-impl<T> From<Resolved<T>> for Fact<T> {
-    fn from(resolved: Resolved<T>) -> Self {
-        Fact::Known(resolved)
     }
 }
 
@@ -194,17 +180,13 @@ pub struct ModelFiles {
 }
 
 impl ModelFiles {
-    pub fn probe(config: &Config) -> Resolved<ModelFiles> {
+    pub fn probe(config: &Config) -> ModelFiles {
         let dir = PathBuf::from(&config.daemon.model_dir);
-        let value = ModelFiles {
+        ModelFiles {
             dir_present: dir.is_dir(),
             detector: ProbedFile::probe(dir.join(&config.recognition.detector_model)),
             embedder: ProbedFile::probe(dir.join(&config.recognition.embedder_model)),
             dir,
-        };
-        Resolved {
-            value,
-            provenance: Provenance::Probed,
         }
     }
 
@@ -231,8 +213,8 @@ impl ModelFiles {
 /// `direct::resolve_camera_device` and friends) and is *not* duplicated here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CameraPresence {
-    /// No path configured: detection happens at open time; nothing to probe
-    /// yet, so this fact stays a claim.
+    /// No path configured: there is no node to stat, so detection is deferred
+    /// to open time.
     AutoDetect,
     Configured {
         path: String,
@@ -241,18 +223,12 @@ pub enum CameraPresence {
 }
 
 impl CameraPresence {
-    pub fn probe(config: &Config) -> Resolved<CameraPresence> {
+    pub fn probe(config: &Config) -> CameraPresence {
         match config.device.path.as_deref() {
-            None => Resolved {
-                value: CameraPresence::AutoDetect,
-                provenance: Provenance::Claimed,
-            },
-            Some(path) => Resolved {
-                value: CameraPresence::Configured {
-                    path: path.to_string(),
-                    present: Path::new(path).exists(),
-                },
-                provenance: Provenance::Probed,
+            None => CameraPresence::AutoDetect,
+            Some(path) => CameraPresence::Configured {
+                path: path.to_string(),
+                present: Path::new(path).exists(),
             },
         }
     }
@@ -287,14 +263,10 @@ impl ExecutionProviderFact {
     /// Probe the installed ONNX Runtime. Loads the ORT shared library unless
     /// the configured provider is `cpu` (or unknown), so call this only on
     /// paths that will load the engine anyway or exist to diagnose (status).
-    pub fn probe(config: &Config) -> Resolved<ExecutionProviderFact> {
-        let value = Self::status_of(&config.recognition.execution_provider, || {
+    pub fn probe(config: &Config) -> ExecutionProviderFact {
+        Self::status_of(&config.recognition.execution_provider, || {
             facelock_face::detect_execution_provider().map(|d| d.available)
-        });
-        Resolved {
-            value,
-            provenance: Provenance::Probed,
-        }
+        })
     }
 
     /// The decision rule, split from the ORT query so it is testable without
@@ -390,18 +362,17 @@ mod tests {
         ));
         let models = ModelFiles::probe(&config);
 
-        assert_eq!(models.provenance, Provenance::Probed);
-        assert!(models.value.dir_present);
-        assert!(models.value.detector.present);
-        assert!(!models.value.embedder.present);
-        assert!(!models.value.all_present());
+        assert!(models.dir_present);
+        assert!(models.detector.present);
+        assert!(!models.embedder.present);
+        assert!(!models.all_present());
         assert_eq!(
-            models.value.missing(),
+            models.missing(),
             vec![dir.path().join("emb.onnx").as_path()]
         );
 
         fs::write(dir.path().join("emb.onnx"), b"x").unwrap();
-        let models = ModelFiles::probe(&config).value;
+        let models = ModelFiles::probe(&config);
         assert!(models.all_present());
         assert!(models.missing().is_empty());
     }
@@ -409,30 +380,29 @@ mod tests {
     #[test]
     fn model_probe_on_missing_directory_is_all_absent() {
         let config = config_with("[daemon]\nmodel_dir = \"/nonexistent/facelock-test-models\"\n");
-        let models = ModelFiles::probe(&config).value;
+        let models = ModelFiles::probe(&config);
         assert!(!models.dir_present);
         assert!(!models.all_present());
         assert_eq!(models.missing().len(), 2);
     }
 
     #[test]
-    fn camera_probe_distinguishes_claim_from_probed_presence() {
-        // No path: a claim — detection is deferred to open time.
-        let auto = CameraPresence::probe(&config_with(""));
-        assert_eq!(auto.value, CameraPresence::AutoDetect);
-        assert_eq!(auto.provenance, Provenance::Claimed);
+    fn camera_probe_reports_auto_detect_and_node_presence() {
+        // No path: nothing to stat — detection is deferred to open time.
+        assert_eq!(
+            CameraPresence::probe(&config_with("")),
+            CameraPresence::AutoDetect
+        );
 
         // Configured and present.
         let dir = tempfile::tempdir().unwrap();
         let node = dir.path().join("video9");
         fs::write(&node, b"").unwrap();
-        let present = CameraPresence::probe(&config_with(&format!(
-            "[device]\npath = \"{}\"\n",
-            node.display()
-        )));
-        assert_eq!(present.provenance, Provenance::Probed);
         assert_eq!(
-            present.value,
+            CameraPresence::probe(&config_with(&format!(
+                "[device]\npath = \"{}\"\n",
+                node.display()
+            ))),
             CameraPresence::Configured {
                 path: node.display().to_string(),
                 present: true
@@ -440,11 +410,10 @@ mod tests {
         );
 
         // Configured and absent.
-        let absent = CameraPresence::probe(&config_with(
-            "[device]\npath = \"/dev/facelock-no-such-video\"\n",
-        ));
         assert_eq!(
-            absent.value,
+            CameraPresence::probe(&config_with(
+                "[device]\npath = \"/dev/facelock-no-such-video\"\n",
+            )),
             CameraPresence::Configured {
                 path: "/dev/facelock-no-such-video".into(),
                 present: false


### PR DESCRIPTION
## The design, and why

**Chosen: (a)** — flatten to `enum Fact<T> { Probed(T), Claimed(T), Unknown { why: String } }`, delete `Resolved<T>` and `Provenance` outright. Not (b): rendering probed-vs-claimed adds user-visible surface nobody asked for, and the reviewers' recommendation was to delete the unused thing, not to find it a job.

The one judgment call worth flagging: I kept the probed/claimed distinction as a **variant name** rather than deleting it entirely. It has exactly one reader — `Backend::select`'s `backend selected` trace, which prints the fact's `Debug`, so an operator debugging why a command went direct can see whether the bus was asked at all. As a variant name it costs nothing, it documents at each construction site whether the answer was verified, and it cannot regrow into a second level of nesting. What it no longer is: a separate type with its own field, read by nobody.

`Fact::probed`/`claimed`/`unknown` survive as constructors. `unknown` has to be a function (its variant holds an owned `String`); keeping the other two beside it means every construction site reads alike, and it is why the two money pins below compile untouched.

`DaemonReachability` and `DaemonPing` stay separate, as intended — selection's probe must never activate the daemon, `status`'s ping may. Both now carry a `Fact` instead of a `Resolved`.

## Deleted

| What | Where | Lines |
|---|---|---|
| `ResolvedConfig` + `impl` | `resolved.rs` | 18 |
| `Provenance` enum | `resolved.rs` | 14 |
| `Resolved<T>` struct | `resolved.rs` | 6 |
| `From<Resolved<T>> for Fact<T>` | `resolved.rs` | 5 |
| `"ResolvedConfig"` forbidden token | `resolved.rs` pin test | 1 |

`ResolvedConfig` had zero call sites anywhere in the tree; its doc named consumers (`daemon` startup logging, `status`) that call the individual probes directly, and #122 built `Health` rather than adopting it. It escaped the dead-code lint only by being `pub` in a `pub mod`. The remaining forbidden token `resolved::` still covers it in the `is-enrolled` isolation pin.

Falling out of the collapse: the three probes in `resolved` are infallible, so they return their value plainly instead of a wrapper that could only ever say "known". Four call sites in `daemon`/`enroll`/`test_cmd` lose a `.value` hop.

Net across the branch: **275 insertions, 259 deletions** — but that includes ~90 lines of new tests and docs; the type machinery itself is a net deletion.

## Bug 1 — a probed absence was tagged as a claim

`health.rs`, `probe_camera` (was ~:255-259). With no `device.path`, `status` runs auto-detection; if detection came back empty, the fact was tagged `Claimed` — "taken from the config without verification" — but the config says nothing to take, and the emptiness is precisely what the probe observed. The other three paths through the same function were `Probed`, so this was drift, not a distinction. Nothing read the tag, so nothing caught it.

```rust
// before
None => Resolved {
    value: CameraHealth::AutoDetect { resolved: None },
    provenance: crate::resolved::Provenance::Claimed,
},
some => Resolved { value: CameraHealth::AutoDetect { resolved: some }, .. Probed },

// after — every arm is Probed, which collapses the inner match entirely
CameraPresence::AutoDetect => Fact::probed(CameraHealth::AutoDetect {
    resolved: interrogate(),
}),
```

The rule moved behind `camera_fact(presence, interrogate)` with the device interrogation injected — the split `backend::classify` already uses — so it is testable without hardware. New tests: `auto_detect_finding_nothing_is_a_probed_absence`, `an_absent_configured_node_is_never_interrogated`.

## Bug 2 — an unknown fact could collapse to a confident `false`

`health.rs`, `probe_oneshot_fallback_at` (was ~:99-104). `Fact::known()` answers `None` for an unknown fact, so the derivation below hands `models_present: false` to the report whenever the model fact is *undetermined* — rendering "models: missing / fallback not usable", a guessed false answer from a fact nobody established. That is the N4 rule this layer exists to enforce, broken at the layer's own call site.

```rust
// before — bool argument, supplied by folding a Fact through a default
let models: Fact<ModelFiles> = ModelFiles::probe(config).into();
let fallback = probe_oneshot_fallback_at(
    Path::new(AUTH_BIN), Path::new(&config.storage.db_path),
    models.known().is_some_and(|m| m.all_present()),
);

// after — derive from the value, then lift; the signature takes &ModelFiles
let models = ModelFiles::probe(config);
let fallback = probe_oneshot_fallback_at(
    Path::new(AUTH_BIN), Path::new(&config.storage.db_path), &models,
);
// ... models: Fact::probed(models)
```

The collapse is now unrepresentable rather than merely unreachable: `models.known().is_some_and(..)` is a `bool` and no longer type-checks against `&ModelFiles`, and at the point `all_present()` is called there is no `Fact` in scope at all.

**On the test.** No value-level test can distinguish the two shapes — that is exactly what made the bug latent, since `ModelFiles::probe` cannot fail today. So `probe_derives_the_fallback_from_the_model_value_not_a_fact` is a source-level pin over `Health::probe`'s body (the idiom `resolved.rs` already uses twice), and it does fail on the old code: the old body contains `known()`, the new one does not. The signature carries the guarantee; the pin guards the call site. `fallback_is_usable_only_with_binary_models_and_database` was also widened to assert `models_present` directly.

## Rendered output

**Unchanged.** `healthy_report_renders_byte_exact` passes untouched, as does every other renderer test. Bug 1 changes only a tag that was never rendered; bug 2 was latent. No golden update was needed.

Both money pins pass **unmodified**: `commands::status::tests::unreachable_daemon_and_unknown_store_never_render_as_not_enrolled` and the out-of-process `tests/health_render.rs`.

## Gates

- `just check` — 245 cli lib tests + all workspace tiers, clippy `-D warnings`, fmt, audit, pam dependency guard: clean
- `just test-arch-pam` — **22 passed, 0 failed**
- `just test-arch-layout` — **21 passed, 0 failed**

No auth-semantics change, no D-Bus wire change, `is-enrolled` untouched.

Review finding: cross-cutting **C2** (four reviewers converged: more fact/provenance structure than consumers), plus REV-116 and REV-122 (findings 1 and 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
