### PR TITLE
fix(cli): keep --json parseable, and let the one-shot clear a stale enrollment marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--json` output corrupted by log lines on stdout** (#149): the CLI's tracing
+  subscriber inherited `tracing_subscriber`'s default writer, which is *stdout*
+  — the same stream `devices --json`, `list --json` and `is-enrolled --json`
+  print their payload on. Any diagnostic that passed the `RUST_LOG` filter was
+  prepended to the JSON, so with `daemon.mode = "daemon"` and the daemon
+  stopped, `facelock devices --json | jq .` failed on the D-Bus fallback WARN.
+  All tracing output now goes to stderr, in `facelock`, `facelock-bench` and
+  `facelock-polkit` alike; stdout carries the payload and nothing else. The
+  three `facelock` init sites were collapsed into one `logging::init_stderr`,
+  and the conformance test that already guarded the log *filter* now also
+  guards the *writer* by asserting no other file in the crate touches
+  `tracing_subscriber` at all. Also: a `RUST_LOG` that cannot be parsed is now
+  reported at WARN instead of being silently discarded.
 - **`setup --systemd --pam` silently dropped `--pam`**: the dispatch was an
   `if systemd {} else if pam {}` chain, so asking for both ran only systemd and
   said nothing about it. It now runs both, systemd first, matching the order the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guards the *writer* by asserting no other file in the crate touches
   `tracing_subscriber` at all. Also: a `RUST_LOG` that cannot be parsed is now
   reported at WARN instead of being silently discarded.
+- **One-shot `facelock auth` could not clear a stale enrollment marker**: the
+  enrollment pre-flight gate short-circuits above the marker convergence point,
+  so on a daemonless install — where daemon startup's `reconcile_all` never runs
+  — a marker left behind by a database restored from a pre-enrollment backup (or
+  a row removed out of band) was permanent: every later attempt was rejected at
+  the gate and returned before converging, and `facelock is-enrolled` reported
+  enrolled forever. The one-shot now deletes a marker the database
+  authoritatively contradicts, at the gate that observes the contradiction. The
+  marker *write* stays below the pre-flight gates exactly as before — this is a
+  removal only (one `unlink`, no temp file, no `chown`, no `rename`, no
+  directory created), it is idempotent, and it is reachable only when the marker
+  is already false, so no attacker-drivable filesystem work is added on the
+  wrong side of the rate limiter. `docs/contracts.md` no longer implies the
+  one-shot path re-derives every marker; it converges exactly one user's.
 - **`setup --systemd --pam` silently dropped `--pam`**: the dispatch was an
   `if systemd {} else if pam {}` chain, so asking for both ran only systemd and
   said nothing about it. It now runs both, systemd first, matching the order the

--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -86,6 +86,10 @@ enum Command {
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(default_env_filter())
+        // Diagnostics on stderr, report on stdout (#149). This binary prints a
+        // measurement report a caller may well capture; `tracing_subscriber`'s
+        // default writer is stdout, which interleaves the two.
+        .with_writer(std::io::stderr)
         .init();
 
     let cli = Cli::parse();

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -119,6 +119,13 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         // change anything today: no pre-flight gate produces the one class
         // that maps to 1 (the camera is not open yet).
         debug!(?resp, "pre-check short-circuit");
+
+        // The only marker work a *rejected* attempt performs, and the reason
+        // the daemonless install can converge downward at all (#137 review).
+        // See the helper for why this specific operation is admissible on this
+        // side of the rate limiter when a marker *write* is not.
+        clear_marker_the_store_contradicts(&config, &store, &user);
+
         return match resp {
             AuthOutcome::Error { kind, .. } => oneshot_exit_code(kind),
             _ => 2,
@@ -339,19 +346,94 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
 ///
 /// `models` is `None` when the store could not be listed — leave the existing
 /// marker alone rather than guessing it away, the same rule
-/// [`crate::commands::enrollment_marker::refresh`] follows. A count of zero is
-/// a real answer ("no models") and does delete the marker.
+/// [`crate::commands::enrollment_marker::refresh`] follows.
 ///
-/// Called unconditionally, before the camera is opened and before the
-/// authentication attempt, so nothing the attempt goes on to do or fail to do
-/// can decide whether it runs: an upgraded user whose face is not recognised
-/// today — or whose camera is busy today — still needs `is-enrolled` to tell
-/// the truth. Best-effort throughout — `set` logs its own failures and never
-/// propagates, so nothing here can fail an authentication.
+/// Called after the pre-flight gates pass, before the camera is opened and
+/// before the authentication attempt, so nothing the attempt goes on to do or
+/// fail to do can decide whether it runs: an upgraded user whose face is not
+/// recognised today — or whose camera is busy today — still needs
+/// `is-enrolled` to tell the truth. Best-effort throughout — `set` logs its own
+/// failures and never propagates, so nothing here can fail an authentication.
+///
+/// **This call converges upward only.** Reaching it means the enrollment gate
+/// passed, i.e. `has_models` was true, so the count is ≥ 1 barring a
+/// concurrent `remove` between the two reads. Clearing a marker the database
+/// contradicts is [`clear_marker_the_store_contradicts`]'s job, on the
+/// rejection path where that evidence actually arrives. `set` is still used
+/// (rather than `write_marker_in`) so the racing-zero case does the right
+/// thing instead of writing `{"models":0}`.
 fn converge_enrollment_marker(config: &Config, user: &str, models: Option<u32>) {
     match models {
         Some(models) => super::enrollment_marker::set(config, user, models),
         None => debug!(user = %user, "model list unavailable; enrollment marker left unchanged"),
+    }
+}
+
+/// Delete `user`'s enrollment marker when the authoritative store says they
+/// have no models — the downward half of #137's convergence, and the only
+/// marker work a pre-flight **rejection** is allowed to do.
+///
+/// # Why the one-shot path needs this at all
+///
+/// [`auth::pre_check_with_context`] short-circuits when `has_models` is false,
+/// which is *above* [`converge_enrollment_marker`] in `run`. So on a daemonless
+/// install — no daemon start, therefore no `reconcile_all`/`prune_markers_in`
+/// — a marker that outlives its database rows can never be cleared: every
+/// subsequent attempt hits the not-enrolled gate and returns before
+/// convergence, and `facelock is-enrolled` reports enrolled forever. The
+/// database being restored from a backup that predates the enrollment, or a row
+/// removed out of band, is enough to get there. That is exactly #137's drift,
+/// running in the opposite direction.
+///
+/// # Why this is admissible here when a marker *write* is not
+///
+/// The placement of [`converge_enrollment_marker`] below `pre_check_audited` is
+/// load-bearing and is not disturbed: it keeps a marker **write** — temp file,
+/// `chown`, `rename`, and a `mkdir` of the marker directory — off the path an
+/// attempt rejected at a pre-flight gate can reach, because that is
+/// attacker-drivable filesystem work from the wrong side of the rate limiter.
+///
+/// What happens here is a different operation with different properties:
+///
+/// - **It only ever removes.** One `unlink(2)` on a path that is a single,
+///   validated component under the marker directory ([`marker_path`] rejects
+///   `..`, `/` and empty names). Nothing is created, nothing is `chown`ed, no
+///   directory is materialized — `remove_marker_in` does not call
+///   `ensure_private_dir`.
+/// - **It is bounded.** The first rejection removes the marker; every
+///   subsequent one finds `ENOENT` and does nothing. Repetition buys an
+///   attacker one failed `unlink` per attempt — nothing accumulates, on disk or
+///   anywhere else. Said plainly, because the ordering matters: the enrollment
+///   gate fires *before* the rate-limit check, so on that path this really does
+///   run unmetered. What makes that acceptable is the bound above and the
+///   property below, not the rate limiter.
+/// - **It cannot be driven to a wrong answer.** It fires only when the
+///   database — the authority — reports zero models for the user, in which case
+///   any marker claiming otherwise is already false. There is no state an
+///   attacker can steer it into: it can delete a stale marker, never a correct
+///   one, so it is not a denial-of-face-unlock primitive either.
+///
+/// The `has_models` read here repeats the one the enrollment gate just did.
+/// That is deliberate: asking the store directly keeps this independent of
+/// which [`AuthOutcome`] variant a gate happens to return, so a future
+/// rejection class cannot silently start or stop clearing markers. The cost is
+/// one indexed `COUNT` on the rejection path only.
+///
+/// Best-effort like every other marker write: `forget` logs its own failures
+/// and never propagates, so nothing here can fail an authentication.
+///
+/// [`marker_path`]: crate::commands::enrollment_marker::marker_path
+fn clear_marker_the_store_contradicts(config: &Config, store: &FaceStore, user: &str) {
+    match store.has_models(user) {
+        // Authoritative "no": the marker, if any, is stale.
+        Ok(false) => super::enrollment_marker::forget(config, user),
+        Ok(true) => {}
+        // An unreadable store is not evidence of anything — the same rule
+        // `converge_enrollment_marker` applies to a `None` count. Guessing
+        // "zero" from a transient database error would delete a correct marker.
+        Err(e) => {
+            debug!(user = %user, error = %e, "enrollment state unreadable; enrollment marker left unchanged")
+        }
     }
 }
 
@@ -809,8 +891,10 @@ path = "{audit_path}"
     // Enrollment marker convergence (#137)
     // -----------------------------------------------------------------------
 
-    use super::converge_enrollment_marker;
-    use crate::commands::enrollment_marker::{MarkerState, marker_dir, read_marker_in};
+    use super::{clear_marker_the_store_contradicts, converge_enrollment_marker};
+    use crate::commands::enrollment_marker::{
+        MarkerState, marker_dir, read_marker_in, write_marker_in,
+    };
 
     /// A config pointing an entire installation at `dir`: the marker directory
     /// is derived from `storage.db_path`. "alice" has no passwd entry, so the
@@ -845,18 +929,82 @@ path = "{audit_path}"
         ));
     }
 
-    /// A count of zero is a real answer from the store: the user has no models,
-    /// so the marker must go.
+    /// The downward half of #137 on a daemonless install, and the case the
+    /// helper this replaces could never actually reach.
+    ///
+    /// The predecessor test called `converge_enrollment_marker(.., Some(0))`
+    /// and asserted the marker went away. It did — but `run` cannot produce
+    /// `Some(0)`: the enrollment gate in `pre_check_audited` short-circuits
+    /// above that call whenever the store has no models, so the zero branch was
+    /// dead on the one-shot path and the test read as coverage of a fix that
+    /// was not there. The real evidence arrives on the *rejection* path, which
+    /// is where this exercises it: a store that genuinely holds nothing for the
+    /// user, and a marker on disk claiming otherwise.
     #[test]
-    fn oneshot_convergence_clears_the_marker_at_zero_models() {
+    fn oneshot_rejection_clears_a_marker_the_store_contradicts() {
         let tmp = tempfile::tempdir().unwrap();
         let config = marker_config(tmp.path());
         let base = marker_dir(&config);
+        let store = FaceStore::open_memory().unwrap();
 
-        converge_enrollment_marker(&config, "alice", Some(1));
-        converge_enrollment_marker(&config, "alice", Some(0));
+        // What a database restored from a pre-enrollment backup leaves behind:
+        // a marker with no rows behind it.
+        write_marker_in(&base, "alice", 1, None).unwrap();
 
+        clear_marker_the_store_contradicts(&config, &store, "alice");
+
+        assert_eq!(
+            read_marker_in(&base, "alice"),
+            MarkerState::Absent,
+            "a marker the database contradicts must not survive the attempt \
+             that observed the contradiction"
+        );
+
+        // Idempotent, and the repeat costs one failed unlink — the bound the
+        // helper's doc comment claims.
+        clear_marker_the_store_contradicts(&config, &store, "alice");
         assert_eq!(read_marker_in(&base, "alice"), MarkerState::Absent);
+    }
+
+    /// The other side of the same gate: a rejection for any *other* reason
+    /// (rate limited, non-IR, lid closed) must leave an enrolled user's marker
+    /// exactly where it is. The store, not the rejection, is the authority.
+    #[test]
+    fn oneshot_rejection_leaves_an_enrolled_users_marker_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = marker_config(tmp.path());
+        let base = marker_dir(&config);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model("alice", "front", &[0.5f32; 512], "test-embedder")
+            .unwrap();
+
+        write_marker_in(&base, "alice", 1, None).unwrap();
+
+        clear_marker_the_store_contradicts(&config, &store, "alice");
+
+        assert!(
+            matches!(read_marker_in(&base, "alice"), MarkerState::Enrolled(m) if m.models == 1),
+            "an enrolled user's marker must survive a rejected attempt"
+        );
+    }
+
+    /// The rejection path writes nothing — no marker, no marker directory. The
+    /// whole reason it is allowed to run on this side of the rate limiter is
+    /// that removal is all it can do.
+    #[test]
+    fn oneshot_rejection_never_creates_a_marker_or_its_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = marker_config(tmp.path());
+        let base = marker_dir(&config);
+        let store = FaceStore::open_memory().unwrap();
+
+        clear_marker_the_store_contradicts(&config, &store, "alice");
+
+        assert!(
+            !base.exists(),
+            "a rejected attempt must not materialize the marker directory"
+        );
     }
 
     /// An unreadable store is not evidence of anything. Guessing "zero" from a
@@ -946,6 +1094,51 @@ path = "{audit_path}"
                 .count(),
             1,
             "run() must converge exactly once"
+        );
+    }
+
+    /// The companion pin for the downward half. The clearing call has one legal
+    /// home: **inside** the pre-flight short-circuit, between the gates and the
+    /// `return` that ends the rejected attempt.
+    ///
+    /// Above `pre_check_audited` it would be a store read (and a marker unlink)
+    /// on every attempt regardless of the gates, which is the hoist the #144
+    /// review rejected. Below the short-circuit's `return` it would be
+    /// unreachable on exactly the path that has the evidence — the not-enrolled
+    /// rejection — which is the dead-code shape this change exists to fix.
+    #[test]
+    fn the_clearing_call_sits_inside_the_pre_flight_short_circuit() {
+        let src = include_str!("auth.rs");
+        let pre_check = src
+            .find("pre_check_audited(")
+            .expect("run() must run the pre-flight gates");
+        let clear = src
+            .find("clear_marker_the_store_contradicts(")
+            .expect("run() must clear a marker the store contradicts");
+        let converge = src
+            .find("converge_enrollment_marker(")
+            .expect("run() must converge the marker");
+
+        assert!(
+            pre_check < clear,
+            "the clearing call must run *after* the gates, not before them"
+        );
+        assert!(
+            clear < converge,
+            "the clearing call belongs inside the short-circuit block, which \
+             returns before the upward convergence below it"
+        );
+
+        // Exactly one call site, for the same reason convergence has one.
+        let definition = src
+            .find("fn clear_marker_the_store_contradicts(")
+            .expect("the helper must be defined in this file");
+        assert_eq!(
+            src[..definition]
+                .matches("clear_marker_the_store_contradicts(")
+                .count(),
+            1,
+            "run() must clear at most once, on the rejection path"
         );
     }
 }

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -33,13 +33,9 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
         }
     };
 
-    tracing_subscriber::fmt()
-        // See crate::logging's module doc for why this must not build its
-        // own fallback filter by hand.
-        .with_env_filter(crate::logging::default_env_filter())
-        .with_target(false)
-        .with_writer(std::io::stderr)
-        .init();
+    // See crate::logging's module doc for why this must not build its own
+    // subscriber by hand: it owns both the filter and the stderr writer.
+    crate::logging::init_stderr(false);
 
     // Loaded once, up front: auto-detection and the interrogation below must
     // be decided by the SAME quirk set, or the device picked and the device

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -236,13 +236,14 @@ fn reconcile_enrollment_markers(config: &Config) {
 pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
     crate::ipc_client::require_root("sudo facelock daemon")?;
 
-    // Init tracing (daemon uses its own tracing setup with target=true).
+    // Init tracing (the daemon is the one caller that wants targets rendered).
     // See crate::logging's module doc for why this must not build its own
-    // fallback filter by hand.
-    tracing_subscriber::fmt()
-        .with_env_filter(crate::logging::default_env_filter())
-        .with_target(true)
-        .init();
+    // subscriber by hand. The writer is stderr rather than the previous
+    // stdout: the shipped unit sets `StandardOutput=journal` *and*
+    // `StandardError=journal`, so the journal sees exactly what it saw before,
+    // and a daemon run in the foreground now behaves like every other
+    // subcommand.
+    crate::logging::init_stderr(true);
 
     info!("facelock daemon starting");
 

--- a/crates/facelock-cli/src/logging.rs
+++ b/crates/facelock-cli/src/logging.rs
@@ -1,15 +1,34 @@
-//! Shared tracing/`EnvFilter` default for the `facelock` binary (gap E9).
+//! The one tracing-subscriber init site for the `facelock` binary (gap E9,
+//! issue #149).
 //!
-//! `RUST_LOG` filters by target, and this binary's own diagnostic events
-//! carry the target `facelock` — the `[[bin]] name` in Cargo.toml — not
-//! `facelock_cli`, the crate directory's name. That mismatch has silently
-//! dropped every diagnostic at an init site three times historically (see
-//! `commands/auth.rs`'s prior fix and CHANGELOG). Every
-//! `tracing_subscriber::fmt()` init site in this crate must build its
-//! fallback filter through [`default_env_filter`] rather than hand-rolling
-//! an `EnvFilter::try_from_default_env().unwrap_or_else(...)` string —
-//! `logging_conformance_test` in this module enforces that no other site in
-//! `src/` bypasses it.
+//! Two contracts live here. Both have been broken by a hand-rolled init before,
+//! and both are invisible until something downstream reads the output:
+//!
+//! **1. The filter targets the bin name.** `RUST_LOG` filters by target, and
+//! this binary's own diagnostic events carry the target `facelock` — the
+//! `[[bin]] name` in Cargo.toml — not `facelock_cli`, the crate directory's
+//! name. That mismatch has silently dropped every diagnostic at an init site
+//! three times historically (see `commands/auth.rs`'s prior fix and CHANGELOG).
+//!
+//! **2. Diagnostics go to stderr, payload goes to stdout.**
+//! `tracing_subscriber::fmt()` defaults its writer to **stdout** — the same
+//! stream the machine-readable payloads are printed on (`devices --json`,
+//! `list --json`, `is-enrolled --json`, and every human-readable renderer).
+//! Any event that passed the filter was therefore prepended to the JSON and the
+//! output stopped parsing (#149: with `daemon.mode = "daemon"` and the daemon
+//! stopped, `facelock devices --json | jq .` failed on the D-Bus fallback WARN
+//! that `backend::select` emits). The split is per-process and per-stream, so
+//! it cannot be fixed at the `println!` call sites one at a time — it is fixed
+//! once, here.
+//!
+//! [`init_stderr`] is the only sanctioned way to install this process's
+//! subscriber. `no_init_site_outside_this_module_builds_its_own_subscriber`
+//! enforces that no other file under `src/` touches `tracing_subscriber` at
+//! all, which is what keeps a copy-pasted `tracing_subscriber::fmt()` from
+//! reintroducing either failure.
+
+/// The environment variable `tracing_subscriber` reads its filter from.
+const ENV_LOG: &str = "RUST_LOG";
 
 /// Fallback `EnvFilter` directive string used when `RUST_LOG` is unset.
 /// Enables `info` level on `facelock` (this crate's bin target) and
@@ -17,12 +36,64 @@
 /// two targets that carry the diagnostics operators care about by default.
 pub const DEFAULT_LOG_FILTER: &str = "facelock=info,facelock_daemon=info";
 
-/// The `EnvFilter` every tracing-subscriber init site in this crate must use:
-/// honors `RUST_LOG` when set and valid, otherwise falls back to
-/// [`DEFAULT_LOG_FILTER`].
-pub fn default_env_filter() -> tracing_subscriber::EnvFilter {
-    tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| DEFAULT_LOG_FILTER.into())
+/// Install this process's tracing subscriber, writing every event to
+/// **stderr**.
+///
+/// `with_target` includes each event's target (module path) in the rendered
+/// line: the daemon wants it, the CLI does not.
+///
+/// Panics only in the way `tracing_subscriber`'s own `init()` does — being
+/// called twice in one process.
+pub fn init_stderr(with_target: bool) {
+    let (filter, rejected) = env_filter();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(with_target)
+        // #149. Not a style preference: stdout carries this binary's payloads.
+        .with_writer(std::io::stderr)
+        .init();
+
+    // Reportable only now that a subscriber exists — the filter has to be
+    // built before it can be installed. Silently ignoring a `RUST_LOG` the
+    // operator deliberately set is its own papercut: the symptom is "my filter
+    // did nothing", which is indistinguishable from "nothing logged".
+    if let Some(reason) = rejected {
+        tracing::warn!(
+            reason = %reason,
+            fallback = DEFAULT_LOG_FILTER,
+            "RUST_LOG could not be parsed and was ignored"
+        );
+    }
+}
+
+/// The `EnvFilter` to install, plus the reason `RUST_LOG` was rejected when it
+/// was set but unparseable.
+///
+/// `RUST_LOG` unset and `RUST_LOG` invalid both fall back to
+/// [`DEFAULT_LOG_FILTER`] — the same outcome the previous
+/// `try_from_default_env().unwrap_or_else(..)` produced — but only the second
+/// is worth telling the operator about, which is why they are distinguished
+/// here rather than collapsed.
+fn env_filter() -> (tracing_subscriber::EnvFilter, Option<String>) {
+    match std::env::var(ENV_LOG) {
+        Ok(raw) => classify_filter(&raw),
+        Err(_) => (fallback_filter(), None),
+    }
+}
+
+/// [`env_filter`] for one already-read `RUST_LOG` value, split out so the
+/// accept/reject classification is testable without mutating the process
+/// environment (which every other test in this binary shares).
+fn classify_filter(raw: &str) -> (tracing_subscriber::EnvFilter, Option<String>) {
+    match tracing_subscriber::EnvFilter::try_new(raw) {
+        Ok(filter) => (filter, None),
+        Err(e) => (fallback_filter(), Some(e.to_string())),
+    }
+}
+
+fn fallback_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER)
 }
 
 #[cfg(test)]
@@ -46,21 +117,49 @@ mod tests {
         assert_eq!(DEFAULT_LOG_FILTER, "facelock=info,facelock_daemon=info");
     }
 
-    /// Walks this crate's `src/` tree at test time and asserts that (a) the
-    /// raw bypass pattern `EnvFilter::try_from_default_env(` /
-    /// `EnvFilter::from_default_env(` appears nowhere outside this file, and
-    /// (b) every file that previously hand-rolled a fallback filter now
-    /// calls `default_env_filter()`.
-    ///
-    /// Honest scope: this is a textual scan, not a borrow-checked guarantee
-    /// — a call site could still be added and shadowed under a different
-    /// name, or the bypass strings could be split across lines/macros to
-    /// dodge the substring match. It catches the actual historical failure
-    /// mode (copy-pasting the old `EnvFilter::try_from_default_env()...`
-    /// block into a new command) and regressions at the three known sites;
-    /// it is not a guarantee that *no* site anywhere can ever bypass it.
+    /// The fallback string has to actually parse — it is what an operator gets
+    /// when their own `RUST_LOG` did not.
     #[test]
-    fn no_init_site_outside_this_module_bypasses_default_env_filter() {
+    fn the_fallback_filter_parses() {
+        assert!(tracing_subscriber::EnvFilter::try_new(DEFAULT_LOG_FILTER).is_ok());
+    }
+
+    /// `tests/json_stream_split.rs` forces a guaranteed WARN by handing the
+    /// binary this exact `RUST_LOG`. If `tracing_subscriber` ever starts
+    /// accepting it, that test emits no diagnostic and silently stops proving
+    /// anything — so the fixture is pinned here, next to the code that
+    /// classifies it.
+    #[test]
+    fn the_stream_split_tests_bad_rust_log_fixture_really_is_unparseable() {
+        let (_, rejected) = classify_filter("facelock=notalevel");
+        assert!(
+            rejected.is_some(),
+            "`facelock=notalevel` must be rejected: it is the fixture \
+             tests/json_stream_split.rs uses to force a WARN"
+        );
+    }
+
+    /// A valid `RUST_LOG` is honored and reported as such; an unset one falls
+    /// back without complaint.
+    #[test]
+    fn a_valid_rust_log_is_honored_without_a_complaint() {
+        assert!(classify_filter("facelock=trace").1.is_none());
+        assert!(classify_filter(DEFAULT_LOG_FILTER).1.is_none());
+    }
+
+    /// Walks this crate's `src/` tree at test time and asserts that no file
+    /// other than this one touches `tracing_subscriber` at all, and that the
+    /// three known init sites go through [`init_stderr`].
+    ///
+    /// Honest scope: this is a textual scan, not a borrow-checked guarantee —
+    /// a site could still be added under a re-exported alias, or the strings
+    /// split across lines to dodge the substring match. It catches the actual
+    /// historical failure mode (copy-pasting a `tracing_subscriber::fmt()`
+    /// block into a new command, inheriting the stdout writer and a
+    /// hand-rolled filter) and regressions at the three known sites; it is not
+    /// a guarantee that *no* site anywhere can ever bypass it.
+    #[test]
+    fn no_init_site_outside_this_module_builds_its_own_subscriber() {
         let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut visited_files = 0usize;
         let mut sites_using_helper = Vec::new();
@@ -70,15 +169,14 @@ mod tests {
             let is_this_file = path.file_name().and_then(|n| n.to_str()) == Some("logging.rs");
             if !is_this_file {
                 assert!(
-                    !contents.contains("EnvFilter::try_from_default_env(")
-                        && !contents.contains("EnvFilter::from_default_env("),
-                    "{} builds an EnvFilter directly instead of calling \
-                     logging::default_env_filter() — see logging.rs's module \
-                     doc comment",
+                    !contents.contains("tracing_subscriber"),
+                    "{} builds its own subscriber instead of calling \
+                     logging::init_stderr() — see logging.rs's module doc \
+                     comment, which owns both the filter and the stderr writer",
                     path.display()
                 );
             }
-            if contents.contains("logging::default_env_filter()") {
+            if contents.contains("logging::init_stderr(") {
                 sites_using_helper.push(path.to_path_buf());
             }
         });
@@ -97,7 +195,7 @@ mod tests {
                 sites_using_helper
                     .iter()
                     .any(|p| p.to_string_lossy().contains(expected_substr)),
-                "expected a call to logging::default_env_filter() in a path \
+                "expected a call to logging::init_stderr() in a path \
                  containing {expected_substr:?}, found calls only in {sites_using_helper:?}"
             );
         }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -248,11 +248,11 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(exit_code);
         }
         other => {
-            // Default tracing init for all other commands
-            tracing_subscriber::fmt()
-                .with_env_filter(logging::default_env_filter())
-                .with_target(false)
-                .init();
+            // Default tracing init for all other commands. Diagnostics land on
+            // stderr, which is what leaves stdout free for the payload these
+            // commands print — `devices --json`, `list --json`,
+            // `is-enrolled --json` (#149). See `crate::logging`.
+            logging::init_stderr(false);
 
             match other {
                 // -- Dispatched before the shared config parse (D7). --

--- a/crates/facelock-cli/tests/json_stream_split.rs
+++ b/crates/facelock-cli/tests/json_stream_split.rs
@@ -1,0 +1,146 @@
+//! Issue #149: a diagnostic must never land on the stream a payload is
+//! printed on.
+//!
+//! `tracing_subscriber::fmt()` defaults its writer to **stdout**, which is
+//! where every `--json` payload is `println!`ed. Any event that passed the
+//! filter was therefore prepended to the JSON and `facelock devices --json |
+//! jq .` stopped parsing. The unit tests next to those renderers
+//! (`commands/devices.rs`, `commands/list.rs`) only ever serialized a struct,
+//! so none of them could see it — the corruption happens on the process's
+//! streams, not in the string. These tests run the real binary and read the
+//! real streams.
+//!
+//! `is-enrolled --json` is the payload command chosen here because it is the
+//! only one that is not root-gated, so this runs unprivileged in CI and on a
+//! developer's `cargo test`. The stream split is a property of the subscriber
+//! (`crate::logging`), which is process-wide and installed once, so pinning it
+//! on one command pins it for all of them.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// A `RUST_LOG` value `tracing_subscriber` cannot parse. The binary reports
+/// this at WARN, which is what gives these tests a diagnostic that is
+/// guaranteed to be emitted on *every* invocation — rather than one that
+/// depends on a daemon being absent, a camera being missing, or some other
+/// ambient condition a test cannot arrange. `logging.rs` pins the same string
+/// so this cannot quietly become parseable and leave the tests asserting
+/// nothing.
+const UNPARSEABLE_RUST_LOG: &str = "facelock=notalevel";
+
+/// The substring the WARN above renders with. Deliberately free of the level
+/// and field names, which `tracing_subscriber` wraps in ANSI escapes.
+const WARN_TEXT: &str = "RUST_LOG could not be parsed";
+
+/// A whole installation pointed at `dir`: the marker directory is derived from
+/// `storage.db_path`, so this keeps the test off `/var/lib/facelock` and makes
+/// the answer deterministic — a user who cannot be enrolled in an empty
+/// tempdir always reads as absent.
+fn config_in(dir: &Path) -> PathBuf {
+    let db_path = dir.join("state").join("facelock.db");
+    let path = dir.join("config.toml");
+    std::fs::write(
+        &path,
+        format!("[storage]\ndb_path = \"{}\"\n", db_path.display()),
+    )
+    .expect("failed to write test config");
+    path
+}
+
+/// `facelock --config <tmp> is-enrolled --user <absent> --json`, with
+/// `RUST_LOG` set to `rust_log` — or removed from the child's environment
+/// entirely when `rust_log` is `None`, since the ambient value a developer
+/// happens to have exported would otherwise decide what these tests observe.
+fn run_is_enrolled_json(dir: &Path, rust_log: Option<&str>) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_facelock"));
+    command.arg("--config").arg(config_in(dir)).args([
+        "is-enrolled",
+        "--user",
+        "facelock-no-such-account",
+        "--json",
+    ]);
+    match rust_log {
+        Some(value) => command.env("RUST_LOG", value),
+        None => command.env_remove("RUST_LOG"),
+    };
+    command
+        .output()
+        .expect("failed to execute the facelock binary")
+}
+
+/// **The #149 regression.** A diagnostic is being emitted; stdout must still
+/// be nothing but the payload.
+#[test]
+fn a_warning_does_not_corrupt_json_on_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = run_is_enrolled_json(tmp.path(), Some(UNPARSEABLE_RUST_LOG));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Non-vacuity first: if no diagnostic was emitted, the assertion below
+    // would pass on a binary that still writes its logs to stdout.
+    assert!(
+        stderr.contains(WARN_TEXT),
+        "the fixture must actually produce a warning, or this test proves \
+         nothing; got stderr:\n{stderr}"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout must be parseable JSON, got {e}:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(parsed["enrolled"], false);
+    assert_eq!(parsed["models"], 0);
+
+    // One line, so a consumer reading a single line off the pipe gets the
+    // whole payload and only the payload.
+    assert_eq!(
+        stdout.trim().lines().count(),
+        1,
+        "the payload must be the only thing on stdout, got:\n{stdout}"
+    );
+}
+
+/// The other half of the split: the diagnostic has to still be *somewhere*.
+/// Routing it to `/dev/null` would also make the test above pass.
+#[test]
+fn the_diagnostic_still_reaches_stderr() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = run_is_enrolled_json(tmp.path(), Some(UNPARSEABLE_RUST_LOG));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains(WARN_TEXT),
+        "the warning belongs on stderr, got stderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains(WARN_TEXT),
+        "the warning must not be on stdout, got stdout:\n{stdout}"
+    );
+}
+
+/// The clean-run control. With no `RUST_LOG` there is no diagnostic to
+/// misroute, so stdout carries the payload and stderr carries nothing.
+///
+/// This is what makes the two tests above mean what they say: without it,
+/// "the warning is on stderr" would also be satisfied by a binary that is
+/// simply noisy on both streams all the time.
+#[test]
+fn a_clean_run_leaves_stderr_empty_and_the_payload_on_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = run_is_enrolled_json(tmp.path(), None);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout must be parseable JSON, got {e}:\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(parsed["enrolled"], false);
+    assert!(
+        stderr.trim().is_empty(),
+        "a clean run must say nothing on stderr, got:\n{stderr}"
+    );
+}

