### PR TITLE
Camera lifecycle: hold only after failure, cancellable auth, one-shot hygiene (ADR 008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One-shot `facelock auth` no longer outlives its PAM host or lights the
+  camera during the model load** (ADR 008 §7). Three changes, no new exit
+  code and no change to the existing one: the ONNX engine now loads *before*
+  the camera opens, so the IR LED is lit for the scan rather than for the
+  model load as well; SIGTERM, SIGINT and SIGHUP end the scan through the same
+  cancel token, which lets `Drop` run STREAMOFF and turn the emitter off
+  before exiting 2 with a `cancelled` log line; and the PAM module sets
+  `PR_SET_PDEATHSIG = SIGTERM` on the child, so a killed PAM host (an aborted
+  locker helper, a killed `sudo`) takes the helper with it instead of leaving
+  it scanning, reparented to init, with the camera on. The PAM module's own
+  timeout now sends SIGTERM and waits up to 500 ms before SIGKILL; it used to
+  SIGKILL immediately, which skips `Drop` and can leave an XU-controlled IR
+  emitter lit.
 - **An authentication whose caller has gone away now ends within one frame**
   (ADR 008 §5). Nothing could shorten the scan loop before: when a screen
   locker aborted PAM because the password was typed first, or a `sudo` was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compares the target user's marker against the database and prints a
   diagnostic when they disagree (or when the marker is unreadable), pointing
   at `sudo facelock setup` to reconcile. `is-enrolled` itself is unchanged.
+- **Opt-in camera hold after a successful authentication**: a new
+  `device.camera_release_after_success_secs` (default **0**) keeps the camera
+  streaming for that many seconds after a success, the way
+  `camera_release_secs` already does after a failure. At its default — which is
+  the recommended value and what every install gets without touching the file —
+  nothing changes: a success ends the interaction, so the stream (and on IR
+  hardware the emitter LED) goes out with the reply. It exists for the one
+  shape that really does re-authenticate immediately: privileged actions
+  repeated with no authentication caching in front of them, `sudo` with a zero
+  `timestamp_timeout` or a polkit action without `auth_admin_keep`, where each
+  action is a fresh authentication that would otherwise pay a camera reopen.
+  Failed attempts keep using `camera_release_secs`; cancellations and errors
+  release the camera at once whatever both keys say. Additive with a serde
+  default: no existing config is rejected, and the daemon reads it per request,
+  so no restart is needed.
 - **`facelock bench camera-reopen`**: measures what it actually costs to go
   from a closed camera to the first frame an authentication can analyze, split
   into device open + format negotiation, `STREAMON` + first frame, warmup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The daemon holds the camera open only after a failed authentication**
+  (ADR 008). Previously every request — success included — left the V4L2 stream
+  live for `device.camera_release_secs`, which on IR hardware is a visible
+  emitter LED burning for five seconds after the screen had already unlocked.
+  Success, cancellation and every error class now release the camera as the
+  request returns; only a no-match or timeout keeps it warm, because that is
+  the one ending a retry plausibly follows. The default drops from **5 to 3
+  seconds**, `0` now means *never hold* instead of being silently substituted
+  with 5, and the release is polled every 250 ms against an absolute deadline
+  rather than once a second. A warm reuse discards the stale V4L2 buffers
+  before analyzing anything, so a fresh attempt can never match on the tail of
+  the previous one. Preview frames keep their own floor of
+  `max(camera_release_secs, 2s)` so a live preview never reopens per frame.
+  **No action required on upgrade**: the key is unchanged in name and type, the
+  shipped config template has it commented out, and the daemon re-reads it per
+  request.
 - **`facelock status` says "cannot determine" instead of guessing**: a section
   whose probe failed — an unreadable database, a config that did not parse —
   now reports exactly that, and a daemon that is unreachable can never render

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **An authentication at an empty chair ends early and costs no rate-limit
+  budget** (ADR 008 §3/§4). A new `recognition.no_face_timeout_secs` (default
+  **2**) ends an attempt once that many seconds have passed with no face
+  detected at all; `recognition.timeout_secs` still bounds the slower case a
+  timeout is actually for — a face was seen and has not matched yet. A laptop
+  opened in front of nobody therefore lights its IR emitter for 2 seconds
+  instead of 5. The key is additive with a serde default, is clamped to
+  `timeout_secs` rather than validated against it, and `0` disables the early
+  exit, so no existing `/etc/facelock/config.toml` needs to change. Separately,
+  and regardless of that timeout, a failed attempt in which the camera never
+  saw a face no longer calls the rate limiter on either the daemon or the
+  one-shot path: an empty chair is not a guess, and charging it let a locker
+  that starts face auth on every wake spend the user's whole 5-attempt budget
+  before they sat down — the real attempt then met a lockout. A face that
+  *was* seen and did not match is charged exactly as before. The early ending
+  reports the same outcome the full timeout reports, so no client, sentinel or
+  audit result gains a case.
 - **One-shot `facelock auth` no longer outlives its PAM host or lights the
   camera during the model load** (ADR 008 §7). Three changes, no new exit
   code and no change to the existing one: the ONNX engine now loads *before*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compares the target user's marker against the database and prints a
   diagnostic when they disagree (or when the marker is unreadable), pointing
   at `sudo facelock setup` to reconcile. `is-enrolled` itself is unchanged.
+- **`facelock bench camera-reopen`**: measures what it actually costs to go
+  from a closed camera to the first frame an authentication can analyze, split
+  into device open + format negotiation, `STREAMON` + first frame, warmup
+  discard, and first usable frame, over `--iterations` cycles (default 5). This
+  is the number `device.camera_release_secs` trades LED-on time against —
+  holding the stream warm after a failed attempt buys a retry exactly this
+  much (ADR 008) — and it had never been measured: the docs asserted "~400 ms"
+  and "~600 ms cold" from nobody's hardware in particular. Those figures are
+  gone from the docs in favor of pointing at this subcommand, since the answer
+  is a property of the camera and its driver, not of facelock. Needs no
+  enrolled face and loads no models.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **An authentication whose caller has gone away now ends within one frame**
+  (ADR 008 §5). Nothing could shorten the scan loop before: when a screen
+  locker aborted PAM because the password was typed first, or a `sudo` was
+  killed, or a client crashed, the daemon kept capturing — and kept the IR
+  emitter lit — until `recognition.timeout_secs`. Every in-flight request now
+  carries a cancel token, checked once per iteration by the auth loop, the
+  enroll loop and both frame-discard loops. It is set when the caller's D-Bus
+  connection disappears (a per-request `NameOwnerChanged` watch on the
+  caller's bus name), on suspend, on `ReleaseCamera`, and on shutdown — all
+  without taking the handler lock, which is what the request being cancelled
+  is holding. A cancelled attempt releases the camera immediately, is audited
+  as `cancelled` rather than `failure`, and **charges no rate-limit budget**:
+  the user never got to make an attempt. On the wire it reuses the
+  recoverable-error encoding with the frozen message `cancelled`, which the
+  PAM module maps to `PAM_IGNORE` — the stack falls through to the password
+  the user was already typing. No new D-Bus method, no signature change. The
+  suspend path in particular no longer gives up with a "handler busy" warning
+  and leaves the camera streaming into sleep.
 - **The daemon holds the camera open only after a failed authentication**
   (ADR 008). Previously every request — success included — left the V4L2 stream
   live for `device.camera_release_secs`, which on IR hardware is a visible

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ just uninstall
 
 | Mode | Config | How it works | Latency |
 |------|--------|-------------|---------|
-| **Daemon** | `mode = "daemon"` (default) | PAM → D-Bus → persistent daemon | ~150-600ms |
-| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms+ cold |
-| **Oneshot** | `mode = "oneshot"` | PAM → `facelock auth` subprocess | ~700ms+ |
+| **Daemon** | `mode = "daemon"` (default) | PAM → D-Bus → persistent daemon | fastest: no model load, no reopen when warm |
+| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | + daemon start on the first call |
+| **Oneshot** | `mode = "oneshot"` | PAM → `facelock auth` subprocess | + model load on every call |
 
-Daemon latency depends on camera state: ~600ms with a cold camera, ~150-180ms on back-to-back auths when the camera is already warm. The lighter default model (`scrfd_2.5g`) keeps inference fast.
+Daemon latency depends on camera state: a cold attempt pays a camera reopen, a retry within `device.camera_release_secs` of a failed attempt does not. That reopen cost is a property of your camera and driver, not a number to quote from someone else's laptop — measure it with `sudo facelock bench camera-reopen`, which prints the open / STREAMON / warmup split. The lighter default model (`scrfd_2.5g`) keeps inference fast.
 
 The CLI works in all modes — it connects to the daemon if available, otherwise operates directly.
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -210,7 +210,10 @@ flowchart LR
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
 - ~600ms typical auth latency (~150ms with warm camera)
-- Camera stays warm between back-to-back requests
+- Camera stays warm after a **failed** attempt for `device.camera_release_secs`
+  (default 3), so the retry a miss invites skips the reopen. Success,
+  cancellation and errors release it at once — on IR hardware the emitter LED
+  goes out with the interaction (ADR 008)
 - Single point of resource management
 
 ### Oneshot Mode

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -209,7 +209,10 @@ flowchart LR
 
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
-- ~600ms typical auth latency (~150ms with warm camera)
+- No per-authentication model load, and no camera reopen when the stream is
+  already warm. The reopen a cold attempt pays is hardware-specific — measure
+  it with `sudo facelock bench camera-reopen`, which splits it into open,
+  STREAMON and warmup
 - Camera stays warm after a **failed** attempt for `device.camera_release_secs`
   (default 3), so the retry a miss invites skips the reopen. Success,
   cancellation and errors release it at once — on IR hardware the emitter LED

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -419,10 +419,17 @@ facelock bench preview                  # frame capture + face detection latency
 facelock bench enrollment               # time to capture and embed snapshots (dry run, embeddings not stored)
 facelock bench model-load               # ONNX model load time (SCRFD + ArcFace)
 facelock bench calibrate                # sweep FAR/FRR thresholds and recommend optimal value
+facelock bench camera-reopen            # cost of reopening the camera: open / STREAMON / warmup split
 facelock bench report                   # full benchmark report
 ```
 
 `cold-auth`, `warm-auth`, `calibrate`, and `report` require enrolled faces. When encryption method is `tpm`, these subcommands require root.
+
+`camera-reopen` needs no enrolled face and loads no models (it is still root,
+like every `bench` subcommand): it closes and reopens the camera
+`--iterations` times (default 5) and reports the per-phase median. That total is what `device.camera_release_secs` trades LED-on time
+against -- holding the stream warm after a failed attempt buys a retry exactly
+this much (ADR 008).
 
 ## facelock encrypt
 

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -423,13 +423,16 @@ facelock bench camera-reopen            # cost of reopening the camera: open / S
 facelock bench report                   # full benchmark report
 ```
 
-`cold-auth`, `warm-auth`, `calibrate`, and `report` require enrolled faces. When encryption method is `tpm`, these subcommands require root.
+**Every `bench` subcommand requires root** (DEC-6): direct-mode access needs the
+`0600` root:root database whatever the subcommand, and the auth benchmarks may
+need TPM access besides. `cold-auth`, `warm-auth`, `calibrate`, and `report`
+additionally require enrolled faces.
 
-`camera-reopen` needs no enrolled face and loads no models (it is still root,
-like every `bench` subcommand): it closes and reopens the camera
-`--iterations` times (default 5) and reports the per-phase median. That total is what `device.camera_release_secs` trades LED-on time
-against -- holding the stream warm after a failed attempt buys a retry exactly
-this much (ADR 008).
+`camera-reopen` needs no enrolled face and loads no models -- but is root like
+the rest: it closes and reopens the camera `--iterations` times (default 5) and
+reports the per-phase median. That total is what `device.camera_release_secs`
+trades LED-on time against -- holding the stream warm after a failed attempt
+buys a retry exactly this much (ADR 008).
 
 ## facelock encrypt
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -17,7 +17,8 @@ Camera settings.
 | `dark_threshold` | f32 | `0.6` | Fraction of pixels that must be darker than `dark_pixel_value` before the frame is treated as unusably dark. |
 | `dark_pixel_value` | u8 | `10` | Pixel brightness cutoff used by the dark-frame check. |
 | `ir_emitter` | bool | `false` | Attempt to enable a controllable IR emitter when the camera opens. Only needed for hardware that does not auto-enable its IR LED. |
-| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Success, cancellation and errors release the camera at once. `0` disables the hold entirely (it used to be silently substituted with 5). |
+| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Cancellation and errors release the camera at once, and so does a success unless `camera_release_after_success_secs` is set. `0` disables the hold entirely (it used to be silently substituted with 5). |
+| `camera_release_after_success_secs` | u32 | `0` | Daemon only. Seconds to keep the camera streaming after a **successful** authentication too. `0` (the default) releases it immediately — the interaction is over, and on IR hardware the emitter LED goes out with it. Set it only where privileged actions repeat with no authentication caching in front of them (`sudo` with a zero `timestamp_timeout`, a polkit action without `auth_admin_keep`), so each one is a fresh authentication that would otherwise pay a camera reopen. Failures still use `camera_release_secs`; cancellations and errors always release at once. |
 
 ## [recognition]
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -64,7 +64,7 @@ Controls how the PAM module reaches the face engine.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (~200ms warm, ~600ms cold). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~600ms+, no background process). |
+| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (models stay loaded; only a cold attempt pays a camera reopen -- measure it with `facelock bench camera-reopen`). `"oneshot"` spawns `facelock auth` per PAM call (slower: model load on every call, no background process). |
 | `model_dir` | string | `"/var/lib/facelock/models"` | Directory containing ONNX model files. |
 | `idle_timeout_secs` | u64 | `0` | Shut down the daemon after this many idle seconds. `0` means never. Useful with D-Bus activation. |
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -27,6 +27,7 @@ Face detection and embedding parameters.
 |-----|------|---------|-------------|
 | `threshold` | f32 | `0.80` | Cosine similarity threshold for accepting a face match. Must be between 0.0 and 1.0. Higher values are stricter. See the range guide below. |
 | `timeout_secs` | u32 | `5` | Maximum seconds to attempt recognition before giving up. Must be > 0. |
+| `no_face_timeout_secs` | u32 | `2` | Seconds to keep scanning when **no face at all** has been detected. Once a face is seen, `timeout_secs` takes over — "seen, not matched yet" is the case worth waiting out. An empty-chair attempt ends early and charges no rate-limit budget. Clamped to `timeout_secs` (never an error); `0` disables the early exit. |
 | `detection_confidence` | f32 | `0.5` | Minimum confidence for the face detector to report a detection. Lower values detect more faces but increase false positives. |
 | `nms_threshold` | f32 | `0.4` | Non-maximum suppression threshold for overlapping detections. |
 | `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. Bundled models are verified against the manifest; custom models require `detector_sha256`. |

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -17,7 +17,7 @@ Camera settings.
 | `dark_threshold` | f32 | `0.6` | Fraction of pixels that must be darker than `dark_pixel_value` before the frame is treated as unusably dark. |
 | `dark_pixel_value` | u8 | `10` | Pixel brightness cutoff used by the dark-frame check. |
 | `ir_emitter` | bool | `false` | Attempt to enable a controllable IR emitter when the camera opens. Only needed for hardware that does not auto-enable its IR LED. |
-| `camera_release_secs` | u32 | `5` | Seconds to keep the camera open after daemon-mode auth before releasing it, to avoid repeated warmup cost on back-to-back requests. |
+| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Success, cancellation and errors release the camera at once. `0` disables the hold entirely (it used to be silently substituted with 5). |
 
 ## [recognition]
 

--- a/book/src/contracts.md
+++ b/book/src/contracts.md
@@ -77,7 +77,7 @@ TOML format. All keys optional -- camera auto-detected, sensible defaults for ev
 
 | Section | Key fields |
 |---------|-----------|
-| `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs` |
+| `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs`, `camera_release_after_success_secs` |
 | `[recognition]` | `threshold`, `timeout_secs`, `detector_model`, `embedder_model`, `threads`, `execution_provider` |
 | `[daemon]` | `mode` (DaemonMode enum), `model_dir`, `idle_timeout_secs` |
 | `[storage]` | `db_path` |

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -17,11 +17,11 @@ No daemon needed -- the CLI auto-falls back to direct mode when no daemon is run
 
 | Mode | Config | How it works | Latency |
 |------|--------|-------------|---------|
-| **Daemon** | `mode = "daemon"` (default) | PAM connects via D-Bus, persistent daemon | ~150-600ms |
-| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | ~700ms+ cold |
-| **Oneshot** | `mode = "oneshot"` | PAM spawns `facelock auth` subprocess | ~700ms+ |
+| **Daemon** | `mode = "daemon"` (default) | PAM connects via D-Bus, persistent daemon | fastest: no model load, no reopen when warm |
+| **D-Bus activation** | systemd + D-Bus service | systemd starts daemon on demand | + daemon start on the first call |
+| **Oneshot** | `mode = "oneshot"` | PAM spawns `facelock auth` subprocess | + model load on every call |
 
-Daemon latency depends on camera state: ~600ms with a cold camera, ~150-180ms on back-to-back auths when the camera is already warm.
+Daemon latency depends on camera state: a cold attempt pays a camera reopen, a retry within `device.camera_release_secs` of a failed attempt does not. That reopen cost is a property of your camera and driver, not a number to quote from someone else's laptop -- measure it with `sudo facelock bench camera-reopen`, which prints the open / STREAMON / warmup split.
 
 The CLI works in all modes -- it connects to the daemon if available, otherwise operates directly.
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -55,7 +55,7 @@
 
 ### First-start latency (~700ms -- 2s)
 
-The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode typically take ~600ms (or ~150ms if the camera is still warm from a recent auth).
+The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode never reload the models; a cold one additionally pays a camera reopen, a warm one does not. What that reopen costs is a property of your camera and driver -- measure it with `sudo facelock bench camera-reopen` (it prints the open / STREAMON / warmup split) rather than comparing against someone else's figure.
 
 ### Consistently slow (~700ms+ every time)
 

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -44,12 +44,24 @@
 # ir_emitter = false
 
 # Daemon only. Seconds to keep the camera streaming after a FAILED
-# authentication so an immediate retry skips the reopen cost. Success,
-# cancellation and errors always release the camera at once — the
-# interaction is over, so the IR LED goes out with it.
+# authentication so an immediate retry skips the reopen cost. Cancellation
+# and errors always release the camera at once — the interaction is over,
+# so the IR LED goes out with it — and so does a success, unless the key
+# below says otherwise.
 # Set it to zero to never hold: every attempt reopens, no LED after a miss.
 # Default: 3
 # camera_release_secs = 3
+
+# Daemon only. Seconds to keep the camera streaming after a SUCCESSFUL
+# authentication as well. Zero, the default, releases it at once: the
+# interaction is over, so holding on only keeps the camera (and on IR
+# hardware its emitter LED) lit for a retry nobody is going to make.
+# Raise it only if you repeat privileged actions with no authentication
+# caching in front of them (sudo with a zero timestamp_timeout, a polkit
+# action without auth_admin_keep), so each one is a fresh authentication
+# that would otherwise pay a camera reopen.
+# Default: 0
+# camera_release_after_success_secs = 0
 
 
 # ── Face Recognition ────────────────────────────────────────────────

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -43,10 +43,13 @@
 # Default: false
 # ir_emitter = false
 
-# In daemon mode, keep the camera open for this many seconds after
-# auth before releasing it to avoid repeated warmup cost.
-# Default: 5
-# camera_release_secs = 5
+# Daemon only. Seconds to keep the camera streaming after a FAILED
+# authentication so an immediate retry skips the reopen cost. Success,
+# cancellation and errors always release the camera at once — the
+# interaction is over, so the IR LED goes out with it.
+# Set it to zero to never hold: every attempt reopens, no LED after a miss.
+# Default: 3
+# camera_release_secs = 3
 
 
 # ── Face Recognition ────────────────────────────────────────────────

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -76,6 +76,15 @@
 # Default: 5
 # timeout_secs = 5
 
+# Seconds to keep looking when no face at all has been detected.
+# Once a face is seen, timeout_secs above takes over — that is the case
+# worth waiting out. Ending an empty-chair attempt early stops the camera
+# (and on IR hardware its emitter LED) from running for nothing, and such an
+# attempt never counts against the rate limit.
+# Values above timeout_secs are clamped to it. 0 disables the early exit.
+# Default: 2
+# no_face_timeout_secs = 2
+
 # ONNX model files (must exist in daemon.model_dir).
 # Run `facelock setup` to select a model tier and download automatically.
 #

--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -7,6 +7,7 @@ use tracing::{info, warn};
 
 use facelock_camera::capture::Camera;
 use facelock_camera::device::{is_ir_camera, validate_device};
+use facelock_camera::{QuirksDb, ResolvedCamera};
 use facelock_core::Config;
 use facelock_core::types::{FaceEmbedding, cosine_similarity};
 use facelock_face::FaceEngine;
@@ -24,6 +25,9 @@ const WARM_ITERATIONS: u32 = 10;
 
 /// Number of snapshots for enrollment benchmark.
 const ENROLLMENT_SNAPSHOTS: u32 = 5;
+
+/// Default number of reopen cycles for `camera-reopen`.
+const REOPEN_ITERATIONS: u32 = 5;
 
 /// Fallback `EnvFilter` directive used when `RUST_LOG` is unset (gap E9).
 ///
@@ -69,6 +73,12 @@ enum Command {
     ModelLoad,
     /// Sweep thresholds and measure FAR/FRR
     Calibrate,
+    /// Measure what reopening the camera costs (open, STREAMON, warmup)
+    CameraReopen {
+        /// Number of close→open→first-usable-frame cycles to time
+        #[arg(long, default_value_t = REOPEN_ITERATIONS)]
+        iterations: u32,
+    },
     /// Generate a benchmark report
     Report,
 }
@@ -87,6 +97,7 @@ fn main() -> Result<()> {
         Command::Enrollment => cmd_enrollment(),
         Command::ModelLoad => cmd_model_load(),
         Command::Calibrate => cmd_calibrate(),
+        Command::CameraReopen { iterations } => cmd_camera_reopen(iterations),
         Command::Report => cmd_report(),
     }
 }
@@ -510,6 +521,134 @@ fn cmd_calibrate() -> Result<()> {
 
         conf += 0.10;
     }
+
+    Ok(())
+}
+
+/// Time what it costs to go from no camera to the first frame an
+/// authentication can analyze — the cost `device.camera_release_secs` trades
+/// LED-on time against (ADR 008 §9).
+///
+/// The canonical implementation is `facelock bench camera-reopen`; this is the
+/// same measurement for the standalone tool. Unlike the other subcommands
+/// here, it loads the real quirks DB: a quirk's `warmup_frames` and
+/// `format_preference` overrides are a large part of what a reopen costs on
+/// the devices that have one, and a number measured without them would not be
+/// the number the daemon pays.
+fn cmd_camera_reopen(iterations: u32) -> Result<()> {
+    let config = load_config()?;
+    if iterations == 0 {
+        bail!("--iterations must be at least 1");
+    }
+
+    println!("=== Camera Reopen Benchmark ===");
+    println!(
+        "Measuring: open + format negotiation, STREAMON + first frame, warmup discard, \
+         first usable frame ({} iterations)",
+        iterations
+    );
+    println!();
+
+    let quirks = QuirksDb::load();
+    let mut opens = Vec::with_capacity(iterations as usize);
+    let mut firsts = Vec::with_capacity(iterations as usize);
+    let mut warmups = Vec::with_capacity(iterations as usize);
+    let mut usables = Vec::with_capacity(iterations as usize);
+    let mut totals = Vec::with_capacity(iterations as usize);
+    let mut device_path = String::new();
+    let mut format = String::new();
+    let mut warmup_frames = 0u32;
+
+    for i in 0..iterations {
+        // Each iteration starts closed: the previous camera was dropped before
+        // this timer started, so its STREAMOFF and IR-emitter shutdown are not
+        // billed to this open.
+        let open_start = Instant::now();
+        let resolved = ResolvedCamera::resolve(&config.device, &quirks)
+            .context("Failed to resolve camera device")?;
+        let warmup = resolved
+            .quirk
+            .as_ref()
+            .and_then(|q| q.warmup_frames)
+            .unwrap_or(config.device.warmup_frames);
+        let path = resolved.info.path.clone();
+        let mut camera = resolved
+            .open(&config.device)
+            .context("Failed to open camera")?;
+        let open_ms = open_start.elapsed().as_millis() as u64;
+
+        // The first capture is what issues STREAMON: the V4L2 stream starts
+        // lazily on the first dequeue.
+        let first_start = Instant::now();
+        camera
+            .capture()
+            .context("Failed to capture the first frame")?;
+        let first_ms = first_start.elapsed().as_millis() as u64;
+
+        // `1..warmup`: the capture above already spent the first warmup frame.
+        let warmup_start = Instant::now();
+        for _ in 1..warmup {
+            camera.capture().context("Failed to capture warmup frame")?;
+        }
+        let warmup_ms = warmup_start.elapsed().as_millis() as u64;
+
+        // With no warmup configured, the frame above is already the one an
+        // authentication would analyze.
+        let usable_ms = if warmup > 0 {
+            let usable_start = Instant::now();
+            camera
+                .capture()
+                .context("Failed to capture the first usable frame")?;
+            usable_start.elapsed().as_millis() as u64
+        } else {
+            0
+        };
+
+        let total_ms = open_ms + first_ms + warmup_ms + usable_ms;
+        device_path = path;
+        format = camera.format().trim().to_string();
+        warmup_frames = warmup;
+
+        println!(
+            "iteration {:<2} open {:>5}ms  first_frame {:>5}ms  warmup {:>5}ms  \
+             usable {:>5}ms  total {:>5}ms",
+            i + 1,
+            open_ms,
+            first_ms,
+            warmup_ms,
+            usable_ms,
+            total_ms
+        );
+        info!(
+            iteration = i + 1,
+            open_ms, first_ms, warmup_ms, usable_ms, total_ms, "camera reopen iteration"
+        );
+
+        // Load-bearing: the drop runs STREAMOFF and disables the IR emitter,
+        // which is what makes the next iteration a cold open.
+        drop(camera);
+        opens.push(open_ms);
+        firsts.push(first_ms);
+        warmups.push(warmup_ms);
+        usables.push(usable_ms);
+        totals.push(total_ms);
+    }
+
+    println!();
+    println!("Device:         {}", device_path);
+    println!("Format:         {}", format);
+    println!("Warmup frames:  {}", warmup_frames);
+    println!();
+    println!("Median split ({} iterations):", iterations);
+    println!("  open:         {}ms", percentile(&mut opens, 50));
+    println!("  first_frame:  {}ms", percentile(&mut firsts, 50));
+    println!("  warmup:       {}ms", percentile(&mut warmups, 50));
+    println!("  usable:       {}ms", percentile(&mut usables, 50));
+    println!("  total:        {}ms", percentile(&mut totals, 50));
+    println!();
+    println!(
+        "camera_release_secs trades this reopen cost against LED-on time after a failed attempt (ADR 008)"
+    );
 
     Ok(())
 }

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -15,6 +15,16 @@ use v4l::video::Capture;
 /// within this time, capture returns an error instead of blocking forever.
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Number of MMAP buffers the capture stream is created with.
+///
+/// Public because it is not a private tuning knob: a consumer that keeps a
+/// stream open between requests (the daemon's warm camera hold, ADR 008 §4)
+/// must discard `MMAP_BUFFERS - 1` frames before analyzing anything, since
+/// V4L2 leaves exactly that many buffers filled with the frames captured
+/// right after the previous request. Reading the count from here is what
+/// keeps that discard correct if the buffer depth ever changes.
+pub const MMAP_BUFFERS: u32 = 4;
+
 use crate::ir_emitter;
 use crate::ir_emitter::EmitterXuInfo;
 use crate::preprocess;
@@ -137,8 +147,8 @@ impl<'a> Camera<'a> {
             "camera format negotiated"
         );
 
-        // Create MMAP stream with 4 buffers and a capture timeout
-        let mut stream = Stream::with_buffers(&dev, Type::VideoCapture, 4)
+        // Create MMAP stream with `MMAP_BUFFERS` buffers and a capture timeout
+        let mut stream = Stream::with_buffers(&dev, Type::VideoCapture, MMAP_BUFFERS)
             .map_err(|e| FacelockError::Camera(format!("failed to create stream: {e}")))?;
         stream.set_timeout(CAPTURE_TIMEOUT);
 

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -471,6 +471,7 @@ mod tests {
             dark_pixel_value: 10,
             ir_emitter: false,
             camera_release_secs: 5,
+            camera_release_after_success_secs: 0,
         };
         let mut cam = Camera::open(&config, &QuirksDb::load()).expect("failed to open camera");
         let frame = cam.capture().expect("failed to capture frame");

--- a/crates/facelock-camera/src/lib.rs
+++ b/crates/facelock-camera/src/lib.rs
@@ -6,7 +6,7 @@ pub mod preprocess;
 pub mod quirks;
 
 pub use caps::{ResolvedCamera, quirk_id};
-pub use capture::{Camera, is_dark_with_config};
+pub use capture::{Camera, MMAP_BUFFERS, is_dark_with_config};
 pub use device::{
     DeviceInfo, FormatInfo, IrSource, auto_detect_device, auto_detect_device_with,
     classify_ir_sources, ir_source, ir_source_resolved, ir_source_with_quirks, is_ir_camera,

--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -288,6 +288,7 @@ impl<'a> Backend<'a> {
                     failure_reason: None,
                 }),
                 AuthOutcome::Error { message, .. } => bail!("daemon error: {message}"),
+                AuthOutcome::Cancelled => bail!("authentication cancelled"),
             },
             BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
                 direct::authenticate(self.config, user)

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -129,22 +129,49 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         };
     }
 
+    // Signals, before anything that turns the camera on. `facelock auth` is a
+    // one-shot: exit *is* the release, so the job of a signal is to end the
+    // scan loop and let `Camera::drop` run (STREAMOFF, IR emitter off).
+    // Killing the process outright would skip that and, on hardware with an
+    // XU-controlled emitter, leave the LED lit (ADR 008 §7).
+    let cancel = CancelToken::new();
+    register_cancel_signals(&cancel);
+
     // Quirk override takes precedence over the config's warmup value.
     let warmup = resolved
         .as_ref()
         .and_then(|r| r.quirk.as_ref())
         .and_then(|q| q.warmup_frames)
         .unwrap_or(config.device.warmup_frames);
-    let camera = match resolved {
-        // The camera carries the caps the pre-flight gates just checked.
-        Some(resolved) => resolved.open(&config.device),
-        // Unqueryable at resolution time: attempt a fresh resolve-and-open so
-        // the failure surfaces as the camera error it is.
-        None => Camera::open(&config.device, &quirks),
-    };
-    let mut camera = match camera {
-        Ok(c) => c,
-        Err(e) => {
+
+    let (mut engine, mut camera) = match start_engine_then_camera(
+        &cancel,
+        || {
+            FaceEngine::load(&config.recognition, Path::new(&config.daemon.model_dir))
+                .map_err(|e| e.to_string())
+        },
+        || {
+            match resolved {
+                // The camera carries the caps the pre-flight gates just checked.
+                Some(resolved) => resolved.open(&config.device),
+                // Unqueryable at resolution time: attempt a fresh
+                // resolve-and-open so the failure surfaces as the camera
+                // error it is.
+                None => Camera::open(&config.device, &quirks),
+            }
+            .map_err(|e| e.to_string())
+        },
+    ) {
+        Ok(pair) => pair,
+        Err(StartupAbort::Cancelled) => {
+            info!(user = %user, "cancelled");
+            return 2;
+        }
+        Err(StartupAbort::Engine(e)) => {
+            error!("models: {e}");
+            return 2;
+        }
+        Err(StartupAbort::Camera(e)) => {
             error!("camera: {e}");
             return 2;
         }
@@ -152,17 +179,12 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
 
     // Discard warmup frames for AGC/AE stabilization.
     for _ in 0..warmup {
+        if cancel.is_cancelled() {
+            info!(user = %user, "cancelled");
+            return 2;
+        }
         let _ = camera.capture();
     }
-
-    let mut engine =
-        match FaceEngine::load(&config.recognition, Path::new(&config.daemon.model_dir)) {
-            Ok(e) => e,
-            Err(e) => {
-                error!("models: {e}");
-                return 2;
-            }
-        };
 
     // Load embeddings through the decryption-aware path so the oneshot binary
     // handles encrypted templates (encrypt-by-default, Plan 04) — the bare
@@ -187,8 +209,7 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         &config,
         &user,
         AuditSource::Oneshot,
-        // Commit 4 replaces this with a token wired to SIGTERM/SIGINT/SIGHUP.
-        &CancelToken::new(),
+        &cancel,
     );
     let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -275,6 +296,73 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     }
 }
 
+/// Why the one-shot never got both of its resources up.
+#[derive(Debug, PartialEq, Eq)]
+enum StartupAbort {
+    /// A signal arrived first. The camera was never opened.
+    Cancelled,
+    /// The ONNX models could not be loaded.
+    Engine(String),
+    /// The camera could not be opened.
+    Camera(String),
+}
+
+/// Bring up the one-shot's two expensive resources **in this order**: models
+/// first, camera second, with a cancellation check in between.
+///
+/// The order is the point. Loading ONNX takes a large fraction of a
+/// one-shot's wall time; opening the camera first meant the IR emitter was
+/// lit for all of it, which the user reads as a strobe that has nothing to do
+/// with being looked at. Opening it last makes LED-on time equal to scan time
+/// (ADR 008 §7). The check between them is what makes a SIGTERM during the
+/// model load exit without ever touching the camera (§8).
+///
+/// Generic over the two resources purely so the ordering — the part that is
+/// policy — is testable without ONNX models or a V4L2 device.
+fn start_engine_then_camera<E, C>(
+    cancel: &CancelToken,
+    load_engine: impl FnOnce() -> Result<E, String>,
+    open_camera: impl FnOnce() -> Result<C, String>,
+) -> Result<(E, C), StartupAbort> {
+    if cancel.is_cancelled() {
+        return Err(StartupAbort::Cancelled);
+    }
+    let engine = load_engine().map_err(StartupAbort::Engine)?;
+    if cancel.is_cancelled() {
+        return Err(StartupAbort::Cancelled);
+    }
+    let camera = open_camera().map_err(StartupAbort::Camera)?;
+    Ok((engine, camera))
+}
+
+/// Wire SIGTERM, SIGINT and SIGHUP to `cancel`.
+///
+/// `signal_hook::flag::register` writes into an `Arc<AtomicBool>` from the
+/// handler — which is why [`CancelToken`] is one. The scan loop reads it once
+/// per frame, unwinds normally, and `Camera::drop` runs STREAMOFF and turns
+/// the IR emitter off. That is the whole point: the default disposition for
+/// all three signals is to die immediately, skipping `Drop` and leaving an
+/// XU-controlled emitter lit.
+///
+/// The three signals are the three ways a PAM host lets go: SIGTERM from the
+/// module's own timeout (and from `PR_SET_PDEATHSIG` when the host is killed),
+/// SIGINT from Ctrl-C at a `sudo` prompt, SIGHUP when the terminal goes away.
+///
+/// Best-effort: a registration failure is logged and the process keeps its
+/// default disposition for that signal, which is exactly today's behavior.
+fn register_cancel_signals(cancel: &CancelToken) {
+    for signal in [
+        signal_hook::consts::SIGTERM,
+        signal_hook::consts::SIGINT,
+        signal_hook::consts::SIGHUP,
+    ] {
+        if let Err(e) = signal_hook::flag::register(signal, cancel.flag()) {
+            // Not fatal: this only costs the clean shutdown, never the auth.
+            debug!(signal, "could not register cancel signal handler: {e}");
+        }
+    }
+}
+
 /// The process exit code for a rejection of class `kind`.
 ///
 /// The oneshot binary is spawned by the PAM module, which turns this number
@@ -308,11 +396,107 @@ fn oneshot_exit_code(kind: ErrorKind) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::oneshot_exit_code;
+    use super::{StartupAbort, oneshot_exit_code, start_engine_then_camera};
     use facelock_core::config::Config;
     use facelock_core::types::MatchResult;
     use facelock_daemon::audit::AuditSource;
     use facelock_daemon::auth::pre_check_audited;
+    use facelock_daemon::cancel::CancelToken;
+
+    /// The ordering of ADR 008 §7, observed rather than asserted from the
+    /// source: models load before the camera opens, so the IR emitter is lit
+    /// for the scan and not for the model load.
+    #[test]
+    fn the_engine_loads_before_the_camera_opens() {
+        let order = std::cell::RefCell::new(Vec::new());
+        let started = start_engine_then_camera(
+            &CancelToken::new(),
+            || {
+                order.borrow_mut().push("engine");
+                Ok::<_, String>(())
+            },
+            || {
+                order.borrow_mut().push("camera");
+                Ok::<_, String>(())
+            },
+        );
+        assert!(started.is_ok());
+        assert_eq!(order.into_inner(), vec!["engine", "camera"]);
+    }
+
+    /// A signal that arrives before start-up costs nothing: neither resource
+    /// is touched, and the camera in particular is never opened, so there is
+    /// no LED to turn back off.
+    #[test]
+    fn a_token_set_before_startup_opens_nothing() {
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let order = std::cell::RefCell::new(Vec::new());
+        let started = start_engine_then_camera(
+            &cancel,
+            || {
+                order.borrow_mut().push("engine");
+                Ok::<_, String>(())
+            },
+            || {
+                order.borrow_mut().push("camera");
+                Ok::<_, String>(())
+            },
+        );
+        assert_eq!(started.unwrap_err(), StartupAbort::Cancelled);
+        assert!(
+            order.into_inner().is_empty(),
+            "a cancelled start-up must not load models or open the camera"
+        );
+    }
+
+    /// The check between the two steps: a signal during the model load
+    /// (which is the long one) stops the start-up before the camera factory
+    /// is ever called — ADR 008 §8's "SIGTERM during model load".
+    #[test]
+    fn a_signal_during_the_model_load_never_opens_the_camera() {
+        let cancel = CancelToken::new();
+        let opened = std::cell::Cell::new(false);
+        let started = start_engine_then_camera(
+            &cancel,
+            || {
+                // Stands in for a SIGTERM arriving mid-load.
+                cancel.cancel();
+                Ok::<_, String>(())
+            },
+            || {
+                opened.set(true);
+                Ok::<_, String>(())
+            },
+        );
+        assert_eq!(started.unwrap_err(), StartupAbort::Cancelled);
+        assert!(!opened.get(), "the camera factory must never have run");
+    }
+
+    /// Each resource's failure keeps its own identity, so the log line names
+    /// the thing that actually broke.
+    #[test]
+    fn each_startup_failure_reports_its_own_resource() {
+        let engine_failed = start_engine_then_camera::<(), ()>(
+            &CancelToken::new(),
+            || Err("no models".into()),
+            || panic!("the camera must not open after a failed model load"),
+        );
+        assert_eq!(
+            engine_failed.unwrap_err(),
+            StartupAbort::Engine("no models".into())
+        );
+
+        let camera_failed = start_engine_then_camera::<(), ()>(
+            &CancelToken::new(),
+            || Ok(()),
+            || Err("device busy".into()),
+        );
+        assert_eq!(
+            camera_failed.unwrap_err(),
+            StartupAbort::Camera("device busy".into())
+        );
+    }
     use facelock_daemon::auth::{AuthOutcome, ErrorKind};
 
     /// The coupling, in one place.

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -12,6 +12,7 @@ use facelock_core::types::MatchResult;
 use facelock_daemon::audit::{self, AuditEntry, AuditSource};
 use facelock_daemon::auth;
 use facelock_daemon::auth::{AuthOutcome, ErrorKind};
+use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
@@ -186,6 +187,8 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         &config,
         &user,
         AuditSource::Oneshot,
+        // Commit 4 replaces this with a token wired to SIGTERM/SIGINT/SIGHUP.
+        &CancelToken::new(),
     );
     let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -226,6 +229,13 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
                 "no match"
             );
             1
+        }
+        AuthOutcome::Cancelled => {
+            // Already audited as `cancelled` by the auth loop. Exit 2 is the
+            // existing "no opinion" code, which PAM maps to PAM_IGNORE — the
+            // contract is unchanged, nothing new is added to it.
+            info!(user = %user, duration_ms, "cancelled");
+            2
         }
         AuthOutcome::Error {
             kind: ErrorKind::AllFramesDark,

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -217,9 +217,17 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
     // camera-based auth loop. The oneshot path relies on those entries, so no
     // additional audit logging is needed here for the auth result itself.
 
+    // The same rule the daemon handler applies: a failed attempt charges the
+    // shared budget, but only if a face was actually seen. An attempt at an
+    // empty chair is not a guess (ADR 008 §4), and both transports write to
+    // the same `rate_limit` table, so they must agree on what counts.
     if matches!(
         response,
-        AuthOutcome::AuthResult(MatchResult { matched: false, .. })
+        AuthOutcome::AuthResult(MatchResult {
+            matched: false,
+            face_detected: true,
+            ..
+        })
     ) {
         if let Err(e) = rate_limiter.record_failure(&store, &user) {
             error!("rate limit record: {e}");

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -28,6 +28,12 @@ const WARM_ITERATIONS: u32 = 10;
 /// Number of snapshots for enrollment benchmark.
 const ENROLLMENT_SNAPSHOTS: u32 = 5;
 
+/// Default number of reopen cycles for `bench camera-reopen`.
+///
+/// Five is enough for a stable median without keeping the IR emitter lit for
+/// long: each cycle costs a full cold open plus the warmup discard.
+const REOPEN_ITERATIONS: u32 = 5;
+
 #[derive(Subcommand)]
 pub enum BenchCommand {
     /// Measure cold auth latency (model load + first auth)
@@ -42,6 +48,12 @@ pub enum BenchCommand {
     ModelLoad,
     /// Sweep thresholds and measure FAR/FRR
     Calibrate,
+    /// Measure what reopening the camera costs (open, STREAMON, warmup)
+    CameraReopen {
+        /// Number of close→open→first-usable-frame cycles to time
+        #[arg(long, default_value_t = REOPEN_ITERATIONS)]
+        iterations: u32,
+    },
     /// Generate a benchmark report
     Report,
 }
@@ -59,6 +71,7 @@ pub fn run(config: &Config, command: BenchCommand) -> Result<()> {
         BenchCommand::Enrollment => cmd_enrollment(config),
         BenchCommand::ModelLoad => cmd_model_load(config),
         BenchCommand::Calibrate => cmd_calibrate(config),
+        BenchCommand::CameraReopen { iterations } => cmd_camera_reopen(config, iterations),
         BenchCommand::Report => cmd_report(config),
     }
 }
@@ -471,6 +484,161 @@ fn cmd_calibrate(config: &Config) -> Result<()> {
 
         conf += 0.10;
     }
+
+    Ok(())
+}
+
+/// One timed close→open→first-usable-frame cycle, split by phase.
+///
+/// The split is the point of the benchmark: "reopening costs ~400 ms" was an
+/// assertion nobody had measured (ADR 008 §2), and the three phases have
+/// different fixes — a slow `open` is driver/format negotiation, a slow
+/// `first_frame` is the sensor starting to stream, a slow `warmup` is
+/// `device.warmup_frames` (or a quirk override) buying AGC/AE settling time.
+#[derive(Default)]
+struct ReopenSplit {
+    /// Resolve the device, open it, negotiate the capture format. No frames.
+    open_ms: u64,
+    /// The first `capture()`, which is what actually issues `STREAMON`: the
+    /// V4L2 stream starts lazily on the first dequeue, so the cost of
+    /// starting the sensor lands here rather than in `open`.
+    first_frame_ms: u64,
+    /// The rest of the warmup discard (the frame above was its first).
+    warmup_ms: u64,
+    /// The first frame an authentication would actually analyze.
+    usable_ms: u64,
+}
+
+impl ReopenSplit {
+    fn total_ms(&self) -> u64 {
+        self.open_ms + self.first_frame_ms + self.warmup_ms + self.usable_ms
+    }
+}
+
+/// Time what it costs to go from no camera to the first frame an
+/// authentication can analyze.
+///
+/// This is the number `device.camera_release_secs` is traded against: holding
+/// the stream open after a failed attempt spends LED-on time to save exactly
+/// this, so the hold length is only arguable once it has been measured on the
+/// device in question (ADR 008 §9, §11).
+fn cmd_camera_reopen(config: &Config, iterations: u32) -> Result<()> {
+    if iterations == 0 {
+        bail!("--iterations must be at least 1");
+    }
+
+    println!("=== Camera Reopen Benchmark ===");
+    println!(
+        "Measuring: open + format negotiation, STREAMON + first frame, warmup discard, \
+         first usable frame ({} iterations)",
+        iterations
+    );
+    println!();
+
+    let mut splits: Vec<ReopenSplit> = Vec::with_capacity(iterations as usize);
+    let mut device_path = String::new();
+    let mut format = String::new();
+    let mut warmup_frames = 0u32;
+
+    for i in 0..iterations {
+        // Every iteration starts closed: the previous camera was dropped
+        // before this timer started, so its STREAMOFF and IR-emitter shutdown
+        // are not billed to this open.
+        let mut split = ReopenSplit::default();
+
+        let open_start = Instant::now();
+        let resolved = direct::resolve_camera_device(config)?;
+        // Quirk override beats the config value, the same rule the auth path
+        // applies (`direct::open_camera`). Read before `open` consumes the
+        // resolution.
+        let warmup = resolved
+            .quirk
+            .as_ref()
+            .and_then(|q| q.warmup_frames)
+            .unwrap_or(config.device.warmup_frames);
+        let path = resolved.info.path.clone();
+        let mut camera = resolved
+            .open(&config.device)
+            .context("Failed to open camera")?;
+        split.open_ms = open_start.elapsed().as_millis() as u64;
+
+        let first_start = Instant::now();
+        camera
+            .capture()
+            .context("Failed to capture the first frame")?;
+        split.first_frame_ms = first_start.elapsed().as_millis() as u64;
+
+        let warmup_start = Instant::now();
+        // `1..warmup`, not `0..warmup`: the capture above already spent the
+        // first of the warmup frames. Empty for `warmup <= 1`.
+        for _ in 1..warmup {
+            camera.capture().context("Failed to capture warmup frame")?;
+        }
+        split.warmup_ms = warmup_start.elapsed().as_millis() as u64;
+
+        // With no warmup configured the frame captured above is already the
+        // one an authentication would analyze, so there is nothing left to
+        // charge — capturing another would report a cost the real path never
+        // pays.
+        if warmup > 0 {
+            let usable_start = Instant::now();
+            camera
+                .capture()
+                .context("Failed to capture the first usable frame")?;
+            split.usable_ms = usable_start.elapsed().as_millis() as u64;
+        }
+
+        device_path = path;
+        format = camera.format().trim().to_string();
+        warmup_frames = warmup;
+
+        println!(
+            "iteration {:<2} open {:>5}ms  first_frame {:>5}ms  warmup {:>5}ms  \
+             usable {:>5}ms  total {:>5}ms",
+            i + 1,
+            split.open_ms,
+            split.first_frame_ms,
+            split.warmup_ms,
+            split.usable_ms,
+            split.total_ms()
+        );
+        info!(
+            iteration = i + 1,
+            open_ms = split.open_ms,
+            first_frame_ms = split.first_frame_ms,
+            warmup_ms = split.warmup_ms,
+            usable_ms = split.usable_ms,
+            total_ms = split.total_ms(),
+            "camera reopen iteration"
+        );
+
+        // Explicit, and load-bearing: the drop runs STREAMOFF and disables the
+        // IR emitter, which is what makes the next iteration a cold open.
+        drop(camera);
+        splits.push(split);
+    }
+
+    let mut opens: Vec<u64> = splits.iter().map(|s| s.open_ms).collect();
+    let mut firsts: Vec<u64> = splits.iter().map(|s| s.first_frame_ms).collect();
+    let mut warmups: Vec<u64> = splits.iter().map(|s| s.warmup_ms).collect();
+    let mut usables: Vec<u64> = splits.iter().map(|s| s.usable_ms).collect();
+    let mut totals: Vec<u64> = splits.iter().map(|s| s.total_ms()).collect();
+
+    println!();
+    println!("Device:         {}", device_path);
+    println!("Format:         {}", format);
+    println!("Warmup frames:  {}", warmup_frames);
+    println!();
+    println!("Median split ({} iterations):", iterations);
+    println!("  open:         {}ms", percentile(&mut opens, 50));
+    println!("  first_frame:  {}ms", percentile(&mut firsts, 50));
+    println!("  warmup:       {}ms", percentile(&mut warmups, 50));
+    println!("  usable:       {}ms", percentile(&mut usables, 50));
+    println!("  total:        {}ms", percentile(&mut totals, 50));
+    println!();
+    println!(
+        "camera_release_secs trades this reopen cost against LED-on time after a failed attempt (ADR 008)"
+    );
 
     Ok(())
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -13,6 +13,7 @@ use facelock_core::types::MatchResult;
 use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::AuthOutcome;
 use facelock_daemon::auth::{PreCheckContext, pre_check_audited_with_context};
+use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::enroll::EnrollOutcome;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_face::FaceEngine;
@@ -151,6 +152,8 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
                 failure_reason: None,
             }),
             AuthOutcome::Error { message, .. } => bail!("{message}"),
+            // No camera has been opened yet, so nothing can have cancelled.
+            AuthOutcome::Cancelled => bail!("authentication cancelled"),
         };
     }
 
@@ -177,12 +180,16 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         config,
         user,
         AuditSource::Test,
+        // The direct path has no bus connection to watch and no signal
+        // handler of its own; `facelock auth` installs one (ADR 008 §7).
+        &CancelToken::new(),
     );
 
     match response {
         AuthOutcome::AuthResult(result) => Ok(result),
         AuthOutcome::Error { message, .. } => bail!("{message}"),
         AuthOutcome::Suppressed => bail!("unexpected auth response"),
+        AuthOutcome::Cancelled => bail!("authentication cancelled"),
     }
 }
 
@@ -296,6 +303,7 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
         label,
         software_sealer.as_ref(),
         device_id.as_deref(),
+        &CancelToken::new(),
     );
 
     match response {
@@ -304,6 +312,7 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
             embedding_count,
         } => Ok((model_id, embedding_count)),
         EnrollOutcome::Error { message } => bail!("{message}"),
+        EnrollOutcome::Cancelled => bail!("enrollment cancelled"),
     }
 }
 

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -5,7 +5,7 @@ use zbus::blocking::Proxy;
 use facelock_core::dbus_interface::*;
 use facelock_core::ipc::{IpcDeviceInfo, PreviewFace};
 use facelock_core::types::{FaceModelInfo, MatchResult};
-use facelock_daemon::auth::{AuthOutcome, ErrorKind};
+use facelock_daemon::auth::{AuthOutcome, CANCELLED_MESSAGE, ErrorKind};
 
 use crate::message::{AccessMessage, explain};
 
@@ -244,6 +244,13 @@ pub fn test_authenticate(user: &str) -> anyhow::Result<AuthOutcome> {
 /// daemon's renderer and the one place that match lives on this side.
 fn decode_auth_result(result: AuthResult) -> AuthOutcome {
     if !result.matched && result.model_id == -2 {
+        // A cancellation shares the recoverable-error encoding but is not a
+        // rejection class: it says the attempt was abandoned, not that this
+        // face was refused. Recovered by its frozen string, the same way
+        // `ErrorKind::classify` recovers the others.
+        if result.label == CANCELLED_MESSAGE {
+            return AuthOutcome::Cancelled;
+        }
         return AuthOutcome::Error {
             kind: ErrorKind::classify(&result.label),
             message: result.label,

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -68,8 +68,12 @@ pub struct DeviceConfig {
     /// only if your camera requires explicit control.
     #[serde(default)]
     pub ir_emitter: bool,
-    /// Seconds to keep the camera open after auth before releasing it.
-    /// Avoids warmup frame cost on consecutive auths. Default: 5.
+    /// Daemon only. Seconds to keep the camera streaming after a **failed**
+    /// authentication, so the retry a failure invites skips the reopen cost.
+    /// Success, cancellation and errors always release immediately — the
+    /// interaction is over and the IR LED must go out with it (ADR 008).
+    /// `0` means never hold; it used to be silently substituted with 5.
+    /// Default: 3.
     #[serde(default = "default_camera_release_secs")]
     pub camera_release_secs: u32,
 }
@@ -538,7 +542,7 @@ fn default_dark_threshold() -> f32 {
     0.6
 }
 fn default_camera_release_secs() -> u32 {
-    5
+    3
 }
 fn default_dark_pixel_value() -> u8 {
     10

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -77,6 +77,24 @@ pub struct DeviceConfig {
     /// Default: 3.
     #[serde(default = "default_camera_release_secs")]
     pub camera_release_secs: u32,
+    /// Daemon only. Seconds to keep the camera streaming after a
+    /// **successful** authentication as well. `0` — the default, and the
+    /// right answer for almost every setup — releases at once: a success ends
+    /// the interaction, so a hold after one keeps the camera, and on IR
+    /// hardware its emitter LED, lit for a retry nobody is going to make.
+    ///
+    /// Raise it only where privileged actions repeat with no authentication
+    /// caching in front of them — `sudo` with `timestamp_timeout=0`, a polkit
+    /// action without `auth_admin_keep` — so that each action is a fresh
+    /// authentication that would otherwise pay a camera reopen. Added on
+    /// maintainer request as the opt-in ADR 008 §3 had deferred.
+    ///
+    /// Failed attempts are unaffected: they hold for
+    /// [`DeviceConfig::camera_release_secs`]. Cancellations and errors
+    /// release immediately whatever either key says.
+    /// Default: 0.
+    #[serde(default)]
+    pub camera_release_after_success_secs: u32,
 }
 
 impl Default for DeviceConfig {
@@ -90,6 +108,9 @@ impl Default for DeviceConfig {
             dark_pixel_value: default_dark_pixel_value(),
             ir_emitter: false,
             camera_release_secs: default_camera_release_secs(),
+            // No `default_*` function: this key's default is the type's, so
+            // `#[serde(default)]` and this line cannot drift apart.
+            camera_release_after_success_secs: 0,
         }
     }
 }
@@ -966,6 +987,43 @@ path = "/dev/video0"
             Config::default().recognition.no_face_timeout_secs,
             2,
             "the documented default"
+        );
+    }
+
+    /// ADR 008 §3, added on maintainer request. The key is purely opt-in:
+    /// absent it is `0`, which is the behavior every install already has —
+    /// a success releases the camera with the reply. Table-driven over the
+    /// ways a config can decline to mention it, plus the one that asks.
+    #[test]
+    fn the_success_hold_is_off_unless_a_config_asks_for_it() {
+        // (toml, expected success hold, expected failure hold) — the second
+        // column is here because the two are separate budgets: writing one
+        // must never move the other.
+        let cases: &[(&str, u32, u32)] = &[
+            ("", 0, 3),
+            ("[device]\n", 0, 3),
+            ("[device]\ncamera_release_secs = 10\n", 0, 10),
+            ("[device]\ncamera_release_after_success_secs = 5\n", 5, 3),
+            // `0` written out means the same as omitting it.
+            ("[device]\ncamera_release_after_success_secs = 0\n", 0, 3),
+        ];
+        for (toml, success_secs, failure_secs) in cases {
+            let config = Config::parse(toml)
+                .unwrap_or_else(|e| panic!("{toml:?} must load — this key never rejects: {e}"));
+            assert_eq!(
+                config.device.camera_release_after_success_secs, *success_secs,
+                "wrong success hold for {toml:?}"
+            );
+            assert_eq!(
+                config.device.camera_release_secs, *failure_secs,
+                "wrong failure hold for {toml:?}"
+            );
+        }
+
+        assert_eq!(
+            Config::default().device.camera_release_after_success_secs,
+            0,
+            "the documented default: a success ends the interaction"
         );
     }
 

--- a/crates/facelock-core/src/config.rs
+++ b/crates/facelock-core/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::time::Duration;
 
 use crate::paths;
 
@@ -99,6 +100,19 @@ pub struct RecognitionConfig {
     pub threshold: f32,
     #[serde(default = "default_timeout")]
     pub timeout_secs: u32,
+    /// End an attempt early once this many seconds have passed with **no face
+    /// at all** detected. `timeout_secs` still bounds the other, slower case —
+    /// a face was seen and has not matched yet — which is the one worth
+    /// waiting out. Scanning an empty chair for the full timeout only keeps
+    /// the camera (and on IR hardware its emitter LED) lit for nothing, and
+    /// such an attempt is not a guess, so it also charges no rate-limit
+    /// budget (ADR 008 §3/§4).
+    ///
+    /// `0` disables the early exit. The effective value is clamped to
+    /// `timeout_secs` — see [`RecognitionConfig::effective_no_face_timeout`].
+    /// Default: 2.
+    #[serde(default = "default_no_face_timeout")]
+    pub no_face_timeout_secs: u32,
     #[serde(default = "default_confidence")]
     pub detection_confidence: f32,
     #[serde(default = "default_nms")]
@@ -128,6 +142,7 @@ impl Default for RecognitionConfig {
         Self {
             threshold: default_threshold(),
             timeout_secs: default_timeout(),
+            no_face_timeout_secs: default_no_face_timeout(),
             detection_confidence: default_confidence(),
             nms_threshold: default_nms(),
             detector_model: default_detector_model(),
@@ -137,6 +152,22 @@ impl Default for RecognitionConfig {
             execution_provider: default_execution_provider(),
             threads: default_threads(),
         }
+    }
+}
+
+impl RecognitionConfig {
+    /// How long an attempt may run before "nobody is there" ends it, or
+    /// `None` when the early exit is switched off (`no_face_timeout_secs = 0`).
+    ///
+    /// Clamped to `timeout_secs` rather than validated against it, on purpose
+    /// (ADR 008 §3, "no migration"): an existing `/etc/facelock/config.toml`
+    /// with a short `timeout_secs` — say 1 — predates this key and must keep
+    /// loading, and a no-face deadline past the overall deadline could never
+    /// fire anyway. So the pair can never be an invalid combination, only a
+    /// redundant one.
+    pub fn effective_no_face_timeout(&self) -> Option<Duration> {
+        (self.no_face_timeout_secs > 0)
+            .then(|| Duration::from_secs(self.no_face_timeout_secs.min(self.timeout_secs) as u64))
     }
 }
 
@@ -553,6 +584,9 @@ fn default_threshold() -> f32 {
 fn default_timeout() -> u32 {
     5
 }
+fn default_no_face_timeout() -> u32 {
+    2
+}
 fn default_confidence() -> f32 {
     0.5
 }
@@ -892,6 +926,47 @@ path = "/dev/video0"
         // Values below the 5s floor still yield the 15s minimum deadline.
         let config = Config::parse("[recognition]\ntimeout_secs = 2\n").unwrap();
         assert_eq!(config.enroll_timeout_secs(), 15);
+    }
+
+    /// ADR 008 §3. Table-driven over the three cases the key has: the
+    /// default, a value that outruns `timeout_secs`, and the off switch.
+    #[test]
+    fn no_face_timeout_defaults_to_two_and_clamps_to_the_overall_timeout() {
+        // (toml, expected effective no-face timeout in seconds)
+        let cases: &[(&str, Option<u64>)] = &[
+            // Default: 2s of an empty chair, well inside the 5s default timeout.
+            ("", Some(2)),
+            // Clamped, not rejected: a config written before this key existed
+            // may already carry a timeout shorter than the new default.
+            ("[recognition]\ntimeout_secs = 1\n", Some(1)),
+            (
+                "[recognition]\ntimeout_secs = 3\nno_face_timeout_secs = 10\n",
+                Some(3),
+            ),
+            // Under the timeout, the value is used as written.
+            (
+                "[recognition]\ntimeout_secs = 30\nno_face_timeout_secs = 4\n",
+                Some(4),
+            ),
+            // 0 disables the early exit entirely.
+            ("[recognition]\nno_face_timeout_secs = 0\n", None),
+        ];
+
+        for (toml, expected) in cases {
+            let config = Config::parse(toml)
+                .unwrap_or_else(|e| panic!("{toml:?} must load — this key never rejects: {e}"));
+            assert_eq!(
+                config.recognition.effective_no_face_timeout(),
+                expected.map(Duration::from_secs),
+                "wrong effective no-face timeout for {toml:?}"
+            );
+        }
+
+        assert_eq!(
+            Config::default().recognition.no_face_timeout_secs,
+            2,
+            "the documented default"
+        );
     }
 
     #[test]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -563,6 +563,11 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
 
     let deadline =
         Instant::now() + std::time::Duration::from_secs(config.recognition.timeout_secs as u64);
+    // The shorter deadline that applies only while the camera has seen nobody
+    // at all (ADR 008 §4). `None` when the early exit is disabled. Clamped to
+    // `timeout_secs` by the accessor, so it can never outlive `deadline`.
+    let no_face_timeout = config.recognition.effective_no_face_timeout();
+    let no_face_deadline = no_face_timeout.map(|d| start + d);
     let threshold = config.recognition.threshold;
     let mut best_similarity: f32 = 0.0;
     // Sliding window over the most recent matched-frame embeddings. The gate
@@ -595,6 +600,24 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
         // frame of the token being set — not at `timeout_secs` (ADR 008 §5).
         if cancel.is_cancelled() {
             return cancelled(config, user, source, start, frame_count);
+        }
+        // Nobody is there. Also checked before the blocking capture, and only
+        // while no face has been seen: once one has, this is the "seen you,
+        // not matched yet" case that `timeout_secs` exists to bound, and the
+        // user is worth waiting for. Scanning an empty chair for the full
+        // timeout only keeps the IR emitter lit for nothing (ADR 008 §4).
+        //
+        // Ends the attempt exactly as the outer deadline does — `break`, not
+        // a separate outcome: to every caller this is the same "no face was
+        // detected" non-match, which the rate limiter then declines to charge.
+        if !face_detected && no_face_deadline.is_some_and(|d| Instant::now() >= d) {
+            debug!(
+                user,
+                frames = frame_count,
+                no_face_timeout_secs = no_face_timeout.map_or(0, |d| d.as_secs()),
+                "no face seen within the no-face timeout, ending the attempt early"
+            );
+            break;
         }
         let frame = match camera.capture() {
             Ok(f) => f,
@@ -1173,6 +1196,149 @@ enabled = false
         );
         assert!(matches!(outcome, AuthOutcome::Cancelled));
         assert_eq!(camera.captures, 0);
+    }
+
+    /// An engine that finds a face on every frame and matches nothing (the
+    /// compare set these tests pass is empty), i.e. the "we can see you, that
+    /// is not you yet" case `timeout_secs` exists to bound.
+    struct SeeingEngine;
+
+    impl FaceProcessor for SeeingEngine {
+        fn process(
+            &mut self,
+            _frame: &Frame,
+        ) -> facelock_core::error::Result<Vec<(facelock_core::types::Detection, FaceEmbedding)>>
+        {
+            Ok(vec![(
+                facelock_test_support::fixtures::center_detection(0.95),
+                facelock_test_support::fixtures::known_embedding(0),
+            )])
+        }
+    }
+
+    fn no_face_config(no_face_timeout_secs: u32, timeout_secs: u32) -> Config {
+        Config::parse(&format!(
+            r#"
+[recognition]
+timeout_secs = {timeout_secs}
+no_face_timeout_secs = {no_face_timeout_secs}
+
+[security]
+require_ir = false
+require_frame_variance = false
+require_landmark_liveness = false
+
+[audit]
+enabled = false
+"#
+        ))
+        .expect("test config must parse")
+    }
+
+    /// Runs an attempt against a camera that never stops producing frames,
+    /// returning the outcome and how long the loop actually ran.
+    fn run_attempt<E: FaceProcessor>(
+        engine: &mut E,
+        config: &Config,
+    ) -> (AuthOutcome, std::time::Duration) {
+        let token = CancelToken::new();
+        let mut camera = CancellingCamera {
+            captures: 0,
+            cancel_at: u32::MAX,
+            token: token.clone(),
+            caps: CameraCaps::default(),
+        };
+        let started = Instant::now();
+        let outcome = authenticate_with_embeddings(
+            &mut camera,
+            engine,
+            &mut [],
+            &[],
+            config,
+            "alice",
+            AuditSource::Daemon,
+            &token,
+        );
+        (outcome, started.elapsed())
+    }
+
+    #[track_caller]
+    fn assert_unmatched_without_a_face(outcome: &AuthOutcome) {
+        match outcome {
+            AuthOutcome::AuthResult(mr) => {
+                assert!(!mr.matched, "must not authenticate: {mr:?}");
+                assert!(
+                    !mr.face_detected,
+                    "nobody was there, so the reply must say so: {mr:?}"
+                );
+            }
+            other => panic!("expected an ordinary non-match, got {other:?}"),
+        }
+    }
+
+    /// ADR 008 §4: an empty chair ends the attempt at `no_face_timeout_secs`,
+    /// not at `timeout_secs` — 1 s here rather than the 30 s the camera and
+    /// its IR emitter would otherwise stay lit for.
+    ///
+    /// The ending is deliberately the *same* outcome the full timeout
+    /// produces, so nothing downstream (PAM's sentinel, the audit trail)
+    /// gains a case.
+    #[test]
+    fn no_face_ends_the_attempt_at_the_no_face_timeout() {
+        let config = no_face_config(1, 30);
+        let (outcome, elapsed) = run_attempt(&mut BlindEngine, &config);
+
+        assert_unmatched_without_a_face(&outcome);
+        assert!(
+            elapsed >= std::time::Duration::from_secs(1),
+            "ended before its own no-face deadline: {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "sat through timeout_secs instead of the no-face timeout: {elapsed:?}"
+        );
+    }
+
+    /// The other half of the rule: the no-face deadline stops applying the
+    /// moment a face is detected. Somebody who is present but not yet
+    /// recognized — bad angle, glasses, a moment of stillness — gets the full
+    /// `timeout_secs`, which is the whole reason the two are separate keys.
+    #[test]
+    fn a_face_seen_once_buys_the_full_timeout() {
+        let config = no_face_config(1, 2);
+        let (outcome, elapsed) = run_attempt(&mut SeeingEngine, &config);
+
+        match outcome {
+            AuthOutcome::AuthResult(mr) => {
+                assert!(!mr.matched, "the compare set is empty: {mr:?}");
+                assert!(mr.face_detected, "a face was detected: {mr:?}");
+            }
+            other => panic!("expected an ordinary non-match, got {other:?}"),
+        }
+        assert!(
+            elapsed >= std::time::Duration::from_millis(1900),
+            "the no-face deadline fired even though a face had been seen: {elapsed:?}"
+        );
+    }
+
+    /// `0` disables the early exit: the attempt runs to `timeout_secs` even
+    /// with nobody in front of the camera, which is what an operator who
+    /// wants the old behavior back sets.
+    #[test]
+    fn a_zero_no_face_timeout_runs_to_the_full_timeout() {
+        let config = no_face_config(0, 2);
+        assert_eq!(
+            config.recognition.effective_no_face_timeout(),
+            None,
+            "0 must switch the deadline off, not make it instant"
+        );
+        let (outcome, elapsed) = run_attempt(&mut BlindEngine, &config);
+
+        assert_unmatched_without_a_face(&outcome);
+        assert!(
+            elapsed >= std::time::Duration::from_millis(1900),
+            "the disabled no-face deadline still ended the attempt: {elapsed:?}"
+        );
     }
 
     /// A rate-limit *check* that fails is a storage fault, not a lockout.

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -927,7 +927,12 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
 /// from "we looked and said no") and logged, but never a `MatchResult`: the
 /// rate limiter charges failed *attempts*, and the user never got to make
 /// one.
-fn cancelled(
+///
+/// Crate-visible because a cancellation can also be noticed *before* the scan
+/// loop is reached — the token can already be set when `CameraLease::acquire`
+/// runs — and that ending must reach the same writer, or the audit trail
+/// would depend on how early the caller went away (`Handler`, ADR 008 §5).
+pub(crate) fn cancelled(
     config: &Config,
     user: &str,
     source: AuditSource,

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -16,6 +16,7 @@ use nix::unistd::Uid;
 use tracing::{debug, info, warn};
 
 use crate::audit::{self, AuditEntry, AuditSource};
+use crate::cancel::CancelToken;
 use crate::liveness::LandmarkTracker;
 use crate::rate_limit::RateLimiter;
 
@@ -173,7 +174,25 @@ pub enum AuthOutcome {
     /// alongside because it is what crosses the D-Bus wire and what the user
     /// sees; nothing on this side of the wire may re-derive `kind` from it.
     Error { kind: ErrorKind, message: String },
+    /// The caller went away, the system is suspending, or the process was
+    /// signalled: the attempt was abandoned, not answered (ADR 008 §5).
+    ///
+    /// Deliberately **not** an [`ErrorKind`]. A rejection class is a
+    /// statement about this user's face; a cancellation is the absence of
+    /// one. It charges no rate limit, audits as `cancelled`, and reaches the
+    /// wire through the recoverable-error encoding as
+    /// [`CANCELLED_MESSAGE`].
+    Cancelled,
 }
+
+/// The wire and log rendering of [`AuthOutcome::Cancelled`]. **Frozen
+/// protocol**: the PAM module substring-matches it to choose `PAM_IGNORE`
+/// (`crates/pam-facelock/src/lib.rs`), exactly as it does for the two frozen
+/// [`ErrorKind`] strings, and it cannot link this crate to share the
+/// constant (its dependency ceiling is libc/toml/serde/zbus). It is also the
+/// audit log's `result` label for an abandoned attempt. Documented in
+/// docs/contracts.md.
+pub const CANCELLED_MESSAGE: &str = "cancelled";
 
 impl AuthOutcome {
     /// A rejection of a class whose message is fixed.
@@ -483,6 +502,7 @@ where
 /// fingerprint (restricting the compare set to templates enrolled on this
 /// camera) are asked of `camera.capabilities()` — the camera in use, not a
 /// parameter a caller could get out of sync with it (gap D8).
+#[allow(clippy::too_many_arguments)]
 pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
     engine: &mut E,
@@ -491,6 +511,7 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     config: &Config,
     user: &str,
     source: AuditSource,
+    cancel: &CancelToken,
 ) -> AuthOutcome {
     let stored = Wiped(stored);
     let device_is_ir = camera.capabilities().is_ir;
@@ -570,6 +591,11 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     let mut last_frame: Option<Frame> = None;
 
     while Instant::now() < deadline {
+        // Checked before the blocking capture, so the attempt ends within one
+        // frame of the token being set — not at `timeout_secs` (ADR 008 §5).
+        if cancel.is_cancelled() {
+            return cancelled(config, user, source, start, frame_count);
+        }
         let frame = match camera.capture() {
             Ok(f) => f,
             Err(e) => {
@@ -872,6 +898,44 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     })
 }
 
+/// End an attempt that was abandoned rather than answered.
+///
+/// Audited (as `cancelled`, so the trail distinguishes "we stopped looking"
+/// from "we looked and said no") and logged, but never a `MatchResult`: the
+/// rate limiter charges failed *attempts*, and the user never got to make
+/// one.
+fn cancelled(
+    config: &Config,
+    user: &str,
+    source: AuditSource,
+    start: Instant,
+    frame_count: u32,
+) -> AuthOutcome {
+    let duration = start.elapsed();
+    info!(
+        user,
+        frames = frame_count,
+        duration_ms = duration.as_millis() as u64,
+        "authentication cancelled"
+    );
+    audit::write_audit_entry(
+        &config.audit,
+        &AuditEntry {
+            timestamp: audit::now_iso8601(),
+            user: user.to_string(),
+            result: CANCELLED_MESSAGE.into(),
+            source: Some(source),
+            similarity: None,
+            frame_count: Some(frame_count),
+            duration_ms: Some(duration.as_millis() as u64),
+            device: config.device.path.clone(),
+            model_label: None,
+            error: None,
+        },
+    );
+    AuthOutcome::Cancelled
+}
+
 fn is_ssh_session() -> bool {
     std::env::var("SSH_CONNECTION").is_ok() || std::env::var("SSH_TTY").is_ok()
 }
@@ -962,6 +1026,153 @@ mod tests {
             ErrorKind::classify("a message from a daemon of another version"),
             ErrorKind::Internal
         );
+    }
+
+    /// The third frozen string. PAM matches `cancelled` exactly to choose
+    /// `PAM_IGNORE`, so no rejection class may render it — otherwise a
+    /// genuine refusal would be reported as an abandoned attempt.
+    #[test]
+    fn no_rejection_class_renders_the_cancelled_string() {
+        assert_eq!(CANCELLED_MESSAGE, "cancelled");
+        for kind in ErrorKind::ALL {
+            if *kind == ErrorKind::Internal {
+                // Renders arbitrary text from elsewhere; unconstrainable.
+                continue;
+            }
+            assert_ne!(
+                kind.render("boom"),
+                CANCELLED_MESSAGE,
+                "{kind:?} renders the frozen cancellation string"
+            );
+        }
+    }
+
+    /// A camera whose k-th capture cancels the attempt, so the loop's
+    /// response to the token can be observed exactly.
+    struct CancellingCamera {
+        captures: u32,
+        cancel_at: u32,
+        token: CancelToken,
+        caps: CameraCaps,
+    }
+
+    impl CameraSource for CancellingCamera {
+        fn capabilities(&self) -> &CameraCaps {
+            &self.caps
+        }
+
+        fn capture(&mut self) -> facelock_core::error::Result<Frame> {
+            self.captures += 1;
+            if self.captures == self.cancel_at {
+                self.token.cancel();
+            }
+            Ok(Frame {
+                rgb: vec![200u8; 64 * 64 * 3],
+                gray: vec![200u8; 64 * 64],
+                width: 64,
+                height: 64,
+            })
+        }
+
+        fn capture_rgb_only(&mut self) -> facelock_core::error::Result<Frame> {
+            self.capture()
+        }
+    }
+
+    /// An engine that never finds a face, so nothing but the token can end
+    /// the loop before its deadline.
+    struct BlindEngine;
+
+    impl FaceProcessor for BlindEngine {
+        fn process(
+            &mut self,
+            _frame: &Frame,
+        ) -> facelock_core::error::Result<Vec<(facelock_core::types::Detection, FaceEmbedding)>>
+        {
+            Ok(Vec::new())
+        }
+    }
+
+    fn cancellable_config() -> Config {
+        Config::parse(
+            r#"
+[recognition]
+timeout_secs = 30
+
+[security]
+require_ir = false
+require_frame_variance = false
+require_landmark_liveness = false
+
+[audit]
+enabled = false
+"#,
+        )
+        .unwrap_or_default()
+    }
+
+    /// The rule of ADR 008 §5: the attempt ends within *one* frame of the
+    /// token being set — not at `timeout_secs`, which with a 30 s deadline
+    /// is what this test would otherwise sit through.
+    #[test]
+    fn a_token_set_at_frame_k_ends_the_attempt_before_frame_k_plus_one() {
+        let token = CancelToken::new();
+        let mut camera = CancellingCamera {
+            captures: 0,
+            cancel_at: 3,
+            token: token.clone(),
+            caps: CameraCaps::default(),
+        };
+        let config = cancellable_config();
+        let started = Instant::now();
+        let outcome = authenticate_with_embeddings(
+            &mut camera,
+            &mut BlindEngine,
+            &mut [],
+            &[],
+            &config,
+            "alice",
+            AuditSource::Daemon,
+            &token,
+        );
+
+        assert!(
+            matches!(outcome, AuthOutcome::Cancelled),
+            "expected Cancelled, got {outcome:?}"
+        );
+        assert_eq!(
+            camera.captures, 3,
+            "the loop must stop before capturing frame k+1"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "the attempt waited out its timeout instead of cancelling"
+        );
+    }
+
+    /// A token already set when the loop starts costs zero frames.
+    #[test]
+    fn a_token_set_before_the_first_frame_captures_nothing() {
+        let token = CancelToken::new();
+        token.cancel();
+        let mut camera = CancellingCamera {
+            captures: 0,
+            cancel_at: u32::MAX,
+            token: token.clone(),
+            caps: CameraCaps::default(),
+        };
+        let outcome = authenticate_with_embeddings(
+            &mut camera,
+            &mut BlindEngine,
+            &mut [],
+            &[],
+            &cancellable_config(),
+            "alice",
+            AuditSource::Daemon,
+            &token,
+        );
+        assert!(matches!(outcome, AuthOutcome::Cancelled));
+        assert_eq!(camera.captures, 0);
     }
 
     /// A rate-limit *check* that fails is a storage fault, not a lockout.

--- a/crates/facelock-daemon/src/cancel.rs
+++ b/crates/facelock-daemon/src/cancel.rs
@@ -1,0 +1,102 @@
+//! The one way an in-flight authentication is stopped early.
+//!
+//! An authentication is a blocking loop over camera frames with a deadline of
+//! `recognition.timeout_secs`. Before this existed, nothing could shorten
+//! that loop: when the caller went away — a screen locker aborting PAM
+//! because the password was typed first, a killed `sudo`, a crashed client —
+//! the daemon kept capturing, kept the IR emitter lit, and answered a
+//! question nobody was waiting for. An invisible cancellation is
+//! indistinguishable from a timeout, and a timeout keeps the camera on
+//! (ADR 008 §5).
+//!
+//! The token makes it visible. It is an `Arc<AtomicBool>`, deliberately: it
+//! must be settable from a signal handler ([`signal_hook::flag::register`]
+//! takes exactly this type) and from a D-Bus watcher task **without taking
+//! the handler mutex**, because the thing being cancelled is holding it.
+//!
+//! Every loop that can run for a perceptible time — the auth loop, the
+//! enroll loop, and both frame-discard loops — checks it once per iteration,
+//! so a request ends within one frame of the token being set.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A shared "stop now" flag for one in-flight request.
+///
+/// Cloning shares the flag; [`CancelToken::new`] makes a fresh one.
+#[derive(Clone, Debug)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// A fresh, un-cancelled token.
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Clear the flag for a request that is about to start.
+    ///
+    /// Called once per request, by whoever also arranges the watchers — so
+    /// arming always *precedes* subscribing, and a cancellation that arrives
+    /// between the two cannot be erased by a later reset.
+    pub fn arm(&self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+
+    /// Stop the in-flight request. Takes no lock, so it is safe to call from
+    /// a signal handler, a D-Bus watcher, or the suspend path while the
+    /// request being cancelled holds the handler mutex.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Checked once per loop iteration.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// The raw flag, for `signal_hook::flag::register`, which registers into
+    /// an `Arc<AtomicBool>` directly.
+    pub fn flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.0)
+    }
+}
+
+impl Default for CancelToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_token_is_not_cancelled() {
+        assert!(!CancelToken::new().is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_one_flag() {
+        let token = CancelToken::new();
+        let watcher = token.clone();
+        watcher.cancel();
+        assert!(token.is_cancelled(), "a clone must set the same flag");
+    }
+
+    #[test]
+    fn the_raw_flag_is_the_same_flag() {
+        let token = CancelToken::new();
+        // This is the handle `signal_hook::flag::register` writes through.
+        token.flag().store(true, Ordering::SeqCst);
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn arming_clears_a_previous_cancellation() {
+        let token = CancelToken::new();
+        token.cancel();
+        token.arm();
+        assert!(!token.is_cancelled());
+    }
+}

--- a/crates/facelock-daemon/src/cancel.rs
+++ b/crates/facelock-daemon/src/cancel.rs
@@ -17,6 +17,18 @@
 //! Every loop that can run for a perceptible time — the auth loop, the
 //! enroll loop, and both frame-discard loops — checks it once per iteration,
 //! so a request ends within one frame of the token being set.
+//!
+//! **One token per request, minted fresh, never reset.** There is no way to
+//! clear a token, because a clearable token has to be shared with somebody
+//! else to be worth clearing — and a shared one is cross-talk waiting to
+//! happen. zbus dispatches every method call in its own task, so with a
+//! single daemon-lifetime token any second call (including one about to be
+//! denied) could clear the flag an in-flight request was about to read, and
+//! any departure watch registered against it could cancel a request that was
+//! never its caller's. A token is created by the request it belongs to,
+//! handed to that request's loops and to that request's caller-departure
+//! watch, and dropped with it. "Fresh" and "un-cancelled" are then the same
+//! statement, which is why arming does not exist.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -31,15 +43,6 @@ impl CancelToken {
     /// A fresh, un-cancelled token.
     pub fn new() -> Self {
         Self(Arc::new(AtomicBool::new(false)))
-    }
-
-    /// Clear the flag for a request that is about to start.
-    ///
-    /// Called once per request, by whoever also arranges the watchers — so
-    /// arming always *precedes* subscribing, and a cancellation that arrives
-    /// between the two cannot be erased by a later reset.
-    pub fn arm(&self) {
-        self.0.store(false, Ordering::SeqCst);
     }
 
     /// Stop the in-flight request. Takes no lock, so it is safe to call from
@@ -92,11 +95,17 @@ mod tests {
         assert!(token.is_cancelled());
     }
 
+    /// The absence of a reset is the design, not an omission: every request
+    /// mints its own, so "is this cancelled" is only ever a question about
+    /// *this* request, and no other request can answer it.
     #[test]
-    fn arming_clears_a_previous_cancellation() {
-        let token = CancelToken::new();
-        token.cancel();
-        token.arm();
-        assert!(!token.is_cancelled());
+    fn two_tokens_never_share_a_flag() {
+        let first = CancelToken::new();
+        let second = CancelToken::new();
+        second.cancel();
+        assert!(
+            !first.is_cancelled(),
+            "a second request's cancellation reached the first request"
+        );
     }
 }

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -8,6 +8,7 @@ use facelock_store::FaceStore;
 use facelock_tpm::SoftwareSealer;
 use tracing::{debug, info, warn};
 
+use crate::cancel::CancelToken;
 use crate::quality;
 
 /// The outcome of an enrollment attempt — shared by the daemon handler
@@ -15,8 +16,18 @@ use crate::quality;
 /// CLI never needs the handler's own request/response enums (D5).
 #[derive(Debug, Clone)]
 pub enum EnrollOutcome {
-    Enrolled { model_id: u32, embedding_count: u32 },
-    Error { message: String },
+    Enrolled {
+        model_id: u32,
+        embedding_count: u32,
+    },
+    Error {
+        message: String,
+    },
+    /// The caller went away, the system is suspending, or the process was
+    /// signalled. Same rule as [`crate::auth::AuthOutcome::Cancelled`]: the
+    /// enrollment was abandoned, not refused, and the camera closes at once
+    /// (ADR 008 §5).
+    Cancelled,
 }
 
 const MIN_CAPTURES: usize = 3;
@@ -155,6 +166,7 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     label: &str,
     sealer: Option<&SoftwareSealer>,
     device_id: Option<&str>,
+    cancel: &CancelToken,
 ) -> EnrollOutcome {
     // Clear any previous model with the same label (re-enrollment)
     match store.remove_model_by_label(user, label) {
@@ -185,6 +197,12 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     let mut rejections = RejectionStats::default();
 
     while Instant::now() < deadline && (stored_count as usize) < MAX_CAPTURES {
+        // Checked before the inter-frame sleep and the blocking capture, so
+        // an abandoned enrollment ends within one frame (ADR 008 §5).
+        if cancel.is_cancelled() {
+            info!(user, label, captures = stored_count, "enrollment cancelled");
+            return EnrollOutcome::Cancelled;
+        }
         // Delay between captures for varied angles
         let since_last = Instant::now().duration_since(last_capture);
         if since_last < INTER_FRAME_DELAY {
@@ -542,6 +560,7 @@ mod tests {
             "2026-08-08-1",
             None,
             None,
+            &CancelToken::new(),
         );
 
         match &response {

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -942,8 +942,16 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         self.lease.finish(Outcome::from(&result), &self.config);
         // Only failed auths count against the rate limit, and only for the
         // real-authentication intent (see [`AuthIntent`]).
+        //
+        // An attempt where the camera never saw a face is not one of them: an
+        // empty chair is not a guess (ADR 008 §4). A locker that starts face
+        // auth on every wake, or a laptop opened in front of nobody, would
+        // otherwise burn the user's whole budget without a single attempt
+        // being made — and the real one, when they sit down, meets a lockout.
+        // A face that *was* seen and did not match still charges: that is a
+        // guess, and a wrong one.
         if let AuthOutcome::AuthResult(ref mr) = result {
-            if !mr.matched && intent.charges_rate_limit() {
+            if !mr.matched && mr.face_detected && intent.charges_rate_limit() {
                 if let Err(e) = self.rate_limiter.record_failure(&self.store, &user) {
                     warn!(user, error = %e, "failed to record auth failure");
                 }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -299,20 +299,21 @@ fn discard_frames<C: CameraSource>(
 
 /// The camera and everything that decides when it closes.
 ///
-/// One owner for the open stream, the warm-hold deadline and the in-flight
-/// cancel token, so the invariant of ADR 008 §8 — *every exit from an active
-/// request either sets a deadline or drops the camera* — is a property of
-/// four methods rather than of every request arm remembering to update two
-/// fields. Nothing outside this struct touches `camera` or `deadline`.
+/// One owner for the open stream and the warm-hold deadline, so the invariant
+/// of ADR 008 §8 — *every exit from an active request either sets a deadline
+/// or drops the camera* — is a property of four methods rather than of every
+/// request arm remembering to update two fields. Nothing outside this struct
+/// touches `camera` or `deadline`.
+///
+/// The cancel token is deliberately *not* a field: it belongs to the request,
+/// not to the lease, and outlives neither (see [`crate::cancel`]). It arrives
+/// as an argument to [`CameraLease::acquire`], which is the only place here
+/// that can block long enough to need one.
 pub(crate) struct CameraLease<C: CameraSource> {
     camera: Option<C>,
     /// Absolute instant the warm hold ends. `None` means "not holding" —
     /// either nothing is open, or a request is in flight.
     deadline: Option<Instant>,
-    /// Set to abort the in-flight request within one frame. Shared with the
-    /// request itself, so suspend/shutdown/`ReleaseCamera` can set it without
-    /// taking the handler lock.
-    cancel: CancelToken,
     factory: Option<CameraFactory<C>>,
     /// Quirk-overridden warmup frames (takes precedence over config).
     warmup_frames_override: Option<u32>,
@@ -323,39 +324,28 @@ impl<C: CameraSource> CameraLease<C> {
         Self {
             camera: None,
             deadline: None,
-            cancel: CancelToken::new(),
             factory,
             warmup_frames_override,
         }
     }
 
-    /// The token an in-flight request checks. Cloned, not borrowed, so a
-    /// watcher can set it without the handler lock — the whole point (§5).
-    pub(crate) fn cancel_token(&self) -> CancelToken {
-        self.cancel.clone()
-    }
-
-    /// Adopt a token minted elsewhere. The D-Bus server owns one for the
-    /// daemon's whole life and re-installs it after a config reload rebuilds
-    /// the handler, so the watchers it handed out keep working.
-    pub(crate) fn set_cancel_token(&mut self, token: CancelToken) {
-        self.cancel = token;
-    }
-
     /// Open the camera (or reuse a warm one) for a request that is about to
     /// run. Clears any warm-hold deadline: from here until `finish`, the
-    /// stream belongs to this request. A request that was already cancelled
+    /// stream belongs to this request. A request whose token is already set
     /// never opens the camera at all.
+    ///
+    /// `cancel` is this request's token and nobody else's, so a cancellation
+    /// seen here is always about the request being served.
     ///
     /// The returned borrow is tied to the lease, not to `config`, so a caller
     /// can still reach the handler's other fields while holding the camera.
-    fn acquire<'a>(&'a mut self, config: &Config) -> Result<&'a mut C, String> {
+    fn acquire<'a>(
+        &'a mut self,
+        config: &Config,
+        cancel: &CancelToken,
+    ) -> Result<&'a mut C, String> {
         self.deadline = None;
-        // The token is *not* reset here. Arming is the caller's job (see
-        // `CancelToken::arm`) and happens before the watchers subscribe, so a
-        // cancellation that lands between subscribing and the first frame
-        // cannot be erased by the request it is meant to stop.
-        if self.cancel.is_cancelled() {
+        if cancel.is_cancelled() {
             self.close("cancelled before the camera was needed");
             return Err(CANCELLED_MESSAGE.to_string());
         }
@@ -366,10 +356,21 @@ impl<C: CameraSource> CameraLease<C> {
             // those would let a fresh attempt match on the tail of the last
             // one. AE is already settled, so no warmup discard is needed.
             let stale = match self.camera.as_mut() {
-                Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale", &self.cancel),
+                Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale", cancel),
                 None => Ok(()),
             };
             if let Err(e) = stale {
+                // A cancellation is not a broken stream, and the difference is
+                // load-bearing: `CANCELLED_MESSAGE` is matched *exactly* by
+                // PAM (→ PAM_IGNORE) and by the caller that writes the
+                // `cancelled` audit row, so wrapping it as "capture error:
+                // cancelled" would silently downgrade an abandoned attempt to
+                // an error on both. Return it verbatim, as the cold-warmup
+                // branch below always did (docs/contracts.md, ADR 008 §5).
+                if cancel.is_cancelled() {
+                    self.close("cancelled during the stale-buffer discard");
+                    return Err(CANCELLED_MESSAGE.to_string());
+                }
                 // A dequeue failure on a warm stream means the stream is gone.
                 // Never hand it to a request (ADR 008 §8).
                 warn!("warm camera reuse failed, closing camera: {e}");
@@ -388,11 +389,11 @@ impl<C: CameraSource> CameraLease<C> {
                 .unwrap_or(config.device.warmup_frames);
             // A cold warmup discard is advisory (AGC/AE settling); a failure
             // here is left for the scan loop to surface, as it always was.
-            if let Err(e) = discard_frames(&mut camera, warmup, "warmup", &self.cancel) {
+            if let Err(e) = discard_frames(&mut camera, warmup, "warmup", cancel) {
                 debug!("warmup discard failed: {e}");
                 // A cancellation during warmup aborts the acquire outright:
                 // the request is over before it started (ADR 008 §8).
-                if self.cancel.is_cancelled() {
+                if cancel.is_cancelled() {
                     return Err(CANCELLED_MESSAGE.to_string());
                 }
             }
@@ -456,13 +457,14 @@ impl<C: CameraSource> CameraLease<C> {
     /// suspend watcher); by the time this runs, that request has already
     /// returned.
     ///
-    /// Which is also why it re-arms the token on the way out: holding the
-    /// mutex proves nothing is in flight, so leaving the flag latched would
-    /// only cancel the *next* request, which nobody asked for.
+    /// Nothing needs un-setting afterwards: the token that was cancelled
+    /// belongs to the request that has just ended, and the next request
+    /// brings its own. This is what used to wedge every later preview frame —
+    /// one `ReleaseCamera` latched the daemon-lifetime token, and a `release`
+    /// that forgot to clear it left the flag set for everyone after.
     fn release(&mut self) {
         self.deadline = None;
         self.close("camera release requested");
-        self.cancel.arm();
     }
 
     /// Drop the stream (`Drop` runs STREAMOFF and disables the IR emitter).
@@ -627,21 +629,6 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         self.lease.expire(now);
     }
 
-    /// The token every camera loop in this handler checks. Cloned, so the
-    /// D-Bus server can hand it to a per-request caller watch, to the
-    /// suspend watcher, and to `ReleaseCamera` without ever taking the
-    /// handler mutex — which the request being cancelled is holding.
-    pub fn cancel_token(&self) -> CancelToken {
-        self.lease.cancel_token()
-    }
-
-    /// Adopt a token minted elsewhere. The server owns one for the daemon's
-    /// whole life and re-installs it on the handler a config reload rebuilds,
-    /// so watchers registered against the old handler keep working.
-    pub fn set_cancel_token(&mut self, token: CancelToken) {
-        self.lease.set_cancel_token(token);
-    }
-
     /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs
     /// through the shared per-row implementation (`crate::embeddings`, N10).
     /// Falls back to the standard `get_user_embeddings` path when nothing could
@@ -678,7 +665,27 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         .map_err(|message| DaemonResponse::Error { message })
     }
 
+    /// Serve a request that nobody can cancel.
+    ///
+    /// The fresh token this mints is never handed out, so it is never set:
+    /// that is exactly right for the arms that do not scan (`ListModels`,
+    /// `ReleaseCamera`, …) and for a preview frame, which is one capture long
+    /// and whose successor must not inherit a cancellation from whatever ran
+    /// before it. Requests that *can* be cancelled — the two authentications
+    /// and enroll — come in through [`Handler::handle_with_cancel`] or
+    /// [`Handler::handle_authenticate`] carrying their caller's token.
     pub fn handle(&mut self, request: DaemonRequest) -> DaemonResponse {
+        self.handle_with_cancel(request, &CancelToken::new())
+    }
+
+    /// [`Handler::handle`], for a request whose caller holds the other end of
+    /// `cancel` — the D-Bus server's caller-departure watch, the suspend
+    /// path, `ReleaseCamera`, shutdown.
+    pub fn handle_with_cancel(
+        &mut self,
+        request: DaemonRequest,
+        cancel: &CancelToken,
+    ) -> DaemonResponse {
         debug!(?request, "handling request");
         match request {
             DaemonRequest::Ping => DaemonResponse::Ok,
@@ -696,7 +703,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
 
             DaemonRequest::Authenticate { user } => {
-                self.handle_authenticate(user, AuthIntent::Authenticate)
+                self.handle_authenticate(user, AuthIntent::Authenticate, cancel)
             }
 
             DaemonRequest::Enroll { user, label } => {
@@ -727,8 +734,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     warn!(user, "enroll refused (encryption unavailable): {message}");
                     return DaemonResponse::Error { message };
                 }
-                let cancel = self.lease.cancel_token();
-                let camera = match self.lease.acquire(&self.config) {
+                let camera = match self.lease.acquire(&self.config, cancel) {
                     Ok(camera) => camera,
                     Err(message) => return DaemonResponse::Error { message },
                 };
@@ -744,7 +750,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     &label,
                     self.software_sealer.as_ref(),
                     device_id.as_deref(),
-                    &cancel,
+                    cancel,
                 );
                 self.lease.finish(Outcome::from(&result), &self.config);
                 result.into()
@@ -811,7 +817,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
 
             DaemonRequest::PreviewFrame => {
-                let captured = match self.lease.acquire(&self.config) {
+                let captured = match self.lease.acquire(&self.config, cancel) {
                     Ok(camera) => camera.capture_rgb_only(),
                     Err(message) => return DaemonResponse::Error { message },
                 };
@@ -830,7 +836,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
 
             DaemonRequest::PreviewDetectFrame { user } => {
-                let captured = match self.lease.acquire(&self.config) {
+                let captured = match self.lease.acquire(&self.config, cancel) {
                     Ok(camera) => camera.capture(),
                     Err(message) => return DaemonResponse::Error { message },
                 };
@@ -880,7 +886,12 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     /// unaffected by the intent: an already-limited user still sees "rate
     /// limited" from `test`, because that decision is made before this
     /// function knows whether the attempt itself will fail.
-    pub fn handle_authenticate(&mut self, user: String, intent: AuthIntent) -> DaemonResponse {
+    pub fn handle_authenticate(
+        &mut self,
+        user: String,
+        intent: AuthIntent,
+        cancel: &CancelToken,
+    ) -> DaemonResponse {
         if let Some(resp) = auth::pre_check_audited_with_context(
             &self.config,
             &self.store,
@@ -917,13 +928,32 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             Err(resp) => return resp,
         };
 
-        let cancel = self.lease.cancel_token();
-        let camera = match self.lease.acquire(&self.config) {
+        let attempt_started = Instant::now();
+        let camera = match self.lease.acquire(&self.config, cancel) {
             Ok(camera) => camera,
             Err(message) => {
                 // The callee below is what normally wipes `stored` (D11);
                 // on this path it never runs, so wipe it here.
                 facelock_core::types::zeroize_stored_embeddings(&mut stored);
+                // A cancellation that lands before the camera is open is
+                // still a cancellation, and docs/contracts.md promises every
+                // one of them an audit row. Returning the error straight from
+                // here skipped the writer entirely, so the trail recorded
+                // nothing at all for the fastest cancellations — the ones a
+                // locker that aborts PAM the instant a password is typed
+                // produces most often. Same writer `auth.rs` uses when the
+                // token is noticed mid-scan; `frame_count` is 0 because none
+                // were captured.
+                if message == CANCELLED_MESSAGE {
+                    return auth::cancelled(
+                        &self.config,
+                        &user,
+                        intent.audit_source(),
+                        attempt_started,
+                        0,
+                    )
+                    .into();
+                }
                 return DaemonResponse::Error { message };
             }
         };
@@ -937,7 +967,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &self.config,
             &user,
             intent.audit_source(),
-            &cancel,
+            cancel,
         );
         self.lease.finish(Outcome::from(&result), &self.config);
         // Only failed auths count against the rate limit, and only for the
@@ -1068,6 +1098,13 @@ mod tests {
         )
     }
 
+    /// The token a request that nobody cancels would bring. Named so the
+    /// tests below read as "acquire for a live request" rather than as an
+    /// argument nobody looked at.
+    fn live() -> CancelToken {
+        CancelToken::new()
+    }
+
     fn match_result(matched: bool) -> MatchResult {
         MatchResult {
             matched,
@@ -1096,6 +1133,10 @@ mod tests {
             Outcome::Failure
         );
         assert_eq!(Outcome::from(&AuthOutcome::Suppressed), Outcome::Error);
+        // Nobody is waiting on a retry they abandoned, so a cancellation
+        // closes the stream rather than holding it — the row this table was
+        // missing while `Cancelled` was the newest variant.
+        assert_eq!(Outcome::from(&AuthOutcome::Cancelled), Outcome::Cancelled);
         for kind in ErrorKind::ALL {
             assert_eq!(
                 Outcome::from(&AuthOutcome::error(*kind)),
@@ -1121,6 +1162,7 @@ mod tests {
             }),
             Outcome::Error
         );
+        assert_eq!(Outcome::from(&EnrollOutcome::Cancelled), Outcome::Cancelled);
     }
 
     /// Only a failed attempt keeps the stream open — the whole policy.
@@ -1142,7 +1184,7 @@ mod tests {
         let config = lease_config(3);
         for outcome in Outcome::ALL {
             let mut lease = lease();
-            lease.acquire(&config).expect("mock camera opens");
+            lease.acquire(&config, &live()).expect("mock camera opens");
             lease.finish(*outcome, &config);
             if outcome.holds_camera() {
                 assert!(lease.camera.is_some(), "{outcome:?} must keep the stream");
@@ -1160,7 +1202,7 @@ mod tests {
     fn zero_release_secs_closes_the_camera_even_on_failure() {
         let config = lease_config(0);
         let mut lease = lease();
-        lease.acquire(&config).expect("mock camera opens");
+        lease.acquire(&config, &live()).expect("mock camera opens");
         lease.finish(Outcome::Failure, &config);
         assert!(lease.camera.is_none());
         assert!(lease.deadline.is_none());
@@ -1173,7 +1215,7 @@ mod tests {
     fn expire_closes_the_camera_only_after_the_deadline() {
         let config = lease_config(3);
         let mut lease = lease();
-        lease.acquire(&config).expect("mock camera opens");
+        lease.acquire(&config, &live()).expect("mock camera opens");
         let at_finish = Instant::now();
         lease.finish(Outcome::Failure, &config);
 
@@ -1196,14 +1238,16 @@ mod tests {
         let warmup = config.device.warmup_frames;
         let mut lease = lease();
 
-        lease.acquire(&config).expect("mock camera opens");
+        lease.acquire(&config, &live()).expect("mock camera opens");
         let after_cold = lease.camera.as_ref().map(|c| c.captures());
         assert_eq!(after_cold, Some(warmup as usize), "cold open runs warmup");
 
         lease.finish(Outcome::Failure, &config);
         assert!(lease.camera.is_some(), "a failure holds the stream");
 
-        lease.acquire(&config).expect("warm camera is reused");
+        lease
+            .acquire(&config, &live())
+            .expect("warm camera is reused");
         let after_warm = lease.camera.as_ref().map(|c| c.captures());
         assert_eq!(
             after_warm,
@@ -1219,7 +1263,7 @@ mod tests {
     fn preview_holds_the_camera_for_at_least_the_floor() {
         let config = lease_config(0);
         let mut lease = lease();
-        lease.acquire(&config).expect("mock camera opens");
+        lease.acquire(&config, &live()).expect("mock camera opens");
         let before = Instant::now();
         lease.touch_preview(&config);
 
@@ -1239,7 +1283,7 @@ mod tests {
     fn preview_hold_takes_the_larger_of_the_floor_and_the_configured_hold() {
         let config = lease_config(10);
         let mut lease = lease();
-        lease.acquire(&config).expect("mock camera opens");
+        lease.acquire(&config, &live()).expect("mock camera opens");
         let before = Instant::now();
         lease.touch_preview(&config);
         let deadline = lease.deadline.expect("preview must set a hold");
@@ -1247,42 +1291,99 @@ mod tests {
     }
 
     /// `ReleaseCamera`, suspend and shutdown all land here. The camera goes
-    /// at once — and the token is left *ready*, not latched: whoever asked
-    /// already set it lock-free to stop the request in flight, and by the
-    /// time this runs that request has returned. Latching it would cancel the
-    /// next request instead, which is how a `ReleaseCamera` used to be able
-    /// to wedge every later preview frame.
+    /// at once, and the *next* request is unaffected: the token whoever asked
+    /// had set belongs to the request that was in flight, and the next request
+    /// brings its own. A shared token that `release` forgot to clear is how a
+    /// single `ReleaseCamera` used to wedge every later preview frame.
     #[test]
-    fn release_closes_the_camera_and_leaves_the_token_ready() {
+    fn release_closes_the_camera_and_never_reaches_the_next_request() {
         let config = lease_config(3);
         let mut lease = lease();
-        let token = lease.cancel_token();
-        lease.acquire(&config).expect("mock camera opens");
+        let in_flight = live();
+        lease
+            .acquire(&config, &in_flight)
+            .expect("mock camera opens");
 
-        token.cancel();
+        in_flight.cancel();
         lease.release();
         assert!(lease.camera.is_none());
         assert!(lease.deadline.is_none());
-        assert!(!token.is_cancelled(), "release must not latch the token");
 
-        // ...and the next request still works.
-        lease.acquire(&config).expect("a later request still opens");
+        // ...and the next request, with its own token, still works.
+        lease
+            .acquire(&config, &live())
+            .expect("a later request still opens");
         assert!(lease.camera.is_some());
     }
 
-    /// The other half of the token contract: a request that finds it set
-    /// never opens the camera at all (ADR 008 §8).
+    /// The other half of the token contract: a request that finds its own
+    /// token set never opens the camera at all (ADR 008 §8).
     #[test]
     fn a_cancelled_request_never_opens_the_camera() {
         let config = lease_config(3);
         let mut lease = lease();
-        lease.cancel_token().cancel();
-        let err = match lease.acquire(&config) {
+        let cancelled = live();
+        cancelled.cancel();
+        let err = match lease.acquire(&config, &cancelled) {
             Ok(_) => panic!("a cancelled request must not get a camera"),
             Err(e) => e,
         };
-        assert_eq!(err, crate::auth::CANCELLED_MESSAGE);
+        assert_eq!(err, CANCELLED_MESSAGE);
         assert!(lease.camera.is_none());
+    }
+
+    /// A cancellation during the *warm* stale discard must reach the caller
+    /// as the frozen `cancelled` string, byte for byte.
+    ///
+    /// It used to arrive as `"capture error: cancelled"`, which nothing
+    /// matches: PAM compares this message exactly (→ `PAM_IGNORE`), and so
+    /// does the caller that writes the `cancelled` audit row. Wrapped, an
+    /// abandoned retry was answered and logged as a camera error instead —
+    /// and only on the warm path, so the same cancellation meant two
+    /// different things depending on whether the previous attempt had failed.
+    #[test]
+    fn a_cancellation_during_the_stale_discard_is_reported_verbatim() {
+        let config = lease_config(3);
+        let mut lease = lease();
+
+        // Get warm: only a failed attempt leaves the stream open.
+        lease.acquire(&config, &live()).expect("mock camera opens");
+        lease.finish(Outcome::Failure, &config);
+        assert!(lease.camera.is_some(), "a failure holds the stream");
+
+        let cancelled = live();
+        cancelled.cancel();
+        let err = match lease.acquire(&config, &cancelled) {
+            Ok(_) => panic!("a cancelled request must not get a warm camera either"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err, CANCELLED_MESSAGE,
+            "a warm-path cancellation must not be wrapped as a capture error"
+        );
+        assert!(
+            lease.camera.is_none(),
+            "a cancelled request closes the stream (ADR 008 §4)"
+        );
+    }
+
+    /// The regression the per-request token exists to make impossible: one
+    /// request's cancellation is invisible to the next, so a cancelled
+    /// authentication cannot wedge whatever runs after it.
+    #[test]
+    fn a_cancelled_request_does_not_cancel_the_next_one() {
+        let config = lease_config(3);
+        let mut lease = lease();
+
+        let cancelled = live();
+        cancelled.cancel();
+        assert!(lease.acquire(&config, &cancelled).is_err());
+        lease.finish(Outcome::Cancelled, &config);
+
+        lease
+            .acquire(&config, &live())
+            .expect("the request after a cancelled one must still open the camera");
+        assert!(lease.camera.is_some());
     }
 
     /// A camera factory that cannot open is an error, never a warm state.
@@ -1291,7 +1392,7 @@ mod tests {
         let config = lease_config(3);
         let mut lease: CameraLease<MockCamera> =
             CameraLease::new(Some(Box::new(|_| Err("no such device".into()))), None);
-        let err = match lease.acquire(&config) {
+        let err = match lease.acquire(&config, &live()) {
             Ok(_) => panic!("a factory that returns Err must not yield a camera"),
             Err(e) => e,
         };

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use facelock_camera::MMAP_BUFFERS;
-use facelock_core::config::{Config, EncryptionMethod};
+use facelock_core::config::{Config, DeviceConfig, EncryptionMethod};
 use facelock_core::ipc::PreviewFace;
 use facelock_core::traits::{CameraSource, FaceProcessor};
 use facelock_core::types::best_match;
@@ -202,7 +202,9 @@ const PREVIEW_MIN_HOLD: Duration = Duration::from_secs(2);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Outcome {
     /// Matched (or enrolled). The interaction is over — the session is
-    /// unlocked, the sudo command is running.
+    /// unlocked, the sudo command is running — so this releases the camera
+    /// unless the operator opted into a hold with
+    /// `device.camera_release_after_success_secs` (default `0`).
     Success,
     /// No match, including the timeout that follows a face the daemon saw but
     /// could not match. The one outcome a retry plausibly follows.
@@ -225,10 +227,31 @@ impl Outcome {
         Outcome::Error,
     ];
 
-    /// Does this outcome keep the stream open for a warm retry? The whole
-    /// policy, in one predicate.
-    pub fn holds_camera(self) -> bool {
-        matches!(self, Outcome::Failure)
+    /// How many seconds this ending keeps the stream open for a warm retry —
+    /// `0` closes it now. The whole policy, in one function, so
+    /// [`CameraLease::finish`] has no rule of its own to drift from it.
+    ///
+    /// Only two endings can hold, and both are the operator's call by value.
+    /// A failure holds for `camera_release_secs` (default 3) because a retry
+    /// plausibly follows it. A success holds only for
+    /// `camera_release_after_success_secs`, which is `0` by default: a
+    /// success ends the interaction, and on IR hardware a hold past it is an
+    /// emitter LED burning after the screen has already unlocked. It exists
+    /// for the one shape that does retry immediately — privileged actions
+    /// repeated with no auth caching in front of them, `sudo` with
+    /// `timestamp_timeout=0` — and was added on maintainer request as the
+    /// opt-in ADR 008 §3 had deferred.
+    ///
+    /// A cancellation or an error never holds, whatever either key says:
+    /// nobody abandons an attempt in order to retry it a moment later, and a
+    /// stream that just failed must never be handed to the next request
+    /// (ADR 008 §8).
+    pub fn hold_secs(self, device: &DeviceConfig) -> u32 {
+        match self {
+            Outcome::Failure => device.camera_release_secs,
+            Outcome::Success => device.camera_release_after_success_secs,
+            Outcome::Cancelled | Outcome::Error => 0,
+        }
     }
 }
 
@@ -407,27 +430,40 @@ impl<C: CameraSource> CameraLease<C> {
 
     /// End the request that `acquire` started. Either sets a deadline or
     /// drops the camera — never neither.
+    ///
+    /// What the outcome is worth in seconds is [`Outcome::hold_secs`]; all
+    /// that happens here is spending it.
     fn finish(&mut self, outcome: Outcome, config: &Config) {
-        if !outcome.holds_camera() {
+        let hold_secs = outcome.hold_secs(&config.device);
+        if hold_secs == 0 {
             self.close(match outcome {
+                // The default for a success: the interaction is over, so the
+                // stream goes out with the reply.
                 Outcome::Success => "authentication succeeded",
+                // `camera_release_secs = 0` used to be silently substituted
+                // with 5 seconds. It now means what it says.
+                Outcome::Failure => "camera hold disabled (device.camera_release_secs = 0)",
                 Outcome::Cancelled => "request cancelled",
-                _ => "request ended without an answer",
+                Outcome::Error => "request ended without an answer",
             });
             return;
         }
-        let hold_secs = config.device.camera_release_secs;
-        if hold_secs == 0 {
-            // `0` used to be silently substituted with 5 seconds. It now means
-            // what it says.
-            self.close("camera hold disabled (device.camera_release_secs = 0)");
-            return;
-        }
         self.deadline = Some(Instant::now() + Duration::from_secs(hold_secs as u64));
-        debug!(
-            hold_secs,
-            "holding camera warm after a failed attempt (retry expected)"
-        );
+        // Only the two holding outcomes reach here, and they hold for
+        // opposite reasons — one because a retry is likely, one because the
+        // operator said so — so the log says which, and by which key.
+        if outcome == Outcome::Success {
+            debug!(
+                hold_secs,
+                "holding camera warm after a successful attempt \
+                 (device.camera_release_after_success_secs)"
+            );
+        } else {
+            debug!(
+                hold_secs,
+                "holding camera warm after a failed attempt (retry expected)"
+            );
+        }
     }
 
     /// Extend the hold for a preview stream, which is a sequence of
@@ -1086,10 +1122,24 @@ mod tests {
     const MOCK_FRAMES: usize = 256;
 
     fn lease_config(release_secs: u32) -> Config {
+        lease_config_with_success_hold(release_secs, 0)
+    }
+
+    /// The same, plus the opt-in success hold — `0` in every test that does
+    /// not name it, which is both the shipped default and the behavior every
+    /// pre-existing test here was written against.
+    fn lease_config_with_success_hold(release_secs: u32, success_secs: u32) -> Config {
         let mut config = Config::default();
         config.device.camera_release_secs = release_secs;
+        config.device.camera_release_after_success_secs = success_secs;
         config
     }
+
+    /// The hold pairs worth running a whole outcome table against:
+    /// `(camera_release_secs, camera_release_after_success_secs)` — the
+    /// shipped default, the maintainer's opt-in, the opt-in with the failure
+    /// hold turned off, and both off.
+    const HOLD_PAIRS: &[(u32, u32)] = &[(3, 0), (3, 2), (0, 2), (0, 0)];
 
     fn lease() -> CameraLease<MockCamera> {
         CameraLease::new(
@@ -1165,15 +1215,107 @@ mod tests {
         assert_eq!(Outcome::from(&EnrollOutcome::Cancelled), Outcome::Cancelled);
     }
 
-    /// Only a failed attempt keeps the stream open — the whole policy.
+    /// The whole policy, over every outcome and every combination of the two
+    /// hold keys: a failure holds for `camera_release_secs`, a success for
+    /// `camera_release_after_success_secs` (`0` unless asked for), and
+    /// nothing makes a cancellation or an error hold.
     #[test]
-    fn only_failure_holds_the_camera() {
-        for outcome in Outcome::ALL {
-            assert_eq!(
-                outcome.holds_camera(),
-                *outcome == Outcome::Failure,
-                "{outcome:?}"
+    fn hold_secs_is_the_whole_camera_policy() {
+        for (failure_secs, success_secs) in HOLD_PAIRS {
+            let config = lease_config_with_success_hold(*failure_secs, *success_secs);
+            for outcome in Outcome::ALL {
+                let expected = match outcome {
+                    Outcome::Failure => *failure_secs,
+                    Outcome::Success => *success_secs,
+                    Outcome::Cancelled | Outcome::Error => 0,
+                };
+                assert_eq!(
+                    outcome.hold_secs(&config.device),
+                    expected,
+                    "{outcome:?} with camera_release_secs = {failure_secs}, \
+                     camera_release_after_success_secs = {success_secs}"
+                );
+            }
+        }
+    }
+
+    /// The default an install that never touches the key gets: a success
+    /// closes the stream as the reply goes out, exactly as it did before the
+    /// key existed.
+    #[test]
+    fn success_closes_the_camera_by_default() {
+        let config = lease_config(3);
+        assert_eq!(config.device.camera_release_after_success_secs, 0);
+        let mut lease = lease();
+        lease.acquire(&config, &live()).expect("mock camera opens");
+        lease.finish(Outcome::Success, &config);
+        assert!(lease.camera.is_none(), "a success must release the camera");
+        assert!(lease.deadline.is_none());
+    }
+
+    /// Opted in, a success holds on the same machinery a failure does: an
+    /// absolute deadline, a stream the next request reuses warm, and an
+    /// `expire` that closes it once the deadline passes.
+    #[test]
+    fn a_configured_success_hold_keeps_the_camera_warm_and_then_expires() {
+        let config = lease_config_with_success_hold(3, 2);
+        let warmup = config.device.warmup_frames;
+        let mut lease = lease();
+        lease.acquire(&config, &live()).expect("mock camera opens");
+
+        let at_finish = Instant::now();
+        lease.finish(Outcome::Success, &config);
+        let deadline = lease.deadline.expect("the success hold must set one");
+        assert!(
+            deadline >= at_finish + Duration::from_secs(2),
+            "the hold must run the configured 2 s"
+        );
+        assert!(
+            deadline < at_finish + Duration::from_secs(3),
+            "and must not borrow the failure key's 3 s"
+        );
+        assert!(
+            lease.camera.is_some(),
+            "the stream stays open for the retry"
+        );
+
+        // And it is a real warm stream: the next request reuses it, paying
+        // the stale-buffer discard and no second warmup.
+        lease
+            .acquire(&config, &live())
+            .expect("the next request reuses the warm camera");
+        assert_eq!(
+            lease.camera.as_ref().map(|c| c.captures()),
+            Some((warmup + MMAP_BUFFERS - 1) as usize),
+            "a warm success hold must not reopen the camera"
+        );
+
+        // Then it ends, on its deadline, like any other hold.
+        let at_second_finish = Instant::now();
+        lease.finish(Outcome::Success, &config);
+        lease.expire(at_second_finish + Duration::from_secs(2) - CAMERA_POLL_INTERVAL);
+        assert!(lease.camera.is_some(), "released a full tick early");
+        lease.expire(at_second_finish + Duration::from_secs(2) + CAMERA_POLL_INTERVAL);
+        assert!(lease.camera.is_none());
+        assert!(lease.deadline.is_none());
+    }
+
+    /// The success hold holds successes and nothing else: an abandoned
+    /// attempt and a broken stream still close immediately with it set, so
+    /// the key can never become a way to leave the IR emitter lit after a
+    /// cancel (ADR 008 §1, §8).
+    #[test]
+    fn a_success_hold_never_leaks_into_a_cancellation_or_an_error() {
+        let config = lease_config_with_success_hold(3, 30);
+        for outcome in [Outcome::Cancelled, Outcome::Error] {
+            let mut lease = lease();
+            lease.acquire(&config, &live()).expect("mock camera opens");
+            lease.finish(outcome, &config);
+            assert!(
+                lease.camera.is_none(),
+                "{outcome:?} must close the stream even with a success hold set"
             );
+            assert!(lease.deadline.is_none(), "{outcome:?}");
         }
     }
 
@@ -1181,17 +1323,23 @@ mod tests {
     /// sets a deadline or drops the camera — never neither, never both.
     #[test]
     fn finish_either_sets_a_deadline_or_drops_the_camera() {
-        let config = lease_config(3);
-        for outcome in Outcome::ALL {
-            let mut lease = lease();
-            lease.acquire(&config, &live()).expect("mock camera opens");
-            lease.finish(*outcome, &config);
-            if outcome.holds_camera() {
-                assert!(lease.camera.is_some(), "{outcome:?} must keep the stream");
-                assert!(lease.deadline.is_some(), "{outcome:?} must set a deadline");
-            } else {
-                assert!(lease.camera.is_none(), "{outcome:?} must close the stream");
-                assert!(lease.deadline.is_none(), "{outcome:?} must clear the hold");
+        for (failure_secs, success_secs) in HOLD_PAIRS {
+            let config = lease_config_with_success_hold(*failure_secs, *success_secs);
+            for outcome in Outcome::ALL {
+                let mut lease = lease();
+                lease.acquire(&config, &live()).expect("mock camera opens");
+                lease.finish(*outcome, &config);
+                let case = format!(
+                    "{outcome:?} with camera_release_secs = {failure_secs}, \
+                     camera_release_after_success_secs = {success_secs}"
+                );
+                if outcome.hold_secs(&config.device) > 0 {
+                    assert!(lease.camera.is_some(), "{case} must keep the stream");
+                    assert!(lease.deadline.is_some(), "{case} must set a deadline");
+                } else {
+                    assert!(lease.camera.is_none(), "{case} must close the stream");
+                    assert!(lease.deadline.is_none(), "{case} must clear the hold");
+                }
             }
         }
     }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
+use facelock_camera::MMAP_BUFFERS;
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::ipc::PreviewFace;
 use facelock_core::traits::{CameraSource, FaceProcessor};
@@ -162,9 +165,262 @@ impl From<EnrollOutcome> for DaemonResponse {
 /// Type alias for the camera factory closure.
 type CameraFactory<C> = Box<dyn Fn(&Config) -> Result<C, String> + Send + Sync>;
 
-/// Fallback camera release delay when config value is 0 (shouldn't happen with default).
-const CAMERA_DEBOUNCE_FALLBACK: Duration = Duration::from_secs(5);
 const JPEG_BUF_CAPACITY: usize = 128 * 1024;
+
+/// How often [`Handler::expire_camera`] is polled, and therefore the accuracy
+/// of the warm hold. The deadline itself is absolute, so a tick that finds
+/// the handler locked loses nothing — the next one releases at the same
+/// wall-clock instant, just late (ADR 008 §8).
+pub const CAMERA_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Floor on the warm hold a preview frame sets.
+///
+/// A preview streams at roughly 10 fps through one-frame-per-request D-Bus
+/// calls, so it must never reopen the camera between frames — not even with
+/// `camera_release_secs = 0`, whose contract is about *authentication* not
+/// holding the camera open after a failed attempt. The CLI still calls
+/// `ReleaseCamera` on exit; this floor is what bounds a *crashed* preview
+/// (ADR 008 §4).
+const PREVIEW_MIN_HOLD: Duration = Duration::from_secs(2);
+
+/// What a finished request means for the camera stream.
+///
+/// The single rule of ADR 008 §1: the camera is on only while an
+/// authentication is in progress or a retry is plausibly imminent. A retry is
+/// plausible after exactly one class of ending — the user was there and was
+/// not recognized — so that is the only one that holds the stream open.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Outcome {
+    /// Matched (or enrolled). The interaction is over — the session is
+    /// unlocked, the sudo command is running.
+    Success,
+    /// No match, including the timeout that follows a face the daemon saw but
+    /// could not match. The one outcome a retry plausibly follows.
+    Failure,
+    /// The caller went away, the system is suspending, or a privileged
+    /// `ReleaseCamera` arrived. Nobody is waiting on a retry.
+    Cancelled,
+    /// Anything that was not an answer about this face: a camera or capture
+    /// failure, a pre-flight rejection, an all-dark scan. Never held warm —
+    /// a broken stream must not be reused (ADR 008 §8).
+    Error,
+}
+
+impl Outcome {
+    /// Every variant, so a table-driven test cannot silently skip one.
+    pub const ALL: &'static [Outcome] = &[
+        Outcome::Success,
+        Outcome::Failure,
+        Outcome::Cancelled,
+        Outcome::Error,
+    ];
+
+    /// Does this outcome keep the stream open for a warm retry? The whole
+    /// policy, in one predicate.
+    pub fn holds_camera(self) -> bool {
+        matches!(self, Outcome::Failure)
+    }
+}
+
+/// The authentication vocabulary's projection onto the camera policy.
+///
+/// Deliberately exhaustive with no wildcard arm: a new [`AuthOutcome`]
+/// variant must be classified here before the daemon compiles, rather than
+/// silently inheriting whichever behavior a `_` arm happened to name.
+impl From<&AuthOutcome> for Outcome {
+    fn from(outcome: &AuthOutcome) -> Self {
+        match outcome {
+            AuthOutcome::AuthResult(result) if result.matched => Outcome::Success,
+            // Includes the timeout: `matched = false` with or without a face.
+            AuthOutcome::AuthResult(_) => Outcome::Failure,
+            // No enrolled models and `suppress_unknown` — the stack falls
+            // through to another module and nobody retries a face here.
+            AuthOutcome::Suppressed => Outcome::Error,
+            // Every `ErrorKind`, including `AllFramesDark` and the camera and
+            // capture failures.
+            AuthOutcome::Error { .. } => Outcome::Error,
+        }
+    }
+}
+
+/// Enrollment's projection onto the same policy. An enrollment that ended —
+/// stored or failed — is a finished interaction: the CLI prints its result
+/// and any re-run is human-paced, so there is no imminent retry to keep the
+/// stream open for.
+impl From<&EnrollOutcome> for Outcome {
+    fn from(outcome: &EnrollOutcome) -> Self {
+        match outcome {
+            EnrollOutcome::Enrolled { .. } => Outcome::Success,
+            EnrollOutcome::Error { .. } => Outcome::Error,
+        }
+    }
+}
+
+/// Dequeue and throw away `count` frames.
+///
+/// The one discard both callers use: a cold open discards `warmup_frames`
+/// while the sensor's AGC/AE settles, and a warm reuse discards the stale
+/// MMAP buffers V4L2 left filled after the previous request. Sharing it is
+/// what keeps "the frames a warm stream hands back first are not analyzed"
+/// true by construction rather than by two similar loops agreeing.
+fn discard_frames<C: CameraSource>(camera: &mut C, count: u32, reason: &str) -> Result<(), String> {
+    if count == 0 {
+        return Ok(());
+    }
+    debug!(count, reason, "discarding frames");
+    for _ in 0..count {
+        camera.capture().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// The camera and everything that decides when it closes.
+///
+/// One owner for the open stream, the warm-hold deadline and the in-flight
+/// cancel token, so the invariant of ADR 008 §8 — *every exit from an active
+/// request either sets a deadline or drops the camera* — is a property of
+/// four methods rather than of every request arm remembering to update two
+/// fields. Nothing outside this struct touches `camera` or `deadline`.
+pub(crate) struct CameraLease<C: CameraSource> {
+    camera: Option<C>,
+    /// Absolute instant the warm hold ends. `None` means "not holding" —
+    /// either nothing is open, or a request is in flight.
+    deadline: Option<Instant>,
+    /// Set to abort the in-flight request within one frame. Shared with the
+    /// request itself, so suspend/shutdown/`ReleaseCamera` can set it without
+    /// taking the handler lock.
+    cancel: Arc<AtomicBool>,
+    factory: Option<CameraFactory<C>>,
+    /// Quirk-overridden warmup frames (takes precedence over config).
+    warmup_frames_override: Option<u32>,
+}
+
+impl<C: CameraSource> CameraLease<C> {
+    fn new(factory: Option<CameraFactory<C>>, warmup_frames_override: Option<u32>) -> Self {
+        Self {
+            camera: None,
+            deadline: None,
+            cancel: Arc::new(AtomicBool::new(false)),
+            factory,
+            warmup_frames_override,
+        }
+    }
+
+    /// The token an in-flight request checks. Cloneable so a watcher can set
+    /// it without the handler lock.
+    #[allow(dead_code)]
+    pub(crate) fn cancel_token(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+
+    /// Open the camera (or reuse a warm one) for a request that is about to
+    /// run. Clears any warm-hold deadline and resets the cancel token: from
+    /// here until `finish`, the stream belongs to this request.
+    ///
+    /// The returned borrow is tied to the lease, not to `config`, so a caller
+    /// can still reach the handler's other fields while holding the camera.
+    fn acquire<'a>(&'a mut self, config: &Config) -> Result<&'a mut C, String> {
+        self.deadline = None;
+        self.cancel.store(false, Ordering::SeqCst);
+
+        if self.camera.is_some() {
+            // Warm reuse. The stream never stopped, so its buffers still hold
+            // the frames captured right after the previous request — analyzing
+            // those would let a fresh attempt match on the tail of the last
+            // one. AE is already settled, so no warmup discard is needed.
+            let stale = match self.camera.as_mut() {
+                Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale"),
+                None => Ok(()),
+            };
+            if let Err(e) = stale {
+                // A dequeue failure on a warm stream means the stream is gone.
+                // Never hand it to a request (ADR 008 §8).
+                warn!("warm camera reuse failed, closing camera: {e}");
+                self.camera = None;
+                return Err(format!("capture error: {e}"));
+            }
+        } else {
+            let factory = self
+                .factory
+                .as_ref()
+                .ok_or_else(|| "no camera available".to_string())?;
+            debug!("opening camera");
+            let mut camera = factory(config).map_err(|e| format!("failed to open camera: {e}"))?;
+            let warmup = self
+                .warmup_frames_override
+                .unwrap_or(config.device.warmup_frames);
+            // A cold warmup discard is advisory (AGC/AE settling); a failure
+            // here is left for the scan loop to surface, as it always was.
+            if let Err(e) = discard_frames(&mut camera, warmup, "warmup") {
+                debug!("warmup discard failed: {e}");
+            }
+            self.camera = Some(camera);
+        }
+
+        self.camera
+            .as_mut()
+            .ok_or_else(|| "no camera available".to_string())
+    }
+
+    /// End the request that `acquire` started. Either sets a deadline or
+    /// drops the camera — never neither.
+    fn finish(&mut self, outcome: Outcome, config: &Config) {
+        if !outcome.holds_camera() {
+            self.close(match outcome {
+                Outcome::Success => "authentication succeeded",
+                Outcome::Cancelled => "request cancelled",
+                _ => "request ended without an answer",
+            });
+            return;
+        }
+        let hold_secs = config.device.camera_release_secs;
+        if hold_secs == 0 {
+            // `0` used to be silently substituted with 5 seconds. It now means
+            // what it says.
+            self.close("camera hold disabled (device.camera_release_secs = 0)");
+            return;
+        }
+        self.deadline = Some(Instant::now() + Duration::from_secs(hold_secs as u64));
+        debug!(
+            hold_secs,
+            "holding camera warm after a failed attempt (retry expected)"
+        );
+    }
+
+    /// Extend the hold for a preview stream, which is a sequence of
+    /// single-frame requests rather than one long one.
+    fn touch_preview(&mut self, config: &Config) {
+        let hold =
+            Duration::from_secs(config.device.camera_release_secs as u64).max(PREVIEW_MIN_HOLD);
+        self.deadline = Some(Instant::now() + hold);
+    }
+
+    /// Close the camera if its warm hold has run out. Driven by the daemon's
+    /// [`CAMERA_POLL_INTERVAL`] tick against the absolute deadline.
+    fn expire(&mut self, now: Instant) {
+        if self.deadline.is_some_and(|deadline| now >= deadline) {
+            self.deadline = None;
+            self.close("warm hold expired");
+        }
+    }
+
+    /// Cancel whatever is in flight and close the camera now — suspend,
+    /// `ReleaseCamera`, shutdown. Setting the token needs no handler lock, so
+    /// this is safe to reach even while a request holds one.
+    fn release(&mut self) {
+        self.cancel.store(true, Ordering::SeqCst);
+        self.deadline = None;
+        self.close("camera release requested");
+    }
+
+    /// Drop the stream (`Drop` runs STREAMOFF and disables the IR emitter).
+    fn close(&mut self, reason: &str) {
+        if self.camera.is_some() {
+            debug!(reason, "releasing camera");
+            self.camera = None;
+        }
+    }
+}
 
 pub struct Handler<C: CameraSource, E: FaceProcessor> {
     pub config: Config,
@@ -177,12 +433,10 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     /// open, its own `capabilities()` are authoritative.
     pub device_caps: facelock_core::types::CameraCaps,
     pub shutdown_requested: bool,
-    camera: Option<C>,
-    camera_factory: Option<CameraFactory<C>>,
-    camera_last_used: Instant,
+    /// The open camera, its warm-hold deadline and the in-flight cancel
+    /// token. The only path to any of the three.
+    pub(crate) lease: CameraLease<C>,
     jpeg_buf: Vec<u8>,
-    /// Quirk-overridden warmup frames (takes precedence over config if `Some`).
-    warmup_frames_override: Option<u32>,
     /// Held TPM sealer for `tpm.seal_database` stores. Without the `tpm`
     /// feature this is the passthrough sealer, whose per-row unseal reports a
     /// clear "compile with tpm" error instead of misreading sealed blobs.
@@ -306,63 +560,19 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             rate_limiter,
             device_caps,
             shutdown_requested: false,
-            camera: None,
-            camera_factory,
-            camera_last_used: Instant::now(),
+            lease: CameraLease::new(camera_factory, warmup_frames_override),
             jpeg_buf: Vec::with_capacity(JPEG_BUF_CAPACITY),
-            warmup_frames_override,
             tpm_sealer,
             software_sealer,
             sealer_init_error,
         })
     }
 
-    pub fn maybe_release_camera(&mut self) {
-        let debounce = if self.config.device.camera_release_secs > 0 {
-            Duration::from_secs(self.config.device.camera_release_secs as u64)
-        } else {
-            CAMERA_DEBOUNCE_FALLBACK
-        };
-        if self.camera.is_some() && self.camera_last_used.elapsed() > debounce {
-            debug!("releasing camera (debounce)");
-            self.camera = None;
-        }
-    }
-
-    fn acquire_camera(&mut self) -> Result<(), DaemonResponse> {
-        if self.camera.is_none() {
-            debug!("opening camera");
-            if let Some(ref factory) = self.camera_factory {
-                let mut cam = factory(&self.config).map_err(|e| DaemonResponse::Error {
-                    message: format!("failed to open camera: {e}"),
-                })?;
-                // Discard warmup frames for AGC/AE stabilization.
-                // Quirk override takes precedence over config value.
-                let warmup = self
-                    .warmup_frames_override
-                    .unwrap_or(self.config.device.warmup_frames);
-                if warmup > 0 {
-                    debug!(warmup, "discarding warmup frames");
-                    for _ in 0..warmup {
-                        let _ = cam.capture();
-                    }
-                }
-                self.camera = Some(cam);
-            } else {
-                return Err(DaemonResponse::Error {
-                    message: "no camera available".into(),
-                });
-            }
-        }
-        self.camera_last_used = Instant::now();
-        Ok(())
-    }
-
-    fn release_camera(&mut self) {
-        if self.camera.is_some() {
-            debug!("releasing camera");
-            self.camera = None;
-        }
+    /// Close the camera if its warm hold has run out. Called from the
+    /// daemon's [`CAMERA_POLL_INTERVAL`] tick; a tick that finds the handler
+    /// locked simply misses, because the deadline is absolute.
+    pub fn expire_camera(&mut self, now: Instant) {
+        self.lease.expire(now);
     }
 
     /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs
@@ -408,13 +618,13 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
 
             DaemonRequest::Shutdown => {
                 info!("shutdown requested via IPC");
-                self.release_camera();
+                self.lease.release();
                 self.shutdown_requested = true;
                 DaemonResponse::Ok
             }
 
             DaemonRequest::ReleaseCamera => {
-                self.release_camera();
+                self.lease.release();
                 DaemonResponse::Ok
             }
 
@@ -450,16 +660,15 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     warn!(user, "enroll refused (encryption unavailable): {message}");
                     return DaemonResponse::Error { message };
                 }
-                if let Err(resp) = self.acquire_camera() {
-                    return resp;
-                }
-
-                let mut camera = self.camera.take().unwrap();
+                let camera = match self.lease.acquire(&self.config) {
+                    Ok(camera) => camera,
+                    Err(message) => return DaemonResponse::Error { message },
+                };
                 // The enrolling camera's own identity — asked of the camera
                 // actually recording the template, not a handler-level copy.
                 let device_id = camera.capabilities().fingerprint.canonical_for_storage();
                 let result = enroll::enroll(
-                    &mut camera,
+                    camera,
                     &mut self.engine,
                     &self.store,
                     &self.config,
@@ -468,8 +677,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     self.software_sealer.as_ref(),
                     device_id.as_deref(),
                 );
-                self.camera = Some(camera);
-                self.camera_last_used = Instant::now();
+                self.lease.finish(Outcome::from(&result), &self.config);
                 result.into()
             }
 
@@ -534,50 +742,58 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
 
             DaemonRequest::PreviewFrame => {
-                if let Err(resp) = self.acquire_camera() {
-                    return resp;
-                }
-                let camera = self.camera.as_mut().unwrap();
-                match camera.capture_rgb_only() {
-                    Ok(frame) => self.encode_frame_response(&frame.rgb, frame.width, frame.height),
-                    Err(e) => DaemonResponse::Error {
-                        message: format!("capture error: {e}"),
-                    },
+                let captured = match self.lease.acquire(&self.config) {
+                    Ok(camera) => camera.capture_rgb_only(),
+                    Err(message) => return DaemonResponse::Error { message },
+                };
+                match captured {
+                    Ok(frame) => {
+                        self.lease.touch_preview(&self.config);
+                        self.encode_frame_response(&frame.rgb, frame.width, frame.height)
+                    }
+                    Err(e) => {
+                        self.lease.finish(Outcome::Error, &self.config);
+                        DaemonResponse::Error {
+                            message: format!("capture error: {e}"),
+                        }
+                    }
                 }
             }
 
             DaemonRequest::PreviewDetectFrame { user } => {
-                if let Err(resp) = self.acquire_camera() {
-                    return resp;
-                }
-                // Take camera for split borrow, put back after
-                let mut camera = self.camera.take().unwrap();
-                let result = match camera.capture() {
-                    Ok(frame) => {
-                        let faces = self.detect_and_match(&frame, &user);
-                        self.jpeg_buf.clear();
-                        let mut encoder = JpegEncoder::new_with_quality(&mut self.jpeg_buf, 60);
-                        match encoder.encode(
-                            &frame.rgb,
-                            frame.width,
-                            frame.height,
-                            image::ExtendedColorType::Rgb8,
-                        ) {
-                            Ok(()) => DaemonResponse::DetectFrame {
-                                jpeg_data: std::mem::take(&mut self.jpeg_buf),
-                                faces,
-                            },
-                            Err(e) => DaemonResponse::Error {
-                                message: format!("JPEG encode error: {e}"),
-                            },
-                        }
-                    }
-                    Err(e) => DaemonResponse::Error {
-                        message: format!("capture error: {e}"),
-                    },
+                let captured = match self.lease.acquire(&self.config) {
+                    Ok(camera) => camera.capture(),
+                    Err(message) => return DaemonResponse::Error { message },
                 };
-                self.camera = Some(camera);
-                result
+                let frame = match captured {
+                    Ok(frame) => {
+                        self.lease.touch_preview(&self.config);
+                        frame
+                    }
+                    Err(e) => {
+                        self.lease.finish(Outcome::Error, &self.config);
+                        return DaemonResponse::Error {
+                            message: format!("capture error: {e}"),
+                        };
+                    }
+                };
+                let faces = self.detect_and_match(&frame, &user);
+                self.jpeg_buf.clear();
+                let mut encoder = JpegEncoder::new_with_quality(&mut self.jpeg_buf, 60);
+                match encoder.encode(
+                    &frame.rgb,
+                    frame.width,
+                    frame.height,
+                    image::ExtendedColorType::Rgb8,
+                ) {
+                    Ok(()) => DaemonResponse::DetectFrame {
+                        jpeg_data: std::mem::take(&mut self.jpeg_buf),
+                        faces,
+                    },
+                    Err(e) => DaemonResponse::Error {
+                        message: format!("JPEG encode error: {e}"),
+                    },
+                }
             }
         }
     }
@@ -623,22 +839,28 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
         };
 
-        if let Err(resp) = self.acquire_camera() {
-            return resp;
-        }
-
         // Pre-load and decrypt embeddings (handles TPM + software encryption)
+        // *before* the camera opens: nothing here needs a frame, and every
+        // millisecond between `open` and the first analyzed frame is LED-on
+        // time the user reads as a strobe (ADR 008 §1).
         let mut stored = match self.load_user_embeddings(&user) {
             Ok(s) => s,
             Err(resp) => return resp,
         };
 
-        // Split borrows: take camera out, run auth, put it back
-        let mut camera = self.camera.take().unwrap();
+        let camera = match self.lease.acquire(&self.config) {
+            Ok(camera) => camera,
+            Err(message) => {
+                // The callee below is what normally wipes `stored` (D11);
+                // on this path it never runs, so wipe it here.
+                facelock_core::types::zeroize_stored_embeddings(&mut stored);
+                return DaemonResponse::Error { message };
+            }
+        };
         // `stored` is wiped by the callee (D11) — this plaintext set must not
         // be read again below.
         let result = auth::authenticate_with_embeddings(
-            &mut camera,
+            camera,
             &mut self.engine,
             &mut stored,
             &models,
@@ -646,8 +868,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &user,
             intent.audit_source(),
         );
-        self.camera = Some(camera);
-        self.camera_last_used = Instant::now();
+        self.lease.finish(Outcome::from(&result), &self.config);
         // Only failed auths count against the rate limit, and only for the
         // real-authentication intent (see [`AuthIntent`]).
         if let AuthOutcome::AuthResult(ref mr) = result {
@@ -741,5 +962,239 @@ mod tests {
     fn each_intent_stamps_its_own_audit_source() {
         assert_eq!(AuthIntent::Authenticate.audit_source(), AuditSource::Daemon);
         assert_eq!(AuthIntent::Test.audit_source(), AuditSource::Test);
+    }
+
+    // -----------------------------------------------------------------
+    // CameraLease (ADR 008 §4, §9)
+    // -----------------------------------------------------------------
+
+    use crate::auth::ErrorKind;
+    use facelock_core::types::MatchResult;
+    use facelock_test_support::MockCamera;
+
+    /// How many frames the mock camera can serve before it wraps (and its
+    /// capture counter resets), kept far above anything these tests take.
+    const MOCK_FRAMES: usize = 256;
+
+    fn lease_config(release_secs: u32) -> Config {
+        let mut config = Config::default();
+        config.device.camera_release_secs = release_secs;
+        config
+    }
+
+    fn lease() -> CameraLease<MockCamera> {
+        CameraLease::new(
+            Some(Box::new(|_| Ok(MockCamera::bright(64, 64, MOCK_FRAMES)))),
+            None,
+        )
+    }
+
+    fn match_result(matched: bool) -> MatchResult {
+        MatchResult {
+            matched,
+            model_id: matched.then_some(1),
+            label: None,
+            similarity: if matched { 0.9 } else { 0.1 },
+            face_detected: true,
+            failure_reason: None,
+        }
+    }
+
+    /// The classification table of ADR 008 §4, over **every** shape an
+    /// authentication can end in — including every `ErrorKind`, so a new
+    /// rejection class cannot quietly inherit a camera policy nobody chose.
+    ///
+    /// The `From` impl it exercises has no wildcard arm, so a new
+    /// `AuthOutcome` variant fails to compile until it is classified here.
+    #[test]
+    fn every_auth_outcome_classifies_into_the_camera_policy() {
+        assert_eq!(
+            Outcome::from(&AuthOutcome::AuthResult(match_result(true))),
+            Outcome::Success
+        );
+        assert_eq!(
+            Outcome::from(&AuthOutcome::AuthResult(match_result(false))),
+            Outcome::Failure
+        );
+        assert_eq!(Outcome::from(&AuthOutcome::Suppressed), Outcome::Error);
+        for kind in ErrorKind::ALL {
+            assert_eq!(
+                Outcome::from(&AuthOutcome::error(*kind)),
+                Outcome::Error,
+                "{kind:?} must never hold the camera open"
+            );
+        }
+    }
+
+    /// Enrollment's half of the same table.
+    #[test]
+    fn every_enroll_outcome_classifies_into_the_camera_policy() {
+        assert_eq!(
+            Outcome::from(&EnrollOutcome::Enrolled {
+                model_id: 1,
+                embedding_count: 3
+            }),
+            Outcome::Success
+        );
+        assert_eq!(
+            Outcome::from(&EnrollOutcome::Error {
+                message: "boom".into()
+            }),
+            Outcome::Error
+        );
+    }
+
+    /// Only a failed attempt keeps the stream open — the whole policy.
+    #[test]
+    fn only_failure_holds_the_camera() {
+        for outcome in Outcome::ALL {
+            assert_eq!(
+                outcome.holds_camera(),
+                *outcome == Outcome::Failure,
+                "{outcome:?}"
+            );
+        }
+    }
+
+    /// The invariant of ADR 008 §8: every exit from an active request either
+    /// sets a deadline or drops the camera — never neither, never both.
+    #[test]
+    fn finish_either_sets_a_deadline_or_drops_the_camera() {
+        let config = lease_config(3);
+        for outcome in Outcome::ALL {
+            let mut lease = lease();
+            lease.acquire(&config).expect("mock camera opens");
+            lease.finish(*outcome, &config);
+            if outcome.holds_camera() {
+                assert!(lease.camera.is_some(), "{outcome:?} must keep the stream");
+                assert!(lease.deadline.is_some(), "{outcome:?} must set a deadline");
+            } else {
+                assert!(lease.camera.is_none(), "{outcome:?} must close the stream");
+                assert!(lease.deadline.is_none(), "{outcome:?} must clear the hold");
+            }
+        }
+    }
+
+    /// `camera_release_secs = 0` means never hold. It used to be silently
+    /// substituted with 5 seconds, which is why honoring it is a fix.
+    #[test]
+    fn zero_release_secs_closes_the_camera_even_on_failure() {
+        let config = lease_config(0);
+        let mut lease = lease();
+        lease.acquire(&config).expect("mock camera opens");
+        lease.finish(Outcome::Failure, &config);
+        assert!(lease.camera.is_none());
+        assert!(lease.deadline.is_none());
+    }
+
+    /// The hold runs to its deadline and not past it. The deadline is
+    /// absolute, so a tick that arrives late still releases at the right
+    /// wall-clock instant rather than restarting the clock.
+    #[test]
+    fn expire_closes_the_camera_only_after_the_deadline() {
+        let config = lease_config(3);
+        let mut lease = lease();
+        lease.acquire(&config).expect("mock camera opens");
+        let at_finish = Instant::now();
+        lease.finish(Outcome::Failure, &config);
+
+        // One poll tick before the deadline: still warm.
+        lease.expire(at_finish + Duration::from_secs(3) - CAMERA_POLL_INTERVAL);
+        assert!(lease.camera.is_some(), "released a full tick early");
+
+        // One tick after: closed, and the hold is cleared with it.
+        lease.expire(at_finish + Duration::from_secs(3) + CAMERA_POLL_INTERVAL);
+        assert!(lease.camera.is_none());
+        assert!(lease.deadline.is_none());
+    }
+
+    /// A warm reuse discards exactly the frames V4L2 left in the ring and
+    /// runs no warmup: AE is already settled, and the stale buffers are the
+    /// only thing standing between this attempt and the previous one's tail.
+    #[test]
+    fn warm_reuse_discards_the_stale_buffers_and_skips_warmup() {
+        let config = lease_config(3);
+        let warmup = config.device.warmup_frames;
+        let mut lease = lease();
+
+        lease.acquire(&config).expect("mock camera opens");
+        let after_cold = lease.camera.as_ref().map(|c| c.captures());
+        assert_eq!(after_cold, Some(warmup as usize), "cold open runs warmup");
+
+        lease.finish(Outcome::Failure, &config);
+        assert!(lease.camera.is_some(), "a failure holds the stream");
+
+        lease.acquire(&config).expect("warm camera is reused");
+        let after_warm = lease.camera.as_ref().map(|c| c.captures());
+        assert_eq!(
+            after_warm,
+            Some((warmup + MMAP_BUFFERS - 1) as usize),
+            "warm reuse must discard exactly MMAP_BUFFERS - 1 frames and no warmup"
+        );
+    }
+
+    /// A preview is a stream of one-frame requests at ~10 fps, so its hold
+    /// has a floor that `camera_release_secs = 0` cannot drop below —
+    /// otherwise every frame would reopen the camera.
+    #[test]
+    fn preview_holds_the_camera_for_at_least_the_floor() {
+        let config = lease_config(0);
+        let mut lease = lease();
+        lease.acquire(&config).expect("mock camera opens");
+        let before = Instant::now();
+        lease.touch_preview(&config);
+
+        let deadline = lease.deadline.expect("preview must set a hold");
+        assert!(
+            deadline >= before + PREVIEW_MIN_HOLD,
+            "preview hold fell below the floor with camera_release_secs = 0"
+        );
+        // And it really is a hold: a tick inside the floor leaves it open.
+        lease.expire(before + PREVIEW_MIN_HOLD - CAMERA_POLL_INTERVAL);
+        assert!(lease.camera.is_some());
+    }
+
+    /// A larger `camera_release_secs` raises the preview hold rather than
+    /// being clamped to the floor.
+    #[test]
+    fn preview_hold_takes_the_larger_of_the_floor_and_the_configured_hold() {
+        let config = lease_config(10);
+        let mut lease = lease();
+        lease.acquire(&config).expect("mock camera opens");
+        let before = Instant::now();
+        lease.touch_preview(&config);
+        let deadline = lease.deadline.expect("preview must set a hold");
+        assert!(deadline >= before + Duration::from_secs(10));
+    }
+
+    /// `ReleaseCamera`, suspend and shutdown all land here: the in-flight
+    /// request is told to stop and the stream closes without waiting for it.
+    #[test]
+    fn release_sets_the_cancel_token_and_closes_the_camera() {
+        let config = lease_config(3);
+        let mut lease = lease();
+        let token = lease.cancel_token();
+        lease.acquire(&config).expect("mock camera opens");
+        assert!(!token.load(Ordering::SeqCst), "acquire resets the token");
+
+        lease.release();
+        assert!(token.load(Ordering::SeqCst));
+        assert!(lease.camera.is_none());
+        assert!(lease.deadline.is_none());
+    }
+
+    /// A camera factory that cannot open is an error, never a warm state.
+    #[test]
+    fn a_failed_open_leaves_nothing_open() {
+        let config = lease_config(3);
+        let mut lease: CameraLease<MockCamera> =
+            CameraLease::new(Some(Box::new(|_| Err("no such device".into()))), None);
+        let err = match lease.acquire(&config) {
+            Ok(_) => panic!("a factory that returns Err must not yield a camera"),
+            Err(e) => e,
+        };
+        assert!(err.contains("failed to open camera"));
+        assert!(lease.camera.is_none());
+        assert!(lease.deadline.is_none());
     }
 }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use facelock_camera::MMAP_BUFFERS;
@@ -12,7 +10,8 @@ use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
 
 use crate::audit::AuditSource;
-use crate::auth::{self, AuthOutcome, PreCheckContext};
+use crate::auth::{self, AuthOutcome, CANCELLED_MESSAGE, PreCheckContext};
+use crate::cancel::CancelToken;
 use crate::enroll::{self, EnrollOutcome};
 use crate::rate_limit::RateLimiter;
 
@@ -143,6 +142,14 @@ impl From<AuthOutcome> for DaemonResponse {
             AuthOutcome::AuthResult(result) => DaemonResponse::AuthResult(result),
             AuthOutcome::Suppressed => DaemonResponse::Suppressed,
             AuthOutcome::Error { message, .. } => DaemonResponse::Error { message },
+            // The wire has no cancellation shape of its own, so a cancelled
+            // attempt travels as a recoverable error whose message is the
+            // frozen `cancelled` string. PAM maps it to PAM_IGNORE — the
+            // stack falls through to password, which is what the user who
+            // just typed one expects (docs/contracts.md).
+            AuthOutcome::Cancelled => DaemonResponse::Error {
+                message: CANCELLED_MESSAGE.to_string(),
+            },
         }
     }
 }
@@ -158,6 +165,9 @@ impl From<EnrollOutcome> for DaemonResponse {
                 embedding_count,
             },
             EnrollOutcome::Error { message } => DaemonResponse::Error { message },
+            EnrollOutcome::Cancelled => DaemonResponse::Error {
+                message: CANCELLED_MESSAGE.to_string(),
+            },
         }
     }
 }
@@ -239,6 +249,7 @@ impl From<&AuthOutcome> for Outcome {
             // Every `ErrorKind`, including `AllFramesDark` and the camera and
             // capture failures.
             AuthOutcome::Error { .. } => Outcome::Error,
+            AuthOutcome::Cancelled => Outcome::Cancelled,
         }
     }
 }
@@ -252,6 +263,7 @@ impl From<&EnrollOutcome> for Outcome {
         match outcome {
             EnrollOutcome::Enrolled { .. } => Outcome::Success,
             EnrollOutcome::Error { .. } => Outcome::Error,
+            EnrollOutcome::Cancelled => Outcome::Cancelled,
         }
     }
 }
@@ -263,12 +275,23 @@ impl From<&EnrollOutcome> for Outcome {
 /// MMAP buffers V4L2 left filled after the previous request. Sharing it is
 /// what keeps "the frames a warm stream hands back first are not analyzed"
 /// true by construction rather than by two similar loops agreeing.
-fn discard_frames<C: CameraSource>(camera: &mut C, count: u32, reason: &str) -> Result<(), String> {
+fn discard_frames<C: CameraSource>(
+    camera: &mut C,
+    count: u32,
+    reason: &str,
+    cancel: &CancelToken,
+) -> Result<(), String> {
     if count == 0 {
         return Ok(());
     }
     debug!(count, reason, "discarding frames");
     for _ in 0..count {
+        // A discard is a blocking capture like any other, so it honors the
+        // token too: cancelling during warmup must not wait out the whole
+        // ring before the camera closes (ADR 008 §8).
+        if cancel.is_cancelled() {
+            return Err(CANCELLED_MESSAGE.to_string());
+        }
         camera.capture().map_err(|e| e.to_string())?;
     }
     Ok(())
@@ -289,7 +312,7 @@ pub(crate) struct CameraLease<C: CameraSource> {
     /// Set to abort the in-flight request within one frame. Shared with the
     /// request itself, so suspend/shutdown/`ReleaseCamera` can set it without
     /// taking the handler lock.
-    cancel: Arc<AtomicBool>,
+    cancel: CancelToken,
     factory: Option<CameraFactory<C>>,
     /// Quirk-overridden warmup frames (takes precedence over config).
     warmup_frames_override: Option<u32>,
@@ -300,28 +323,42 @@ impl<C: CameraSource> CameraLease<C> {
         Self {
             camera: None,
             deadline: None,
-            cancel: Arc::new(AtomicBool::new(false)),
+            cancel: CancelToken::new(),
             factory,
             warmup_frames_override,
         }
     }
 
-    /// The token an in-flight request checks. Cloneable so a watcher can set
-    /// it without the handler lock.
-    #[allow(dead_code)]
-    pub(crate) fn cancel_token(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.cancel)
+    /// The token an in-flight request checks. Cloned, not borrowed, so a
+    /// watcher can set it without the handler lock — the whole point (§5).
+    pub(crate) fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
+    }
+
+    /// Adopt a token minted elsewhere. The D-Bus server owns one for the
+    /// daemon's whole life and re-installs it after a config reload rebuilds
+    /// the handler, so the watchers it handed out keep working.
+    pub(crate) fn set_cancel_token(&mut self, token: CancelToken) {
+        self.cancel = token;
     }
 
     /// Open the camera (or reuse a warm one) for a request that is about to
-    /// run. Clears any warm-hold deadline and resets the cancel token: from
-    /// here until `finish`, the stream belongs to this request.
+    /// run. Clears any warm-hold deadline: from here until `finish`, the
+    /// stream belongs to this request. A request that was already cancelled
+    /// never opens the camera at all.
     ///
     /// The returned borrow is tied to the lease, not to `config`, so a caller
     /// can still reach the handler's other fields while holding the camera.
     fn acquire<'a>(&'a mut self, config: &Config) -> Result<&'a mut C, String> {
         self.deadline = None;
-        self.cancel.store(false, Ordering::SeqCst);
+        // The token is *not* reset here. Arming is the caller's job (see
+        // `CancelToken::arm`) and happens before the watchers subscribe, so a
+        // cancellation that lands between subscribing and the first frame
+        // cannot be erased by the request it is meant to stop.
+        if self.cancel.is_cancelled() {
+            self.close("cancelled before the camera was needed");
+            return Err(CANCELLED_MESSAGE.to_string());
+        }
 
         if self.camera.is_some() {
             // Warm reuse. The stream never stopped, so its buffers still hold
@@ -329,7 +366,7 @@ impl<C: CameraSource> CameraLease<C> {
             // those would let a fresh attempt match on the tail of the last
             // one. AE is already settled, so no warmup discard is needed.
             let stale = match self.camera.as_mut() {
-                Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale"),
+                Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale", &self.cancel),
                 None => Ok(()),
             };
             if let Err(e) = stale {
@@ -351,8 +388,13 @@ impl<C: CameraSource> CameraLease<C> {
                 .unwrap_or(config.device.warmup_frames);
             // A cold warmup discard is advisory (AGC/AE settling); a failure
             // here is left for the scan loop to surface, as it always was.
-            if let Err(e) = discard_frames(&mut camera, warmup, "warmup") {
+            if let Err(e) = discard_frames(&mut camera, warmup, "warmup", &self.cancel) {
                 debug!("warmup discard failed: {e}");
+                // A cancellation during warmup aborts the acquire outright:
+                // the request is over before it started (ADR 008 §8).
+                if self.cancel.is_cancelled() {
+                    return Err(CANCELLED_MESSAGE.to_string());
+                }
             }
             self.camera = Some(camera);
         }
@@ -404,13 +446,23 @@ impl<C: CameraSource> CameraLease<C> {
         }
     }
 
-    /// Cancel whatever is in flight and close the camera now — suspend,
-    /// `ReleaseCamera`, shutdown. Setting the token needs no handler lock, so
-    /// this is safe to reach even while a request holds one.
+    /// Close the camera now — the `ReleaseCamera`, shutdown and suspend
+    /// paths.
+    ///
+    /// Cancelling the request that may be holding the camera is *not* done
+    /// here, because it cannot be: this method needs the handler mutex, and a
+    /// capture in flight is holding it. The token is set first, lock-free, by
+    /// whoever is asking (see `FacelockService::release_camera_as` and the
+    /// suspend watcher); by the time this runs, that request has already
+    /// returned.
+    ///
+    /// Which is also why it re-arms the token on the way out: holding the
+    /// mutex proves nothing is in flight, so leaving the flag latched would
+    /// only cancel the *next* request, which nobody asked for.
     fn release(&mut self) {
-        self.cancel.store(true, Ordering::SeqCst);
         self.deadline = None;
         self.close("camera release requested");
+        self.cancel.arm();
     }
 
     /// Drop the stream (`Drop` runs STREAMOFF and disables the IR emitter).
@@ -575,6 +627,21 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         self.lease.expire(now);
     }
 
+    /// The token every camera loop in this handler checks. Cloned, so the
+    /// D-Bus server can hand it to a per-request caller watch, to the
+    /// suspend watcher, and to `ReleaseCamera` without ever taking the
+    /// handler mutex — which the request being cancelled is holding.
+    pub fn cancel_token(&self) -> CancelToken {
+        self.lease.cancel_token()
+    }
+
+    /// Adopt a token minted elsewhere. The server owns one for the daemon's
+    /// whole life and re-installs it on the handler a config reload rebuilds,
+    /// so watchers registered against the old handler keep working.
+    pub fn set_cancel_token(&mut self, token: CancelToken) {
+        self.lease.set_cancel_token(token);
+    }
+
     /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs
     /// through the shared per-row implementation (`crate::embeddings`, N10).
     /// Falls back to the standard `get_user_embeddings` path when nothing could
@@ -660,6 +727,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     warn!(user, "enroll refused (encryption unavailable): {message}");
                     return DaemonResponse::Error { message };
                 }
+                let cancel = self.lease.cancel_token();
                 let camera = match self.lease.acquire(&self.config) {
                     Ok(camera) => camera,
                     Err(message) => return DaemonResponse::Error { message },
@@ -676,6 +744,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     &label,
                     self.software_sealer.as_ref(),
                     device_id.as_deref(),
+                    &cancel,
                 );
                 self.lease.finish(Outcome::from(&result), &self.config);
                 result.into()
@@ -848,6 +917,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             Err(resp) => return resp,
         };
 
+        let cancel = self.lease.cancel_token();
         let camera = match self.lease.acquire(&self.config) {
             Ok(camera) => camera,
             Err(message) => {
@@ -867,6 +937,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &self.config,
             &user,
             intent.audit_source(),
+            &cancel,
         );
         self.lease.finish(Outcome::from(&result), &self.config);
         // Only failed auths count against the rate limit, and only for the
@@ -1167,20 +1238,43 @@ mod tests {
         assert!(deadline >= before + Duration::from_secs(10));
     }
 
-    /// `ReleaseCamera`, suspend and shutdown all land here: the in-flight
-    /// request is told to stop and the stream closes without waiting for it.
+    /// `ReleaseCamera`, suspend and shutdown all land here. The camera goes
+    /// at once — and the token is left *ready*, not latched: whoever asked
+    /// already set it lock-free to stop the request in flight, and by the
+    /// time this runs that request has returned. Latching it would cancel the
+    /// next request instead, which is how a `ReleaseCamera` used to be able
+    /// to wedge every later preview frame.
     #[test]
-    fn release_sets_the_cancel_token_and_closes_the_camera() {
+    fn release_closes_the_camera_and_leaves_the_token_ready() {
         let config = lease_config(3);
         let mut lease = lease();
         let token = lease.cancel_token();
         lease.acquire(&config).expect("mock camera opens");
-        assert!(!token.load(Ordering::SeqCst), "acquire resets the token");
 
+        token.cancel();
         lease.release();
-        assert!(token.load(Ordering::SeqCst));
         assert!(lease.camera.is_none());
         assert!(lease.deadline.is_none());
+        assert!(!token.is_cancelled(), "release must not latch the token");
+
+        // ...and the next request still works.
+        lease.acquire(&config).expect("a later request still opens");
+        assert!(lease.camera.is_some());
+    }
+
+    /// The other half of the token contract: a request that finds it set
+    /// never opens the camera at all (ADR 008 §8).
+    #[test]
+    fn a_cancelled_request_never_opens_the_camera() {
+        let config = lease_config(3);
+        let mut lease = lease();
+        lease.cancel_token().cancel();
+        let err = match lease.acquire(&config) {
+            Ok(_) => panic!("a cancelled request must not get a camera"),
+            Err(e) => e,
+        };
+        assert_eq!(err, crate::auth::CANCELLED_MESSAGE);
+        assert!(lease.camera.is_none());
     }
 
     /// A camera factory that cannot open is an error, never a warm state.

--- a/crates/facelock-daemon/src/lib.rs
+++ b/crates/facelock-daemon/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod auth;
+pub mod cancel;
 pub mod embeddings;
 pub mod enroll;
 pub mod handler;

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -24,7 +24,7 @@ use nix::unistd::{Uid, User};
 use tracing::{error, info, warn};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
-use crate::handler::{AuthIntent, DaemonRequest, DaemonResponse, Handler};
+use crate::handler::{AuthIntent, CAMERA_POLL_INTERVAL, DaemonRequest, DaemonResponse, Handler};
 
 /// Production type alias for the handler with real Camera and FaceEngine.
 pub type ProductionHandler = Handler<Camera<'static>, FaceEngine>;
@@ -1317,7 +1317,7 @@ async fn poll_shutdown(
     idle_timeout_secs: u64,
 ) {
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(CAMERA_POLL_INTERVAL).await;
 
         // Check idle timeout (0 = disabled)
         if idle_timeout_secs > 0 {
@@ -1339,7 +1339,7 @@ async fn poll_shutdown(
                 if h.shutdown_requested {
                     return true;
                 }
-                h.maybe_release_camera();
+                h.expire_camera(Instant::now());
             }
             false
         })

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -144,6 +144,86 @@ impl Drop for CaptureGuard {
     }
 }
 
+/// The cancel token of the request currently holding the capture slot, if
+/// any — the one handle suspend, `ReleaseCamera` and shutdown have on
+/// whatever is in flight.
+///
+/// They cannot reach it any other way: cancelling means setting a flag the
+/// running request reads, and the running request is holding the handler
+/// mutex, so anything that has to take that mutex first is already too late.
+/// Hence a slot of its own, guarded by a mutex held only long enough to clone
+/// a token out of it — never across a capture, never nested inside the
+/// handler lock.
+///
+/// The generation counter is what makes a *stale* token harmless. Requests
+/// overlap at the edges (one is delivering its notification while the next
+/// has already claimed the capture slot), so "clear the slot when my request
+/// ends" must mean "clear it only if it is still mine". Without that, a
+/// finishing request would clear its successor's entry and the next
+/// `ReleaseCamera` would find an empty slot and cancel nothing.
+#[derive(Clone, Debug, Default)]
+pub struct CurrentRequest(Arc<CurrentRequestInner>);
+
+#[derive(Debug, Default)]
+struct CurrentRequestInner {
+    slot: Mutex<Option<(u64, CancelToken)>>,
+    generation: AtomicU64,
+}
+
+impl CurrentRequest {
+    /// Publish `token` as the in-flight request's, until the returned guard
+    /// drops. Called once the request is certain to run — after
+    /// authorization, after the capture slot is claimed — so a rejected call
+    /// never displaces the request it was rejected in favour of.
+    fn install(&self, token: CancelToken) -> CurrentRequestGuard {
+        let generation = self.0.generation.fetch_add(1, Ordering::Relaxed) + 1;
+        *self.lock() = Some((generation, token));
+        CurrentRequestGuard {
+            current: self.clone(),
+            generation,
+        }
+    }
+
+    /// Cancel whatever is in flight. Lock-free from the request's point of
+    /// view (this mutex is not the handler's), and a no-op when the slot is
+    /// empty — nothing is running, so there is nothing to stop.
+    pub fn cancel(&self) {
+        if let Some((_, token)) = self.lock().as_ref() {
+            token.cancel();
+        }
+    }
+
+    /// A poisoned slot is recovered rather than propagated: the only code
+    /// that holds this lock stores or clones, so a poisoned mutex means some
+    /// *other* thread panicked, and refusing to cancel over it would leave
+    /// the camera streaming into a suspend.
+    fn lock(&self) -> MutexGuard<'_, Option<(u64, CancelToken)>> {
+        match self.0.slot.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+/// Clears the [`CurrentRequest`] slot when its request ends — but only if the
+/// slot still names that request (see the generation counter above).
+struct CurrentRequestGuard {
+    current: CurrentRequest,
+    generation: u64,
+}
+
+impl Drop for CurrentRequestGuard {
+    fn drop(&mut self) {
+        let mut slot = self.current.lock();
+        if slot
+            .as_ref()
+            .is_some_and(|(installed, _)| *installed == self.generation)
+        {
+            *slot = None;
+        }
+    }
+}
+
 /// A running watch on the caller's bus name, aborted when the request that
 /// registered it ends.
 ///
@@ -526,12 +606,11 @@ where
     config_mtime: Arc<Mutex<Option<std::time::SystemTime>>>,
     /// In-flight guard for camera-capture operations (DoS control).
     capture_slot: Arc<CaptureSlot>,
-    /// The daemon's cancel token, installed on the handler (and re-installed
-    /// on every rebuilt handler) so that suspend, `ReleaseCamera`, shutdown
-    /// and the per-request caller watch can stop an in-flight capture
-    /// **without taking the handler mutex** — which is exactly what the
-    /// request being cancelled is holding (ADR 008 §5).
-    cancel: CancelToken,
+    /// The cancel token of the request currently holding that capture slot,
+    /// so suspend, `ReleaseCamera` and shutdown can stop it **without taking
+    /// the handler mutex** — which is exactly what the request being
+    /// cancelled is holding (ADR 008 §5).
+    current: CurrentRequest,
     /// Builds per-user notifiers for auth outcomes. Injected from `main` so
     /// the server never names the delivery implementation (D9) — a
     /// prerequisite for moving this server out of facelock-cli.
@@ -549,31 +628,30 @@ where
     /// Construct the service around a built handler. [`run_dbus_server`]
     /// does this with production types; integration tests with mocks.
     pub fn new(
-        mut handler: Handler<C, E>,
+        handler: Handler<C, E>,
         startup_config_mtime: Option<std::time::SystemTime>,
         rebuild: Option<HandlerRebuild<C, E>>,
         notifier_factory: NotifierFactory,
     ) -> Self {
-        // One token for the daemon's lifetime. Minted here rather than read
-        // off the handler because a config reload builds a *new* handler, and
-        // every watcher already holding a clone must keep working across that
-        // swap — so the service owns it and the handler adopts it.
-        let cancel = CancelToken::new();
-        handler.set_cancel_token(cancel.clone());
         Self {
             handler: Arc::new(Mutex::new(handler)),
             last_activity: Arc::new(AtomicU64::new(now_secs())),
             config_mtime: Arc::new(Mutex::new(startup_config_mtime)),
             capture_slot: Arc::new(CaptureSlot::default()),
-            cancel,
+            // The slot starts empty: nothing is in flight, so there is
+            // nothing to cancel. It survives a config reload untouched
+            // because it holds a *request's* token, not the handler's — and
+            // reload only runs between requests anyway.
+            current: CurrentRequest::default(),
             notifier_factory,
             rebuild,
         }
     }
 
-    /// The daemon's cancel token, for the watchers `run_dbus_server` spawns.
-    pub fn cancel_token(&self) -> CancelToken {
-        self.cancel.clone()
+    /// The in-flight request's cancel token, for the suspend watcher
+    /// `run_dbus_server` spawns and for the tests that stand in for it.
+    pub fn current_request(&self) -> CurrentRequest {
+        self.current.clone()
     }
 
     /// Check if the config file has been modified since the handler was built.
@@ -603,17 +681,13 @@ where
 
         info!("config file changed, reloading");
 
-        let mut new_handler = match rebuild() {
+        let new_handler = match rebuild() {
             Ok(handler) => handler,
             Err(e) => {
                 warn!("failed to reload config: {e} — continuing with old config");
                 return;
             }
         };
-        // The rebuilt handler starts with a token of its own; replace it with
-        // the service's, so the watchers already holding clones keep reaching
-        // whatever is in flight after the swap.
-        new_handler.set_cancel_token(self.cancel.clone());
 
         // Swap in the new handler
         if let Ok(mut guard) = self.handler.lock() {
@@ -649,13 +723,25 @@ where
     /// charged. The diagnostic carve-out now lives in
     /// [`FacelockService::test_authenticate_as`], where it is asked for
     /// explicitly instead of inferred.
+    ///
+    /// `cancel` is this request's token and nobody else's — the glue mints it
+    /// per call and subscribes the caller-departure watch to it, so a second
+    /// caller (even one about to be denied) can neither clear it nor have its
+    /// own departure land on this request (ADR 008 §5).
     pub async fn authenticate_as(
         &self,
         caller: CallerIdentity,
         user: &str,
+        cancel: CancelToken,
     ) -> fdo::Result<AuthResult> {
-        self.run_authentication(caller, user, Method::Authenticate, AuthIntent::Authenticate)
-            .await
+        self.run_authentication(
+            caller,
+            user,
+            Method::Authenticate,
+            AuthIntent::Authenticate,
+            cancel,
+        )
+        .await
     }
 
     /// The root-only diagnostic entry point behind `facelock test` (N11,
@@ -672,9 +758,16 @@ where
         &self,
         caller: CallerIdentity,
         user: &str,
+        cancel: CancelToken,
     ) -> fdo::Result<AuthResult> {
-        self.run_authentication(caller, user, Method::TestAuthenticate, AuthIntent::Test)
-            .await
+        self.run_authentication(
+            caller,
+            user,
+            Method::TestAuthenticate,
+            AuthIntent::Test,
+            cancel,
+        )
+        .await
     }
 
     /// The body both authentication entry points share, so the diagnostic
@@ -689,18 +782,26 @@ where
         user: &str,
         method: Method,
         intent: AuthIntent,
+        cancel: CancelToken,
     ) -> fdo::Result<AuthResult> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
         authorize_method(&caller, method, Some(user))?;
         let caller_is_root = caller.uid == 0;
         let capture_guard = self.capture_slot.try_acquire(method.name())?;
+        // Publish the token only now. Both `?` above return without ever
+        // touching the slot, which is the point: the capture slot is what
+        // decides which request is *the* request, so a denied or busy-rejected
+        // call must not be able to displace the entry belonging to the one
+        // actually running — nor to leave its own dead token behind for the
+        // next suspend to cancel instead. Dropped at the end of this method.
+        let _current = self.current.install(cancel.clone());
         let handler = self.handler.clone();
         let notifier_factory = self.notifier_factory.clone();
         let user = user.to_string();
         let result = tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
-            let response = handler.handle_authenticate(user.clone(), intent);
+            let response = handler.handle_authenticate(user.clone(), intent, &cancel);
             // Notification settings come from the handler's config — the
             // freshest parse, since maybe_reload_handler ran at method entry.
             // No mid-request file re-read (D7).
@@ -755,16 +856,21 @@ where
         result.map(|auth| auth.redact_similarity_unless_root(caller_is_root))
     }
 
+    /// `cancel` is this request's own token; see [`Self::authenticate_as`].
     pub async fn enroll_as(
         &self,
         caller: CallerIdentity,
         user: &str,
         label: &str,
+        cancel: CancelToken,
     ) -> fdo::Result<(u32, u32)> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
         authorize_method(&caller, Method::Enroll, None)?;
         let capture_guard = self.capture_slot.try_acquire("Enroll")?;
+        // Same ordering rule as `run_authentication`: authorized and holding
+        // the capture slot, therefore this is the request in flight.
+        let _current = self.current.install(cancel.clone());
         let handler = self.handler.clone();
         let user = user.to_string();
         let label = label.to_string();
@@ -772,7 +878,7 @@ where
             let _capture_guard = capture_guard;
             let mut handler = lock_handler_with_timeout(&handler)?;
             let request = DaemonRequest::Enroll { user, label };
-            let response = handler.handle(request);
+            let response = handler.handle_with_cancel(request, &cancel);
             match response {
                 DaemonResponse::Enrolled {
                     model_id,
@@ -981,11 +1087,11 @@ where
     pub async fn release_camera_as(&self, caller: CallerIdentity) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         authorize_method(&caller, Method::ReleaseCamera, None)?;
-        // Set the token before queuing for the handler mutex. If a capture is
-        // in flight it holds that mutex, so the store below is the only thing
-        // that reaches it — and it is what lets the lock be acquired at all,
-        // within one frame instead of at `timeout_secs`.
-        self.cancel.cancel();
+        // Cancel the in-flight request before queuing for the handler mutex.
+        // If a capture is in flight it holds that mutex, so the store below is
+        // the only thing that reaches it — and it is what lets the lock be
+        // acquired at all, within one frame instead of at `timeout_secs`.
+        self.current.cancel();
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
@@ -1014,7 +1120,7 @@ where
         authorize_method(&caller, Method::Shutdown, None)?;
         // Same reason as `ReleaseCamera`: stop the capture before waiting on
         // the mutex it is holding.
-        self.cancel.cancel();
+        self.current.cancel();
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
@@ -1041,11 +1147,17 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         user: &str,
     ) -> fdo::Result<AuthResult> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
-        // Arm first, then subscribe: a cancellation that arrives after the
-        // subscription can never be erased by a later reset (ADR 008 §5).
-        self.cancel.arm();
-        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
-        let result = self.authenticate_as(caller, user).await;
+        // One token for this call and nothing else. zbus dispatches each
+        // method in its own task, so anything shared between calls is shared
+        // between *concurrent* calls: a token owned by the service could be
+        // cleared out from under an in-flight request by a second caller, and
+        // a departure watch subscribed against it would cancel whoever
+        // happened to be running when some other client exited. Minted fresh
+        // here, watched here, and passed down — nobody else can reach it
+        // (ADR 008 §5).
+        let cancel = CancelToken::new();
+        let _watch = watch_caller_departure(connection, hdr.sender(), cancel.clone()).await;
+        let result = self.authenticate_as(caller, user, cancel).await;
 
         // Emit auth_attempted signal (best-effort, don't fail auth if signal
         // fails). The payload deliberately carries no similarity score — the
@@ -1071,9 +1183,9 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         user: &str,
     ) -> fdo::Result<AuthResult> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
-        self.cancel.arm();
-        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
-        let result = self.test_authenticate_as(caller, user).await;
+        let cancel = CancelToken::new();
+        let _watch = watch_caller_departure(connection, hdr.sender(), cancel.clone()).await;
+        let result = self.test_authenticate_as(caller, user, cancel).await;
 
         // Emitted for the same reason and with the same payload as
         // `Authenticate`'s: a camera-backed attempt happened for `user`.
@@ -1095,9 +1207,9 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         // `facelock enroll` is a long capture loop; Ctrl-C on the CLI drops
         // its bus connection and must end it, not leave the camera running
         // to the enrollment deadline.
-        self.cancel.arm();
-        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
-        self.enroll_as(caller, user, label).await
+        let cancel = CancelToken::new();
+        let _watch = watch_caller_departure(connection, hdr.sender(), cancel.clone()).await;
+        self.enroll_as(caller, user, label, cancel).await
     }
 
     async fn list_models(
@@ -1357,7 +1469,7 @@ async fn run_dbus_server(
     let service = FacelockService::new(handler, startup_config_mtime, rebuild, notifier_factory);
     let handler = service.handler.clone();
     let last_activity = service.last_activity.clone();
-    let service_cancel = service.cancel_token();
+    let current_request = service.current_request();
 
     let _connection = zbus::connection::Builder::system()?
         .name(BUS_NAME)?
@@ -1379,9 +1491,9 @@ async fn run_dbus_server(
     // Spawn a background task to release the camera on system suspend.
     // Best-effort: if logind is unavailable, log a warning and continue.
     let handler_for_sleep = handler.clone();
-    let cancel_for_sleep = service_cancel.clone();
+    let current_for_sleep = current_request.clone();
     tokio::spawn(async move {
-        if let Err(e) = watch_sleep_signals(handler_for_sleep, cancel_for_sleep).await {
+        if let Err(e) = watch_sleep_signals(handler_for_sleep, current_for_sleep).await {
             tracing::warn!("failed to watch logind sleep signals: {e}");
         }
     });
@@ -1418,7 +1530,7 @@ async fn run_dbus_server(
 /// ```
 async fn watch_sleep_signals(
     handler: Arc<Mutex<ProductionHandler>>,
-    cancel: CancelToken,
+    current: CurrentRequest,
 ) -> zbus::Result<()> {
     let connection = zbus::Connection::system().await?;
     let proxy = zbus::Proxy::new(
@@ -1436,10 +1548,10 @@ async fn watch_sleep_signals(
         let suspending: bool = signal.body().deserialize().unwrap_or(false);
         if suspending {
             // Lock-free and first: a capture in flight is holding the handler
-            // mutex, so the token is the only thing that reaches it. This
+            // mutex, so its token is the only thing that reaches it. This
             // replaces the old single `try_lock` that gave up with a "handler
             // busy" warning and left the camera streaming into suspend.
-            cancel.cancel();
+            current.cancel();
             let handler = handler.clone();
             let _ = tokio::task::spawn_blocking(move || {
                 // The cancelled request exits within one frame and drops the
@@ -1874,6 +1986,94 @@ mod tests {
             cancel.cancel();
         }
         assert!(cancel.is_cancelled());
+    }
+
+    /// Each caller's watch is subscribed against that caller's own token, so
+    /// B leaving cannot end A's authentication. This is the shape of the
+    /// glue, replayed: two requests, two tokens, one departure.
+    #[test]
+    fn one_callers_departure_never_cancels_anothers_request() {
+        let alice = CancelToken::new();
+        let bob = CancelToken::new();
+
+        // Bob's watch fires. It holds only Bob's token.
+        if caller_departed(":1.43", ":1.43", None) {
+            bob.cancel();
+        }
+
+        assert!(bob.is_cancelled(), "Bob's own request must end");
+        assert!(
+            !alice.is_cancelled(),
+            "Bob's departure reached Alice's in-flight authentication"
+        );
+    }
+
+    // --- ADR 008 §5: the in-flight request slot ---
+
+    /// Nothing running, nothing to stop. `ReleaseCamera` on an idle daemon
+    /// must not leave a set flag lying around for the next request to find.
+    #[test]
+    fn cancelling_an_empty_slot_is_a_no_op() {
+        let current = CurrentRequest::default();
+        current.cancel();
+        let next = CancelToken::new();
+        let _guard = current.install(next.clone());
+        assert!(
+            !next.is_cancelled(),
+            "a cancel with nothing in flight reached the next request"
+        );
+    }
+
+    /// What suspend, `ReleaseCamera` and shutdown do: reach exactly the
+    /// request that is running.
+    #[test]
+    fn cancel_reaches_the_installed_request() {
+        let current = CurrentRequest::default();
+        let in_flight = CancelToken::new();
+        let _guard = current.install(in_flight.clone());
+        current.cancel();
+        assert!(in_flight.is_cancelled());
+    }
+
+    /// The generation check. Requests overlap at the edges — one is still
+    /// finishing while the next has claimed the capture slot — so the older
+    /// guard's drop must not clear the newer entry, or the next cancellation
+    /// would find the slot empty and stop nothing.
+    #[test]
+    fn a_finishing_request_never_clears_its_successors_slot() {
+        let current = CurrentRequest::default();
+        let first = CancelToken::new();
+        let second = CancelToken::new();
+
+        let first_guard = current.install(first.clone());
+        let _second_guard = current.install(second.clone());
+        drop(first_guard);
+
+        current.cancel();
+        assert!(
+            second.is_cancelled(),
+            "the request in flight was not reached"
+        );
+        assert!(
+            !first.is_cancelled(),
+            "a cancellation reached a request that had already finished"
+        );
+    }
+
+    /// And the converse: once a request's guard has dropped with the slot
+    /// still its own, the slot is empty — a stale token can never be
+    /// cancelled in place of the next request's.
+    #[test]
+    fn a_finished_requests_token_is_not_left_in_the_slot() {
+        let current = CurrentRequest::default();
+        let finished = CancelToken::new();
+        drop(current.install(finished.clone()));
+
+        current.cancel();
+        assert!(
+            !finished.is_cancelled(),
+            "a finished request stayed cancellable"
+        );
     }
 
     #[test]

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -24,6 +24,7 @@ use nix::unistd::{Uid, User};
 use tracing::{error, info, warn};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
+use crate::cancel::CancelToken;
 use crate::handler::{AuthIntent, CAMERA_POLL_INTERVAL, DaemonRequest, DaemonResponse, Handler};
 
 /// Production type alias for the handler with real Camera and FaceEngine.
@@ -51,6 +52,12 @@ pub enum ServerError {
 /// This prevents D-Bus clients from hanging indefinitely if a previous auth
 /// call is stuck (e.g., camera blocking on DQBUF).
 const HANDLER_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the suspend path waits for the handler mutex after cancelling.
+/// A cancelled request exits within one frame, so this is generous; when it
+/// runs out the camera is left to close on the request's own return rather
+/// than blocking the suspend transition any longer.
+const SUSPEND_RELEASE_WAIT: Duration = Duration::from_secs(1);
 
 /// Try to acquire the handler mutex with a timeout.
 /// Uses try_lock in a polling loop to avoid blocking the thread indefinitely.
@@ -135,6 +142,98 @@ impl Drop for CaptureGuard {
     fn drop(&mut self) {
         self.0.busy.store(false, Ordering::Release);
     }
+}
+
+/// A running watch on the caller's bus name, aborted when the request that
+/// registered it ends.
+///
+/// The guard matters as much as the watch: without it a watch would outlive
+/// its request and cancel *the next one* when the previous caller finally
+/// exited.
+struct CallerWatch(tokio::task::JoinHandle<()>);
+
+impl Drop for CallerWatch {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Cancel the in-flight request when the caller's D-Bus connection
+/// disappears.
+///
+/// This is what makes an abandoned authentication *visible* to the daemon
+/// (ADR 008 §5). A screen locker that aborts PAM because the password was
+/// typed first, a killed `sudo`, a crashed client — all of them drop their
+/// bus connection, and the bus broadcasts `NameOwnerChanged` with an empty
+/// new owner. Without this, the daemon cannot tell that from a slow user and
+/// keeps the camera (and the IR emitter) running to `timeout_secs`.
+///
+/// Best-effort by design: if the subscription cannot be set up, this logs and
+/// returns `None`, and that request is bounded by its timeout exactly as
+/// every request was before. A client that dies *before* the subscription is
+/// established is missed the same way — accepted, since the alternative is
+/// synchronizing every method call with the bus.
+async fn watch_caller_departure(
+    connection: &zbus::Connection,
+    sender: Option<&zbus::names::UniqueName<'_>>,
+    cancel: CancelToken,
+) -> Option<CallerWatch> {
+    let sender = sender?.to_string();
+
+    let proxy = match fdo::DBusProxy::new(connection).await {
+        Ok(proxy) => proxy,
+        Err(e) => {
+            warn!(
+                sender,
+                "cannot watch caller for departure ({e}); request is timeout-bounded"
+            );
+            return None;
+        }
+    };
+    // Arg-0 match: the bus filters to this name, so every event on the
+    // stream is about our caller and nothing else.
+    let mut stream = match proxy
+        .receive_name_owner_changed_with_args(&[(0, sender.as_str())])
+        .await
+    {
+        Ok(stream) => stream,
+        Err(e) => {
+            warn!(
+                sender,
+                "cannot watch caller for departure ({e}); request is timeout-bounded"
+            );
+            return None;
+        }
+    };
+
+    let watched = sender.clone();
+    Some(CallerWatch(tokio::spawn(async move {
+        while let Some(signal) = stream.next().await {
+            let Ok(args) = signal.args() else { continue };
+            let name = args.name().to_string();
+            let new_owner = args.new_owner().as_ref().map(|owner| owner.to_string());
+            if caller_departed(&watched, &name, new_owner.as_deref()) {
+                info!(
+                    sender = watched,
+                    "caller disconnected, cancelling in-flight request"
+                );
+                cancel.cancel();
+                return;
+            }
+        }
+    })))
+}
+
+/// Does this `NameOwnerChanged` event mean the watched caller is gone?
+///
+/// Two conditions, both required. The name must be the one we registered
+/// for — the bus's arg-0 match already guarantees that, and checking it again
+/// here is what makes "one request's watch never cancels another's" a
+/// property of this crate rather than of a match rule. And the new owner must
+/// be absent: an empty new owner is a departure, a different one is a
+/// handover of a well-known name, which is not our caller leaving.
+fn caller_departed(watched: &str, name: &str, new_owner: Option<&str>) -> bool {
+    name == watched && new_owner.is_none_or(str::is_empty)
 }
 
 /// Raw camera frames require privilege: only root gets them. When frames are
@@ -427,6 +526,12 @@ where
     config_mtime: Arc<Mutex<Option<std::time::SystemTime>>>,
     /// In-flight guard for camera-capture operations (DoS control).
     capture_slot: Arc<CaptureSlot>,
+    /// The daemon's cancel token, installed on the handler (and re-installed
+    /// on every rebuilt handler) so that suspend, `ReleaseCamera`, shutdown
+    /// and the per-request caller watch can stop an in-flight capture
+    /// **without taking the handler mutex** — which is exactly what the
+    /// request being cancelled is holding (ADR 008 §5).
+    cancel: CancelToken,
     /// Builds per-user notifiers for auth outcomes. Injected from `main` so
     /// the server never names the delivery implementation (D9) — a
     /// prerequisite for moving this server out of facelock-cli.
@@ -444,19 +549,31 @@ where
     /// Construct the service around a built handler. [`run_dbus_server`]
     /// does this with production types; integration tests with mocks.
     pub fn new(
-        handler: Handler<C, E>,
+        mut handler: Handler<C, E>,
         startup_config_mtime: Option<std::time::SystemTime>,
         rebuild: Option<HandlerRebuild<C, E>>,
         notifier_factory: NotifierFactory,
     ) -> Self {
+        // One token for the daemon's lifetime. Minted here rather than read
+        // off the handler because a config reload builds a *new* handler, and
+        // every watcher already holding a clone must keep working across that
+        // swap — so the service owns it and the handler adopts it.
+        let cancel = CancelToken::new();
+        handler.set_cancel_token(cancel.clone());
         Self {
             handler: Arc::new(Mutex::new(handler)),
             last_activity: Arc::new(AtomicU64::new(now_secs())),
             config_mtime: Arc::new(Mutex::new(startup_config_mtime)),
             capture_slot: Arc::new(CaptureSlot::default()),
+            cancel,
             notifier_factory,
             rebuild,
         }
+    }
+
+    /// The daemon's cancel token, for the watchers `run_dbus_server` spawns.
+    pub fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
     }
 
     /// Check if the config file has been modified since the handler was built.
@@ -486,13 +603,17 @@ where
 
         info!("config file changed, reloading");
 
-        let new_handler = match rebuild() {
+        let mut new_handler = match rebuild() {
             Ok(handler) => handler,
             Err(e) => {
                 warn!("failed to reload config: {e} — continuing with old config");
                 return;
             }
         };
+        // The rebuilt handler starts with a token of its own; replace it with
+        // the service's, so the watchers already holding clones keep reaching
+        // whatever is in flight after the swap.
+        new_handler.set_cancel_token(self.cancel.clone());
 
         // Swap in the new handler
         if let Ok(mut guard) = self.handler.lock() {
@@ -860,6 +981,11 @@ where
     pub async fn release_camera_as(&self, caller: CallerIdentity) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         authorize_method(&caller, Method::ReleaseCamera, None)?;
+        // Set the token before queuing for the handler mutex. If a capture is
+        // in flight it holds that mutex, so the store below is the only thing
+        // that reaches it — and it is what lets the lock be acquired at all,
+        // within one frame instead of at `timeout_secs`.
+        self.cancel.cancel();
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
@@ -886,6 +1012,9 @@ where
     pub async fn shutdown_as(&self, caller: CallerIdentity) -> fdo::Result<()> {
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         authorize_method(&caller, Method::Shutdown, None)?;
+        // Same reason as `ReleaseCamera`: stop the capture before waiting on
+        // the mutex it is holding.
+        self.cancel.cancel();
         let handler = self.handler.clone();
         tokio::task::spawn_blocking(move || {
             let mut handler = lock_handler_with_timeout(&handler)?;
@@ -912,6 +1041,10 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         user: &str,
     ) -> fdo::Result<AuthResult> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
+        // Arm first, then subscribe: a cancellation that arrives after the
+        // subscription can never be erased by a later reset (ADR 008 §5).
+        self.cancel.arm();
+        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
         let result = self.authenticate_as(caller, user).await;
 
         // Emit auth_attempted signal (best-effort, don't fail auth if signal
@@ -938,6 +1071,8 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         user: &str,
     ) -> fdo::Result<AuthResult> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
+        self.cancel.arm();
+        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
         let result = self.test_authenticate_as(caller, user).await;
 
         // Emitted for the same reason and with the same payload as
@@ -957,6 +1092,11 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         label: &str,
     ) -> fdo::Result<(u32, u32)> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
+        // `facelock enroll` is a long capture loop; Ctrl-C on the CLI drops
+        // its bus connection and must end it, not leave the camera running
+        // to the enrollment deadline.
+        self.cancel.arm();
+        let _watch = watch_caller_departure(connection, hdr.sender(), self.cancel_token()).await;
         self.enroll_as(caller, user, label).await
     }
 
@@ -1217,6 +1357,7 @@ async fn run_dbus_server(
     let service = FacelockService::new(handler, startup_config_mtime, rebuild, notifier_factory);
     let handler = service.handler.clone();
     let last_activity = service.last_activity.clone();
+    let service_cancel = service.cancel_token();
 
     let _connection = zbus::connection::Builder::system()?
         .name(BUS_NAME)?
@@ -1238,8 +1379,9 @@ async fn run_dbus_server(
     // Spawn a background task to release the camera on system suspend.
     // Best-effort: if logind is unavailable, log a warning and continue.
     let handler_for_sleep = handler.clone();
+    let cancel_for_sleep = service_cancel.clone();
     tokio::spawn(async move {
-        if let Err(e) = watch_sleep_signals(handler_for_sleep).await {
+        if let Err(e) = watch_sleep_signals(handler_for_sleep, cancel_for_sleep).await {
             tracing::warn!("failed to watch logind sleep signals: {e}");
         }
     });
@@ -1274,7 +1416,10 @@ async fn run_dbus_server(
 /// sudo systemctl suspend
 /// # After resume, check: journalctl -u facelock-daemon --since "5 min ago"
 /// ```
-async fn watch_sleep_signals(handler: Arc<Mutex<ProductionHandler>>) -> zbus::Result<()> {
+async fn watch_sleep_signals(
+    handler: Arc<Mutex<ProductionHandler>>,
+    cancel: CancelToken,
+) -> zbus::Result<()> {
     let connection = zbus::Connection::system().await?;
     let proxy = zbus::Proxy::new(
         &connection,
@@ -1290,14 +1435,40 @@ async fn watch_sleep_signals(handler: Arc<Mutex<ProductionHandler>>) -> zbus::Re
     while let Some(signal) = stream.next().await {
         let suspending: bool = signal.body().deserialize().unwrap_or(false);
         if suspending {
+            // Lock-free and first: a capture in flight is holding the handler
+            // mutex, so the token is the only thing that reaches it. This
+            // replaces the old single `try_lock` that gave up with a "handler
+            // busy" warning and left the camera streaming into suspend.
+            cancel.cancel();
             let handler = handler.clone();
-            let _ = tokio::task::spawn_blocking(move || match handler.try_lock() {
-                Ok(mut h) => {
-                    h.handle(DaemonRequest::ReleaseCamera);
-                    info!("released camera for suspend");
-                }
-                Err(_) => {
-                    warn!("could not release camera for suspend: handler busy");
+            let _ = tokio::task::spawn_blocking(move || {
+                // The cancelled request exits within one frame and drops the
+                // lock; wait about that long for it rather than giving up
+                // immediately (ADR 008 §8).
+                let deadline = Instant::now() + SUSPEND_RELEASE_WAIT;
+                loop {
+                    match handler.try_lock() {
+                        Ok(mut h) => {
+                            h.handle(DaemonRequest::ReleaseCamera);
+                            info!("released camera for suspend");
+                            return;
+                        }
+                        Err(TryLockError::Poisoned(e)) => {
+                            e.into_inner().handle(DaemonRequest::ReleaseCamera);
+                            info!("released camera for suspend (recovered poisoned lock)");
+                            return;
+                        }
+                        Err(TryLockError::WouldBlock) => {
+                            if Instant::now() >= deadline {
+                                warn!(
+                                    "could not release camera for suspend within {SUSPEND_RELEASE_WAIT:?}: \
+                                     handler still busy (the camera closes when the request returns)"
+                                );
+                                return;
+                            }
+                            std::thread::sleep(Duration::from_millis(25));
+                        }
+                    }
                 }
             })
             .await;
@@ -1661,6 +1832,48 @@ mod tests {
     fn preview_jpeg_kept_when_frames_allowed() {
         let jpeg = vec![0xFF, 0xD8, 0xFF, 0xE0];
         assert_eq!(sanitize_preview_jpeg(jpeg.clone(), true), jpeg);
+    }
+
+    // --- ADR 008 §5: caller departure ---
+
+    /// The event that means "cancel": our caller's name lost its owner.
+    #[test]
+    fn an_empty_new_owner_for_the_watched_name_is_a_departure() {
+        assert!(caller_departed(":1.42", ":1.42", None));
+        assert!(caller_departed(":1.42", ":1.42", Some("")));
+    }
+
+    /// The one thing a per-request watch must never do: cancel somebody
+    /// else's request. A `NameOwnerChanged` for any other name is ignored
+    /// even if it reaches this stream.
+    #[test]
+    fn a_departure_of_another_name_cancels_nothing() {
+        assert!(!caller_departed(":1.42", ":1.43", None));
+        assert!(!caller_departed(":1.42", "org.freedesktop.login1", None));
+    }
+
+    /// A well-known name changing hands is not our caller leaving.
+    #[test]
+    fn a_handover_to_a_new_owner_is_not_a_departure() {
+        assert!(!caller_departed(":1.42", ":1.42", Some(":1.99")));
+    }
+
+    /// End to end over the decision the watch task runs, with the token it
+    /// would set: only the registered sender's departure cancels.
+    #[test]
+    fn only_the_registered_senders_departure_sets_the_token() {
+        let cancel = CancelToken::new();
+        for (name, new_owner) in [(":1.43", None), (":1.42", Some(":1.99"))] {
+            if caller_departed(":1.42", name, new_owner) {
+                cancel.cancel();
+            }
+        }
+        assert!(!cancel.is_cancelled(), "an unrelated event cancelled us");
+
+        if caller_departed(":1.42", ":1.42", None) {
+            cancel.cancel();
+        }
+        assert!(cancel.is_cancelled());
     }
 
     #[test]

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1113,3 +1113,86 @@ fn a_cancellation_before_the_camera_opens_is_still_audited() {
     let _ = std::fs::remove_dir_all(&dir);
     cleanup_db(&db_path);
 }
+
+/// ADR 008 §3/§4 end to end, through the real `Authenticate` request path:
+/// what `device.camera_release_after_success_secs` buys is that the *next*
+/// authentication does not reopen the camera. The factory is the observable —
+/// it is called exactly once per cold open — so this pins the feature by its
+/// only user-visible effect rather than by the lease's private fields.
+///
+/// Both columns matter: with the key at its default `0` a success closes the
+/// stream, so the second authentication pays a second open. That is the
+/// behavior of every install that never sets the key.
+#[test]
+fn a_success_hold_is_what_lets_the_next_authentication_skip_the_reopen() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // (camera_release_after_success_secs, expected camera opens for two
+    // consecutive successful authentications)
+    for (success_secs, expected_opens) in [(0, 2), (5, 1)] {
+        let db_path = temp_db_path(&format!("success-hold-{success_secs}"));
+        cleanup_db(&db_path);
+
+        let db_path_str = db_path.to_string_lossy().into_owned();
+        let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
+        config.device.camera_release_after_success_secs = success_secs;
+        // Isolate the camera policy from the liveness gates: this test is
+        // about what happens *after* a match, not about earning one.
+        config.security.require_frame_variance = false;
+        config.security.require_landmark_liveness = false;
+
+        let face = unit_at_angle(0.0);
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store.add_model("testuser", "front", &face, "").unwrap();
+        }
+
+        let opens = Arc::new(AtomicUsize::new(0));
+        let counter = opens.clone();
+        let factory: MockCameraFactory = Box::new(move |_cfg| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(MockCamera::bright(64, 64, 64))
+        });
+
+        let mut handler = Handler::new(
+            config.clone(),
+            MockFaceEngine::one_face(face),
+            FaceStore::create(&db_path).unwrap(),
+            RateLimiter::new(
+                config.security.rate_limit.max_attempts,
+                config.security.rate_limit.window_secs,
+            ),
+            facelock_core::types::CameraCaps::default(),
+            Some(factory),
+            None,
+        )
+        .unwrap();
+
+        for attempt in 0..2 {
+            let resp = handler.handle(DaemonRequest::Authenticate {
+                user: "testuser".into(),
+            });
+            assert!(
+                matches!(
+                    resp,
+                    DaemonResponse::AuthResult(MatchResult { matched: true, .. })
+                ),
+                "attempt {attempt} with camera_release_after_success_secs = \
+                 {success_secs} must match: {resp:?}"
+            );
+        }
+
+        assert_eq!(
+            opens.load(Ordering::SeqCst),
+            expected_opens,
+            "two successful authentications with \
+             camera_release_after_success_secs = {success_secs} must open the \
+             camera {expected_opens} time(s)"
+        );
+
+        cleanup_db(&db_path);
+    }
+}

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -694,7 +694,11 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
 
     let db_path_str = db_path.to_string_lossy().into_owned();
     let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
-    config.recognition.timeout_secs = 0;
+    // A second of scanning against an engine that *sees* a face and matches
+    // nothing. Since ADR 008 §4 only that kind of failure is charged, so an
+    // attempt that never saw anybody — which a zero-length scan also is —
+    // would make this test pass for the wrong reason.
+    config.recognition.timeout_secs = 1;
     config.security.rate_limit.max_attempts = 1;
     config.security.require_frame_variance = false;
     config.security.require_landmark_liveness = false;
@@ -710,7 +714,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
 
     let mut first_handler = Handler::new(
         config.clone(),
-        MockFaceEngine::no_faces(),
+        MockFaceEngine::one_face(unit_at_angle(0.0)),
         FaceStore::create(&db_path).unwrap(),
         RateLimiter::new(
             config.security.rate_limit.max_attempts,
@@ -734,7 +738,7 @@ fn failed_auth_rate_limit_persists_across_handler_restart() {
 
     let mut restarted_handler = Handler::new(
         config.clone(),
-        MockFaceEngine::no_faces(),
+        MockFaceEngine::one_face(unit_at_angle(0.0)),
         FaceStore::create(&db_path).unwrap(),
         RateLimiter::new(
             config.security.rate_limit.max_attempts,
@@ -775,7 +779,10 @@ fn test_intent_does_not_consume_rate_limit_budget() {
 
     let db_path_str = db_path.to_string_lossy().into_owned();
     let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
-    config.recognition.timeout_secs = 0;
+    // The engine sees a face and matches nothing, so each attempt is the one
+    // failure class that *is* charged (ADR 008 §4) — otherwise the intent
+    // rule under test would be masked by the no-face exemption.
+    config.recognition.timeout_secs = 1;
     config.security.rate_limit.max_attempts = 1;
     config.security.require_frame_variance = false;
     config.security.require_landmark_liveness = false;
@@ -791,7 +798,7 @@ fn test_intent_does_not_consume_rate_limit_budget() {
 
     let mut handler = Handler::new(
         config.clone(),
-        MockFaceEngine::no_faces(),
+        MockFaceEngine::one_face(unit_at_angle(0.0)),
         FaceStore::create(&db_path).unwrap(),
         RateLimiter::new(
             config.security.rate_limit.max_attempts,

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -5,6 +5,7 @@ use facelock_core::config::Config;
 use facelock_core::types::MatchResult;
 use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::AuthOutcome;
+use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::handler::{AuthIntent, DaemonRequest, DaemonResponse};
 use facelock_store::FaceStore;
 use facelock_test_support::fixtures;
@@ -225,6 +226,7 @@ fn device_mismatch_never_reaches_success() {
         &config,
         "u",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
     match resp {
         AuthOutcome::AuthResult(MatchResult { matched, .. }) => {
@@ -258,6 +260,7 @@ fn device_mismatch_never_reaches_success() {
         &config,
         "u",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
     match resp2 {
         AuthOutcome::AuthResult(MatchResult { matched, .. }) => {
@@ -310,6 +313,7 @@ fn legacy_null_device_id_still_authenticates() {
         &config,
         "u",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
     match resp {
         AuthOutcome::AuthResult(MatchResult { matched, .. }) => {
@@ -451,6 +455,7 @@ fn static_matching_frames_report_variance_reason() {
         &config,
         "testuser",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
 
     match resp {
@@ -502,6 +507,7 @@ fn still_then_moving_frames_recover_and_authenticate() {
         &config,
         "testuser",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
 
     match resp {
@@ -551,6 +557,7 @@ fn failed_auth_writes_audit_entry() {
         &config,
         "testuser",
         AuditSource::Daemon,
+        &CancelToken::new(),
     );
     assert!(
         matches!(resp, AuthOutcome::AuthResult(ref r) if !r.matched),
@@ -570,6 +577,7 @@ fn failed_auth_writes_audit_entry() {
         &config,
         "testuser",
         AuditSource::Test,
+        &CancelToken::new(),
     );
 
     let written = std::fs::read_to_string(&log_path).expect("audit log must exist");
@@ -934,6 +942,7 @@ fn auth_loop_wipes_the_callers_embeddings() {
         &config,
         "alice",
         AuditSource::Test,
+        &CancelToken::new(),
     );
 
     assert!(
@@ -975,6 +984,7 @@ fn auth_loop_wipes_the_callers_embeddings_on_failure() {
         &config,
         "alice",
         AuditSource::Test,
+        &CancelToken::new(),
     );
 
     assert!(

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -813,7 +813,8 @@ fn test_intent_does_not_consume_rate_limit_budget() {
     // Run more failed attempts than max_attempts (1). None may report "rate
     // limited" — the budget starts and stays at zero recorded failures.
     for i in 0..3 {
-        let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Test);
+        let resp =
+            handler.handle_authenticate("testuser".into(), AuthIntent::Test, &CancelToken::new());
         assert!(
             matches!(
                 resp,
@@ -893,7 +894,11 @@ fn authenticate_storage_failure_is_error_and_charges_no_rate_limit() {
 
     // The real-authentication intent, which always charges; the diagnostic
     // carve-out exists only for `facelock test`.
-    let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Authenticate);
+    let resp = handler.handle_authenticate(
+        "testuser".into(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    );
     match resp {
         DaemonResponse::Error { ref message } => {
             assert!(
@@ -1007,4 +1012,104 @@ fn auth_loop_wipes_the_callers_embeddings_on_failure() {
             "caller-side embedding {id} was not wiped on the failure path"
         );
     }
+}
+
+/// A cancellation that arrives *before* the camera opens is audited as
+/// `cancelled`, exactly like one noticed mid-scan (ADR 008 §5,
+/// docs/contracts.md).
+///
+/// This is the earliest and most common cancellation there is — a locker that
+/// aborts PAM the moment a password is typed produces it — and it used to
+/// leave no trace at all: `CameraLease::acquire` reported the frozen string,
+/// `handle_authenticate` returned it straight to the caller, and the audit
+/// writer that every other ending goes through was never reached. The trail
+/// then said nothing about the attempts that were abandoned fastest.
+///
+/// `frame_count` is 0 because none were captured, which is also how a reader
+/// tells this row from a mid-scan cancellation.
+#[test]
+fn a_cancellation_before_the_camera_opens_is_still_audited() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let db_path = temp_db_path("cancel-before-open-audit");
+    cleanup_db(&db_path);
+    // A dedicated directory: write_audit_entry chmods the log's parent.
+    let dir = std::env::temp_dir().join(format!(
+        "facelock-cancel-audit-{}-{unique}",
+        std::process::id()
+    ));
+    let log_path = dir.join("audit.jsonl");
+
+    let db_path_str = db_path.to_string_lossy().into_owned();
+    let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
+    config.recognition.timeout_secs = 1;
+    config.audit.enabled = true;
+    config.audit.path = log_path.display().to_string();
+
+    {
+        let store = FaceStore::create(&db_path).unwrap();
+        store
+            .add_model("testuser", "front", &fixtures::known_embedding(0), "")
+            .unwrap();
+    }
+
+    // A factory that panics if called: the point of this path is that the
+    // camera is never opened, so reaching it at all would be the bug.
+    let factory: MockCameraFactory =
+        Box::new(|_cfg| panic!("a cancelled request must not open the camera"));
+
+    let mut handler = Handler::new(
+        config.clone(),
+        MockFaceEngine::one_face(unit_at_angle(0.0)),
+        FaceStore::create(&db_path).unwrap(),
+        RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        ),
+        facelock_core::types::CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+
+    let cancel = CancelToken::new();
+    cancel.cancel();
+    let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Authenticate, &cancel);
+    match resp {
+        DaemonResponse::Error { ref message } => assert_eq!(
+            message, "cancelled",
+            "the frozen wire string PAM matches exactly"
+        ),
+        other => panic!("expected a cancellation, got {other:?}"),
+    }
+
+    let written = std::fs::read_to_string(&log_path).expect("audit log must exist");
+    let entries: Vec<serde_json::Value> = written
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("audit entry must be valid JSON"))
+        .collect();
+    assert_eq!(entries.len(), 1, "one attempt, one entry: {entries:?}");
+    assert_eq!(entries[0]["result"], "cancelled");
+    assert_eq!(entries[0]["user"], "testuser");
+    assert_eq!(entries[0]["source"], "daemon");
+    assert_eq!(entries[0]["frame_count"], 0);
+    assert!(
+        entries[0]["similarity"].is_null(),
+        "no comparison ran, so there is no score to report"
+    );
+
+    // And it is an abstention, not a failed attempt: nothing is charged.
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect.check_rate_limit("testuser", 1, 60).unwrap(),
+        "a cancellation must leave the rate-limit budget untouched"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    cleanup_db(&db_path);
 }

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -528,6 +528,38 @@ async fn root_failed_authenticate_charges_the_rate_limit() {
     cleanup_db(&db_path);
 }
 
+/// A cancelled attempt is an abstention, not a failed attempt: the user
+/// never got to make one, so it must cost no rate-limit budget (ADR 008 §5).
+/// Otherwise a screen locker that aborts PAM on every unlock would walk the
+/// user into a lockout.
+#[tokio::test]
+async fn a_cancelled_authenticate_charges_no_rate_limit() {
+    let db_path = temp_db_path("cancel-charges-nothing");
+    cleanup_db(&db_path);
+    // Budget of one failed attempt — three cancelled runs must not reach it.
+    let svc = failing_service_at(&db_path, "alice", 1);
+
+    for _ in 0..3 {
+        // What `ReleaseCamera`, suspend and the caller-departure watch all do.
+        svc.cancel_token().cancel();
+        let reply = svc.authenticate_as(root(), "alice").await.unwrap();
+        assert!(!reply.matched);
+        assert_eq!(
+            reply.model_id, -2,
+            "a cancellation travels as a recoverable error: {reply:?}"
+        );
+        assert_eq!(reply.label, "cancelled", "frozen wire string");
+    }
+
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect.check_rate_limit("alice", 1, 60).unwrap(),
+        "cancelled attempts must leave the budget untouched"
+    );
+
+    cleanup_db(&db_path);
+}
+
 /// The other half: a non-root user's own failed attempts are charged, as
 /// they always were.
 #[tokio::test]

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -25,6 +25,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use facelock_core::config::Config;
 use facelock_core::notify::{Notifier, NullNotifier};
 use facelock_core::types::CameraCaps;
+use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::handler::Handler;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_daemon::server::{CallerIdentity, FacelockService};
@@ -181,6 +182,87 @@ fn service_at(
     service(handler_with(test_config(max_attempts, 1), engine, store))
 }
 
+/// A rendezvous with a request that is inside its camera factory.
+///
+/// The factory runs after authorization and after the capture slot is claimed,
+/// so a request parked there is unambiguously *the* request in flight — which
+/// is what the concurrency tests below need to state as a fact rather than
+/// win as a race. Two flags, no channel: the factory runs on the blocking
+/// pool, where a plain sleep loop is the cheapest correct thing.
+#[derive(Debug, Default)]
+struct CameraGate {
+    opening: std::sync::atomic::AtomicBool,
+    released: std::sync::atomic::AtomicBool,
+}
+
+impl CameraGate {
+    /// Called from the camera factory: announce arrival, then park.
+    fn park(&self) {
+        use std::sync::atomic::Ordering;
+        self.opening.store(true, Ordering::SeqCst);
+        while !self.released.load(Ordering::SeqCst) {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+    }
+
+    /// Resolves once a request has reached the factory.
+    async fn wait_until_opening(&self) {
+        use std::sync::atomic::Ordering;
+        for _ in 0..2_000 {
+            if self.opening.load(Ordering::SeqCst) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        panic!("no request reached the camera factory");
+    }
+
+    fn release(&self) {
+        self.released
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Re-arm for a second request through the same service.
+    fn reopen(&self) {
+        use std::sync::atomic::Ordering;
+        self.opening.store(false, Ordering::SeqCst);
+        self.released.store(false, Ordering::SeqCst);
+    }
+}
+
+/// A service whose camera factory parks on `gate`, holding one enrolled model
+/// for `user` and an engine that matches it — so a released request succeeds
+/// and only the cancellation under test can make it end otherwise.
+fn gated_service_at(db_path: &Path, user: &str, gate: Arc<CameraGate>) -> MockService {
+    let emb = fixtures::known_embedding(1);
+    let store = FaceStore::create(db_path).unwrap();
+    store
+        .add_model(user, "front", &emb, "test-embedder")
+        .unwrap();
+
+    let config = test_config(5, 2);
+    let rate_limiter = RateLimiter::new(
+        config.security.rate_limit.max_attempts,
+        config.security.rate_limit.window_secs,
+    );
+    let factory: MockCameraFactory = Box::new(move |_| {
+        gate.park();
+        Ok(MockCamera::bright(64, 64, 60))
+    });
+    service(
+        Handler::new(
+            config,
+            MockFaceEngine::one_face(emb),
+            store,
+            rate_limiter,
+            CameraCaps::default(),
+            Some(factory),
+            None,
+        )
+        .unwrap(),
+    )
+}
+
 fn caller(uid: u32, username: Option<&str>) -> CallerIdentity {
     CallerIdentity {
         uid,
@@ -222,10 +304,15 @@ async fn every_entry_point_except_authenticate_denies_non_root() {
     let a = alice();
 
     assert_denied(
-        svc.test_authenticate_as(a.clone(), "alice").await,
+        svc.test_authenticate_as(a.clone(), "alice", CancelToken::new())
+            .await,
         "TestAuthenticate",
     );
-    assert_denied(svc.enroll_as(a.clone(), "alice", "front").await, "Enroll");
+    assert_denied(
+        svc.enroll_as(a.clone(), "alice", "front", CancelToken::new())
+            .await,
+        "Enroll",
+    );
     assert_denied(svc.list_models_as(a.clone(), "alice").await, "ListModels");
     assert_denied(
         svc.remove_model_as(a.clone(), "alice", 1).await,
@@ -254,7 +341,7 @@ async fn root_passes_authorization_on_every_entry_point() {
 
     assert_eq!(svc.ping_as(r.clone()).await.unwrap(), "pong");
     assert!(
-        svc.test_authenticate_as(r.clone(), "alice")
+        svc.test_authenticate_as(r.clone(), "alice", CancelToken::new())
             .await
             .unwrap()
             .matched
@@ -275,7 +362,11 @@ async fn root_passes_authorization_on_every_entry_point() {
     assert_not_denied(svc.list_devices_as(r.clone()).await, "ListDevices");
     // `method = "none"` without allow_plaintext: enroll refuses fast, but as
     // a handler error — authorization must already have passed.
-    assert_not_denied(svc.enroll_as(r.clone(), "alice", "front").await, "Enroll");
+    assert_not_denied(
+        svc.enroll_as(r.clone(), "alice", "front", CancelToken::new())
+            .await,
+        "Enroll",
+    );
     svc.shutdown_as(r).await.unwrap();
 }
 
@@ -286,21 +377,28 @@ async fn root_passes_authorization_on_every_entry_point() {
 async fn authenticate_is_scoped_to_the_caller_own_user() {
     let svc = matching_service_for("alice");
 
-    let own = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let own = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(own.matched, "self-request must run the real comparison");
 
     assert_denied(
-        svc.authenticate_as(alice(), "bob").await,
+        svc.authenticate_as(alice(), "bob", CancelToken::new())
+            .await,
         "Authenticate (cross-user)",
     );
     assert!(
-        svc.authenticate_as(caller(1000, None), "alice")
+        svc.authenticate_as(caller(1000, None), "alice", CancelToken::new())
             .await
             .is_err(),
         "an unresolvable caller username must fail closed"
     );
 
-    let as_root = svc.authenticate_as(root(), "alice").await.unwrap();
+    let as_root = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(as_root.matched, "root may authenticate any user");
 }
 
@@ -311,7 +409,10 @@ async fn authenticate_is_scoped_to_the_caller_own_user() {
 async fn similarity_is_redacted_for_non_root_callers() {
     let svc = matching_service_for("alice");
 
-    let unredacted = svc.authenticate_as(root(), "alice").await.unwrap();
+    let unredacted = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(unredacted.matched);
     assert!(
         unredacted.similarity > 0.9,
@@ -319,7 +420,10 @@ async fn similarity_is_redacted_for_non_root_callers() {
         unredacted.similarity
     );
 
-    let redacted = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let redacted = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(redacted.matched, "redaction must not change the outcome");
     assert_eq!(redacted.model_id, unredacted.model_id);
     assert_eq!(
@@ -349,7 +453,10 @@ async fn rate_limited_flows_in_band_with_the_exact_protocol_string() {
         store,
     ));
 
-    let result = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let result = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!result.matched);
     assert_eq!(result.model_id, -2, "recoverable error sentinel");
     assert_eq!(
@@ -371,7 +478,10 @@ async fn require_ir_flows_in_band_with_the_exact_protocol_string() {
     // CameraCaps::default() is non-IR, so the gate must reject in-band.
     let svc = service(handler_with(config, MockFaceEngine::one_face(emb), store));
 
-    let result = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let result = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!result.matched);
     assert_eq!(result.model_id, -2);
     assert!(
@@ -394,7 +504,10 @@ async fn suppress_unknown_maps_to_the_minus_three_sentinel() {
         FaceStore::open_memory().unwrap(),
     ));
 
-    let result = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let result = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!result.matched);
     assert_eq!(result.model_id, -3, "suppressed sentinel");
     assert!(result.label.is_empty());
@@ -442,7 +555,10 @@ async fn a_redacted_caller_can_tell_a_seen_face_from_an_empty_frame() {
         store,
     ));
 
-    let seen = saw_someone.authenticate_as(alice(), "alice").await.unwrap();
+    let seen = saw_someone
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!seen.matched, "an unrelated face must not authenticate");
     assert_eq!(
         seen.similarity, 0.0,
@@ -469,7 +585,10 @@ async fn a_redacted_caller_can_tell_a_seen_face_from_an_empty_frame() {
         empty_store,
     ));
 
-    let unseen = saw_nobody.authenticate_as(alice(), "alice").await.unwrap();
+    let unseen = saw_nobody
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!unseen.matched);
     assert_eq!(unseen.similarity, 0.0);
     assert_eq!(unseen.model_id, -1, "no face was detected: {unseen:?}");
@@ -499,7 +618,10 @@ async fn a_match_still_reports_its_model_id_and_score_to_root() {
         store,
     ));
 
-    let result = svc.authenticate_as(root(), "alice").await.unwrap();
+    let result = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(result.matched);
     assert_eq!(result.model_id, model_id as i32);
     assert!(
@@ -531,7 +653,10 @@ async fn root_failed_authenticate_charges_the_rate_limit() {
     // Budget of one failed attempt.
     let svc = failing_service_at(&db_path, "alice", 1);
 
-    let first = svc.authenticate_as(root(), "alice").await.unwrap();
+    let first = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!first.matched);
     assert_eq!(
         first.model_id, -4,
@@ -547,7 +672,10 @@ async fn root_failed_authenticate_charges_the_rate_limit() {
 
     // And the charge is enforced: the next attempt is rejected in-band
     // before the camera runs, root or not.
-    let limited = svc.authenticate_as(root(), "alice").await.unwrap();
+    let limited = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert_eq!(limited.model_id, -2);
     assert_eq!(limited.label, "rate limited");
 
@@ -566,9 +694,12 @@ async fn a_cancelled_authenticate_charges_no_rate_limit() {
     let svc = failing_service_at(&db_path, "alice", 1);
 
     for _ in 0..3 {
-        // What `ReleaseCamera`, suspend and the caller-departure watch all do.
-        svc.cancel_token().cancel();
-        let reply = svc.authenticate_as(root(), "alice").await.unwrap();
+        // A request whose token is already set — what `ReleaseCamera`,
+        // suspend and the caller-departure watch each do to the one request
+        // they are aimed at.
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let reply = svc.authenticate_as(root(), "alice", cancel).await.unwrap();
         assert!(!reply.matched);
         assert_eq!(
             reply.model_id, -2,
@@ -603,7 +734,10 @@ async fn a_no_face_authenticate_charges_no_rate_limit() {
     let svc = unseen_service_at(&db_path, "alice", 1);
 
     for attempt in 0..2 {
-        let reply = svc.authenticate_as(root(), "alice").await.unwrap();
+        let reply = svc
+            .authenticate_as(root(), "alice", CancelToken::new())
+            .await
+            .unwrap();
         assert!(!reply.matched);
         assert_eq!(
             reply.model_id, -1,
@@ -629,11 +763,17 @@ async fn user_failed_authenticate_charges_the_rate_limit() {
     cleanup_db(&db_path);
     let svc = failing_service_at(&db_path, "alice", 1);
 
-    let charged = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let charged = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!charged.matched);
     assert_eq!(charged.model_id, -4, "a face was seen and did not match");
 
-    let limited = svc.authenticate_as(alice(), "alice").await.unwrap();
+    let limited = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert_eq!(limited.model_id, -2);
     assert_eq!(limited.label, "rate limited");
 
@@ -653,7 +793,10 @@ async fn test_authenticate_does_not_charge_the_rate_limit() {
     let svc = failing_service_at(&db_path, "alice", 1);
 
     for attempt in 0..3 {
-        let result = svc.test_authenticate_as(root(), "alice").await.unwrap();
+        let result = svc
+            .test_authenticate_as(root(), "alice", CancelToken::new())
+            .await
+            .unwrap();
         assert!(!result.matched);
         assert_eq!(
             result.model_id, -4,
@@ -670,8 +813,13 @@ async fn test_authenticate_does_not_charge_the_rate_limit() {
 
     // The *check* is not exempted: an already-limited user still sees it.
     // (Charge through the real method, then test again.)
-    svc.authenticate_as(root(), "alice").await.unwrap();
-    let limited = svc.test_authenticate_as(root(), "alice").await.unwrap();
+    svc.authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
+    let limited = svc
+        .test_authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert_eq!(limited.model_id, -2);
     assert_eq!(
         limited.label, "rate limited",
@@ -689,16 +837,21 @@ async fn test_authenticate_denies_a_non_root_caller() {
     let svc = matching_service_for("alice");
 
     assert_denied(
-        svc.test_authenticate_as(alice(), "alice").await,
+        svc.test_authenticate_as(alice(), "alice", CancelToken::new())
+            .await,
         "TestAuthenticate (own user)",
     );
     assert_denied(
-        svc.test_authenticate_as(alice(), "bob").await,
+        svc.test_authenticate_as(alice(), "bob", CancelToken::new())
+            .await,
         "TestAuthenticate (cross-user)",
     );
 
     // Root runs the real comparison through it.
-    let as_root = svc.test_authenticate_as(root(), "alice").await.unwrap();
+    let as_root = svc
+        .test_authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(as_root.matched, "root must reach the comparison loop");
 }
 
@@ -717,5 +870,139 @@ async fn preview_detect_frame_for_root_returns_frames_and_scores() {
         faces[0].similarity > 0.9,
         "root sees the unredacted score, got {}",
         faces[0].similarity
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Per-request cancellation (ADR 008 §5)
+//
+// zbus dispatches every method call in its own task, so "concurrent" is the
+// normal case, not an exotic one. These pin that a request's cancel token is
+// reachable by exactly one request: the one that owns it.
+// ---------------------------------------------------------------------------
+
+/// Nothing another call does can disturb an in-flight request's cancellation.
+///
+/// With a single service-owned token this was false three ways over: a second
+/// call re-armed the flag (clearing a cancellation the running request had not
+/// read yet), a rejected call re-armed it just the same because the reset ran
+/// *before* authorization and before the capture slot, and the rejected
+/// caller's departure watch — subscribed against that same shared flag — could
+/// cancel the request it had just been rejected in favour of.
+///
+/// The concurrency is real rather than simulated, and deterministic rather
+/// than timed: the first request parks inside its camera factory — which runs
+/// after authorization and after the capture slot is claimed — until this test
+/// lets it go, so "while the first request is in flight" is a fact here, not a
+/// race the test hopes to win.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_concurrent_request_cannot_disturb_the_one_in_flight() {
+    let db_path = temp_db_path("concurrent-token-isolation");
+    cleanup_db(&db_path);
+    let gate = Arc::new(CameraGate::default());
+    let svc = Arc::new(gated_service_at(&db_path, "alice", gate.clone()));
+
+    let in_flight = CancelToken::new();
+    let running = {
+        let svc = svc.clone();
+        let token = in_flight.clone();
+        tokio::spawn(async move { svc.authenticate_as(root(), "alice", token).await })
+    };
+    gate.wait_until_opening().await;
+
+    // A second caller, arriving while the first holds the capture slot. It is
+    // rejected — and the rejection must cost the running request nothing.
+    let second = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await;
+    assert!(
+        matches!(second, Err(fdo::Error::Failed(ref m)) if m.contains("daemon busy")),
+        "expected a busy rejection while a capture was in flight, got {second:?}"
+    );
+    assert!(
+        !in_flight.is_cancelled(),
+        "a busy-rejected request reached the in-flight request's token"
+    );
+
+    // ...and so is a call that authorization turns away before it can get
+    // anywhere near the capture slot.
+    assert_denied(
+        svc.test_authenticate_as(alice(), "alice", CancelToken::new())
+            .await,
+        "TestAuthenticate",
+    );
+    assert!(
+        !in_flight.is_cancelled(),
+        "a denied request reached the in-flight request's token"
+    );
+
+    // The slot still names the running request, so suspend / ReleaseCamera /
+    // shutdown reach it and nothing else — the rejected calls above did not
+    // displace it with a token of their own.
+    svc.current_request().cancel();
+    assert!(
+        in_flight.is_cancelled(),
+        "the in-flight request was not reachable through the current-request slot"
+    );
+
+    gate.release();
+    let reply = running.await.unwrap().unwrap();
+    assert_eq!(reply.label, "cancelled", "frozen wire string: {reply:?}");
+
+    // And the slot is empty again: a `ReleaseCamera` arriving with nothing in
+    // flight must not leave a set flag behind for whoever comes next.
+    svc.current_request().cancel();
+    let next = CancelToken::new();
+    gate.reopen();
+    let following = {
+        let svc = svc.clone();
+        let token = next.clone();
+        tokio::spawn(async move { svc.authenticate_as(root(), "alice", token).await })
+    };
+    gate.wait_until_opening().await;
+    assert!(
+        !next.is_cancelled(),
+        "a cancel aimed at a finished request landed on its successor"
+    );
+    gate.release();
+    let reply = following.await.unwrap().unwrap();
+    assert_ne!(
+        reply.label, "cancelled",
+        "the request after a cancelled one must run normally: {reply:?}"
+    );
+
+    cleanup_db(&db_path);
+}
+
+/// Each request is born with a fresh token, so a cancellation never outlives
+/// the request it was aimed at.
+///
+/// The wedge this replaces: `CameraLease::finish` did not clear the shared
+/// flag, so after any cancelled authentication every later request — a preview
+/// frame most visibly, since a preview issues ten a second — found the flag
+/// already set and failed with `cancelled` forever.
+#[tokio::test]
+async fn a_cancelled_request_does_not_wedge_the_next_one() {
+    let svc = matching_service_for("alice");
+
+    let cancel = CancelToken::new();
+    cancel.cancel();
+    let cancelled = svc.authenticate_as(root(), "alice", cancel).await.unwrap();
+    assert!(!cancelled.matched);
+    assert_eq!(cancelled.label, "cancelled", "{cancelled:?}");
+
+    let frame = svc
+        .preview_frame_as(root())
+        .await
+        .expect("a preview frame after a cancelled authentication");
+    assert!(!frame.is_empty(), "the preview was wedged by the cancel");
+
+    let after = svc
+        .authenticate_as(root(), "alice", CancelToken::new())
+        .await
+        .unwrap();
+    assert!(
+        after.matched,
+        "the authentication after a cancelled one must run normally: {after:?}"
     );
 }

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -8,8 +8,8 @@
 //! root-only catch-all), the in-band `-2`/`-3`/`-4` sentinel encoding with its
 //! byte-exact protocol strings, similarity redaction for non-root callers
 //! (and the `-4` sentinel that keeps a redacted caller able to tell a
-//! face-seen non-match from an empty frame), and which entry point charges
-//! the rate limit (N11).
+//! face-seen non-match from an empty frame), and which entry point — and
+//! which kind of failure — charges the rate limit (N11, ADR 008 §4).
 //!
 //! NOT covered here, deliberately: the zbus wiring — caller-identity
 //! resolution from message headers (`GetConnectionUnixUser`), signal
@@ -139,9 +139,36 @@ fn cleanup_db(path: &Path) {
 }
 
 /// A service whose store lives at `db_path` and holds one enrolled model for
-/// `user`, with an engine that never sees a face — so every attempt fails and
-/// the only question is what it costs. `max_attempts` sets the budget.
+/// `user`, with an engine that sees a face on every frame and matches none of
+/// them — so every attempt is a real failed attempt (a guess, and a wrong
+/// one) and the only question is what it costs. `max_attempts` sets the
+/// budget.
+///
+/// Deliberately not `MockFaceEngine::no_faces()`: since ADR 008 §4 an attempt
+/// where the camera saw nobody charges nothing, so a blind engine would make
+/// every "this failure is charged" test below pass vacuously. That case has
+/// its own helper, [`unseen_service_at`].
 fn failing_service_at(db_path: &Path, user: &str, max_attempts: u32) -> MockService {
+    service_at(
+        db_path,
+        user,
+        max_attempts,
+        MockFaceEngine::one_face(unrelated_embedding()),
+    )
+}
+
+/// The counterpart: an engine that never sees a face, for the attempts that
+/// must cost nothing.
+fn unseen_service_at(db_path: &Path, user: &str, max_attempts: u32) -> MockService {
+    service_at(db_path, user, max_attempts, MockFaceEngine::no_faces())
+}
+
+fn service_at(
+    db_path: &Path,
+    user: &str,
+    max_attempts: u32,
+    engine: MockFaceEngine,
+) -> MockService {
     let store = FaceStore::create(db_path).unwrap();
     store
         .add_model(
@@ -151,11 +178,7 @@ fn failing_service_at(db_path: &Path, user: &str, max_attempts: u32) -> MockServ
             "test-embedder",
         )
         .unwrap();
-    service(handler_with(
-        test_config(max_attempts, 1),
-        MockFaceEngine::no_faces(),
-        store,
-    ))
+    service(handler_with(test_config(max_attempts, 1), engine, store))
 }
 
 fn caller(uid: u32, username: Option<&str>) -> CallerIdentity {
@@ -510,7 +533,10 @@ async fn root_failed_authenticate_charges_the_rate_limit() {
 
     let first = svc.authenticate_as(root(), "alice").await.unwrap();
     assert!(!first.matched);
-    assert_eq!(first.model_id, -1, "an ordinary non-match: {first:?}");
+    assert_eq!(
+        first.model_id, -4,
+        "a face was seen and did not match — the failure that is charged: {first:?}"
+    );
 
     let inspect = FaceStore::create(&db_path).unwrap();
     assert!(
@@ -560,6 +586,41 @@ async fn a_cancelled_authenticate_charges_no_rate_limit() {
     cleanup_db(&db_path);
 }
 
+/// The complement of the pin above: a failure where the camera never saw a
+/// face costs no budget (ADR 008 §4). It is not a guess — nobody was there —
+/// and charging it means a laptop opened in front of an empty desk, or a
+/// locker that starts face auth on every wake, burns the user's whole
+/// allowance before they sit down and meets them with a lockout.
+///
+/// Asserted twice over: through the reply of a *second* attempt (which would
+/// be the `-2` rate-limit rejection if the first had charged) and directly
+/// against the on-disk `rate_limit` table.
+#[tokio::test]
+async fn a_no_face_authenticate_charges_no_rate_limit() {
+    let db_path = temp_db_path("no-face-charges-nothing");
+    cleanup_db(&db_path);
+    // Budget of one failed attempt — neither no-face run may reach it.
+    let svc = unseen_service_at(&db_path, "alice", 1);
+
+    for attempt in 0..2 {
+        let reply = svc.authenticate_as(root(), "alice").await.unwrap();
+        assert!(!reply.matched);
+        assert_eq!(
+            reply.model_id, -1,
+            "attempt {attempt} must stay an ordinary no-face non-match, never \
+             a rate-limit rejection: {reply:?}"
+        );
+    }
+
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect.check_rate_limit("alice", 1, 60).unwrap(),
+        "an attempt at an empty chair must leave the budget untouched"
+    );
+
+    cleanup_db(&db_path);
+}
+
 /// The other half: a non-root user's own failed attempts are charged, as
 /// they always were.
 #[tokio::test]
@@ -570,7 +631,7 @@ async fn user_failed_authenticate_charges_the_rate_limit() {
 
     let charged = svc.authenticate_as(alice(), "alice").await.unwrap();
     assert!(!charged.matched);
-    assert_eq!(charged.model_id, -1);
+    assert_eq!(charged.model_id, -4, "a face was seen and did not match");
 
     let limited = svc.authenticate_as(alice(), "alice").await.unwrap();
     assert_eq!(limited.model_id, -2);
@@ -595,9 +656,9 @@ async fn test_authenticate_does_not_charge_the_rate_limit() {
         let result = svc.test_authenticate_as(root(), "alice").await.unwrap();
         assert!(!result.matched);
         assert_eq!(
-            result.model_id, -1,
-            "test attempt {attempt} must be an ordinary non-match, not a \
-             rate-limit rejection: {result:?}"
+            result.model_id, -4,
+            "test attempt {attempt} must be an ordinary face-seen non-match, \
+             not a rate-limit rejection: {result:?}"
         );
     }
 

--- a/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
+++ b/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use facelock_core::config::Config;
 use facelock_core::notify::{Notifier, NullNotifier};
 use facelock_core::types::CameraCaps;
+use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::handler::Handler;
 use facelock_daemon::rate_limit::RateLimiter;
 use facelock_daemon::server::{CallerIdentity, FacelockService};
@@ -93,13 +94,19 @@ enabled = false
     unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 5678 10.0.0.1 22") };
 
     // Real authentication: the gate fires, in-band, before the camera runs.
-    let real = svc.authenticate_as(root.clone(), "alice").await.unwrap();
+    let real = svc
+        .authenticate_as(root.clone(), "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(!real.matched);
     assert_eq!(real.model_id, -2, "recoverable error sentinel: {real:?}");
     assert_eq!(real.label, "SSH session detected");
 
     // The diagnostic entry point runs the comparison anyway.
-    let diagnostic = svc.test_authenticate_as(root, "alice").await.unwrap();
+    let diagnostic = svc
+        .test_authenticate_as(root, "alice", CancelToken::new())
+        .await
+        .unwrap();
     assert!(
         diagnostic.matched,
         "TestAuthenticate must skip the SSH gate and reach the comparison \

--- a/crates/facelock-polkit/src/main.rs
+++ b/crates/facelock-polkit/src/main.rs
@@ -57,8 +57,19 @@ impl PolkitAgent {
         }
 
         // Race the face auth call against the cancellation signal.
+        //
+        // The face-auth branch owns a **dedicated** system-bus connection
+        // (see `try_face_auth`), so when the select drops that future on
+        // cancel it drops the connection with it. That is the whole
+        // mechanism: the daemon watches the caller's bus name and cancels
+        // the in-flight authentication when it disappears, so dropping this
+        // connection turns "the user pressed Cancel in the dialog" into a
+        // camera that goes dark within one frame instead of one that keeps
+        // scanning to `timeout_secs` (ADR 008 §5). No new D-Bus API is
+        // needed for it, which is why this agent does not have — and should
+        // not grow — a `Cancel` method of its own.
         let face_result = tokio::select! {
-            result = try_face_auth(&self.system_conn, &user) => Some(result),
+            result = try_face_auth(&user) => Some(result),
             _ = cancel_rx => {
                 tracing::info!(cookie, user = %user, "auth cancelled by polkit");
                 None
@@ -136,9 +147,26 @@ fn current_username() -> String {
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-/// Attempt face authentication via the facelock D-Bus daemon.
-async fn try_face_auth(system_conn: &Connection, user: &str) -> anyhow::Result<bool> {
-    let proxy = zbus::Proxy::new(system_conn, BUS_NAME, OBJECT_PATH, INTERFACE_NAME)
+/// Attempt face authentication via the facelock D-Bus daemon, on a
+/// connection opened for this one call.
+///
+/// The agent already holds a long-lived `system_conn` and this could have
+/// borrowed it — but then a cancelled dialog would drop only the *future*,
+/// leaving the connection (and therefore the daemon's view of the caller)
+/// alive, and the daemon would keep scanning until it timed out. Because the
+/// connection is created inside this future and moved nowhere else, dropping
+/// the future closes it, the bus broadcasts `NameOwnerChanged` with an empty
+/// new owner, and the daemon's per-request watch ends the authentication
+/// (ADR 008 §5).
+///
+/// The cost is one bus connection per `BeginAuthentication`, which is
+/// human-paced. `respond_to_polkit` still uses the agent's long-lived
+/// connection: that call happens after the race is over.
+async fn try_face_auth(user: &str) -> anyhow::Result<bool> {
+    let connection = Connection::system()
+        .await
+        .context("failed to open a dedicated system bus connection for face auth")?;
+    let proxy = zbus::Proxy::new(&connection, BUS_NAME, OBJECT_PATH, INTERFACE_NAME)
         .await
         .context("failed to build facelock D-Bus proxy")?;
 

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -783,9 +783,87 @@ fn oneshot_child_env(
     env
 }
 
+/// How long an overrunning one-shot child gets to exit on SIGTERM before it
+/// is killed. Generous: the child's own cancel check runs once per captured
+/// frame, so it normally exits in well under one frame time.
+const ONESHOT_TERM_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Poll interval while waiting out [`ONESHOT_TERM_GRACE`].
+const ONESHOT_TERM_POLL: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// The two things the termination sequence needs from a child process.
+///
+/// A trait rather than a `std::process::Child` in the signature purely so the
+/// sequence itself — the part that is auth-adjacent policy, not mechanism —
+/// can be unit-tested without spawning anything.
+trait Terminable {
+    /// Send a signal to the child.
+    fn signal(&mut self, signal: libc::c_int) -> std::io::Result<()>;
+    /// Has it exited yet? Non-blocking.
+    fn has_exited(&mut self) -> std::io::Result<bool>;
+}
+
+impl Terminable for std::process::Child {
+    fn signal(&mut self, signal: libc::c_int) -> std::io::Result<()> {
+        // SAFETY: `kill` with a pid we own and a valid signal number. A dead
+        // child yields ESRCH, which is reported as an error, never UB.
+        let rc = unsafe { libc::kill(self.id() as libc::pid_t, signal) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    fn has_exited(&mut self) -> std::io::Result<bool> {
+        self.try_wait().map(|status| status.is_some())
+    }
+}
+
+/// Stop an overrunning one-shot child: **SIGTERM, wait, then SIGKILL**.
+///
+/// The module used to send SIGKILL straight away. A killed `facelock auth`
+/// never runs `Drop`, so the camera is closed by the kernel without a
+/// STREAMOFF and, on hardware whose IR emitter is under explicit XU control,
+/// the LED stays on. SIGTERM gives the child the chance to end its scan and
+/// clean up; SIGKILL is the backstop for a child wedged in a driver call,
+/// where leaking the emitter beats hanging the PAM stack.
+///
+/// Returns the signals actually sent, in order — which is what the tests
+/// assert on.
+fn terminate_oneshot_child<T: Terminable>(
+    child: &mut T,
+    grace: std::time::Duration,
+) -> Vec<libc::c_int> {
+    let mut sent = Vec::with_capacity(2);
+    if child.signal(libc::SIGTERM).is_ok() {
+        sent.push(libc::SIGTERM);
+    }
+
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        // An error here means we cannot tell whether it exited, which is
+        // treated as "not yet" — the grace period still bounds the wait, and
+        // the SIGKILL below is harmless against a dead child.
+        if child.has_exited().unwrap_or(false) {
+            return sent;
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(ONESHOT_TERM_POLL.min(grace));
+    }
+
+    if child.signal(libc::SIGKILL).is_ok() {
+        sent.push(libc::SIGKILL);
+    }
+    sent
+}
+
 /// Run facelock auth as a subprocess for daemonless authentication.
 /// Exit codes: 0 = matched, 1 = no match, 2+ = error.
 fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_int {
+    use std::os::unix::process::CommandExt;
     use std::process::Command;
 
     let timeout_secs = config.recognition.timeout_secs as u64 + 3; // buffer for model load
@@ -803,7 +881,8 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
         }
     };
 
-    let result = Command::new(&auth_bin)
+    let mut command = Command::new(&auth_bin);
+    command
         .arg("auth")
         .arg("--user")
         .arg(user)
@@ -817,8 +896,34 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
         .envs(oneshot_child_env(std::env::vars_os()))
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .spawn();
+        .stderr(std::process::Stdio::piped());
+
+    // Tie the child's life to this PAM host's. If the host is killed — a
+    // screen locker's PAM helper torn down on unlock, a killed `sudo` — the
+    // kernel sends the child SIGTERM, which `facelock auth` handles by
+    // ending its scan and running `Drop` (STREAMOFF, IR emitter off). Without
+    // it the child is reparented to init and keeps the camera on, alone, for
+    // the rest of its timeout: the one-shot analogue of the daemon's caller
+    // watch (ADR 008 §7).
+    //
+    // SAFETY: `pre_exec` runs in the forked child between fork and exec,
+    // where only async-signal-safe work is allowed. `prctl` is a single
+    // syscall with no allocation, no locks and no libc state — it is one of
+    // the operations `pre_exec` exists for. PDEATHSIG is cleared by exec only
+    // for setuid binaries; `facelock` is not one (its trust is verified
+    // above), so it survives into the execed image.
+    unsafe {
+        command.pre_exec(|| {
+            // The result is deliberately ignored: losing the parent-death
+            // signal costs the promptness, never the authentication — the
+            // child still exits on its own timeout, and the kill sequence
+            // below still applies.
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+            Ok(())
+        });
+    }
+
+    let result = command.spawn();
 
     let mut child = match result {
         Ok(c) => c,
@@ -862,7 +967,16 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
             }
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
-                    let _ = child.kill();
+                    // SIGTERM first, SIGKILL only if it will not go. A
+                    // SIGKILL skips the child's `Drop`, so the V4L2 stream is
+                    // torn down by the kernel with no STREAMOFF and an
+                    // XU-controlled IR emitter is left lit until something
+                    // else turns it off (ADR 008 §7).
+                    terminate_oneshot_child(&mut child, ONESHOT_TERM_GRACE);
+                    // Non-blocking reap of the now-dead child. Deliberately
+                    // not `wait()`: if the signals could not be delivered,
+                    // blocking here would hang the whole PAM stack.
+                    let _ = child.try_wait();
                     log_auth(service, "timeout (oneshot)", user, LOG_WARNING);
                     return PAM_AUTH_ERR;
                 }
@@ -1471,6 +1585,69 @@ auth_bin = "/usr/local/bin/evil"
             pam_code_for_daemon_error("IR camera required for authentication. ...");
         assert_eq!(code, PAM_IGNORE);
         assert_eq!(reason, "ir_required");
+    }
+
+    /// A child that records what it was sent and exits when told to.
+    struct FakeChild {
+        sent: Vec<libc::c_int>,
+        exits_on_term: bool,
+    }
+
+    impl Terminable for FakeChild {
+        fn signal(&mut self, signal: libc::c_int) -> std::io::Result<()> {
+            self.sent.push(signal);
+            Ok(())
+        }
+
+        fn has_exited(&mut self) -> std::io::Result<bool> {
+            Ok(self.exits_on_term && self.sent.contains(&libc::SIGTERM))
+        }
+    }
+
+    /// The ordering that matters: a well-behaved child is asked to stop, not
+    /// killed. A SIGKILL skips `Drop`, so the V4L2 stream is never told to
+    /// STREAMOFF and an XU-controlled IR emitter is left lit.
+    #[test]
+    fn a_child_that_exits_on_sigterm_is_never_killed() {
+        let mut child = FakeChild {
+            sent: Vec::new(),
+            exits_on_term: true,
+        };
+        let sent = terminate_oneshot_child(&mut child, std::time::Duration::from_millis(50));
+        assert_eq!(sent, vec![libc::SIGTERM]);
+        assert!(
+            !sent.contains(&libc::SIGKILL),
+            "a child that exited on SIGTERM must not be killed"
+        );
+    }
+
+    /// The backstop: a child wedged in a driver call is killed after the
+    /// grace period. Leaking the emitter beats hanging the PAM stack.
+    #[test]
+    fn a_wedged_child_is_killed_after_the_grace_period() {
+        let grace = std::time::Duration::from_millis(60);
+        let mut child = FakeChild {
+            sent: Vec::new(),
+            exits_on_term: false,
+        };
+        let started = std::time::Instant::now();
+        let sent = terminate_oneshot_child(&mut child, grace);
+        assert_eq!(
+            sent,
+            vec![libc::SIGTERM, libc::SIGKILL],
+            "SIGTERM must come first, and SIGKILL only after it"
+        );
+        assert!(
+            started.elapsed() >= grace,
+            "the child was killed before its grace period ran out"
+        );
+    }
+
+    /// The grace period is the documented one: half a second, matching the
+    /// container assertion that the child exits within it.
+    #[test]
+    fn the_sigterm_grace_period_is_half_a_second() {
+        assert_eq!(ONESHOT_TERM_GRACE, std::time::Duration::from_millis(500));
     }
 
     /// A cancelled attempt is an abstention, never a failure: the daemon

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -791,7 +791,14 @@ const ONESHOT_TERM_GRACE: std::time::Duration = std::time::Duration::from_millis
 /// Poll interval while waiting out [`ONESHOT_TERM_GRACE`].
 const ONESHOT_TERM_POLL: std::time::Duration = std::time::Duration::from_millis(20);
 
-/// The two things the termination sequence needs from a child process.
+/// How long a SIGKILLed child is polled for before the blocking reap.
+///
+/// SIGKILL is uncatchable, so a child that received one is already dying and
+/// this normally expires after a single poll; the bound exists so the reap
+/// below is never the first thing that waits.
+const ONESHOT_KILL_REAP_WAIT: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// The three things the termination sequence needs from a child process.
 ///
 /// A trait rather than a `std::process::Child` in the signature purely so the
 /// sequence itself — the part that is auth-adjacent policy, not mechanism —
@@ -801,6 +808,9 @@ trait Terminable {
     fn signal(&mut self, signal: libc::c_int) -> std::io::Result<()>;
     /// Has it exited yet? Non-blocking.
     fn has_exited(&mut self) -> std::io::Result<bool>;
+    /// Block until it is reaped. Only ever called after a SIGKILL that the
+    /// kernel accepted, so the wait is bounded by the kernel, not by us.
+    fn reap(&mut self) -> std::io::Result<()>;
 }
 
 impl Terminable for std::process::Child {
@@ -817,6 +827,12 @@ impl Terminable for std::process::Child {
 
     fn has_exited(&mut self) -> std::io::Result<bool> {
         self.try_wait().map(|status| status.is_some())
+    }
+
+    fn reap(&mut self) -> std::io::Result<()> {
+        // `wait` returns the cached status immediately if a `try_wait` above
+        // already reaped it, so calling this after the poll loop is free.
+        self.wait().map(|_| ())
     }
 }
 
@@ -856,6 +872,25 @@ fn terminate_oneshot_child<T: Terminable>(
 
     if child.signal(libc::SIGKILL).is_ok() {
         sent.push(libc::SIGKILL);
+        // Reap it. A child killed here is dead within microseconds, but until
+        // somebody waits on it, it is a zombie occupying a PID slot for as
+        // long as this PAM host lives — and the host may be a long-running
+        // screen locker, not a `sudo` that exits a second later. The old
+        // single non-blocking `try_wait` at the call site was a coin flip on
+        // whether the child had been scheduled off yet.
+        //
+        // Blocking is safe *only* because SIGKILL was accepted: it cannot be
+        // caught, blocked or ignored, so the kernel bounds this wait. When the
+        // signal could not be delivered at all this branch is skipped and
+        // nothing blocks — the case the original comment was worried about.
+        let deadline = std::time::Instant::now() + ONESHOT_KILL_REAP_WAIT;
+        while !child.has_exited().unwrap_or(false) {
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(ONESHOT_TERM_POLL.min(ONESHOT_KILL_REAP_WAIT));
+        }
+        let _ = child.reap();
     }
     sent
 }
@@ -906,19 +941,37 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
     // the rest of its timeout: the one-shot analogue of the daemon's caller
     // watch (ADR 008 §7).
     //
+    // Read before the fork so the closure has something to compare against.
+    //
+    // SAFETY: `getpid` is a plain syscall with no preconditions.
+    let expected_parent_pid = unsafe { libc::getpid() };
+
     // SAFETY: `pre_exec` runs in the forked child between fork and exec,
-    // where only async-signal-safe work is allowed. `prctl` is a single
-    // syscall with no allocation, no locks and no libc state — it is one of
-    // the operations `pre_exec` exists for. PDEATHSIG is cleared by exec only
-    // for setuid binaries; `facelock` is not one (its trust is verified
-    // above), so it survives into the execed image.
+    // where only async-signal-safe work is allowed. `prctl`, `getppid` and
+    // `raise` are single syscalls with no allocation, no locks and no libc
+    // state — they are the operations `pre_exec` exists for, and the closure
+    // captures only a `pid_t` by copy, so it allocates nothing either.
+    // PDEATHSIG is cleared by exec only for setuid binaries; `facelock` is not
+    // one (its trust is verified above), so it survives into the execed image.
     unsafe {
-        command.pre_exec(|| {
+        command.pre_exec(move || {
             // The result is deliberately ignored: losing the parent-death
             // signal costs the promptness, never the authentication — the
             // child still exits on its own timeout, and the kill sequence
             // below still applies.
             libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+            // PDEATHSIG fires on the parent's death, not on already being an
+            // orphan — so a host that died in the window between `fork` and
+            // the `prctl` above has already been mourned and nothing will
+            // ever arrive. That leaves exactly what PDEATHSIG exists to
+            // prevent: a `facelock auth` reparented to init, holding the
+            // camera and the IR emitter alone for the rest of its timeout,
+            // with no PAM host left to run the kill sequence. Closing the
+            // window means asking once, after the fact, whether we are still
+            // the child we thought we were.
+            if libc::getppid() != expected_parent_pid {
+                libc::raise(libc::SIGTERM);
+            }
             Ok(())
         });
     }
@@ -972,11 +1025,10 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
                     // torn down by the kernel with no STREAMOFF and an
                     // XU-controlled IR emitter is left lit until something
                     // else turns it off (ADR 008 §7).
+                    // Reaps the child itself: a child that exits on SIGTERM is
+                    // reaped by the poll, and one that had to be killed is
+                    // waited for there (both bounded — see the function).
                     terminate_oneshot_child(&mut child, ONESHOT_TERM_GRACE);
-                    // Non-blocking reap of the now-dead child. Deliberately
-                    // not `wait()`: if the signals could not be delivered,
-                    // blocking here would hang the whole PAM stack.
-                    let _ = child.try_wait();
                     log_auth(service, "timeout (oneshot)", user, LOG_WARNING);
                     return PAM_AUTH_ERR;
                 }
@@ -1591,16 +1643,45 @@ auth_bin = "/usr/local/bin/evil"
     struct FakeChild {
         sent: Vec<libc::c_int>,
         exits_on_term: bool,
+        /// Whether the sequence blocked on a wait — the difference between
+        /// reaping the child and leaving a zombie behind.
+        reaped: bool,
+        /// Delivery failure, for the child that cannot be signalled at all.
+        signals_fail: bool,
+    }
+
+    impl FakeChild {
+        fn new(exits_on_term: bool) -> Self {
+            Self {
+                sent: Vec::new(),
+                exits_on_term,
+                reaped: false,
+                signals_fail: false,
+            }
+        }
     }
 
     impl Terminable for FakeChild {
         fn signal(&mut self, signal: libc::c_int) -> std::io::Result<()> {
+            if self.signals_fail {
+                return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
+            }
             self.sent.push(signal);
             Ok(())
         }
 
         fn has_exited(&mut self) -> std::io::Result<bool> {
+            // A SIGKILLed child is gone by the next poll; a SIGTERMed one only
+            // if it is the well-behaved kind.
+            if self.sent.contains(&libc::SIGKILL) {
+                return Ok(true);
+            }
             Ok(self.exits_on_term && self.sent.contains(&libc::SIGTERM))
+        }
+
+        fn reap(&mut self) -> std::io::Result<()> {
+            self.reaped = true;
+            Ok(())
         }
     }
 
@@ -1609,10 +1690,7 @@ auth_bin = "/usr/local/bin/evil"
     /// STREAMOFF and an XU-controlled IR emitter is left lit.
     #[test]
     fn a_child_that_exits_on_sigterm_is_never_killed() {
-        let mut child = FakeChild {
-            sent: Vec::new(),
-            exits_on_term: true,
-        };
+        let mut child = FakeChild::new(true);
         let sent = terminate_oneshot_child(&mut child, std::time::Duration::from_millis(50));
         assert_eq!(sent, vec![libc::SIGTERM]);
         assert!(
@@ -1626,10 +1704,7 @@ auth_bin = "/usr/local/bin/evil"
     #[test]
     fn a_wedged_child_is_killed_after_the_grace_period() {
         let grace = std::time::Duration::from_millis(60);
-        let mut child = FakeChild {
-            sent: Vec::new(),
-            exits_on_term: false,
-        };
+        let mut child = FakeChild::new(false);
         let started = std::time::Instant::now();
         let sent = terminate_oneshot_child(&mut child, grace);
         assert_eq!(
@@ -1640,6 +1715,50 @@ auth_bin = "/usr/local/bin/evil"
         assert!(
             started.elapsed() >= grace,
             "the child was killed before its grace period ran out"
+        );
+    }
+
+    /// ...and it is *reaped*, not merely killed.
+    ///
+    /// A single non-blocking `try_wait` after the kill was a coin flip on
+    /// whether the child had been scheduled off yet; when it lost, the PAM
+    /// host held a zombie for the rest of its own life — and that host can be
+    /// a screen locker that lives for days, not a `sudo` that exits in a
+    /// second. Blocking here is safe because SIGKILL cannot be caught, so the
+    /// kernel bounds the wait.
+    #[test]
+    fn a_killed_child_is_reaped_rather_than_left_a_zombie() {
+        let mut child = FakeChild::new(false);
+        let sent = terminate_oneshot_child(&mut child, std::time::Duration::from_millis(20));
+        assert!(sent.contains(&libc::SIGKILL));
+        assert!(child.reaped, "the killed child was never waited for");
+    }
+
+    /// The child that exits on its own is reaped by the grace-period poll —
+    /// `try_wait` reaps as it reports — so the sequence must not go on to
+    /// block on a wait it does not need.
+    #[test]
+    fn a_child_that_exits_on_sigterm_is_not_waited_on_again() {
+        let mut child = FakeChild::new(true);
+        terminate_oneshot_child(&mut child, std::time::Duration::from_millis(50));
+        assert!(
+            !child.reaped,
+            "a child already reaped by the poll must not be waited on again"
+        );
+    }
+
+    /// The case the blocking wait must never be reached in: signals that
+    /// cannot be delivered at all. Waiting on a child we could not signal is
+    /// how the whole PAM stack would hang, so no signal means no wait.
+    #[test]
+    fn a_child_that_cannot_be_signalled_is_never_waited_on() {
+        let mut child = FakeChild::new(false);
+        child.signals_fail = true;
+        let sent = terminate_oneshot_child(&mut child, std::time::Duration::from_millis(20));
+        assert!(sent.is_empty(), "nothing was delivered: {sent:?}");
+        assert!(
+            !child.reaped,
+            "blocked on a child that could not be signalled"
         );
     }
 

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -895,6 +895,15 @@ fn pam_code_for_daemon_error(message: &str) -> (libc::c_int, &'static str) {
         (PAM_AUTH_ERR, "rate_limited")
     } else if message.contains("IR camera required") || message.contains("ir_required") {
         (PAM_IGNORE, "ir_required")
+    } else if message == "cancelled" {
+        // The attempt was abandoned, not refused: the caller's connection
+        // went away, the system is suspending, or `ReleaseCamera` arrived.
+        // The daemon has no opinion about this face, so abstain and let the
+        // password modules run — which is what the user who just typed a
+        // password expects. Matched exactly (not `contains`) so an arbitrary
+        // error message that happens to mention cancelling cannot claim it.
+        // The string is frozen protocol; see docs/contracts.md.
+        (PAM_IGNORE, "cancelled")
     } else {
         (PAM_IGNORE, "error: internal")
     }
@@ -1464,6 +1473,29 @@ auth_bin = "/usr/local/bin/evil"
         assert_eq!(reason, "ir_required");
     }
 
+    /// A cancelled attempt is an abstention, never a failure: the daemon
+    /// stopped looking, it did not look and say no.
+    #[test]
+    fn daemon_error_cancelled_maps_to_ignore() {
+        let (code, reason) = pam_code_for_daemon_error("cancelled");
+        assert_eq!(code, PAM_IGNORE);
+        assert_eq!(reason, "cancelled");
+    }
+
+    /// The cancellation row matches the frozen string exactly, so an error
+    /// that merely mentions cancelling still lands on the generic branch.
+    #[test]
+    fn only_the_exact_cancelled_string_claims_the_cancelled_row() {
+        for message in [
+            "camera error: capture cancelled by driver",
+            "storage error: transaction cancelled",
+        ] {
+            let (code, reason) = pam_code_for_daemon_error(message);
+            assert_eq!(code, PAM_IGNORE);
+            assert_eq!(reason, "error: internal", "message: {message}");
+        }
+    }
+
     #[test]
     fn daemon_error_never_maps_to_success() {
         for message in [
@@ -1471,6 +1503,7 @@ auth_bin = "/usr/local/bin/evil"
             "IR camera required",
             "camera error: device busy",
             "storage error: disk io",
+            "cancelled",
             "",
         ] {
             let (code, _) = pam_code_for_daemon_error(message);

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -79,10 +79,10 @@ stateDiagram-v2
     Warm --> Closed: deadline · ReleaseCamera · suspend · reload · shutdown
 ```
 
-**`CameraLease`** — one struct inside `Handler` owning `camera: Option<C>`, `deadline: Option<Instant>`, `cancel: Arc<AtomicBool>`. All request arms use it; nothing else touches the camera or the deadline.
+**`CameraLease`** — one struct inside `Handler` owning `camera: Option<C>` and `deadline: Option<Instant>`. All request arms use it; nothing else touches the camera or the deadline. The cancel token is *not* a field: it belongs to the request, arrives as an argument to `acquire`, and dies with the request (§5).
 
 ```rust
-fn acquire(&mut self, cfg) -> Result<&mut C>   // Closed: open + discard(warmup)  |  Warm: discard(MMAP_BUFFERS-1); clears deadline, resets cancel
+fn acquire(&mut self, cfg, cancel) -> Result<&mut C>   // Closed: open + discard(warmup)  |  Warm: discard(MMAP_BUFFERS-1); clears deadline
 fn finish(&mut self, outcome: Outcome)         // Success|Cancelled|Error → drop camera; Failure → deadline = now + release_secs (or drop if 0)
 fn touch_preview(&mut self)                    // deadline = now + max(release_secs, PREVIEW_MIN_HOLD=2s)
 fn expire(&mut self, now)                      // deadline passed → drop camera   (called from the 250 ms poll)
@@ -103,7 +103,9 @@ Warm reuse skips warmup (AE is settled) but discards `MMAP_BUFFERS − 1` frames
 
 ## 5. Cancellation
 
-One token, one rule: **the request ends within one frame, `finish(Cancelled)`, no rate-limit charge, audit `cancelled`.** The auth loop (`auth.rs:572`), enroll loop (`enroll.rs:187`), and both discard loops check the token per iteration.
+One token **per request**, one rule: **the request ends within one frame, `finish(Cancelled)`, no rate-limit charge, audit `cancelled`.** The auth loop (`auth.rs:572`), enroll loop (`enroll.rs:187`), and both discard loops check the token per iteration — including a cancellation noticed before the camera opens, which audits the same way with `frame_count: 0`.
+
+The token is minted by the `#[interface]` glue for the one call it belongs to, and there is deliberately no way to clear one. zbus dispatches each method in its own task, so a token shared across calls is shared across *concurrent* calls: a second caller (even one about to be denied) could clear the flag an in-flight request had not read yet, and a departure watch subscribed against it could cancel a request that was never its caller's. Fresh and un-cancelled are therefore the same statement. Suspend, `ReleaseCamera` and shutdown reach the running request through a small lock-free slot on the service holding the token of whichever request currently owns the capture slot; it is published only *after* authorization and the capture-slot claim, and generation-checked on clear, so a rejected or already-finished request can neither displace nor erase the entry of the one actually running.
 
 Who sets it:
 
@@ -111,7 +113,7 @@ Who sets it:
 |---|---|
 | Caller's bus connection disappears — PAM host aborted/killed (omarchy shell `abort()`, sudo exit), CLI Ctrl-C, client crash | Per request: glue takes `hdr.sender()`, races the blocking work against `DBusProxy::receive_name_owner_changed_with_args([(0, sender)])`; a `(sender, old, "")` event sets the token. Subscription failure → log, degrade to timeout-bounded (today). A client that dies before we subscribe is missed → also timeout-bounded, accepted. |
 | polkit agent `CancelAuthentication` | Agent uses a **dedicated `Connection::system()` per `Authenticate`** and drops it on cancel — same mechanism, no new API. |
-| Suspend, `ReleaseCamera`, shutdown | Set the token directly (it's an `Arc<AtomicBool>`, no handler lock needed). |
+| Suspend, `ReleaseCamera`, shutdown | Set the in-flight request's token through the service's current-request slot (it's an `Arc<AtomicBool>`, no handler lock needed). Nothing in flight → nothing to cancel. |
 | One-shot: SIGTERM/SIGINT/SIGHUP, parent death | `signal_hook::flag::register` into the same token type; PDEATHSIG delivers SIGTERM (§7). |
 
 Not doing (until a client needs it): an explicit `Cancel()` D-Bus method. If Quattro's PAM helper turns out to keep its connection alive across `abort()`, that is the moment to add it — one method, caller-UID authz.

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -37,7 +37,7 @@ Success, cancel, and error end the interaction → release now. No-match/timeout
 
 | | Today | After |
 |---|---|---|
-| Hold | live V4L2 stream for `camera_release_secs` (5) after *every* request; `0` silently = 5; released by a 1 s `try_lock` poll (`server.rs:1320-1350`, `handler.rs:320-329`) | stream held **only after a failed attempt**, `camera_release_secs` = **3**, `0` = no hold, 250 ms poll |
+| Hold | live V4L2 stream for `camera_release_secs` (5) after *every* request; `0` silently = 5; released by a 1 s `try_lock` poll (`server.rs:1320-1350`, `handler.rs:320-329`) | stream held **only after a failed attempt**, `camera_release_secs` = **3**, `0` = no hold, 250 ms poll; a success holds only if `camera_release_after_success_secs` is set (default `0`, §3) |
 | Warm reuse | dequeues up to 3 stale frames from the hold (`handler.rs:332-359`) | discards `MMAP_BUFFERS − 1` frames first (same helper as cold warmup) |
 | Cancel | none — scan runs to `timeout_secs` after the client is gone (`auth.rs:543-572`); polkit agent's cancel only drops its future (`facelock-polkit/src/main.rs:52-102`) | per-request cancel token; set when the caller's bus connection vanishes, on suspend/shutdown, or (one-shot) on SIGTERM |
 | One-shot | opens camera before loading the engine (`cli/commands/auth.rs:130-160`); PAM SIGKILLs a slow child (`pam-facelock/src/lib.rs:836-870`); child can outlive its PAM host | engine first; SIGTERM handled → clean `Drop`; `PR_SET_PDEATHSIG` |
@@ -49,9 +49,12 @@ Success, cancel, and error end the interaction → release now. No-match/timeout
 ```toml
 [device]
 # Daemon only. Seconds to keep the camera streaming after a FAILED attempt so a
-# retry skips reopen (~0.4 s). Success, cancel and errors always release at once.
+# retry skips reopen (~0.4 s). Cancel and errors always release at once.
 # 0 = never hold.
 camera_release_secs = 3
+
+# Opt-in: hold after a SUCCESSFUL attempt too. 0 = release at once (default).
+camera_release_after_success_secs = 0
 
 [recognition]
 # End an attempt after this many seconds if no face at all has been seen.
@@ -65,7 +68,9 @@ no_face_timeout_secs = 2
 - `no_face_timeout_secs` is additive with a serde default. Effective value is `min(no_face_timeout_secs, timeout_secs)`, `0` disables; it never rejects an existing config (a user with `timeout_secs = 2` sees identical behavior). PAM's private schema ignores it (no `deny_unknown_fields`; template parity test unaffected because the template key ships commented).
 - Everything else — success/cancel release, stale discard, cancel token, no-face not charging the limiter, one-shot ordering/signals — is behavior with no config surface.
 
-Deliberately not offered: a success-hold key. sudo `timestamp_timeout` and polkit `auth_admin_keep` already cache successes; add `camera_release_after_success_secs` later only if a real user asks. Docs touched: template comment, `docs/configuration.md`, `docs/contracts.md` wording, CHANGELOG "Changed", one upgrade-notes line ("no action required").
+Docs touched: template comment, `docs/configuration.md`, `docs/contracts.md` wording, CHANGELOG, one upgrade-notes line ("no action required").
+
+**`camera_release_after_success_secs`, added after the fact.** This key was deferred here — sudo `timestamp_timeout` and polkit `auth_admin_keep` already cache successes, so on most setups a hold after a success only lights the IR emitter for a retry nobody makes — and was then added on maintainer request as an opt-in, default **0**, which is byte for byte the behavior described above. Non-zero keeps the stream warm after a success for that many seconds, for the flows those caches are turned off in (`timestamp_timeout=0`, no `auth_admin_keep`), where every privileged action is a fresh authentication that pays a reopen. Additive with a serde default, so it rejects no existing config and needs no migration, and the daemon reads it per request like its sibling. Failures still use `camera_release_secs`; cancel and error still release at once regardless of either key.
 
 ## 4. Daemon lifecycle
 
@@ -74,8 +79,9 @@ stateDiagram-v2
     [*] --> Closed
     Closed --> Active: request — open, warmup
     Warm --> Active: request — discard stale
-    Active --> Closed: Success · Cancelled · Error
+    Active --> Closed: Success (default) · Cancelled · Error
     Active --> Warm: Failure · Timeout
+    Active --> Warm: Success — only with camera_release_after_success_secs
     Warm --> Closed: deadline · ReleaseCamera · suspend · reload · shutdown
 ```
 
@@ -83,7 +89,7 @@ stateDiagram-v2
 
 ```rust
 fn acquire(&mut self, cfg, cancel) -> Result<&mut C>   // Closed: open + discard(warmup)  |  Warm: discard(MMAP_BUFFERS-1); clears deadline
-fn finish(&mut self, outcome: Outcome)         // Success|Cancelled|Error → drop camera; Failure → deadline = now + release_secs (or drop if 0)
+fn finish(&mut self, outcome: Outcome)         // Cancelled|Error → drop camera; Failure → deadline = now + release_secs; Success → drop, or deadline = now + release_after_success_secs when that is set (both: drop if 0)
 fn touch_preview(&mut self)                    // deadline = now + max(release_secs, PREVIEW_MIN_HOLD=2s)
 fn expire(&mut self, now)                      // deadline passed → drop camera   (called from the 250 ms poll)
 ```

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -1,0 +1,206 @@
+# ADR 008: Outcome-Based Camera Hold and Cancellable Authentication
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-15
+
+## Decision
+
+The camera is on only while an authentication is in progress or a retry is
+plausibly imminent. Success, cancel, and error release the camera immediately;
+a no-match/timeout keeps it warm for `device.camera_release_secs` (default 3,
+`0` = never; previously 5 after every request). Every in-flight request carries
+a cancel token set when the caller's bus connection disappears, on
+suspend/shutdown, or (one-shot) on SIGTERM. Warm reuse discards the stale V4L2
+buffers first. One-shot loads the engine before opening the camera and dies with
+its PAM host. `recognition.no_face_timeout_secs` (default 2) ends attempts at an
+empty chair early and such attempts never charge the rate limiter. No config
+migration is required.
+
+The full design, flows, failure handling and validation plan follow.
+
+---
+
+How long the camera stays open around an authentication, in daemon and one-shot mode.
+Baseline `main` @ `7def547`. Motivation: [omarchy#4982](https://github.com/basecamp/omarchy/discussions/4982) (LED strobes for the 5 s hold) and [omarchy PR #6863](https://github.com/basecamp/omarchy/pull/6863) (auto-start, 3 × 250 ms retries, password typed in parallel, PAM aborted on unlock/lid-close).
+
+## 1. Principle
+
+**The camera is on only while an authentication is in progress or a retry is plausibly imminent.**
+Success, cancel, and error end the interaction → release now. No-match/timeout predicts a retry → keep warm briefly. Anything the daemon can't see (a client that already left) must be made visible, because an invisible cancel is a timeout, and a timeout keeps the camera on.
+
+## 2. Today → after
+
+| | Today | After |
+|---|---|---|
+| Hold | live V4L2 stream for `camera_release_secs` (5) after *every* request; `0` silently = 5; released by a 1 s `try_lock` poll (`server.rs:1320-1350`, `handler.rs:320-329`) | stream held **only after a failed attempt**, `camera_release_secs` = **3**, `0` = no hold, 250 ms poll |
+| Warm reuse | dequeues up to 3 stale frames from the hold (`handler.rs:332-359`) | discards `MMAP_BUFFERS − 1` frames first (same helper as cold warmup) |
+| Cancel | none — scan runs to `timeout_secs` after the client is gone (`auth.rs:543-572`); polkit agent's cancel only drops its future (`facelock-polkit/src/main.rs:52-102`) | per-request cancel token; set when the caller's bus connection vanishes, on suspend/shutdown, or (one-shot) on SIGTERM |
+| One-shot | opens camera before loading the engine (`cli/commands/auth.rs:130-160`); PAM SIGKILLs a slow child (`pam-facelock/src/lib.rs:836-870`); child can outlive its PAM host | engine first; SIGTERM handled → clean `Drop`; `PR_SET_PDEATHSIG` |
+| No face | scans full `timeout_secs`, charges the rate limiter | ends at `no_face_timeout_secs` (2), never charges |
+| Reopen cost | asserted ~400 ms (`docs/architecture.md:211`), never measured | `bench camera-reopen` |
+
+## 3. Configuration
+
+```toml
+[device]
+# Daemon only. Seconds to keep the camera streaming after a FAILED attempt so a
+# retry skips reopen (~0.4 s). Success, cancel and errors always release at once.
+# 0 = never hold.
+camera_release_secs = 3
+
+[recognition]
+# End an attempt after this many seconds if no face at all has been seen.
+# timeout_secs still bounds "face seen, not yet matched". 0 = disabled.
+no_face_timeout_secs = 2
+```
+
+**Compatibility — no migration.** `/etc/facelock/config.toml` is a protected conffile in every package (`backup=`, `%config(noreplace)`, dpkg conffile); the shipped template has every key commented out; `facelock setup` writes only device path / provider / encryption / models. So:
+
+- `camera_release_secs` is reused unchanged in name and type. Almost every install has it unset → the new default (3) applies on upgrade with no file change. Explicit values keep working and now apply after failure only. `0` was silently 5 — nobody set it wanting 5 — so honoring it is a fix, not a migration. No `config --edit` restart entry needed: the daemon live-reloads and reads it per request.
+- `no_face_timeout_secs` is additive with a serde default. Effective value is `min(no_face_timeout_secs, timeout_secs)`, `0` disables; it never rejects an existing config (a user with `timeout_secs = 2` sees identical behavior). PAM's private schema ignores it (no `deny_unknown_fields`; template parity test unaffected because the template key ships commented).
+- Everything else — success/cancel release, stale discard, cancel token, no-face not charging the limiter, one-shot ordering/signals — is behavior with no config surface.
+
+Deliberately not offered: a success-hold key. sudo `timestamp_timeout` and polkit `auth_admin_keep` already cache successes; add `camera_release_after_success_secs` later only if a real user asks. Docs touched: template comment, `docs/configuration.md`, `docs/contracts.md` wording, CHANGELOG "Changed", one upgrade-notes line ("no action required").
+
+## 4. Daemon lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> Active: request — open, warmup
+    Warm --> Active: request — discard stale
+    Active --> Closed: Success · Cancelled · Error
+    Active --> Warm: Failure · Timeout
+    Warm --> Closed: deadline · ReleaseCamera · suspend · reload · shutdown
+```
+
+**`CameraLease`** — one struct inside `Handler` owning `camera: Option<C>`, `deadline: Option<Instant>`, `cancel: Arc<AtomicBool>`. All request arms use it; nothing else touches the camera or the deadline.
+
+```rust
+fn acquire(&mut self, cfg) -> Result<&mut C>   // Closed: open + discard(warmup)  |  Warm: discard(MMAP_BUFFERS-1); clears deadline, resets cancel
+fn finish(&mut self, outcome: Outcome)         // Success|Cancelled|Error → drop camera; Failure → deadline = now + release_secs (or drop if 0)
+fn touch_preview(&mut self)                    // deadline = now + max(release_secs, PREVIEW_MIN_HOLD=2s)
+fn expire(&mut self, now)                      // deadline passed → drop camera   (called from the 250 ms poll)
+```
+
+`Outcome` is derived from `AuthOutcome` in one `From` impl (`Success` matched; `Failure` = `matched=false` incl. timeout; `Cancelled`; `Error` = every `ErrorKind` incl. `AllFramesDark`, camera/capture errors). Enroll: stored ≥ min → Success, deadline hit → Failure. `TestAuthenticate` follows the same rule (a repeated `facelock test` is human-paced).
+
+| Request | Camera |
+|---|---|
+| `Authenticate`, `TestAuthenticate`, `Enroll` | `acquire` → run → `finish(outcome)` |
+| `PreviewFrame`, `PreviewDetectFrame` | `acquire` → capture → `touch_preview` (a preview streams at ~10 fps; must not reopen per frame even with `release_secs = 0`; CLI exit still calls `ReleaseCamera`) |
+| `ReleaseCamera` (root) | set cancel, drop camera |
+| Config reload, `Shutdown`, SIGTERM/idle | handler dropped → camera dropped (`Drop` disables the IR emitter) |
+| logind `PrepareForSleep(true)` | set cancel (lock-free), then drop camera — replaces today's `try_lock`/"busy" warning |
+| Second request while `Active` | capture slot "busy" error, unchanged; PAM degrades to password |
+
+Warm reuse skips warmup (AE is settled) but discards `MMAP_BUFFERS − 1` frames: V4L2 leaves those buffers filled with the frames right after the last capture, and they would otherwise be analyzed first. ≤100 ms, closes the "matched on the previous auth's tail" window.
+
+## 5. Cancellation
+
+One token, one rule: **the request ends within one frame, `finish(Cancelled)`, no rate-limit charge, audit `cancelled`.** The auth loop (`auth.rs:572`), enroll loop (`enroll.rs:187`), and both discard loops check the token per iteration.
+
+Who sets it:
+
+| Source | Mechanism |
+|---|---|
+| Caller's bus connection disappears — PAM host aborted/killed (omarchy shell `abort()`, sudo exit), CLI Ctrl-C, client crash | Per request: glue takes `hdr.sender()`, races the blocking work against `DBusProxy::receive_name_owner_changed_with_args([(0, sender)])`; a `(sender, old, "")` event sets the token. Subscription failure → log, degrade to timeout-bounded (today). A client that dies before we subscribe is missed → also timeout-bounded, accepted. |
+| polkit agent `CancelAuthentication` | Agent uses a **dedicated `Connection::system()` per `Authenticate`** and drops it on cancel — same mechanism, no new API. |
+| Suspend, `ReleaseCamera`, shutdown | Set the token directly (it's an `Arc<AtomicBool>`, no handler lock needed). |
+| One-shot: SIGTERM/SIGINT/SIGHUP, parent death | `signal_hook::flag::register` into the same token type; PDEATHSIG delivers SIGTERM (§7). |
+
+Not doing (until a client needs it): an explicit `Cancel()` D-Bus method. If Quattro's PAM helper turns out to keep its connection alive across `abort()`, that is the moment to add it — one method, caller-UID authz.
+
+`Ctrl-C` on `sudo` is ambiguous ("never mind" vs "again"); cancel wins — LED off is the unambiguous expectation, a retry pays one reopen. Whether sudo tears down mid-`pam_authenticate` is to verify on hardware; if it defers, nothing regresses.
+
+## 6. Flows (defaults: 3 s window, `timeout_secs` 5, `no_face` 2, reopen ≈ 0.4 s)
+
+| Surface · flow | Daemon outcome | Camera / LED |
+|---|---|---|
+| Omarchy lid open → match | Success | off ≤ 100 ms after unlock |
+| Omarchy try 1 misses, try 2 (+250 ms) matches | Failure → Warm; warm reuse; Success | on through both, no reopen, off at unlock |
+| Omarchy three misses (backlight) | 3 × Failure (≤ 5 s each, face seen) → Warm | on ≤ 15 s + 3 s, off; user types password |
+| Omarchy lid open, nobody there | 3 × Timeout at 2 s, not charged | on ≤ 6 s + 3 s |
+| Omarchy password typed first / lid closed / unlock | shell aborts PAM → connection gone → Cancelled | off ≤ 100 ms (today ≈ 10 s) |
+| Omarchy key press after the misses | Warm if < 3 s since last failure, else cold | — |
+| hyprlock Enter → match / miss → Enter again / miss → password | Success / Failure→Warm→warm reuse / Failure→Warm→expire | off at unlock / on through both / on 3 s then off |
+| sudo match; second sudo soon after | Success; **usually no request** (sudo cache) | off before the command runs |
+| sudo miss → password prompt | Failure → Warm 3 s | strobe 3 s while typing; `0` removes it |
+| sudo miss → Ctrl-C → rerun | Cancelled → cold rerun (or Failure → warm rerun if sudo defers) | either satisfies §1 |
+| polkit match / dialog Cancel / miss | Success / Cancelled (dedicated connection dropped) / Failure → Warm | off with dialog / off ≤ 100 ms / 3 s |
+| `facelock test`, `enroll` (Ctrl-C) | Success → off; Cancelled via connection drop | off before the prompt returns |
+| `facelock preview` | rolling `touch_preview`; exit → `ReleaseCamera` | off ≤ 2 s after even a crashed preview |
+| Suspend mid-scan | Cancelled, closed | off before sleep |
+| Rate-limited / lid closed / ssh / IR required | Error before open | never on |
+
+## 7. One-shot mode
+
+Never holds; exit is the release. `camera_release_secs` ignored.
+
+```
+pre-flight gates → load engine → open camera + discard(warmup) → scan (token, no_face, timeout) → Drop (STREAMOFF, emitter off) → exit 0/1/2
+```
+
+- Engine before camera: LED-on time = scan time (today it spans model load).
+- `facelock auth` registers SIGTERM/SIGINT/SIGHUP → token → clean `Drop`, exit 2, log `cancelled`. Existing exit-code contract unchanged.
+- `pre_exec`: `prctl(PR_SET_PDEATHSIG, SIGTERM)` so an aborted PAM host (killed quickshell helper, killed sudo) takes the child with it — the one-shot analogue of the connection watch.
+- PAM child timeout: SIGTERM, wait ≤ 500 ms, then SIGKILL (today: SIGKILL only, which skips `Drop` and leaves an XU-controlled emitter on).
+- Fallback while the daemon holds the camera: `STREAMON` → `EBUSY` → exit 2 → `PAM_IGNORE` → password. Logged with device path; rarer with a 3 s window; not worth evicting the daemon.
+
+## 8. Failure handling
+
+Invariant (tested): **every exit from `Active` either sets a deadline or drops the camera.**
+
+| Failure | Behavior |
+|---|---|
+| Camera open error / capture error mid-scan / warm-reuse `next()` error | `Error` → drop camera (never `Warm`); not charged; PAM degrades to password |
+| Cancel token during warmup/stale discard | abort acquire → `Cancelled`, closed |
+| Name-owner watch fails to subscribe | warn; that request is timeout-bounded as today |
+| Poll tick lands while a request holds the lock | `try_lock` fails, retried 250 ms later; deadline is absolute so nothing is lost |
+| Daemon crash while streaming | kernel closes fd (implicit `STREAMOFF`); if `ir_emitter = true`, daemon start runs `disable_emitter` once (idempotent) |
+| Suspend while a request is stuck in the driver | token set; if not exited in 1 s, drop the camera anyway (`Camera` drop is safe from any state) |
+| Config reload while `Warm` | old handler dropped → closed; new value applies next request (reload only runs between requests) |
+| PAM D-Bus timeout before the daemon answers | `PAM_AUTH_ERR`, no one-shot fallback (unchanged); daemon ends via its own deadline or the connection drop |
+| One-shot SIGTERM during model load | token checked before open → exit 2, camera never touched |
+
+## 9. Validation
+
+**Config** — every existing config still parses (template + PAM parity tests); `no_face_timeout_secs` clamps to `timeout_secs` (no error); `camera_release_secs = 0` logs "camera hold disabled"; contract table test extended for the two keys.
+
+**Daemon — unit** (mock `CameraSource`, mock clock): `Outcome` × `finish` matrix (table-driven over every `AuthOutcome`/`ErrorKind` variant so a new variant fails to compile until classified); `expire` at `deadline ± 250 ms`; `release_secs = 0` closes on Failure; warm reuse discards exactly `MMAP_BUFFERS − 1` and no warmup; token set at frame *k* → `Cancelled` before *k+1*, no limiter record, camera closed; `no_face` → Timeout at 2 s, `face_detected=false`, not charged; one detection → full timeout; preview floor with `release_secs = 0`; suspend with `Active`/`Warm`.
+**Daemon — integration/container** (`just test-arch-integration`): kill client mid-`Authenticate` → journal `cancelled` < 200 ms + `releasing camera`; Failure → release at 3.0 ± 0.25 s; Success → release before the reply; polkit `CancelAuthentication` → `cancelled`.
+**Daemon — hardware** (BRIO IR + one quirked camera): LED off ≤ 150 ms after match; off at 3 s after miss; Quattro + #6863 password-first unlock → LED off with the unlock (verifies the abort ⇒ connection-drop assumption); warm retry logs no `camera format negotiated`.
+
+**One-shot — unit**: engine load precedes camera open (mock call order); token set before open → exit 2, factory never called.
+**One-shot — container** (`just test-arch-oneshot`): PAM timeout → child gets SIGTERM, exits ≤ 500 ms, no SIGKILL, audit `cancelled`; kill PAM host → no `facelock auth` survives > 200 ms; daemon-held camera → exit 2 with `EBUSY` logged; 0/1 paths unchanged.
+**One-shot — hardware**: Ctrl-C on hand-run `facelock auth` → LED off immediately, emitter disabled.
+
+**Bench**: `facelock bench camera-reopen` — N × (drop → open → warmup → first frame), open/`STREAMON`/warmup split. Decides 3 s vs 2 s and replaces the "~600 ms cold" doc line.
+
+**Acceptance**: (1) LED off ≤ one frame + 250 ms after Success/Cancel; (2) off at `release_secs ± 250 ms` after Failure; (3) warm retry: no `open()`/`STREAMON`, first analyzed frame is fresh; (4) no `facelock auth` outlives its PAM host by > 500 ms; (5) `release_secs = 0` never holds; (6) invariant in §8.
+
+## 10. Delivery
+
+**One PR, atomic commits, merge commit (not squash).** The pieces are genuinely stacked (`finish(Cancelled)` sits on `CameraLease`; the no-face timeout lives in the loop the cancel token threads through) and `ci.yml` runs only on `push: main` / `pull_request: main`, so stacked PRs would get no CI until each predecessor merged. One PR keeps one contract change, one CHANGELOG entry, one docs pass, one omarchy reply, and review happens commit-by-commit:
+
+| Commit | Scope | Contract |
+|---|---|---|
+| 1 | `CameraLease` + outcome rule, `0` = no hold, default 3, 250 ms poll, stale discard, preview floor, tests, docs (no migration) | `camera_release_secs` semantics |
+| 2 | Cancel token in auth/enroll/discard loops; per-request name-owner watch; suspend/`ReleaseCamera`/shutdown via token; audit `cancelled` | audit, `auth_attempted` result |
+| 3 | polkit agent: dedicated connection per `Authenticate`, dropped on cancel | — |
+| 4 | One-shot: engine before camera, SIGTERM/SIGINT/SIGHUP → token, `PR_SET_PDEATHSIG`; PAM SIGTERM-then-SIGKILL | — |
+| 5 | `no_face_timeout_secs` (clamped, additive), no-face never charges the limiter | config key |
+| 6 | `bench camera-reopen`; replace the "~600 ms cold" doc line with measured numbers | — |
+
+Only reason to split: replying on omarchy#4982 before the cancellation work is hardware-verified (Quattro abort, sudo Ctrl-C). Then cut **two sequential PRs, not stacked**: A = commits 1 + 5 + 6 (daemon/core only, answers the thread), B = commits 2–4 (cross-crate, needs the checks), developed on A and retargeted to `main` once A merges so it gets CI.
+
+## 11. Open questions
+
+1. 3 s or 2 s — from the bench.
+2. Does quickshell `PamContext.abort()` drop the helper's bus connection? Decides only whether an explicit `Cancel` method is needed.
+3. Does sudo tear down on Ctrl-C inside `pam_authenticate`? Decides which mechanism fires, not the outcome.

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -165,7 +165,7 @@ Invariant (tested): **every exit from `Active` either sets a deadline or drops t
 | Name-owner watch fails to subscribe | warn; that request is timeout-bounded as today |
 | Poll tick lands while a request holds the lock | `try_lock` fails, retried 250 ms later; deadline is absolute so nothing is lost |
 | Daemon crash while streaming | kernel closes fd (implicit `STREAMOFF`); if `ir_emitter = true`, daemon start runs `disable_emitter` once (idempotent) |
-| Suspend while a request is stuck in the driver | token set; if not exited in 1 s, drop the camera anyway (`Camera` drop is safe from any state) |
+| Suspend while a request is stuck in the driver | token set (lock-free), then the handler mutex is polled for 1 s and the camera dropped as soon as it is free — the cancelled request exits within one frame, so this is the normal path. It cannot be dropped *out from under* a request still holding that mutex, so if the second still has not freed it, the suspend path warns and returns: the token is set, so the camera closes when the request returns, one frame later at worst. |
 | Config reload while `Warm` | old handler dropped → closed; new value applies next request (reload only runs between requests) |
 | PAM D-Bus timeout before the daemon answers | `PAM_AUTH_ERR`, no one-shot fallback (unchanged); daemon ends via its own deadline or the connection drop |
 | One-shot SIGTERM during model load | token checked before open → exit 2, camera never touched |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,4 +9,4 @@
 | [005](005-anti-spoofing-layered-defense.md) | Layered passive anti-spoofing defense | Accepted |
 | [006](006-constant-time-matching.md) | Constant-time embedding comparison via `subtle` | Accepted |
 | [007](007-systemd-hardening-tradeoffs.md) | Selective systemd hardening with documented exclusions | Accepted |
-| [008](008-camera-lifecycle.md) | Outcome-based camera hold and cancellable authentication | Proposed |
+| [008](008-camera-lifecycle.md) | Outcome-based camera hold and cancellable authentication | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@
 | [005](005-anti-spoofing-layered-defense.md) | Layered passive anti-spoofing defense | Accepted |
 | [006](006-constant-time-matching.md) | Constant-time embedding comparison via `subtle` | Accepted |
 | [007](007-systemd-hardening-tradeoffs.md) | Selective systemd hardening with documented exclusions | Accepted |
+| [008](008-camera-lifecycle.md) | Outcome-based camera hold and cancellable authentication | Proposed |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,7 +209,10 @@ flowchart LR
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
 - ~200ms warm auth latency (camera open, models loaded); ~600ms cold auth (camera reopen)
-- Camera stays warm between back-to-back requests
+- Camera stays warm after a **failed** attempt for `device.camera_release_secs`
+  (default 3), so the retry a miss invites skips the reopen. Success,
+  cancellation and errors release it at once — on IR hardware the emitter LED
+  goes out with the interaction (ADR 008)
 - Single point of resource management
 
 ### Oneshot Mode

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,7 +208,10 @@ flowchart LR
 
 ### Daemon Mode
 The daemon (`facelock daemon`) runs persistently, holding ONNX models and camera resources in memory. The PAM module and CLI connect via D-Bus system bus. Benefits:
-- ~200ms warm auth latency (camera open, models loaded); ~600ms cold auth (camera reopen)
+- No per-authentication model load, and no camera reopen when the stream is
+  already warm. The reopen a cold attempt pays is hardware-specific — measure
+  it with `sudo facelock bench camera-reopen`, which splits it into open,
+  STREAMON and warmup
 - Camera stays warm after a **failed** attempt for `device.camera_release_secs`
   (default 3), so the retry a miss invites skips the reopen. Success,
   cancellation and errors release it at once — on IR hardware the emitter LED

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,10 +206,17 @@ facelock bench preview                  # frame capture + face detection latency
 facelock bench enrollment               # time to capture and embed snapshots (dry run, embeddings not stored)
 facelock bench model-load               # ONNX model load time (SCRFD + ArcFace)
 facelock bench calibrate                # sweep FAR/FRR thresholds and recommend optimal value
+facelock bench camera-reopen            # cost of reopening the camera: open / STREAMON / warmup split
 facelock bench report                   # full benchmark report
 ```
 
 `cold-auth`, `warm-auth`, `calibrate`, and `report` require enrolled faces. When encryption method is `tpm`, these subcommands require root.
+
+`camera-reopen` needs no enrolled face and loads no models (it is still root,
+like every `bench` subcommand): it closes and reopens the camera
+`--iterations` times (default 5) and reports the per-phase median. That total is what `device.camera_release_secs` trades LED-on time
+against — holding the stream warm after a failed attempt buys a retry exactly
+this much (ADR 008).
 
 ## facelock encrypt
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,13 +210,16 @@ facelock bench camera-reopen            # cost of reopening the camera: open / S
 facelock bench report                   # full benchmark report
 ```
 
-`cold-auth`, `warm-auth`, `calibrate`, and `report` require enrolled faces. When encryption method is `tpm`, these subcommands require root.
+**Every `bench` subcommand requires root** (DEC-6): direct-mode access needs the
+`0600` root:root database whatever the subcommand, and the auth benchmarks may
+need TPM access besides. `cold-auth`, `warm-auth`, `calibrate`, and `report`
+additionally require enrolled faces.
 
-`camera-reopen` needs no enrolled face and loads no models (it is still root,
-like every `bench` subcommand): it closes and reopens the camera
-`--iterations` times (default 5) and reports the per-phase median. That total is what `device.camera_release_secs` trades LED-on time
-against — holding the stream warm after a failed attempt buys a retry exactly
-this much (ADR 008).
+`camera-reopen` needs no enrolled face and loads no models — but is root like
+the rest: it closes and reopens the camera `--iterations` times (default 5) and
+reports the per-phase median. That total is what `device.camera_release_secs`
+trades LED-on time against — holding the stream warm after a failed attempt
+buys a retry exactly this much (ADR 008).
 
 ## facelock encrypt
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ Controls how the PAM module reaches the face engine.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (~200ms warm, ~600ms cold). `"oneshot"` spawns `facelock auth` per PAM call (slower, ~600ms+, no background process). |
+| `mode` | string | `"daemon"` | `"daemon"` connects to a persistent daemon via D-Bus system bus (models stay loaded; only a cold attempt pays a camera reopen — measure it with `facelock bench camera-reopen`). `"oneshot"` spawns `facelock auth` per PAM call (slower: model load on every call, no background process). |
 | `model_dir` | string | `"/var/lib/facelock/models"` | Directory containing ONNX model files. An explicitly configured value is honored verbatim and never rewritten. |
 | `idle_timeout_secs` | u64 | `0` | Shut down the daemon after this many idle seconds. `0` means never. Useful with D-Bus activation. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ Face detection and embedding parameters.
 |-----|------|---------|-------------|
 | `threshold` | f32 | `0.80` | Cosine similarity threshold for accepting a face match. Must be between 0.0 and 1.0. Higher values are stricter. See the range guide below. |
 | `timeout_secs` | u32 | `5` | Maximum seconds to attempt recognition before giving up. Must be > 0. |
+| `no_face_timeout_secs` | u32 | `2` | Seconds to keep scanning when **no face at all** has been detected. Once a face is seen, `timeout_secs` takes over — "seen, not matched yet" is the case worth waiting out. An empty-chair attempt ends early and charges no rate-limit budget. Clamped to `timeout_secs` (never an error); `0` disables the early exit. |
 | `detection_confidence` | f32 | `0.5` | Minimum confidence for the face detector to report a detection. Lower values detect more faces but increase false positives. |
 | `nms_threshold` | f32 | `0.4` | Non-maximum suppression threshold for overlapping detections. |
 | `detector_model` | string | `"scrfd_2.5g_bnkps.onnx"` | ONNX detector model filename. Must exist in `daemon.model_dir`. Bundled models are verified against the manifest; custom models require `detector_sha256`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,8 @@ Camera settings.
 | `dark_threshold` | f32 | `0.6` | Fraction of pixels that must be darker than `dark_pixel_value` before the frame is treated as unusably dark. |
 | `dark_pixel_value` | u8 | `10` | Pixel brightness cutoff used by the dark-frame check. |
 | `ir_emitter` | bool | `false` | Attempt to enable a controllable IR emitter when the camera opens. Only needed for hardware that does not auto-enable its IR LED. |
-| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Success, cancellation and errors release the camera at once. `0` disables the hold entirely (it used to be silently substituted with 5). |
+| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Cancellation and errors release the camera at once, and so does a success unless `camera_release_after_success_secs` is set. `0` disables the hold entirely (it used to be silently substituted with 5). |
+| `camera_release_after_success_secs` | u32 | `0` | Daemon only. Seconds to keep the camera streaming after a **successful** authentication too. `0` (the default) releases it immediately — the interaction is over, and on IR hardware the emitter LED goes out with it. Set it only where privileged actions repeat with no authentication caching in front of them (`sudo` with a zero `timestamp_timeout`, a polkit action without `auth_admin_keep`), so each one is a fresh authentication that would otherwise pay a camera reopen. Failures still use `camera_release_secs`; cancellations and errors always release at once. |
 
 ## [recognition]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ Camera settings.
 | `dark_threshold` | f32 | `0.6` | Fraction of pixels that must be darker than `dark_pixel_value` before the frame is treated as unusably dark. |
 | `dark_pixel_value` | u8 | `10` | Pixel brightness cutoff used by the dark-frame check. |
 | `ir_emitter` | bool | `false` | Attempt to enable a controllable IR emitter when the camera opens. Only needed for hardware that does not auto-enable its IR LED. |
-| `camera_release_secs` | u32 | `5` | Seconds to keep the camera open after daemon-mode auth before releasing it, to avoid repeated warmup cost on back-to-back requests. |
+| `camera_release_secs` | u32 | `3` | Daemon only. Seconds to keep the camera streaming after a **failed** authentication so an immediate retry skips the reopen cost. Success, cancellation and errors release the camera at once. `0` disables the hold entirely (it used to be silently substituted with 5). |
 
 ## [recognition]
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -278,7 +278,9 @@ binary; none of it touches the data itself.
 
 ### Audit Log Entries
 
-`audit.jsonl` is JSONL; each line carries `timestamp`, `user`, `result` (`success`, `failure`, `error`, `rate_limited`, `suppressed`) and, when known, `similarity`, `frame_count`, `duration_ms`, `device`, `model_label`, `error`.
+`audit.jsonl` is JSONL; each line carries `timestamp`, `user`, `result` (`success`, `failure`, `error`, `rate_limited`, `suppressed`, `cancelled`) and, when known, `similarity`, `frame_count`, `duration_ms`, `device`, `model_label`, `error`.
+
+`cancelled` (ADR 008 §5) is an attempt that was **abandoned, not answered**: the caller's bus connection went away, the system suspended, `ReleaseCamera` arrived, or a one-shot process was signalled. It is deliberately not a `failure` — no comparison reached a verdict, so it charges no rate-limit budget. The entry carries `frame_count` and `duration_ms` (how far the attempt got) and no `similarity`.
 
 `source` names the code path that produced the entry — `daemon` (the `Authenticate` D-Bus method), `oneshot` (the `facelock auth` helper PAM spawns), or `test` (`facelock test`, on either transport: the daemon's `TestAuthenticate` method or the in-process direct loop). It records the **enforcement path, not the caller's identity**: `daemon` and `oneshot` are fully-enforced authentications whose failures count against the rate limit, while `test` skips the SSH/lid physical-presence gates and charges nothing. So a `success` stamped `test` is a recognition result, not a policy-approved authentication — and a real authentication is never stamped `test`, whatever privilege its caller holds. The field is absent on entries written before it existed.
 
@@ -528,17 +530,34 @@ it; `ErrorKind::render` is the only place any of these sentences is written.
 The wire has no field for the class, so the CLI's D-Bus client reconstructs it
 with `ErrorKind::classify`, the exact inverse of `render`.
 
-Two rendered messages are **frozen protocol** because the PAM module
-substring-matches them to choose its return code, and it cannot link the daemon
+Three rendered messages are **frozen protocol** because the PAM module
+matches them to choose its return code, and it cannot link the daemon
 crate to share the type (its dependency ceiling is libc/toml/serde/zbus):
 
 | Substring PAM matches | Class | PAM code |
 |---|---|---|
 | `rate limited` | `RateLimited` | `PAM_AUTH_ERR` |
 | `IR camera required` | `IrRequired` | `PAM_IGNORE` |
+| `cancelled` (matched **exactly**) | `AuthOutcome::Cancelled` | `PAM_IGNORE` |
 
-Changing either string is a protocol break. They are pinned byte-exactly in
-`crates/facelock-daemon/src/auth.rs` (renderer) and
+Changing any of these strings is a protocol break.
+
+`cancelled` is not an `ErrorKind`. A rejection class is a statement about this
+user's face; a cancellation is the absence of one, so it is its own
+`AuthOutcome` variant (`facelock_daemon::auth::CANCELLED_MESSAGE`) that reuses
+the recoverable-error encoding to cross a wire with no field for it. PAM
+abstains on it: the attempt was abandoned, so the daemon has no opinion and the
+password modules run. It is matched exactly rather than as a substring, so an
+arbitrary error message that happens to mention cancelling cannot claim the row.
+
+**`auth_attempted` and a cancelled attempt.** The signal carries only `user` and
+`matched`, and its signature is frozen; a cancelled attempt therefore emits
+`auth_attempted(user, false)`, indistinguishable on the signal from a non-match.
+The audit log is where the two are told apart (`cancelled` vs `failure`).
+
+They are pinned byte-exactly in
+`crates/facelock-daemon/src/auth.rs` (renderer, including the frozen
+cancellation string) and
 `crates/facelock-daemon/tests/server_authz.rs` (wire), and every class's
 message, audit label and exit code are pinned together in
 `crates/facelock-cli/src/commands/auth.rs`.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -158,8 +158,20 @@ in exactly two documented ways:
    root already owns the database and can clear the limiter directly, so
    exempting *consumption* for it costs nothing.
 
-`Authenticate` always charges a failed attempt, on every transport and for
-every caller including root.
+`Authenticate` charges a failed attempt on every transport and for every
+caller including root — with one exception, added by ADR 008 §4: **an attempt
+where the camera never saw a face charges nothing** (`face_detected == false`,
+the `-1` wire sentinel). Nobody was there, so no guess was made; a screen
+locker that starts face auth on every wake, or a laptop opened in front of an
+empty desk, would otherwise spend the user's whole budget before they sit
+down. A face that *was* seen and did not match (`-4`) still charges. The rule
+is identical on the daemon and one-shot paths, which share the `rate_limit`
+table.
+
+Such an attempt also ends early, at `recognition.no_face_timeout_secs`
+(default 2, clamped to `timeout_secs`, `0` disables) rather than at
+`timeout_secs`; the outcome it reports is exactly the one the full timeout
+reports, so no client gains a case.
 
 The rate-limit *check* (whether `user` is already over budget) is unaffected
 by any of the above and still runs on both methods and both transports: an
@@ -293,7 +305,7 @@ TOML format. All keys optional — camera auto-detected, sensible defaults for e
 | Section | Key fields |
 |---------|-----------|
 | `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs` |
-| `[recognition]` | `threshold`, `timeout_secs`, `detector_model`, `detector_sha256`, `embedder_model`, `embedder_sha256`, `threads`, `execution_provider` |
+| `[recognition]` | `threshold`, `timeout_secs`, `no_face_timeout_secs`, `detector_model`, `detector_sha256`, `embedder_model`, `embedder_sha256`, `threads`, `execution_provider` |
 | `[daemon]` | `mode` (DaemonMode enum), `model_dir`, `idle_timeout_secs` |
 | `[storage]` | `db_path` |
 | `[security]` | `disabled`, `suppress_unknown`, `require_landmark_liveness`, `require_ir`, `require_frame_variance`, `frame_variance_max_similarity`, `ir_texture_min_stddev`, `min_auth_frames`, `bind_templates_to_device`, `device_match_granularity`, `bind_legacy_templates`, `bind_device_aad`, `allow_plaintext`, `abort_if_ssh`, `abort_if_lid_closed`, `pam_policy`, `rate_limit` |
@@ -403,7 +415,7 @@ CREATE TABLE rate_limit (
 );
 ```
 
-Only failed authentication attempts are recorded in `rate_limit`. Daemon mode and oneshot mode share the same SQLite-backed window, so daemon restarts do not clear lockout state.
+Only failed authentication attempts are recorded in `rate_limit`, and only those where a face was actually detected (ADR 008 §4 — see §facelock test Semantics for the full charging rule). Daemon mode and oneshot mode share the same SQLite-backed window, so daemon restarts do not clear lockout state.
 
 **Schema version** is tracked in `schema_version`; migrations are additive and forward-only. Current version: **6**. Migration V6 adds the nullable `face_models.device_id` column (Plan 02 device coupling); pre-V6 databases open cleanly, keep their rows, and leave `device_id` NULL. NULL rows are governed by `security.bind_legacy_templates` (default allow-with-warn), so upgrades never lock a user out.
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -304,7 +304,7 @@ TOML format. All keys optional — camera auto-detected, sensible defaults for e
 
 | Section | Key fields |
 |---------|-----------|
-| `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs` |
+| `[device]` | `path` (Option), `max_height`, `rotation`, `warmup_frames`, `dark_threshold`, `dark_pixel_value`, `ir_emitter`, `camera_release_secs`, `camera_release_after_success_secs` |
 | `[recognition]` | `threshold`, `timeout_secs`, `no_face_timeout_secs`, `detector_model`, `detector_sha256`, `embedder_model`, `embedder_sha256`, `threads`, `execution_provider` |
 | `[daemon]` | `mode` (DaemonMode enum), `model_dir`, `idle_timeout_secs` |
 | `[storage]` | `db_path` |
@@ -346,15 +346,20 @@ never a lockout.
 **Camera hold semantics (ADR 008).** `device.camera_release_secs` (default **3**) is the
 number of seconds the **daemon** keeps the camera streaming **after a failed
 authentication** — the one ending a retry plausibly follows — so that retry skips the
-reopen cost. Every other ending (success, cancellation, and any error, including a
-capture failure or an all-dark scan) releases the camera immediately: the interaction is
-over, and on IR hardware the emitter LED goes out with it. `0` means **never hold**; it
-previously fell back to 5 seconds. Enrollment follows the same rule (stored or failed, the
-interaction ended). Preview frames are exempt: each one extends the hold to
-`max(camera_release_secs, 2s)` so a ~10 fps preview never reopens per frame, and the CLI
-still calls `ReleaseCamera` on exit. The hold deadline is absolute and polled every 250 ms.
-One-shot mode (`facelock auth`) never holds — process exit is the release — and ignores
-the key. Changing the value needs no daemon restart: it is read per request.
+reopen cost. A success releases the camera immediately **unless**
+`device.camera_release_after_success_secs` (default **0**) is greater than zero, in which
+case a success holds for that many seconds instead; it is an opt-in for repeated
+privileged actions with no authentication caching in front of them, and at its default
+nothing about a success changes. Cancellation and every error (including a capture failure
+or an all-dark scan) always release immediately, whatever both keys say: the interaction is
+over, and on IR hardware the emitter LED goes out with it. `camera_release_secs = 0` means
+**never hold** after a failure; it previously fell back to 5 seconds. Enrollment follows
+the same rule as authentication, on both keys. Preview frames are exempt: each one extends
+the hold to `max(camera_release_secs, 2s)` so a ~10 fps preview never reopens per frame,
+and the CLI still calls `ReleaseCamera` on exit. The hold deadline is absolute and polled
+every 250 ms. One-shot mode (`facelock auth`) never holds — process exit is the release —
+and ignores both keys. Changing either value needs no daemon restart: they are read per
+request.
 
 **Hard device binding (opt-in).** `security.bind_device_aad = true` folds the enrolling
 camera's `device_id` into the AES-GCM AAD, so a template cannot be decrypted under a

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -329,6 +329,19 @@ on first use if absent. `method = "none"` (plaintext) is **refused at enrollment
 `security.allow_plaintext = true`. Auth always degrades to password on a decrypt failure —
 never a lockout.
 
+**Camera hold semantics (ADR 008).** `device.camera_release_secs` (default **3**) is the
+number of seconds the **daemon** keeps the camera streaming **after a failed
+authentication** — the one ending a retry plausibly follows — so that retry skips the
+reopen cost. Every other ending (success, cancellation, and any error, including a
+capture failure or an all-dark scan) releases the camera immediately: the interaction is
+over, and on IR hardware the emitter LED goes out with it. `0` means **never hold**; it
+previously fell back to 5 seconds. Enrollment follows the same rule (stored or failed, the
+interaction ended). Preview frames are exempt: each one extends the hold to
+`max(camera_release_secs, 2s)` so a ~10 fps preview never reopens per frame, and the CLI
+still calls `ReleaseCamera` on exit. The hold deadline is absolute and polled every 250 ms.
+One-shot mode (`facelock auth`) never holds — process exit is the release — and ignores
+the key. Changing the value needs no daemon restart: it is read per request.
+
 **Hard device binding (opt-in).** `security.bind_device_aad = true` folds the enrolling
 camera's `device_id` into the AES-GCM AAD, so a template cannot be decrypted under a
 different camera. Default false (fails closed on unstable ids). Complements the advisory

--- a/docs/security.md
+++ b/docs/security.md
@@ -555,6 +555,22 @@ Implementation note:
 - Daemon mode and oneshot mode use the same window and thresholds
 - Restarting the daemon must not reset a user's lockout state
 
+**An attempt where no face was detected is not charged** (ADR 008 §4). The
+limiter exists to bound *guessing* — presenting material to the camera and
+being told no — and an empty chair presents nothing. Charging it made the
+budget consumable without any attacker input: a lock screen that starts face
+auth on every wake, a laptop opened facing an empty desk, or an unattended
+`sudo` prompt would each spend the five attempts on nobody, so the user's real
+attempt met a lockout. The distinction is the detector's, not the caller's
+(`face_detected` on the result, the `-4` versus `-1` wire sentinel), so it
+cannot be asked for: an attacker who wants a free attempt has to keep their
+face out of frame, which is also an attempt that could never have succeeded.
+A detected face that fails any later gate — no match, IR texture, frame
+variance, landmark liveness — is charged as it always was. A no-face attempt
+also *ends* after `recognition.no_face_timeout_secs` (default 2) instead of
+running the full `recognition.timeout_secs`, which turns the camera and its IR
+emitter off that much sooner.
+
 ### 5. PAM Module Hardening
 
 #### A0. Config File Trust (Required)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,7 +55,7 @@
 
 ### First-start latency (~700ms -- 2s)
 
-The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode typically take ~200ms (warm: camera open, models loaded) or ~600ms (cold: camera reopen).
+The first authentication after boot (or after the daemon starts) is slow because ONNX models must be loaded into memory. This is normal. Subsequent auths in daemon mode never reload the models; a cold one additionally pays a camera reopen, a warm one does not. What that reopen costs is a property of your camera and driver — measure it with `sudo facelock bench camera-reopen` (it prints the open / STREAMON / warmup split) rather than comparing against someone else's figure.
 
 ### Consistently slow (~700ms+ every time)
 

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -57,6 +57,43 @@ run_test_contains() {
     return 1
 }
 
+# ADR 008 §9: like run_test, but a check may report that there was nothing to
+# observe (exit 3) instead of passing or failing. The camera-lifecycle
+# assertions below depend on a live face being in front of the camera; when one
+# is not, "no successful authentication happened" is not a lifecycle bug and
+# must not be reported as one. Anything the check printed is echoed either way,
+# so a SKIP always says which precondition was missing.
+run_test_or_skip() {
+    local name="$1"
+    local cmd="$2"
+
+    echo -n "TEST: $name ... "
+    local result=0
+    set +o pipefail
+    # `|| result=$?` rather than `set +e`: errexit stays exactly as the script
+    # set it, so a check that returns non-zero reports a FAIL here instead of
+    # aborting the run.
+    eval "$cmd" > /tmp/test-output 2>&1 || result=$?
+    set -o pipefail
+
+    case "$result" in
+        0)
+            echo "PASS"
+            PASS=$((PASS + 1))
+            sed 's/^/      /' /tmp/test-output
+            ;;
+        3)
+            echo "SKIP"
+            sed 's/^/      /' /tmp/test-output
+            ;;
+        *)
+            echo "FAIL (exit=$result)"
+            cat /tmp/test-output
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+}
+
 wait_for_daemon() {
     local deadline=$((SECONDS + 30))
     local output=""
@@ -85,17 +122,30 @@ mkdir -p /run/dbus
 dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true
 dbus-daemon --system --fork --nopidfile
 
+# ADR 008 §9: the camera-lifecycle assertions at the end of this script read
+# the daemon's own log, so it goes to a file instead of the console — and at
+# debug level on the facelock_daemon target, because `releasing camera`, the
+# warm-hold line and the frame discards are debug events. The file is dumped
+# from `cleanup` when anything failed, so redirecting it costs no diagnostics.
+DAEMON_LOG="/tmp/facelock-daemon.log"
+: > "$DAEMON_LOG"
+
 cleanup() {
     if [ -n "${DAEMON_PID:-}" ]; then
         kill "$DAEMON_PID" 2>/dev/null || true
         wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+    if [ "$FAIL" -gt 0 ] && [ -s "$DAEMON_LOG" ]; then
+        echo ""
+        echo "--- daemon log (last 200 lines) ---"
+        tail -n 200 "$DAEMON_LOG" || true
     fi
     pkill dbus-daemon 2>/dev/null || true
 }
 trap cleanup EXIT
 
 # Start daemon in background
-facelock daemon &
+RUST_LOG="${RUST_LOG:-facelock=info,facelock_daemon=debug}" facelock daemon > "$DAEMON_LOG" 2>&1 &
 DAEMON_PID=$!
 sleep 2
 
@@ -372,6 +422,194 @@ check_sequential_auth_not_starved() {
 }
 run_test "Sequential auth not starved after busy rejection" \
     "check_sequential_auth_not_starved"
+
+# --- ADR 008: camera lifecycle (outcome-based hold, cancellation) ---
+#
+# The invariant these assertions pin is §1: the camera is on only while an
+# authentication is in progress or a retry is plausibly imminent. Success and
+# cancellation end the interaction, so the stream closes at once; only a failed
+# attempt keeps it warm, and only for device.camera_release_secs. Everything is
+# read from the daemon's own log, whose strings live in
+# crates/facelock-daemon/src/handler.rs (`releasing camera`, `holding camera
+# warm after a failed attempt`), src/auth.rs (`authentication cancelled`) and
+# src/server.rs (`caller disconnected, cancelling in-flight request`).
+
+# Milliseconds since the epoch.
+now_ms() {
+    echo $(( $(date +%s%N) / 1000000 ))
+}
+
+# Lines currently in the daemon log — the "from here on" marker every
+# assertion takes before it provokes the daemon.
+daemon_log_lines() {
+    wc -l < "$DAEMON_LOG" 2>/dev/null || echo 0
+}
+
+# ADR 008 §9: wait for a daemon log line that contains EVERY pattern given,
+# looking only at lines added after line $1, for at most $2 milliseconds.
+# Echoes how long the wait took, in milliseconds; returns 1 on timeout.
+#
+# The patterns are applied one at a time to the same line rather than as a
+# single string because tracing writes ANSI styling between a field's name and
+# its value, so `reason="warm hold expired"` is not contiguous in the file.
+wait_for_daemon_log() {
+    local from_line="$1"
+    local timeout_ms="$2"
+    shift 2
+    local start deadline matched pat
+    start=$(now_ms)
+    deadline=$((start + timeout_ms))
+    while :; do
+        matched="$(tail -n "+$((from_line + 1))" "$DAEMON_LOG" 2>/dev/null || true)"
+        for pat in "$@"; do
+            matched="$(printf '%s\n' "$matched" | grep -F -- "$pat" || true)"
+        done
+        if [ -n "$matched" ]; then
+            echo $(( $(now_ms) - start ))
+            return 0
+        fi
+        [ "$(now_ms)" -lt "$deadline" ] || return 1
+        sleep 0.05
+    done
+}
+
+# ADR 008 §9, acceptance (1): a successful authentication ends the interaction,
+# so `finish(Success)` drops the camera before the reply is even sent. The
+# release line must therefore already be in the log by the time the client has
+# its answer; the 500 ms budget is for the log write, not for the daemon.
+adr008_success_releases_camera() {
+    local from elapsed
+    from=$(daemon_log_lines)
+    timeout --foreground "$LIVE_TIMEOUT" facelock test --user testuser \
+        > /tmp/adr008-success.log 2>&1 || true
+    if ! grep -q "Matched" /tmp/adr008-success.log; then
+        cat /tmp/adr008-success.log
+        echo "no successful authentication to observe (needs a live enrolled face)"
+        return 3
+    fi
+    if ! elapsed=$(wait_for_daemon_log "$from" 500 "releasing camera" "authentication succeeded"); then
+        echo "camera not released within 500ms of a successful reply"
+        tail -n "+$((from + 1))" "$DAEMON_LOG"
+        return 1
+    fi
+    echo "camera released ${elapsed}ms after the successful reply"
+}
+
+# ADR 008 §9, acceptance (2): a failed attempt is the one outcome that predicts
+# a retry, so the stream stays open for device.camera_release_secs and then
+# closes. Runs inside the forged-device_id window below, which is what makes
+# the failure certain rather than dependent on who is in front of the camera.
+adr008_failure_holds_then_releases() {
+    local secs from after elapsed lo hi
+    secs="$({ grep -E '^[[:space:]]*camera_release_secs[[:space:]]*=' /etc/facelock/config.toml \
+        || true; } | tail -1 | sed -E 's/[^0-9]//g')"
+    [ -n "$secs" ] || secs=3
+    if [ "$secs" -eq 0 ]; then
+        echo "camera_release_secs = 0: the daemon never holds, nothing to time"
+        return 3
+    fi
+
+    from=$(daemon_log_lines)
+    timeout --foreground "$LIVE_TIMEOUT" facelock test --user testuser \
+        > /tmp/adr008-failure.log 2>&1 || true
+    after=$(daemon_log_lines)
+
+    if ! wait_for_daemon_log "$from" 0 "holding camera warm after a failed attempt" > /dev/null; then
+        cat /tmp/adr008-failure.log
+        echo "the attempt did not end in a failure the daemon holds the camera for"
+        return 3
+    fi
+    if ! elapsed=$(wait_for_daemon_log "$after" $(( secs * 1000 + 1500 )) "releasing camera" "warm hold expired"); then
+        echo "warm hold never expired (camera still open ${secs}s + 1.5s after the failed attempt)"
+        tail -n "+$((from + 1))" "$DAEMON_LOG"
+        return 1
+    fi
+    lo=$(( secs * 1000 - 500 ))
+    hi=$(( secs * 1000 + 500 ))
+    if [ "$elapsed" -lt "$lo" ] || [ "$elapsed" -gt "$hi" ]; then
+        echo "warm hold expired ${elapsed}ms after the reply, expected ${secs}000ms +/-500ms"
+        return 1
+    fi
+    echo "warm hold expired ${elapsed}ms after the failed reply (camera_release_secs=${secs})"
+}
+
+# Has the daemon reached the per-frame scan loop since line $1? Any of these
+# three debug lines carries a frame number, so seeing one means the camera is
+# open, the warmup discard is done, and the request is somewhere it can be
+# cancelled per frame.
+daemon_is_scanning() {
+    tail -n "+$(($1 + 1))" "$DAEMON_LOG" 2>/dev/null \
+        | grep -qE "face comparison|no faces detected|dark frame"
+}
+
+# ADR 008 §9, acceptance (1) and §5: a caller that goes away is not a slow
+# user. SIGKILLing the client drops its bus connection, the daemon's name-owner
+# watch fires, and the request ends within one frame instead of running to
+# recognition.timeout_secs with the emitter lit.
+#
+# The kill waits for the scan rather than firing at a fixed offset: a client
+# that dies during the camera open aborts the acquire instead (ADR 008 §8),
+# which is a different path with different log lines, so a fixed offset would
+# be timing the camera open on whatever hardware happens to be mounted.
+adr008_caller_departure_cancels() {
+    local from client deadline cancel_ms auth_ms release_ms
+    from=$(daemon_log_lines)
+    facelock test --user testuser > /tmp/adr008-cancel.log 2>&1 &
+    client=$!
+    deadline=$(( $(now_ms) + 20000 ))
+    while [ "$(now_ms)" -lt "$deadline" ]; do
+        daemon_is_scanning "$from" && break
+        kill -0 "$client" 2>/dev/null || break
+        sleep 0.05
+    done
+    if ! daemon_is_scanning "$from"; then
+        kill -9 "$client" 2>/dev/null || true
+        wait "$client" 2>/dev/null || true
+        cat /tmp/adr008-cancel.log
+        echo "the daemon never reached the scan loop; nothing was in flight to cancel"
+        return 3
+    fi
+    kill -9 "$client" 2>/dev/null || true
+    wait "$client" 2>/dev/null || true
+    if ! cancel_ms=$(wait_for_daemon_log "$from" 500 "caller disconnected, cancelling in-flight request"); then
+        echo "daemon did not notice the caller's departure within 500ms"
+        tail -n "+$((from + 1))" "$DAEMON_LOG"
+        return 1
+    fi
+    if ! auth_ms=$(wait_for_daemon_log "$from" 500 "authentication cancelled"); then
+        echo "request did not end as cancelled within 500ms of the kill"
+        tail -n "+$((from + 1))" "$DAEMON_LOG"
+        return 1
+    fi
+    if ! release_ms=$(wait_for_daemon_log "$from" 500 "releasing camera" "request cancelled"); then
+        echo "camera not released within 500ms of the cancellation"
+        tail -n "+$((from + 1))" "$DAEMON_LOG"
+        return 1
+    fi
+    echo "caller departure seen at ${cancel_ms}ms, attempt cancelled at ${auth_ms}ms, camera released at ${release_ms}ms"
+}
+
+run_test_or_skip "ADR 008: success releases the camera immediately" \
+    "adr008_success_releases_camera"
+
+# The two checks below need an attempt that does NOT match: one to observe the
+# warm hold a failure earns, one to have something still in flight to cancel.
+# A forged device_id makes every enrolled template ineligible, so the attempt
+# sees a face and matches nothing, and the scan runs to recognition
+# .timeout_secs instead of ending on the first frame. `facelock test` charges
+# no rate-limit budget (AuthIntent::Test) and a cancelled attempt charges none
+# either, so neither costs the later tests an attempt.
+sqlite3 "$DB" "PRAGMA busy_timeout=8000; UPDATE face_models SET device_id='ffff:ffff:forged' WHERE user='testuser'" || true
+
+run_test_or_skip "ADR 008: a failed attempt holds the camera, then releases it at camera_release_secs" \
+    "adr008_failure_holds_then_releases"
+
+run_test_or_skip "ADR 008: a departed caller cancels the request and closes the camera" \
+    "adr008_caller_departure_cancels"
+
+sqlite3 "$DB" "PRAGMA busy_timeout=8000; UPDATE face_models SET device_id=NULL WHERE user='testuser'" || true
+
+# --- End ADR 008 camera lifecycle ---
 
 # Clean up
 run_test "Clear enrolled models" \

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -477,12 +477,17 @@ wait_for_daemon_log() {
 # so `finish(Success)` drops the camera before the reply is even sent. The
 # release line must therefore already be in the log by the time the client has
 # its answer; the 500 ms budget is for the log write, not for the daemon.
+#
+# The precondition reads the daemon's own log rather than the client's output.
+# `facelock test` prints "Matched ..." through gettext and exits 0 whether it
+# matched or not, so the CLI offers this check neither a stable string nor a
+# usable exit code; the daemon's `tracing` lines are never translated.
 adr008_success_releases_camera() {
     local from elapsed
     from=$(daemon_log_lines)
     timeout --foreground "$LIVE_TIMEOUT" facelock test --user testuser \
         > /tmp/adr008-success.log 2>&1 || true
-    if ! grep -q "Matched" /tmp/adr008-success.log; then
+    if ! wait_for_daemon_log "$from" 500 "authentication succeeded" > /dev/null; then
         cat /tmp/adr008-success.log
         echo "no successful authentication to observe (needs a live enrolled face)"
         return 3
@@ -599,6 +604,14 @@ run_test_or_skip "ADR 008: success releases the camera immediately" \
 # .timeout_secs instead of ending on the first frame. `facelock test` charges
 # no rate-limit budget (AuthIntent::Test) and a cancelled attempt charges none
 # either, so neither costs the later tests an attempt.
+#
+# Captured as a SQL literal so the window really is a window: `quote()` renders
+# a real fingerprint as a quoted string and a legacy row as the bare token
+# NULL, which is the one distinction a plain SELECT loses — and writing NULL
+# back unconditionally would silently un-couple the template from its camera
+# for every test after this point.
+ADR008_DEVID="$(sqlite3 "$DB" "PRAGMA busy_timeout=8000; SELECT quote(device_id) FROM face_models WHERE user='testuser' LIMIT 1" 2>/dev/null || echo 'NULL')"
+[ -n "$ADR008_DEVID" ] || ADR008_DEVID='NULL'
 sqlite3 "$DB" "PRAGMA busy_timeout=8000; UPDATE face_models SET device_id='ffff:ffff:forged' WHERE user='testuser'" || true
 
 run_test_or_skip "ADR 008: a failed attempt holds the camera, then releases it at camera_release_secs" \
@@ -607,7 +620,7 @@ run_test_or_skip "ADR 008: a failed attempt holds the camera, then releases it a
 run_test_or_skip "ADR 008: a departed caller cancels the request and closes the camera" \
     "adr008_caller_departure_cancels"
 
-sqlite3 "$DB" "PRAGMA busy_timeout=8000; UPDATE face_models SET device_id=NULL WHERE user='testuser'" || true
+sqlite3 "$DB" "PRAGMA busy_timeout=8000; UPDATE face_models SET device_id=$ADR008_DEVID WHERE user='testuser'" || true
 
 # --- End ADR 008 camera lifecycle ---
 

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -57,6 +57,42 @@ run_test_contains() {
     return 1
 }
 
+# ADR 008 §9: like run_test, but a check may report that there was nothing to
+# observe (exit 3) instead of passing or failing — a one-shot that answered
+# before it could be signalled is not a lifecycle bug. Anything the check
+# printed is echoed either way, so a SKIP always says which precondition was
+# missing.
+run_test_or_skip() {
+    local name="$1"
+    local cmd="$2"
+
+    echo -n "TEST: $name ... "
+    local result=0
+    set +o pipefail
+    # `|| result=$?` rather than `set +e`: errexit stays exactly as the script
+    # set it, so a check that returns non-zero reports a FAIL here instead of
+    # aborting the run.
+    eval "$cmd" > /tmp/test-output 2>&1 || result=$?
+    set -o pipefail
+
+    case "$result" in
+        0)
+            echo "PASS"
+            PASS=$((PASS + 1))
+            sed 's/^/      /' /tmp/test-output
+            ;;
+        3)
+            echo "SKIP"
+            sed 's/^/      /' /tmp/test-output
+            ;;
+        *)
+            echo "FAIL (exit=$result)"
+            cat /tmp/test-output
+            FAIL=$((FAIL + 1))
+            ;;
+    esac
+}
+
 echo "=== Oneshot Mode Tests (fully daemonless, with camera) ==="
 echo ""
 
@@ -355,6 +391,158 @@ trap - EXIT
 # PAM authentication (the real deal — no daemon)
 run_test "pamtester authenticates (oneshot, no daemon)" \
     "timeout --foreground $LIVE_TIMEOUT pamtester facelock-test testuser authenticate"
+
+# --- ADR 008: one-shot lifecycle (signals, parent death) ---
+#
+# The invariant (§7): a one-shot never holds the camera, and its exit is the
+# release. Both assertions below therefore care about the same thing — that the
+# process runs its own `Drop` (STREAMOFF, IR emitter off) rather than being
+# killed outright — which is why the exit code matters as much as the timing:
+# 2 means facelock decided to stop, 143 means the signal did it and Drop never
+# ran.
+
+# Milliseconds since the epoch.
+now_ms() {
+    echo $(( $(date +%s%N) / 1000000 ))
+}
+
+# Wait until pid $1 has a /dev/video* device open, i.e. it is past the ONNX
+# model load and actually scanning. Returns 1 if it never gets there.
+#
+# This is what makes the 500 ms budgets below measure what they claim to. A
+# signal that lands inside the model load is only acted on when the load
+# returns (ADR 008 §8 says as much: the token is checked *between* engine and
+# camera), so signalling at a fixed offset would time the ONNX loader instead
+# of the cancellation. /proc is all it takes to tell the two apart, and it
+# needs no tooling the image does not already have.
+wait_until_scanning() {
+    local pid="$1"
+    local deadline=$(( $(now_ms) + 20000 ))
+    while [ "$(now_ms)" -lt "$deadline" ]; do
+        kill -0 "$pid" 2>/dev/null || return 1
+        if ls -l /proc/"$pid"/fd 2>/dev/null | grep -q '/dev/video'; then
+            return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+
+# ADR 008 §7: SIGTERM must end `facelock auth` through its own cancel token —
+# exit 2, within one frame — not kill it. A process killed by an unhandled
+# SIGTERM reports 143 and skips `Drop`, which is exactly the path that leaves
+# an XU-controlled IR emitter lit.
+adr008_oneshot_sigterm_exits_cleanly() {
+    local pid rc start elapsed
+    facelock auth --user testuser --config /etc/facelock/config.toml \
+        > /tmp/adr008-oneshot-term.log 2>&1 &
+    pid=$!
+
+    if ! wait_until_scanning "$pid"; then
+        rc=0
+        wait "$pid" || rc=$?
+        cat /tmp/adr008-oneshot-term.log
+        echo "the one-shot never reached the camera (exit=$rc); nothing to signal"
+        return 3
+    fi
+
+    start=$(now_ms)
+    kill -TERM "$pid" 2>/dev/null || true
+    rc=0
+    wait "$pid" || rc=$?
+    elapsed=$(( $(now_ms) - start ))
+
+    if [ "$rc" -ne 2 ]; then
+        cat /tmp/adr008-oneshot-term.log
+        echo "exit=$rc after SIGTERM, expected 2 (143 means the signal killed it and Drop never ran)"
+        return 1
+    fi
+    if [ "$elapsed" -gt 500 ]; then
+        echo "exited ${elapsed}ms after SIGTERM, expected within 500ms (one frame)"
+        return 1
+    fi
+    if pgrep -f "facelock auth" > /dev/null 2>&1; then
+        echo "a facelock auth process survived the signal:"
+        pgrep -af "facelock auth" || true
+        return 1
+    fi
+    echo "exited 2 in ${elapsed}ms, no process left"
+}
+
+# ADR 008 §7 and acceptance (4): a one-shot must not outlive its PAM host. The
+# module sets PR_SET_PDEATHSIG = SIGTERM in pre_exec, so killing the host
+# delivers SIGTERM to the child, which then takes the clean exit above. Only
+# PAM can exercise this — the flag is set by the module, not by whatever shell
+# happens to be the parent — so the host here is pamtester.
+adr008_oneshot_dies_with_pam_host() {
+    local pam_pid child start elapsed
+    command -v pgrep > /dev/null 2>&1 || {
+        echo "pgrep is unavailable; cannot observe the child"
+        return 3
+    }
+
+    pamtester facelock-test testuser authenticate < /dev/null \
+        > /tmp/adr008-pdeathsig.log 2>&1 &
+    pam_pid=$!
+
+    child=""
+    local deadline=$(( $(now_ms) + 20000 ))
+    while [ "$(now_ms)" -lt "$deadline" ]; do
+        child="$(pgrep -f 'facelock auth' 2>/dev/null | head -1)"
+        if [ -n "$child" ] && ls -l /proc/"$child"/fd 2>/dev/null | grep -q '/dev/video'; then
+            break
+        fi
+        child=""
+        kill -0 "$pam_pid" 2>/dev/null || break
+        sleep 0.05
+    done
+    if [ -z "$child" ]; then
+        kill -9 "$pam_pid" 2>/dev/null || true
+        wait "$pam_pid" 2>/dev/null || true
+        cat /tmp/adr008-pdeathsig.log
+        echo "no 'facelock auth' child reached the camera; nothing to orphan"
+        return 3
+    fi
+
+    # SIGKILL, so the host cannot tidy up after itself: whatever ends the child
+    # is the kernel's PDEATHSIG, not PAM.
+    start=$(now_ms)
+    kill -9 "$pam_pid" 2>/dev/null || true
+    wait "$pam_pid" 2>/dev/null || true
+    while kill -0 "$child" 2>/dev/null; do
+        if [ $(( $(now_ms) - start )) -gt 500 ]; then
+            echo "facelock auth (pid $child) outlived its PAM host by more than 500ms"
+            kill -9 "$child" 2>/dev/null || true
+            return 1
+        fi
+        sleep 0.02
+    done
+    elapsed=$(( $(now_ms) - start ))
+
+    if pgrep -f "facelock auth" > /dev/null 2>&1; then
+        echo "another facelock auth process is still running:"
+        pgrep -af "facelock auth" || true
+        return 1
+    fi
+    echo "child gone ${elapsed}ms after its PAM host was killed"
+}
+
+# Both checks need an attempt that is still running when the signal arrives. A
+# forged device_id makes every enrolled template ineligible, so the scan runs
+# to recognition.timeout_secs instead of matching on the first frame and
+# exiting before there is anything to signal. Neither attempt charges the rate
+# limiter: a cancelled attempt is not a guess (ADR 008 §5).
+sqlite3 "$DB" "UPDATE face_models SET device_id='ffff:ffff:forged' WHERE user='testuser'" || true
+
+run_test_or_skip "ADR 008: SIGTERM ends facelock auth cleanly (exit 2, not 143)" \
+    "adr008_oneshot_sigterm_exits_cleanly"
+
+run_test_or_skip "ADR 008: facelock auth dies with its PAM host (PDEATHSIG)" \
+    "adr008_oneshot_dies_with_pam_host"
+
+sqlite3 "$DB" "UPDATE face_models SET device_id=NULL WHERE user='testuser'" || true
+
+# --- End ADR 008 one-shot lifecycle ---
 
 # facelock auth rejects unknown user
 run_test "facelock auth rejects unknown user" \

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -532,6 +532,13 @@ adr008_oneshot_dies_with_pam_host() {
 # to recognition.timeout_secs instead of matching on the first frame and
 # exiting before there is anything to signal. Neither attempt charges the rate
 # limiter: a cancelled attempt is not a guess (ADR 008 §5).
+# Captured as a SQL literal so the window really is a window: `quote()` renders
+# a real fingerprint as a quoted string and a legacy row as the bare token
+# NULL, which is the one distinction a plain SELECT loses — and writing NULL
+# back unconditionally would silently un-couple the template from its camera
+# for every test after this point.
+ADR008_DEVID="$(sqlite3 "$DB" "SELECT quote(device_id) FROM face_models WHERE user='testuser' LIMIT 1" 2>/dev/null || echo 'NULL')"
+[ -n "$ADR008_DEVID" ] || ADR008_DEVID='NULL'
 sqlite3 "$DB" "UPDATE face_models SET device_id='ffff:ffff:forged' WHERE user='testuser'" || true
 
 run_test_or_skip "ADR 008: SIGTERM ends facelock auth cleanly (exit 2, not 143)" \
@@ -540,7 +547,7 @@ run_test_or_skip "ADR 008: SIGTERM ends facelock auth cleanly (exit 2, not 143)"
 run_test_or_skip "ADR 008: facelock auth dies with its PAM host (PDEATHSIG)" \
     "adr008_oneshot_dies_with_pam_host"
 
-sqlite3 "$DB" "UPDATE face_models SET device_id=NULL WHERE user='testuser'" || true
+sqlite3 "$DB" "UPDATE face_models SET device_id=$ADR008_DEVID WHERE user='testuser'" || true
 
 # --- End ADR 008 one-shot lifecycle ---
 

--- a/website/index.html
+++ b/website/index.html
@@ -194,7 +194,7 @@
             <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
           </div>
           <h3>Sudo without typing</h3>
-          <p>Every <code>sudo</code> prompt becomes a glance at the camera. The daemon keeps ONNX models loaded &mdash; ~600ms on a cold camera, dropping to 150&ndash;200ms on back-to-back unlocks.</p>
+          <p>Every <code>sudo</code> prompt becomes a glance at the camera. The daemon keeps ONNX models loaded, so no authentication waits for a model load &mdash; only a cold camera pays a reopen. Measure yours with <code>facelock bench camera-reopen</code>.</p>
         </div>
 
         <div class="feature-card">
@@ -239,7 +239,7 @@
             <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
           </div>
           <h3>Sub-Second Auth</h3>
-          <p>Persistent daemon keeps ONNX models loaded. ~600ms typical, dropping to ~150ms on back-to-back auths when the camera stays warm.</p>
+          <p>Persistent daemon keeps ONNX models loaded, so no authentication waits for a model load. A retry after a miss reuses the still-warm camera and skips the reopen too; <code>facelock bench camera-reopen</code> measures what that reopen costs on your hardware.</p>
         </div>
 
         <div class="feature-card">
@@ -477,7 +477,7 @@
             </tr>
             <tr>
               <td>Daemon mode<span class="cmp-why">Auth completes before you finish typing your password.</span></td>
-              <td><span class="check">Yes (~150&ndash;600ms auth)</span></td>
+              <td><span class="check">Yes (models stay loaded)</span></td>
               <td><span class="cross">No (process per auth)</span></td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary

Implements ADR 008 (`docs/adr/008-camera-lifecycle.md`): the camera is on only while an authentication is in progress or a retry is plausibly imminent. Success, cancel and error release it immediately; a no-match/timeout keeps it warm for `device.camera_release_secs` (now default 3, `0` = never; previously 5 after *every* request). Every in-flight request carries a cancel token set when the caller's bus connection disappears, on suspend/shutdown, or (one-shot) on SIGTERM. Warm reuse discards the stale V4L2 buffers first. One-shot loads the engine before opening the camera and dies with its PAM host. `recognition.no_face_timeout_secs` (default 2) ends attempts at an empty chair early, and such attempts no longer charge the rate limiter. No config migration.

Motivation: [omarchy#4982](https://github.com/basecamp/omarchy/discussions/4982) (IR LEDs strobe for the 5 s hold after every auth) and [omarchy PR #6863](https://github.com/basecamp/omarchy/pull/6863) (auto-start on lid/key, 3 × 250 ms retries, password typed in parallel, PAM aborted on unlock/lid-close).

## Commits (one per ADR §10 row; please review commit-by-commit, merge with a merge commit)

- `3158f37` docs(adr): ADR 008 — outcome-based camera hold and cancellable authentication
- `11bcb59` feat(daemon): hold the camera only after a failed attempt — `CameraLease` (acquire/finish/touch_preview/expire), outcome rule, `0` = never, default 3, 250 ms poll on an absolute deadline, `MMAP_BUFFERS − 1` stale discard on warm reuse, preview floor, docs/contracts/CHANGELOG
- `0ad208c` feat(daemon): cancel an authentication when its caller goes away — `CancelToken` checked per frame in auth/enroll/discard loops, per-request `NameOwnerChanged` watch on the sender, `cancelled` frozen string → PAM_IGNORE, audit `cancelled`, no limiter charge, suspend/`ReleaseCamera`/shutdown via the token
- `da3fcf0` fix(polkit): drop a dedicated bus connection when the dialog is cancelled
- `18b8ee8` fix(pam): one-shot loads models first, dies with its host, and cleans up — engine before camera, SIGTERM/SIGINT/SIGHUP → clean `Drop` (exit 2), `PR_SET_PDEATHSIG` in `pre_exec`, PAM child timeout TERM-then-KILL (≤500 ms)
- `8361d20` feat(daemon): end no-face attempts early and stop charging them — `recognition.no_face_timeout_secs` (clamped to `timeout_secs`, `0` disables, additive), no-face failures don't charge on daemon or one-shot path
- `8520ce0` feat(bench): camera-reopen microbench; container assertions for ADR 008 — `facelock bench camera-reopen` (open / first-frame / warmup split), doc numbers replaced by "measure it", ADR-tagged assertions in `test/run-integration-tests.sh` and `test/run-oneshot-tests.sh`
- `93364e4` fix(daemon): per-request cancel token; audit and classify every cancellation — review H1/H2/M1–M3: a fresh `CancelToken` per D-Bus call (departure watch bound to it alone; a denied or concurrent caller can no longer clear or trigger another request's cancellation), generation-counted `CurrentRequest` slot for suspend/`ReleaseCamera`, warm-discard cancellation returns the frozen `cancelled` string, pre-open cancellations audited, `Cancelled` rows added to both outcome tables
- `a25b331` fix(pam,cli,docs): oneshot child reaping and PDEATHSIG race; doc corrections
- `44cad3a` feat(daemon): opt-in camera hold after a successful attempt — `device.camera_release_after_success_secs` (default `0` = release immediately, unchanged behavior; `N` = keep warm N s after a success too, for repeated privileged actions with no auth caching, e.g. `sudo` with `timestamp_timeout=0`). Added on maintainer request as the knob ADR §3 had deferred; cancel/error still never hold
- `f33bd78` docs(adr): accept ADR 008 — Status → Accepted, verified as below — review L1/L2/L5/L6/L7: reap after SIGKILL, `getppid()` check after `prctl` closes the fork/exec race, `bench` root-gate docs made truthful, ADR §8 suspend wording matches the code, container scripts restore the original `device_id` and use a locale-independent success signal

## Verification

Ran on the full branch (Arch, host toolchain per `rust-toolchain.toml`) — all green:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (14/14 test binaries; new tests: outcome×finish matrix over every `AuthOutcome`/`ErrorKind` variant, expire timing, discard count, cancel-at-frame-k, name-owner-changed sender matching, no-face timing, rate-limit charge/no-charge, engine-before-camera order, PAM TERM-then-KILL sequence)
- `cargo build -p pam-facelock` (isolated) + dependency-surface guard (57 crates, no nix/signal-hook)
- `just test-arch-pam` (camera-free Arch container PAM smoke tier): 22/22 passed
- `bash -n test/run-integration-tests.sh test/run-oneshot-tests.sh`
- CI on the final push (`a25b331`): Build/Test/Lint, Container PAM Smoke, cargo-audit, TPM tests — all green

Commits `11bcb59`..`18b8ee8` were additionally verified green in the cloud sandbox (Ubuntu) where they were authored.

## Camera container tiers (run locally by Ty on the BRIO, 8-commit branch)

- `just test-arch-integration`: **26/26 passed** — ADR 008 assertions with measured timings on the live daemon: success → camera released **3 ms** after the reply; failed attempt → warm hold expired **3206 ms** after the reply (`camera_release_secs=3`, 250 ms poll); client killed mid-`Authenticate` → departure seen at 2 ms, attempt **cancelled at 107 ms** (one frame), camera released 3 ms later.
- `just test-arch-oneshot`: **27/27 passed** — SIGTERM ends `facelock auth` with **exit 2 in 486 ms**, no process left; `facelock auth` gone **507 ms** after its PAM host was SIGKILLed (PDEATHSIG). Both signals landed during model load, where the token is first checked, so these are engine-load-bounded, not scan-loop latency.

## Host verification (Ty, branch installed via `just install` on the BRIO desktop)

- Default config: LED goes off immediately on a successful match (design: success releases at once). ✔
- `[device] camera_release_after_success_secs = 5`: LED stays on ~5 s after a successful match, then goes off; picked up by live reload without a daemon restart. ✔
- Note for others reading the config: `no_face_timeout_secs` is the empty-chair timer under `[recognition]`, not a hold.

## Still open (do not block merge; tracked in ADR §11)

- Quattro + omarchy PR #6863: password-first unlock → LED off with the unlock (verifies quickshell's `PamContext.abort()` drops the PAM helper's bus connection so the name-owner watch fires; if not, add the deferred explicit `Cancel()` D-Bus method)
- `sudo` Ctrl-C inside `pam_authenticate`: which path fires (cancelled vs. normal failure/warm) — either satisfies the design
- `sudo facelock bench camera-reopen` on the BRIO and a quirked IR camera — decides whether the 3 s default should drop to 2 s

## Review

Independent opus review of `3158f37..8520ce0` against ADR 008 (posted as a PR comment): 2 high, 3 medium, 7 low. H1/H2/M1–M3 and L1/L2/L5/L6/L7 are fixed in `93364e4` / `a25b331`; L3 (second-signal forced shutdown for a hand-run `facelock auth`) deliberately deferred; L4 resolved by `f33bd78` (ADR accepted) except §11 Q1, which awaits the bench numbers.

## Deviations from ADR 008

None known.

## Contract changes (docs/contracts.md updated in-commit)

- `device.camera_release_secs`: semantics narrowed to "after a failed attempt", default 5 → 3, `0` honored (was silently 5)
- `device.camera_release_after_success_secs`: new, additive, default 0 (opt-in hold after success)
- `recognition.no_face_timeout_secs`: new, additive, default 2
- audit `result` gains `cancelled`; frozen error string `cancelled` (PAM → PAM_IGNORE)
- no new D-Bus methods, no exit-code changes, no PAM defaults changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
