### PR TITLE
feat(cli): add devices --json; retarget oneshot IR test to it

### DIFF
--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -1,9 +1,10 @@
 use facelock_core::Config;
+use facelock_core::ipc::IpcDeviceInfo;
 
 use crate::backend::Backend;
 use crate::ipc_client;
 
-pub fn run(config: &Config) -> anyhow::Result<()> {
+pub fn run(config: &Config, json: bool) -> anyhow::Result<()> {
     // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
     ipc_client::require_root("sudo facelock devices")?;
 
@@ -12,6 +13,11 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
     // its own loop.
     let backend = Backend::select(config);
     let devices = backend.list_devices()?;
+
+    if json {
+        print_json(&devices);
+        return Ok(());
+    }
 
     if devices.is_empty() {
         println!("No video devices found.");
@@ -54,8 +60,73 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `facelock devices --json`: serde-derived output (see
+/// `facelock_core::ipc::IpcDeviceInfo`), so a consumer parses a stable typed
+/// schema instead of the human-readable renderer above — the renderer's
+/// layout (columns, the `[IR]` tag, indentation) is free to change without
+/// breaking anything that reads `--json`.
+fn print_json(devices: &[IpcDeviceInfo]) {
+    let json = serde_json::to_string(devices).unwrap_or_else(|_| "[]".to_string());
+    println!("{json}");
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use facelock_core::ipc::IpcFormatInfo;
+
+    fn sample_devices() -> Vec<IpcDeviceInfo> {
+        vec![
+            IpcDeviceInfo {
+                path: "/dev/video0".to_string(),
+                name: "Logitech BRIO".to_string(),
+                driver: "uvcvideo".to_string(),
+                is_ir: false,
+                formats: vec![IpcFormatInfo {
+                    fourcc: "YUYV".to_string(),
+                    description: "YUYV 4:2:2".to_string(),
+                    sizes: vec![(1920, 1080), (640, 480)],
+                }],
+            },
+            IpcDeviceInfo {
+                path: "/dev/video2".to_string(),
+                name: "Logitech BRIO IR".to_string(),
+                driver: "uvcvideo".to_string(),
+                is_ir: true,
+                formats: vec![IpcFormatInfo {
+                    fourcc: "GREY".to_string(),
+                    description: "8-bit Greyscale".to_string(),
+                    sizes: vec![(640, 480)],
+                }],
+            },
+        ]
+    }
+
     // Device listing requires hardware or a running daemon; the transport
-    // fork and its failure policy are pinned in `crate::backend`.
+    // fork and its failure policy are pinned in `crate::backend`. What is
+    // pure and testable here is the JSON shape itself.
+
+    #[test]
+    fn json_output_is_a_parseable_array_with_the_documented_fields() {
+        let rendered = serde_json::to_string(&sample_devices()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let arr = parsed.as_array().expect("top level must be a JSON array");
+        assert_eq!(arr.len(), 2);
+
+        assert_eq!(arr[0]["path"], "/dev/video0");
+        assert_eq!(arr[0]["is_ir"], false);
+        assert_eq!(arr[0]["formats"][0]["fourcc"], "YUYV");
+        assert_eq!(arr[0]["formats"][0]["sizes"][0][0], 1920);
+        assert_eq!(arr[0]["formats"][0]["sizes"][0][1], 1080);
+
+        assert_eq!(arr[1]["path"], "/dev/video2");
+        assert_eq!(arr[1]["is_ir"], true);
+        assert_eq!(arr[1]["formats"][0]["fourcc"], "GREY");
+    }
+
+    #[test]
+    fn json_output_is_an_empty_array_when_no_devices() {
+        let rendered = serde_json::to_string(&Vec::<IpcDeviceInfo>::new()).unwrap();
+        assert_eq!(rendered, "[]");
+    }
 }

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -66,22 +66,34 @@ fn print_table(user: &str, models: &[FaceModelInfo]) {
 }
 
 fn print_json(models: &[FaceModelInfo]) {
-    println!("[");
-    for (i, model) in models.iter().enumerate() {
-        let comma = if i + 1 < models.len() { "," } else { "" };
-        let device_id = model.device_id.as_deref().unwrap_or("");
-        println!(
-            "  {{\"id\": {}, \"label\": \"{}\", \"user\": \"{}\", \"created_at\": {}, \"embedder_model\": \"{}\", \"device_id\": \"{}\"}}{}",
-            model.id,
-            model.label,
-            model.user,
-            model.created_at,
-            model.embedder_model,
-            device_id,
-            comma
-        );
-    }
-    println!("]");
+    println!("{}", list_json(models));
+}
+
+/// `[{"id", "label", "user", "created_at", "embedder_model", "device_id"}, ...]`.
+///
+/// Built through `serde_json::json!` (same pattern as
+/// `commands::is_enrolled::enrolled_json`) rather than interpolating fields
+/// into a `format!` string: `label`, `user`, and `embedder_model` are not
+/// trusted to be free of `"` or `\` (E10) — a `format!` version emits invalid
+/// JSON for a label like `my "favorite" face`, which `json!` escapes
+/// correctly. `device_id` renders as `""` rather than `null` for a legacy
+/// row, matching the pre-existing output contract.
+fn list_json(models: &[FaceModelInfo]) -> String {
+    let values: Vec<serde_json::Value> = models
+        .iter()
+        .map(|model| {
+            let device_id = model.device_id.as_deref().unwrap_or("");
+            serde_json::json!({
+                "id": model.id,
+                "label": model.label,
+                "user": model.user,
+                "created_at": model.created_at,
+                "embedder_model": model.embedder_model,
+                "device_id": device_id,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(values).to_string()
 }
 
 fn format_timestamp(unix_ts: u64) -> String {
@@ -108,5 +120,61 @@ mod tests {
             formatted.contains("1970") || formatted.contains("1969"),
             "expected 1970 or 1969 (timezone-dependent) in {formatted}"
         );
+    }
+
+    fn model(label: &str, device_id: Option<&str>) -> FaceModelInfo {
+        FaceModelInfo {
+            id: 1,
+            user: "alice".to_string(),
+            label: label.to_string(),
+            created_at: 1700000000,
+            embedder_model: "w600k_r50.onnx".to_string(),
+            device_id: device_id.map(str::to_string),
+        }
+    }
+
+    /// The regression this fixes (E10): the old `format!`-based `print_json`
+    /// interpolated `label` directly into a JSON string literal, so a label
+    /// containing `"` produced invalid JSON. `list_json` must still parse and
+    /// must preserve the label's exact text.
+    #[test]
+    fn json_escapes_a_label_containing_a_quote() {
+        let models = vec![model(r#"my "favorite" face"#, None)];
+        let rendered = list_json(&models);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&rendered).expect("must be valid JSON");
+        assert_eq!(parsed[0]["label"], r#"my "favorite" face"#);
+    }
+
+    #[test]
+    fn json_escapes_a_label_containing_a_backslash() {
+        let models = vec![model(r"back\slash", None)];
+        let rendered = list_json(&models);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&rendered).expect("must be valid JSON");
+        assert_eq!(parsed[0]["label"], r"back\slash");
+    }
+
+    #[test]
+    fn json_output_matches_the_documented_shape() {
+        let models = vec![model("front", Some("046d:085e:abc123"))];
+        let rendered = list_json(&models);
+        assert_eq!(
+            rendered,
+            r#"[{"created_at":1700000000,"device_id":"046d:085e:abc123","embedder_model":"w600k_r50.onnx","id":1,"label":"front","user":"alice"}]"#
+        );
+    }
+
+    #[test]
+    fn json_renders_a_legacy_null_device_id_as_empty_string() {
+        let models = vec![model("front", None)];
+        let rendered = list_json(&models);
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed[0]["device_id"], "");
+    }
+
+    #[test]
+    fn json_output_is_an_empty_array_when_no_models() {
+        assert_eq!(list_json(&[]), "[]");
     }
 }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -160,7 +160,11 @@ enum Commands {
     /// Check system status
     Status,
     /// List available camera devices
-    Devices,
+    Devices {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Run the persistent authentication daemon
     Daemon {
         /// Path to config file
@@ -333,7 +337,7 @@ fn main() -> anyhow::Result<()> {
                         Commands::Preview { text_only, user } => {
                             commands::preview::run(&config, text_only, user)
                         }
-                        Commands::Devices => commands::devices::run(&config),
+                        Commands::Devices { json } => commands::devices::run(&config, json),
                         Commands::Bench { command } => commands::bench::run(&config, command),
                         Commands::Tpm { command } => commands::tpm::run(&config, command),
                         Commands::Encrypt { generate_key } => {

--- a/crates/facelock-core/src/ipc.rs
+++ b/crates/facelock-core/src/ipc.rs
@@ -2,6 +2,8 @@
 //! both directions (preview faces, device enumeration). The daemon handler's
 //! own request/response enums are internal to `facelock-daemon` (D5).
 
+use serde::Serialize;
+
 /// A detected face in a preview frame with its recognition status.
 #[derive(Debug, Clone)]
 pub struct PreviewFace {
@@ -19,7 +21,10 @@ pub struct PreviewFace {
 }
 
 /// Information about a V4L2 video device, returned via IPC.
-#[derive(Debug, Clone)]
+///
+/// `Serialize` backs `facelock devices --json` (serde-derived, unlike the
+/// hand-rolled `format!` JSON `list --json` used to build — see E10).
+#[derive(Debug, Clone, Serialize)]
 pub struct IpcDeviceInfo {
     pub path: String,
     pub name: String,
@@ -29,7 +34,7 @@ pub struct IpcDeviceInfo {
 }
 
 /// A supported pixel format with available resolutions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct IpcFormatInfo {
     pub fourcc: String,
     pub description: String,

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -295,57 +295,113 @@ if grep -q '^require_ir' /tmp/facelock-requireir.toml; then
 else
     sed -i '/^\[security\]/a require_ir = true' /tmp/facelock-requireir.toml
 fi
-# Enumerated with the quirks DB already aside, so the [IR] tags here mean exactly
-# what the auth gate will decide for the same nodes. `facelock devices` is the
-# only format enumerator in the image (no v4l-utils), and the BRIO assertions
-# above already parse this same listing.
-NOQUIRK_DEVICES="$(facelock devices)"
-# The first node offering a non-mono format, i.e. one the rule above classifies as
-# NOT IR. The fourcc list mirrors IR_TYPICAL_FOURCCS in facelock-camera's
-# device.rs. Format lines read `      FOURCC (description) — sizes`, so a `(` in
-# the second field is what tells them from Name:/Driver:/Formats: and from any log
-# line the binary writes to stdout. Selecting on format evidence rather than on
-# the absence of the [IR] tag is deliberate: if the classifier ever regressed and
-# tagged a colour node [IR], this picks it anyway and the assertion says so
-# instead of quietly skipping.
-NON_IR_NODE="$(printf '%s\n' "$NOQUIRK_DEVICES" | awk '
-    $1 ~ /^\/dev\/video/ { node = $1; next }
-    node != "" && NF >= 2 && $2 ~ /^\(/ && $1 !~ /^(GREY|Y8|Y10|Y12|Y16)$/ && pick == "" { pick = node }
-    END { print pick }
+# Enumerated with the quirks DB already aside, so `is_ir` here means exactly
+# what the auth gate will decide for the same nodes. `--json` is serde-derived
+# (facelock_core::ipc::IpcDeviceInfo, see main.rs's `devices` subcommand)
+# rather than the human-readable renderer this used to awk-parse: a renderer
+# layout change (columns, wording, the `[IR]` tag) can no longer silently
+# break this selection the way it could before — see `select_camera_node`
+# below for how a genuinely broken selector is told apart from "this host
+# has no camera of that kind" (the loud-skip requirement this replaces).
+NOQUIRK_DEVICES_JSON="$(facelock devices --json)"
+
+# Parses $NOQUIRK_DEVICES_JSON once to assert it is a non-empty array before
+# either selection below decides anything. A malformed/non-array payload
+# (from json.load or the isinstance check) exits non-zero, and because this
+# runs under `set -euo pipefail` with no `|| true`, that aborts the whole
+# script instead of being swallowed into an empty selection — a broken
+# producer fails loud. Zero devices is the one legitimate reason both
+# selections below skip: nothing was passed through to classify.
+DEVICE_COUNT="$(printf '%s' "$NOQUIRK_DEVICES_JSON" | python3 -c '
+import json, sys
+
+devices = json.load(sys.stdin)
+if not isinstance(devices, list):
+    sys.exit(f"selector error: expected a JSON array of devices, got {type(devices).__name__}")
+print(len(devices))
 ')"
-if [ -n "$NON_IR_NODE" ]; then
-    cp /tmp/facelock-requireir.toml /tmp/facelock-requireir-nonir.toml
-    pin_device_path /tmp/facelock-requireir-nonir.toml "$NON_IR_NODE"
-    run_test "facelock auth refuses non-IR camera when require_ir=true (anti-spoof, H1; pinned $NON_IR_NODE)" \
-        "facelock auth --user testuser --config /tmp/facelock-requireir-nonir.toml" \
-        2
-    # Exit 2 is shared by every pre-flight rejection — and by a config parse error,
-    # which is what a stale device.path pin in the source config would produce. Pin
-    # the rejection to the IR gate itself so neither can read as a pass. Piping
-    # into grep makes the test's status grep's, as in the auto-detect assertion above.
-    run_test "the refusal above is the IR gate, not another pre-flight rejection" \
-        "facelock auth --user testuser --config /tmp/facelock-requireir-nonir.toml 2>&1 | grep -q 'IR camera required but device is not IR'"
+
+# Prints the path of the first device in $NOQUIRK_DEVICES_JSON matching $1
+# ("non_ir" or "ir"), or nothing (exit 0) if every device classified fine but
+# none matched — the legitimate skip case. jq is not in this test image (see
+# test/Containerfile); python3 is (the fake-daemon harness already requires
+# it), so it parses the JSON.
+#
+# A device missing an expected key, or of the wrong type, is a genuine
+# selector/schema break — not "no camera" — so it is left to raise
+# (KeyError/TypeError) and propagate as a non-zero exit rather than being
+# caught and mapped to an empty result. Combined with $DEVICE_COUNT above,
+# that is what turns "the awk selects nothing" into "the script fails" for a
+# broken selector, per the plan this replaces.
+#
+# NON_IR selection mirrors the old awk's format-evidence rule (not the is_ir
+# field) deliberately: if the classifier ever regressed and marked a colour
+# node is_ir=true, this still finds it and the assertion says so instead of
+# quietly skipping. IR_NOQUIRK selection uses is_ir directly — the JSON
+# equivalent of the old renderer's `[IR]` tag.
+read -r -d '' SELECT_CAMERA_NODE_PY <<'PYEOF' || true
+import json
+import sys
+
+want = sys.argv[1]
+devices = json.load(sys.stdin)
+if not isinstance(devices, list):
+    sys.exit(f"selector error: expected a JSON array of devices, got {type(devices).__name__}")
+
+IR_FOURCCS = {"GREY", "Y8", "Y10", "Y12", "Y16"}
+
+for dev in devices:
+    path = dev["path"]
+    is_ir = dev["is_ir"]
+    fourccs = [fmt["fourcc"].strip() for fmt in dev["formats"]]
+
+    if want == "non_ir" and any(fc not in IR_FOURCCS for fc in fourccs):
+        print(path)
+        sys.exit(0)
+    if want == "ir" and is_ir:
+        print(path)
+        sys.exit(0)
+PYEOF
+select_camera_node() {
+    python3 -c "$SELECT_CAMERA_NODE_PY" "$1"
+}
+
+if [ "$DEVICE_COUNT" -eq 0 ]; then
+    echo "TEST: facelock auth refuses non-IR camera when require_ir=true ... SKIP (facelock devices --json enumerated no cameras)"
+    echo "TEST: require_ir=true admits a genuine IR node ... SKIP (facelock devices --json enumerated no cameras)"
 else
-    echo "TEST: facelock auth refuses non-IR camera when require_ir=true ... SKIP (no node enumerates a colour format; nothing on this host classifies as non-IR)"
-fi
-# Converse half of the contract: with a genuinely IR node pinned, that same
-# require_ir = true config must NOT refuse. Asserted as "the gate did not fire and
-# the run reached capture" rather than "auth exited 0": a successful match would
-# additionally need a live face in front of THIS node at this instant and a
-# template enrolled from it, neither of which holds on an arbitrary host. The exit
-# code is ignored for the same reason; the probe log is teed so a failure here
-# reports the camera error that caused it instead of an empty output.
-IR_NODE_NOQUIRK="$(printf '%s\n' "$NOQUIRK_DEVICES" | awk '
-    $1 ~ /^\/dev\/video/ && $2 == "[IR]" && pick == "" { pick = $1 }
-    END { print pick }
-')"
-if [ -n "$IR_NODE_NOQUIRK" ]; then
-    cp /tmp/facelock-requireir.toml /tmp/facelock-requireir-ir.toml
-    pin_device_path /tmp/facelock-requireir-ir.toml "$IR_NODE_NOQUIRK"
-    run_test "require_ir=true admits a genuine IR node (converse, H1; pinned $IR_NODE_NOQUIRK)" \
-        "RUST_LOG=info timeout --foreground 20 facelock auth --user testuser --config /tmp/facelock-requireir-ir.toml 2>&1 | tee /tmp/ir-admit-probe.log || true; ! grep -q 'IR camera required but device is not IR' /tmp/ir-admit-probe.log && grep -q 'camera format negotiated' /tmp/ir-admit-probe.log"
-else
-    echo "TEST: require_ir=true admits a genuine IR node ... SKIP (no [IR]-classified node; this host exposes no mono-only sensor)"
+    NON_IR_NODE="$(printf '%s' "$NOQUIRK_DEVICES_JSON" | select_camera_node non_ir)"
+    if [ -n "$NON_IR_NODE" ]; then
+        cp /tmp/facelock-requireir.toml /tmp/facelock-requireir-nonir.toml
+        pin_device_path /tmp/facelock-requireir-nonir.toml "$NON_IR_NODE"
+        run_test "facelock auth refuses non-IR camera when require_ir=true (anti-spoof, H1; pinned $NON_IR_NODE)" \
+            "facelock auth --user testuser --config /tmp/facelock-requireir-nonir.toml" \
+            2
+        # Exit 2 is shared by every pre-flight rejection — and by a config parse error,
+        # which is what a stale device.path pin in the source config would produce. Pin
+        # the rejection to the IR gate itself so neither can read as a pass. Piping
+        # into grep makes the test's status grep's, as in the auto-detect assertion above.
+        run_test "the refusal above is the IR gate, not another pre-flight rejection" \
+            "facelock auth --user testuser --config /tmp/facelock-requireir-nonir.toml 2>&1 | grep -q 'IR camera required but device is not IR'"
+    else
+        echo "TEST: facelock auth refuses non-IR camera when require_ir=true ... SKIP (no node enumerates a colour format; nothing on this host classifies as non-IR)"
+    fi
+    # Converse half of the contract: with a genuinely IR node pinned, that same
+    # require_ir = true config must NOT refuse. Asserted as "the gate did not fire and
+    # the run reached capture" rather than "auth exited 0": a successful match would
+    # additionally need a live face in front of THIS node at this instant and a
+    # template enrolled from it, neither of which holds on an arbitrary host. The exit
+    # code is ignored for the same reason; the probe log is teed so a failure here
+    # reports the camera error that caused it instead of an empty output.
+    IR_NODE_NOQUIRK="$(printf '%s' "$NOQUIRK_DEVICES_JSON" | select_camera_node ir)"
+    if [ -n "$IR_NODE_NOQUIRK" ]; then
+        cp /tmp/facelock-requireir.toml /tmp/facelock-requireir-ir.toml
+        pin_device_path /tmp/facelock-requireir-ir.toml "$IR_NODE_NOQUIRK"
+        run_test "require_ir=true admits a genuine IR node (converse, H1; pinned $IR_NODE_NOQUIRK)" \
+            "RUST_LOG=info timeout --foreground 20 facelock auth --user testuser --config /tmp/facelock-requireir-ir.toml 2>&1 | tee /tmp/ir-admit-probe.log || true; ! grep -q 'IR camera required but device is not IR' /tmp/ir-admit-probe.log && grep -q 'camera format negotiated' /tmp/ir-admit-probe.log"
+    else
+        echo "TEST: require_ir=true admits a genuine IR node ... SKIP (no [IR]-classified node; this host exposes no mono-only sensor)"
+    fi
 fi
 # Restore the system quirks DB inline so the remaining tests see it, then drop the
 # trap now that shared state is consistent again.


### PR DESCRIPTION
## Summary

`test/run-oneshot-tests.sh`'s `require_ir` block picks a non-IR and an IR camera node by awk-parsing `facelock devices`'s human-readable output, keyed on its exact layout (node lines starting `/dev/video`, the `[IR]` tag, a `(` starting the second field of a format line). This is correct today, but if the renderer's layout ever changes (a column, re-indenting, localizing a label), the awk silently selects nothing, the picked-node variable is empty, and the test takes its **skip** branch — a security assertion about `require_ir` degrades from "verified" to "skipped" while the tier still reports all-green.

- **2a.** Added `facelock devices --json`: serde-derived output via a new `Serialize` derive on `IpcDeviceInfo`/`IpcFormatInfo` (`facelock-core/src/ipc.rs`), following the precedent of `is-enrolled --json`/`list --json`. `devices` stays root-only (DEC-6) for both output modes.
- **2b.** Retargeted the test to `facelock devices --json`.
- **2c. (the part that actually closes the gap)** A device missing an expected key, or malformed JSON from the producer, is left to raise (`KeyError`/`TypeError`/`JSONDecodeError`) instead of being caught and mapped to an empty result. Under the script's `set -euo pipefail`, that **aborts the whole test run** rather than being swallowed into a silent skip. A device count is asserted up front (`DEVICE_COUNT`) so a genuinely empty (headless) enumeration is still a legitimate, distinct skip — the one case the plan says should still skip.
- **2d.** `jq` is **not** in `test/Containerfile`'s package list. Per the plan, did not add it solely for this — `python3` is already required there (the fake-daemon harness), so a small python script does the JSON parsing.
- **Bonus (same defect class, E10):** `list --json`'s hand-rolled `format!` JSON interpolated `label`/`user`/`embedder_model` directly into a string literal — a label containing `"` or `\` produced invalid JSON. Converted to `serde_json` (mirrors `commands::is_enrolled::enrolled_json`), keeping the exact same field set and the `device_id: ""` (not `null`) contract for legacy rows. Added tests with a quoted and a backslash-containing label.

The non-IR selection still mirrors the prior rule exactly: it picks by **format evidence** (any format not in `GREY/Y8/Y10/Y12/Y16`), not the `is_ir` field — so if the classifier ever regresses and mistags a colour node `is_ir=true`, this still finds it and the assertion says so, instead of quietly skipping. The IR selection uses `is_ir` directly, the JSON equivalent of the old `[IR]` tag.

## Constraints respected

- No auth-semantics change, no D-Bus wire change. `is-enrolled`'s output contract/exit codes untouched.
- `devices --json` stays root-only, same as the table renderer.

## Verification

**Unit tests** (new): JSON shape for `devices --json` (parseable array, `is_ir`, nested `formats[].fourcc`/`sizes`, empty-list case) and for the fixed `list --json` (valid-JSON-despite-quote, valid-JSON-despite-backslash, exact documented shape, legacy `device_id` renders `""`, empty-list case). `cargo test --workspace`: all green.

**Selector logic, hand-traced against both node shapes documented in the plan (Logitech BRIO: `/dev/video0` YUYV/MJPG/NV12 non-IR, `/dev/video2` GREY-only IR)** — and empirically run standalone (extracted verbatim, `facelock devices --json` stubbed) against synthetic JSON, since I cannot run `just test-arch-oneshot` here (no camera/ONNX models):

| Case | DEVICE_COUNT | NON_IR_NODE | IR_NODE_NOQUIRK | Result |
|---|---|---|---|---|
| BRIO shape (video0 YUYV/MJPG/NV12, video2 GREY-only) | 3 | `/dev/video0` | `/dev/video2` | matches the documented hardware trace |
| IR-only host (single GREY-only node) | 1 | *(empty)* | `/dev/video2` | legitimate skip of the non-IR assertion only |
| Headless (`[]`) | 0 | — | — | both assertions skip via the `DEVICE_COUNT` guard |
| **Broken: device missing `formats` key (schema regression)** | 1 (count itself still parses) | — | — | **script aborts, exit 1** (`KeyError: 'formats'`) — proves the fail-not-skip requirement |
| **Broken: malformed JSON (producer crashed/truncated)** | — | — | — | **script aborts, exit 1** (`JSONDecodeError`) — proves the fail-not-skip requirement |

This is the concrete proof that "a broken selector fails rather than skips": under the old awk, a layout change would have produced an empty `pick` and a silent `SKIP` line; the new selector aborts the run instead.

**⚠️ UNVERIFIED-BY-EXECUTION:** I cannot run `just test-arch-oneshot` in this environment (no camera, no ONNX models). The hand-trace and standalone harness above are the strongest verification available to me; the container tier itself needs to be run by Ty against real hardware.

## Test plan

- [x] `cargo test --workspace` (all green)
- [x] `just check`
- [x] `just test-arch-pam` (22/22)
- [x] `just test-arch-layout` (21/21)
- [x] Standalone hand-trace of the new selector against both BRIO node shapes and two broken-input cases (see table above)
- [x] **`just test-arch-oneshot` — NOT run (no camera/models available here); UNVERIFIED-BY-EXECUTION, needs Ty**

🤖 Generated with [Claude Code](https://claude.com/claude-code)