### PR TITLE
feat(setup): offer omarchy-lock-face as an opt-in PAM candidate

### DIFF
--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -2713,6 +2713,14 @@ const PAM_CANDIDATES: &[PamCandidate] = &[
         description: "KDE Plasma screen lock",
         default_enabled: true,
     },
+    // Opt-in, unlike the other lock screens: this is an Omarchy-specific service
+    // file, so leave the choice to users who know they have it.
+    PamCandidate {
+        service: "omarchy-lock-face",
+        category: PamCategory::LockScreen,
+        description: "omarchy-lock-face (Omarchy face-unlock screen lock)",
+        default_enabled: false,
+    },
     PamCandidate {
         service: "gdm-password",
         category: PamCategory::DisplayManager,
@@ -3600,6 +3608,31 @@ account include   system-login
         assert!(!found.contains(&"sddm"));
         assert!(!found.contains(&"gdm-password"));
         assert!(!found.contains(&"swaylock"));
+    }
+
+    #[test]
+    fn omarchy_lock_face_is_offered_but_opt_in() {
+        let candidate = PAM_CANDIDATES
+            .iter()
+            .find(|c| c.service == "omarchy-lock-face")
+            .expect("omarchy-lock-face must be offered by the wizard");
+        assert_eq!(candidate.category, PamCategory::LockScreen);
+        assert!(
+            !candidate.default_enabled,
+            "omarchy-lock-face is opt-in: the multi-select must not pre-check it"
+        );
+
+        // ...and, like every other candidate, it is only offered when its
+        // service file is actually present.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let present = |base: &Path| {
+            candidates_in(base)
+                .iter()
+                .any(|c| c.service == "omarchy-lock-face")
+        };
+        assert!(!present(tmp.path()));
+        std::fs::write(tmp.path().join("omarchy-lock-face"), "").unwrap();
+        assert!(present(tmp.path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `omarchy-lock-face` to `PAM_CANDIDATES`, so `sudo facelock setup` offers it in the PAM multi-select whenever `/etc/pam.d/omarchy-lock-face` exists on the machine.

It ships `default_enabled: false`. Every other `LockScreen` candidate is pre-checked, so the entry carries a short comment explaining the difference: it is an Omarchy-specific service file, and staying opt-in keeps the wizard from pre-checking something the user may not have deliberately installed.

Detection is unchanged and existence-gated — `candidates_in` filters `PAM_CANDIDATES` by whether `<pam.d>/<service>` exists, and `pam_install_in` re-checks before writing, backs up to `.facelock-backup`, and is idempotent on the `pam_facelock.so` line.

## Scope notes

- `facelock setup --pam --service omarchy-lock-face` already worked before this change — `--service` takes any name and is not validated against the candidate list. This PR only affects what the interactive wizard *offers*.
- The wizard's hyprlock handoff (`wizard_hyprlock_handoff`) still triggers only on the `hyprlock` service. Whether `omarchy-lock-face` warrants a similar handoff is left alone here.
- No `docs/contracts.md` change: the contract covers `facelock setup --pam` writing to `/etc/pam.d/`, not the wizard's candidate list.

## Test plan

- New `omarchy_lock_face_is_offered_but_opt_in` asserts the entry is `LockScreen`, is **not** `default_enabled`, and is surfaced by `candidates_in` only once the service file is present.
- `cargo test --workspace` — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)