### PR TITLE
polish(camera,docs): quirk precedence, matchable patterns, honest caps (review polish P1)

### DIFF
--- a/book/src/security.md
+++ b/book/src/security.md
@@ -112,7 +112,7 @@ For high-security deployments, embeddings can be encrypted with AES-256-GCM usin
 
 The D-Bus system bus policy (`/usr/share/dbus-1/system.d/org.facelock.Daemon.conf`) restricts which users and groups can own the bus name and invoke methods. Only root and members of the `facelock` group are granted access. (`/etc/dbus-1/system.d/` is the admin-override location for local customization.)
 
-Beyond bus-level access, the daemon enforces per-method UID authorization. Before executing any method, the daemon calls `GetConnectionUnixUser` to verify the caller's UID. `Authenticate` allows the caller's own UID. `Enroll` and `Shutdown` are restricted to root (UID 0) only. This prevents a `facelock` group member from enrolling faces or shutting down the daemon without root privileges.
+Beyond bus-level access, the daemon enforces per-method UID authorization. Before executing any method, the daemon calls `GetConnectionUnixUser` to verify the caller's UID. `Authenticate` allows the caller's own UID — a user must be able to request authentication for themselves, since screen lockers run their PAM stack as that user. Every other method, including `Enroll`, `Shutdown`, and the preview methods, is restricted to root (UID 0). This prevents a `facelock` group member from enrolling faces, pulling camera frames, or shutting down the daemon without root privileges.
 
 #### B. D-Bus Message Size Limits (Required)
 

--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -9,6 +9,12 @@
 #   name_pattern            - glob-like pattern matched against the WHOLE device
 #                             name (fallback). NOT regex: only (?i) and .* are
 #                             supported, and the pattern is anchored (#99).
+#                             Because the matcher has no alternation, a token
+#                             that can appear either at the start of a card
+#                             string or in the middle of one needs TWO entries:
+#                             a start-anchored form and a `.* `-prefixed,
+#                             space-bounded form. That is why the name entries
+#                             below come in pairs.
 #   force_ir                - treat this device as an IR camera regardless of format detection
 #   emitter_xu_guid         - UVC Extension Unit GUID for IR emitter control
 #   emitter_xu_selector     - UVC XU control selector for emitter toggle
@@ -45,18 +51,24 @@ notes = "Intel RealSense D455 IR module"
 
 # --- Lenovo ThinkPad IR cameras ---
 
-# Anchored (#99): name_pattern now matches the WHOLE device name, not a
-# substring of it, so this requires the name to literally START with
-# "IR Camera" (a trailing wildcard still allows a model-number suffix, e.g.
-# "IR Camera 5MP"). It intentionally does NOT match names where "IR Camera"
-# isn't the leading text (e.g. "Integrated IR Camera") — add a corrected,
-# still-anchored pattern for your exact device string (see `facelock
-# list-devices`) rather than reintroducing a bare leading wildcard here.
+# Anchored (#99): name_pattern matches the WHOLE device name, not a substring
+# of it. The first entry covers card strings that literally START with "IR
+# Camera" (a trailing wildcard still allows a model-number suffix, e.g. "IR
+# Camera 5MP"); the second covers the far more common ThinkPad spelling, where
+# "IR Camera" sits mid-string ("Integrated IR Camera"). The leading `.* ` is
+# space-bounded, so it still rejects a name that merely CONTAINS the letters
+# "ir" ("Sirius Camera", "AIR-Cam") — a bare leading `.*` would not.
 [[quirk]]
 name_pattern = "(?i)ir camera.*"
 force_ir = true
 warmup_frames = 8
 notes = "ThinkPad integrated IR camera (various models)"
+
+[[quirk]]
+name_pattern = "(?i).* ir camera.*"
+force_ir = true
+warmup_frames = 8
+notes = "ThinkPad integrated IR camera, vendor-prefixed name (various models)"
 
 # --- Logitech BRIO ---
 
@@ -74,16 +86,22 @@ notes = "Logitech BRIO 4K with IR sensor"
 
 # --- Microsoft Surface cameras ---
 
-# Anchored (#99): requires the name to START with "surface", then a
-# word-bounded " ir" later (the literal leading space stops an unrelated
-# word ending in "...ir", e.g. "Air", from matching). Does NOT match names
-# where "Microsoft" precedes "Surface" — add a corrected pattern for your
-# exact device string if needed.
+# Anchored (#99): each entry requires a word-bounded " ir" later in the name
+# (the literal leading space stops an unrelated word ending in "...ir", e.g.
+# "Air", from matching). The first requires the name to START with "surface";
+# the second admits a vendor word before it, which is how Surface parts
+# normally enumerate ("Microsoft Surface ... IR ...").
 [[quirk]]
 name_pattern = "(?i)surface.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "Microsoft Surface IR camera"
+
+[[quirk]]
+name_pattern = "(?i).* surface.* ir.*"
+force_ir = true
+warmup_frames = 8
+notes = "Microsoft Surface IR camera, vendor-prefixed name"
 
 [[quirk]]
 vendor_id = "045e"
@@ -95,12 +113,20 @@ notes = "Microsoft Surface Pro IR camera"
 # --- HP IR cameras ---
 
 # Anchored (#99): see the ThinkPad/Surface entries above for the pattern
-# rationale (start-anchored vendor prefix + word-bounded " ir").
+# rationale (vendor token + word-bounded " ir", in both a start-anchored and
+# a space-bounded mid-name form — OEM cameras are often enumerated by their
+# module maker, e.g. "Chicony HP IR Camera").
 [[quirk]]
 name_pattern = "(?i)hp.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "HP IR camera (various models)"
+
+[[quirk]]
+name_pattern = "(?i).* hp.* ir.*"
+force_ir = true
+warmup_frames = 8
+notes = "HP IR camera, vendor-prefixed name (various models)"
 
 # --- Dell IR cameras ---
 
@@ -109,3 +135,9 @@ name_pattern = "(?i)dell.* ir.*"
 force_ir = true
 warmup_frames = 8
 notes = "Dell IR camera (various models)"
+
+[[quirk]]
+name_pattern = "(?i).* dell.* ir.*"
+force_ir = true
+warmup_frames = 8
+notes = "Dell IR camera, vendor-prefixed name (various models)"

--- a/crates/facelock-camera/src/caps.rs
+++ b/crates/facelock-camera/src/caps.rs
@@ -13,7 +13,6 @@ use facelock_core::types::CameraCaps;
 
 use crate::capture::Camera;
 use crate::device::{self, DeviceInfo};
-use crate::ir_emitter::EmitterXuInfo;
 use crate::quirks::{Quirk, QuirksDb, device_fingerprint};
 
 /// A resolved-but-not-yet-opened camera device: its identity, its matched
