### PR TITLE
refactor(auth): carry rejection class as a type, not as prose (review C4)

### DIFF
--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -265,6 +265,7 @@ impl<'a> Backend<'a> {
                     model_id: None,
                     label: None,
                     similarity: 0.0,
+                    face_detected: false,
                     failure_reason: None,
                 }),
                 AuthOutcome::Error { message, .. } => bail!("daemon error: {message}"),

--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -267,7 +267,7 @@ impl<'a> Backend<'a> {
                     similarity: 0.0,
                     failure_reason: None,
                 }),
-                AuthOutcome::Error { message } => bail!("daemon error: {message}"),
+                AuthOutcome::Error { message, .. } => bail!("daemon error: {message}"),
             },
             _ => direct::authenticate(self.config, user),
         }

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -11,7 +11,7 @@ use facelock_core::types::CameraCaps;
 use facelock_core::types::MatchResult;
 use facelock_daemon::audit::{self, AuditEntry, AuditSource};
 use facelock_daemon::auth;
-use facelock_daemon::auth::AuthOutcome;
+use facelock_daemon::auth::{AuthOutcome, ErrorKind};
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
@@ -113,8 +113,16 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         // password rather than registering a failed match (exit 1). The
         // suppressed / not-enrolled / rate-limited distinction is carried by
         // the audit record and the tracing output, not the exit code.
+        //
+        // `oneshot_exit_code` is the single table, so the recommendation to
+        // stop collapsing these classes has one place to land. It cannot
+        // change anything today: no pre-flight gate produces the one class
+        // that maps to 1 (the camera is not open yet).
         debug!(?resp, "pre-check short-circuit");
-        return 2;
+        return match resp {
+            AuthOutcome::Error { kind, .. } => oneshot_exit_code(kind),
+            _ => 2,
+        };
     }
 
     // Quirk override takes precedence over the config's warmup value.
@@ -215,19 +223,25 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             );
             1
         }
-        AuthOutcome::Error { message } if message.contains("all frames dark") => {
+        AuthOutcome::Error {
+            kind: ErrorKind::AllFramesDark,
+            ..
+        } => {
+            // `authenticate_inner` already audited this one, so unlike the
+            // arm below there is nothing to write here.
             info!(user = %user, "all frames dark");
-            1
+            oneshot_exit_code(ErrorKind::AllFramesDark)
         }
-        AuthOutcome::Error { message } => {
-            // Errors from authenticate() that aren't "all frames dark" are storage errors
-            // which happen before the auth loop — audit those here.
+        AuthOutcome::Error { kind, message } => {
+            // Errors from authenticate() other than all-frames-dark are
+            // storage errors which happen before the auth loop — audit those
+            // here, under the class's own label.
             audit::write_audit_entry(
                 &config.audit,
                 &AuditEntry {
                     timestamp: audit::now_iso8601(),
                     user: user.clone(),
-                    result: "error".into(),
+                    result: kind.audit_result().into(),
                     source: Some(AuditSource::Oneshot),
                     similarity: None,
                     frame_count: None,
@@ -238,7 +252,7 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
                 },
             );
             error!(user = %user, "auth error: {message}");
-            2
+            oneshot_exit_code(kind)
         }
         _ => {
             error!("unexpected response");
@@ -247,13 +261,124 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     }
 }
 
+/// The process exit code for a rejection of class `kind`.
+///
+/// The oneshot binary is spawned by the PAM module, which turns this number
+/// into a PAM code, so this table is auth policy — it used to be
+/// `message.contains("all frames dark")`, one reword away from changing it.
+///
+/// Exhaustive on purpose: a new class must be assigned a code here.
+///
+/// Today only the camera-produced class earns exit 1; every rejection reached
+/// before the camera collapses to 2 (PAM_IGNORE). That collapse is itself a
+/// defect — it softens a rate-limited rejection whenever the daemon is
+/// unavailable and PAM falls back to this path — but fixing it changes PAM
+/// semantics under `required`/`requisite` stacks and belongs in its own
+/// reviewed change. This function is where that fix will land.
+fn oneshot_exit_code(kind: ErrorKind) -> i32 {
+    match kind {
+        // The camera produced no usable image. Not an error the stack should
+        // ignore, and not a non-match either; exit 1 keeps PAM falling
+        // through to the password.
+        ErrorKind::AllFramesDark => 1,
+        ErrorKind::Disabled
+        | ErrorKind::SshSession
+        | ErrorKind::LidClosed
+        | ErrorKind::Storage
+        | ErrorKind::RateLimited
+        | ErrorKind::RateLimitCheckFailed
+        | ErrorKind::IrRequired
+        | ErrorKind::Internal => 2,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::oneshot_exit_code;
     use facelock_core::config::Config;
     use facelock_core::types::MatchResult;
     use facelock_daemon::audit::AuditSource;
-    use facelock_daemon::auth::AuthOutcome;
     use facelock_daemon::auth::pre_check_audited;
+    use facelock_daemon::auth::{AuthOutcome, ErrorKind};
+
+    /// The coupling, in one place.
+    ///
+    /// A rejection class has four consequences, and they used to be derived
+    /// from four independent substring matches on the same English sentence:
+    /// the text the user and the wire see, the audit log's `result` label, the
+    /// PAM return code, and this binary's exit code. Rewording a message
+    /// silently changed PAM policy, and no test spanned the four.
+    ///
+    /// This table is that test. The first three columns are asserted directly;
+    /// the fourth — PAM's code — is asserted where it can be: the two messages
+    /// PAM substring-matches are pinned byte-exactly here, in
+    /// `facelock-daemon`'s `frozen_protocol_strings_render_byte_exactly`, and
+    /// at the wire in `server_authz.rs`. `pam-facelock` cannot be linked here
+    /// (its dependency ceiling is libc/toml/serde/zbus), so its matcher is
+    /// pinned by those strings rather than by calling it.
+    ///
+    /// Changing a value here is changing auth policy. Do it deliberately.
+    #[test]
+    fn every_rejection_class_pins_its_message_audit_label_and_exit_code() {
+        // (class, rendered message with detail "boom", audit result, exit code)
+        let table: &[(ErrorKind, &str, &str, i32)] = &[
+            (ErrorKind::Disabled, "facelock is disabled", "error", 2),
+            (ErrorKind::SshSession, "SSH session detected", "error", 2),
+            (ErrorKind::LidClosed, "lid closed", "error", 2),
+            (ErrorKind::Storage, "storage error: boom", "error", 2),
+            // Frozen: PAM reads this one as a deliberate lockout
+            // (PAM_AUTH_ERR, no oneshot retry).
+            (ErrorKind::RateLimited, "rate limited", "rate_limited", 2),
+            (
+                ErrorKind::RateLimitCheckFailed,
+                "rate limit check failed: boom",
+                "error",
+                2,
+            ),
+            // Frozen: PAM reads this one as PAM_IGNORE.
+            (
+                ErrorKind::IrRequired,
+                "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).",
+                "error",
+                2,
+            ),
+            (ErrorKind::AllFramesDark, "all frames dark", "error", 1),
+            (ErrorKind::Internal, "boom", "error", 2),
+        ];
+
+        for (kind, message, audit_result, exit_code) in table {
+            assert_eq!(
+                &kind.render("boom"),
+                message,
+                "{kind:?}: wire/user message changed — PAM and docs/contracts.md read this"
+            );
+            assert_eq!(
+                kind.audit_result(),
+                *audit_result,
+                "{kind:?}: audit label changed — log consumers read this"
+            );
+            assert_eq!(
+                oneshot_exit_code(*kind),
+                *exit_code,
+                "{kind:?}: exit code changed — PAM maps this to a return code"
+            );
+        }
+
+        // A new class must be given a row, not silently inherit a neighbour's
+        // policy. `render`, `audit_result` and `oneshot_exit_code` are all
+        // exhaustive matches, so this is the only gap left to close.
+        assert_eq!(
+            table.len(),
+            ErrorKind::ALL.len(),
+            "every ErrorKind needs a row here"
+        );
+        for kind in ErrorKind::ALL {
+            assert!(
+                table.iter().any(|(k, ..)| k == kind),
+                "{kind:?} has no row in the coupling table"
+            );
+        }
+    }
     use facelock_daemon::rate_limit::RateLimiter;
     use facelock_store::FaceStore;
     use std::path::Path;
@@ -331,7 +456,7 @@ path = "{audit_path}"
         )
         .expect("rate-limited user must short-circuit");
         assert!(
-            matches!(resp, AuthOutcome::Error { ref message } if message.contains("rate limited")),
+            matches!(resp, AuthOutcome::Error { kind, .. } if kind == ErrorKind::RateLimited),
             "expected rate-limited error, got {resp:?}"
         );
 

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -150,7 +150,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
                 similarity: 0.0,
                 failure_reason: None,
             }),