--- a/crates/facelock-polkit/src/main.rs
+++ b/crates/facelock-polkit/src/main.rs
@@ -246,7 +246,12 @@ async fn register_agent(system_conn: &Connection) -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    // Diagnostics on stderr, the same split every other binary here uses
+    // (#149). This agent prints no payload of its own, so nothing changes for
+    // a journal reader — it keeps the rule uniform across the repository.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
 
     let system_conn = Connection::system()
         .await

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -42,6 +42,24 @@ Stable contracts. Do not change without updating this document.
 | `facelock bench` | Benchmarks |
 | `facelock restart` | Restart daemon |
 
+### CLI Output Streams
+
+**stdout is the answer; stderr is everything else.** Every `facelock`
+subcommand prints its result — the JSON payload of `--json`, the rendered
+table, the state word — on stdout, and *only* that. Diagnostics (`tracing`
+output, whatever `RUST_LOG` selects, warnings such as the D-Bus fallback
+notice) go to stderr on every process this repository builds.
+
+This is what makes `facelock devices --json | jq .` and
+`facelock is-enrolled --json` safe to pipe: an integration reading stdout gets
+the payload whatever the log level, and an operator raising `RUST_LOG` to debug
+cannot break a script by doing so. Before this was contract, the subscriber
+inherited `tracing_subscriber`'s stdout default and a single WARN corrupted the
+JSON (#149).
+
+An unparseable `RUST_LOG` is reported at WARN (on stderr) and the built-in
+filter is used, rather than the value being silently discarded.
+
 ### facelock setup Flag Composition
 
 Flags **compose**; they are not mutually exclusive. The rule:

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -230,10 +230,17 @@ unprivileged user. The marker is a hint that can drift from the database; **PAM
 at auth time remains authoritative** and nothing in the auth path consults it.
 
 Markers are written by `enroll`, `remove` and `clear`, and converged from the
-database by `setup`, by daemon startup, and by the one-shot `facelock auth` path
-for the user being authenticated. Convergence re-derives every marker from the
-database, so it is idempotent and there is no migration state to keep. An
-install upgraded from a release that predates markers backfills itself on the
+database by `setup`, by daemon startup, and by the one-shot `facelock auth`
+path. Convergence re-derives markers from the database rather than replaying
+recorded steps, so it is idempotent and there is no migration state to keep.
+The scope differs by caller and that difference is contract:
+
+| Caller | Scope |
+|--------|-------|
+| `setup`, daemon startup (`reconcile_all`) | **Every** marker: backfills each enrolled user and prunes every marker the database does not account for |
+| one-shot `facelock auth` | **One** marker — the user being authenticated. It has no reason to read other users' rows and no privileged directory listing to prune with |
+
+An install upgraded from a release that predates markers backfills itself on the
 first daemon start or the first authentication; until one of those happens,
 `is-enrolled` reports `not-enrolled` for a user who is in fact enrolled.
 
@@ -247,6 +254,18 @@ a camera another process is holding, an undecryptable template, the no-face
 timeout, a plain non-match — leaves the marker already converged. In short: an
 attempt that reaches the camera has converged the marker, whatever it goes on
 to decide.
+
+That placement means the one-shot's *write* only ever converges a marker
+upward: reaching it requires the enrollment gate to have passed. The downward
+direction — a marker whose database rows are gone, which a daemonless install
+has no `reconcile_all` to prune — is handled at the gate that has the evidence:
+when the database authoritatively reports **zero** models for the user, the
+one-shot deletes any marker claiming otherwise before returning the rejection.
+That is a removal and nothing else: one `unlink(2)` on a single validated path
+component, no temp file, no `chown`, no `rename`, and no marker directory
+created. It is idempotent (a repeat attempt finds nothing to unlink) and it is
+reachable only when the marker is already false, so it can delete a stale marker
+and never a correct one.
 
 ### facelock auth Exit Codes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -402,6 +402,25 @@ the indicator appears, the PAM attempt fails, and the password context was
 running in parallel the whole time. **PAM at auth time remains authoritative.**
 Nothing in the authentication path may consult the marker.
 
+**No marker write is reachable from a rejected attempt.** On the one-shot path
+the marker convergence sits *below* `pre_check_audited`, deliberately: a write
+means a temp file, a `chown`, a `rename` and possibly a `mkdir`, and putting
+that above the gates would let an attempt rejected as disabled / SSH / lid /
+rate-limited / non-IR drive filesystem work from the wrong side of the rate
+limiter.
+
+There is exactly one operation on the rejection side, and it is a **removal**:
+when the database authoritatively reports zero models for the user, the
+one-shot unlinks a marker that claims otherwise (it must, because a daemonless
+install has no `reconcile_all` to prune with, so the marker would otherwise be
+permanent). It creates nothing, `chown`s nothing, and touches one validated
+path component under `enrolled/`. It is idempotent — a repeat attempt finds
+`ENOENT` — and it fires only when the marker is already false, so it can delete
+a stale marker and never a correct one. Note that the enrollment gate runs
+*before* the rate-limit check, so this genuinely runs unmetered; the bound (one
+`unlink` per attempt, nothing accumulating) and the "cannot delete a correct
+marker" property are what make that acceptable, not the rate limiter.
+
 #### B. Embedding Sensitivity Warning (Required)
 
 Face embeddings are **biometric data**. Unlike passwords, they cannot be changed. Document this:


### PR DESCRIPTION
Two independent fixes to the CLI, both found by review rather than by a failing test.

## 1. `--json` corrupted by tracing on stdout (#149)

`tracing_subscriber::fmt()` defaults its writer to **stdout** — the same stream
`devices --json`, `list --json` and `is-enrolled --json` print their payload on.
Any diagnostic that passed the `RUST_LOG` filter was prepended to the JSON and
the output stopped parsing. Reproduction: with `daemon.mode = "daemon"` and the
daemon stopped, `facelock devices --json | jq .` fails on the D-Bus fallback
WARN.

The corruption is a property of the process's streams, not of any one renderer,
so it is fixed once rather than at each `println!`. The three `facelock` init
sites collapse into a single `logging::init_stderr`, which now owns both the
stderr writer and the bin-name filter. `facelock-bench` and `facelock-polkit`
get the same writer for uniformity.

**Daemon logging does not regress.** The daemon keeps `with_target(true)` and
moves stdout → stderr; the shipped unit sets `StandardOutput=journal` *and*
`StandardError=journal` (verified in `systemd/facelock-daemon.service`), so the
journal sees exactly what it saw before. A foreground daemon now behaves like
every other subcommand.

Two guards, because the old tests could not have caught this:

- The conformance test that already guarded the log *filter* now guards the
  *writer* too, asserting no file in the crate outside `logging.rs` names
  `tracing_subscriber` at all. The historical failure mode is a copy-pasted
  `fmt()` block silently inheriting the stdout default.
- A new integration test, `crates/facelock-cli/tests/json_stream_split.rs`,
  **runs the real binary and reads its real streams.** The pre-existing tests at
  `commands/devices.rs` only serialized a struct and never touched a stream,
  which is exactly why the bug was invisible to them. It asserts stdout parses
  as JSON and is a single line, that the warning is on stderr and *not* stdout,
  and — as a control — that a clean run leaves stderr empty, so "warning on
  stderr" cannot be satisfied by a binary that is merely noisy on both.

To get a diagnostic guaranteed on *every* invocation (rather than one depending
on an absent daemon or a missing camera), an unparseable `RUST_LOG` is now
reported at WARN instead of being silently discarded — a papercut in its own
right, since "my filter did nothing" was indistinguishable from "nothing
logged". `logging.rs` pins the same fixture string so it cannot quietly become
parseable and leave the test asserting nothing.

## 2. The one-shot path could never *clear* a stale marker

From the #144 review. `pre_check_with_context` short-circuits when the store
reports no models, and that gate sits **above** `converge_enrollment_marker` in
`run`. So the zero branch was dead on the one-shot path, and
`oneshot_convergence_clears_the_marker_at_zero_models` called the helper with
`Some(0)` — a value `run` cannot produce — so it read as coverage of a fix that
was not there.

Failure scenario: a daemonless install (no daemon start, so no `reconcile_all` /
`prune_markers_in`) whose database is restored from a backup predating
enrollment. The marker still says `{"models":1}`, every attempt hits the
not-enrolled gate and returns before convergence, and `facelock is-enrolled`
reports enrolled forever. Daemon-mode installs were never affected.

**Which fix, and why.** The brief allowed either making the one-shot able to
clear, or narrowing the `docs/contracts.md` sentence and deleting the misleading
test. This PR does the first — and also narrows the contract sentence, because
it overstated the path either way. Documenting the hole would have left a real
daemonless install with a permanently wrong `is-enrolled`, and that is the
answer PAM-adjacent tooling and the user's own shell prompt consume; the
downward direction is cheap and safe to support, so supporting it beats writing
it off. The misleading test does not survive: it is replaced by three that drive
the rejection path itself.

**The ordering constraint holds — verified in the code as it now stands.**
`converge_enrollment_marker` remains **below** `pre_check_audited`
(`crates/facelock-cli/src/commands/auth.rs`: `pre_check_audited` at line 102,
`converge_enrollment_marker` at line 167, below the short-circuit's `return`).
A marker *write* — temp file, `chown`, `rename`, possibly a `mkdir` — is still
unreachable from an attempt rejected at a pre-flight gate.

What the rejection path gains is a **removal and nothing else**:

- **Only removes.** One `unlink(2)` on a single validated path component
  (`marker_path` rejects `..`, `/`, NUL and empty names). Nothing created,
  chowned or renamed; `remove_marker_in` never calls `ensure_private_dir`.
- **Bounded.** A repeat attempt finds `ENOENT`. Nothing accumulates.
- **Cannot be driven to a wrong answer.** It fires only when the database
  authoritatively reports zero models, i.e. only when the marker is already
  false. It can delete a stale marker and never a correct one, so it is not a
  denial-of-face-unlock primitive either. An unreadable store is treated as no
  evidence and leaves the marker alone — the same rule the upward path applies
  to a `None` count.

Stated plainly in `docs/security.md` rather than glossed: the enrollment gate
runs *before* the rate-limit check, so this genuinely runs unmetered. The bound
and the "cannot delete a correct marker" property are what make that acceptable,
not the rate limiter.

A companion test pins the call site: the clearing call must sit inside the
pre-flight short-circuit — after the gates, above the `return` — since hoisting
it is the change the #144 review rejected, and sinking it below the `return`
makes it unreachable on precisely the path that has the evidence.

`docs/contracts.md` no longer claims convergence re-derives every marker on this
path; per-caller scope is now a table (`setup` / daemon startup reconcile every
marker, the one-shot converges exactly one).

## Gates

Run, all green:

| Gate | Result |
|---|---|
| `cargo test --workspace` | pass (exit 0) |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, no warnings |
| `cargo fmt --check` | pass |
| `just test-arch-pam` | 22 passed, 0 failed |
| `just test-arch-layout` | 21 passed, 0 failed |

**Not run**, they need a live camera and a human in frame — for @tyvsmith to
validate separately:

- `just test-arch-integration`
- `just test-arch-oneshot`

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