@@ -37,7 +36,9 @@ impl ResolvedCamera {
     pub fn resolve(config: &DeviceConfig, quirks: &QuirksDb) -> Result<Self> {
         let info = match config.path.as_deref() {
             Some(path) => device::validate_device(path)?,
-            None => device::auto_detect_device()?,
+            // The caller's DB, not a second `QuirksDb::load()`: the quirk set
+            // that picks the device must be the one that then classifies it.
+            None => device::auto_detect_device_with(quirks)?,
         };
         Ok(Self::interrogate(info, quirks))
     }
@@ -48,15 +49,15 @@ impl ResolvedCamera {
     ///   (`ir_source_resolved`, #98): queried mono-only formats or a
     ///   corroborated quirk — never the free-text device name.
     /// - `fingerprint` reads sysfs identity; all-`None` when unreadable.
-    /// - `has_emitter` and `applied_quirks` reflect the quirks match.
+    /// - `applied_quirks` reflects the quirks match.
+    ///
+    /// The device's enumerated formats are deliberately NOT copied onto the
+    /// caps: they already live on `info`, which every holder of a
+    /// `ResolvedCamera` has.
     pub fn interrogate(info: DeviceInfo, quirks: &QuirksDb) -> Self {
         let quirk = quirks.find_match(&info).cloned();
         let caps = CameraCaps {
             is_ir: device::is_ir_camera_resolved(&info, Some(quirks)),
-            has_emitter: quirk
-                .as_ref()
-                .is_some_and(|q| EmitterXuInfo::from_quirk(q).is_some()),
-            formats: info.formats.clone(),
             fingerprint: device_fingerprint(&info.path),
             applied_quirks: quirk.as_ref().map(quirk_id).into_iter().collect(),
         };
@@ -90,6 +91,7 @@ pub fn quirk_id(quirk: &Quirk) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir_emitter::EmitterXuInfo;
     use facelock_core::types::{DeviceFingerprint, FormatInfo};
 
     fn device_with(name: &str, fourccs: &[&str]) -> DeviceInfo {
@@ -133,9 +135,9 @@ mod tests {
             ResolvedCamera::interrogate(device_with("USB Camera", &["GREY"]), &QuirksDb::default());
         assert!(resolved.caps.is_ir);
         assert!(resolved.caps.applied_quirks.is_empty());
-        assert!(!resolved.caps.has_emitter);
-        assert_eq!(resolved.caps.formats.len(), 1);
-        assert_eq!(resolved.caps.formats[0].fourcc, "GREY");
+        // The enumerated formats stay on `info`; the caps do not copy them.
+        assert_eq!(resolved.info.formats.len(), 1);
+        assert_eq!(resolved.info.formats[0].fourcc, "GREY");
         // Fake path → no sysfs identity → all-None fingerprint, not an error.
         assert_eq!(resolved.caps.fingerprint, DeviceFingerprint::default());
     }
@@ -153,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn matched_quirk_populates_applied_quirks_and_emitter() {
+    fn matched_quirk_populates_applied_quirks() {
         let mut db = QuirksDb::default();
         let mut q = quirk("(?i)test.*module");
         q.emitter_xu_guid = Some("04".into());
@@ -162,15 +164,15 @@ mod tests {
         db.push_quirk_for_test(q);
 
         // GREY-only: the quirk match is corroborated by the device's own
-        // format evidence, and the emitter declaration carries over.
+        // format evidence. The matched quirk itself rides on `resolved.quirk`,
+        // which is what the emitter path reads at open time.
         let resolved = ResolvedCamera::interrogate(device_with("Test IR Module", &["GREY"]), &db);
         assert!(resolved.caps.is_ir);
-        assert!(resolved.caps.has_emitter);
         assert_eq!(
             resolved.caps.applied_quirks,
             vec!["name:(?i)test.*module (test emitter module)".to_string()]
         );
-        assert!(resolved.quirk.is_some());
+        assert!(EmitterXuInfo::from_quirk(resolved.quirk.as_ref().unwrap()).is_some());
     }
 
     #[test]
@@ -179,8 +181,27 @@ mod tests {
         db.push_quirk_for_test(quirk("(?i)plain.*cam"));
 
         let resolved = ResolvedCamera::interrogate(device_with("Plain Cam", &["YUYV"]), &db);
-        assert!(!resolved.caps.has_emitter);
         assert_eq!(resolved.caps.applied_quirks.len(), 1);
+        assert!(EmitterXuInfo::from_quirk(resolved.quirk.as_ref().unwrap()).is_none());
+    }
+
+    #[test]
+    fn unqueryable_caps_fail_closed_but_keep_identity() {
+        // The state both the daemon and the oneshot path fall back to when
+        // the configured device exists but cannot be interrogated: nothing
+        // the device did not demonstrate is asserted, but the sysfs identity
+        // (readable from the path alone) survives so device coupling still
+        // has something to compare.
+        let fp = DeviceFingerprint {
+            vid: Some("046d".into()),
+            pid: Some("085e".into()),
+            serial: None,
+            by_path: None,
+        };
+        let caps = CameraCaps::unqueryable(fp.clone());
+        assert!(!caps.is_ir, "an uninterrogated device must not claim IR");
+        assert!(caps.applied_quirks.is_empty());
+        assert_eq!(caps.fingerprint, fp);
     }
 
     #[test]

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -305,23 +305,19 @@ impl<'a> Camera<'a> {
 
         Ok((rgb, width, height))
     }
-
-    /// Check if a frame is too dark using default thresholds.
-    pub fn is_dark(frame: &Frame) -> bool {
-        is_dark(frame)
-    }
 }
 
-/// Check if a frame is too dark using default thresholds.
+/// Check if a frame is too dark to process.
 ///
 /// A free function, not a `CameraSource` method: darkness is a property of a
 /// frame, and hanging it off the trait was what made the trait non-object-safe
 /// (`where Self: Sized`).
-pub fn is_dark(frame: &Frame) -> bool {
-    is_dark_with_config(frame, 0.6, 10)
-}
-
-/// Check if a frame is too dark to process.
+///
+/// The thresholds are always passed in, from `device.dark_threshold` and
+/// `device.dark_pixel_value`. There is deliberately no default-threshold
+/// variant: one existed, hardcoding the same 0.6/10 the config defaults to,
+/// which is a second source of truth that drifts silently the day those
+/// defaults change.
 ///
 /// Uses both a per-pixel threshold check and mean brightness:
 /// - If the fraction of pixels below `dark_value` exceeds `threshold`, the frame is dark.
@@ -374,28 +370,6 @@ impl CameraSource for Camera<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn is_dark_all_black() {
-        let frame = Frame {
-            rgb: vec![0u8; 64 * 64 * 3],
-            gray: vec![0u8; 64 * 64],
-            width: 64,
-            height: 64,
-        };
-        assert!(Camera::is_dark(&frame));
-    }
-
-    #[test]
-    fn is_dark_all_white() {
-        let frame = Frame {
-            rgb: vec![255u8; 64 * 64 * 3],
-            gray: vec![255u8; 64 * 64],
-            width: 64,
-            height: 64,
-        };
-        assert!(!Camera::is_dark(&frame));
-    }
 
     #[test]
     fn all_black_frame_is_dark_with_config() {

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -136,11 +136,10 @@ fn has_mono_only_formats(device: &DeviceInfo) -> bool {
             .all(|f| is_ir_typical_fourcc(&f.fourcc))
 }
 
-/// Queryable IR-relevant evidence about a device — the facts a future
-/// `CameraCaps.is_ir` (gap D8) should be derived from. Populated strictly
-/// from queried V4L2 data (the capture formats the device actually
-/// enumerates), NEVER from the free-text device/card name, which is
-/// trivially attacker-controlled on virtual devices such as v4l2loopback (#98).
+/// An IR-ness verdict derived purely from queryable device evidence: the
+/// capture formats the device actually enumerates, NEVER the free-text
+/// device/card name, which is trivially attacker-controlled on virtual
+/// devices such as v4l2loopback (#98).
 ///
 /// Format evidence is stronger than the name, but it is NOT unforgeable:
 /// deriving IR-ness from the enumerated formats raises the attacker's cost from
@@ -150,26 +149,8 @@ fn has_mono_only_formats(device: &DeviceInfo) -> bool {
 /// backstops against a fabricated IR device are the liveness / frame-variance
 /// checks and the privilege required to create such a device — not this signal
 /// alone. See `docs/security.md` §A ("Honest residual").
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct IrEvidence {
-    /// The device enumerates ONLY IR-typical mono capture formats — see
-    /// [`has_mono_only_formats`].
-    pub mono_only_formats: bool,
-}
-
-/// Query IR-relevant evidence for a device from its enumerated capture
-/// formats. Never looks at `device.name`.
-fn query_ir_evidence(device: &DeviceInfo) -> IrEvidence {
-    IrEvidence {
-        mono_only_formats: has_mono_only_formats(device),
-    }
-}
-
-/// Derive an IR-ness verdict purely from queried device evidence — never
-/// from the free-text device name. This is the function a future
-/// `CameraCaps.is_ir` (gap D8) can adopt directly.
-pub fn derive_ir_from_evidence(evidence: &IrEvidence) -> bool {
-    evidence.mono_only_formats
+fn has_queried_ir_evidence(device: &DeviceInfo) -> bool {
+    has_mono_only_formats(device)
 }
 
 /// The quirk-free heuristic classification, derived SOLELY from queried
@@ -177,7 +158,7 @@ pub fn derive_ir_from_evidence(evidence: &IrEvidence) -> bool {
 /// consulted here at all; it is used only as a tiebreak hint during
 /// auto-detection selection (see [`pick_auto_device`]).
 fn heuristic_ir_source(device: &DeviceInfo) -> IrSource {
-    if derive_ir_from_evidence(&query_ir_evidence(device)) {
+    if has_queried_ir_evidence(device) {
         IrSource::Format
     } else {
         IrSource::None
@@ -242,7 +223,7 @@ fn ir_source_with_quirks_and_ids(
                         // alone can no longer win force_ir through the
                         // quirks path (#98 Task 3).
                         crate::quirks::QuirkMatchKind::NameOnly => {
-                            usb_ids.is_some() || derive_ir_from_evidence(&query_ir_evidence(device))
+                            usb_ids.is_some() || has_queried_ir_evidence(device)
                         }
                     };
                     if corroborated {
@@ -394,9 +375,18 @@ pub fn is_ir_camera_resolved(
 /// NOTE (seam for Plan 02): device selection here is by capability/heuristic, not
 /// by stable device identity. Plan 02 will pin the enrolled camera by identity.
 pub fn auto_detect_device() -> Result<DeviceInfo> {
+    auto_detect_device_with(&crate::quirks::QuirksDb::load())
+}
+
+/// [`auto_detect_device`] against a caller-supplied quirks DB.
+///
+/// Callers that have already loaded a DB use this so selection and the
+/// classification recorded afterwards are decided by the SAME quirk set —
+/// loading a second copy would let the two disagree if the quirks files
+/// changed in between, and costs a directory walk either way.
+pub fn auto_detect_device_with(quirks: &crate::quirks::QuirksDb) -> Result<DeviceInfo> {
     let devices = list_devices()?;
-    let quirks = crate::quirks::QuirksDb::load();
-    let sources = classify_ir_sources(&devices, Some(&quirks));
+    let sources = classify_ir_sources(&devices, Some(quirks));
     pick_auto_device(&devices, &sources)
         .cloned()
         .ok_or_else(|| FacelockError::Camera("no video devices found".into()))

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -6,11 +6,11 @@ pub mod preprocess;
 pub mod quirks;
 
 pub use caps::{ResolvedCamera, quirk_id};
-pub use capture::{Camera, is_dark, is_dark_with_config};
+pub use capture::{Camera, is_dark_with_config};
 pub use device::{
-    DeviceInfo, FormatInfo, IrSource, auto_detect_device, classify_ir_sources, ir_source,
-    ir_source_resolved, ir_source_with_quirks, is_ir_camera, is_ir_camera_resolved,
-    is_ir_camera_with_quirks, list_devices, validate_device,
+    DeviceInfo, FormatInfo, IrSource, auto_detect_device, auto_detect_device_with,
+    classify_ir_sources, ir_source, ir_source_resolved, ir_source_with_quirks, is_ir_camera,
+    is_ir_camera_resolved, is_ir_camera_with_quirks, list_devices, validate_device,
 };
 pub use ir_emitter::EmitterXuInfo;
 pub use preprocess::{check_ir_texture, clahe, extract_bbox_region, rgb_to_gray, yuyv_to_rgb};

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -85,7 +85,12 @@ impl QuirksDb {
     /// Load quirks from both system and user directories.
     /// System: `/usr/share/facelock/quirks.d/`
     /// User overrides: `/etc/facelock/quirks.d/`
-    /// Files are loaded in alphabetical order; later files can override earlier ones.
+    ///
+    /// Files are loaded in alphabetical order within each directory, and the
+    /// system directory before the user one. Later entries override earlier
+    /// ones for the same device: matching is last-wins per pass, so an
+    /// operator's `/etc` entry shadows the shipped entry it corrects. See
+    /// [`find_match_with_kind`](Self::find_match_with_kind).
     pub fn load() -> Self {
         let mut db = Self::default();
         for dir in &["/usr/share/facelock/quirks.d", "/etc/facelock/quirks.d"] {
@@ -133,7 +138,8 @@ impl QuirksDb {
     }
 
     /// Find a matching quirk for the given device.
-    /// Matches by USB vendor:product ID first, then by name pattern.
+    /// Matches by USB vendor:product ID first, then by name pattern; within
+    /// each pass the LAST-loaded entry wins (see [`find_match_with_kind`](Self::find_match_with_kind)).
     pub fn find_match(&self, device: &DeviceInfo) -> Option<&Quirk> {
         self.find_match_with_ids(device, read_usb_ids(&device.path).as_ref())
     }
@@ -158,44 +164,58 @@ impl QuirksDb {
     /// free-text device name, which is attacker-controlled on virtual
     /// devices such as v4l2loopback, and should not be trusted the same way
     /// as a [`QuirkMatchKind::UsbId`] match.
+    ///
+    /// A USB-ID match always beats a name match — that is specificity, and it
+    /// is independent of load order. *Within* each pass the LAST-loaded entry
+    /// wins, which is what makes [`load`](Self::load)'s ordering an override
+    /// mechanism: `/usr/share/facelock/quirks.d` is loaded first and
+    /// `/etc/facelock/quirks.d` second, so an operator's `/etc` entry shadows
+    /// the shipped entry for the same device. First-match-wins would have
+    /// silently ignored that override — and since `force_ir = false` is
+    /// authoritative unconditionally, the entry an operator writes precisely
+    /// to disable a bad shipped `force_ir` is the one that most needs to win.
     pub fn find_match_with_kind(
         &self,
         device: &DeviceInfo,
         usb_ids: Option<&(String, String)>,
     ) -> Option<(&Quirk, QuirkMatchKind)> {
-        // First pass: match by USB vendor:product ID (most specific)
+        // First pass: match by USB vendor:product ID (most specific).
         if let Some((vendor, product)) = usb_ids {
-            for quirk in &self.quirks {
-                if let (Some(qv), Some(qp)) = (&quirk.vendor_id, &quirk.product_id) {
-                    if qv.eq_ignore_ascii_case(vendor) && qp.eq_ignore_ascii_case(product) {
-                        debug!(
-                            device = %device.path,
-                            vendor, product,
-                            notes = quirk.notes.as_deref().unwrap_or(""),
-                            "matched quirk by USB ID"
-                        );
-                        return Some((quirk, QuirkMatchKind::UsbId));
-                    }
-                }
+            let matched = self.quirks.iter().rev().find(|quirk| {
+                matches!(
+                    (&quirk.vendor_id, &quirk.product_id),
+                    (Some(qv), Some(qp))
+                        if qv.eq_ignore_ascii_case(vendor) && qp.eq_ignore_ascii_case(product)
+                )
+            });
+            if let Some(quirk) = matched {
+                debug!(
+                    device = %device.path,
+                    vendor, product,
+                    notes = quirk.notes.as_deref().unwrap_or(""),
+                    "matched quirk by USB ID"
+                );
+                return Some((quirk, QuirkMatchKind::UsbId));
             }
         }
 
-        // Second pass: match by name pattern
-        for quirk in &self.quirks {
-            if let Some(pattern) = &quirk.name_pattern {
-                // Simple case-insensitive substring/pattern matching
-                // We avoid the regex crate dependency by using a simple approach
-                if name_matches(pattern, &device.name) {
-                    debug!(
-                        device = %device.path,
-                        name = %device.name,
-                        pattern,
-                        notes = quirk.notes.as_deref().unwrap_or(""),
-                        "matched quirk by name pattern"
-                    );
-                    return Some((quirk, QuirkMatchKind::NameOnly));
-                }
-            }
+        // Second pass: match by name pattern. Simple case-insensitive
+        // pattern matching (see `name_matches`); we avoid the regex crate.
+        let matched = self.quirks.iter().rev().find(|quirk| {
+            quirk
+                .name_pattern
+                .as_deref()
+                .is_some_and(|pattern| name_matches(pattern, &device.name))
+        });
+        if let Some(quirk) = matched {
+            debug!(
+                device = %device.path,
+                name = %device.name,
+                pattern = quirk.name_pattern.as_deref().unwrap_or(""),
+                notes = quirk.notes.as_deref().unwrap_or(""),
+                "matched quirk by name pattern"
+            );
+            return Some((quirk, QuirkMatchKind::NameOnly));
         }
 
         None
@@ -613,6 +633,91 @@ notes = "Test camera"
         assert!(fp.is_unknown());
     }
 
+    /// An `/etc/facelock/quirks.d` entry must beat the shipped
+    /// `/usr/share/facelock/quirks.d` entry for the same device, in both
+    /// match passes.
+    ///
+    /// `load()` loads the shipped directory first and the operator's second,
+    /// and the shipped TOML comments direct operators to `/etc` to correct a
+    /// bad entry. That promise is only kept if matching honors load order, so
+    /// this exercises the real `load_dir` path rather than an in-memory
+    /// vector. The override under test disables a shipped `force_ir = true`,
+    /// which is the case that matters most: `force_ir = false` is
+    /// authoritative unconditionally, so a shadowed override is silent.
+    #[test]
+    fn etc_override_beats_shipped_quirk_for_same_device() {
+        let root =
+            std::env::temp_dir().join(format!("facelock-quirks-load-order-{}", std::process::id()));
+        let shipped = root.join("usr-share");
+        let etc = root.join("etc");
+        std::fs::create_dir_all(&shipped).unwrap();
+        std::fs::create_dir_all(&etc).unwrap();
+        std::fs::write(
+            shipped.join("00-defaults.toml"),
+            r#"
+[[quirk]]
+name_pattern = "(?i).* ir camera.*"
+force_ir = true
+warmup_frames = 8
+notes = "shipped"
+
+[[quirk]]
+vendor_id = "dead"
+product_id = "beef"
+force_ir = true
+notes = "shipped by usb id"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            etc.join("99-local.toml"),
+            r#"
+[[quirk]]
+name_pattern = "(?i).* ir camera.*"
+force_ir = false
+notes = "local override"
+
+[[quirk]]
+vendor_id = "dead"
+product_id = "beef"
+force_ir = false
+notes = "local override by usb id"
+"#,
+        )
+        .unwrap();
+
+        let mut db = QuirksDb::default();
+        db.load_dir(&shipped);
+        db.load_dir(&etc); // same order as QuirksDb::load()
+        std::fs::remove_dir_all(&root).ok();
+
+        // Name pass.
+        let device = make_device("Integrated IR Camera");
+        let (quirk, kind) = db
+            .find_match_with_kind(&device, None)
+            .expect("a name pattern matches");
+        assert_eq!(kind, QuirkMatchKind::NameOnly);
+        assert_eq!(
+            quirk.notes.as_deref(),
+            Some("local override"),
+            "the /etc name entry must win over the shipped one"
+        );
+        assert_eq!(quirk.force_ir, Some(false));
+
+        // USB-ID pass.
+        let ids = ("dead".to_string(), "beef".to_string());
+        let (quirk, kind) = db
+            .find_match_with_kind(&device, Some(&ids))
+            .expect("a USB id matches");
+        assert_eq!(kind, QuirkMatchKind::UsbId);
+        assert_eq!(
+            quirk.notes.as_deref(),
+            Some("local override by usb id"),
+            "the /etc USB-ID entry must win over the shipped one"
+        );
+        assert_eq!(quirk.force_ir, Some(false));
+    }
+
     #[test]
     fn quirks_load_dir_nonexistent() {
         let mut db = QuirksDb::default();
@@ -661,15 +766,19 @@ notes = "Full test quirk"
         }
     }
 
-    /// Table-driven regression for #99: every shipped `name_pattern` quirk
-    /// in `config/quirks.d/00-defaults.toml` must still match a plausible
-    /// real device name after anchoring, and none of them may match an
-    /// ordinary RGB webcam name — including the specific decoys ("Sirius
-    /// Camera", "AIR-Cam") that the pre-anchoring substring matcher was
-    /// fooled by. This mirrors `device::tests::ir_classification_corpus`'s
-    /// decoy corpus.
-    #[test]
-    fn shipped_quirk_name_patterns_match_intended_devices_and_reject_decoys() {
+    /// Ordinary RGB webcam names that no shipped `name_pattern` may match.
+    /// Includes the specific decoys ("Sirius Camera", "AIR-Cam") that the
+    /// pre-anchoring substring matcher was fooled by (#99). Mirrors
+    /// `device::tests::ir_classification_corpus`.
+    const QUIRK_NAME_DECOYS: &[&str] = &[
+        "Integrated Webcam",
+        "USB2.0 HD UVC WebCam",
+        "AIR-Cam",
+        "Sirius Camera",
+        "Chicony USB2.0 Camera",
+    ];
+
+    fn shipped_default_quirks() -> Option<Vec<Quirk>> {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
@@ -677,25 +786,35 @@ notes = "Full test quirk"
             .unwrap()
             .join("config/quirks.d/00-defaults.toml");
         if !path.exists() {
-            return;
+            return None;
         }
-        let quirks = QuirksDb::load_file(&path).expect("defaults file parses");
+        Some(QuirksDb::load_file(&path).expect("defaults file parses"))
+    }
 
-        // (substring identifying which pattern this is, a representative
-        // real device name it must still match)
+    /// Table-driven regression for #99: every shipped `name_pattern` quirk in
+    /// `config/quirks.d/00-defaults.toml` must still match a device name of
+    /// the shape it is written for, and none of them may match an ordinary
+    /// RGB webcam name.
+    ///
+    /// Keyed on the EXACT pattern string, not a substring of it. The earlier
+    /// substring keying silently collapsed several patterns onto one case, so
+    /// a pattern could be added without any name being asserted against it.
+    #[test]
+    fn shipped_quirk_name_patterns_match_intended_devices_and_reject_decoys() {
+        let Some(quirks) = shipped_default_quirks() else {
+            return;
+        };
+
+        // (exact shipped pattern, a device name of the shape it targets)
         let cases: &[(&str, &str)] = &[
-            ("ir camera", "IR Camera"),
-            ("surface", "Surface Pro IR Camera"),
-            ("hp", "HP IR Camera 5MP"),
-            ("dell", "Dell IR Camera"),
-        ];
-
-        let decoys = [
-            "Integrated Webcam",
-            "USB2.0 HD UVC WebCam",
-            "AIR-Cam",
-            "Sirius Camera",
-            "Chicony USB2.0 Camera",
+            ("(?i)ir camera.*", "IR Camera"),
+            ("(?i).* ir camera.*", "Integrated IR Camera"),
+            ("(?i)surface.* ir.*", "Surface Pro IR Camera"),
+            ("(?i).* surface.* ir.*", "Microsoft Surface IR Camera"),
+            ("(?i)hp.* ir.*", "HP IR Camera 5MP"),
+            ("(?i).* hp.* ir.*", "Chicony HP IR Camera"),
+            ("(?i)dell.* ir.*", "Dell IR Camera"),
+            ("(?i).* dell.* ir.*", "Integrated Dell IR Camera"),
         ];
 
         let mut exercised = 0;
@@ -703,18 +822,17 @@ notes = "Full test quirk"
             let Some(pattern) = &quirk.name_pattern else {
                 continue;
             };
-            let lower = pattern.to_lowercase();
             let (_, expected_name) = cases
                 .iter()
-                .find(|(needle, _)| lower.contains(needle))
+                .find(|(shipped, _)| shipped == pattern)
                 .unwrap_or_else(|| {
                     panic!("no test case wired up for shipped pattern {pattern:?} — add one")
                 });
             assert!(
                 name_matches(pattern, expected_name),
-                "pattern {pattern:?} should still match {expected_name:?} after anchoring"
+                "pattern {pattern:?} should match {expected_name:?}"
             );
-            for decoy in decoys {
+            for decoy in QUIRK_NAME_DECOYS {
                 assert!(
                     !name_matches(pattern, decoy),
                     "pattern {pattern:?} must NOT match decoy {decoy:?}"
@@ -727,5 +845,51 @@ notes = "Full test quirk"
             cases.len(),
             "every expected shipped name_pattern quirk was exercised"
         );
+    }
+
+    /// Card strings real IR cameras report, each of which must be matched by
+    /// at least ONE shipped `name_pattern`.
+    ///
+    /// The companion test above only proves each pattern matches *something*.
+    /// After #99's anchoring the shipped patterns were checked against names
+    /// derived from the patterns themselves, so nothing caught that
+    /// `(?i)ir camera.*` — the ThinkPad entry — could no longer match the
+    /// "Integrated IR Camera" nodes its own notes name. That false negative
+    /// is silent: the device still works, it just loses `warmup_frames`. This
+    /// test is keyed on hardware-reported names instead, so a pattern that
+    /// matches no real device fails here.
+    #[test]
+    fn shipped_quirk_name_patterns_match_real_hardware_names() {
+        let Some(quirks) = shipped_default_quirks() else {
+            return;
+        };
+        let patterns: Vec<&str> = quirks
+            .iter()
+            .filter_map(|q| q.name_pattern.as_deref())
+            .collect();
+
+        // V4L2 card strings are capped at 31 chars, hence the truncated forms.
+        let real_names = [
+            "IR Camera",
+            "Integrated IR Camera",
+            "Integrated IR Camera: Integrate",
+            "Chicony HP IR Camera",
+            "Microsoft Surface IR Camera",
+        ];
+
+        for name in real_names {
+            assert!(
+                patterns.iter().any(|p| name_matches(p, name)),
+                "no shipped name_pattern matches the real device name {name:?}"
+            );
+        }
+
+        // The corpus above must not have been bought with false positives.
+        for decoy in QUIRK_NAME_DECOYS {
+            assert!(
+                !patterns.iter().any(|p| name_matches(p, decoy)),
+                "a shipped name_pattern matches decoy {decoy:?}"
+            );
+        }
     }
 }

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use facelock_camera::quirks::QuirksDb;
-use facelock_camera::{Camera, ResolvedCamera, auto_detect_device, validate_device};
+use facelock_camera::{Camera, ResolvedCamera, auto_detect_device_with, validate_device};
 use facelock_core::config::Config;
 use facelock_core::types::CameraCaps;
 use facelock_core::types::MatchResult;
@@ -40,8 +40,13 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         .with_writer(std::io::stderr)
         .init();
 
+    // Loaded once, up front: auto-detection and the interrogation below must
+    // be decided by the SAME quirk set, or the device picked and the device
+    // classified could disagree.
+    let quirks = QuirksDb::load();
+
     if config.device.path.is_none() {
-        match auto_detect_device() {
+        match auto_detect_device_with(&quirks) {
             Ok(dev) => {
                 info!(device = %dev.path, name = %dev.name, "auto-detected camera");
                 config.device.path = Some(dev.path);
@@ -59,7 +64,6 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     // cannot be queried: non-IR caps with whatever identity sysfs still
     // offers, so `require_ir` rejects rather than a hard error here.
     let device_path = config.device.path.clone().unwrap();
-    let quirks = QuirksDb::load();
     let resolved = match validate_device(&device_path) {
         Ok(info) => Some(ResolvedCamera::interrogate(info, &quirks)),
         Err(_) => None,
@@ -67,9 +71,8 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     let caps = resolved
         .as_ref()
         .map(|r| r.caps.clone())
-        .unwrap_or_else(|| CameraCaps {
-            fingerprint: facelock_camera::device_fingerprint(&device_path),
-            ..Default::default()
+        .unwrap_or_else(|| {
+            CameraCaps::unqueryable(facelock_camera::device_fingerprint(&device_path))
         });
 
     // Best-effort mode fixing before the store is opened: this is the PAM

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use facelock_camera::quirks::QuirksDb;
 use facelock_camera::{
-    Camera, ResolvedCamera, auto_detect_device, is_ir_camera_resolved, validate_device,
+    Camera, ResolvedCamera, auto_detect_device_with, is_ir_camera_resolved, validate_device,
 };
 use facelock_core::config::Config;
 use facelock_core::notify::NotifierFactory;
@@ -45,7 +45,9 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
     let quirks = QuirksDb::load();
 
     if config.device.path.is_none() {
-        let info = auto_detect_device()
+        // The DB loaded above, not a second load: the quirk set that picks the
+        // device must be the one that then classifies it.
+        let info = auto_detect_device_with(&quirks)
             .map_err(|e| format!("no camera device specified and auto-detection failed: {e}"))?;
         let is_ir = is_ir_camera_resolved(&info, Some(&quirks));
         info!(device = %info.path, name = %info.name, ir = is_ir, "auto-detected camera device");
@@ -79,9 +81,10 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
     let device_caps = resolved
         .as_ref()
         .map(|r| r.caps.clone())
-        .unwrap_or_else(|| facelock_core::types::CameraCaps {
-            fingerprint: facelock_camera::device_fingerprint(&device_path),
-            ..Default::default()
+        .unwrap_or_else(|| {
+            facelock_core::types::CameraCaps::unqueryable(facelock_camera::device_fingerprint(
+                &device_path,
+            ))
         });
 
     // Explicit resolution before construction (D7): name what is missing or
@@ -147,21 +150,18 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
         .as_ref()
         .and_then(|r| r.quirk.as_ref())
         .and_then(|q| q.warmup_frames);
-    let camera_factory: CameraFactory = match resolved {
-        // Reuse the startup interrogation for every (re)open, exactly as the
-        // startup-captured quirk used to be reused.
-        Some(resolved) => Box::new(move |config: &Config| {
-            resolved
-                .clone()
-                .open(&config.device)
-                .map_err(|e| e.to_string())
-        }),
-        // Unqueryable at startup: retry a fresh resolve-and-open per request
-        // so a later-appearing device surfaces its own open error (or works).
-        None => Box::new(move |config: &Config| {
-            Camera::open(&config.device, &QuirksDb::load()).map_err(|e| e.to_string())
-        }),
-    };
+    // Resolve and interrogate afresh on every (re)open rather than replaying
+    // the startup interrogation. Replaying it would let a device swapped in at
+    // the same /dev/videoN after startup inherit the startup device's `is_ir`
+    // and fingerprint — caps it never demonstrated — which is exactly the
+    // invariant `ResolvedCamera` exists to hold: the caps a camera carries are
+    // the caps that camera showed. Reopens happen at idle-timeout frequency,
+    // not per frame, so the extra interrogation is not on the hot path. A
+    // device that is unqueryable at startup gets the same treatment, and so
+    // still surfaces its own open error (or works) if it appears later.
+    let camera_factory: CameraFactory = Box::new(move |config: &Config| {
+        Camera::open(&config.device, &QuirksDb::load()).map_err(|e| e.to_string())
+    });
     let handler = facelock_daemon::handler::Handler::new(
         config,
         engine,

--- a/crates/facelock-core/src/traits.rs
+++ b/crates/facelock-core/src/traits.rs
@@ -6,7 +6,7 @@ use crate::types::{CameraCaps, Detection, FaceEmbedding, Frame};
 /// Object-safe: capabilities are computed once at construction and asked of
 /// the camera, never threaded alongside it as loose parameters (gap D8).
 /// Frame darkness is a property of a frame, not a camera — see the free
-/// function `facelock_camera::is_dark`.
+/// function `facelock_camera::is_dark_with_config`.
 pub trait CameraSource {
     /// Capabilities of the underlying device, computed at construction.
     fn capabilities(&self) -> &CameraCaps;

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -166,12 +166,6 @@ pub struct CameraCaps {
     /// from the free-text device name, which is attacker-controlled on
     /// virtual devices (#98). `security.require_ir` gates on this field.
     pub is_ir: bool,
-    /// The quirks DB declares a controllable IR emitter (XU GUID + selector)
-    /// for this device. Declared, not probed: whether the ioctl actually
-    /// works is only known when the emitter is enabled at capture time.
-    pub has_emitter: bool,
-    /// The capture formats the device enumerates.
-    pub formats: Vec<FormatInfo>,
     /// Hardware identity used for device coupling. All fields are `None`
     /// when the device exposes no readable USB identity — "unknown" is a
     /// value inside [`DeviceFingerprint`], not an `Option` around it.
@@ -179,6 +173,24 @@ pub struct CameraCaps {
     /// Human-readable identifiers of the quirks applied to this device, for
     /// diagnostics ("why did this camera behave oddly").
     pub applied_quirks: Vec<String>,
+}
+
+impl CameraCaps {
+    /// Caps for a device that could not be interrogated at all — it exists at
+    /// the configured path, but querying it failed.
+    ///
+    /// Fails closed on everything the device did not demonstrate: `is_ir` is
+    /// false, so `security.require_ir` rejects rather than admits, and no
+    /// quirks are recorded as applied. The fingerprint is passed in because
+    /// sysfs identity is readable straight from the path even when the V4L2
+    /// query fails, and dropping it would turn every unqueryable camera into
+    /// a device-coupling mismatch.
+    pub fn unqueryable(fingerprint: DeviceFingerprint) -> Self {
+        Self {
+            fingerprint,
+            ..Default::default()
+        }
+    }
 }
 
 /// Granularity at which a live camera must match a template's enrolling camera.

--- a/docs/security.md
+++ b/docs/security.md
@@ -454,10 +454,12 @@ enabling it is a deliberate operator choice that commits to the reseal workflow.
 Access to the daemon is restricted by the D-Bus system bus policy defined in `dbus/org.facelock.Daemon.conf`. Only root and members of the `facelock` group are allowed to send messages to the daemon interface. The policy file is installed to `/usr/share/dbus-1/system.d/` and enforced by the bus daemon itself. Setup and package install may also refresh a legacy `/etc/dbus-1/system.d/` copy when present, but `/usr/share/...` is the canonical install path.
 
 The daemon must also verify the caller UID via `GetConnectionUnixUser` on every method call and apply method-level authorization:
-- `Authenticate`, `ListModels`, `PreviewDetectFrame`: root or the matching Unix user
-- `Enroll`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `Shutdown`: root only
-- `ReleaseCamera`: root or the Unix user that owns the active preview camera session
-- `ListDevices`: root or a caller in the `facelock` group
+- `Authenticate`: root, or a non-root caller acting on their own username. This is the **only** user-scoped method, and it is architecture rather than policy: screen lockers run their PAM stack as the user, so a user must be able to request authentication for themselves.
+- Everything else is **root only**: `TestAuthenticate`, `Enroll`, `ListModels`, `RemoveModel`, `ClearModels`, `PreviewFrame`, `PreviewDetectFrame`, `ListDevices`, `ReleaseCamera`, `Ping`, `Shutdown`.
+
+The scope table's catch-all arm is root-only, so a method added later is closed until it is deliberately opened up. Two entries are spelled out explicitly rather than left to that catch-all, because their root-only scope is load-bearing rather than incidental:
+- `PreviewDetectFrame` runs per-frame with neither `pre_check` nor the rate limiter. For any weaker caller it would be a continuous similarity feed at camera framerate; together with score redaction, denying non-root callers closes the hill-climbing oracle by construction (see A5 below).
+- `TestAuthenticate` is the entry point that does *not* charge the rate limit, which is exactly why it is only safe to offer to root.
 
 The policy also self-contains two explicit defaults rather than relying on system-wide bus defaults:
 - `<deny own="org.facelock.Daemon"/>` in the default context (name-squatting protection; only root may own the name).

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -258,28 +258,36 @@ check_own_denied() {
 run_test "Unprivileged user cannot own org.facelock.Daemon" \
     "check_own_denied"
 
-# (b) PreviewDetectFrame authz parity — a facelock-group non-root caller may
-# call it for itself, but the reply must not contain raw frame bytes
-# (dbus-send renders non-empty byte arrays as hex; a JPEG starts with ff d8).
-check_preview_detect_frame_stripped() {
-    local out
-    if ! out=$(runuser -u testuser -- dbus-send --system --print-reply \
+# (b) PreviewDetectFrame authz parity — the intent here has always been that a
+# non-root caller obtains no imagery. Under N13 the method became root-only, so
+# the way that holds changed: a facelock-group non-root caller is now denied
+# outright, before the method reaches the camera, rather than receiving a reply
+# with jpeg_data stripped. This asserts the denial AND that the error reply
+# carries no frame bytes (dbus-send renders non-empty byte arrays as hex; a
+# JPEG starts with ff d8).
+check_preview_detect_frame_denied() {
+    local out rc
+    set +e
+    out=$(runuser -u testuser -- dbus-send --system --print-reply \
         --reply-timeout=60000 \
         --dest=org.facelock.Daemon /org/facelock/Daemon \
-        org.facelock.Daemon.PreviewDetectFrame string:testuser 2>&1); then
-        echo "$out"
-        return 1
-    fi
+        org.facelock.Daemon.PreviewDetectFrame string:testuser 2>&1)
+    rc=$?
+    set -e
     echo "$out"
-    echo "$out" | grep -q "method return" || return 1
+    [ "$rc" -ne 0 ] || {
+        echo "PreviewDetectFrame unexpectedly succeeded for a non-root caller"
+        return 1
+    }
+    echo "$out" | grep -qi "AccessDenied" || return 1
     if echo "$out" | grep -qi "ff d8"; then
-        echo "reply contains JPEG frame bytes (ff d8) — should be stripped"
+        echo "denial reply contains JPEG frame bytes (ff d8)"
         return 1
     fi
     return 0
 }
-run_test "PreviewDetectFrame returns no raw frame to non-root caller" \
-    "check_preview_detect_frame_stripped"
+run_test "PreviewDetectFrame denies non-root caller (no raw frame)" \
+    "check_preview_detect_frame_denied"
 
 # Release the preview camera session before the concurrency test
 dbus-send --system --print-reply --dest=org.facelock.Daemon /org/facelock/Daemon \


### PR DESCRIPTION
Polish pass over the camera subsystem and the security docs, from the principal-architect review of #107–#122 plus two findings from the fix waves. Ten items, each re-verified against the current tree before changing anything.

**Review finding:** REV-110 (items 1, 2), REV-117 (item 3), plus two fix-wave findings (items 9, 10). Items 4–8 are the lower-severity cleanups from the same review.

---

### 1. Quirk precedence was backwards (MEDIUM, pre-existing)

`QuirksDb::load` appends `/usr/share/facelock/quirks.d` then `/etc/facelock/quirks.d`, and both the `load()` doc and the shipped TOML comments direct operators to `/etc` to correct a bad shipped entry. But `find_match_with_kind` returned the FIRST hit in vector order in both passes, so the shipped entry always shadowed the override. This matters more since #110 made `force_ir = false` authoritative unconditionally: the entry an operator writes precisely to disable a bad shipped `force_ir` was the one most reliably ignored, silently.

Matching is now last-wins within each pass, so load order is the override mechanism the docs already promise. A USB-ID match still beats a name match — that is specificity, independent of load order.

**Pins it:** `quirks::tests::etc_override_beats_shipped_quirk_for_same_device` — writes a shipped entry and an `/etc` entry for the same device into two real directories, loads them through `load_dir` in `load()`'s order, and asserts the `/etc` entry wins in *both* the name pass and the USB-ID pass.

### 2. Shipped patterns could not match the hardware their notes name (MEDIUM)

After #99's anchoring, `(?i)ir camera.*` requires the card string to START with "ir camera" — but real ThinkPad IR nodes enumerate as `Integrated IR Camera...`. The Surface/HP/Dell entries are unmatchable the same way against names that lead with a vendor word. The failure is silent: the device still works, it just loses `warmup_frames`.

The matcher has no alternation, so each affected token now ships a second `.* `-prefixed entry alongside the start-anchored one. That prefix is space-bounded, so the decoy corpus is still rejected — a bare leading `.*` would not be.

**Pins it:** the table test is now keyed on the exact pattern string rather than a substring of it (the old keying let several patterns collapse onto one case, so a pattern could be added with no name ever asserted against it), and a new `shipped_quirk_name_patterns_match_real_hardware_names` asserts real hardware-reported card strings — including `Integrated IR Camera` and the 31-char-truncated `Integrated IR Camera: Integrate` — are each matched by at least one shipped pattern, with the decoys still rejected by all of them.

### 3. Stale caps on daemon camera reopen (LOW)

The camera factory's `Some(resolved)` arm cloned the startup interrogation for every reopen, so a device swapped in at the same `/dev/videoN` after startup inherited the startup device's `is_ir` and fingerprint — caps it never demonstrated. The `None` arm already resolved fresh per open and was the honest one; both now do, so the two arms collapse into one. Reopens happen at idle-timeout frequency, not per frame.

**Pins it:** no unit test — the factory closure is built inside `build_handler`, which needs a real device, a loadable ONNX engine and a writable store. The behaviour is now structural (there is no longer a code path that replays a stale interrogation) rather than conditional.

### 4. Two `CameraCaps` fields with no production consumer (LOW)

Both dropped. `has_emitter` was asserted only by its own tests; the emitter path reads `EmitterXuInfo::from_quirk` off the matched quirk directly, and the name overstated a value that was quirk-*declared*, not probed. Renaming it to `emitter_declared` would have kept a field nothing reads, so deletion won. `formats` duplicated `DeviceInfo.formats`, which every `ResolvedCamera` holder already has, and was re-cloned on every handler build.

Every construction site outside `interrogate` uses `..Default::default()`, so no caller needed changing.

**Pins it:** the two caps tests that asserted on the removed fields now assert the surviving source of truth — `resolved.info.formats` for the format set, `EmitterXuInfo::from_quirk(resolved.quirk)` for the emitter declaration.

### 5. The unqueryable-device caps state was built inline twice (LOW)

`daemon.rs` and `auth.rs` both constructed `CameraCaps { fingerprint: device_fingerprint(..), ..Default::default() }` with a comment explaining the fail-closed semantics. Now `CameraCaps::unqueryable(fingerprint)`, documented once.

**Pins it:** `caps::tests::unqueryable_caps_fail_closed_but_keep_identity` — asserts `is_ir` is false (so `require_ir` rejects rather than admits), no quirks are recorded as applied, and the fingerprint survives, since sysfs identity is readable from the path even when the V4L2 query fails and dropping it would turn every unqueryable camera into a device-coupling mismatch.

### 6. Three public spellings of the darkness check (LOW)

`Camera::is_dark` delegated to the free `is_dark`, which hardcoded the same `0.6`/`10` that `device.dark_threshold` and `device.dark_pixel_value` default to. Production reads neither — auth and enroll both call `is_dark_with_config` with the operator's configured values. A second set of constants for the same decision drifts silently the day the config defaults change, so both default-threshold spellings are gone and `is_dark_with_config` is the only one left. `facelock-core`'s trait doc, which cited the free function as the reason darkness is not a trait method, points at it now.

**Pins it:** the two deleted tests were exact duplicates of the `*_with_config` tests beside them; coverage is unchanged.

**Not done — reported instead:** `MockCamera::is_dark` (`facelock-test-support`) still uses divergent thresholds (`ratio > 0.4`, and empty-frame → dark rather than not-dark). That crate is another agent's scope in this wave, so it is untouched here.

### 7. Double enumeration / ignored parameter (LOW)

`ResolvedCamera::resolve` took a `&QuirksDb` but `auto_detect_device` loaded its own, so the quirks were read twice and the detection pick could in principle use a different quirk set than the recorded classification. Added `auto_detect_device_with(&QuirksDb)`; `auto_detect_device` keeps its signature and loads one.

While adopting it I found the same double-load at two more call sites I own: `daemon.rs` loads a DB and then calls the no-arg `auto_detect_device`, and `auth.rs` auto-detected *before* loading its DB. Both now lend the DB they already have (`auth.rs`'s load moved above the detection).

**Pins it:** no direct test — `auto_detect_device*` enumerates `/dev/video*`, so it cannot be exercised hermetically. The parameter is now actually threaded rather than accepted and ignored.

**Not done — reported instead:** `direct.rs:67` has the same pattern; it is another agent's file this wave.

### 8. Speculative public API (LOW)

`IrEvidence` and `derive_ir_from_evidence` were `pub`, never re-exported, and had no caller outside `device.rs` — scaffolding for a `CameraCaps.is_ir` that ended up adopting `is_ir_camera_resolved`. A one-bool struct plus a query and a derive function fold into the single private predicate the two call sites wanted; the security rationale in the doc comment is preserved on it.

### 9. Security doc described the pre-N13 authorization matrix (MEDIUM, docs)

`docs/security.md` §4A still listed `Authenticate`/`ListModels`/`PreviewDetectFrame` as "root or the matching Unix user" and `ReleaseCamera` as scoped to the owner of the active preview camera session — a concept deleted outright in #127. It contradicted the corrected A5 passage ~46 lines below it in the same file, and `docs/contracts.md`, which is right.

Corrected against `Method::scope` in `facelock-daemon/src/server.rs`: `Authenticate` is the only user-scoped method, everything else is root-only including the #126 `TestAuthenticate`. Also records why `PreviewDetectFrame` and `TestAuthenticate` are spelled out explicitly rather than left to the root-only catch-all. **A5 is untouched.**

Also corrected the book's shorter user-facing copy, which named only `Enroll` and `Shutdown` as root-only — reading as though a `facelock`-group member may call the rest, including the preview methods.

### 10. Camera-tier test broken since N13 (MEDIUM, test) — ⚠️ UNVERIFIED BY EXECUTION

`check_preview_detect_frame_stripped` required `method return` in the dbus-send output, but `PreviewDetectFrame` became root-only, so a non-root caller gets `AccessDenied`, dbus-send exits non-zero, and the guard fails before it ever inspects the reply.

Its intent — a non-root caller must obtain no imagery — is still exactly right; only the mechanism changed, from a stripped reply to a denial before the method reaches the camera. It now asserts the denial: non-zero exit, `AccessDenied` in the output, and still no frame bytes in the error reply. The dbus-send invocation and the `set +e` / `rc` / `set -e` shape mirror `check_own_denied` in the same file.

**⚠️ This change is unverified by execution.** That tier needs a camera and ONNX models, so it cannot run in CI, in a container, or here. `bash -n` passes; the assertion logic has not been observed against a live daemon.

---

## Gates

All three run locally on the final tree.

- `just check` — **exit 0** (test, lint, fmt-check, audit, check-pam-standalone). Full workspace suite green; `cargo clippy --workspace -- -D warnings` clean. The "2 allowed warnings" line is cargo-audit's pre-existing allowlist, not new.
- `just test-arch-pam` — **22 passed, 0 failed** (unchanged)
- `just test-arch-layout` — **21 passed, 0 failed** (unchanged)

Each of the three code commits was also built in isolation to confirm the history is bisectable.

## Notes

- No sibling-agent files were touched. Two items produced findings in files owned by other agents this wave (`MockCamera::is_dark` thresholds, `direct.rs:67`); both are reported above rather than changed.
- Commits are signed (verified in the raw objects: `git cat-file commit <sha> | grep '^gpgsig'` shows an SSH signature on all five). Note that `git log --show-signature` and `%G?` report "No signature" on this machine because `gpg.ssh.allowedSignersFile` is unset — that is a verification-display gap, not an absence of signatures. Nothing was bypassed; no `--no-gpg-sign` was passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