-            AuthOutcome::Error { message } => bail!("{message}"),
+            AuthOutcome::Error { message, .. } => bail!("{message}"),
         };
     }
 
@@ -180,7 +180,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
 
     match response {
         AuthOutcome::AuthResult(result) => Ok(result),
-        AuthOutcome::Error { message } => bail!("{message}"),
+        AuthOutcome::Error { message, .. } => bail!("{message}"),
         AuthOutcome::Suppressed => bail!("unexpected auth response"),
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -148,6 +148,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
                 model_id: None,
                 label: None,
                 similarity: 0.0,
+                face_detected: false,
                 failure_reason: None,
             }),
             AuthOutcome::Error { message, .. } => bail!("{message}"),

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -233,9 +233,10 @@ pub fn test_authenticate(user: &str) -> anyhow::Result<AuthOutcome> {
 /// "Authenticate error encoding"): `model_id == -2` is a recoverable daemon
 /// error travelling as data (label carries the message, byte-identical —
 /// PAM string-matches "rate limited"), `-3` is the `suppress_unknown`
-/// short-circuit. Split from the transport so the sentinel decoding is
-/// testable without a bus, and so any future method replying with an
-/// `AuthResult` decodes it identically.
+/// short-circuit, `-4` is a no-match in which the detector did see a face.
+/// Split from the transport so the sentinel decoding is testable without a
+/// bus, and so any future method replying with an `AuthResult` decodes it
+/// identically.
 ///
 /// The wire has no field for the rejection's class, so `-2` is re-classified
 /// from its message here. [`ErrorKind::classify`] is the inverse of the
@@ -263,6 +264,7 @@ fn decode_auth_result(result: AuthResult) -> AuthOutcome {
             Some(result.label)
         },
         similarity: result.similarity as f32,
+        face_detected: result.matched || result.model_id == -4,
         // Not part of the D-Bus AuthResult contract; derived client-side
         // where needed (see test_cmd).
         failure_reason: None,

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -5,7 +5,7 @@ use zbus::blocking::Proxy;
 use facelock_core::dbus_interface::*;
 use facelock_core::ipc::{IpcDeviceInfo, PreviewFace};
 use facelock_core::types::{FaceModelInfo, MatchResult};
-use facelock_daemon::auth::AuthOutcome;
+use facelock_daemon::auth::{AuthOutcome, ErrorKind};
 
 /// Check if running as root; if not, offer to re-exec via sudo.
 ///
@@ -236,9 +236,14 @@ pub fn test_authenticate(user: &str) -> anyhow::Result<AuthOutcome> {
 /// short-circuit. Split from the transport so the sentinel decoding is
 /// testable without a bus, and so any future method replying with an
 /// `AuthResult` decodes it identically.
+///
+/// The wire has no field for the rejection's class, so `-2` is re-classified
+/// from its message here. [`ErrorKind::classify`] is the inverse of the
+/// daemon's renderer and the one place that match lives on this side.
 fn decode_auth_result(result: AuthResult) -> AuthOutcome {
     if !result.matched && result.model_id == -2 {
         return AuthOutcome::Error {
+            kind: ErrorKind::classify(&result.label),
             message: result.label,
         };
     }
@@ -494,7 +499,12 @@ mod tests {
     #[test]
     fn recoverable_error_sentinel_decodes_with_the_message_intact() {
         match decode_auth_result(reply(false, -2, "rate limited")) {
-            AuthOutcome::Error { message } => assert_eq!(message, "rate limited"),
+            AuthOutcome::Error { kind, message } => {
+                assert_eq!(message, "rate limited");
+                // ...and the class is recovered from it, so nothing
+                // downstream has to match the text again.
+                assert_eq!(kind, ErrorKind::RateLimited);
+            }
             other => panic!("expected a recoverable error, got {other:?}"),
         }
     }

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -321,6 +321,19 @@ pub struct MatchResult {
     pub model_id: Option<u32>,
     pub label: Option<String>,
     pub similarity: f32,
+    /// Whether the detector found a face at any point during the attempt.
+    ///
+    /// Carried explicitly because it cannot be inferred from `similarity`: the
+    /// score is redacted to `0.0` for every non-root D-Bus caller, which made
+    /// "a face was seen and did not match" indistinguishable from "the camera
+    /// saw nobody" for user-run lockers. Reaches the wire as the `model_id`
+    /// `-4` sentinel (docs/contracts.md).
+    ///
+    /// This is a *detector* signal, not a matcher signal — it says a face was
+    /// present, never how close it came to an enrolled template — so unlike
+    /// `similarity` it is not a hill-climbing oracle and is not redacted.
+    #[serde(default)]
+    pub face_detected: bool,
     /// Why the attempt failed despite matching frames (internal diagnostics;
     /// not part of the D-Bus wire contract).
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -293,6 +293,9 @@ pub fn pre_check_with_context(
             model_id: None,
             label: None,
             similarity: 0.0,
+            // No camera was opened on this path, so no face can have been
+            // seen — the gate rejected before any capture.
+            face_detected: false,
             failure_reason: None,
         }));
     }
@@ -520,6 +523,11 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     let mut variance_ever_passed = false;
     let mut dark_count: u32 = 0;
     let mut frame_count: u32 = 0;
+    // Whether the detector ever found a face during this attempt. Reported to
+    // clients so "we looked and nobody was there" is distinguishable from "we
+    // saw you and it wasn't a match" without reading the similarity score,
+    // which is redacted to 0.0 for non-root callers (review C4 / #108's N12).
+    let mut face_detected = false;
     let mut best_model_id: Option<u32> = None;
     let mut landmark_tracker = LandmarkTracker::new(
         10,
@@ -565,6 +573,9 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
             debug!(frame = frame_count, "no faces detected");
             continue;
         }
+        // Detection, not recognition: a face rejected below by the IR texture
+        // gate or by the compare set still means the camera saw somebody.
+        face_detected = true;
 
         // Push landmarks from the first detected face for liveness tracking
         if let Some((det, _)) = faces.first() {
@@ -692,6 +703,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                     model_id: best_model_id,
                     label: best_model_id.and_then(&label_for),
                     similarity: best_similarity,
+                    face_detected,
                     failure_reason: None,
                 });
                 // Zero sensitive data before returning
@@ -743,6 +755,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                 model_id: best_model_id,
                 label: best_model_id.and_then(&label_for),
                 similarity: best_similarity,
+                face_detected,
                 failure_reason: None,
             });
             zeroize_stored_embeddings(stored);
@@ -831,6 +844,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
         model_id: None,
         label: None,
         similarity: best_similarity,
+        face_detected,
         failure_reason,
     })
 }

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -19,13 +19,147 @@ use crate::audit::{self, AuditEntry, AuditSource};
 use crate::liveness::LandmarkTracker;
 use crate::rate_limit::RateLimiter;
 
