### PR TITLE
polish(auth,daemon): callee-side wipe, honest seams, exhaustive matches (review polish P2)

### DIFF
--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -60,7 +60,10 @@ pub enum BackendKind {
 
 impl BackendKind {
     pub fn is_direct(self) -> bool {
-        !matches!(self, BackendKind::Daemon)
+        match self {
+            BackendKind::Daemon => false,
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => true,
+        }
     }
 }
 
@@ -157,11 +160,13 @@ impl<'a> Backend<'a> {
     pub fn has_models(&self, user: &str) -> anyhow::Result<bool> {
         match self.kind {
             BackendKind::Daemon => Ok(!self.daemon_list_models(user)?.is_empty()),
-            _ => self.direct_read(false, |store| {
-                store
-                    .has_models(user)
-                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-            }),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                self.direct_read(false, |store| {
+                    store
+                        .has_models(user)
+                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+                })
+            }
         }
     }
 
@@ -172,11 +177,13 @@ impl<'a> Backend<'a> {
                 .daemon_list_models(user)?
                 .iter()
                 .any(|model| model.embedder_model == embedder)),
-            _ => self.direct_read(false, |store| {
-                store
-                    .has_models_for_embedder(user, embedder)
-                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-            }),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                self.direct_read(false, |store| {
+                    store
+                        .has_models_for_embedder(user, embedder)
+                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+                })
+            }
         }
     }
 
@@ -184,11 +191,13 @@ impl<'a> Backend<'a> {
     pub fn list_models(&self, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
         match self.kind {
             BackendKind::Daemon => self.daemon_list_models(user),
-            _ => self.direct_read(Vec::new(), |store| {
-                store
-                    .list_models(user)
-                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-            }),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                self.direct_read(Vec::new(), |store| {
+                    store
+                        .list_models(user)
+                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+                })
+            }
         }
     }
 
@@ -204,12 +213,14 @@ impl<'a> Backend<'a> {
             // An absent store provably holds nothing to remove: report "not
             // found" without materializing a database (the per-site version
             // used the creating opener here).
-            _ => self.direct_read(Some(false), |store| {
-                store
-                    .remove_model(user, model_id)
-                    .map(Some)
-                    .map_err(|e| anyhow::anyhow!("{e}"))
-            }),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                self.direct_read(Some(false), |store| {
+                    store
+                        .remove_model(user, model_id)
+                        .map(Some)
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                })
+            }
         }
     }
 
@@ -222,13 +233,19 @@ impl<'a> Backend<'a> {
                 ipc_client::clear_models(user)?;
                 Ok(None)
             }
-            _ => {
-                // No `Absent` shortcut: callers check `has_models` first, so
-                // a vanished database is an error — erroring beats
-                // re-creating an empty database in its place.
-                let store = direct::open_store_existing(self.config)?;
-                let count = store.clear_user(user).map_err(|e| anyhow::anyhow!("{e}"))?;
-                Ok(Some(count as usize))
+            // An absent store provably holds nothing to clear, so the honest
+            // answer is "cleared 0" — same as [`Backend::remove_model`]'s
+            // `Some(false)` for the same state, and without materializing the
+            // database (C7). This used to error on the grounds that callers
+            // check `has_models` first, which made the answer depend on call
+            // ordering the type could not express.
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                self.direct_read(Some(0), |store| {
+                    store
+                        .clear_user(user)
+                        .map(|count| Some(count as usize))
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                })
             }
         }
     }
@@ -239,7 +256,9 @@ impl<'a> Backend<'a> {
     pub fn enroll(&self, user: &str, label: &str) -> anyhow::Result<(u32, u32)> {
         match self.kind {
             BackendKind::Daemon => ipc_client::send_enroll(user, label, self.config),
-            _ => direct::enroll(self.config, user, label),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                direct::enroll(self.config, user, label)
+            }
         }
     }
 
@@ -270,7 +289,9 @@ impl<'a> Backend<'a> {
                 }),
                 AuthOutcome::Error { message, .. } => bail!("daemon error: {message}"),
             },
-            _ => direct::authenticate(self.config, user),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                direct::authenticate(self.config, user)
+            }
         }
     }
 
@@ -290,7 +311,9 @@ impl<'a> Backend<'a> {
                     }
                 })
             }
-            _ => direct::list_devices_info(),
+            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
+                direct::list_devices_info()
+            }
         }
     }
 
@@ -554,6 +577,9 @@ mod tests {
         );
         assert!(backend.list_models("alice").unwrap().is_empty());
         assert_eq!(backend.remove_model("alice", 3).unwrap(), Some(false));
