### PR TITLE
fix(markers): converge enrollment markers outside setup (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since the group is required to reach the daemon at all. The
   marker is a hint for the UI, not authority: it can drift, and PAM at
   authentication time remains authoritative. Markers are maintained by `enroll`,
-  `remove` and `clear`, and every `setup` run reconciles them from the database,
-  which backfills users enrolled before this feature existed.
+  `remove` and `clear`, and converged from the database — the authoritative
+  source — by every `setup` run, by daemon startup, and by the one-shot
+  `facelock auth` path for the user it is authenticating (#137). An install
+  upgraded from a release without markers therefore backfills itself on the
+  first daemon start or the first authentication, without a migration step:
+  each convergence re-derives the markers rather than replaying recorded
+  changes, so it is idempotent and keeps no state that a restored backup could
+  contradict.
 - **Enrollment failure breakdown** (#89): when enrollment captures too few
   frames, the error now reports why frames were rejected (too dark, no face,
   multiple faces, low quality, capture errors with the last error message) and
@@ -182,6 +188,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bare "AccessDenied".
 
 ### Security
+
+- **`CAP_CHOWN` added to the daemon's capability bounding set, for startup
+  only** (#137). Root without `CAP_CHOWN` cannot `chown(2)` at all, and two
+  startup steps need it on an *upgraded* install: `ensure_state_layout` (which
+  chowns `/var/lib/facelock` to `root:facelock`, and whose failure is fatal —
+  the daemon exits 1) and the enrollment-marker reconcile (which chowns each
+  marker to its user). The capability is deliberately **not** ambient and is
+  cleared by the in-process `drop_capabilities()` as soon as the daemon claims
+  its bus name, so it is never held while authenticating anyone and no exec'd
+  child inherits it. `systemd-analyze security` moves 2.6 → 2.8 (still OK); it
+  scores the bounding set and cannot see the in-process drop.
 
 ## [0.1.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,10 +303,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chowns `/var/lib/facelock` to `root:facelock`, and whose failure is fatal —
   the daemon exits 1) and the enrollment-marker reconcile (which chowns each
   marker to its user). The capability is deliberately **not** ambient and is
-  cleared by the in-process `drop_capabilities()` as soon as the daemon claims
-  its bus name, so it is never held while authenticating anyone and no exec'd
-  child inherits it. `systemd-analyze security` moves 2.6 → 2.8 (still OK); it
-  scores the bounding set and cannot see the in-process drop.
+  cleared by the in-process capability drop as soon as the daemon claims its bus
+  name, so it is never held while authenticating anyone and no exec'd child
+  inherits it. `systemd-analyze security` moves 2.6 → 2.8 (still OK); it scores
+  the bounding set and cannot see the in-process drop.
+- **The daemon's capability drop is now verified, and refuses to serve if it did
+  not happen.** It used to log `failed to drop capabilities (continuing)` and
+  carry on, which made "narrowed after initialization" a best-effort claim. That
+  was defensible while the dropped set held nothing the security model had
+  promised to remove; with `CAP_CHOWN` in the bounding set (above) it is not — a
+  failed drop would leave the daemon serving every authentication with
+  `chown(2)` in reach. The daemon now reads its capabilities back with `capget`
+  and exits before answering a single call if anything beyond
+  `CAP_SETUID`+`CAP_SETGID` survived. Refusing is not a lockout: PAM degrades to
+  the password exactly as it does when the daemon is not running. A daemon
+  started under a *narrower* set than the shipped unit grants still runs (it
+  holds nothing extra) with a warning that notifications may not work.
 
 ## [0.1.4] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,10 +303,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chowns `/var/lib/facelock` to `root:facelock`, and whose failure is fatal —
   the daemon exits 1) and the enrollment-marker reconcile (which chowns each
   marker to its user). The capability is deliberately **not** ambient and is
-  cleared by the in-process capability drop as soon as the daemon claims its bus
-  name, so it is never held while authenticating anyone and no exec'd child
-  inherits it. `systemd-analyze security` moves 2.6 → 2.8 (still OK); it scores
-  the bounding set and cannot see the in-process drop.
+  cleared by the in-process capability drop as soon as those two steps are done
+  and before the daemon creates its first thread, so no thread of the process
+  holds it while anyone is being authenticated and no exec'd child inherits it.
+  `systemd-analyze security` moves 2.6 → 2.8 (still OK); it scores the bounding
+  set and cannot see the in-process drop.
 - **The daemon's capability drop is now verified, and refuses to serve if it did
   not happen.** It used to log `failed to drop capabilities (continuing)` and
   carry on, which made "narrowed after initialization" a best-effort claim. That
@@ -318,7 +319,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CAP_SETUID`+`CAP_SETGID` survived. Refusing is not a lockout: PAM degrades to
   the password exactly as it does when the daemon is not running. A daemon
   started under a *narrower* set than the shipped unit grants still runs (it
-  holds nothing extra) with a warning that notifications may not work.
+  holds nothing extra) with a warning that notifications may not work — the drop
+  requests only capabilities the process already has, so a narrower start can no
+  longer fail the drop wholesale and trip the refusal.
+- **The capability drop happens while the daemon is still single-threaded.**
+  Capabilities and `PR_SET_NO_NEW_PRIVS` are per-*thread* and inherited only
+  forwards, so a drop performed once the ONNX Runtime pools and the tokio
+  runtime existed narrowed only the calling thread — leaving every thread that
+  actually serves `Authenticate` holding `CAP_CHOWN`, with a per-thread `capget`
+  read-back that could not see it. `test/pkg-validate.sh` now walks
+  `/proc/<pid>/task/*/status` on the running daemon and asserts `CAP_CHOWN` is
+  clear on every thread.
 
 ## [0.1.4] - 2026-05-31
 

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -174,7 +174,19 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             return 1;
         }
     };
-    let models = store.list_models(&user).unwrap_or_default();
+    let listed = store.list_models(&user);
+    // Converge this user's enrollment marker from the list we just read (#137),
+    // before the authentication decides anything. Free: the count is already in
+    // hand. This is the daemonless install's only convergence point — the
+    // daemon's startup reconcile never runs there.
+    //
+    // Here and not above `pre_check_audited`: hoisting it would put a marker
+    // rewrite (temp file, chown, rename) behind every rate-limited attempt —
+    // filesystem work an attacker can drive from the wrong side of the rate
+    // limiter. The cost is that a pre-flight rejection does not converge; the
+    // next attempt that reaches this line does.
+    converge_enrollment_marker(&config, &user, listed.as_ref().ok().map(|m| m.len() as u32));
+    let models = listed.unwrap_or_default();
 
     let start = std::time::Instant::now();
     // Wipes `stored` (D11): nothing below may read the plaintext set again.
@@ -262,6 +274,25 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
             error!("unexpected response");
             2
         }
+    }
+}
+
+/// Write `user`'s enrollment marker from a model count just read from the
+/// authoritative store (#137).
+///
+/// `models` is `None` when the store could not be listed — leave the existing
+/// marker alone rather than guessing it away, the same rule
+/// [`crate::commands::enrollment_marker::refresh`] follows. A count of zero is
+/// a real answer ("no models") and does delete the marker.
+///
+/// Called unconditionally, before the authentication attempt and regardless of
+/// its outcome: an upgraded user whose face is not recognised today still needs
+/// `is-enrolled` to tell the truth. Best-effort throughout — `set` logs its own
+/// failures and never propagates, so nothing here can fail an authentication.
+fn converge_enrollment_marker(config: &Config, user: &str, models: Option<u32>) {
+    match models {
+        Some(models) => super::enrollment_marker::set(config, user, models),
+        None => debug!(user = %user, "model list unavailable; enrollment marker left unchanged"),
     }
 }
 
@@ -550,5 +581,100 @@ path = "{audit_path}"
         );
         assert!(resp.is_none(), "gates must pass, got {resp:?}");
         assert!(audit_lines(&audit_path).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Enrollment marker convergence (#137)
+    // -----------------------------------------------------------------------
+
+    use super::converge_enrollment_marker;
+    use crate::commands::enrollment_marker::{MarkerState, marker_dir, read_marker_in};
+
+    /// A config pointing an entire installation at `dir`: the marker directory
+    /// is derived from `storage.db_path`. "alice" has no passwd entry, so the
+    /// write skips its `chown` and the test needs no privileges.
+    fn marker_config(dir: &std::path::Path) -> Config {
+        let mut config = Config::parse("").expect("empty config parses to defaults");
+        config.storage.db_path = dir.join("facelock.db").to_string_lossy().into_owned();
+        config
+    }
+
+    /// #137 on a daemonless install: the marker the upgrade never wrote gets
+    /// written the first time the user authenticates — whatever the
+    /// authentication then decides, since this runs before it.
+    #[test]
+    fn oneshot_converges_an_absent_marker_from_the_model_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = marker_config(tmp.path());
+        let base = marker_dir(&config);
+
+        converge_enrollment_marker(&config, "alice", Some(2));
+
+        match read_marker_in(&base, "alice") {
+            MarkerState::Enrolled(m) => assert_eq!(m.models, 2),
+            other => panic!("expected alice enrolled, got {other:?}"),
+        }
+
+        // Same idempotence the daemon path relies on.
+        converge_enrollment_marker(&config, "alice", Some(2));
+        assert!(matches!(
+            read_marker_in(&base, "alice"),
+            MarkerState::Enrolled(m) if m.models == 2
+        ));
+    }
+
+    /// A count of zero is a real answer from the store: the user has no models,
+    /// so the marker must go.
+    #[test]
+    fn oneshot_convergence_clears_the_marker_at_zero_models() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = marker_config(tmp.path());
+        let base = marker_dir(&config);
+
+        converge_enrollment_marker(&config, "alice", Some(1));
+        converge_enrollment_marker(&config, "alice", Some(0));
+
+        assert_eq!(read_marker_in(&base, "alice"), MarkerState::Absent);
+    }
+
+    /// An unreadable store is not evidence of anything. Guessing "zero" from a
+    /// failed `list_models` would delete a correct marker on a transient
+    /// database error — the opposite of the bug being fixed.
+    #[test]
+    fn oneshot_convergence_leaves_the_marker_alone_when_the_count_is_unknown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = marker_config(tmp.path());
+        let base = marker_dir(&config);
+
+        converge_enrollment_marker(&config, "alice", Some(3));
+        converge_enrollment_marker(&config, "alice", None);
+
+        assert!(
+            matches!(read_marker_in(&base, "alice"), MarkerState::Enrolled(m) if m.models == 3),
+            "an unknown count must not overwrite a known one"
+        );
+    }
+
+    /// Structural pin, in the style of `resolved.rs`: the convergence call sits
+    /// ahead of the authentication attempt in `run`'s straight-line code. That
+    /// ordering is the whole of "regardless of whether authentication succeeds"
+    /// — move the call below the result and convergence silently becomes
+    /// conditional on a face being recognised, which is exactly the population
+    /// #137 is about.
+    #[test]
+    fn marker_convergence_precedes_the_authentication_attempt() {
+        let src = include_str!("auth.rs");
+        // First occurrence is the call in `run`; the definition and this test
+        // both live further down the file.
+        let converge = src
+            .find("converge_enrollment_marker(")
+            .expect("run() must converge the marker");
+        let authenticate = src
+            .find("::authenticate_with_embeddings(")
+            .expect("run() must attempt an authentication");
+        assert!(
+            converge < authenticate,
+            "marker convergence must run before the authentication attempt"
+        );
     }
 }

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -37,16 +37,41 @@ type CameraFactory = Box<dyn Fn(&Config) -> Result<Camera<'static>, String> + Se
 /// makes that unrepresentable, and it is the same one `server`'s mtime watch
 /// stats (`paths::config_path()`).
 fn build_handler() -> Result<(ProductionHandler, u64), String> {
+    build_handler_from(load_config_and_ensure_layout()?)
+}
+
+/// The privileged prologue: parse the config and converge the on-disk layout.
+///
+/// Split out of [`build_handler`] because it is the part that needs
+/// `CAP_CHOWN`, and the daemon narrows its capabilities between this and the
+/// rest of startup (see [`run`]). `build_handler` still runs both halves back
+/// to back, because it is also the live-reload recipe — a reload re-reads the
+/// config and re-converges the layout exactly as before. What a reload no
+/// longer has is `CAP_CHOWN`, which is the documented model rather than a
+/// regression: the steady state chowns nothing, and a reload that genuinely
+/// needed one now fails the rebuild (the daemon logs it and keeps serving with
+/// the handler it already has) instead of quietly succeeding on a thread that
+/// happened to still hold the capability.
+fn load_config_and_ensure_layout() -> Result<Config, String> {
     // Deliberate re-read (D7): this is the daemon's config lifecycle — one
     // parse at startup, one per mtime-triggered reload (maybe_reload_handler).
     // Everything downstream consumes the Config held by the handler.
-    let mut config = Config::load().map_err(|e| format!("failed to load config: {e}"))?;
+    let config = Config::load().map_err(|e| format!("failed to load config: {e}"))?;
 
     // Before anything opens the store: the daemon runs as root, so this is
     // where an upgraded install converges on the documented modes. A handful
     // of stat calls in the steady state.
     crate::state_layout::ensure_state_layout(&config).map_err(|e| format!("{e:#}"))?;
 
+    Ok(config)
+}
+
+/// Everything after the privileged prologue: device resolution, the ONNX
+/// engine, the store, the handler. None of it needs a capability, which is why
+/// [`run`] can drop them before calling this — and must, because
+/// `FaceEngine::load` is where ONNX Runtime brings up its intra-op thread
+/// pools, and those threads keep whatever credentials they are born with.
+fn build_handler_from(mut config: Config) -> Result<(ProductionHandler, u64), String> {
     let quirks = QuirksDb::load();
 
     if config.device.path.is_none() {
@@ -221,18 +246,47 @@ pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
 
     info!("facelock daemon starting");
 
-    let (handler, idle_timeout_secs) = match build_handler() {
-        Ok(r) => r,
+    // Startup is ordered around one hinge: everything that needs CAP_CHOWN
+    // runs first, then the process narrows itself, then everything that
+    // creates a thread runs.
+    //
+    // The narrowing has to land in that gap because capabilities and
+    // PR_SET_NO_NEW_PRIVS are per-*thread* and inherited only forwards. Doing
+    // it later — as this did, after the bus name was claimed — leaves every
+    // thread already in flight holding CAP_CHOWN for the daemon's lifetime:
+    // ONNX Runtime's intra-op pools (six threads, spawned inside
+    // `FaceEngine::load`) and every tokio worker and blocking thread, which is
+    // to say precisely the threads that go on to serve `Authenticate`.
+    // `capget` would not have caught it either, being per-thread itself.
+    //
+    // Here the process is still single-threaded, so the narrowing reaches the
+    // whole daemon, and refusing costs nothing anyone can observe: no bus name
+    // is claimed yet, so a client sees the same thing it sees when the daemon
+    // is not running at all.
+    let config = match load_config_and_ensure_layout() {
+        Ok(c) => c,
         Err(e) => {
             error!("{e}");
             std::process::exit(1);
         }
     };
 
-    // After the handler, so the store exists and the state layout has been
-    // ensured; the handler owns the parsed config, so this adds no second read
-    // of the config file (resolved::config_load_call_sites_are_pinned).
-    reconcile_enrollment_markers(&handler.config);
+    // The other CAP_CHOWN user, and the last one: markers are chowned to the
+    // user each describes. Moved ahead of the handler (it used to read
+    // `handler.config`) so it stays on the privileged side of the hinge; it
+    // takes the same parsed Config, so this still adds no second read of the
+    // config file (resolved::config_load_call_sites_are_pinned).
+    reconcile_enrollment_markers(&config);
+
+    let narrowed = facelock_daemon::server::drop_capabilities_or_refuse()?;
+
+    let (handler, idle_timeout_secs) = match build_handler_from(config) {
+        Ok(r) => r,
+        Err(e) => {
+            error!("{e}");
+            std::process::exit(1);
+        }
+    };
 
     let config_mtime = std::fs::metadata(facelock_core::paths::config_path())
         .and_then(|m| m.modified())
@@ -247,6 +301,7 @@ pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
         config_mtime,
         Some(rebuild),
         notifier_factory,
+        &narrowed,
     )
     .map_err(Into::into)
 }

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -180,6 +180,30 @@ fn build_handler() -> Result<(ProductionHandler, u64), String> {
     Ok((handler, idle_timeout_secs))
 }
 
+/// Converge every enrollment marker with the database, once, at startup (#137).
+///
+/// Markers are newer than the databases they describe, so an install upgraded
+/// from a release without them has enrolled users and an empty `enrolled/` —
+/// and `facelock is-enrolled` answers "not enrolled" for a user whose face
+/// authentication works. This is the same shape as
+/// [`crate::state_layout::ensure_state_layout`] a few lines above in
+/// `build_handler`: it does not ask "has this run before?", it re-derives the
+/// right answer from the authoritative source, so it needs no ledger and
+/// cannot drift from one.
+///
+/// Deliberately in `run` and not in `build_handler`: the daemon's config
+/// reload goes through the builder, and reconciling is a startup concern, not
+/// something to repeat on every edit of the config file.
+///
+/// Best-effort by contract: a marker is a hint for `is-enrolled`, so failing
+/// to write one must never stop the daemon from serving authentications.
+fn reconcile_enrollment_markers(config: &Config) {
+    match crate::commands::enrollment_marker::reconcile_all(config) {
+        Ok(()) => info!("enrollment markers reconciled"),
+        Err(e) => warn!("enrollment markers not reconciled: {e:#}"),
+    }
+}
+
 /// `--config` is honored through the process-level override `main` installs
 /// before dispatch, which is what `Config::load()` and
 /// `paths::config_path()` both read — so startup, the live reload and the
@@ -205,6 +229,11 @@ pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
         }
     };
 
+    // After the handler, so the store exists and the state layout has been
+    // ensured; the handler owns the parsed config, so this adds no second read
+    // of the config file (resolved::config_load_call_sites_are_pinned).
+    reconcile_enrollment_markers(&handler.config);
+
     let config_mtime = std::fs::metadata(facelock_core::paths::config_path())
         .and_then(|m| m.modified())
         .ok();
@@ -220,4 +249,101 @@ pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
         notifier_factory,
     )
     .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::commands::enrollment_marker::{MarkerState, marker_dir, read_marker_in};
+
+    /// A config pointing an entire installation at `dir` — the marker
+    /// directory is derived from `storage.db_path`, so this is all it takes.
+    fn config_rooted_at(dir: &Path) -> Config {
+        let mut config = Config::parse("").expect("empty config parses to defaults");
+        config.storage.db_path = dir.join("facelock.db").to_string_lossy().into_owned();
+        config
+    }
+
+    /// The account the test runs as: `reconcile_all` skips users with no
+    /// passwd entry, and `chown`ing to your own uid/gid is a no-op an
+    /// unprivileged test may perform.
+    fn current_account() -> Option<String> {
+        nix::unistd::User::from_uid(nix::unistd::Uid::current())
+            .ok()
+            .flatten()
+            .map(|u| u.name)
+    }
+
+    /// #137: a database enrolled before markers existed, plus an empty
+    /// `enrolled/`, is exactly the state an upgrade from v0.1.4 leaves behind.
+    /// Daemon startup is what fixes it on a daemon-mode install — and fixes it
+    /// again, unchanged, on every restart after that.
+    #[test]
+    fn startup_reconcile_backfills_an_upgraded_install_and_repeats_cleanly() {
+        let Some(me) = current_account() else {
+            return;
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let config = config_rooted_at(tmp.path());
+
+        {
+            let store = FaceStore::create(Path::new(&config.storage.db_path)).unwrap();
+            store.add_model(&me, "front", &[0.0f32; 512], "").unwrap();
+        }
+        let base = marker_dir(&config);
+        assert!(!base.exists(), "the upgrade leaves no markers behind");
+
+        reconcile_enrollment_markers(&config);
+        match read_marker_in(&base, &me) {
+            MarkerState::Enrolled(m) => assert_eq!(m.models, 1, "count comes from the database"),
+            other => panic!("expected {me} enrolled after startup reconcile, got {other:?}"),
+        }
+
+        // Restart: same derivation, same answer, no ledger consulted.
+        reconcile_enrollment_markers(&config);
+        assert!(matches!(
+            read_marker_in(&base, &me),
+            MarkerState::Enrolled(m) if m.models == 1
+        ));
+    }
+
+    /// Failure isolation: reconcile is best-effort, so a database it cannot
+    /// open is logged and stepped over. If this ever propagates, a corrupt
+    /// state directory stops the daemon from serving authentications — which
+    /// is a far worse outcome than a stale `is-enrolled` answer.
+    #[test]
+    fn startup_reconcile_swallows_a_database_it_cannot_open() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = config_rooted_at(tmp.path());
+        // Not a database. Stands in for any reconcile failure; asserted to
+        // actually fail first so this test cannot go vacuous.
+        std::fs::write(&config.storage.db_path, b"not a sqlite file").unwrap();
+        assert!(
+            crate::commands::enrollment_marker::reconcile_all(&config).is_err(),
+            "test setup must produce a reconcile failure to swallow"
+        );
+
+        reconcile_enrollment_markers(&config);
+    }
+
+    /// Nothing about reconciling may bring a database into existence — the
+    /// daemon's own `FaceStore::create` owns that decision, and it has already
+    /// run by the time this is called.
+    #[test]
+    fn startup_reconcile_creates_no_database() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = config_rooted_at(tmp.path());
+
+        reconcile_enrollment_markers(&config);
+
+        assert!(
+            !Path::new(&config.storage.db_path).exists(),
+            "reconcile must not create a database as a side effect"
+        );
+        assert!(
+            marker_dir(&config).is_dir(),
+            "the marker directory is still created"
+        );
+    }
 }

--- a/crates/facelock-cli/src/commands/enrollment_marker.rs
+++ b/crates/facelock-cli/src/commands/enrollment_marker.rs
@@ -318,8 +318,17 @@ fn count_models(backend: &crate::backend::Backend, user: &str) -> Option<u32> {
 /// Rebuild every marker from the authoritative database.
 ///
 /// This is what backfills users who enrolled before markers existed, which is
-/// why the feature is safe to ship into an existing install. It needs DB access,
-/// so it only ever runs from privileged `setup` — never from `is-enrolled`.
+/// why the feature is safe to ship into an existing install. It runs from
+/// privileged `setup` and from daemon startup
+/// (`commands::daemon::reconcile_enrollment_markers`) — **never from
+/// `is-enrolled`**, which needs DB access it does not have and privileges it
+/// must not require.
+///
+/// Convergence, not migration: every call re-derives the markers from the
+/// database rather than replaying recorded steps, so it is idempotent, needs no
+/// ordering and keeps no "has this run?" state that a restored backup or a
+/// copied database could contradict. `markers_converge_idempotently` is the
+/// test that pins it.
 ///
 /// Users present in the DB but absent from `/etc/passwd` (stale rows) are
 /// skipped rather than failing the whole reconcile.
@@ -362,8 +371,12 @@ pub fn reconcile_all(config: &Config) -> anyhow::Result<()> {
         };
         if let Err(e) = write_marker_in(&base, &user, models, Some(owner)) {
             tracing::warn!(user, error = %e, "failed to write enrollment marker");
-            continue;
         }
+        // Kept whatever the write did. `wanted` answers "the database says this
+        // user is enrolled", not "the write succeeded" — pruning on a failed
+        // write turns *could not refresh* into *deleted a correct marker*, and
+        // a caller that reconciles on every start (daemon startup, #137) would
+        // then destroy state on the first transient failure.
         wanted.push(user);
     }
 
@@ -722,6 +735,143 @@ mod tests {
             read_marker_in(&base, "facelock-stale-user"),
             MarkerState::Absent,
             "a marker with no models behind it must be pruned"
+        );
+    }
+
+    /// The observable state of a marker directory: which markers exist, what
+    /// each one claims, and the mode of every entry. Deliberately excludes
+    /// `updated` — it is a timestamp, nothing reads it as state, and a rewrite
+    /// is expected to move it.
+    fn marker_snapshot(base: &Path) -> Vec<(String, MarkerState, u32)> {
+        let mut entries: Vec<(String, MarkerState, u32)> = fs::read_dir(base)
+            .unwrap()
+            .flatten()
+            .map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                let state = match read_marker_in(base, &name) {
+                    MarkerState::Enrolled(m) => MarkerState::Enrolled(Marker {
+                        models: m.models,
+                        updated: String::new(),
+                    }),
+                    other => other,
+                };
+                (name, state, mode_of(&e.path()))
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    /// **The load-bearing test.** This change ships convergence instead of a
+    /// migration, and this assertion is what makes that safe: a second run
+    /// re-derives the same answer from the same database, so there is nothing
+    /// to record as "already applied" — and therefore no recorded state that a
+    /// restored backup, a database copied between machines, or a wiped state
+    /// directory could contradict.
+    ///
+    /// If this ever fails, convergence has become order-dependent and the
+    /// callers added for #137 (daemon startup, the oneshot auth path) are no
+    /// longer safe to run unconditionally.
+    #[test]
+    fn markers_converge_idempotently() {
+        let me = nix::unistd::User::from_uid(nix::unistd::Uid::current())
+            .ok()
+            .flatten()
+            .map(|u| u.name);
+        let Some(me) = me else {
+            // No passwd entry for the test runner: reconcile can resolve no
+            // owner, so there is no convergence to assert idempotent.
+            return;
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("facelock.db");
+        let mut config = test_config();
+        config.storage.db_path = db_path.to_string_lossy().into_owned();
+
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            let emb = [0.0f32; 512];
+            store.add_model(&me, "front", &emb, "").unwrap();
+            store.add_model(&me, "side", &emb, "").unwrap();
+        }
+
+        let base = marker_dir(&config);
+        // Start from the upgrade's actual state: enrolled users, no markers,
+        // plus one stale marker for a user who is not in the database.
+        write_marker_in(&base, "facelock-stale-user", 1, None).unwrap();
+
+        reconcile_all(&config).unwrap();
+        let first = marker_snapshot(&base);
+
+        reconcile_all(&config).unwrap();
+        let second = marker_snapshot(&base);
+
+        assert_eq!(
+            first, second,
+            "a second reconcile must change nothing — that property is what \
+             replaces a migration ledger"
+        );
+        assert_eq!(
+            first.len(),
+            1,
+            "expected exactly {me}'s marker to survive, got {first:?}"
+        );
+        assert_eq!(first[0].0, me);
+        assert!(
+            matches!(&first[0].1, MarkerState::Enrolled(m) if m.models == 2),
+            "got {:?}",
+            first[0].1
+        );
+        assert_eq!(first[0].2, MARKER_FILE_MODE);
+        assert_eq!(mode_of(&base), MARKER_DIR_MODE, "directory mode is stable");
+    }
+
+    /// A marker the reconcile could not *write* must survive it.
+    ///
+    /// The failure is the real one: writing a marker `chown`s it to its user,
+    /// which needs `CAP_CHOWN`. A daemon under the shipped systemd unit has a
+    /// capability bounding set, so a missing `CAP_CHOWN` makes every marker
+    /// write fail with `EPERM` — and if a failed write dropped the user from
+    /// the keep-list, the very next daemon start would delete every correct
+    /// marker `setup` had written. Reproduced here by `chown`ing to another
+    /// account from an unprivileged test, which fails for the same reason.
+    #[test]
+    fn a_marker_that_cannot_be_written_is_not_pruned() {
+        if nix::unistd::Uid::effective().is_root() {
+            // Root has CAP_CHOWN, so the write below succeeds and there is no
+            // failure to isolate.
+            return;
+        }
+        // Any account that is not the test runner: `chown`ing to it is the
+        // privileged operation being denied.
+        let other = ["nobody", "daemon", "bin", "root"]
+            .into_iter()
+            .find(|u| resolve_owner(u).is_some());
+        let Some(other) = other else {
+            return;
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("facelock.db");
+        let mut config = test_config();
+        config.storage.db_path = db_path.to_string_lossy().into_owned();
+
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            store.add_model(other, "front", &[0.0f32; 512], "").unwrap();
+        }
+
+        // A correct marker already on disk — what `setup` would have left.
+        let base = marker_dir(&config);
+        write_marker_in(&base, other, 1, None).unwrap();
+
+        reconcile_all(&config).unwrap();
+
+        assert!(
+            matches!(read_marker_in(&base, other), MarkerState::Enrolled(m) if m.models == 1),
+            "an enrolled user's marker must survive a write this reconcile \
+             could not perform"
         );
     }
 

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -1341,12 +1341,21 @@ fn notify_auth_outcome(
 
 /// Run the daemon's D-Bus server until shutdown (signal, D-Bus `Shutdown`,
 /// or idle timeout). Blocking: builds its own multi-threaded tokio runtime.
+///
+/// Takes a [`CapabilitiesDropped`] because building that runtime is the point
+/// of no return for the capability narrowing: `Builder::build()` spawns the
+/// worker threads, each worker's blocking-pool threads descend from a worker,
+/// and every D-Bus method body runs its real work on one of those. A thread
+/// keeps the credentials it was created with, so a narrowing that happens
+/// after this line reaches none of them. The token is the caller's proof it
+/// happened before.
 pub fn run(
     handler: ProductionHandler,
     idle_timeout_secs: u64,
     startup_config_mtime: Option<std::time::SystemTime>,
     rebuild: Option<ProductionRebuild>,
     notifier_factory: NotifierFactory,
+    _narrowed: &CapabilitiesDropped,
 ) -> Result<(), ServerError> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -1376,6 +1385,49 @@ const fn retained_capability_mask() -> u32 {
     // CAP_SETGID = 6, CAP_SETUID = 7.
     (1 << 7) | (1 << 6)
 }
+
+/// The part of [`retained_capability_mask`] this process can actually keep,
+/// given what it currently holds as `permitted`.
+///
+/// `capset(2)` requires the new permitted set to be a subset of the old one,
+/// and enforces it *wholesale*: a request naming one capability the process
+/// does not have is rejected in its entirety and drops nothing at all. So the
+/// retained mask cannot be requested absolutely. An operator who wants no
+/// desktop notifications and writes a drop-in with
+/// `CapabilityBoundingSet=CAP_CHOWN` + `AmbientCapabilities=` starts the
+/// daemon with `permitted == {CAP_CHOWN}`; an absolute request for
+/// `{CAP_SETUID, CAP_SETGID}` returns `EPERM`, `CAP_CHOWN` survives, the
+/// read-back below calls that a violation, and `Restart=on-failure` turns a
+/// legitimate narrower configuration into a permanent 3-second restart loop —
+/// with the journal blaming the wrong thing.
+///
+/// Intersecting first makes the call only ever *remove*, so it cannot fail for
+/// this reason, and a narrower-than-retained start lands in the "warn and
+/// serve" branch the asymmetric policy describes instead of the fatal one.
+/// Whatever comes back, `CAP_CHOWN` is not in it: the mask has no bit 0.
+const fn capabilities_to_keep(permitted: u64) -> u32 {
+    (permitted & retained_capability_mask() as u64) as u32
+}
+
+/// Proof that the capability narrowing has already run, on a thread that is an
+/// ancestor of every thread the process goes on to create.
+///
+/// Linux capabilities and `PR_SET_NO_NEW_PRIVS` are per-*thread* attributes:
+/// `capset(2)`/`prctl(2)` with `hdr.pid == 0` change the calling thread and
+/// nothing else, and a thread that already exists keeps what it had for as
+/// long as it lives. (This is why libcap ships `libpsx` to broadcast a
+/// capability change across a process's threads.) Narrowing therefore has to
+/// happen while the daemon is still single-threaded — before
+/// `FaceEngine::load` brings up ONNX Runtime's intra-op pools and before
+/// [`run`] builds the tokio runtime.
+///
+/// That ordering is not something [`run`] can verify for itself, and a
+/// read-back cannot catch a mistake either: `capget(pid = 0)` inspects the one
+/// thread that *did* drop, so the verification would be self-confirming. A
+/// token only [`drop_capabilities_or_refuse`] can mint moves the requirement
+/// to where the compiler checks it.
+#[derive(Debug)]
+pub struct CapabilitiesDropped(());
 
 /// CAP_CHOWN's capability number.
 ///
@@ -1449,20 +1501,24 @@ struct CapData {
 /// `_LINUX_CAPABILITY_VERSION_3`. Two [`CapData`] words: caps 0-31, then 32-63.
 const LINUX_CAP_V3: u32 = 0x2008_0522;
 
-/// Drop all Linux capabilities except CAP_SETUID + CAP_SETGID, and set
-/// PR_SET_NO_NEW_PRIVS.
+/// Drop every Linux capability except `keep`, and set PR_SET_NO_NEW_PRIVS.
 ///
-/// After initialization the daemon has already opened the camera fd, loaded
-/// models, connected to D-Bus, and opened the database. It no longer needs any
-/// elevated capabilities EXCEPT the two required to drop privilege for desktop
-/// notifications (`runuser` → `setgroups`/`setuid`); those are retained via
-/// [`retained_capability_mask`] in the effective, permitted, AND inheritable
-/// sets, and everything else is cleared.
+/// By the time this runs the daemon has converged the state layout and the
+/// enrollment markers — the only two things it ever needed `CAP_CHOWN` for —
+/// so it no longer needs any elevated capability EXCEPT the two required to
+/// drop privilege for desktop notifications (`runuser` →
+/// `setgroups`/`setuid`). `keep` comes from [`capabilities_to_keep`] and is
+/// therefore always a subset of what is currently permitted; it goes in the
+/// effective, permitted, AND inheritable sets, and everything else is cleared.
+///
+/// **Per-thread.** `hdr.pid = 0` means the calling thread, so this narrows one
+/// thread and every thread created from it afterwards — see
+/// [`CapabilitiesDropped`] for why that constrains where it may be called.
 ///
 /// Returns `Ok(())` on success. Callers must not treat an error as merely
 /// advisory: [`drop_capabilities_or_refuse`] is the entry point, and it decides
 /// what a failure costs by *reading back* what is actually held.
-fn drop_capabilities() -> std::result::Result<(), String> {
+fn drop_capabilities(keep: u32) -> std::result::Result<(), String> {
     unsafe {
         // Prevent the process (and children) from ever gaining new privileges
         let ret = libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
@@ -1473,15 +1529,15 @@ fn drop_capabilities() -> std::result::Result<(), String> {
             ));
         }
 
-        // Retain exactly CAP_SETUID + CAP_SETGID (needed for the runuser/su
-        // notification privilege-drop); clear every other capability. The
-        // retained bits go in effective, permitted, AND inheritable — the
-        // inheritable set is what lets systemd AmbientCapabilities keep these
-        // caps across the exec into the non-setuid `runuser` under
-        // NoNewPrivileges. V3 uses two CapData structs (caps 0-31 and 32-63);
-        // the retained caps (6, 7) live in the low word, so the high word
-        // stays fully zeroed.
-        let keep = retained_capability_mask();
+        // Retain `keep` — normally CAP_SETUID + CAP_SETGID, the two the
+        // runuser/su notification privilege-drop needs; clear every other
+        // capability. The retained bits go in effective, permitted, AND
+        // inheritable — the inheritable set is what lets systemd
+        // AmbientCapabilities keep these caps across the exec into the
+        // non-setuid `runuser` under NoNewPrivileges. V3 uses two CapData
+        // structs (caps 0-31 and 32-63); the retained caps (6, 7) live in the
+        // low word, so the high word stays fully zeroed — which is also what
+        // clears anything above 31.
         let mut header = CapHeader {
             version: LINUX_CAP_V3,
             pid: 0,
@@ -1549,6 +1605,10 @@ fn read_capabilities() -> std::result::Result<HeldCapabilities, String> {
 /// Drop capabilities, verify the drop actually happened, and refuse to serve if
 /// it did not.
 ///
+/// **Call this from the daemon's main thread, before anything spawns a
+/// thread.** The narrowing is per-thread and is inherited only forwards; see
+/// [`CapabilitiesDropped`], the token this returns, which [`run`] demands.
+///
 /// This used to log `failed to drop capabilities (continuing)` and carry on.
 /// That was tolerable while the dropped set held nothing the security model had
 /// promised to remove — the two retained caps were the whole story, and a
@@ -1573,41 +1633,60 @@ fn read_capabilities() -> std::result::Result<HeldCapabilities, String> {
 ///   trade `state_layout::ensure_state_layout` already makes a few lines
 ///   earlier in startup, and the same "fail closed" convention as the model
 ///   SHA-256 check.
-/// - **Drop failed but nothing extra is held → warn and continue.** The daemon
-///   was started under a narrower capability set than the shipped unit grants,
-///   so `capset` could not *raise* into the retained mask. Notifications may
-///   not work; nothing about the security model is violated, and refusing here
-///   would turn an operator's hardening edit into a daemon that will not run.
+/// - **Drop failed but nothing extra is held → warn and continue.** Nothing
+///   about the security model is violated, and refusing here would turn an
+///   operator's hardening edit into a daemon that will not run.
 /// - **The read-back itself failed → fatal.** An unverifiable guarantee is not
 ///   a guarantee.
-fn drop_capabilities_or_refuse() -> std::result::Result<(), String> {
-    let dropped = drop_capabilities();
+///
+/// A daemon started under a narrower capability set than the shipped unit
+/// grants reaches none of those branches any more: [`capabilities_to_keep`]
+/// asks only for capabilities the process already has, so the drop succeeds
+/// and simply keeps less.
+pub fn drop_capabilities_or_refuse() -> std::result::Result<CapabilitiesDropped, ServerError> {
+    let refuse = |m: String| ServerError::Capabilities(m);
 
-    let held = read_capabilities()
-        .map_err(|e| format!("could not verify that capabilities were dropped: {e}"))?;
+    // Read before dropping: the request has to be a subset of what is already
+    // permitted or the kernel rejects it wholesale and nothing is dropped.
+    let before = read_capabilities()
+        .map_err(|e| refuse(format!("could not read the capabilities to drop: {e}")))?;
+    let keep = capabilities_to_keep(before.permitted);
+    let dropped = drop_capabilities(keep);
+
+    let held = read_capabilities().map_err(|e| {
+        refuse(format!(
+            "could not verify that capabilities were dropped: {e}"
+        ))
+    })?;
     let extra = capabilities_beyond_retained(held);
     if extra != 0 {
         let why = match &dropped {
             Ok(()) => "the drop reported success".to_string(),
             Err(e) => format!("the drop failed: {e}"),
         };
-        return Err(format!(
+        return Err(refuse(format!(
             "still holding capabilities that must be dropped before serving: {} ({why})",
             describe_capability_mask(extra)
-        ));
+        )));
     }
 
     match dropped {
-        Ok(()) => info!(
-            "retained CAP_SETUID+CAP_SETGID for notification privilege-drop; verified all others dropped (including CAP_CHOWN) and set no-new-privs"
+        Ok(()) if keep == retained_capability_mask() => info!(
+            "narrowed to CAP_SETUID+CAP_SETGID for the notification privilege-drop before any \
+             other thread exists; verified all others dropped (including CAP_CHOWN) and set \
+             no-new-privs"
+        ),
+        Ok(()) => warn!(
+            "started under a narrower capability set than the shipped unit grants: kept {keep:#010x} \
+             of the retained mask, so desktop notifications may not work. Everything else, \
+             CAP_CHOWN included, is dropped and verified."
         ),
         Err(e) => warn!(
             "capability drop reported a failure, but nothing beyond the retained set is held — \
-             started under a narrower capability set than the shipped unit grants? \
              desktop notifications may not work: {e}"
         ),
     }
-    Ok(())
+    Ok(CapabilitiesDropped(()))
 }
 
 async fn run_dbus_server(
@@ -1635,20 +1714,20 @@ async fn run_dbus_server(
 
     info!("facelock daemon running on D-Bus system bus as {BUS_NAME}");
 
-    // Drop capabilities now that initialization is complete — camera fd is
-    // open, models are loaded, D-Bus is connected, database is open.
+    // The capability narrowing does NOT happen here. It used to, on the
+    // reasoning that a failure after the bus name is claimed is one clients
+    // pay for — but by this line the process is long since multi-threaded
+    // (ONNX Runtime's intra-op pools, then every tokio worker), and the
+    // narrowing only ever reaches the calling thread and its descendants. The
+    // threads that actually serve `Authenticate` would have kept CAP_CHOWN for
+    // the daemon's whole life, and the `capget` read-back — also per-thread —
+    // would have inspected the one thread that did drop and confirmed itself.
     //
-    // This is also what bounds CAP_CHOWN's window. The unit puts it in the
-    // bounding set (not the ambient set) for two startup-only chowns — the
-    // state layout and the enrollment-marker reconcile — and this call is what
-    // takes it away again, before the first authentication. See the capability
-    // block in systemd/facelock-daemon.service.
-    //
-    // `?`, not a warning: the bus name is already claimed above, so from here
-    // on every failure to narrow the process is a failure the *clients* would
-    // pay for. Returning unwinds `_connection`, releases the name, and exits
-    // non-zero before a single authentication is served.
-    drop_capabilities_or_refuse().map_err(ServerError::Capabilities)?;
+    // So it moved to the top of `commands::daemon::run`, before anything
+    // spawns a thread, and `run` demands the `CapabilitiesDropped` token as
+    // proof. The bus-name argument gets simpler rather than weaker: refusing
+    // before the name is claimed means no client ever sees a half-privileged
+    // daemon at all.
 
     // Spawn a background task to release the camera on system suspend.
     // Best-effort: if logind is unavailable, log a warning and continue.
@@ -2294,10 +2373,9 @@ mod tests {
 
     /// The deliberate asymmetry: holding *fewer* caps than the mask is not a
     /// violation. A daemon started under a narrower bounding set than the
-    /// shipped unit grants (an operator edit, an unusual container) cannot
-    /// raise into the retained mask, so `capset` fails — that costs desktop
-    /// notifications and nothing the security model promised, and must not
-    /// stop the daemon from serving.
+    /// shipped unit grants (an operator edit, an unusual container) keeps less
+    /// than the retained mask — that costs desktop notifications and nothing
+    /// the security model promised, and must not stop it from serving.
     #[test]
     fn holding_fewer_caps_than_retained_is_not_a_violation() {
         // CAP_SETUID only: CAP_SETGID was never in the bounding set.
@@ -2307,6 +2385,87 @@ mod tests {
             inheritable: 0,
         };
         assert_eq!(capabilities_beyond_retained(held), 0);
+    }
+
+    /// The realistic narrower shape, which is *not* a subset of the retained
+    /// mask and so is not covered by the test above: an operator who wants no
+    /// desktop notifications writes a drop-in with
+    /// `CapabilityBoundingSet=CAP_CHOWN` and `AmbientCapabilities=`, and the
+    /// daemon starts with `permitted == {CAP_CHOWN}` — narrower than the mask
+    /// in one direction and wider in the other.
+    ///
+    /// Requesting the retained mask absolutely is `EPERM` here (the kernel
+    /// requires the new permitted set to be a subset of the old), and `capset`
+    /// rejects wholesale, so *nothing* would be dropped: CAP_CHOWN survives,
+    /// the read-back calls it a violation, and `Restart=on-failure` flaps the
+    /// daemon every `RestartSec` forever over a legitimate configuration.
+    /// Intersecting first asks for nothing the process lacks.
+    #[test]
+    fn a_bounding_set_of_cap_chown_alone_narrows_to_nothing() {
+        let permitted = 1u64 << CAP_CHOWN;
+
+        // Pre-drop, this state *is* a violation — which is what makes the
+        // wholesale-rejection failure mode fatal rather than merely untidy.
+        let before = HeldCapabilities {
+            effective: permitted,
+            permitted,
+            inheritable: 0,
+        };
+        assert_eq!(capabilities_beyond_retained(before), 1 << CAP_CHOWN);
+
+        // The drop asks for nothing, so it cannot be refused, and clears
+        // CAP_CHOWN on the way.
+        let keep = capabilities_to_keep(permitted);
+        assert_eq!(keep, 0, "must not request a capability the process lacks");
+
+        let after = HeldCapabilities {
+            effective: u64::from(keep),
+            permitted: u64::from(keep),
+            inheritable: u64::from(keep),
+        };
+        assert_eq!(capabilities_beyond_retained(after), 0);
+    }
+
+    /// `capset` requires the new permitted set to be a subset of the old one.
+    /// The mask handed to it must satisfy that for *every* starting set, not
+    /// just the shipped one — this is the property that keeps the drop from
+    /// failing wholesale and dropping nothing.
+    #[test]
+    fn the_kept_mask_is_always_a_subset_of_what_is_already_permitted() {
+        for permitted in [
+            0,
+            1 << CAP_CHOWN,
+            u64::from(retained_capability_mask()),
+            u64::from(retained_capability_mask()) | (1 << CAP_CHOWN), // the shipped unit
+            1 << 7,                                                   // CAP_SETUID alone
+            u64::MAX,                                                 // unconfined root
+        ] {
+            let keep = u64::from(capabilities_to_keep(permitted));
+            assert_eq!(
+                keep & !permitted,
+                0,
+                "kept {keep:#x} is not a subset of permitted {permitted:#x}"
+            );
+            assert_eq!(
+                keep & !u64::from(retained_capability_mask()),
+                0,
+                "kept {keep:#x} reaches beyond the retained mask"
+            );
+            assert_eq!(
+                keep & (1 << CAP_CHOWN),
+                0,
+                "CAP_CHOWN must never be kept, whatever the process started with"
+            );
+        }
+    }
+
+    /// The shipped configuration is unchanged by the intersection: bounding
+    /// `CAP_SETUID CAP_SETGID CAP_CHOWN` with the first two ambient still keeps
+    /// exactly the two the notification privilege-drop needs.
+    #[test]
+    fn the_shipped_unit_still_keeps_both_notification_caps() {
+        let permitted = u64::from(retained_capability_mask()) | (1 << CAP_CHOWN);
+        assert_eq!(capabilities_to_keep(permitted), retained_capability_mask());
     }
 
     /// **The load-bearing test.** CAP_CHOWN surviving in *any* of the three
@@ -2407,5 +2566,95 @@ mod tests {
             0,
             "effective must be a subset of permitted; got {held:?}"
         );
+    }
+
+    /// This thread's `NoNewPrivs` bit, straight from `/proc`. `None` when
+    /// `/proc` is not mounted or the field is absent.
+    ///
+    /// `/proc/thread-self` is the calling *thread*, not the process — which is
+    /// the whole point of the test below, and the same distinction that makes
+    /// `/proc/<pid>/status` (the main thread) the wrong thing to assert on a
+    /// running daemon.
+    fn no_new_privs() -> Option<bool> {
+        let status = std::fs::read_to_string("/proc/thread-self/status").ok()?;
+        let value = status.lines().find_map(|l| l.strip_prefix("NoNewPrivs:"))?;
+        Some(value.trim() == "1")
+    }
+
+    fn set_no_new_privs() -> std::io::Result<()> {
+        // SAFETY: PR_SET_NO_NEW_PRIVS takes no pointer arguments, and setting
+        // it is unprivileged and always permitted.
+        let ret = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// **The regression pin for the ordering.** Narrowing a process is a
+    /// per-thread operation inherited only forwards, so *when* it happens
+    /// decides *which* threads it reaches. This runs both orders against a
+    /// real `tokio` multi-threaded runtime and shows the difference.
+    ///
+    /// Demonstrated with `PR_SET_NO_NEW_PRIVS` rather than `capset` because
+    /// the two travel by the same mechanism — a `task_struct` field copied at
+    /// `clone(2)` and never broadcast to siblings — and this is the half an
+    /// unprivileged test can actually set. `/proc/<tid>/status` reports it per
+    /// thread, exactly as it reports `CapPrm`, which is what
+    /// `test/pkg-validate.sh` walks across `/proc/<pid>/task/*` on the running
+    /// daemon.
+    ///
+    /// The whole experiment runs on a thread this test spawns: the bit is
+    /// irreversible, so it must land somewhere the test owns rather than on a
+    /// harness thread.
+    #[test]
+    fn only_threads_created_after_the_narrowing_inherit_it() {
+        std::thread::spawn(|| {
+            if no_new_privs() != Some(false) {
+                // No /proc, or something already set it for this process tree.
+                // Nothing left to demonstrate either way.
+                return;
+            }
+
+            let build = || {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .expect("multi-threaded runtime")
+            };
+            let worker_bit = |rt: &tokio::runtime::Runtime| {
+                rt.block_on(async { tokio::spawn(async { no_new_privs() }).await.unwrap() })
+            };
+
+            // A runtime built BEFORE the narrowing: the order this code used
+            // to have, where the drop sat after the bus name was claimed.
+            let early = build();
+            // Force its workers into existence now, as production does long
+            // before that old drop site (models loaded, bus connected).
+            early.block_on(async { tokio::spawn(async {}).await.unwrap() });
+
+            set_no_new_privs().expect("PR_SET_NO_NEW_PRIVS is unprivileged");
+            assert_eq!(no_new_privs(), Some(true), "the calling thread narrows");
+
+            // A runtime built AFTER it: the order `commands::daemon::run` now
+            // guarantees by demanding a `CapabilitiesDropped`.
+            let late = build();
+
+            assert_eq!(
+                worker_bit(&early),
+                Some(false),
+                "a worker that existed before the narrowing kept the wider credentials. \
+                 This is the defect: narrowing once the runtime is up reaches none of the \
+                 threads that serve Authenticate, and a per-thread read-back cannot see it."
+            );
+            assert_eq!(
+                worker_bit(&late),
+                Some(true),
+                "a worker created after the narrowing must inherit it"
+            );
+        })
+        .join()
+        .expect("experiment thread");
     }
 }

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -1228,6 +1228,12 @@ async fn run_dbus_server(
 
     // Drop capabilities now that initialization is complete — camera fd is
     // open, models are loaded, D-Bus is connected, database is open.
+    //
+    // This is also what bounds CAP_CHOWN's window. The unit puts it in the
+    // bounding set (not the ambient set) for two startup-only chowns — the
+    // state layout and the enrollment-marker reconcile — and this call is what
+    // takes it away again, before the first authentication. See the capability
+    // block in systemd/facelock-daemon.service.
     match drop_capabilities() {
         Ok(()) => info!(
             "retained CAP_SETUID+CAP_SETGID for notification privilege-drop; dropped all others and set no-new-privs"

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -46,6 +46,10 @@ pub enum ServerError {
     Bus(#[from] zbus::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    /// The daemon is still holding a capability it promised to drop before
+    /// serving anyone. See [`drop_capabilities_or_refuse`].
+    #[error("refusing to serve authentications: {0}")]
+    Capabilities(String),
 }
 
 /// Maximum time to wait for the handler mutex before returning a "busy" error.
@@ -1373,6 +1377,78 @@ const fn retained_capability_mask() -> u32 {
     (1 << 7) | (1 << 6)
 }
 
+/// CAP_CHOWN's capability number.
+///
+/// Named because docs/security.md makes a promise about this one specifically:
+/// the shipped unit puts CAP_CHOWN in the daemon's *bounding* set (never the
+/// ambient set) for two startup-only chowns — `ensure_state_layout` and the
+/// enrollment-marker reconcile (#137) — and the drop below is the whole of
+/// what takes it away again before the first authentication.
+const CAP_CHOWN: u32 = 0;
+
+/// The capability sets a process actually holds, as read back from `capget`.
+///
+/// Each field is a mask over capability numbers 0-63: the two 32-bit words
+/// `_LINUX_CAPABILITY_VERSION_3` uses, low word in the low half.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct HeldCapabilities {
+    effective: u64,
+    permitted: u64,
+    inheritable: u64,
+}
+
+/// Capabilities held beyond [`retained_capability_mask`], across all three sets.
+///
+/// Zero means the daemon holds exactly what it promised to hold — nothing
+/// wider. Deliberately one-sided: it answers "is anything *extra* still here?"
+/// and never "are the retained caps present?". A daemon started under a
+/// narrower capability set than the shipped unit grants (an operator edit, an
+/// unusual container) holds *fewer* caps than the mask, which costs
+/// notifications and nothing else — it is not a security failure and must not
+/// stop the daemon.
+///
+/// The ambient set needs no separate check: the kernel clears a capability
+/// from ambient the moment it leaves permitted or inheritable, so an ambient
+/// cap that survived is a permitted cap that survived.
+///
+/// Pure so the policy is testable without privilege or syscalls — the same
+/// reason [`retained_capability_mask`] is a `const fn`.
+const fn capabilities_beyond_retained(held: HeldCapabilities) -> u64 {
+    let want = retained_capability_mask() as u64;
+    (held.effective | held.permitted | held.inheritable) & !want
+}
+
+/// Render a capability mask for a log line: the hex `capsh --decode=` takes,
+/// with CAP_CHOWN called out by name when present because that is the one
+/// docs/security.md names.
+fn describe_capability_mask(mask: u64) -> String {
+    if mask & (1u64 << CAP_CHOWN) != 0 {
+        format!("{mask:#018x} (includes CAP_CHOWN)")
+    } else {
+        format!("{mask:#018x}")
+    }
+}
+
+// capget/capset use syscall numbers directly since libc doesn't expose the cap
+// structs on all platforms. Shared by the drop and by the read-back that
+// verifies it.
+#[repr(C)]
+struct CapHeader {
+    version: u32,
+    pid: i32,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct CapData {
+    effective: u32,
+    permitted: u32,
+    inheritable: u32,
+}
+
+/// `_LINUX_CAPABILITY_VERSION_3`. Two [`CapData`] words: caps 0-31, then 32-63.
+const LINUX_CAP_V3: u32 = 0x2008_0522;
+
 /// Drop all Linux capabilities except CAP_SETUID + CAP_SETGID, and set
 /// PR_SET_NO_NEW_PRIVS.
 ///
@@ -1383,27 +1459,10 @@ const fn retained_capability_mask() -> u32 {
 /// [`retained_capability_mask`] in the effective, permitted, AND inheritable
 /// sets, and everything else is cleared.
 ///
-/// Returns `Ok(())` on success. Errors are non-fatal — the caller should
-/// warn and continue.
+/// Returns `Ok(())` on success. Callers must not treat an error as merely
+/// advisory: [`drop_capabilities_or_refuse`] is the entry point, and it decides
+/// what a failure costs by *reading back* what is actually held.
 fn drop_capabilities() -> std::result::Result<(), String> {
-    // capget/capset use syscall numbers directly since libc doesn't expose
-    // the cap structs on all platforms.
-    #[repr(C)]
-    struct CapHeader {
-        version: u32,
-        pid: i32,
-    }
-
-    #[repr(C)]
-    struct CapData {
-        effective: u32,
-        permitted: u32,
-        inheritable: u32,
-    }
-
-    // _LINUX_CAPABILITY_VERSION_3 = 0x20080522
-    const LINUX_CAP_V3: u32 = 0x2008_0522;
-
     unsafe {
         // Prevent the process (and children) from ever gaining new privileges
         let ret = libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
@@ -1454,6 +1513,103 @@ fn drop_capabilities() -> std::result::Result<(), String> {
     Ok(())
 }
 
+/// Ask the kernel which capabilities this process actually holds.
+///
+/// `capget` is in `@system-service`, so the unit's seccomp allowlist permits
+/// it (docs/security.md, Phase 3).
+fn read_capabilities() -> std::result::Result<HeldCapabilities, String> {
+    let mut header = CapHeader {
+        version: LINUX_CAP_V3,
+        pid: 0,
+    };
+    let mut data = [CapData::default(), CapData::default()];
+    // SAFETY: `header` and `data` are correctly sized and aligned for
+    // _LINUX_CAPABILITY_VERSION_3, which requires exactly two CapData words.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_capget,
+            &mut header as *mut CapHeader,
+            data.as_mut_ptr(),
+        )
+    };
+    if ret != 0 {
+        return Err(format!(
+            "capget syscall failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let word = |lo: u32, hi: u32| u64::from(lo) | (u64::from(hi) << 32);
+    Ok(HeldCapabilities {
+        effective: word(data[0].effective, data[1].effective),
+        permitted: word(data[0].permitted, data[1].permitted),
+        inheritable: word(data[0].inheritable, data[1].inheritable),
+    })
+}
+
+/// Drop capabilities, verify the drop actually happened, and refuse to serve if
+/// it did not.
+///
+/// This used to log `failed to drop capabilities (continuing)` and carry on.
+/// That was tolerable while the dropped set held nothing the security model had
+/// promised to remove — the two retained caps were the whole story, and a
+/// failed drop cost only the "narrowed after init" nicety. It is not tolerable
+/// now: the shipped unit's bounding set includes **CAP_CHOWN** for two
+/// startup-only chowns (#137), and docs/security.md tells the reader it is
+/// "never held while authenticating anyone". A warning cannot keep that
+/// promise — a failed drop would leave the daemon serving every authentication
+/// with `chown(2)` in reach, announced only in the journal.
+///
+/// So the guarantee is *checked* rather than assumed: `capget` reports what the
+/// kernel really left behind, and anything beyond
+/// [`retained_capability_mask`] ends startup. Verifying beats trusting
+/// `capset`'s return code — it also catches a mask that stopped being what this
+/// code thinks it is.
+///
+/// The refusal is deliberately narrow, and asymmetric:
+///
+/// - **Extra capabilities held → fatal.** The daemon exits before the first
+///   authentication. PAM degrades to the password, exactly as it does when the
+///   daemon is not running at all, so this is never a lockout — the same
+///   trade `state_layout::ensure_state_layout` already makes a few lines
+///   earlier in startup, and the same "fail closed" convention as the model
+///   SHA-256 check.
+/// - **Drop failed but nothing extra is held → warn and continue.** The daemon
+///   was started under a narrower capability set than the shipped unit grants,
+///   so `capset` could not *raise* into the retained mask. Notifications may
+///   not work; nothing about the security model is violated, and refusing here
+///   would turn an operator's hardening edit into a daemon that will not run.
+/// - **The read-back itself failed → fatal.** An unverifiable guarantee is not
+///   a guarantee.
+fn drop_capabilities_or_refuse() -> std::result::Result<(), String> {
+    let dropped = drop_capabilities();
+
+    let held = read_capabilities()
+        .map_err(|e| format!("could not verify that capabilities were dropped: {e}"))?;
+    let extra = capabilities_beyond_retained(held);
+    if extra != 0 {
+        let why = match &dropped {
+            Ok(()) => "the drop reported success".to_string(),
+            Err(e) => format!("the drop failed: {e}"),
+        };
+        return Err(format!(
+            "still holding capabilities that must be dropped before serving: {} ({why})",
+            describe_capability_mask(extra)
+        ));
+    }
+
+    match dropped {
+        Ok(()) => info!(
+            "retained CAP_SETUID+CAP_SETGID for notification privilege-drop; verified all others dropped (including CAP_CHOWN) and set no-new-privs"
+        ),
+        Err(e) => warn!(
+            "capability drop reported a failure, but nothing beyond the retained set is held — \
+             started under a narrower capability set than the shipped unit grants? \
+             desktop notifications may not work: {e}"
+        ),
+    }
+    Ok(())
+}
+
 async fn run_dbus_server(
     handler: ProductionHandler,
     idle_timeout_secs: u64,
@@ -1487,12 +1643,12 @@ async fn run_dbus_server(
     // state layout and the enrollment-marker reconcile — and this call is what
     // takes it away again, before the first authentication. See the capability
     // block in systemd/facelock-daemon.service.
-    match drop_capabilities() {
-        Ok(()) => info!(
-            "retained CAP_SETUID+CAP_SETGID for notification privilege-drop; dropped all others and set no-new-privs"
-        ),
-        Err(e) => warn!("failed to drop capabilities (continuing): {e}"),
-    }
+    //
+    // `?`, not a warning: the bus name is already claimed above, so from here
+    // on every failure to narrow the process is a failure the *clients* would
+    // pay for. Returning unwinds `_connection`, releases the name, and exits
+    // non-zero before a single authentication is served.
+    drop_capabilities_or_refuse().map_err(ServerError::Capabilities)?;
 
     // Spawn a background task to release the camera on system suspend.
     // Best-effort: if logind is unavailable, log a warning and continue.
@@ -2117,5 +2273,139 @@ mod tests {
 
         // Exactly two bits set, and none in the high word (caps 32-63).
         assert_eq!(mask.count_ones(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // The capability drop is verified, not assumed (#137)
+    // -----------------------------------------------------------------------
+
+    /// Every set holding exactly the retained mask is the intended steady
+    /// state: nothing extra, so nothing to refuse.
+    #[test]
+    fn a_clean_drop_leaves_nothing_beyond_the_retained_set() {
+        let want = u64::from(retained_capability_mask());
+        let held = HeldCapabilities {
+            effective: want,
+            permitted: want,
+            inheritable: want,
+        };
+        assert_eq!(capabilities_beyond_retained(held), 0);
+    }
+
+    /// The deliberate asymmetry: holding *fewer* caps than the mask is not a
+    /// violation. A daemon started under a narrower bounding set than the
+    /// shipped unit grants (an operator edit, an unusual container) cannot
+    /// raise into the retained mask, so `capset` fails — that costs desktop
+    /// notifications and nothing the security model promised, and must not
+    /// stop the daemon from serving.
+    #[test]
+    fn holding_fewer_caps_than_retained_is_not_a_violation() {
+        // CAP_SETUID only: CAP_SETGID was never in the bounding set.
+        let held = HeldCapabilities {
+            effective: 1 << 7,
+            permitted: 1 << 7,
+            inheritable: 0,
+        };
+        assert_eq!(capabilities_beyond_retained(held), 0);
+    }
+
+    /// **The load-bearing test.** CAP_CHOWN surviving in *any* of the three
+    /// sets is the failure docs/security.md's "never held while authenticating
+    /// anyone" claim is about. Checked per-set because they are not
+    /// interchangeable: `permitted` is what `chown(2)` needs here, and
+    /// `inheritable` is what an exec'd child could carry away.
+    #[test]
+    fn cap_chown_surviving_in_any_set_is_refused() {
+        let want = u64::from(retained_capability_mask());
+        let chown = 1u64 << CAP_CHOWN;
+        for (label, held) in [
+            (
+                "effective",
+                HeldCapabilities {
+                    effective: want | chown,
+                    permitted: want,
+                    inheritable: want,
+                },
+            ),
+            (
+                "permitted",
+                HeldCapabilities {
+                    effective: want,
+                    permitted: want | chown,
+                    inheritable: want,
+                },
+            ),
+            (
+                "inheritable",
+                HeldCapabilities {
+                    effective: want,
+                    permitted: want,
+                    inheritable: want | chown,
+                },
+            ),
+        ] {
+            assert_eq!(
+                capabilities_beyond_retained(held),
+                chown,
+                "CAP_CHOWN left in the {label} set was not detected"
+            );
+        }
+    }
+
+    /// A failed drop leaves *everything* — the case the old
+    /// `warn!("failed to drop capabilities (continuing)")` waved through. Full
+    /// root under the shipped bounding set is CAP_SETUID + CAP_SETGID +
+    /// CAP_CHOWN, so the extra is exactly the capability the unit added.
+    #[test]
+    fn a_drop_that_did_not_happen_is_refused() {
+        let bounding = u64::from(retained_capability_mask()) | (1 << CAP_CHOWN);
+        let held = HeldCapabilities {
+            effective: bounding,
+            permitted: bounding,
+            inheritable: bounding,
+        };
+        assert_eq!(capabilities_beyond_retained(held), 1 << CAP_CHOWN);
+    }
+
+    /// Capabilities above 31 live in the second `capget` word. Reading only
+    /// the low word would silently ignore half the capability space.
+    #[test]
+    fn capabilities_in_the_high_word_are_not_missed() {
+        // CAP_CHECKPOINT_RESTORE = 40.
+        let high = 1u64 << 40;
+        let held = HeldCapabilities {
+            effective: 0,
+            permitted: high,
+            inheritable: 0,
+        };
+        assert_eq!(capabilities_beyond_retained(held), high);
+    }
+
+    /// The refusal has to be readable in a journal at 3am: a hex mask
+    /// `capsh --decode=` accepts, and CAP_CHOWN spelled out because that is
+    /// the capability the docs make a promise about.
+    #[test]
+    fn the_refusal_names_cap_chown() {
+        let described = describe_capability_mask(1 << CAP_CHOWN);
+        assert!(described.contains("CAP_CHOWN"), "got {described}");
+        assert!(described.contains("0x"), "got {described}");
+        assert!(
+            !describe_capability_mask(1 << 21).contains("CAP_CHOWN"),
+            "CAP_SYS_ADMIN must not be reported as CAP_CHOWN"
+        );
+    }
+
+    /// Smoke test for the `capget` wiring itself — the struct layout and the
+    /// two-word V3 read are the parts a unit test on masks cannot cover. Runs
+    /// unprivileged: every process can read its own capability sets, and the
+    /// kernel guarantees effective is a subset of permitted whatever they are.
+    #[test]
+    fn this_process_can_read_back_its_own_capabilities() {
+        let held = read_capabilities().expect("capget on self must succeed");
+        assert_eq!(
+            held.effective & !held.permitted,
+            0,
+            "effective must be a subset of permitted; got {held:?}"
+        );
     }
 }

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -43,6 +43,15 @@ post_upgrade() {
     systemd-tmpfiles --create
     _facelock_secure_paths
 
+    # Pick up unit changes before the restart below, not after. Without this,
+    # `systemctl restart` re-runs the *cached* unit and every change the new
+    # package made to facelock-daemon.service — the CapabilityBoundingSet
+    # among them — waits for the next daemon-reload or reboot. post_install
+    # already reloads; the Debian postinst and the RPM
+    # %systemd_postun_with_restart macro both do too, so this is the one
+    # upgrade path that was missing it.
+    systemctl daemon-reload 2>/dev/null || true
+
     # Restart daemon if running
     if systemctl is-active --quiet facelock-daemon; then
         echo "==> Restarting facelock-daemon..."

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -199,6 +199,14 @@ database — so it is safe to call repeatedly from a lock screen as an
 unprivileged user. The marker is a hint that can drift from the database; **PAM
 at auth time remains authoritative** and nothing in the auth path consults it.
 
+Markers are written by `enroll`, `remove` and `clear`, and converged from the
+database by `setup`, by daemon startup, and by the one-shot `facelock auth` path
+for the user being authenticated. Convergence re-derives every marker from the
+database, so it is idempotent and there is no migration state to keep. An
+install upgraded from a release that predates markers backfills itself on the
+first daemon start or the first authentication; until one of those happens,
+`is-enrolled` reports `not-enrolled` for a user who is in fact enrolled.
+
 ### facelock auth Exit Codes
 
 | Code | Meaning | PAM Code |

--- a/docs/security.md
+++ b/docs/security.md
@@ -636,18 +636,39 @@ denied_services = ["login", "sshd", "su"]
 
 ### 6. Daemon Process Hardening
 
-#### A. Capability Dropping (Recommended)
+#### A. Capability Dropping (Implemented — verified, and fatal if it did not happen)
 
-After initialization, drop unnecessary capabilities:
+Once initialization is complete — camera fd open, models loaded, database open, bus name
+claimed — the daemon narrows its own capability set to
+[`retained_capability_mask()`](../crates/facelock-daemon/src/server.rs): `CAP_SETUID` +
+`CAP_SETGID` and nothing else (`capset` on all three of effective/permitted/inheritable, plus
+`PR_SET_NO_NEW_PRIVS`). Those two are the notification privilege-drop's, and only its; see
+Phase 3 in §6.B for why they cannot be given up.
 
-```rust
-// After opening camera, loading models, connecting to D-Bus:
-// Drop all capabilities except what's needed for ongoing operation
-use caps::{CapSet, Capability};
-caps::clear(None, CapSet::Effective)?;
-caps::clear(None, CapSet::Permitted)?;
-// Only keep what's needed: nothing (camera fd already open, D-Bus session attached)
-```
+**The drop is then read back and checked.** `capget` reports what the kernel actually left
+behind, and `drop_capabilities_or_refuse()` compares it against the retained mask:
+
+| Outcome | What the daemon does |
+|---------|----------------------|
+| Nothing beyond the retained set is held | Serve. This is the steady state. |
+| Anything beyond it survived (including a `capset` that failed outright) | **Refuse to serve** — return before the first authentication, release the bus name, exit non-zero |
+| Held set is *narrower* than the retained mask | Warn and serve — desktop notifications may not work, nothing the security model promised is violated |
+| `capget` itself failed | **Refuse to serve** — an unverifiable guarantee is not a guarantee |
+
+The check is deliberately one-sided ("is anything *extra* still here?"). A daemon started under
+a narrower bounding set than the shipped unit grants cannot raise into the retained mask, so its
+`capset` fails; that costs notifications and must not stop it from authenticating anyone. The
+ambient set needs no separate check — the kernel clears a capability from ambient the moment it
+leaves permitted or inheritable.
+
+**Why fatal.** This used to warn and continue, which was defensible while the dropped set held
+nothing the security model had promised to remove. With `CAP_CHOWN` in the bounding set for
+startup (§6.B, #137), a failed drop would leave the daemon serving every authentication with
+`chown(2)` in reach and only a journal line to say so. Refusing is not a lockout: PAM degrades to
+the password exactly as it does when the daemon is not running at all — the same trade
+`ensure_state_layout` already makes earlier in startup, and the same fail-closed convention as
+the model SHA-256 check. `Restart=on-failure` will retry, and systemd's start rate limiting stops
+the loop.
 
 #### B. systemd Hardening (Implemented)
 
@@ -669,19 +690,24 @@ The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
   `CAP_SETGID` + `CAP_SETUID`. They are declared **Ambient** (not merely in the bounding set) so
   the caps survive the exec into the non-setuid `runuser` under `NoNewPrivileges=yes`. The daemon
   also narrows its in-process capability set to exactly these two after initialization
-  (`drop_capabilities()` in `facelock-cli`, holding them in effective/permitted/inheritable);
-  everything else is dropped.
-  - **`CAP_CHOWN` is startup-only.** It is in the bounding set but deliberately **not** ambient,
-    and `drop_capabilities()` clears it the moment the daemon has claimed its bus name — so it is
-    never held while authenticating anyone, and no exec'd child can inherit it. Root without
-    `CAP_CHOWN` cannot `chown(2)` at all, and two startup steps need it on an install that is
+  (`drop_capabilities_or_refuse()` in `facelock-daemon/src/server.rs`, holding them in
+  effective/permitted/inheritable); everything else is dropped.
+  - **`CAP_CHOWN` is startup-only, and that is enforced rather than attempted.** It is in the
+    bounding set but deliberately **not** ambient, and the in-process drop clears it the moment
+    the daemon has claimed its bus name — so it is never held while authenticating anyone, and no
+    exec'd child can inherit it. Root without `CAP_CHOWN` cannot `chown(2)` at all, and two
+    startup steps need it on an install that is
     being *upgraded* rather than freshly packaged: `state_layout::ensure_state_layout`, which
     chowns `/var/lib/facelock` and the files under it to `root:facelock` (a failure there is
     fatal — the daemon exits 1), and the enrollment-marker reconcile, which chowns each marker
     to the user it describes (#137). Both skip paths that are already correct, so a steady-state
     install never chowns. The reachable blast radius is small: `ProtectSystem=strict` leaves only
     `ReadWritePaths=/var/lib/facelock /var/log/facelock` and the private `/tmp` writable, and
-    `chown` on a read-only mount fails with `EROFS`.
+    `chown` on a read-only mount fails with `EROFS`. **The drop is verified with `capget` and the
+    daemon refuses to serve if anything beyond the retained set survived it** — see §6.A. Until
+    #137 the drop was best-effort (`warn!("failed to drop capabilities (continuing)")`), which
+    was tolerable only because the dropped set held nothing the security model had promised to
+    remove. It does now.
   - **This was empirically required.** An earlier revision set both directives **empty** on the
     theory that the daemon needs no capabilities. That was wrong: on real hardware it broke
     notifications with `runuser: cannot set groups: Operation not permitted`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -667,8 +667,11 @@ startup (§6.B, #137), a failed drop would leave the daemon serving every authen
 `chown(2)` in reach and only a journal line to say so. Refusing is not a lockout: PAM degrades to
 the password exactly as it does when the daemon is not running at all — the same trade
 `ensure_state_layout` already makes earlier in startup, and the same fail-closed convention as
-the model SHA-256 check. `Restart=on-failure` will retry, and systemd's start rate limiting stops
-the loop.
+the model SHA-256 check. `Restart=on-failure` will retry it every `RestartSec=3`, which is the
+same restart loop a failed `ensure_state_layout` already produces (the unit sets no
+`StartLimit*`, so systemd's defaults may not trip on a 3-second interval). Each attempt logs the
+capability mask that survived, so the journal says exactly what is wrong rather than only that
+something is.
 
 #### B. systemd Hardening (Implemented)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -638,12 +638,31 @@ denied_services = ["login", "sshd", "su"]
 
 #### A. Capability Dropping (Implemented — verified, and fatal if it did not happen)
 
-Once initialization is complete — camera fd open, models loaded, database open, bus name
-claimed — the daemon narrows its own capability set to
-[`retained_capability_mask()`](../crates/facelock-daemon/src/server.rs): `CAP_SETUID` +
-`CAP_SETGID` and nothing else (`capset` on all three of effective/permitted/inheritable, plus
-`PR_SET_NO_NEW_PRIVS`). Those two are the notification privilege-drop's, and only its; see
-Phase 3 in §6.B for why they cannot be given up.
+As soon as the two startup steps that need `CAP_CHOWN` are done — the state layout and the
+enrollment-marker reconcile — and **before the daemon creates its first thread**, it narrows its
+own capability set to [`retained_capability_mask()`](../crates/facelock-daemon/src/server.rs):
+`CAP_SETUID` + `CAP_SETGID` and nothing else (`capset` on all three of
+effective/permitted/inheritable, plus `PR_SET_NO_NEW_PRIVS`). Those two are the notification
+privilege-drop's, and only its; see Phase 3 in §6.B for why they cannot be given up.
+
+**Why that timing is the whole of the guarantee.** Linux capabilities and `PR_SET_NO_NEW_PRIVS`
+are per-*thread* attributes: `capset(2)`/`prctl(2)` with `pid = 0` change the calling thread and
+nothing else, and a thread that already exists keeps what it had for as long as it lives. (This
+is why libcap ships `libpsx` to broadcast a capability change across a process's threads.) The
+drop therefore has to happen while the daemon is still single-threaded — before
+`FaceEngine::load` brings up ONNX Runtime's intra-op pools, and before the tokio runtime spawns
+the workers and blocking threads that every D-Bus method body does its real work on. Narrowing
+any later reaches none of them, and `capget` cannot report the mistake either: it is per-thread
+too, so it would inspect the one thread that *did* drop and confirm itself. `server::run` takes
+a `CapabilitiesDropped` token it cannot construct, so the ordering is a compile-time
+requirement rather than a comment.
+
+The narrowing asks only for capabilities the process already holds
+(`capabilities_to_keep(permitted)`). `capset` requires the new permitted set to be a subset of
+the old and rejects a non-conforming request *wholesale* — dropping nothing at all — so a
+daemon started under, say, `CapabilityBoundingSet=CAP_CHOWN` with no ambient caps would
+otherwise fail the drop entirely and land in the fatal branch below. Intersecting first means
+the call only ever removes, and `CAP_CHOWN` is never in the result.
 
 **The drop is then read back and checked.** `capget` reports what the kernel actually left
 behind, and `drop_capabilities_or_refuse()` compares it against the retained mask:
@@ -651,15 +670,15 @@ behind, and `drop_capabilities_or_refuse()` compares it against the retained mas
 | Outcome | What the daemon does |
 |---------|----------------------|
 | Nothing beyond the retained set is held | Serve. This is the steady state. |
-| Anything beyond it survived (including a `capset` that failed outright) | **Refuse to serve** — return before the first authentication, release the bus name, exit non-zero |
+| Anything beyond it survived (including a `capset` that failed outright) | **Refuse to serve** — exit non-zero before claiming the bus name, so no client ever sees a half-privileged daemon |
 | Held set is *narrower* than the retained mask | Warn and serve — desktop notifications may not work, nothing the security model promised is violated |
 | `capget` itself failed | **Refuse to serve** — an unverifiable guarantee is not a guarantee |
 
 The check is deliberately one-sided ("is anything *extra* still here?"). A daemon started under
-a narrower bounding set than the shipped unit grants cannot raise into the retained mask, so its
-`capset` fails; that costs notifications and must not stop it from authenticating anyone. The
-ambient set needs no separate check — the kernel clears a capability from ambient the moment it
-leaves permitted or inheritable.
+a narrower bounding set than the shipped unit grants simply keeps less than the retained mask;
+that costs notifications and must not stop it from authenticating anyone. The ambient set needs
+no separate check — the kernel clears a capability from ambient the moment it leaves permitted
+or inheritable.
 
 **Why fatal.** This used to warn and continue, which was defensible while the dropped set held
 nothing the security model had promised to remove. With `CAP_CHOWN` in the bounding set for
@@ -671,7 +690,17 @@ the model SHA-256 check. `Restart=on-failure` will retry it every `RestartSec=3`
 same restart loop a failed `ensure_state_layout` already produces (the unit sets no
 `StartLimit*`, so systemd's defaults may not trip on a 3-second interval). Each attempt logs the
 capability mask that survived, so the journal says exactly what is wrong rather than only that
-something is.
+something is. Reaching that loop takes a genuine kernel-level refusal to narrow: an operator
+running the daemon with fewer capabilities than the shipped unit grants is *not* a failure here,
+because the drop only ever asks for what is already held.
+
+**Regression coverage.** `test/pkg-validate.sh` reads `CapPrm`/`CapEff` from
+`/proc/<pid>/task/*/status` on the running daemon and asserts `CAP_CHOWN` is clear on **every**
+thread. That walk is the point: `/proc/<pid>/status` reports the main thread, which is the one
+thread that always drops, so it is exactly the blind spot a per-thread bug hides in. The unit
+tests cover the mask arithmetic, and
+`server::tests::only_threads_created_after_the_narrowing_inherit_it` pins the ordering itself by
+running both orders against a real tokio runtime.
 
 #### B. systemd Hardening (Implemented)
 
@@ -692,13 +721,15 @@ The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
   drop into the user's session bus, and `runuser` calls `setgroups()`/`setuid()`, which require
   `CAP_SETGID` + `CAP_SETUID`. They are declared **Ambient** (not merely in the bounding set) so
   the caps survive the exec into the non-setuid `runuser` under `NoNewPrivileges=yes`. The daemon
-  also narrows its in-process capability set to exactly these two after initialization
-  (`drop_capabilities_or_refuse()` in `facelock-daemon/src/server.rs`, holding them in
-  effective/permitted/inheritable); everything else is dropped.
+  also narrows its in-process capability set to exactly these two once the startup chowns are
+  done and while it is still single-threaded (`drop_capabilities_or_refuse()` in
+  `facelock-daemon/src/server.rs`, holding them in effective/permitted/inheritable); everything
+  else is dropped.
   - **`CAP_CHOWN` is startup-only, and that is enforced rather than attempted.** It is in the
-    bounding set but deliberately **not** ambient, and the in-process drop clears it the moment
-    the daemon has claimed its bus name — so it is never held while authenticating anyone, and no
-    exec'd child can inherit it. Root without `CAP_CHOWN` cannot `chown(2)` at all, and two
+    bounding set but deliberately **not** ambient, and the in-process drop clears it as soon as
+    the two startup chowns are done and before the daemon spawns a single thread — so no thread
+    of the process holds it while anyone is being authenticated, and no exec'd child can inherit
+    it. Root without `CAP_CHOWN` cannot `chown(2)` at all, and two
     startup steps need it on an install that is
     being *upgraded* rather than freshly packaged: `state_layout::ensure_state_layout`, which
     chowns `/var/lib/facelock` and the files under it to `root:facelock` (a failure there is

--- a/docs/security.md
+++ b/docs/security.md
@@ -643,8 +643,10 @@ The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
 
 **Phase 3 (shipped — capabilities, seccomp, network):**
 
-- `CapabilityBoundingSet=CAP_SETUID CAP_SETGID` / `AmbientCapabilities=CAP_SETUID CAP_SETGID` —
-  the daemon retains **exactly** these two capabilities and no others. Device access needs no
+- `CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN` /
+  `AmbientCapabilities=CAP_SETUID CAP_SETGID` —
+  the daemon retains **exactly** the two ambient capabilities while it is serving
+  authentications, plus `CAP_CHOWN` for the duration of startup only. Device access needs no
   caps (`/dev/video*` and `/dev/tpmrm0` are root-owned and opened via standard file
   permissions), but the desktop-notification path execs `runuser -u <user> -- notify-send` to
   drop into the user's session bus, and `runuser` calls `setgroups()`/`setuid()`, which require
@@ -653,6 +655,17 @@ The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
   also narrows its in-process capability set to exactly these two after initialization
   (`drop_capabilities()` in `facelock-cli`, holding them in effective/permitted/inheritable);
   everything else is dropped.
+  - **`CAP_CHOWN` is startup-only.** It is in the bounding set but deliberately **not** ambient,
+    and `drop_capabilities()` clears it the moment the daemon has claimed its bus name — so it is
+    never held while authenticating anyone, and no exec'd child can inherit it. Root without
+    `CAP_CHOWN` cannot `chown(2)` at all, and two startup steps need it on an install that is
+    being *upgraded* rather than freshly packaged: `state_layout::ensure_state_layout`, which
+    chowns `/var/lib/facelock` and the files under it to `root:facelock` (a failure there is
+    fatal — the daemon exits 1), and the enrollment-marker reconcile, which chowns each marker
+    to the user it describes (#137). Both skip paths that are already correct, so a steady-state
+    install never chowns. The reachable blast radius is small: `ProtectSystem=strict` leaves only
+    `ReadWritePaths=/var/lib/facelock /var/log/facelock` and the private `/tmp` writable, and
+    `chown` on a read-only mount fails with `EROFS`.
   - **This was empirically required.** An earlier revision set both directives **empty** on the
     theory that the daemon needs no capabilities. That was wrong: on real hardware it broke
     notifications with `runuser: cannot set groups: Operation not permitted`.
@@ -691,11 +704,13 @@ The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:
 - `User=` — the daemon must open the camera/TPM as root; non-root operation has not been
   validated on real hardware.
 
-**Exposure score:** `systemd-analyze security --offline=true` reports **2.6 (OK)** for the
+**Exposure score:** `systemd-analyze security --offline=true` reports **2.8 (OK)** for the
 Phase 1–3 unit, down from 7.1 (MEDIUM) with Phase 1–2 only. (The score rose from 2.2 to 2.6
 when the empty capability sets were corrected to `CAP_SETUID CAP_SETGID` — the two caps the
 notification privilege-drop genuinely needs; the small increase is the honest cost of a working
-notification path.) Verify with:
+notification path. It rose again from 2.6 to 2.8 with the startup-only `CAP_CHOWN` above:
+`systemd-analyze` scores the bounding set, so it cannot see that the capability is dropped
+in-process before the first authentication.) Verify with:
 ```bash
 systemd-analyze security facelock-daemon.service
 ```

--- a/systemd/facelock-daemon.service
+++ b/systemd/facelock-daemon.service
@@ -51,8 +51,8 @@ RestrictSUIDSGID=yes
 # These are declared as Ambient (not just in the bounding set) so the caps
 # survive the exec into the non-setuid `runuser` under NoNewPrivileges=yes.
 # The daemon further narrows its in-process capability set to exactly these
-# two after initialization (see daemon.rs::drop_capabilities); everything else
-# stays denied.
+# two once the startup chowns are done, while it is still single-threaded (see
+# server.rs::drop_capabilities_or_refuse); everything else stays denied.
 #
 # NOTE (empirically required): an earlier revision set both of these empty on
 # the theory that "the daemon needs no capabilities." That was wrong — it broke
@@ -63,9 +63,11 @@ RestrictSUIDSGID=yes
 # is required.
 #
 # CAP_CHOWN is a third capability, and unlike the two above it is a STARTUP-ONLY
-# one: it is in the bounding set but NOT Ambient, and drop_capabilities() clears
-# it as soon as the daemon has claimed its bus name — so it is never held while
-# authenticating anyone. Root without CAP_CHOWN cannot chown(2) at all, and two
+# one: it is in the bounding set but NOT Ambient, and the in-process drop clears
+# it as soon as the two startup chowns below are done — before the daemon
+# creates its first thread, because capabilities are per-thread and inherited
+# only forwards, so no thread of the process holds it while anyone is being
+# authenticated. Root without CAP_CHOWN cannot chown(2) at all, and two
 # startup steps need it on an install that is being upgraded rather than freshly
 # packaged:
 #   - state_layout::ensure_state_layout, which chowns /var/lib/facelock (and

--- a/systemd/facelock-daemon.service
+++ b/systemd/facelock-daemon.service
@@ -61,7 +61,21 @@ RestrictSUIDSGID=yes
 # is NOT a viable alternative: dbus-broker rejects UID 0 on a user session bus
 # ("Broken pipe"), so the setuid-via-runuser path — and thus these two caps —
 # is required.
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID
+#
+# CAP_CHOWN is a third capability, and unlike the two above it is a STARTUP-ONLY
+# one: it is in the bounding set but NOT Ambient, and drop_capabilities() clears
+# it as soon as the daemon has claimed its bus name — so it is never held while
+# authenticating anyone. Root without CAP_CHOWN cannot chown(2) at all, and two
+# startup steps need it on an install that is being upgraded rather than freshly
+# packaged:
+#   - state_layout::ensure_state_layout, which chowns /var/lib/facelock (and
+#     the files under it) to root:facelock. A failure here is fatal — the daemon
+#     exits 1 — so without this cap an upgraded install can fail to start.
+#   - the enrollment-marker reconcile (#137), which chowns each marker to the
+#     user it describes. Without this cap it would silently write nothing on
+#     every systemd install, which is where nearly all daemon-mode users are.
+# Both are no-ops once the tree is correct, so the steady state never chowns.
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN
 AmbientCapabilities=CAP_SETUID CAP_SETGID
 # Only local sockets: D-Bus (system bus + per-user session bus for
 # notifications) is AF_UNIX. AF_NETLINK is retained conservatively: no

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -139,13 +139,67 @@ af_inet_unrestricted() {
 }
 export -f af_inet_unrestricted
 
+# Is CAP_CHOWN (bit 0) clear in CapPrm/CapEff on EVERY thread of the running
+# daemon?
+#
+# Every other capability assertion in this file reads `systemctl show`, i.e.
+# how systemd was *configured*. None of them read what the daemon actually
+# ended up holding, and the difference is where a real bug lived: capabilities
+# are per-thread, so a drop performed after the process went multi-threaded
+# narrowed one thread and left ONNX Runtime's inference pools and every tokio
+# worker holding CAP_CHOWN for the daemon's whole life. `/proc/<pid>/status`
+# would not have shown it either — that is the main thread, the one thread that
+# did drop. Walking /proc/<pid>/task/* is the only read that can tell.
+#
+# Prints the offending thread ids so a failure is actionable.
+daemon_threads_without_cap_chown() {
+    pid=$(systemctl show facelock-daemon -p MainPID --value 2>/dev/null)
+    [ -n "$pid" ] && [ "$pid" != "0" ] && [ -d "/proc/$pid/task" ] || {
+        echo "no running daemon to inspect" >&2
+        return 1
+    }
+
+    checked=0
+    bad=""
+    for t in /proc/"$pid"/task/*; do
+        [ -r "$t/status" ] || continue
+        checked=$((checked + 1))
+        # CapPrm/CapEff are 16 hex digits; CAP_CHOWN is bit 0, so it is set iff
+        # the last nibble is odd.
+        for field in CapPrm CapEff; do
+            v=$(awk -v f="$field:" '$1 == f { print $2 }' "$t/status")
+            case "$v" in
+                *[13579bdfBDF]) bad="$bad ${t##*/}($field=$v)" ;;
+            esac
+        done
+    done
+
+    # A single thread means the walk found nothing worth walking (unreadable
+    # /proc, ProtectProc hiding the tree) — treat that as a failure rather than
+    # a pass, or the assertion becomes decorative.
+    [ "$checked" -gt 1 ] || {
+        echo "only $checked thread(s) readable under /proc/$pid/task — cannot verify" >&2
+        return 1
+    }
+
+    [ -z "$bad" ] || {
+        echo "CAP_CHOWN still held by:$bad" >&2
+        return 1
+    }
+    echo "verified $checked threads, none holding CAP_CHOWN"
+}
+export -f daemon_threads_without_cap_chown
+
 if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1; then
     # Not empty: the notification privilege-drop needs CAP_SETUID+CAP_SETGID
     # (ambient, to survive the exec into runuser), and startup needs CAP_CHOWN
     # to chown the state tree and the enrollment markers on an upgraded install.
-    # CAP_CHOWN is bounding-only and dropped in-process once the bus name is
-    # claimed — asserting it is *absent* from the ambient set is the half that
-    # matters here. See docs/security.md, Phase 3.
+    # CAP_CHOWN is bounding-only and dropped in-process before the daemon
+    # spawns its first thread — asserting it is *absent* from the ambient set
+    # is the half of that these `systemctl show` reads can see. The other half,
+    # that the drop actually happened on every thread, is asserted against the
+    # running daemon further down (daemon_threads_without_cap_chown); these
+    # directive checks cannot substitute for it. See docs/security.md, Phase 3.
     run_test "unit: CapabilityBoundingSet is SETUID+SETGID+CHOWN only" 'v=$(unit_prop CapabilityBoundingSet); echo "$v" | grep -q cap_setuid && echo "$v" | grep -q cap_setgid && echo "$v" | grep -q cap_chown && [ "$(echo "$v" | tr " " "\n" | grep -c .)" = 3 ]'
     run_test "unit: AmbientCapabilities is SETUID+SETGID only" 'v=$(unit_prop AmbientCapabilities); echo "$v" | grep -q cap_setuid && echo "$v" | grep -q cap_setgid && ! echo "$v" | grep -q cap_chown'
     run_test "unit: RestrictAddressFamilies is AF_UNIX+AF_NETLINK only" 'v=$(unit_prop RestrictAddressFamilies); echo "$v" | grep -q AF_UNIX && echo "$v" | grep -q AF_NETLINK && ! echo "$v" | grep -q AF_INET'
@@ -182,6 +236,12 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         fi
         run_test "facelock-daemon starts under hardened unit" "systemctl start facelock-daemon && systemctl is-active --quiet facelock-daemon"
         run_test "facelock-daemon answers on D-Bus" "busctl --system call org.facelock.Daemon /org/facelock/Daemon org.freedesktop.DBus.Peer Ping"
+        # The runtime counterpart to the unit-property assertions above: what
+        # the daemon *holds* while it is serving, on every thread, not what the
+        # unit was configured to allow. docs/security.md §6.A promises
+        # CAP_CHOWN is "never held while authenticating anyone" — this is the
+        # assertion that makes the promise checkable.
+        run_test "runtime: no daemon thread holds CAP_CHOWN while serving" "daemon_threads_without_cap_chown"
         systemctl stop facelock-daemon 2>/dev/null || true
     else
         echo "SKIP: daemon start test (no ONNX models at /var/lib/facelock/models — run via just test-deb-pkg/test-rpm-pkg with repo models present)"

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -140,8 +140,14 @@ af_inet_unrestricted() {
 export -f af_inet_unrestricted
 
 if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1; then
-    run_test "unit: CapabilityBoundingSet is empty" '[ -z "$(unit_prop CapabilityBoundingSet)" ]'
-    run_test "unit: AmbientCapabilities is empty" '[ -z "$(unit_prop AmbientCapabilities)" ]'
+    # Not empty: the notification privilege-drop needs CAP_SETUID+CAP_SETGID
+    # (ambient, to survive the exec into runuser), and startup needs CAP_CHOWN
+    # to chown the state tree and the enrollment markers on an upgraded install.
+    # CAP_CHOWN is bounding-only and dropped in-process once the bus name is
+    # claimed — asserting it is *absent* from the ambient set is the half that
+    # matters here. See docs/security.md, Phase 3.
+    run_test "unit: CapabilityBoundingSet is SETUID+SETGID+CHOWN only" 'v=$(unit_prop CapabilityBoundingSet); echo "$v" | grep -q cap_setuid && echo "$v" | grep -q cap_setgid && echo "$v" | grep -q cap_chown && [ "$(echo "$v" | tr " " "\n" | grep -c .)" = 3 ]'
+    run_test "unit: AmbientCapabilities is SETUID+SETGID only" 'v=$(unit_prop AmbientCapabilities); echo "$v" | grep -q cap_setuid && echo "$v" | grep -q cap_setgid && ! echo "$v" | grep -q cap_chown'
     run_test "unit: RestrictAddressFamilies is AF_UNIX+AF_NETLINK only" 'v=$(unit_prop RestrictAddressFamilies); echo "$v" | grep -q AF_UNIX && echo "$v" | grep -q AF_NETLINK && ! echo "$v" | grep -q AF_INET'
     # systemctl show expands @system-service into individual syscalls: assert
     # allowlist mode (no "~" prefix), a marker syscall the daemon needs


### PR DESCRIPTION
Closes #137.

After upgrading from v0.1.4, `facelock is-enrolled` reports `not enrolled` for
users who are enrolled and whose face authentication works. Markers are new;
packaging creates `/var/lib/facelock/enrolled/` but never populates it, and the
backfill — `enrollment_marker::reconcile_all` — only ever ran from `setup`,
which an upgrade does not run.

> **Merged with `main` after #145 (ADR 008, camera lifecycle).** The conflict was
> in one file and was semantic rather than textual — the oneshot convergence
> point had to move. See [After #145](#after-145-the-convergence-point-moved)
> below; it is the first thing to review. A second merge picks up #142 and #143,
> which landed during the work and touch no file this branch does.

## Convergence, not migration

`reconcile_all` derives markers from the database, which is authoritative. That
makes it idempotent, order-free, and stateless: there is no "which steps have
run" ledger to keep, and therefore none that can disagree with reality after a
restored backup, a database copied between machines, or a wiped state directory.
So this PR adds **callers**, not marker logic, and does not touch
`facelock-store/src/migrations.rs` — a real version-gated runner, correct for
its own job (`ALTER TABLE` genuinely cannot run twice).

`markers_converge_idempotently` is the load-bearing test: it asserts a second
reconcile changes nothing observable. That assertion is what a migration ledger
would otherwise have bought.

## The two call sites

1. **Daemon startup** (`commands/daemon.rs::reconcile_enrollment_markers`) —
   once, in `run`, after the handler is built (so the state layout is ensured
   and the store exists) and before the bus name is claimed. Not in
   `build_handler`, because that also runs on config reload. Logged and
   swallowed on failure: a marker problem must never stop the daemon serving
   authentications.
2. **Oneshot auth** (`commands/auth.rs::converge_enrollment_marker`) —
   immediately after `pre_check_audited`, with the model list read there and
   handed to the attempt. This is the only convergence point on a daemonless
   install. See below for why that is where it sits.

`is-enrolled` is untouched: it still reads its own `0600` marker and nothing
else, and the existing pins (`resolved::is_enrolled_module_stays_probe_free`,
the three layout-tier assertions) pass unmodified. The daemon's per-request
handler is also untouched — `enrollment_marker` lives in `facelock-cli`, which
depends on `facelock-daemon` and not the reverse.

## After #145: the convergence point moved

#145 rewrote the one-shot path this branch had inserted into. The textual
conflict was small, and that was the trap: git happily auto-merged the *call
site*, because `store.list_models(&user)` is still there — it just is not where
it was. #145 moved that line **below** the camera bring-up, so a straight merge
left marker convergence downstream of the engine load, the camera open and the
warmup discard.

That is the wrong side of a line this branch cares about. Before #145 the only
thing between convergence and the attempt was the attempt. #145 added five new
ways to leave early:

- a cancel token set by SIGTERM / SIGINT / SIGHUP (including `PR_SET_PDEATHSIG`
  when the PAM host is killed),
- a failed ONNX model load,
- a camera another process is holding,
- a template that will not decrypt,
- `recognition.no_face_timeout_secs` firing at an empty chair.

None of those is a pre-flight rejection, and none of them is evidence about
whether anyone is enrolled — but left where the merge put it, every one of them
would silently veto the backfill. "Camera busy" is not exotic here: it is the
shape #137's upgraded user hits on a laptop whose locker is already looking at
them.

So the call moved up, with the `list_models` read that feeds it, to sit
immediately after `pre_check_audited`. The window is now bounded on **both**
sides, and both bounds are contract:

- **Still below the gates.** This is the property that has not changed, and
  re-verified: a marker rewrite is a temp file, a `chown` and a `rename`; above
  the gates that is filesystem work an attacker can drive from the wrong side of
  the rate limiter. A pre-flight rejection (disabled, SSH, lid, rate limit,
  `require_ir`) still converges nothing; the next attempt that passes the gates
  still fixes it.
- **Now above `start_engine_then_camera`.** An attempt that reaches the camera
  has already converged, whatever it goes on to decide. A cancelled or
  timed-out attempt is one of those — it leaves a correct marker behind rather
  than one more reason not to write one.

Hoisting the read is free and slightly better than free: it is the ordering the
daemon handler already uses deliberately, so that no database work happens
between the camera open and the first analyzed frame (ADR 008 §1 — that gap is
LED-on time). `list_models` returns metadata only, so nothing plaintext crosses
the bring-up because of it; `load_user_embeddings`, which *does* carry plaintext
biometric material, deliberately stays where #145 put it.

`marker_convergence_sits_between_the_gates_and_the_camera` is the structural pin
and it grew the bound it was missing. The old version asserted only "convergence
precedes the authentication" — which the bad merge satisfied. It now pins
`pre_check_audited` < convergence < `start_engine_then_camera`, and that exactly
one call site exists.

## Three things found on the way in — please review these specifically

**1. `reconcile_all` pruned markers it had merely failed to write.** `wanted`
collected only *successful* writes, so a failed write dropped the user from the
keep-list and the prune then deleted their marker. With reconcile running on
every daemon start, one transient failure would destroy correct state.
`wanted` now means "the database says this user is enrolled", which is what the
prune should be answering. Pinned by
`a_marker_that_cannot_be_written_is_not_pruned` (verified to fail against the
old behaviour; survived the merge unchanged).

**2. `CAP_CHOWN` added to the daemon's capability bounding set — startup only.**
Writing a marker `chown`s it to its user, and root without `CAP_CHOWN` cannot
`chown(2)` at all (verified: `podman run --cap-drop=CHOWN` → `Operation not
permitted`). Under the shipped unit's `CapabilityBoundingSet=CAP_SETUID
CAP_SETGID`, the startup reconcile would have written **nothing** on every
systemd install — i.e. the fix would have been a no-op exactly where most
daemon-mode users are — and, before fix (1), would have deleted every marker
`setup` had written.

The same capability is needed by an existing startup step:
`state_layout::ensure_state_layout` chowns `/var/lib/facelock` to
`root:facelock` on an upgraded install, and its failure is **fatal** (the daemon
exits 1). It survives today only because a correctly-packaged tree makes the
chown a no-op. That is the deciding argument: the shipped unit is already
narrower than what the daemon does at startup, independently of #137.

Scoped as tightly as I could: bounding set only (**not** ambient, so no exec'd
child inherits it), and the in-process drop clears it as soon as the bus name is
claimed — before the first authentication. Blast radius is the two
`ReadWritePaths` plus the private `/tmp`; everything else is a read-only mount
under `ProtectSystem=strict`, where `chown` fails with `EROFS`.
`systemd-analyze security --offline=true` moves **2.6 → 2.8** (still OK); it
scores the bounding set and cannot see the in-process drop. Documented in
`docs/security.md` and the unit's own comments.

> ### ⚠️ This is a working assumption, not a settled decision
>
> Carrying `CAP_CHOWN` is **your call and still fully reversible.** It is
> implemented this way because the `ensure_state_layout` argument above says the
> unit is already too narrow — but nothing downstream depends on the choice.
>
> The alternative is an **`ExecStartPre=+…` reconcile**: the `+` prefix runs the
> command outside the sandbox with full privileges, so the bounding set stays
> `CAP_SETUID CAP_SETGID` and the marker chowns happen in a separate short-lived
> process. Cost: a new subcommand and a second process at every start, and it
> does *not* address `ensure_state_layout` — that chown is inside the daemon and
> would still fail on an upgraded install under a `CAP_CHOWN`-less bounding set.
> Say the word and I will switch it.

**3. The daemon's capability drop was best-effort, and this PR is what makes
that matter.** It used to log `failed to drop capabilities (continuing)` and
serve anyway. That was defensible while the dropped set held nothing the
security model had promised to remove. It is not defensible next to item (2):
under the exact configuration this PR ships, a failed `capset` leaves the daemon
answering every `Authenticate` call with `chown(2)` in reach, on a host whose
operator has been told in `docs/security.md` that `CAP_CHOWN` is "never held
while authenticating anyone", announced only by a journal line.

So the guarantee is now **checked**, not asserted: after the drop the daemon
reads its capabilities back with `capget` and compares them against the retained
mask. Reading back beats trusting `capset`'s return code — it also catches a
mask, or a struct layout, that stopped being what the code thinks it is.

The refusal is deliberately one-sided — *"is anything extra still here?"*, never
*"are the retained caps present?"*:

| Observed after the drop | Daemon does |
|---|---|
| Nothing beyond `CAP_SETUID`+`CAP_SETGID` | serve — the steady state |
| Anything extra survived (incl. a `capset` that failed outright) | **refuse**: release the bus name, exit non-zero, before the first authentication |
| Held set is *narrower* than the retained mask | warn and serve — an operator's tighter bounding set costs notifications and violates nothing |
| `capget` itself failed | **refuse** — an unverifiable guarantee is not a guarantee |

Fatal matches the codebase's existing convention for a load-bearing startup
invariant (`ensure_state_layout` exits 1 a few steps earlier; so does the model
SHA-256 check) and it is **not a lockout**: the bus name is released and PAM
degrades to the password exactly as it does when the daemon is not running at
all. `Restart=on-failure` retries every `RestartSec=3` — the same restart loop a
failed `ensure_state_layout` already produces; the unit sets no `StartLimit*`,
so systemd's defaults may not trip at that interval. Each attempt logs the
capability mask that survived, so the journal names the problem.

The comparison is a pure function over the three sets, unit-testable without
privilege. CAP_CHOWN is pinned surviving in each of effective, permitted and
inheritable *separately* (they are not interchangeable: `permitted` is what
`chown(2)` needs, `inheritable` is what an exec'd child could carry away), and
capabilities above 31 are covered because `capget`'s second word is easy to
forget and is half the space. Ambient needs no check of its own — the kernel
drops a capability from ambient the moment it leaves permitted or inheritable.

Also updated two stale assertions in `test/pkg-validate.sh` that asserted the
capability sets were *empty* — already false before this PR (they have said
`CAP_SETUID CAP_SETGID` since the notification privilege-drop landed). They only
run under a real systemd with the unit installed, which is why they never
failed in CI.

## Gates

| Gate | Result |
|---|---|
| `cargo test --workspace` | pass, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo clippy --workspace --all-targets --features tpm -- -D warnings` | pass |
| `cargo fmt --all -- --check` | pass |
| `just test-arch-pam` | 22 passed, 0 failed — unchanged |
| `just test-arch-layout` | 21 passed, 0 failed — unchanged |
| `just test-arch-integration` | **not run** — needs a camera and the ONNX models |
| `just test-arch-oneshot` | **not run** — same |
| `just pkg-validate-*` (systemd tiers) | **not run** — needs the deb/rpm images under systemd; this is the tier that exercises the edited `pkg-validate.sh` assertions and the new unit |

The camera tiers are the ones that would exercise the daemon-startup reconcile
and the oneshot convergence end to end on real hardware. I have no coverage
there and am not claiming any. The systemd tier is also the only place the new
capability refusal is exercised against a real `CapabilityBoundingSet` — the
unit tests cover the decision, not the syscall under the shipped sandbox.

## Residual (documented, not chased)

A user who enrolled before the upgrade, on an install where the daemon never
runs **and** who has not attempted an authentication since, still has no marker
until one of those happens (or `setup` is re-run). That is inherent to
convergence: it fixes state when something touches it. No timer, no background
sweep.

Narrower than that, on the oneshot path only: an attempt rejected by a
pre-flight gate (disabled, SSH, lid, rate limit, `require_ir`) does not
converge. The next attempt that passes the gates does. Deliberate rather than
incidental — see the bound above. Everything *after* the gates now converges,
including the attempts #145 taught the one-shot to abandon early.

## Noted, not fixed (out of scope for this PR)

On the one-shot path, `store.list_models(&user)` folds a storage failure into an
empty list via `unwrap_or_default()`. An empty `models` means an empty
device-allowed compare set, therefore a guaranteed "no match", therefore a
rate-limit charge for an attempt the user never got to make — which is exactly
the #105/C3 defect the daemon handler fixed on its side (it returns a storage
error instead, with a comment explaining that retries otherwise walk into a
lockout). The one-shot never got the same treatment, and it sits on the line
this PR edits, so it is worth a decision — but fixing it changes auth-path
behaviour (a transient storage error would exit 2 instead of running a doomed
scan) and belongs in its own reviewed change rather than riding along in a merge
resolution. Marker convergence itself already treats an unlistable store as "no
evidence" and leaves the marker alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