+/// The class of a recoverable authentication rejection — the discriminant
+/// every consumer switches on.
+///
+/// It exists because the same English sentence used to be four things at
+/// once: the user-facing message, the audit `result` label, the PAM wire
+/// discriminant, and the oneshot exit-code selector. Four independent
+/// substring matchers read it, so rewording a message silently changed PAM
+/// policy and mislabelled the audit trail. The class now travels as a type
+/// and the prose is *rendered* from it at the boundary, never parsed back
+/// out of it.
+///
+/// [`ErrorKind::render`] is the single producer of that prose, and two of the
+/// strings it renders are **frozen protocol**: PAM substring-matches
+/// "rate limited" and "IR camera required" to pick `PAM_AUTH_ERR` vs
+/// `PAM_IGNORE` (`crates/pam-facelock/src/lib.rs`), and
+/// `tests/server_authz.rs` pins them byte-exactly. They are documented in
+/// docs/contracts.md. Change the rendering of any other class freely; changing
+/// those two is a protocol break.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorKind {
+    /// `security.disabled` is set.
+    Disabled,
+    /// `security.abort_if_ssh` and the caller is on an SSH session.
+    SshSession,
+    /// `security.abort_if_lid_closed` and the lid is closed.
+    LidClosed,
+    /// The face store could not be read. Carries the underlying error.
+    Storage,
+    /// The user has exhausted their face-auth budget. **Frozen wire string.**
+    RateLimited,
+    /// The rate-limit *check itself* failed (a storage fault, not a
+    /// rejection). Deliberately distinct from [`ErrorKind::RateLimited`]:
+    /// PAM must not read a broken limiter as a deliberate lockout. Carries
+    /// the underlying error.
+    RateLimitCheckFailed,
+    /// `security.require_ir` and the resolved device is not IR.
+    /// **Frozen wire string.**
+    IrRequired,
+    /// Every captured frame was below the darkness threshold — the camera
+    /// produced no usable image, which is not a non-match.
+    AllFramesDark,
+    /// A class this build does not name. Only [`ErrorKind::classify`]
+    /// produces it, for a message from a daemon of a different version.
+    /// Carries that message verbatim.
+    Internal,
+}
+
+impl ErrorKind {
+    /// Every variant, so a table-driven test cannot silently skip one.
+    pub const ALL: &'static [ErrorKind] = &[
+        ErrorKind::Disabled,
+        ErrorKind::SshSession,
+        ErrorKind::LidClosed,
+        ErrorKind::Storage,
+        ErrorKind::RateLimited,
+        ErrorKind::RateLimitCheckFailed,
+        ErrorKind::IrRequired,
+        ErrorKind::AllFramesDark,
+        ErrorKind::Internal,
+    ];
+
+    /// The exact user- and wire-facing text for this class.
+    ///
+    /// `detail` is the interpolated underlying error for the classes that
+    /// carry one ([`Storage`](ErrorKind::Storage),
+    /// [`RateLimitCheckFailed`](ErrorKind::RateLimitCheckFailed),
+    /// [`Internal`](ErrorKind::Internal)); the fixed-text classes ignore it.
+    /// This is the *only* place any of these sentences is written.
+    pub fn render(self, detail: &str) -> String {
+        match self {
+            ErrorKind::Disabled => "facelock is disabled".to_string(),
+            ErrorKind::SshSession => "SSH session detected".to_string(),
+            ErrorKind::LidClosed => "lid closed".to_string(),
+            ErrorKind::Storage => format!("storage error: {detail}"),
+            ErrorKind::RateLimited => "rate limited".to_string(),
+            ErrorKind::RateLimitCheckFailed => format!("rate limit check failed: {detail}"),
+            ErrorKind::IrRequired => "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).".to_string(),
+            ErrorKind::AllFramesDark => "all frames dark".to_string(),
+            ErrorKind::Internal => detail.to_string(),
+        }
+    }
+
+    /// The audit log's `result` field for this class. Was
+    /// `message.contains("rate limited")`.
+    ///
+    /// Exhaustive on purpose: a new class must be given a label here, not
+    /// silently fall into `"error"`.
+    pub fn audit_result(self) -> &'static str {
+        match self {
+            ErrorKind::RateLimited => "rate_limited",
+            ErrorKind::Disabled
+            | ErrorKind::SshSession
+            | ErrorKind::LidClosed
+            | ErrorKind::Storage
+            | ErrorKind::RateLimitCheckFailed
+            | ErrorKind::IrRequired
+            | ErrorKind::AllFramesDark
+            | ErrorKind::Internal => "error",
+        }
+    }
+
+    /// Recover the class from a message that crossed the D-Bus wire.
+    ///
+    /// The wire has no room for the discriminant (`AuthResult` carries only
+    /// `matched`/`model_id`/`label`/`similarity`, and its signature is
+    /// frozen), so the CLI's client rebuilds the class from the rendered
+    /// text. This is the inverse of [`ErrorKind::render`] and the *only*
+    /// remaining place a rejection message is matched as text on this side of
+    /// the wire — `daemon_error_classify_inverts_render` pins the round trip.
+    ///
+    /// Unrecognized text is [`ErrorKind::Internal`], which is what a message
+    /// from an older or newer daemon lands on.
+    pub fn classify(message: &str) -> ErrorKind {
+        for kind in ErrorKind::ALL {
+            match kind {
+                // Detail-carrying classes match on their rendered prefix.
+                ErrorKind::Storage | ErrorKind::RateLimitCheckFailed => {
+                    let prefix = kind.render("");
+                    if message.starts_with(&prefix) {
+                        return *kind;
+                    }
+                }
+                // `Internal` renders the detail verbatim, so it has no
+                // recognizable form; it is the fallback below.
+                ErrorKind::Internal => {}
+                _ => {
+                    if message == kind.render("") {
+                        return *kind;
+                    }
+                }
+            }
+        }
+        ErrorKind::Internal
+    }
+}
+
 /// The outcome of an authentication attempt or its pre-flight gates — the
 /// vocabulary every transport shares. The daemon handler maps it onto its
 /// wire response; the direct path (`facelock test`, oneshot `facelock auth`)
 /// and the D-Bus client consume it as-is, so the CLI never needs the