+        // Nothing enrolled anywhere is nothing to clear — not an error, and
+        // not a different answer from `remove_model`'s for the same state.
+        assert_eq!(backend.clear_models("alice").unwrap(), Some(0));
         assert!(
             !db_path.exists(),
             "benign reads must not create the database they report empty"

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -174,7 +174,8 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     let models = store.list_models(&user).unwrap_or_default();
 
     let start = std::time::Instant::now();
-    let response = crate::direct::authenticate_and_wipe(
+    // Wipes `stored` (D11): nothing below may read the plaintext set again.
+    let response = facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
         &mut stored,
@@ -185,9 +186,9 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     );
     let duration_ms = start.elapsed().as_millis() as u64;
 
-    // Note: authenticate_inner already writes audit entries for the camera-based
-    // auth loop. The oneshot path relies on those entries, so no additional audit
-    // logging is needed here for the auth result itself.
+    // Note: authenticate_with_embeddings already writes audit entries for the
+    // camera-based auth loop. The oneshot path relies on those entries, so no
+    // additional audit logging is needed here for the auth result itself.
 
     if matches!(
         response,
@@ -227,8 +228,8 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             kind: ErrorKind::AllFramesDark,
             ..
         } => {
-            // `authenticate_inner` already audited this one, so unlike the
-            // arm below there is nothing to write here.
+            // `authenticate_with_embeddings` already audited this one, so
+            // unlike the arm below there is nothing to write here.
             info!(user = %user, "all frames dark");
             oneshot_exit_code(ErrorKind::AllFramesDark)
         }

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -27,15 +27,20 @@ type CameraFactory = Box<dyn Fn(&Config) -> Result<Camera<'static>, String> + Se
 
 /// Build a new handler from config. Used at startup and for live config reload.
 /// Returns the handler and idle_timeout_secs from the loaded config.
-fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), String> {
+///
+/// Which file that is comes from `Config::load()` — i.e. from the
+/// process-level config override `run` installs — and from nowhere else.
+/// This used to take an explicit path for the startup call while the reload
+/// recipe passed `None`; the two agreed only because `main` sets the
+/// override too. A caller that set one without the other would have started
+/// on one file and reloaded from another, silently. One source of truth
+/// makes that unrepresentable, and it is the same one `server`'s mtime watch
+/// stats (`paths::config_path()`).
+fn build_handler() -> Result<(ProductionHandler, u64), String> {
     // Deliberate re-read (D7): this is the daemon's config lifecycle — one
     // parse at startup, one per mtime-triggered reload (maybe_reload_handler).
     // Everything downstream consumes the Config held by the handler.
-    let config = match config_path {
-        Some(p) => Config::load_from(Path::new(p)),
-        None => Config::load(),
-    };
-    let mut config = config.map_err(|e| format!("failed to load config: {e}"))?;
+    let mut config = Config::load().map_err(|e| format!("failed to load config: {e}"))?;
 
     // Before anything opens the store: the daemon runs as root, so this is
     // where an upgraded install converges on the documented modes. A handful
@@ -175,7 +180,11 @@ fn build_handler(config_path: Option<&str>) -> Result<(ProductionHandler, u64), 
     Ok((handler, idle_timeout_secs))
 }
 
-pub fn run(config_path: Option<String>, notifier_factory: NotifierFactory) -> anyhow::Result<()> {
+/// `--config` is honored through the process-level override `main` installs
+/// before dispatch, which is what `Config::load()` and
+/// `paths::config_path()` both read — so startup, the live reload and the
+/// mtime watch cannot disagree about which file is the config.
+pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
     crate::ipc_client::require_root("sudo facelock daemon")?;
 
     // Init tracing (daemon uses its own tracing setup with target=true).
@@ -188,7 +197,7 @@ pub fn run(config_path: Option<String>, notifier_factory: NotifierFactory) -> an
 
     info!("facelock daemon starting");
 
-    let (handler, idle_timeout_secs) = match build_handler(config_path.as_deref()) {
+    let (handler, idle_timeout_secs) = match build_handler() {
         Ok(r) => r,
         Err(e) => {
             error!("{e}");
@@ -200,10 +209,8 @@ pub fn run(config_path: Option<String>, notifier_factory: NotifierFactory) -> an
         .and_then(|m| m.modified())
         .ok();
 
-    // The reload recipe: same builder, no explicit path — `Config::load()`
-    // honors the process-level config override `main` set for --config runs.
-    let rebuild: ProductionRebuild =
-        Box::new(|| build_handler(None).map(|(handler, _idle)| handler));
+    // The reload recipe: the same builder reading the same file.
+    let rebuild: ProductionRebuild = Box::new(|| build_handler().map(|(handler, _idle)| handler));
 
     facelock_daemon::server::run(
         handler,

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -9,8 +9,7 @@ use anyhow::{Context, bail};
 use facelock_camera::quirks::QuirksDb;
 use facelock_camera::{Camera, ResolvedCamera, auto_detect_device, list_devices, validate_device};
 use facelock_core::config::{Config, EncryptionMethod};
-use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::{MatchResult, zeroize_stored_embeddings};
+use facelock_core::types::MatchResult;
 use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::AuthOutcome;
 use facelock_daemon::auth::{PreCheckContext, pre_check_audited_with_context};
@@ -169,7 +168,8 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
 
     // Shared with daemon mode (crates/facelock-daemon/src/auth.rs). A local copy
     // of this loop previously lived here and silently drifted — do not re-fork it.
-    let response = authenticate_and_wipe(
+    // It wipes `stored` (D11), so nothing below may read it again.
+    let response = facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
         &mut stored,
@@ -184,26 +184,6 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         AuthOutcome::Error { message, .. } => bail!("{message}"),
         AuthOutcome::Suppressed => bail!("unexpected auth response"),
     }
-}
-
-/// Run the shared camera auth loop, then wipe the caller-side decrypted
-/// embeddings (#100). `authenticate_with_embeddings` copies the compare set
-/// and zeroizes only its own copies, so without this the plaintext templates
-/// passed in would outlive authentication in the caller's memory.
-pub fn authenticate_and_wipe<C: CameraSource, E: FaceProcessor>(
-    camera: &mut C,
-    engine: &mut E,
-    stored: &mut [(u32, facelock_core::types::FaceEmbedding)],
-    models: &[facelock_core::types::FaceModelInfo],
-    config: &Config,
-    user: &str,
-    source: AuditSource,
-) -> AuthOutcome {
-    let response = facelock_daemon::auth::authenticate_with_embeddings(
-        camera, engine, stored, models, config, user, source,
-    );
-    zeroize_stored_embeddings(stored);
-    response
 }
 
 /// Initialize a software sealer based on encryption config.
@@ -501,73 +481,5 @@ warmup_frames = 9
         let loaded = load_user_embeddings(&store, &config, "alice").unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].1, emb);
-    }
-
-    // --- D11 (#100): caller-side wipe of decrypted embeddings ---
-
-    /// The compare set handed to `authenticate_with_embeddings` is copied
-    /// internally and only the copies are zeroized; `authenticate_and_wipe`
-    /// must wipe the caller's buffer too. Covers the `facelock auth` and
-    /// direct-mode callers, which both go through this helper; the daemon
-    /// handler's inline wipe at its call site cannot be black-box asserted
-    /// from here.
-    #[test]
-    fn authenticate_and_wipe_zeroizes_caller_embeddings() {
-        use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
-
-        let emb = fixtures::known_embedding(1);
-        let mut camera = MockCamera::bright(64, 64, 4);
-        let mut engine = MockFaceEngine::one_face(emb);
-        let config = Config::parse(
-            r#"
-[recognition]
-threshold = 0.45
-timeout_secs = 2
-
-[security]
-require_ir = false
-require_frame_variance = false
-require_landmark_liveness = false
-abort_if_ssh = false
-abort_if_lid_closed = false
-"#,
-        )
-        .unwrap();
-
-        let mut stored = vec![(1u32, emb)];
-        let models = vec![facelock_core::types::FaceModelInfo {
-            id: 1,
-            user: "alice".into(),
-            label: "front".into(),
-            created_at: 0,
-            embedder_model: String::new(),
-            device_id: None,
-        }];
-
-        // The mock's default caps are non-IR with an all-None fingerprint —
-        // the same facts the removed loose parameters used to carry.
-        let response = authenticate_and_wipe(
-            &mut camera,
-            &mut engine,
-            &mut stored,
-            &models,
-            &config,
-            "alice",
-            AuditSource::Test,
-        );
-
-        assert!(
-            matches!(
-                response,
-                AuthOutcome::AuthResult(MatchResult { matched: true, .. })
-            ),
-            "auth loop must run to completion: {response:?}"
-        );
-        for (id, e) in &stored {
-            assert!(
-                e.iter().all(|&v| v == 0.0),
-                "caller-side embedding {id} was not wiped"
-            );
-        }
     }
 }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -229,10 +229,12 @@ fn main() -> anyhow::Result<()> {
     match command {
         // Daemon and auth init their own tracing, so handle them separately
         Commands::Daemon { config } => {
-            if let Some(ref path) = config {
+            // The override is how `--config` reaches the daemon: startup, the
+            // live reload and the mtime watch all resolve the path through it.
+            if let Some(path) = config {
                 facelock_core::paths::set_process_config_override(PathBuf::from(path));
             }
-            commands::daemon::run(config, notifications::daemon_notifier_factory())
+            commands::daemon::run(notifications::daemon_notifier_factory())
         }
         Commands::Auth { user, config } => {
             if let Some(ref path) = config {

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -61,13 +61,13 @@ impl Message for AccessMessage {
                 "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying",
             ),
             DaemonUnreachableFallback => translate(
-                "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\nStart it with: sudo systemctl start facelock-daemon",
+                "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\nStart the facelock-daemon service to use it.",
             ),
             PreviewGraphicalNeedsDaemonOneshot => translate(
                 "Graphical preview requires the daemon. In oneshot mode, use --text-only.\nFalling back to text-only mode.\n",
             ),
             PreviewGraphicalDaemonUnreachable => translate(
-                "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the daemon with: sudo systemctl start facelock-daemon\n",
+                "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the facelock-daemon service to use it.\n",
             ),
         }
     }

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -383,39 +383,6 @@ pub fn pre_check_audited_with_context(
     Some(resp)
 }
 
-/// Run the camera-based authentication loop with pre-loaded (decrypted) embeddings.
-///
-/// This is the only entry point: callers MUST load embeddings through their
-/// decryption-aware path (the daemon handler and the oneshot `facelock auth`
-/// binary both do), because embeddings are encrypted at rest by default
-/// (Plan 04). There is deliberately no store-reading variant here — reading
-/// `get_user_embeddings` directly would treat an encrypted blob as a raw
-/// embedding and fail.
-///
-/// `source` records which code path ran the loop; it is stamped into every
-/// audit entry written here. It marks the enforcement path, not caller intent:
-/// only `Test` (direct-mode `facelock test`) skips `pre_check`, so a `success`
-/// stamped `test` is a recognition result rather than an approved
-/// authentication.
-///
-/// The device's IR-ness (gating the IR texture liveness check) and its
-/// fingerprint (restricting the compare set to templates enrolled on this
-/// camera) are asked of `camera.capabilities()` — the camera in use, not a
-/// parameter a caller could get out of sync with it (gap D8).
-pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
-    camera: &mut C,
-    engine: &mut E,
-    stored: &[(u32, FaceEmbedding)],
-    models: &[facelock_core::types::FaceModelInfo],
-    config: &Config,
-    user: &str,
-    source: AuditSource,
-) -> AuthOutcome {
-    let mut stored = stored.to_vec();
-    let models = models.to_vec();
-    authenticate_inner(camera, engine, &mut stored, &models, config, user, source)
-}
-
 /// Save a snapshot of the last captured frame to disk.
 /// Failures are logged but never propagate — snapshots must not block auth.
 fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, frame: &Frame) {
@@ -457,7 +424,66 @@ fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, 
     debug!(path = %path.display(), "saved auth snapshot");
 }
 
-fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
+/// Plaintext embeddings wiped when the guard leaves scope — on every return
+/// path *and* on an unwind, which the hand-written per-return-site wipes this
+/// replaces could not cover (D11).
+///
+/// Generic over how the plaintext is held so the same guard covers both sets
+/// this module handles: the caller's buffer (`&mut [_]`, borrowed) and the
+/// device-filtered compare set (`Vec<_>`, owned). `zeroize`'s own `Zeroizing`
+/// cannot: it needs `T: Zeroize`, which `(u32, FaceEmbedding)` is not.
+struct Wiped<T>(T)
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>;
+
+impl<T> std::ops::Deref for Wiped<T>
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+{
+    type Target = [(u32, FaceEmbedding)];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Drop for Wiped<T>
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+{
+    fn drop(&mut self) {
+        zeroize_stored_embeddings(self.0.as_mut());
+    }
+}
+
+/// Run the camera-based authentication loop with pre-loaded (decrypted) embeddings.
+///
+/// This is the only entry point: callers MUST load embeddings through their
+/// decryption-aware path (the daemon handler and the oneshot `facelock auth`
+/// binary both do), because embeddings are encrypted at rest by default
+/// (Plan 04). There is deliberately no store-reading variant here — reading
+/// `get_user_embeddings` directly would treat an encrypted blob as a raw
+/// embedding and fail.
+///
+/// **`stored` is consumed, not borrowed** (D11): this function wipes the
+/// caller's plaintext buffer as soon as it has filtered its own compare set
+/// out of it, so no caller has to remember to. That is why the parameter is
+/// `&mut` — the rule used to be caller-side convention, implemented once in a
+/// CLI-only wrapper and again inline in the daemon handler, which the daemon
+/// could not share. Every embedding here is zeroized on every exit path,
+/// including an unwind (see [`Wiped`]). Do not read `stored` after the call.
+///
+/// `source` records which code path ran the loop; it is stamped into every
+/// audit entry written here. It marks the enforcement path, not caller intent:
+/// only `Test` (direct-mode `facelock test`) skips `pre_check`, so a `success`
+/// stamped `test` is a recognition result rather than an approved
+/// authentication.
+///
+/// The device's IR-ness (gating the IR texture liveness check) and its
+/// fingerprint (restricting the compare set to templates enrolled on this
+/// camera) are asked of `camera.capabilities()` — the camera in use, not a
+/// parameter a caller could get out of sync with it (gap D8).
+pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
     engine: &mut E,
     stored: &mut [(u32, FaceEmbedding)],
@@ -466,6 +492,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     user: &str,
     source: AuditSource,
 ) -> AuthOutcome {
+    let stored = Wiped(stored);
     let device_is_ir = camera.capabilities().is_ir;
     let live_fingerprint = camera.capabilities().fingerprint.clone();
     let start = Instant::now();
@@ -480,11 +507,13 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     // a lockout. Fail SOFT by construction.
     let policy = config.security.device_binding_policy();
     let allowed = device_allowed_model_ids(models, &live_fingerprint, &policy);
-    let mut compare_set: Vec<(u32, FaceEmbedding)> = stored
-        .iter()
-        .filter(|(id, _)| allowed.contains(id))
-        .cloned()
-        .collect();
+    let compare_set = Wiped(
+        stored
+            .iter()
+            .filter(|(id, _)| allowed.contains(id))
+            .cloned()
+            .collect::<Vec<(u32, FaceEmbedding)>>(),
+    );
     if policy.enabled && compare_set.len() != stored.len() {
         let skipped = stored.len() - compare_set.len();
         warn!(
@@ -505,10 +534,11 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
             "device coupling: authenticating legacy template(s) with no device id (bind_legacy_templates); re-enroll to couple them to this camera"
         );
     }
-    // `compare_set` holds independent copies of the allowed embeddings; zero the
-    // original full set now that we no longer need it.
-    zeroize_stored_embeddings(stored);
-    let stored = compare_set.as_mut_slice();
+    // `compare_set` holds independent copies of the allowed embeddings, so the
+    // caller's full set is done here — dropping the guard wipes it (D11). This
+    // is the contract stated on this function: the caller keeps no plaintext
+    // after the call and has nothing to remember.
+    drop(stored);
 
     let deadline =
         Instant::now() + std::time::Duration::from_secs(config.recognition.timeout_secs as u64);
@@ -517,7 +547,9 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     // Sliding window over the most recent matched-frame embeddings. The gate
     // evaluates only this window, so an early too-still moment is forgotten
     // once the user moves (a static input still never passes: every window
-    // of a static sequence stays above the cutoff).
+    // of a static sequence stays above the cutoff). Like `compare_set` and the
+    // captured `Frame`s, it zeroizes itself on drop, so every exit path from
+    // here on — including an unwind — wipes it.
     let mut variance_window = FrameVarianceWindow::new(config.security.min_auth_frames);
     let mut matched_frames_total: u32 = 0;
     let mut variance_ever_passed = false;
@@ -616,7 +648,7 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                 );
                 continue;
             }
-            let (frame_best_sim, frame_best_id) = best_match(embedding, stored);
+            let (frame_best_sim, frame_best_id) = best_match(embedding, &compare_set);
 
             if frame_best_sim > best_similarity {
                 best_similarity = frame_best_sim;
@@ -706,9 +738,6 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                     face_detected,
                     failure_reason: None,
                 });
