### PR TITLE
fix(packaging): remove pam_facelock.so from every service on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a caller that is not root or in the `facelock` group, the CLI now appends an
   actionable hint (add user to group, re-login, or re-run setup) instead of a
   bare "AccessDenied".
+- **Uninstall left `pam_facelock.so` lines behind**: the Arch, RPM and
+  `just uninstall` cleanup paths stripped the facelock line from three
+  `/etc/pam.d` files (`sudo`, `polkit-1`, `hyprlock`) while `facelock setup`
+  offers eight, so `swaylock`, `kscreenlocker_greet`, `gdm-password`, `sddm`
+  and `lightdm` kept a line pointing at a module that was no longer installed.
+  All four packaging paths now share one list per file covering every service
+  setup offers, plus the ones `--service` gates behind a confirmation
+  (`system-auth`, `login`, `sshd`). A test in `facelock-cli` reads the
+  packaging files and fails if a new PAM candidate is not covered.
+- **Debian/Ubuntu uninstall removed no PAM lines at all**: `debian/prerm`
+  delegated everything to `pam-auth-update --remove facelock`, which only
+  manages the shared `common-auth` profile — it knows nothing about the direct
+  `/etc/pam.d/<service>` edits `facelock setup --pam` makes, so *every*
+  configured service kept its line. `prerm` now runs the same explicit removal
+  loop as the other packagers in addition to the `pam-auth-update` call.
 
 ### Security
 

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -3621,6 +3621,68 @@ account include   system-login
         }
     }
 