-/// handler's own request/response enums (D5). The `Error` messages are
-/// protocol-bearing: PAM string-matches "rate limited" and "IR camera
-/// required", so they must flow through every mapping byte-identical.
+/// handler's own request/response enums (D5).
 #[derive(Debug, Clone)]
 pub enum AuthOutcome {
     /// The comparison loop ran (or a gate produced a definitive non-match).
@@ -34,7 +168,27 @@ pub enum AuthOutcome {
     Suppressed,
     /// A recoverable error (rate limited, IR required, storage/camera
     /// failure) that must not read as "no match".
-    Error { message: String },
+    ///
+    /// `kind` is what consumers switch on. `message` is its rendering, kept
+    /// alongside because it is what crosses the D-Bus wire and what the user
+    /// sees; nothing on this side of the wire may re-derive `kind` from it.
+    Error { kind: ErrorKind, message: String },
+}
+
+impl AuthOutcome {
+    /// A rejection of a class whose message is fixed.
+    pub fn error(kind: ErrorKind) -> Self {
+        Self::error_with(kind, "")
+    }
+
+    /// A rejection of a class that interpolates an underlying error
+    /// ([`Storage`](ErrorKind::Storage),
+    /// [`RateLimitCheckFailed`](ErrorKind::RateLimitCheckFailed),
+    /// [`Internal`](ErrorKind::Internal)).
+    pub fn error_with(kind: ErrorKind, detail: impl std::fmt::Display) -> Self {
+        let message = kind.render(&detail.to_string());
+        Self::Error { kind, message }
+    }
 }
 
 /// Which of [`pre_check`]'s environment gates a caller may skip.
@@ -107,31 +261,23 @@ pub fn pre_check_with_context(
 ) -> Option<AuthOutcome> {
     if config.security.disabled {
         warn!(user, "facelock is disabled");
-        return Some(AuthOutcome::Error {
-            message: "facelock is disabled".into(),
-        });
+        return Some(AuthOutcome::error(ErrorKind::Disabled));
     }
 
     if !ctx.skip_ssh_gate && config.security.abort_if_ssh && is_ssh_session() {
         info!(user, "SSH session detected, aborting");
-        return Some(AuthOutcome::Error {
-            message: "SSH session detected".into(),
-        });
+        return Some(AuthOutcome::error(ErrorKind::SshSession));
     }
 
     if !ctx.skip_lid_gate && config.security.abort_if_lid_closed && is_lid_closed() {
         info!(user, "lid closed, aborting");
-        return Some(AuthOutcome::Error {
-            message: "lid closed".into(),
-        });
+        return Some(AuthOutcome::error(ErrorKind::LidClosed));
     }
 
     let has_models = match store.has_models(user) {
         Ok(v) => v,
         Err(e) => {
-            return Some(AuthOutcome::Error {
-                message: format!("storage error: {e}"),
-            });
+            return Some(AuthOutcome::error_with(ErrorKind::Storage, e));
         }
     };
     if !has_models {
@@ -155,23 +301,17 @@ pub fn pre_check_with_context(
         Ok(true) => {}
         Ok(false) => {
             warn!(user, "rate limited");
-            return Some(AuthOutcome::Error {
-                message: "rate limited".into(),
-            });
+            return Some(AuthOutcome::error(ErrorKind::RateLimited));
         }
         Err(e) => {
             warn!(user, error = %e, "rate limit check failed");
-            return Some(AuthOutcome::Error {
-                message: format!("rate limit check failed: {e}"),
-            });
+            return Some(AuthOutcome::error_with(ErrorKind::RateLimitCheckFailed, e));
         }
     }
 
     if config.security.require_ir && !caps.is_ir {
         warn!(user, "IR camera required but device is not IR");
-        return Some(AuthOutcome::Error {
-            message: "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).".into(),
-        });
+        return Some(AuthOutcome::error(ErrorKind::IrRequired));
     }
 
     None
@@ -213,10 +353,11 @@ pub fn pre_check_audited_with_context(
 ) -> Option<AuthOutcome> {
     let resp = pre_check_with_context(config, store, user, rate_limiter, caps, ctx)?;
     let (result, error) = match &resp {
-        AuthOutcome::Error { message } if message.contains("rate limited") => {
-            ("rate_limited".to_string(), Some(message.clone()))
+        // The label comes from the rejection's class, never from its prose
+        // (review C4): rewording a message must not relabel the audit trail.
+        AuthOutcome::Error { kind, message } => {
+            (kind.audit_result().to_string(), Some(message.clone()))
         }
-        AuthOutcome::Error { message } => ("error".to_string(), Some(message.clone())),
         AuthOutcome::AuthResult(mr) if !mr.matched => ("failure".to_string(), None),
         AuthOutcome::Suppressed => ("suppressed".to_string(), None),
         _ => ("error".to_string(), None),
@@ -646,13 +787,11 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                 duration_ms: Some(duration.as_millis() as u64),
                 device: config.device.path.clone(),
                 model_label: None,
-                error: Some("all frames dark".into()),
+                error: Some(ErrorKind::AllFramesDark.render("")),
             },
         );
         // No snapshot for all-dark: last_frame is None since dark frames are skipped
-        return AuthOutcome::Error {
-            message: "all frames dark".into(),
-        };
+        return AuthOutcome::error(ErrorKind::AllFramesDark);
     }
 
     info!(
@@ -709,6 +848,96 @@ fn is_lid_closed() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two strings PAM substring-matches to choose `PAM_AUTH_ERR` over
+    /// `PAM_IGNORE` are frozen protocol (docs/contracts.md). They now come out
+    /// of [`ErrorKind::render`]; this pins that they come out byte-identical.
+    /// `tests/server_authz.rs` pins them again where they reach the wire.
+    #[test]
+    fn frozen_protocol_strings_render_byte_exactly() {
+        assert_eq!(ErrorKind::RateLimited.render(""), "rate limited");
+        assert_eq!(
+            ErrorKind::IrRequired.render(""),
+            "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED)."
+        );
+    }
+
+    /// PAM's own predicates, replicated here because `pam-facelock` cannot
+    /// depend on this crate (its dependency ceiling is libc/toml/serde/zbus),
+    /// so nothing else can catch the two classifications drifting apart.
+    ///
+    /// The converse direction is the one that used to be invisible: if some
+    /// *other* class started containing PAM's needles, it would silently
+    /// inherit that class's PAM code.
+    #[test]
+    fn only_the_two_intended_classes_trip_pams_matchers() {
+        // Verbatim from `pam_code_for_daemon_error`.
+        let is_rate_limited = |m: &str| m.contains("rate_limit") || m.contains("rate limited");
+        let is_ir_required =
+            |m: &str| m.contains("IR camera required") || m.contains("ir_required");
+
+        assert!(is_rate_limited(&ErrorKind::RateLimited.render("")));
+        assert!(is_ir_required(&ErrorKind::IrRequired.render("")));
+
+        for kind in ErrorKind::ALL {
+            // `Internal` renders arbitrary text from elsewhere, so it cannot
+            // be constrained — it is the class for messages this build does
+            // not name.
+            if *kind == ErrorKind::Internal {
+                continue;
+            }
+            let message = kind.render("boom");
+            if *kind != ErrorKind::RateLimited {
+                assert!(
+                    !is_rate_limited(&message),
+                    "{kind:?} renders {message:?}, which PAM would read as a rate-limit lockout"
+                );
+            }
+            if *kind != ErrorKind::IrRequired {
+                assert!(
+                    !is_ir_required(&message),
+                    "{kind:?} renders {message:?}, which PAM would read as an IR rejection"
+                );
+            }
+        }
+    }
+
+    /// The D-Bus wire has no field for the class, so the CLI's client rebuilds
+    /// it from the rendered message. That reconstruction must be the exact
+    /// inverse of the rendering, or the one remaining text matcher reintroduces
+    /// the defect it replaced.
+    #[test]
+    fn classify_inverts_render() {
+        for kind in ErrorKind::ALL {
+            // `Internal` renders its detail verbatim and so has no
+            // recognizable form; it is what unrecognized text lands on.
+            if *kind == ErrorKind::Internal {
+                continue;
+            }
+            let message = kind.render("boom");
+            assert_eq!(
+                ErrorKind::classify(&message),
+                *kind,
+                "{kind:?} rendered {message:?}, which classified as something else"
+            );
+        }
+        assert_eq!(
+            ErrorKind::classify("a message from a daemon of another version"),
+            ErrorKind::Internal
+        );
+    }
+
+    /// A rate-limit *check* that fails is a storage fault, not a lockout.
+    /// PAM must not read it as a deliberate rejection, and the audit trail
+    /// must not label it one — the substring matcher this replaced got both
+    /// right only by accident of wording.
+    #[test]
+    fn a_failed_rate_limit_check_is_not_a_rate_limit_rejection() {
+        let broken = ErrorKind::RateLimitCheckFailed;
+        assert_ne!(broken.audit_result(), ErrorKind::RateLimited.audit_result());
+        assert_eq!(broken.audit_result(), "error");
+        assert!(!broken.render("disk gone").contains("rate limited"));
+    }
 
     /// `SSH_CONNECTION` is process-global state; `cargo test` runs this
     /// file's tests on multiple threads, and four of them now mutate it
@@ -862,7 +1091,7 @@ mod tests {
         }
 
         assert!(
-            matches!(resp, Some(AuthOutcome::Error { ref message }) if message.contains("SSH")),
+            matches!(resp, Some(AuthOutcome::Error { kind, .. }) if kind == ErrorKind::SshSession),
             "the default/enforced context must still reject an SSH session, got: {resp:?}"
         );
     }
@@ -892,7 +1121,7 @@ mod tests {
         }
 
         assert!(
-            matches!(resp, Some(AuthOutcome::Error { ref message }) if message.contains("SSH")),
+            matches!(resp, Some(AuthOutcome::Error { kind, .. }) if kind == ErrorKind::SshSession),
             "pre_check() must stay fully enforced, got: {resp:?}"
         );
     }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -139,7 +139,7 @@ impl From<AuthOutcome> for DaemonResponse {
         match outcome {
             AuthOutcome::AuthResult(result) => DaemonResponse::AuthResult(result),
             AuthOutcome::Suppressed => DaemonResponse::Suppressed,
-            AuthOutcome::Error { message } => DaemonResponse::Error { message },
+            AuthOutcome::Error { message, .. } => DaemonResponse::Error { message },
         }
     }
 }

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -375,6 +375,35 @@ fn recoverable_auth_error(message: String) -> AuthResult {
     }
 }
 