-                // Zero sensitive data before returning
-                zeroize_stored_embeddings(stored);
-                variance_window.zeroize_all();
                 return response;
             }
         } else if best_similarity >= threshold {
@@ -758,8 +787,6 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
                 face_detected,
                 failure_reason: None,
             });
-            zeroize_stored_embeddings(stored);
-            variance_window.zeroize_all();
             return response;
         }
     }
@@ -776,10 +803,6 @@ fn authenticate_inner<C: CameraSource, E: FaceProcessor>(
     } else {
         None
     };
-
-    // Zero sensitive data before returning
-    zeroize_stored_embeddings(stored);
-    variance_window.zeroize_all();
 
     if dark_count == frame_count && frame_count > 0 {
         warn!(

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::PreviewFace;
 use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::{best_match, zeroize_stored_embeddings};
+use facelock_core::types::best_match;
 use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
@@ -635,18 +635,17 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
 
         // Split borrows: take camera out, run auth, put it back
         let mut camera = self.camera.take().unwrap();
+        // `stored` is wiped by the callee (D11) — this plaintext set must not
+        // be read again below.
         let result = auth::authenticate_with_embeddings(
             &mut camera,
             &mut self.engine,
-            &stored,
+            &mut stored,
             &models,
             &self.config,
             &user,
             intent.audit_source(),
         );
-        // `authenticate_with_embeddings` works on an internal copy;
-        // wipe the caller-side plaintext set too (#100).
-        zeroize_stored_embeddings(&mut stored);
         self.camera = Some(camera);
         self.camera_last_used = Instant::now();
         // Only failed auths count against the rate limit, and only for the

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -590,7 +590,15 @@ where
             drop(capture_guard);
             match response {
                 DaemonResponse::AuthResult(result) => {
-                    // Send desktop notification (fire-and-forget, runs as root → setpriv)
+                    // Desktop notification, delivered as root via setpriv. NOT
+                    // fire-and-forget: the delivery path runs the helper with
+                    // `Command::output()`, which waits for the child, and this
+                    // runs before the reply below is built — so an auth reply
+                    // waits on it. The `Notifier` contract is that delivery
+                    // must not FAIL an authentication (errors are logged and
+                    // swallowed); staying cheap enough not to delay one is an
+                    // obligation of the implementation, not a guarantee of
+                    // this call site.
                     notify_auth_outcome(&notify_config, notifier_factory(&user).as_ref(), &result);
 
                     Ok(AuthResult {

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -184,61 +184,64 @@ async fn resolve_caller_identity(
     Ok(CallerIdentity { uid, username })
 }
 
-/// Every method on the `org.facelock.Daemon` D-Bus interface. Keep in sync
-/// with the `#[interface]` block below. This enum plus [`Method::scope`] is
-/// the authorization matrix; the in-module unit tests pin the table itself,
-/// and tests/server_authz.rs exercises it through the method-level entry
-/// points (D6).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Method {
-    Authenticate,
-    TestAuthenticate,
-    Enroll,
-    ListModels,
-    RemoveModel,
-    ClearModels,
-    PreviewFrame,
-    PreviewDetectFrame,
-    ListDevices,
-    ReleaseCamera,
-    Ping,
-    Shutdown,
+/// Declare the D-Bus method vocabulary once: the variants, their wire names,
+/// and [`Method::ALL`] all come from this single list.
+///
+/// The matrix tests iterate `ALL`, so `ALL` being *complete* is what makes
+/// them mean anything — and a hand-written second copy of the variant list is
+/// exactly the thing that drifts. Generating it removes the possibility: a
+/// method added here lands in `ALL` and in `name()` or does not exist. (Drift
+/// could only ever under-test, since [`Method::scope`]'s catch-all keeps an
+/// unlisted method root-only, but a test that claims completeness should have
+/// it.)
+macro_rules! declare_methods {
+    ($($variant:ident => $wire:literal,)+) => {
+        /// Every method on the `org.facelock.Daemon` D-Bus interface. Keep in
+        /// sync with the `#[interface]` block below — the one direction no
+        /// type can enforce, and what
+        /// `interface_methods_and_the_authz_matrix_are_the_same_set` pins by
+        /// scanning this file. This enum plus [`Method::scope`] is the
+        /// authorization matrix; the in-module unit tests pin the table
+        /// itself, and tests/server_authz.rs exercises it through the
+        /// method-level entry points (D6).
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        enum Method {
+            $($variant,)+
+        }
+
+        impl Method {
+            /// Every variant, complete by construction — see
+            /// [`declare_methods`].
+            #[cfg(test)]
+            const ALL: &'static [Method] = &[$(Method::$variant,)+];
+
+            /// The wire name, which is what denial messages and capture-slot
+            /// contention errors quote.
+            fn name(self) -> &'static str {
+                match self {
+                    $(Method::$variant => $wire,)+
+                }
+            }
+        }
+    };
+}
+
+declare_methods! {
+    Authenticate => "Authenticate",
+    TestAuthenticate => "TestAuthenticate",
+    Enroll => "Enroll",
+    ListModels => "ListModels",
+    RemoveModel => "RemoveModel",
+    ClearModels => "ClearModels",
+    PreviewFrame => "PreviewFrame",
+    PreviewDetectFrame => "PreviewDetectFrame",
+    ListDevices => "ListDevices",
+    ReleaseCamera => "ReleaseCamera",
+    Ping => "Ping",
+    Shutdown => "Shutdown",
 }
 
 impl Method {
-    #[cfg(test)]
-    const ALL: [Method; 12] = [
-        Method::Authenticate,
-        Method::TestAuthenticate,
-        Method::Enroll,
-        Method::ListModels,
-        Method::RemoveModel,
-        Method::ClearModels,
-        Method::PreviewFrame,
-        Method::PreviewDetectFrame,
-        Method::ListDevices,
-        Method::ReleaseCamera,
-        Method::Ping,
-        Method::Shutdown,
-    ];
-
-    fn name(self) -> &'static str {
-        match self {
-            Method::Authenticate => "Authenticate",
-            Method::TestAuthenticate => "TestAuthenticate",
-            Method::Enroll => "Enroll",
-            Method::ListModels => "ListModels",
-            Method::RemoveModel => "RemoveModel",
-            Method::ClearModels => "ClearModels",
-            Method::PreviewFrame => "PreviewFrame",
-            Method::PreviewDetectFrame => "PreviewDetectFrame",
-            Method::ListDevices => "ListDevices",
-            Method::ReleaseCamera => "ReleaseCamera",
-            Method::Ping => "Ping",
-            Method::Shutdown => "Shutdown",
-        }
-    }
-
     /// Authorization target for each method.
     ///
     /// `Authenticate` is the only user-scoped method: screen lockers run
@@ -470,12 +473,11 @@ where
             .and_then(|m| m.modified())
             .ok();
 
-        let needs_reload = {
-            let stored = self.config_mtime.lock().unwrap();
-            match (*stored, current_mtime) {
-                (Some(old), Some(new)) => new > old,
-                _ => false,
-            }
+        // A poisoned lock is not a reason to reload: keep serving with the
+        // handler already built, exactly as the two swap sites below do.
+        let needs_reload = match self.config_mtime.lock() {
+            Ok(stored) => matches!((*stored, current_mtime), (Some(old), Some(new)) if new > old),
+            Err(_) => false,
         };
 
         if !needs_reload {
@@ -1082,8 +1084,6 @@ pub fn run(
     rebuild: Option<ProductionRebuild>,
     notifier_factory: NotifierFactory,
 ) -> Result<(), ServerError> {
-    let handler = Arc::new(Mutex::new(handler));
-
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
@@ -1195,21 +1195,20 @@ fn drop_capabilities() -> std::result::Result<(), String> {
 }
 
 async fn run_dbus_server(
-    handler: Arc<Mutex<ProductionHandler>>,
+    handler: ProductionHandler,
     idle_timeout_secs: u64,
     startup_config_mtime: Option<std::time::SystemTime>,
     rebuild: Option<ProductionRebuild>,
     notifier_factory: NotifierFactory,
 ) -> Result<(), ServerError> {
-    let last_activity = Arc::new(AtomicU64::new(now_secs()));
-    let service = FacelockService {
-        handler: handler.clone(),
-        last_activity: last_activity.clone(),
-        config_mtime: Arc::new(Mutex::new(startup_config_mtime)),
-        capture_slot: Arc::new(CaptureSlot::default()),
-        notifier_factory,
-        rebuild,
-    };
+    // Production builds the service through the same constructor the tests
+    // use, so an invariant added to `new` cannot silently skip the only
+    // instance that authenticates anyone. The struct literal this replaces
+    // existed to keep the two handles below; cloning them back off the
+    // service is what that cost.
+    let service = FacelockService::new(handler, startup_config_mtime, rebuild, notifier_factory);
+    let handler = service.handler.clone();
+    let last_activity = service.last_activity.clone();
 
     let _connection = zbus::connection::Builder::system()?
         .name(BUS_NAME)?
@@ -1444,8 +1443,9 @@ mod tests {
     // --- Authorization matrix (N13) ---
     //
     // Authenticate is the only user-scoped method; everything else is
-    // root-only. These tests iterate Method::ALL so a new method cannot be
-    // added without landing in the matrix.
+    // root-only. These tests iterate Method::ALL, which `declare_methods!`
+    // generates from the same list as the variants — so a new method really
+    // cannot be added without landing in the matrix.
 
     /// The wire method set and the authorization matrix must be the same
     /// set. `Method` is what [`authorize_method`] keys on, and zbus derives
@@ -1496,9 +1496,9 @@ mod tests {
         );
     }
 
-    /// `Method::name` is the wire name: it is what the denial messages and
-    /// the capture-slot contention errors quote, and what the scan above
-    /// compares against the interface block.
+    /// The wire name in the snake_case form zbus derives for the
+    /// `#[interface]` function, which is what the scan above compares
+    /// against.
     fn snake_case(name: &str) -> String {
         let mut out = String::with_capacity(name.len() + 3);
         for (i, ch) in name.char_indices() {
@@ -1517,7 +1517,7 @@ mod tests {
     #[test]
     fn authz_matrix_root_is_allowed_everywhere() {
         let root = caller(0, Some("root"));
-        for method in Method::ALL {
+        for method in Method::ALL.iter().copied() {
             assert!(
                 authorize_method(&root, method, Some("alice")).is_ok(),
                 "root must be allowed to call {method:?}"
@@ -1527,7 +1527,7 @@ mod tests {
 
     #[test]
     fn authz_matrix_every_method_is_root_only_except_authenticate() {
-        for method in Method::ALL {
+        for method in Method::ALL.iter().copied() {
             let expected = if method == Method::Authenticate {
                 Scope::UserScoped
             } else {
@@ -1540,7 +1540,7 @@ mod tests {
     #[test]
     fn authz_matrix_non_root_is_denied_every_root_scoped_method() {
         let alice = caller(1000, Some("alice"));
-        for method in Method::ALL {
+        for method in Method::ALL.iter().copied() {
             if method == Method::Authenticate {
                 continue;
             }

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -10,6 +10,12 @@ use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
 use facelock_test_support::{MockCamera, MockFaceEngine};
 
+/// The camera factory `Handler::new` takes. Named because the spelled-out
+/// type trips `clippy::type_complexity`, which the `--all-targets` lint gate
+/// makes a hard failure. Each integration test file is its own crate, so this
+/// cannot be shared without exporting a test-only type from production code.
+type MockCameraFactory = Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync>;
+
 // Import the handler module (it's pub in the crate)
 // We need to reference it via the crate directly since it's a binary crate.
 // Instead, we'll replicate the handler construction here.
@@ -335,9 +341,7 @@ fn warmup_frames_discarded_on_camera_open() {
     let capture_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let _counter = capture_count.clone();
 
-    let factory: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| {
+    let factory: MockCameraFactory = Box::new(move |_cfg| {
         // Camera with enough frames for warmup + auth
         Ok(MockCamera::bright(64, 64, 20))
     });
@@ -381,9 +385,7 @@ fn warmup_frames_zero_skips_discard() {
         config.security.rate_limit.window_secs,
     );
 
-    let factory: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
 
     let mut handler = Handler::new(
         config,
@@ -623,9 +625,7 @@ fn keyfile_sealer_init_failure_fails_enroll_closed_no_plaintext() {
 
     // A camera + engine that WOULD drive a valid enrollment, so the pre-fix code
     // path reaches plaintext storage (proving the downgrade the fix closes).
-    let factory: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(640, 480, 40)));
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(640, 480, 40)));
     let engine = MockFaceEngine::cycling(vec![
         fixtures::known_embedding(0),
         fixtures::known_embedding(40),
@@ -698,9 +698,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
             .unwrap();
     }
 
-    let factory1: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+    let factory1: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
 
     let mut first_handler = Handler::new(
         config.clone(),
@@ -724,9 +722,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
         DaemonResponse::AuthResult(MatchResult { matched: false, .. })
     ));
 
-    let factory2: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+    let factory2: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
 
     let mut restarted_handler = Handler::new(
         config.clone(),
@@ -783,9 +779,7 @@ fn test_intent_does_not_consume_rate_limit_budget() {
             .unwrap();
     }
 
-    let factory: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
 
     let mut handler = Handler::new(
         config.clone(),
@@ -871,9 +865,7 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
             .unwrap();
     }
 
-    let factory: Box<
-        dyn Fn(&facelock_core::config::Config) -> Result<MockCamera, String> + Send + Sync,
-    > = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
 
     let mut handler = Handler::new(
         config.clone(),

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -188,7 +188,7 @@ fn device_mismatch_never_reaches_success() {
     );
 
     let emb = fixtures::known_embedding(7);
-    let stored = vec![(1u32, emb)];
+    let mut stored = vec![(1u32, emb)];
     let models = vec![FaceModelInfo {
         id: 1,
         user: "u".into(),
@@ -214,7 +214,7 @@ fn device_mismatch_never_reaches_success() {
     let resp = authenticate_with_embeddings(
         &mut cam,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         &config,
         "u",
@@ -237,6 +237,8 @@ fn device_mismatch_never_reaches_success() {
         serial: None,
         by_path: None,
     };
+    // A fresh compare set: the call above wiped `stored` in place (D11).
+    let mut stored = vec![(1u32, emb)];
     let mut engine2 = MockFaceEngine::one_face(emb);
     let mut cam2 = MockCamera::bright(64, 64, 10).with_caps(facelock_core::types::CameraCaps {
         fingerprint: matching,
@@ -245,7 +247,7 @@ fn device_mismatch_never_reaches_success() {
     let resp2 = authenticate_with_embeddings(
         &mut cam2,
         &mut engine2,
-        &stored,
+        &mut stored,
         &models,
         &config,
         "u",
@@ -272,7 +274,7 @@ fn legacy_null_device_id_still_authenticates() {
     config.recognition.timeout_secs = 2;
 
     let emb = fixtures::known_embedding(11);
-    let stored = vec![(1u32, emb)];
+    let mut stored = vec![(1u32, emb)];
     let models = vec![FaceModelInfo {
         id: 1,
         user: "u".into(),
@@ -297,7 +299,7 @@ fn legacy_null_device_id_still_authenticates() {
     let resp = authenticate_with_embeddings(
         &mut cam,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         &config,
         "u",
@@ -436,13 +438,13 @@ fn static_matching_frames_report_variance_reason() {
     let emb = unit_at_angle(0.0);
     let mut camera = MockCamera::bright(64, 64, 4);
     let mut engine = MockFaceEngine::one_face(emb);
-    let stored = vec![(1u32, emb)];
+    let mut stored = vec![(1u32, emb)];
     let models = vec![legacy_model(1)];
 
     let resp = facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         &config,
         "testuser",
@@ -487,13 +489,13 @@ fn still_then_moving_frames_recover_and_authenticate() {
     ];
     let mut camera = MockCamera::bright(64, 64, 16);
     let mut engine = MockFaceEngine::cycling(frames);
-    let stored = vec![(1u32, still)];
+    let mut stored = vec![(1u32, still)];
     let models = vec![legacy_model(1)];
 
     let resp = facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
-        &stored,
+        &mut stored,
         &models,
         &config,
         "testuser",
@@ -542,7 +544,7 @@ fn failed_auth_writes_audit_entry() {
     let resp = facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
-        &[],
+        &mut [],
         &[],
         &config,
         "testuser",
@@ -561,7 +563,7 @@ fn failed_auth_writes_audit_entry() {
     facelock_daemon::auth::authenticate_with_embeddings(
         &mut camera,
         &mut engine,
-        &[],
+        &mut [],
         &[],
         &config,
         "testuser",
@@ -914,4 +916,91 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
     );
 
     cleanup_db(&db_path);
+}
+
+/// D11 (#100): the auth loop wipes the caller's plaintext compare set itself.
+///
+/// The rule used to be caller-side convention — a wrapper in facelock-cli for
+/// the two CLI callers, re-implemented inline in the daemon handler because
+/// the daemon cannot depend on the CLI. Now the callee owns it, so this one
+/// test covers every caller: the daemon handler, `facelock auth`, and direct
+/// mode all hand over a `&mut` buffer and get it back zeroized.
+#[test]
+fn auth_loop_wipes_the_callers_embeddings() {
+    let emb = fixtures::known_embedding(1);
+    let mut camera = MockCamera::bright(64, 64, 4);
+    let mut engine = MockFaceEngine::one_face(emb);
+    let mut config = test_config();
+    config.recognition.threshold = 0.45;
+    config.recognition.timeout_secs = 2;
+    config.security.require_frame_variance = false;
+    config.security.require_landmark_liveness = false;
+
+    let mut stored = vec![(1u32, emb)];
+    let models = vec![legacy_model(1)];
+
+    let response = facelock_daemon::auth::authenticate_with_embeddings(
+        &mut camera,
+        &mut engine,
+        &mut stored,
+        &models,
+        &config,
+        "alice",
+        AuditSource::Test,
+    );
+
+    assert!(
+        matches!(
+            response,
+            AuthOutcome::AuthResult(MatchResult { matched: true, .. })
+        ),
+        "auth loop must run to completion: {response:?}"
+    );
+    for (id, e) in &stored {
+        assert!(
+            e.iter().all(|&v| v == 0.0),
+            "caller-side embedding {id} was not wiped"
+        );
+    }
+}
+
+/// The same wipe on the failure path: a timed-out attempt leaves no plaintext
+/// behind either. The success path returns early from inside the loop, this
+/// one falls out of the bottom — both are covered by the guard, not by a
+/// hand-placed call at each return site.
+#[test]
+fn auth_loop_wipes_the_callers_embeddings_on_failure() {
+    let mut config = test_config();
+    config.recognition.timeout_secs = 1;
+
+    let enrolled = fixtures::known_embedding(3);
+    let presented = fixtures::known_embedding(9);
+    let mut camera = MockCamera::bright(64, 64, 4);
+    let mut engine = MockFaceEngine::one_face(presented);
+    let mut stored = vec![(1u32, enrolled)];
+    let models = vec![legacy_model(1)];
+
+    let response = facelock_daemon::auth::authenticate_with_embeddings(
+        &mut camera,
+        &mut engine,
+        &mut stored,
+        &models,
+        &config,
+        "alice",
+        AuditSource::Test,
+    );
+
+    assert!(
+        matches!(
+            response,
+            AuthOutcome::AuthResult(MatchResult { matched: false, .. })
+        ),
+        "sanity: a different face must not authenticate: {response:?}"
+    );
+    for (id, e) in &stored {
+        assert!(
+            e.iter().all(|&v| v == 0.0),
+            "caller-side embedding {id} was not wiped on the failure path"
+        );
+    }
 }

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -35,6 +35,12 @@ use zbus::fdo;
 
 type MockService = FacelockService<MockCamera, MockFaceEngine>;
 
+/// The camera factory `Handler::new` takes. Named because the spelled-out
+/// type trips `clippy::type_complexity`, which the `--all-targets` lint gate
+/// makes a hard failure. Each integration test file is its own crate, so this
+/// cannot be shared without exporting a test-only type from production code.
+type MockCameraFactory = Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync>;
+
 /// Gates configured so the mock flow reaches the comparison loop: no IR
 /// requirement, no variance/liveness gates, environment aborts off,
 /// plaintext store (no sealer), audit off.
@@ -75,8 +81,7 @@ fn handler_with(
         config.security.rate_limit.max_attempts,
         config.security.rate_limit.window_secs,
     );
-    let factory: Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync> =
-        Box::new(|_| Ok(MockCamera::bright(64, 64, 60)));
+    let factory: MockCameraFactory = Box::new(|_| Ok(MockCamera::bright(64, 64, 60)));
     Handler::new(
         config,
         engine,

--- a/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
+++ b/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
@@ -28,6 +28,12 @@ use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
 use facelock_test_support::{MockCamera, MockFaceEngine};
 
+/// The camera factory `Handler::new` takes. Named because the spelled-out
+/// type trips `clippy::type_complexity`, which the `--all-targets` lint gate
+/// makes a hard failure. Each integration test file is its own crate, so this
+/// cannot be shared without exporting a test-only type from production code.
+type MockCameraFactory = Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync>;
+
 #[tokio::test]
 async fn test_authenticate_skips_the_ssh_gate_that_authenticate_enforces() {
     let config = Config::parse(
@@ -61,8 +67,7 @@ enabled = false
         config.security.rate_limit.max_attempts,
         config.security.rate_limit.window_secs,
     );
-    let factory: Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync> =
-        Box::new(|_| Ok(MockCamera::bright(64, 64, 60)));
+    let factory: MockCameraFactory = Box::new(|_| Ok(MockCamera::bright(64, 64, 60)));
     let handler = Handler::new(
         config,
         MockFaceEngine::one_face(emb),

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -38,8 +38,10 @@ const DEFAULT_TIMEOUT_SECS: u32 = 5;
 
 /// The binary spawned for oneshot authentication. Hardcoded: a configurable
 /// path would let anyone who can influence the config select which binary a
-/// root PAM context executes (E7/N9). The path is still validated as
-/// root-owned and non-writable before spawning.
+/// root PAM context executes (E7/N9). It and its ancestors are still checked
+/// for root ownership and non-writability before spawning
+/// ([`verify_binary_trust`]) — the constant says which binary, the check says
+/// whether that binary is still trustworthy.
 const AUTH_BIN: &str = "/usr/bin/facelock";
 
 // D-Bus constants
@@ -684,31 +686,32 @@ fn read_trusted_config(path: &str) -> Result<String, String> {
     Ok(content)
 }
 
-fn validate_auth_bin(path: &str) -> Result<PathBuf, String> {
-    if path.is_empty() {
-        return Err("auth_bin must not be empty".into());
-    }
-
-    let candidate = Path::new(path);
-    if !candidate.is_absolute() {
-        return Err("auth_bin must be an absolute path".into());
-    }
-
-    let canonical = candidate
+/// Establish that `path` is a binary this module may exec as root.
+///
+/// The trust is entirely in the filesystem checks: resolve symlinks, then
+/// require the target *and every ancestor directory* to be root-owned and not
+/// group- or world-writable. Nothing else about the path is validated —
+/// `AUTH_BIN` is a compiled-in absolute constant (there has been no
+/// configurable `auth_bin` since N9), and `canonicalize` returns an absolute
+/// path regardless, so the walk below establishes trust on its own.
+///
+/// Returns the canonical path to exec, or the reason it is not trusted.
+fn verify_binary_trust(path: &str) -> Result<PathBuf, String> {
+    let canonical = Path::new(path)
         .canonicalize()
-        .map_err(|e| format!("failed to resolve auth_bin: {e}"))?;
+        .map_err(|e| format!("failed to resolve {path}: {e}"))?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
         let metadata = std::fs::metadata(&canonical)
-            .map_err(|e| format!("failed to stat auth_bin {}: {e}", canonical.display()))?;
+            .map_err(|e| format!("failed to stat {}: {e}", canonical.display()))?;
 
         validate_root_owned_nonwritable(
             metadata.uid(),
             metadata.permissions().mode(),
-            &format!("auth_bin {}", canonical.display()),
+            &format!("auth binary {}", canonical.display()),
         )?;
 
         let mut current = canonical.parent();
@@ -769,12 +772,12 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
 
     let timeout_secs = config.recognition.timeout_secs as u64 + 3; // buffer for model load
 
-    let auth_bin = match validate_auth_bin(AUTH_BIN) {
+    let auth_bin = match verify_binary_trust(AUTH_BIN) {
         Ok(path) => path,
         Err(e) => {
             log_auth(
                 service,
-                &format!("error: unsafe_auth_bin: {e}"),
+                &format!("error: untrusted_auth_binary: {e}"),
                 user,
                 LOG_WARNING,
             );
@@ -1217,30 +1220,27 @@ auth_bin = "/usr/local/bin/evil"
         assert_eq!(config.daemon.mode, "oneshot");
     }
 
+    /// An absent binary is untrusted, not "assume it's fine": the module
+    /// falls through to the next PAM module rather than exec'ing something
+    /// that appears later at that path.
     #[test]
-    fn validate_auth_bin_rejects_relative_paths() {
-        let err = validate_auth_bin("facelock").unwrap_err();
-        assert!(err.contains("absolute"));
-    }
-
-    #[test]
-    fn validate_auth_bin_rejects_missing_paths() {
-        let err = validate_auth_bin("/definitely/missing/facelock").unwrap_err();
+    fn verify_binary_trust_rejects_missing_paths() {
+        let err = verify_binary_trust("/definitely/missing/facelock").unwrap_err();
         assert!(err.contains("failed to resolve"));
     }
 
     #[cfg(unix)]
     #[test]
     fn validate_root_owned_nonwritable_rejects_group_writable_mode() {
-        let err =
-            validate_root_owned_nonwritable(0, 0o100775, "auth_bin /usr/bin/facelock").unwrap_err();
+        let err = validate_root_owned_nonwritable(0, 0o100775, "auth binary /usr/bin/facelock")
+            .unwrap_err();
         assert!(err.contains("group- or world-writable"));
     }
 
     #[cfg(unix)]
     #[test]
     fn validate_root_owned_nonwritable_rejects_non_root_owner() {
-        let err = validate_root_owned_nonwritable(1000, 0o100755, "auth_bin /usr/bin/facelock")
+        let err = validate_root_owned_nonwritable(1000, 0o100755, "auth binary /usr/bin/facelock")
             .unwrap_err();
         assert!(err.contains("owned by root"));
     }

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -111,18 +111,17 @@ impl Default for PamSecurityConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)] // Variants used via deserialization
 enum PamNotificationMode {
     Off,
-    /// Default must agree with `PamNotificationConfig::default()` below and
-    /// with facelock-core's `NotificationMode` (Terminal). This enum-level
-    /// default is what a present `[notification]` section with `mode` omitted
-    /// produces; the struct `Default` is what an absent section produces.
-    /// The two had drifted (`Both` here, `Terminal` there) — benign only
-    /// because `terminal()` treats Both and Terminal identically.
-    #[default]
+    /// The default mode, named once in [`PamNotificationConfig::default`] and
+    /// nowhere else. It must equal facelock-core's `NotificationMode`
+    /// default. This enum deliberately has no `Default` impl: it carried a
+    /// second answer to the same question, and the two drifted (`Both` here,
+    /// `Terminal` there) — undetected because `terminal()` treats Both and
+    /// Terminal identically.
     Terminal,
     Desktop,
     Both,
@@ -135,13 +134,18 @@ enum PamNotificationMode {
 /// vocabulary as `facelock_core::notify::NotifyEvent`: `notify_prompt` ↔
 /// Scanning, `notify_on_success` ↔ Success. (This module renders them as
 /// PAM conversation text; desktop delivery is the daemon's job.)
+///
+/// `#[serde(default)]` sits on the container, not on the fields: every
+/// omitted key falls back to the [`Default`] impl below, so "section present,
+/// key omitted" and "section absent" produce the same values by construction
+/// instead of by two lists happening to agree. They did not agree once (D9),
+/// and the same shape in facelock-core's `NotificationConfig` shipped the
+/// same class of bug.
 #[derive(Deserialize)]
+#[serde(default)]
 struct PamNotificationConfig {
-    #[serde(default)]
     mode: PamNotificationMode,
-    #[serde(default = "default_true")]
     notify_prompt: bool,
-    #[serde(default = "default_true")]
     notify_on_success: bool,
 }
 

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -118,10 +118,24 @@ enum PamNotificationMode {
     Off,
     /// The default mode, named once in [`PamNotificationConfig::default`] and
     /// nowhere else. It must equal facelock-core's `NotificationMode`
-    /// default. This enum deliberately has no `Default` impl: it carried a
-    /// second answer to the same question, and the two drifted (`Both` here,
-    /// `Terminal` there) — undetected because `terminal()` treats Both and
-    /// Terminal identically.
+    /// default.
+    ///
+    /// This enum deliberately has no `Default` impl. It carried a second
+    /// answer to the same question and the two drifted (`Both` here,
+    /// `Terminal` there), undetected because `terminal()` treats Both and
+    /// Terminal identically. Deleting it is not just tidying: with no
+    /// `Default`, re-adding `#[serde(default)]` to the `mode` field does not
+    /// compile, so the drift cannot come back the way it arrived. The one
+    /// remaining route — `#[serde(default = "some_fn")]`, which needs no
+    /// `Default` — is caught by
+    /// `notification_section_present_with_keys_omitted_equals_absent`.
+    ///
+    /// facelock-core's mirror of this enum KEEPS its `Default`, deliberately:
+    /// two sibling enums there (`SnapshotMode`, `EncryptionMethod`) still
+    /// have live field-level defaults, so removing only this one would be a
+    /// locally-invisible asymmetry. The two crates must agree on the default
+    /// *value*, not on how each spells it. Do not "restore" this impl for
+    /// symmetry with core.
     Terminal,
     Desktop,
     Both,

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 14:03-0700\n"
+"POT-Creation-Date: 2026-08-14 14:26-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgstr ""
 #: crates/facelock-cli/src/message/access.rs:64
 msgid ""
 "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\n"
-"Start it with: sudo systemctl start facelock-daemon"
+"Start the facelock-daemon service to use it."
 msgstr ""
 
 #: crates/facelock-cli/src/message/access.rs:67
@@ -69,7 +69,7 @@ msgstr ""
 #: crates/facelock-cli/src/message/access.rs:70
 msgid ""
 "Graphical preview requires the daemon, which is configured but not reachable.\n"
-"Falling back to text-only mode. Start the daemon with: sudo systemctl start facelock-daemon\n"
+"Falling back to text-only mode. Start the facelock-daemon service to use it.\n"
 msgstr ""
 
 #: crates/facelock-cli/src/message/device.rs:38

--- a/po/pam_facelock.pot
+++ b/po/pam_facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 01:55-0700\n"
+"POT-Creation-Date: 2026-08-14 14:23-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/pam-facelock/src/lib.rs:936
+#: crates/pam-facelock/src/lib.rs:973
 msgid "Identifying face..."
 msgstr ""
 
-#: crates/pam-facelock/src/lib.rs:946 crates/pam-facelock/src/lib.rs:960
-#: crates/pam-facelock/src/lib.rs:1002
+#: crates/pam-facelock/src/lib.rs:983 crates/pam-facelock/src/lib.rs:997
+#: crates/pam-facelock/src/lib.rs:1039
 msgid "Face recognized."
 msgstr ""


### PR DESCRIPTION
Fourteen reviewer-identified defects in the authentication path and daemon, from the principal-architect review of PRs #107–#122, plus reconciliation items handed over by the hygiene package. No authentication decision changes: item 1 changes memory hygiene, item 10 changes a failure response. The two frozen protocol strings PAM substring-matches ("rate limited", "IR camera required") are byte-identical, the D-Bus wire is unchanged (`TestAuthenticate` from #126 and the `-4` model_id sentinel from #129 both intact), and `is-enrolled` is untouched.

## 1. The D11 zeroization contract was caller-side convention, implemented three ways

`authenticate_with_embeddings` took `&[(u32, FaceEmbedding)]` and did `.to_vec()` internally, so wiping the caller's plaintext was the caller's job. The wrapper that enforced it (`direct::authenticate_and_wipe`) lived in facelock-cli, which the daemon cannot depend on, so `handler.rs` carried an inline copy of the same wipe — one rule, two implementations. The `to_vec()` also created a third simultaneous plaintext copy purely to keep the signature immutable.

The parameter is now `&mut` and the callee owns the wipe. `authenticate_and_wipe`, the handler's inline duplicate, the `to_vec()` copy and the private `authenticate_inner` (merged into the public entry point) are all gone. Every caller — daemon handler, `facelock auth`, direct mode — hands over a buffer and gets it back zeroized.

**Pinning tests:** `auth_loop_wipes_the_callers_embeddings` and `auth_loop_wipes_the_callers_embeddings_on_failure` (`crates/facelock-daemon/tests/daemon_integration.rs`), covering both exit shapes — success returns from inside the loop, failure falls out of the bottom. Moved up from facelock-cli, where it could only cover the two CLI callers.

The signature change surfaced one real buffer reuse: `device_mismatch_never_reaches_success` ran a second auth against the same `stored`, which is now wiped by the first call. It rebuilds the compare set, which is what a caller must do.

## 2. No unwind path wiped anything (done, not deferred)

Both plaintext sets are held in a `Wiped` drop guard, so a panic wipes them too; the per-return-site `zeroize_stored_embeddings` and `variance_window.zeroize_all()` calls it replaces could not. The variance window and captured `Frame`s already zeroized on drop, so nothing else needed restructuring. `zeroize`'s own `Zeroizing` does not fit: it requires `T: Zeroize`, which the `(u32, FaceEmbedding)` tuple does not implement.

## 3. `validate_auth_bin` kept dead input validation and config-era naming

`AUTH_BIN` has been a compiled-in absolute constant since #109, so the empty-string and relative-path branches were unreachable — yet their messages and the syslog label still described a configurable `auth_bin`, and two tests pinned the dead branches. Renamed to `verify_binary_trust`; unreachable branches and their tests dropped; errors and the syslog label now say `untrusted_auth_binary`.

The runtime half is kept intact — canonicalize, then require the binary and every ancestor directory to be root-owned and non-group/world-writable. `canonicalize` returns an absolute path whatever it is given, so that walk establishes trust without the removed pre-check.

**Pinning tests:** `verify_binary_trust_rejects_missing_paths` (an absent binary is a real untrusted case) plus the two `validate_root_owned_nonwritable` tests. Dependency constraint honored: nothing added, `cargo build -p pam-facelock` clean, guard reports 57 crates.

## 4. Production bypassed the service constructor

`run_dbus_server` built `FacelockService` with a struct literal while `FacelockService::new` existed for tests, so an invariant added to the constructor would have missed the only instance that authenticates anyone. It now calls `new` and clones the handler and last-activity handles back off the service.

## 5. `unwrap()` on a lock in a library crate

The config-mtime lock in `maybe_reload_handler` used `unwrap()`, against the project rule and against the two sibling lock sites in the same function. A poisoned lock now reads as "no reload" — keep serving with the handler already built.

## 6. Startup and reload could disagree about the config file

`build_handler` took an explicit `config_path` at startup while the reload recipe passed `None` → `Config::load()`, and the mtime watch stats `paths::config_path()`. These agreed only because `main` also installs a process-level override. The redundant parameter is gone; `--config` still works through the override that was already doing the work.

## 7. Stale doc reference — already fixed upstream

The cited comment ("The D-Bus layer (commands/daemon.rs) passes false…") no longer exists anywhere in facelock-daemon; #126's `AuthIntent` rewrite replaced that whole doc block. No change needed.

## 8. The authorization matrix's completeness was convention

Adding a `Method` variant forced updating `name()` but not `Method::ALL`, which the matrix tests iterate — so the test comment claiming "a new method cannot be added without landing in the matrix" was aspiration. A `declare_methods!` macro now generates the enum, `ALL` and `name()` from one list, making the claim true by construction and deleting the duplicated name table. Drift here could only ever under-test (`scope()`'s catch-all keeps an unlisted method root-only), so this is hygiene, not a hole.

## 9. Wildcard arms defeated the exhaustiveness enum dispatch earns

All eight `Backend` operation methods matched `BackendKind::Daemon => …, _ => …`, so a fourth kind would have silently inherited direct-transport behavior in eight places instead of producing eight compile errors. All eight now spell out both direct variants, as `caps()` already did — as does `is_direct`, whose `!matches!` was the same wildcard in miniature.

## 10. A seam method whose contract depended on call ordering

`clear_models` errored on `StoreError::Absent` because "callers check `has_models` first", while the sibling `remove_model` answers `Some(false)` for the same state. Absent now means `Some(0)`, routed through `direct_read` so it still never materializes the database it reports empty (C7). An unreadable store remains an error on every operation.

**Pinning test:** `absent_store_reads_are_benign_and_create_nothing` now asserts `clear_models → Some(0)` beside the sibling reads it agrees with, and still asserts no database was created.

## 11. Init-system-specific hints in user-facing messages

Both the daemon-unreachable fallback and the preview-unreachable message hardcoded `sudo systemctl start facelock-daemon`, though this repo also ships an OpenRC service; the fallback prints on every backend-using invocation in a degraded state. Both now say to start the facelock-daemon service without naming an init system.

These strings live in `crates/facelock-cli/src/message/access.rs`, the current location after #130's per-domain split. `po/facelock.pot` regenerated with `just pot`; `po/pam_facelock.pot` picks up unrelated line-number drift in the same pass, having not been regenerated since lib.rs last moved.

## 12 & 13. Reconciliation handed over by the hygiene package

Both are in files this branch owns, so they landed here rather than on `polish/p3-hygiene`.

**`PamNotificationConfig` had two lists of defaults.** Per-field `#[serde(default = ...)]` alongside a manual `Default` impl — the exact shape that already shipped a drift bug in this struct (the mode enum's `#[default]` said `Both` while the struct's said `Terminal`, undetected because `terminal()` treats them identically). The two agree today, so moving `#[serde(default)]` to the container and deleting the per-field ones is behavior-preserving: "section present, key omitted" and "section absent" are now identical by construction. `PamNotificationMode`'s `Default` impl is deleted rather than left unused — it was the second answer that drifted, and nothing called it. `default_true` stays, since `PamSecurityConfig` still uses it.

The hygiene package made the same change to facelock-core's `NotificationConfig`. The two are hand-kept mirrors (the PAM dependency ceiling forbids sharing the type) and must keep agreeing.

**Pinning tests:** both existing drift pins pass unchanged and now guard the container mechanism — `notification_section_present_with_keys_omitted_equals_absent` and `shipped_template_notification_settings_equal_defaults`.

**`server.rs` called desktop delivery "fire-and-forget".** It is not: `notifications.rs` runs the helper with `Command::output()`, which waits for the child, and the call sits inside the `spawn_blocking` closure before the reply is constructed — so an auth reply waits on it. The comment now says so and states the real contract (delivery must not *fail* an auth; staying cheap is the implementation's obligation, not a guarantee of the call site). Delivery is not restructured.

## 14. Daemon-crate lints under the `--all-targets` gate

Added to this package by the orchestrator after the hygiene package tightened `just lint` to `cargo clippy --workspace --all-targets -- -D warnings`, which makes test code visible to clippy for the first time.

Surveyed per-package rather than workspace-wide, because `facelock-store`'s two non-octal-permissions **errors** abort that crate's test build and truncate a workspace run before it reaches later crates — a workspace-wide green is not evidence here.

`cargo clippy -p facelock-daemon --all-targets -- -D warnings` reports **nine** hits, all `clippy::type_complexity`, all the same hand-spelled box:

```
Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync>
```

at `daemon_integration.rs` 338/384/626/701/727/786/874, `server_authz.rs:78`, `test_authenticate_ssh_gate.rs:64`. There are no `needless_range_loop`, `redundant_closure`, manual-fill or needless-borrow lints in this crate — those live in crates the hygiene package owns.

All nine are now a `MockCameraFactory` alias. Type annotations only: no test logic, no assertions, no test names, no production code. The alias is defined once per test file because each integration test file is its own crate; sharing it would mean exporting a test-only type from the daemon's production API or adding it to `facelock-test-support`, which this package does not own. `server_authz.rs` already had a local `MockService` alias, so this matches the file's idiom.

The name is deliberately the one the hygiene package intended to export from `facelock-test-support` before these files were reassigned here — so if that export lands later, resolution is to delete three `type` lines and add one `use`, with every annotation already correct.

`cargo clippy -p facelock-daemon --all-targets -- -D warnings` is clean; all 130 daemon tests pass.

## Gates

Re-run in full after every added item:

- `just check` — pass (test, clippy `-D warnings`, fmt, audit, pam standalone guard at 57 crates)
- `just test-arch-pam` — 22 passed, 0 failed
- `just test-arch-layout` — 21 passed, 0 failed

Review finding: REV-109, REV-121, REV-120, REV-108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
