### PR TITLE
test: make three silent gates actually check

### DIFF
--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -34,6 +34,17 @@ just test-arch-oneshot      # full E2E with camera (no daemon)
 just test-arch-dev-shell    # interactive shell for manual testing
 ```
 
+The two camera tiers time-box each live enroll/auth step at 90s. If you need
+longer in front of the camera, set `FACELOCK_LIVE_TIMEOUT` -- the recipes
+forward it into the container:
+
+```bash
+FACELOCK_LIVE_TIMEOUT=300s just test-arch-integration
+```
+
+The value goes straight into `timeout --foreground`, so pass a `timeout(1)`
+duration (`300s`, `5m`); anything else is rejected before the container starts.
+
 Container tests validate:
 - PAM module loads without crashing
 - Returns PAM_IGNORE when daemon unavailable

--- a/docs/security.md
+++ b/docs/security.md
@@ -702,6 +702,12 @@ tests cover the mask arithmetic, and
 `server::tests::only_threads_created_after_the_narrowing_inherit_it` pins the ordering itself by
 running both orders against a real tokio runtime.
 
+That walk only happens if the daemon actually starts, which needs `models/*.onnx` in the
+checkout (they are gitignored). `just test-deb-pkg` / `just test-rpm-pkg` refuse to run without
+them, and `pkg-validate.sh` fails rather than skipping — set
+`FACELOCK_ALLOW_MISSING_MODELS=1` to accept a partial run, which then reports the missing
+assertions in its `N skipped` count instead of passing silently.
+
 #### B. systemd Hardening (Implemented)
 
 The systemd unit (`systemd/facelock-daemon.service`) includes layered hardening:

--- a/docs/testing-safety.md
+++ b/docs/testing-safety.md
@@ -34,6 +34,17 @@ just test-arch-oneshot      # full E2E with camera (no daemon)
 just test-arch-dev-shell    # interactive shell for manual testing
 ```
 
+The two camera tiers time-box each live enroll/auth step at 90s. If you need
+longer in front of the camera, set `FACELOCK_LIVE_TIMEOUT` — the recipes
+forward it into the container:
+
+```bash
+FACELOCK_LIVE_TIMEOUT=300s just test-arch-integration
+```
+
+The value goes straight into `timeout --foreground`, so pass a `timeout(1)`
+duration (`300s`, `5m`); anything else is rejected before the container starts.
+
 Container tests validate:
 - PAM module loads without crashing
 - Returns PAM_IGNORE when daemon unavailable

--- a/justfile
+++ b/justfile
@@ -136,8 +136,23 @@ test-arch-integration: _require-models _build-test-container
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
     done
-    podman run --rm $devices facelock-pam-test /run-integration-tests.sh
+    env_args=()
+    # run-integration-tests.sh reads FACELOCK_LIVE_TIMEOUT *inside* the
+    # container, so without -e a caller's value is silently ignored and every
+    # live step keeps the stock 90s — the one knob that helps when a human has
+    # to sit still in frame. The value is interpolated straight into
+    # `timeout --foreground`, so it must be a timeout(1) duration.
+    if [ -n "${FACELOCK_LIVE_TIMEOUT:-}" ]; then
+        if [[ ! "$FACELOCK_LIVE_TIMEOUT" =~ ^[0-9]+(\.[0-9]+)?[smhd]?$ ]]; then
+            echo "error: FACELOCK_LIVE_TIMEOUT='$FACELOCK_LIVE_TIMEOUT' is not a timeout(1) duration (e.g. 300s, 5m)" >&2
+            exit 1
+        fi
+        env_args+=(-e "FACELOCK_LIVE_TIMEOUT=$FACELOCK_LIVE_TIMEOUT")
+        echo "live steps time out after $FACELOCK_LIVE_TIMEOUT (default 90s)"
+    fi
+    podman run --rm $devices "${env_args[@]}" facelock-pam-test /run-integration-tests.sh
 
+# FACELOCK_LIVE_TIMEOUT=300s just test-arch-oneshot      # relax the live steps
 # Automated oneshot (daemonless) integration tests (Arch, requires camera)
 test-arch-oneshot: _require-models _build-test-container
     #!/usr/bin/env bash
@@ -146,7 +161,18 @@ test-arch-oneshot: _require-models _build-test-container
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
     done
-    podman run --rm $devices facelock-pam-test /run-oneshot-tests.sh
+    env_args=()
+    # As in test-arch-integration: the timeout is read inside the container, so
+    # it has to be forwarded or the caller's value does nothing.
+    if [ -n "${FACELOCK_LIVE_TIMEOUT:-}" ]; then
+        if [[ ! "$FACELOCK_LIVE_TIMEOUT" =~ ^[0-9]+(\.[0-9]+)?[smhd]?$ ]]; then
+            echo "error: FACELOCK_LIVE_TIMEOUT='$FACELOCK_LIVE_TIMEOUT' is not a timeout(1) duration (e.g. 300s, 5m)" >&2
+            exit 1
+        fi
+        env_args+=(-e "FACELOCK_LIVE_TIMEOUT=$FACELOCK_LIVE_TIMEOUT")
+        echo "live steps time out after $FACELOCK_LIVE_TIMEOUT (default 90s)"
+    fi
+    podman run --rm $devices "${env_args[@]}" facelock-pam-test /run-oneshot-tests.sh
 
 # Dev shell — interactive Arch container with host models for fast iteration (requires camera)
 test-arch-dev-shell: _build-test-container

--- a/justfile
+++ b/justfile
@@ -86,30 +86,47 @@ test-arch-pam: _build-test-container
 test-arch-layout: _build-test-container
     podman run --rm facelock-pam-test /run-layout-tests.sh
 
-# Guard for the camera tiers: the Containerfile bakes models/ into the image
-# with a tolerant `|| true`, so building from a checkout without the ONNX
-# models (fresh clone/worktree — they are downloaded, not tracked) produces an
-# image whose daemon cannot load the face engine and whose enroll bails before
-# opening the camera. Fail loudly here instead of debugging opaque test FAILs.
+# Guard for every tier that needs a daemon which can actually load the face
+# engine: the camera tiers (the Containerfile bakes models/ into the image with
+# a tolerant `|| true`, so a checkout without the ONNX models produces an image
+# whose daemon cannot load the engine and whose enroll bails before opening the
+# camera) and the package tiers (pkg-validate.sh starts the daemon under the
+# hardened unit and walks /proc/<pid>/task/* for CAP_CHOWN — no models, no
+# daemon, no assertion). Fail loudly here instead of debugging opaque test
+# FAILs, or worse, reading a green summary that skipped the interesting half.
 # Check the two non-optional models by name: a checkout holding only the
 # optional ones (det_10g.onnx, glintr100.onnx) satisfies a bare *.onnx glob but
 # still leaves the default detector/embedder missing at runtime.
-_require-models:
+#
+# `allow_opt_out=1` (package tiers only) lets FACELOCK_ALLOW_MISSING_MODELS=1
+# turn the refusal into a warning: those tiers still validate packaging without
+# models, and pkg-validate.sh then *counts* what it skipped. The camera tiers
+# pass "0" — without models they have nothing left to test.
+_require-models allow_opt_out="0":
     #!/usr/bin/env bash
     set -euo pipefail
     missing=()
     for m in models/scrfd_2.5g_bnkps.onnx models/w600k_r50.onnx; do
         [ -f "$m" ] || missing+=("$m")
     done
-    if [ ${#missing[@]} -gt 0 ]; then
-        echo "error: missing required ONNX models — the camera test tiers need them baked into the image:" >&2
-        for m in "${missing[@]}"; do echo "         $m" >&2; done
-        echo "       They are downloaded, not tracked. Copy them from the install tree" >&2
-        echo "       ('sudo facelock setup' downloads them to /var/lib/facelock/models):" >&2
-        echo "         sudo cp /var/lib/facelock/models/*.onnx models/" >&2
-        echo "       (models/*.onnx is gitignored, so this cannot be committed by accident.)" >&2
-        exit 1
+    [ ${#missing[@]} -gt 0 ] || exit 0
+    if [ "{{allow_opt_out}}" = "1" ] && [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
+        echo "warning: missing ONNX models, continuing (FACELOCK_ALLOW_MISSING_MODELS=1):" >&2
+        for m in "${missing[@]}"; do echo "           $m" >&2; done
+        echo "         The daemon-start assertions will be reported as SKIPPED, not passed." >&2
+        exit 0
     fi
+    echo "error: missing required ONNX models — this test tier needs them baked into the image:" >&2
+    for m in "${missing[@]}"; do echo "         $m" >&2; done
+    echo "       They are downloaded, not tracked. Copy them from the install tree" >&2
+    echo "       ('sudo facelock setup' downloads them to /var/lib/facelock/models):" >&2
+    echo "         sudo cp /var/lib/facelock/models/*.onnx models/" >&2
+    echo "       (models/*.onnx is gitignored, so this cannot be committed by accident.)" >&2
+    if [ "{{allow_opt_out}}" = "1" ]; then
+        echo "       To validate packaging only, with the daemon-start assertions counted" >&2
+        echo "       as skipped: FACELOCK_ALLOW_MISSING_MODELS=1 just <recipe>" >&2
+    fi
+    exit 1
 
 # Automated daemon integration tests (Arch, requires camera)
 test-arch-integration: _require-models _build-test-container
@@ -622,8 +639,11 @@ test-deb: build-release
     podman build -t facelock-deb-test -f test/Containerfile.ubuntu .
     podman run --rm facelock-deb-test
 
+# Needs models/*.onnx: the validation starts the daemon under the hardened unit
+# and checks what it holds at runtime. FACELOCK_ALLOW_MISSING_MODELS=1 runs the
+# packaging half only, with the rest counted as skipped.
 # Package test — build real .deb, install via dpkg, validate under booted systemd
-test-deb-pkg: build-release
+test-deb-pkg: (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
     podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
@@ -636,8 +656,9 @@ test-deb-tpm-pkg: build-release
     podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-tpm-pkg -f test/Containerfile.deb-tpm-e2e .
     podman run --rm facelock-deb-tpm-pkg
 
+# Same model requirement (and same opt-out) as test-deb-pkg.
 # Package test — build real .rpm, install via dnf, validate under booted systemd
-test-rpm-pkg: build-release
+test-rpm-pkg: (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
     podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -3,6 +3,23 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+SKIP=0
+
+# Record an assertion (or a whole block of them) that did not run.
+#
+# Counting these is the point. A summary that can only say "N passed, 0 failed"
+# reads identically whether every assertion ran or a third of them were stepped
+# over — which is exactly how the runtime CAP_CHOWN thread walk went missing
+# from a green "39 passed, 0 failed" run while the same command with models
+# present reported 42. A run that skips must not be able to look like a run
+# that checked.
+skip_test() {
+    local name="$1"
+    local reason="$2"
+
+    echo "SKIP: $name ($reason)"
+    SKIP=$((SKIP + 1))
+}
 
 run_test() {
     local name="$1"
@@ -82,6 +99,8 @@ run_test "facelock runtime directories exist (tmpfiles)" "if command -v systemd-
 # PAM tests (only if pamtester is available)
 if command -v pamtester >/dev/null 2>&1 && [ -f /etc/pam.d/facelock-test ]; then
     run_test "PAM module loads via pamtester" "pamtester facelock-test testuser authenticate < /dev/null 2>&1 | grep -qiE '(successfully|authentication failure)'"
+else
+    skip_test "PAM module loads via pamtester" "pamtester or /etc/pam.d/facelock-test unavailable"
 fi
 
 # D-Bus tests (only if dbus-daemon is available)
@@ -94,13 +113,19 @@ if command -v dbus-daemon >/dev/null 2>&1; then
         run_test "D-Bus facelock service activatable" "busctl --system list --activatable 2>/dev/null | grep -q org.facelock.Daemon"
     elif command -v dbus-send >/dev/null 2>&1; then
         run_test "D-Bus facelock service activatable" "dbus-send --system --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListActivatableNames 2>/dev/null | grep -q org.facelock.Daemon"
+    else
+        skip_test "D-Bus facelock service activatable" "neither busctl nor dbus-send available"
     fi
 
     # Polkit agent D-Bus boundary: non-allowlisted actions decline (fall
     # through to password), allowlisted actions pass the allowlist gate.
     if [ -x /polkit-agent-validate.sh ]; then
         run_test "polkit agent allowlist gate (D-Bus boundary)" "/polkit-agent-validate.sh"
+    else
+        skip_test "polkit agent allowlist gate (D-Bus boundary)" "/polkit-agent-validate.sh not present in this image"
     fi
+else
+    skip_test "D-Bus block (bus starts, service activatable, polkit allowlist gate)" "dbus-daemon unavailable"
 fi
 
 # systemd hardening validation — only runs under a booted systemd
@@ -222,7 +247,8 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         run_test "sandbox blocks AF_INET socket (outbound TCP impossible)" "! af_inet_in_sandbox"
         run_test "control: AF_INET socket allowed without sandbox" "af_inet_unrestricted"
     else
-        echo "SKIP: outbound-TCP-blocked check (systemd-run or python3 unavailable)"
+        skip_test "sandbox blocks AF_INET socket (outbound TCP impossible)" "systemd-run or python3 unavailable"
+        skip_test "control: AF_INET socket allowed without sandbox" "systemd-run or python3 unavailable"
     fi
 
     # Daemon start test. The daemon loads ONNX models at startup, so this
@@ -243,11 +269,35 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         # assertion that makes the promise checkable.
         run_test "runtime: no daemon thread holds CAP_CHOWN while serving" "daemon_threads_without_cap_chown"
         systemctl stop facelock-daemon 2>/dev/null || true
+    elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
+        # Explicitly asked for a partial run. Name every assertion that is not
+        # running so the results line has to account for them.
+        no_models="no ONNX models at /var/lib/facelock/models, FACELOCK_ALLOW_MISSING_MODELS=1"
+        skip_test "facelock-daemon starts under hardened unit" "$no_models"
+        skip_test "facelock-daemon answers on D-Bus" "$no_models"
+        skip_test "runtime: no daemon thread holds CAP_CHOWN while serving" "$no_models"
     else
-        echo "SKIP: daemon start test (no ONNX models at /var/lib/facelock/models — run via just test-deb-pkg/test-rpm-pkg with repo models present)"
+        # Under a booted systemd, missing models are a broken invocation, not a
+        # property of the environment: the whole reason to boot systemd here is
+        # to start the daemon and read what it holds. Silently dropping the
+        # block left `just test-deb-pkg` reporting a clean pass on a checkout
+        # that never started a daemon — and the assertion it dropped is the
+        # only one that can catch a per-thread capability regression. Fail.
+        echo "FAIL: daemon-start block did not run (no ONNX models at /var/lib/facelock/models)"
+        echo "      Missing: the daemon start, its D-Bus Ping, and the runtime"
+        echo "      CAP_CHOWN thread walk — the regression pin for the per-thread"
+        echo "      capability drop. The unit: CapabilityBoundingSet assertions above"
+        echo "      read systemd configuration only and pass either way."
+        echo "      Fix: run from a checkout with the ONNX models present"
+        echo "        sudo cp /var/lib/facelock/models/*.onnx models/   # gitignored, cannot be committed"
+        echo "        just test-deb-pkg   # or test-rpm-pkg"
+        echo "      To accept a partial run, set FACELOCK_ALLOW_MISSING_MODELS=1;"
+        echo "      the three assertions are then counted as skipped, not passed."
+        FAIL=$((FAIL + 1))
     fi
 else
-    echo "SKIP: not running under a booted systemd (unit directives not verifiable here)"
+    skip_test "systemd hardening + daemon-runtime block (unit directives, sandbox probes, daemon start, runtime CAP_CHOWN walk)" \
+        "not running under a booted systemd"
 fi
 
 # Package removal test — must come last since it removes the package
@@ -269,11 +319,16 @@ elif command -v rpm >/dev/null 2>&1 && rpm -q facelock >/dev/null 2>&1; then
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
     run_test "Config preserved after rpm -e (config(noreplace))" "[ -f /etc/facelock/config.toml ] || [ -f /etc/facelock/config.toml.rpmsave ]"
 else
-    echo "(no package-manager-installed facelock — skipping removal tests)"
+    skip_test "package removal block (removal, binary/PAM module gone, config preserved)" \
+        "facelock was not installed by dpkg or rpm here"
 fi
 
 echo ""
-echo "=== Results: $PASS passed, $FAIL failed ==="
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+if [ "$SKIP" -gt 0 ]; then
+    echo "NOTE: $SKIP assertion(s)/block(s) above did not run — this run proves less"
+    echo "      than a full one. Grep the log for '^SKIP:' to see which."
+fi
 
 if [ "$FAIL" -gt 0 ]; then
     exit 1

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+# Per-step budget for the live camera steps (someone has to be in frame). Read
+# inside the container, so `just test-arch-integration` forwards the variable
+# with -e; a `podman run` by hand must do the same. Interpolated straight into
+# `timeout --foreground`, so it is a timeout(1) duration: 300s, 5m.
 LIVE_TIMEOUT="${FACELOCK_LIVE_TIMEOUT:-90s}"
 
 run_test() {

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+# Per-step budget for the live camera steps (someone has to be in frame). Read
+# inside the container, so `just test-arch-oneshot` forwards the variable with
+# -e; a `podman run` by hand must do the same. Interpolated straight into
+# `timeout --foreground`, so it is a timeout(1) duration: 300s, 5m.
 LIVE_TIMEOUT="${FACELOCK_LIVE_TIMEOUT:-90s}"
 
 run_test() {

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -469,7 +469,7 @@ now_ms() {
 # Wait until pid $1 has a /dev/video* device open, i.e. it is past the ONNX
 # model load and actually scanning. Returns 1 if it never gets there.
 #
-# This is what makes the 500 ms budgets below measure what they claim to. A
+# This is what makes the timing budgets below measure what they claim to. A
 # signal that lands inside the model load is only acted on when the load
 # returns (ADR 008 §8 says as much: the token is checked *between* engine and
 # camera), so signalling at a fixed offset would time the ONNX loader instead
@@ -529,6 +529,32 @@ adr008_oneshot_sigterm_exits_cleanly() {
     echo "exited 2 in ${elapsed}ms, no process left"
 }
 
+# Budget for the PDEATHSIG check below. Deliberately not the 500 ms the SIGTERM
+# check uses, because the two do not measure the same thing:
+#
+#   * SIGTERM measures exactly. The one-shot is this shell's own child, so
+#     `wait` returns the moment it is reaped and the elapsed time is the
+#     shutdown itself — 17 ms on an idle box, a 29x margin against 500 ms.
+#   * PDEATHSIG cannot. The one-shot belongs to pamtester, so it is polled with
+#     `kill -0` at 20 ms granularity, and the pid keeps answering until whoever
+#     adopts the orphan reaps it. On top of the real work (PDEATHSIG delivery,
+#     the cancel token checked between frames, Drop running STREAMOFF and the
+#     IR emitter off) that adds latency this script neither controls nor cares
+#     about. Measured 506 ms on an idle box (load 0.59) — i.e. it passed the old
+#     500 ms budget only because a poll happened to step over the boundary.
+#
+# A budget with no headroom turns one scheduling hiccup into a "camera
+# lifecycle regression". 1500 ms is ~3x the observed cost and still nowhere
+# near what a genuine failure looks like: if PDEATHSIG does not fire, the child
+# keeps scanning until its own recognition timeout (tens of seconds) and blows
+# any budget in this range. The measured value is printed on PASS so drift
+# stays visible instead of hiding under a generous ceiling.
+#
+# Not reconciled here: ADR 008 §9 quotes 200 ms for this check while its
+# acceptance (4) quotes 500 ms, and the path costs ~500 ms. Both numbers were
+# written before anything measured it.
+PDEATHSIG_BUDGET_MS=1500
+
 # ADR 008 §7 and acceptance (4): a one-shot must not outlive its PAM host. The
 # module sets PR_SET_PDEATHSIG = SIGTERM in pre_exec, so killing the host
 # delivers SIGTERM to the child, which then takes the clean exit above. Only
@@ -570,8 +596,8 @@ adr008_oneshot_dies_with_pam_host() {
     kill -9 "$pam_pid" 2>/dev/null || true
     wait "$pam_pid" 2>/dev/null || true
     while kill -0 "$child" 2>/dev/null; do
-        if [ $(( $(now_ms) - start )) -gt 500 ]; then
-            echo "facelock auth (pid $child) outlived its PAM host by more than 500ms"
+        if [ $(( $(now_ms) - start )) -gt "$PDEATHSIG_BUDGET_MS" ]; then
+            echo "facelock auth (pid $child) outlived its PAM host by more than ${PDEATHSIG_BUDGET_MS}ms"
             kill -9 "$child" 2>/dev/null || true
             return 1
         fi
@@ -584,7 +610,7 @@ adr008_oneshot_dies_with_pam_host() {
         pgrep -af "facelock auth" || true
         return 1
     fi
-    echo "child gone ${elapsed}ms after its PAM host was killed"
+    echo "child gone ${elapsed}ms after its PAM host was killed (budget ${PDEATHSIG_BUDGET_MS}ms)"
 }
 
 # Both checks need an attempt that is still running when the signal arrives. A

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -12,18 +12,33 @@ set -euo pipefail
 
 IMAGE="${1:?usage: run-pkg-validate-systemd.sh <image>}"
 
-# Bind-mount repo ONNX models (if present) so the daemon-start test can run:
-# `facelock daemon` loads models at startup. Models are large and gitignored,
-# so this is best-effort — pkg-validate.sh skips the daemon-start test
-# honestly when the mount is absent.
+# Bind-mount repo ONNX models so the daemon-start test can run: `facelock
+# daemon` loads models at startup. Models are large and gitignored, so a fresh
+# worktree does not have them — which used to mean the daemon-start block (and
+# the runtime CAP_CHOWN thread walk inside it) quietly vanished from an
+# otherwise green run. It is now a failure inside the container unless
+# FACELOCK_ALLOW_MISSING_MODELS=1 says a partial run is wanted, and that
+# opt-out is forwarded into the exec below.
 mounts=()
 shopt -s nullglob
 onnx=(models/*.onnx)
 shopt -u nullglob
 if [ "${#onnx[@]}" -gt 0 ]; then
     mounts=(-v "$PWD/models:/var/lib/facelock/models")
+elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
+    echo "WARNING: no models/*.onnx in repo — the daemon-start assertions will be" >&2
+    echo "         reported as skipped (FACELOCK_ALLOW_MISSING_MODELS=1)." >&2
 else
-    echo "NOTE: no models/*.onnx in repo — daemon-start test will be skipped"
+    echo "WARNING: no models/*.onnx in repo — the daemon-start assertions cannot run" >&2
+    echo "         and pkg-validate.sh will FAIL. Copy them in first:" >&2
+    echo "           sudo cp /var/lib/facelock/models/*.onnx models/" >&2
+    echo "         or set FACELOCK_ALLOW_MISSING_MODELS=1 to accept a partial run." >&2
+fi
+
+# Forward the opt-out into the container; pkg-validate.sh reads it.
+exec_env=()
+if [ -n "${FACELOCK_ALLOW_MISSING_MODELS:-}" ]; then
+    exec_env=(-e "FACELOCK_ALLOW_MISSING_MODELS=$FACELOCK_ALLOW_MISSING_MODELS")
 fi
 
 # --systemd=always: podman sets up /run, /tmp, cgroups and SIGRTMIN+3 for a
@@ -51,4 +66,4 @@ if [ -z "$booted" ]; then
     exit 1
 fi
 
-podman exec "$cid" /pkg-validate.sh
+podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh


### PR DESCRIPTION
Three gates that reported green while not actually checking.

Fixes #152
Fixes #150
Fixes #153

## #152 — pkg-validate.sh skipped its daemon-start block and still said "0 failed"

`test/pkg-validate.sh` skipped the daemon-start block, and every assertion inside it, whenever
`models/*.onnx` were absent — then printed a clean `=== Results: 39 passed, 0 failed ===` and
exited 0. `models/*.onnx` is gitignored, so a fresh clone or worktree is the skipping case by
default.

The assertion that went missing is the `/proc/<pid>/task/*/status` walk that pins the per-thread
capability defect fixed in #144. The surviving `unit: CapabilityBoundingSet` assertions only read
unit properties, so they pass whether or not the in-process drop actually works.

Changes:

- The summary line counts and names skips: `N passed, N failed, N skipped`, plus a note pointing
  at `^SKIP:`. A partial run can no longer read like a full one.
- Under a booted systemd, missing models are now a **failure**, not a silent skip — the whole
  point of booting systemd there is to start the daemon and read what it holds.
- **`FACELOCK_ALLOW_MISSING_MODELS=1`** opts into a partial run. The three daemon assertions are
  then reported as skipped rather than passed, and `test/run-pkg-validate-systemd.sh` forwards the
  variable into the container.
- `just test-deb-pkg` / `just test-rpm-pkg` refuse in the recipe, before `build-release`, so the
  feedback is immediate rather than several minutes in. The same guard already covered the camera
  tiers; it grew an opt-out parameter that only the package tiers pass.

## #150 — FACELOCK_LIVE_TIMEOUT was unreachable through the camera recipes

Both runner scripts read `FACELOCK_LIVE_TIMEOUT` *inside* the container, but neither camera recipe
passed `-e`, so `FACELOCK_LIVE_TIMEOUT=300s just test-arch-integration` silently ran every live
step at the stock 90s. Same in `test-arch-oneshot`.

Both recipes now forward it, and validate it before the container starts — the value is
interpolated straight into `timeout --foreground`, so a non-duration would otherwise fail deep
inside a live step instead of at the call site. Pass a `timeout(1)` duration: `300s`, `5m` (a bare
number is accepted and means seconds). Documented in `book/src/testing.md`,
`docs/testing-safety.md`, and at the declaration in both runner scripts.

## #153 — the PDEATHSIG timing budget never had headroom

`ADR 008: facelock auth dies with its PAM host (PDEATHSIG)` measured `child gone 506ms` against a
500ms budget on an idle box. It passed only because it polls with `kill -0` at 20ms granularity
rather than measuring exactly.

Two checks were sharing one budget while measuring different things. The SIGTERM check owns its
child, so `wait` returns the moment it is reaped — 17ms observed, a 29x margin. The PDEATHSIG child
belongs to pamtester and can only be polled, and the path inherently costs ~500ms (PDEATHSIG
delivery, the cancel token checked between frames, then Drop running STREAMOFF and the IR emitter
off).

The PDEATHSIG check gets its own `PDEATHSIG_BUDGET_MS=1500` (~3x observed, still nowhere near a
genuine failure, where the child scans on for tens of seconds). SIGTERM's tight budget is
unchanged. The measured value is printed on PASS so drift stays visible.

Left unreconciled, and noted in the comment: ADR 008 §9 quotes 200ms for this check while its
acceptance (4) quotes 500ms, and the path costs ~500ms. Both numbers predate anything measuring it.

## Verification

Ran, on this branch:

| Gate | Result |
|---|---|
| `cargo test --workspace` | 864 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `shellcheck` on all four touched scripts | no new findings (10 pre-existing SC2016 before and after) |
| `bash -n` on all four touched scripts | clean |
| `just --summary` at each of the three commits | parses (bisectable) |

**#152 verified in both directions** — a fix that only ever passes is the same class of bug:

| State | Result |
|---|---|
| models present | `42 passed, 0 failed, 0 skipped`, exit 0 — daemon start, D-Bus Ping and the CAP_CHOWN thread walk all execute |
| models absent, no opt-out, via `just test-deb-pkg` | recipe refuses in **0.003s**, exit 1, before `build-release` |
| models absent, `FACELOCK_ALLOW_MISSING_MODELS=1` | `39 passed, 0 failed, 3 skipped`, exit 0, each skipped assertion named |
| models absent, no opt-out, runner invoked directly | `39 passed, 1 failed, 0 skipped`, **exit 1**, with a diagnostic naming what was lost |

For contrast, the same `just test-deb-pkg` with models absent, run against the pre-fix tooling
(`test/pkg-validate.sh`, `test/run-pkg-validate-systemd.sh` and `justfile` byte-identical to
`affba42`): `SKIP: daemon start test`, `=== Results: 39 passed, 0 failed ===`, **exit 0**. That is
the bug — a green summary that never started a daemon.

### Not verified by execution

**#153 could not be run.** It lives in the one-shot tier, which needs a live camera and a human in
frame. The change is a constant and its two use sites; surrounding logic is untouched, and the file
passes `bash -n` and `shellcheck`. The 1500ms figure comes from the 506ms measurement quoted in the
issue, not from a run here.

`just test-arch-integration` and `just test-arch-oneshot` were not run (camera tiers, out of scope
for this environment), so the #150 forwarding is verified by inspection and by the recipes' own
pre-flight validation, not by a live camera run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