+/// `model_id` for an unmatched attempt in which the detector saw nobody (and
+/// for the pre-camera gates, which reject before a face could be seen).
+const NO_MATCH_NO_FACE: i32 = -1;
+
+/// `model_id` for an unmatched attempt in which the detector *did* see a face.
+///
+/// PAM needs this distinction to choose `PAM_AUTH_ERR` (we looked at you and
+/// said no) over `PAM_IGNORE` (we have no opinion), and it cannot read it off
+/// `similarity`, which is redacted to `0.0` for every non-root caller — so a
+/// hyprlock user's genuine no-match used to be indistinguishable from an empty
+/// frame (#108's N12, deferred to #109 and never carried).
+///
+/// A pre-`-4` PAM module decodes this as a plain no-match (its `match` falls
+/// through to the same arm as `-1`), so the sentinel is safe to emit at a
+/// daemon that is newer than the installed module.
+const NO_MATCH_FACE_SEEN: i32 = -4;
+
+/// The `model_id` field for a [`MatchResult`] on the wire.
+///
+/// A matched attempt carries the winning model's id; an unmatched one carries
+/// the sentinel that says whether a face was there at all.
+fn wire_model_id(result: &facelock_core::types::MatchResult) -> i32 {
+    match result.model_id {
+        Some(id) => id as i32,
+        None if result.face_detected && !result.matched => NO_MATCH_FACE_SEEN,
+        None => NO_MATCH_NO_FACE,
+    }
+}
+
 /// The `org.facelock.Daemon` service.
 ///
 /// Generic over the handler's camera and engine so integration tests can
@@ -564,7 +593,7 @@ where
 
                     Ok(AuthResult {
                         matched: result.matched,
-                        model_id: result.model_id.map(|id| id as i32).unwrap_or(-1),
+                        model_id: wire_model_id(&result),
                         label: result.label.unwrap_or_default(),
                         similarity: result.similarity as f64,
                     })
@@ -1357,6 +1386,7 @@ mod tests {
             model_id: matched.then_some(1),
             label: matched.then(|| "front".to_string()),
             similarity: 0.42,
+            face_detected: true,
             failure_reason: None,
         }
     }

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -5,9 +5,11 @@
 //!
 //! Covered here: the method-level entry points end to end minus zbus —
 //! per-method authorization (denials, the Authenticate self-scope, the
-//! root-only catch-all), the in-band `-2`/`-3` sentinel encoding with its
-//! byte-exact protocol strings, similarity redaction for non-root callers,
-//! and which entry point charges the rate limit (N11).
+//! root-only catch-all), the in-band `-2`/`-3`/`-4` sentinel encoding with its
+//! byte-exact protocol strings, similarity redaction for non-root callers
+//! (and the `-4` sentinel that keeps a redacted caller able to tell a
+//! face-seen non-match from an empty frame), and which entry point charges
+//! the rate limit (N11).
 //!
 //! NOT covered here, deliberately: the zbus wiring — caller-identity
 //! resolution from message headers (`GetConnectionUnixUser`), signal
@@ -368,6 +370,114 @@ async fn suppress_unknown_maps_to_the_minus_three_sentinel() {
     assert!(!result.matched);
     assert_eq!(result.model_id, -3, "suppressed sentinel");
     assert!(result.label.is_empty());
+}
+
+/// An embedding no fixture is near. The `known_embedding` family are all
+/// near-uniform unit vectors (cosine ≈ 1.0 to each other), so a genuine
+/// non-match needs a vector pointing elsewhere: cosine from this one to any
+/// of them is ≈ 1/√512 ≈ 0.044, far under the 0.45 test threshold.
+fn unrelated_embedding() -> facelock_core::types::FaceEmbedding {
+    let mut emb = [0.0f32; 512];
+    emb[0] = 1.0;
+    emb
+}
+
+/// A non-root caller must be able to tell "we saw you and it was not a match"
+/// from "the camera saw nobody" — the distinction PAM needs to choose
+/// `PAM_AUTH_ERR` over `PAM_IGNORE`.
+///
+/// It could not: PAM inferred "no face was seen" from `similarity == 0.0`,
+/// but the N12 redaction (PR #108) zeroes the score for *every* non-root
+/// caller, so for a user-run locker (hyprlock) both cases arrived identical
+/// and both abstained. #108 spotted this and deferred it to #109, which never
+/// carried it.
+///
+/// What this covers: the daemon's reply, through the real service and the
+/// real redaction, for the two cases as an unprivileged caller sees them.
+/// What it does not: PAM itself, which is a separate binary that cannot be
+/// linked here — `pam_code_for_no_match` in `pam-facelock` covers the
+/// decision this reply feeds.
+#[tokio::test]
+async fn a_redacted_caller_can_tell_a_seen_face_from_an_empty_frame() {
+    let store = FaceStore::open_memory().unwrap();
+    store
+        .add_model(
+            "alice",
+            "front",
+            &fixtures::known_embedding(1),
+            "test-embedder",
+        )
+        .unwrap();
+    let saw_someone = service(handler_with(
+        test_config(5, 1),
+        MockFaceEngine::one_face(unrelated_embedding()),
+        store,
+    ));
+
+    let seen = saw_someone.authenticate_as(alice(), "alice").await.unwrap();
+    assert!(!seen.matched, "an unrelated face must not authenticate");
+    assert_eq!(
+        seen.similarity, 0.0,
+        "the score is redacted for a non-root caller, which is why the \
+         sentinel has to carry the signal instead"
+    );
+    assert_eq!(
+        seen.model_id, -4,
+        "a face was detected and did not match: {seen:?}"
+    );
+
+    let empty_store = FaceStore::open_memory().unwrap();
+    empty_store
+        .add_model(
+            "alice",
+            "front",
+            &fixtures::known_embedding(1),
+            "test-embedder",
+        )
+        .unwrap();
+    let saw_nobody = service(handler_with(
+        test_config(5, 1),
+        MockFaceEngine::no_faces(),
+        empty_store,
+    ));
+
+    let unseen = saw_nobody.authenticate_as(alice(), "alice").await.unwrap();
+    assert!(!unseen.matched);
+    assert_eq!(unseen.similarity, 0.0);
+    assert_eq!(unseen.model_id, -1, "no face was detected: {unseen:?}");
+
+    // The point of the whole exercise: the two replies are no longer the same
+    // bytes to a caller who cannot see the score.
+    assert_ne!(
+        (seen.model_id, seen.similarity),
+        (unseen.model_id, unseen.similarity),
+        "a redacted caller must still be able to distinguish these"
+    );
+}
+
+/// The `-4` sentinel must not reach a caller who did match, and must not
+/// disturb the score a root caller is allowed to see.
+#[tokio::test]
+async fn a_match_still_reports_its_model_id_and_score_to_root() {
+    let emb = fixtures::known_embedding(1);
+    let store = FaceStore::open_memory().unwrap();
+    let model_id = store
+        .add_model("alice", "front", &emb, "test-embedder")
+        .unwrap();
+
+    let svc = service(handler_with(
+        test_config(5, 1),
+        MockFaceEngine::one_face(emb),
+        store,
+    ));
+
+    let result = svc.authenticate_as(root(), "alice").await.unwrap();
+    assert!(result.matched);
+    assert_eq!(result.model_id, model_id as i32);
+    assert!(
+        result.similarity > 0.45,
+        "root sees the real score: {result:?}"
+    );
 }
 
 /// REGRESSION PIN: a ROOT caller's failed `Authenticate` charges the

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -434,8 +434,12 @@ enum AuthResponse {
         #[allow(dead_code)]
         similarity: f32,
     },
-    /// Face not matched
+    /// Face not matched, and the daemon gave no face-seen signal — either it
+    /// saw nobody, or it predates the `-4` sentinel.
     NoMatch { similarity: f32 },
+    /// Face not matched, and the daemon explicitly reports that its detector
+    /// did see a face (`model_id == -4`).
+    NoMatchFaceSeen,
     /// No enrolled models and suppress_unknown is enabled.
     /// PAM should return PAM_AUTHINFO_UNAVAIL to let the stack try the next module.
     Suppressed,