+    /// The uninstall paths of all four packagers each hardcode the set of
+    /// `/etc/pam.d/<service>` files to strip `pam_facelock.so` out of, because
+    /// they are shell run by a package manager and cannot read
+    /// `PAM_CANDIDATES`. That duplication has already rotted once: the lists
+    /// covered three services while setup offered eight, so five services kept
+    /// a stale facelock line after the package was removed. Nothing failed
+    /// loudly — the drift is only visible on an uninstall nobody runs in CI.
+    ///
+    /// This pins the direction that matters: every service setup *offers* must
+    /// be *covered* by every packager. It is deliberately a superset check and
+    /// not set equality — the packaging lists also carry `SENSITIVE_SERVICES`
+    /// (reachable via `setup --pam --service <name> --yes`) and services that
+    /// are not candidates yet, and naming a service that no host has is inert
+    /// because every loop is guarded by `[ -f "$PAM_FILE" ]`. Equality would
+    /// turn "packaging cleans up more than setup writes" — always safe — into
+    /// a failure, and would break whenever a candidate lands in one branch and
+    /// the packaging list in another.
+    #[test]
+    fn packaging_uninstall_covers_every_pam_candidate() {
+        // Assembled so this test's own prose is not what it matches on.
+        let decl = format!("FACELOCK_PAM_SERVICES={}", '"');
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+        for rel in [
+            "dist/facelock.install",
+            "dist/facelock.spec",
+            "dist/debian/prerm",
+            "justfile",
+        ] {
+            let path = root.join(rel);
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("{rel} must be readable from the workspace: {e}"));
+
+            let listed: Vec<&str> = source
+                .lines()
+                .find_map(|l| l.trim_start().strip_prefix(&decl)?.split_once('"'))
+                .map(|(value, _)| value.split_whitespace().collect())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{rel} must declare its PAM service list on one line as \
+                         FACELOCK_PAM_SERVICES=\"svc svc ...\". It is the single \
+                         literal both uninstall loops (pam_facelock.so lines and \
+                         .facelock-backup files) read, and this test's only handle \
+                         on it."
+                    )
+                });
+
+            for candidate in PAM_CANDIDATES {
+                assert!(
+                    listed.contains(&candidate.service),
+                    "{rel} does not clean up /etc/pam.d/{svc}, but `facelock setup` \
+                     offers to write a pam_facelock.so line into it. Uninstalling \
+                     would leave that line behind, pointing at a module that is no \
+                     longer on disk. Add {svc} to FACELOCK_PAM_SERVICES in {rel} \
+                     (naming a service the host lacks is inert — the loops skip \
+                     missing files). Currently listed there: {listed:?}",
+                    svc = candidate.service,
+                );
+            }
+        }
+    }
+
     #[test]
     fn check_model_correct_sha256() {
         let dir = tempfile::tempdir().unwrap();

--- a/dist/debian/prerm
+++ b/dist/debian/prerm
@@ -9,13 +9,41 @@ case "$1" in
             systemctl disable facelock-daemon 2>/dev/null || true
         fi
 
-        # Remove PAM configuration via pam-auth-update
+        # Remove the common-auth profile installed from debian/pam-auth-update.
         if [ -x /usr/sbin/pam-auth-update ]; then
             pam-auth-update --remove facelock 2>/dev/null || true
         fi
 
+        # pam-auth-update only manages the shared common-auth stack, but
+        # `facelock setup --pam` edits /etc/pam.d/<service> directly and
+        # pam-auth-update knows nothing about those edits. Without the loop
+        # below every service configured through setup keeps its
+        # pam_facelock.so line after the package is gone.
+        #
+        # Every PAM service `facelock setup` can write to: the services offered
+        # by the setup multi-select (PAM_CANDIDATES in
+        # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates
+        # behind a confirmation (SENSITIVE_SERVICES). `--service` accepts an
+        # arbitrary name, so this list can never be exhaustive; it covers
+        # everything facelock itself offers or gates. Missing files are
+        # skipped, so naming a service this host does not have is inert. A
+        # drift test in setup.rs
+        # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
+        # candidate is added without being listed here.
+        FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd"
+
+        # Remove PAM lines (regex match — tolerates whitespace/option variations)
+        for service in $FACELOCK_PAM_SERVICES; do
+            PAM_FILE="/etc/pam.d/$service"
+            if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
+                sed -i '/pam_facelock\.so/d' "$PAM_FILE"
+                echo "Removed face authentication from $PAM_FILE"
+            fi
+        done
+
         # Remove PAM safety backups created by `facelock setup`
-        for backup in /etc/pam.d/sudo.facelock-backup /etc/pam.d/polkit-1.facelock-backup /etc/pam.d/hyprlock.facelock-backup; do
+        for service in $FACELOCK_PAM_SERVICES; do
+            backup="/etc/pam.d/$service.facelock-backup"
             [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
         done
 

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -58,8 +58,20 @@ pre_remove() {
     # Kill facelock polkit agent if running (lets the DE's agent take over)
     pkill -f facelock-polkit-agent 2>/dev/null || true
 
+    # Every PAM service `facelock setup` can write to: the services offered by
+    # the setup multi-select (PAM_CANDIDATES in
+    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind
+    # a confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary
+    # name, so this list can never be exhaustive; it covers everything facelock
+    # itself offers or gates. Missing files are skipped, so naming a service
+    # this host does not have is inert. A drift test in setup.rs
+    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
+    # candidate is added without being listed here.
+    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd"
+
     # Remove PAM lines (regex match — tolerates whitespace/option variations)
-    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+    for service in $FACELOCK_PAM_SERVICES; do
+        PAM_FILE="/etc/pam.d/$service"
         if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
             sed -i '/pam_facelock\.so/d' "$PAM_FILE"
             echo "==> Removed face authentication from $PAM_FILE"
@@ -67,9 +79,15 @@ pre_remove() {
     done
 
     # Remove PAM safety backups created by `facelock setup`
-    for backup in /etc/pam.d/sudo.facelock-backup /etc/pam.d/polkit-1.facelock-backup /etc/pam.d/hyprlock.facelock-backup; do
+    for service in $FACELOCK_PAM_SERVICES; do
+        backup="/etc/pam.d/$service.facelock-backup"
         [ -f "$backup" ] && rm -f "$backup" && echo "==> Removed $backup"
     done
+    # The loop above exits non-zero when the last service has no backup — which
+    # is the common case — and that would be pre_remove's return value. Same
+    # guard as _facelock_secure_paths, so pacman does not report a failed
+    # scriptlet on an uninstall that did exactly what it should.
+    return 0
 }
 
 post_remove() {

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -118,15 +118,33 @@ echo "  2. sudo facelock enroll      (register your face)"
 
 # Only on full uninstall ($1 == 0), not upgrade.
 # Remove PAM lines that `facelock setup` may have added — otherwise stale
-# references to pam_facelock.so survive removal and can break sudo auth.
+# references to pam_facelock.so survive removal. facelock writes
+# `auth sufficient pam_facelock.so`, so with the module gone PAM logs a dlopen
+# failure, treats the module as failed and — being `sufficient` — falls through
+# to pam_unix: the cost is log noise and an auth stack that reads wrong, not a
+# lockout. At `required` (a hand-edit facelock never makes) the same stale line
+# would lock the service out, which is why the cleanup still matters.
 if [ $1 -eq 0 ]; then
-    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+    # Every PAM service `facelock setup` can write to: the services offered by
+    # the setup multi-select (PAM_CANDIDATES in
+    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind
+    # a confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary
+    # name, so this list can never be exhaustive; it covers everything facelock
+    # itself offers or gates. Missing files are skipped, so naming a service
+    # this host does not have is inert. A drift test in setup.rs
+    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
+    # candidate is added without being listed here.
+    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd"
+
+    for service in $FACELOCK_PAM_SERVICES; do
+        PAM_FILE="/etc/pam.d/$service"
         if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
             sed -i '/pam_facelock\.so/d' "$PAM_FILE"
         fi
     done
     # Remove PAM safety backups created by `facelock setup`
-    for backup in /etc/pam.d/sudo.facelock-backup /etc/pam.d/polkit-1.facelock-backup /etc/pam.d/hyprlock.facelock-backup; do
+    for service in $FACELOCK_PAM_SERVICES; do
+        backup="/etc/pam.d/$service.facelock-backup"
         [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
     done
     # Kill facelock polkit agent if running (lets the DE's agent take over)

--- a/justfile
+++ b/justfile
@@ -329,8 +329,20 @@ uninstall-files:
     systemctl stop facelock-daemon.service 2>/dev/null || true
     systemctl disable facelock-daemon.service 2>/dev/null || true
 
-    # Remove PAM lines from all known services (match on module name, not exact spacing)
-    for PAM_FILE in /etc/pam.d/sudo /etc/pam.d/polkit-1 /etc/pam.d/hyprlock; do
+    # Every PAM service `facelock setup` can write to: the services offered by
+    # the setup multi-select (PAM_CANDIDATES in
+    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind a
+    # confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary name,
+    # so this list can never be exhaustive; it covers everything facelock itself
+    # offers or gates. Missing files are skipped, so naming a service this host
+    # does not have is inert. A drift test in setup.rs
+    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new candidate
+    # is added without being listed here.
+    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd"
+
+    # Remove PAM lines (match on module name, not exact spacing)
+    for service in $FACELOCK_PAM_SERVICES; do
+        PAM_FILE="/etc/pam.d/$service"
         if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
             sed -i '/pam_facelock\.so/d' "$PAM_FILE"
             echo "Removed face auth from $PAM_FILE"
@@ -338,7 +350,8 @@ uninstall-files:
     done
 
     # Remove PAM safety backups created by `facelock setup`
-    for backup in /etc/pam.d/sudo.facelock-backup /etc/pam.d/polkit-1.facelock-backup /etc/pam.d/hyprlock.facelock-backup; do
+    for service in $FACELOCK_PAM_SERVICES; do
+        backup="/etc/pam.d/$service.facelock-backup"
         [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
     done
 


### PR DESCRIPTION
## The drift: 3 covered, 8 offered

`facelock setup` offers a multi-select of PAM services to configure, defined by `PAM_CANDIDATES` in `crates/facelock-cli/src/commands/setup.rs`. On `main` that is **eight** services:

`sudo`, `polkit-1`, `hyprlock`, `swaylock`, `kscreenlocker_greet`, `gdm-password`, `sddm`, `lightdm`

The uninstall hooks that strip the `pam_facelock.so` line back out covered **three**: `sudo`, `polkit-1`, `hyprlock`. Five services kept an `auth sufficient pam_facelock.so` line pointing at a module that was no longer on disk, plus their `.facelock-backup` files. The lists just drifted as `PAM_CANDIDATES` grew — four packaging sites each carried **two** hardcoded copies of the same list (one loop for line removal, one for backups), eight literals in total, none of which had a test.

Each file now declares **one** `FACELOCK_PAM_SERVICES` list that both of its loops read. The lists stay self-contained per file: these are scriptlets run by a package manager, so there is nothing to source.

## The Debian case was a separate, worse bug

`dist/debian/prerm` delegated *all* line removal to `pam-auth-update --remove facelock`. But the profile in `dist/debian/pam-auth-update` only manages the shared `common-auth` stack, whereas `facelock setup --pam` writes directly into `/etc/pam.d/<service>`. pam-auth-update knows nothing about those edits, so on Debian/Ubuntu **every** configured service kept its line on uninstall — not five of eight, all of them.

The `pam-auth-update --remove` call stays (it is still the right thing for the common-auth profile) and an explicit removal loop matching the other three packagers is added alongside it.

## Severity correction

`dist/facelock.spec` claimed a stale reference "can break sudo auth". That is overstated. The line facelock writes is `auth sufficient pam_facelock.so`; with the `.so` gone PAM logs a dlopen failure, treats the module as failed, and — because it is `sufficient` — the stack falls through to `pam_unix`. The real cost is log noise and an auth stack that reads wrong, **not a lockout**. It *would* be a lockout at `required` (a hand-edit facelock never makes), which is why the cleanup still matters. Comment reworded. The `justfile`'s "all known services" comment — the false half of the bug — is gone too.

## The service list

```
sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd
```

That is every `PAM_CANDIDATES` service, plus:

- **`omarchy-lock-face`** — the 9th candidate added by #146. This PR is branched off `main` and is deliberately **not** stacked on #146; every loop is guarded by `[ -f "$PAM_FILE" ]`, so naming a service that does not exist yet is inert.
- **`system-auth`, `login`, `sshd`** — the `SENSITIVE_SERVICES` reachable via `facelock setup --pam --service <name> --yes`. facelock can have written to them, so it should clean up after itself. The loops only delete lines matching `pam_facelock\.so`, so touching `system-auth` is safe.

### Residual limitation

`--service` accepts an **arbitrary** name, so exhaustive coverage is impossible by construction. A user who runs `setup --pam --service foo` gets a line in `/etc/pam.d/foo` that no packager will remove. This list covers everything facelock itself *offers* or *gates*; anything beyond that is out of reach of a static list. `facelock setup --pam --remove --service <name>` remains the escape hatch.

## Drift test

`packaging_uninstall_covers_every_pam_candidate` in `crates/facelock-cli/src/commands/setup.rs` reads the four packaging files off disk via `env!("CARGO_MANIFEST_DIR")` and asserts every `PAM_CANDIDATES` service appears in each list. It follows the shape of the existing `auth_bin_matches_the_path_pam_actually_spawns` in `crates/facelock-cli/src/health.rs`, which pins a constant duplicated into `pam-facelock` the same way.

It asserts the **superset** direction only (packaging ⊇ `PAM_CANDIDATES`), never set equality. Packaging cleaning up *more* than setup writes is always safe, and equality would fail whenever a candidate and its packaging entry land in different branches — exactly the #146 situation.

## Merge ordering with #146

Verified rather than assumed. #146 (`feat/pam-candidate-omarchy-lock-face`) adds `omarchy-lock-face` to `PAM_CANDIDATES`:

- **On `main` today** (8 candidates, 12 packaged): green — checked by `cargo test --workspace`.
- **After #146 merges**: test-merged the two branches locally. `setup.rs` auto-merged with no conflict (#146 inserts its test before `no_excluded_services_in_candidates`, this PR inserts after), and all 52 `setup::` tests passed with 9 candidates present. Either merge order works.

`PAM_CANDIDATES` itself is untouched here — that is #146's change. The only edit to `setup.rs` in this PR is the added test.

## Test plan

- `cargo test --workspace` — pass (exit 0)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `shellcheck dist/debian/prerm dist/debian/postinst` — clean; also clean on `dist/facelock.install` (`-s bash`) and on the `%preun` body extracted from `dist/facelock.spec` with rpm macro lines stripped. `bash -n`, `sh -n` and `just --summary` all parse.
- **Negative test of the drift test**: dropped `lightdm` from the justfile list; the test failed with the intended message naming the file and the service. Restored.
- **Functional test of all four loops**: extracted each packager's uninstall shell, retargeted `/etc/pam.d` at a temp root seeded with all 11 existing services (each with a facelock line, a `pam_unix` line and a `.facelock-backup`) plus one unrelated `untouched` file. All four removed every facelock line and every backup, left `untouched` and the `pam_unix` lines alone, and exited 0.
- **`set -e` contract**: reran the same harness against an *empty* pam.d, where every `[ -f "$backup" ]` is false. All four exit 0.

## One extra line, called out for review

`pre_remove` in `dist/facelock.install` now ends with `return 0`, matching the existing `_facelock_secure_paths`. Its last statement is the backup loop, and the `[ -f "$backup" ] && rm -f "$backup"` idiom exits non-zero when the last service has no backup — the common case — making that the function's return value, so pacman reports a failed scriptlet on an uninstall that did exactly what it should. This reproduces on `main` (verified: `pre_remove` from `origin/main` exits 1 against an empty pam.d), so it is pre-existing rather than introduced here, but it is one line in a function this PR already rewrites. Happy to drop it if you would rather keep it separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
