### PR TITLE
chore(test): daemon uses the shared schema-fault helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,6 @@ dependencies = [
  "image",
  "libc",
  "nix",
- "rusqlite",
  "serde",
  "serde_json",
  "signal-hook",

--- a/crates/facelock-daemon/Cargo.toml
+++ b/crates/facelock-daemon/Cargo.toml
@@ -36,6 +36,4 @@ tpm = ["facelock-tpm/tpm"]
 
 [dev-dependencies]
 facelock-test-support = { path = "../facelock-test-support" }
-# Raw SQL access for schema-level failure injection in integration tests.
-rusqlite = { version = "0.40", features = ["bundled"] }
 tempfile = "3"

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -855,15 +855,10 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
     }
 
     // Corrupt the schema so only `list_models` fails (see doc comment). The
-    // migrations' unconditional `CREATE TABLE IF NOT EXISTS` no-ops on the
-    // still-present table, and the V5 migration that would re-add the column
-    // is gated behind a schema version this database is already past, so the
-    // handler's own connection opens cleanly.
-    {
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
-        conn.execute_batch("ALTER TABLE face_models DROP COLUMN embedder_model;")
-            .unwrap();
-    }
+    // injection — and the migration gating that keeps the handler's own
+    // re-open from healing it — lives in `facelock_test_support::
+    // schema_faults`, shared with facelock-cli's keygen-guard test.
+    facelock_test_support::schema_faults::drop_embedder_model_column(&db_path);
 
     let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 1)));
 

--- a/crates/facelock-test-support/src/schema_faults.rs
+++ b/crates/facelock-test-support/src/schema_faults.rs
@@ -93,12 +93,9 @@ pub fn break_face_models_table(db_path: &Path) {
 /// Remove the `embedder_model` column from `face_models`, so a query that
 /// selects it fails while the database as a whole stays open and usable.
 ///
-/// Its caller — the daemon's `authenticate_storage_failure_*` integration
-/// test — is **not** on this branch: `crates/facelock-daemon` belongs to a
-/// concurrent change, and still carries the raw `ALTER TABLE` this replaces
-/// (along with the `rusqlite` dev-dependency it needs). Converting that call
-/// site is a cross-branch follow-up; this half is exported and documented so
-/// the conversion is a one-line change when it lands.
+/// Its only caller is the daemon's
+/// `authenticate_storage_failure_is_error_and_charges_no_rate_limit`
+/// integration test.
 ///
 /// **Schema coupling, two ways.** First, the column must actually be in the
 /// select list of the query under test — drop a column nothing reads and the


### PR DESCRIPTION
## What was duplicated

SQLite schema-level fault injection existed twice, privately, in two crates. Each copy carried its own `rusqlite` dev-dependency, and each independently encoded the same non-obvious coupling to the schema: which columns the query under test actually selects, and which migration gating keeps a re-open from silently healing the injected fault. Two private copies means a future schema change breaks in two places, each needing the same re-derivation.

A prior hygiene change hoisted both injectors into `crates/facelock-test-support/src/schema_faults.rs` and converted the facelock-cli caller. The facelock-daemon caller could not be converted then — the new module and that call site lived on separate branches. Both halves are in this tree now, so this finishes the job.

## The conversion

`crates/facelock-daemon/tests/daemon_integration.rs`, in the C3 regression test `authenticate_storage_failure_is_error_and_charges_no_rate_limit`:

```diff
     // Corrupt the schema so only `list_models` fails (see doc comment). The
-    // migrations' unconditional `CREATE TABLE IF NOT EXISTS` no-ops on the
-    // still-present table, and the V5 migration that would re-add the column
-    // is gated behind a schema version this database is already past, so the
-    // handler's own connection opens cleanly.
-    {
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
-        conn.execute_batch("ALTER TABLE face_models DROP COLUMN embedder_model;")
-            .unwrap();
-    }
+    // injection — and the migration gating that keeps the handler's own
+    // re-open from healing it — lives in `facelock_test_support::
+    // schema_faults`, shared with facelock-cli's keygen-guard test.
+    facelock_test_support::schema_faults::drop_embedder_model_column(&db_path);
```

The helper's signature, `pub fn drop_embedder_model_column(db_path: &Path)`, fit the call site as-is: the test holds a `PathBuf`, not a live connection, so `&db_path` coerces. The helper itself is unchanged apart from one doc-comment paragraph that claimed its caller "is **not** on this branch" and described the conversion as a pending follow-up — now false, so it is replaced with a plain statement of who calls it. That is a comment-only edit; the facelock-cli caller is untouched and still compiles.

**No assertion changed.** The test still pins C3 (#105): a storage failure during `Authenticate` must surface as `DaemonResponse::Error` and must not consume rate-limit budget, including the on-disk rate-limit counter re-check. Only the injection mechanism moved.

## Dev-dependency disposition

`rusqlite` is removed from `crates/facelock-daemon/Cargo.toml`. Grep across the entire crate — `src/`, `tests/`, no benches or examples exist — found exactly one use, the line this change deletes:

```
crates/facelock-daemon/Cargo.toml:40:rusqlite = { version = "0.40", features = ["bundled"] }
crates/facelock-daemon/tests/daemon_integration.rs:863:        let conn = rusqlite::Connection::open(&db_path).unwrap();
```

`Cargo.lock` is updated accordingly (`rusqlite` drops out of the `facelock-daemon` dependency list).

## Vacuity proof

The risk in this change is that the shared helper fails to break the query the test depends on, leaving the test to pass against a healthy store. It does not — the fault still bites.

**Injection commented out — FAILS:**

```
running 1 test

thread 'authenticate_storage_failure_is_error_and_charges_no_rate_limit' panicked at
crates/facelock-daemon/tests/daemon_integration.rs:890:18:
a storage failure must be reported as Error, never as a no-match AuthResult; got
AuthResult(MatchResult { matched: false, model_id: None, label: None, similarity: 0.0,
face_detected: false, failure_reason: None })
test authenticate_storage_failure_is_error_and_charges_no_rate_limit ... FAILED

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 23 filtered out
```

That is exactly the silent failure mode being guarded against: without the fault, the handler returns a healthy no-match result rather than a storage error.

**Injection restored — PASSES:**

```
running 1 test
test authenticate_storage_failure_is_error_and_charges_no_rate_limit ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.00s
```

## Gates

`just check` (exit 0; includes the stricter `cargo clippy --workspace --all-targets -- -D warnings`):

```
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s   # daemon_integration
pam-facelock crate count: 57
pam-facelock dependency guard passed
```

`just test-arch-pam`:

```
=== Results: 22 passed, 0 failed ===
```

`just test-arch-layout`:

```
=== Results: 21 passed, 0 failed ===
```

Test-only change plus a manifest edit. No production code, no behavior change, no auth-semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