@@ -494,6 +498,7 @@ fn classify_fdo_error(prefix: &str, err: &zbus::fdo::Error) -> String {
 /// - `-2`: recoverable daemon error, `label` carries the error message
 ///   (rate limited, IR required, camera/storage failure).
 /// - `-3`: suppressed (no enrolled models + `suppress_unknown`).
+/// - `-4`: no match, and the daemon's detector did see a face.
 fn parse_auth_reply(matched: bool, model_id: i32, label: String, similarity: f64) -> AuthResponse {
     if matched {
         return AuthResponse::Matched {
@@ -503,6 +508,7 @@ fn parse_auth_reply(matched: bool, model_id: i32, label: String, similarity: f64
     match model_id {
         -2 => AuthResponse::Error { message: label },
         -3 => AuthResponse::Suppressed,
+        -4 => AuthResponse::NoMatchFaceSeen,
         _ => AuthResponse::NoMatch {
             similarity: similarity as f32,
         },
@@ -873,6 +879,34 @@ fn pam_code_for_daemon_error(message: &str) -> (libc::c_int, &'static str) {
     }
 }
 
+/// Map an unmatched authentication onto a PAM return code.
+///
+/// `face_seen` is the daemon's explicit answer to "did the detector see
+/// anybody?", carried by the `model_id == -4` sentinel. Reading it off
+/// `similarity` instead is what this exists to stop: the score is redacted to
+/// `0.0` for every non-root caller, so for a user-run locker (hyprlock) a
+/// genuine face-seen non-match was indistinguishable from an empty frame and
+/// wrongly abstained (#108's N12, deferred to #109 and never carried).
+///
+/// `similarity` is only consulted when the reply carries no face-seen signal,
+/// which for a current daemon means no face was seen — the same answer. It is
+/// the fallback for a daemon older than the `-4` sentinel, where it reproduces
+/// the previous behavior exactly.
+///
+/// Never PAM_SUCCESS: an unmatched attempt either fails or abstains.
+fn pam_code_for_no_match(face_seen: bool, similarity: f32) -> libc::c_int {
+    if face_seen {
+        // The daemon looked at a face and said no. That is a decision, so
+        // fail rather than abstain.
+        return PAM_AUTH_ERR;
+    }
+    if similarity == 0.0 {
+        PAM_IGNORE
+    } else {
+        PAM_AUTH_ERR
+    }
+}
+
 fn identify(pamh: *mut libc::c_void) -> libc::c_int {
     // 0. Get PAM service name for logging
     let service = unsafe { pam_get_service(pamh) }.unwrap_or_else(|| "unknown".to_string());
@@ -961,13 +995,13 @@ fn identify(pamh: *mut libc::c_void) -> libc::c_int {
             }
             PAM_SUCCESS
         }
+        Ok(AuthResponse::NoMatchFaceSeen) => {
+            log_auth(&service, "no_match", &user, LOG_INFO);
+            pam_code_for_no_match(true, 0.0)
+        }
         Ok(AuthResponse::NoMatch { similarity }) => {
             log_auth(&service, "no_match", &user, LOG_INFO);
-            if similarity == 0.0 {
-                PAM_IGNORE
-            } else {
-                PAM_AUTH_ERR
-            }
+            pam_code_for_no_match(false, similarity)
         }
         Ok(AuthResponse::Suppressed) => {
             log_auth(&service, "suppressed (no enrolled models)", &user, LOG_INFO);
@@ -1322,6 +1356,66 @@ auth_bin = "/usr/local/bin/evil"
         match parse_auth_reply(false, -1, String::new(), 0.4) {
             AuthResponse::NoMatch { similarity } => assert!((similarity - 0.4).abs() < 1e-6),
             _ => panic!("expected NoMatch"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_reply_decodes_face_seen_no_match() {
+        assert!(matches!(
+            parse_auth_reply(false, -4, String::new(), 0.0),
+            AuthResponse::NoMatchFaceSeen
+        ));
+    }
+
+    /// The defect: a non-root caller's score is redacted to 0.0 by the daemon
+    /// (PR #108's N12), so "we saw a face and it did not match" and "the
+    /// camera saw nobody" arrived as the same reply and both abstained. A
+    /// user-run locker (hyprlock) is exactly that caller.
+    ///
+    /// Both replies below carry `similarity == 0.0`, as a redacted caller's
+    /// always do; only the sentinel separates them, and only the sentinel is
+    /// consulted.
+    #[test]
+    fn a_redacted_face_seen_no_match_is_not_read_as_an_empty_frame() {
+        let face_seen = parse_auth_reply(false, -4, String::new(), 0.0);
+        let no_face = parse_auth_reply(false, -1, String::new(), 0.0);
+
+        let code_for = |response: &AuthResponse| match response {
+            AuthResponse::NoMatchFaceSeen => pam_code_for_no_match(true, 0.0),
+            AuthResponse::NoMatch { similarity } => pam_code_for_no_match(false, *similarity),
+            _ => panic!("expected a non-match reply"),
+        };
+
+        assert_eq!(
+            code_for(&face_seen),
+            PAM_AUTH_ERR,
+            "the daemon looked at a face and said no — that is a decision"
+        );
+        assert_eq!(
+            code_for(&no_face),
+            PAM_IGNORE,
+            "the camera saw nobody — abstain"
+        );
+    }
+
+    /// The pre-`-4` fallback, which a daemon older than the sentinel still
+    /// exercises: `-1` plus an unredacted (root-caller) score reproduces the
+    /// previous behavior exactly, so an upgrade window cannot change any
+    /// existing decision.
+    #[test]
+    fn no_match_without_a_face_seen_signal_falls_back_to_the_score() {
+        assert_eq!(pam_code_for_no_match(false, 0.0), PAM_IGNORE);
+        assert_eq!(pam_code_for_no_match(false, 0.31), PAM_AUTH_ERR);
+    }
+
+    #[test]
+    fn no_match_never_maps_to_success() {
+        for (face_seen, similarity) in [(true, 0.0), (true, 0.9), (false, 0.0), (false, 0.42)] {
+            assert_ne!(
+                pam_code_for_no_match(face_seen, similarity),
+                PAM_SUCCESS,
+                "fail-open for face_seen={face_seen} similarity={similarity}"
+            );
         }
     }
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -492,6 +492,30 @@ daemon is unavailable". D-Bus errors remain for authorization failures,
 daemon-busy, and transport problems. In particular, a rate-limited state is a
 daemon decision and must never make the PAM client retry via a root oneshot.
 
+### Rejection classes (`AuthOutcome::Error`)
+
+The class of a rejection is carried as a type
+(`facelock_daemon::auth::ErrorKind`), not inferred from its message. The audit
+`result` label, the oneshot exit code, and the message itself all derive from
+it; `ErrorKind::render` is the only place any of these sentences is written.
+The wire has no field for the class, so the CLI's D-Bus client reconstructs it
+with `ErrorKind::classify`, the exact inverse of `render`.
+
+Two rendered messages are **frozen protocol** because the PAM module
+substring-matches them to choose its return code, and it cannot link the daemon
+crate to share the type (its dependency ceiling is libc/toml/serde/zbus):
+
+| Substring PAM matches | Class | PAM code |
+|---|---|---|
+| `rate limited` | `RateLimited` | `PAM_AUTH_ERR` |
+| `IR camera required` | `IrRequired` | `PAM_IGNORE` |
+
+Changing either string is a protocol break. They are pinned byte-exactly in
+`crates/facelock-daemon/src/auth.rs` (renderer) and
+`crates/facelock-daemon/tests/server_authz.rs` (wire), and every class's
+message, audit label and exit code are pinned together in
+`crates/facelock-cli/src/commands/auth.rs`.
+
 ### Daemon peer verification (PAM client)
 
 Before trusting an `Authenticate` reply, the PAM module resolves the owner of

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -482,15 +482,29 @@ Sentinel `model_id` values (only meaningful with `matched == false`):
 | model_id | Meaning |
 |----------|---------|
 | >= 0 | Matched model id (with `matched == true`) |
-| -1 | No match / no enrolled faces |
+| -1 | No match, and no face was detected (also: no enrolled faces, and the pre-camera gates) |
 | -2 | Recoverable daemon error; `label` carries the error message (rate limited, IR required, camera/storage failure) |
 | -3 | Suppressed: no enrolled models and `security.suppress_unknown = true` |
+| -4 | No match, and the detector **did** see a face |
 
 Recoverable errors travel **in-band** (model_id `-2`), not as D-Bus errors, so
 clients can distinguish "the daemon decided auth cannot proceed" from "the
 daemon is unavailable". D-Bus errors remain for authorization failures,
 daemon-busy, and transport problems. In particular, a rate-limited state is a
 daemon decision and must never make the PAM client retry via a root oneshot.
+
+`-4` exists because `similarity` cannot carry "was a face seen?": the score is
+redacted to `0.0` for every non-root caller, so a user-run locker (hyprlock)
+could not tell a genuine face-seen non-match from an empty frame and abstained
+(`PAM_IGNORE`) for both. It is a *detector* signal — a face was present, never
+how close it came to an enrolled template — so unlike `similarity` it is not a
+hill-climbing oracle and is not redacted.
+
+A PAM module older than `-4` decodes it as an ordinary non-match (its sentinel
+match falls through to the same arm as `-1`), so a daemon newer than the
+installed module degrades to the previous behavior rather than breaking. In the
+other direction, a `-1` reply carries no face-seen signal at all, and the module
+falls back to the score test it used before.
 
 ### Rejection classes (`AuthOutcome::Error`)
 
@@ -529,7 +543,8 @@ the module falls through (oneshot fallback / password), never `PAM_SUCCESS`.
 | Outcome | PAM Code |
 |---------|----------|
 | Face matched | `PAM_SUCCESS` (0) |
-| No match | `PAM_AUTH_ERR` (7) |
+| No match, face seen (model_id -4) | `PAM_AUTH_ERR` (7) |
+| No match, no face seen (model_id -1) | `PAM_IGNORE` (25) |
 | Rate limited (daemon, model_id -2) | `PAM_AUTH_ERR` (7) — no oneshot fallback |
 | IR required / internal daemon error (model_id -2) | `PAM_IGNORE` (25) — no oneshot fallback |
 | Suppressed (model_id -3) | `PAM_AUTHINFO_UNAVAIL` (9) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -495,6 +495,14 @@ PAM still matches the message because it cannot link the daemon crate, so the
 two strings it matches (`rate limited`, `IR camera required`) are frozen
 protocol — see docs/contracts.md, "Rejection classes".
 
+A non-match reply also states explicitly whether a face was detected
+(`model_id == -4`). PAM used to infer that from `similarity == 0.0`, which is
+wrong for any non-root caller because the score is redacted to `0.0` for all of
+them; a user-run locker therefore abstained on genuine non-matches. The
+face-detected bit is a detector signal, not a matcher signal — it says a face
+was present, never how close it came — so it is not a hill-climbing oracle and
+is not redacted.
+
 #### A4. Auth-Attempt Signal Hygiene (Implemented)
 
 **Attack**: Any local user adds a match rule (or runs `dbus-monitor`) and passively observes `AuthAttempted` broadcast signals to learn who authenticates when — and, if the payload carried the raw similarity score, uses it as a spoof-tuning oracle (iterate on a photo/mask until the score climbs).

--- a/docs/security.md
+++ b/docs/security.md
@@ -488,6 +488,13 @@ budget exhausted, password modules still run), everything else to
 `PAM_IGNORE`. D-Bus errors remain reserved for authorization failures and
 transport-level problems, which do fall back to the oneshot path.
 
+Daemon-side, the rejection's *class* is a type
+(`facelock_daemon::auth::ErrorKind`) and the message is rendered from it; the
+audit label and the oneshot exit code derive from the class, not from the text.
+PAM still matches the message because it cannot link the daemon crate, so the
+two strings it matches (`rate limited`, `IR camera required`) are frozen
+protocol — see docs/contracts.md, "Rejection classes".
+
 #### A4. Auth-Attempt Signal Hygiene (Implemented)
 
 **Attack**: Any local user adds a match rule (or runs `dbus-monitor`) and passively observes `AuthAttempted` broadcast signals to learn who authenticates when — and, if the payload carried the raw similarity score, uses it as a spoof-tuning oracle (iterate on a photo/mask until the score climbs).


### PR DESCRIPTION
Two defects that share one disease: a value that should have been a type was
carried as English prose, and four independent matchers read it.

## Defect 1 — the rejection class was free text

A recoverable rejection has four consequences. All four were derived by
substring-matching the same sentence:

| Consequence | Before | After |
|---|---|---|
| Audit `result` label | `message.contains("rate limited")` — `facelock-daemon/src/auth.rs:216` | `kind.audit_result()` — `auth.rs:341` |
| Oneshot exit code | `message.contains("all frames dark")` — `facelock-cli/src/commands/auth.rs:218` | `oneshot_exit_code(kind)` — `commands/auth.rs:226,286` |
| CLI wire decode | `AuthOutcome::Error { message: label }`, class lost — `facelock-cli/src/ipc_client.rs:241` | `ErrorKind::classify(&label)` — `ipc_client.rs:249` |
| PAM return code | `message.contains("rate limited")` / `"IR camera required"` — `pam-facelock/src/lib.rs:865-873` | **unchanged, deliberately** |

Rewording a message changed PAM policy and mislabelled the audit trail,
silently, with no test spanning the four. `AuthOutcome`'s own doc comment
admitted the strings were "protocol-bearing" — a comment doing a type's job.

`AuthOutcome::Error` now carries `{ kind: ErrorKind, message: String }`, and
`ErrorKind::render` is the only place any of these sentences is written.

### The class set, and who produces each

Derived from the actual producers, not invented:

| Class | Producer |
|---|---|
| `Disabled` | `pre_check_with_context`, `security.disabled` |
| `SshSession` | `pre_check_with_context`, `abort_if_ssh` |
| `LidClosed` | `pre_check_with_context`, `abort_if_lid_closed` |
| `Storage` | `pre_check_with_context`, `store.has_models` failure |
| `RateLimited` | `pre_check_with_context`, budget exhausted |
| `RateLimitCheckFailed` | `pre_check_with_context`, the limiter itself errored |
| `IrRequired` | `pre_check_with_context`, `require_ir` vs non-IR device |
| `AllFramesDark` | `authenticate_inner`, every frame below the dark threshold |
| `Internal` | `ErrorKind::classify` only — a message from a daemon of another version |

Two things the brief listed are deliberately absent. `NotEnrolled` is not an
`Error` at all: it is `AuthResult { matched: false }` or `Suppressed`, so
giving it a class would have invented a producer. And `RateLimitCheckFailed`
is split out from `RateLimited` because a limiter that failed to answer is a
storage fault, not a lockout — the old substring matcher got that right only
by accident of wording (`"rate limit check failed: …"` happens to contain
neither `"rate limited"` nor `"rate_limit"`). It is now right by construction.

### The frozen strings are byte-identical

PAM's matcher is untouched, so the daemon must keep producing the exact bytes
it matches. Evidence:

- `frozen_protocol_strings_render_byte_exactly` (`facelock-daemon/src/auth.rs`)
  asserts `render` returns `"rate limited"` and the full `"IR camera required
  for authentication. Set security.require_ir = false to override (NOT
  RECOMMENDED)."` verbatim.
- `only_the_two_intended_classes_trip_pams_matchers` replicates PAM's two
  predicates and asserts the converse — that **no other** class trips them.
  This is the direction that was previously invisible; `pam-facelock` cannot
  link `facelock-daemon` (dependency ceiling: libc/toml/serde/zbus), so
  nothing else can catch the two classifications drifting apart.
- The pre-existing wire pins in `tests/server_authz.rs`
  (`rate_limited_flows_in_band_with_the_exact_protocol_string`,
  `require_ir_flows_in_band_with_the_exact_protocol_string`) still pass
  unmodified — I did not touch them, and they assert `result.label ==
  "rate limited"` at the D-Bus boundary.
- Mutation check: rewording `RateLimited` to `"too many attempts"` fails
  `every_rejection_class_pins_its_message_audit_label_and_exit_code` and
  `recoverable_error_sentinel_decodes_with_the_message_intact`.

`ErrorKind::classify` is the inverse of `render`, pinned round-trip by
`classify_inverts_render`. It is now the only text match on the daemon/CLI
side of the wire.

## Defect 2 — the redaction sentinel aliased PAM's "was a face seen?" signal

PAM chose `PAM_IGNORE` vs `PAM_AUTH_ERR` on a non-match by testing
`similarity == 0.0`, reading a zero score as "the camera saw nobody". But
#108's N12 redaction zeroes the score for **every** non-root caller, so for a
user-run locker (hyprlock) a genuine face-seen non-match was byte-identical to
an empty frame and wrongly abstained. #108 spotted this and deferred it to
#109; #109 never carried it. It cannot grant access — a match drives success
independently and both branches degrade — so this is a correctness and
telemetry defect, not a bypass.

### Sentinel design

`MatchResult::face_detected` records whether the detector ever found a face,
set in `authenticate_inner` right after the `faces.is_empty()` check —
detection, not recognition, so a face rejected by the IR texture gate or
dropped by device coupling still counts as seen. It reaches the wire as
`model_id == -4` via `wire_model_id`, using the sentinel space the protocol
already documents rather than a struct field, so **the D-Bus signature is
unchanged**.

What `model_id` carried before, verified rather than assumed: every non-match
sent `-1` unconditionally (`result.model_id.map(…).unwrap_or(-1)`), and the
face-seen information existed only in `similarity`. `-1`, `-2` and `-3` keep
their exact meanings; `-4` is purely additive. Documented in
`docs/contracts.md`.

Both skew directions are byte-compatible, which is why this shape was chosen
over redefining `-1`:

- **new daemon, old PAM**: `-4` falls through that module's sentinel `match`
  to the same arm as `-1` → today's behavior exactly.
- **old daemon, new PAM**: `-1` carries no face-seen signal and the module
  falls back to the score test it used before → today's behavior exactly.

Only new/new changes, and only to become correct. The realistic window — a
package upgrade whose daemon has not restarted — is the second case.

`face_detected` is a *detector* signal, not a matcher signal: it says a face
was present, never how close it came to an enrolled template. It is therefore
not a hill-climbing oracle, which is why it is not redacted while `similarity`
is.

### The pam-facelock diff, line by line

Four hunks, no new dependencies (the crate-count guard still reports 57):

1. `enum AuthResponse` — adds `NoMatchFaceSeen` (no fields). Needed because
   the decoded reply must be able to represent the new sentinel; adding a
   field to `NoMatch` instead would have touched every existing arm.
2. `parse_auth_reply` — adds `-4 => AuthResponse::NoMatchFaceSeen`. One arm,
   above the existing `_` fallback, so every other sentinel decodes unchanged.
3. `pam_code_for_no_match(face_seen, similarity)` — new. The decision that was
   inline in `identify()`. Extracted, not rewritten: the `similarity == 0.0`
   branch is verbatim, now reachable only when the reply carries no face-seen
   signal. Extracted so the fix is testable at all — `identify()` needs a live
   `pamh`. It is a sibling of the existing `pam_code_for_daemon_error`, which
   exists for exactly this reason, so this follows the file's own pattern.
4. `identify()` — the two `NoMatch` arms now call it. Behavior for
   `NoMatch { similarity }` is unchanged.

Every other PAM behavior is identical: `pam_code_for_daemon_error` and its
frozen matcher, the oneshot fallback, peer verification, timeouts, logging.

## Tests

- `every_rejection_class_pins_its_message_audit_label_and_exit_code`
  (`facelock-cli/src/commands/auth.rs`) — **the coupling test**. One table:
  every class × (exact wire message, audit label, oneshot exit code), plus an
  assertion that every `ErrorKind::ALL` variant has a row. `render`,
  `audit_result` and `oneshot_exit_code` are all exhaustive matches, so a new
  class cannot silently inherit a neighbour's policy.
- `frozen_protocol_strings_render_byte_exactly` and
  `only_the_two_intended_classes_trip_pams_matchers` — the frozen-string pins
  in both directions.
- `classify_inverts_render` — the wire decode is the exact inverse of the
  renderer.
- `a_failed_rate_limit_check_is_not_a_rate_limit_rejection` — pins the split.
- `a_redacted_caller_can_tell_a_seen_face_from_an_empty_frame`
  (`tests/server_authz.rs`) — defect 2 through the real service and the real
  redaction: a non-root caller's face-seen non-match returns `(-4, 0.0)`, an
  empty-frame non-match returns `(-1, 0.0)`, and the two replies differ.
  **Covers**: the daemon's reply as an unprivileged caller actually sees it,
  including redaction. **Does not cover**: PAM itself, a separate binary that
  cannot be linked into this test.
- `a_redacted_face_seen_no_match_is_not_read_as_an_empty_frame`
  (`pam-facelock`) — the other half: both replies carry `similarity == 0.0`,
  as a redacted caller's always do, and only the sentinel separates them.
  Plus `no_match_without_a_face_seen_signal_falls_back_to_the_score` (the
  old-daemon window) and `no_match_never_maps_to_success`.
- `a_match_still_reports_its_model_id_and_score_to_root` — the `-4` sentinel
  does not leak into a matched reply.

Both fixes were mutation-checked: removing the `-4` arm makes the daemon test
fail with `model_id: -1, similarity: 0.0` — literally the aliased reply.

## Recommendation NOT implemented here

The oneshot path collapses **every** pre-flight rejection to exit 2 →
`PAM_IGNORE`, while the daemon path distinguishes rate-limited
(`PAM_AUTH_ERR`) and suppressed (`PAM_AUTHINFO_UNAVAIL`). So whenever the
daemon is unavailable and PAM falls back to the oneshot, rate-limiting's PAM
consequence silently softens — under `required`/`requisite` stacks that is a
real semantic difference. This PR does not change it: it changes PAM
semantics and deserves its own reviewed change.

`ErrorKind` makes it a one-table edit. `oneshot_exit_code` is already the
single place both call sites consult (I routed the pre-flight short-circuit
through it here, which changes nothing today because no pre-flight gate can
produce `AllFramesDark`). Codes I would reserve:

| Exit | Meaning | Classes | PAM maps to |
|---|---|---|---|
| 0 | matched | — | `PAM_SUCCESS` |
| 1 | no match / no usable image | `AllFramesDark` | `PAM_AUTH_ERR` |
| 2 | error, no opinion | `Disabled`, `SshSession`, `LidClosed`, `IrRequired`, `Storage`, `RateLimitCheckFailed`, `Internal` | `PAM_IGNORE` |
| 3 | **rate limited** | `RateLimited` | `PAM_AUTH_ERR`, no retry |
| 4 | **suppressed** | `AuthOutcome::Suppressed` | `PAM_AUTHINFO_UNAVAIL` |

Size: ~15 lines in `oneshot_exit_code` plus the `Suppressed` arm, ~20 in
`run_oneshot_auth`'s exit-code mapping in `pam-facelock`, one row per code in
the `docs/contracts.md` PAM table, and a container test per new code. The risk
is entirely in the PAM half — 3 and 4 must not reach a module that reads them
as "no match".

## Constraints honored

No auth-decision change. No D-Bus method signature change. `is-enrolled`
untouched. `AuditSource` semantics untouched. `just check` (clippy
`-D warnings` on facelock-cli's lib target) passes.

## Gates

- `just check` — pass (clippy `-D warnings`, fmt, audit: 2 pre-existing
  allowed yanked-crate warnings, pam dependency guard: **57 crates**,
  unchanged)
- `just test-arch-pam` — **22 passed, 0 failed**
- `just test-arch-layout` — **21 passed, 0 failed**

Review finding: REV-109 / REV-108 / REV-BP (C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
