### PR TITLE
test: add `just link-models` to populate models/ in a fresh worktree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,25 @@ cargo clippy --workspace -- -D warnings
 
 Run these before every commit. They require no camera or models.
 
+### Models
+
+`models/*.onnx` is gitignored, so a fresh clone -- and every `git worktree add`
+-- starts without models, while tiers 2 and 3 need them. If another checkout on
+the machine has them, or `sudo facelock setup` has already downloaded them to
+`/var/lib/facelock/models`, populate the new checkout from there instead of
+downloading 435MB again:
+
+```bash
+just link-models                  # main checkout first, then the install tree
+just link-models /path/to/models  # or say where to look
+```
+
+It hardlinks where it can (a worktree shares a filesystem with its main
+checkout, so that is free and instant), copies where it cannot, and verifies
+every file against the sha256 in `models/manifest.toml`. The camera tiers run
+it themselves, hardlink-only, so a fresh worktree usually provisions itself
+before you notice it was empty.
+
 ### Tier 2: Hardware tests (camera + models)
 
 ```bash

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -78,6 +78,23 @@ cargo build --workspace
 cargo run --bin facelock -- setup       # download models
 ```
 
+`models/*.onnx` is gitignored, so a fresh clone -- and every `git worktree add`
+-- starts without models, while tiers 2 and 3 need them. Rather than download
+435MB per checkout, populate the new one from any checkout on the machine that
+already has them, or from what `sudo facelock setup` put in
+`/var/lib/facelock/models`:
+
+```bash
+just link-models                  # main checkout first, then the install tree
+just link-models /path/to/models  # or say where to look
+```
+
+It hardlinks where it can (a worktree shares a filesystem with its main
+checkout, so that is free and instant), copies where it cannot, and verifies
+every file against the sha256 in `models/manifest.toml`. The camera tiers run
+it themselves, hardlink-only, so a fresh worktree usually provisions itself
+before you notice it was empty.
+
 ### No-Daemon Development
 All CLI commands work without a daemon -- the CLI falls back to direct mode silently:
 ```bash
@@ -144,6 +161,7 @@ Local full CI: `bash test/run-tests.sh`
 
 | Recipe | Description |
 |--------|-------------|
+| `just link-models` | Populate `models/*.onnx` from an existing checkout or install tree |
 | `just test` | Unit tests |
 | `just lint` | Clippy |
 | `just check` | test + lint + fmt |

--- a/docs/testing-safety.md
+++ b/docs/testing-safety.md
@@ -78,6 +78,23 @@ cargo build --workspace
 cargo run --bin facelock -- setup       # download models
 ```
 
+`models/*.onnx` is gitignored, so a fresh clone — and every `git worktree add`
+— starts without models, while tiers 2 and 3 need them. Rather than download
+435MB per checkout, populate the new one from any checkout on the machine that
+already has them, or from what `sudo facelock setup` put in
+`/var/lib/facelock/models`:
+
+```bash
+just link-models                  # main checkout first, then the install tree
+just link-models /path/to/models  # or say where to look
+```
+
+It hardlinks where it can (a worktree shares a filesystem with its main
+checkout, so that is free and instant), copies where it cannot, and verifies
+every file against the sha256 in `models/manifest.toml`. The camera tiers run
+it themselves, hardlink-only, so a fresh worktree usually provisions itself
+before you notice it was empty.
+
 ### No-Daemon Development
 All CLI commands work without a daemon — the CLI falls back to direct mode silently:
 ```bash
@@ -144,6 +161,7 @@ Local full CI: `bash test/run-tests.sh`
 
 | Recipe | Description |
 |--------|-------------|
+| `just link-models` | Populate `models/*.onnx` from an existing checkout or install tree |
 | `just test` | Unit tests |
 | `just lint` | Clippy |
 | `just check` | test + lint + fmt |

--- a/justfile
+++ b/justfile
@@ -86,6 +86,223 @@ test-arch-pam: _build-test-container
 test-arch-layout: _build-test-container
     podman run --rm facelock-pam-test /run-layout-tests.sh
 
+# models/*.onnx is gitignored and never tracked, so a fresh clone — and every
+# `git worktree add`, which is how this repo is normally worked in — starts
+# with an empty models/, while the camera and package test tiers all need the
+# two required models baked into the image. Run this once per checkout.
+#
+# Sources, cheapest first (or pass one: `just link-models /path/to/models`):
+#   1. the main checkout's models/. A worktree normally lives inside the main
+#      checkout, so this is the same filesystem and the link costs nothing.
+#   2. /var/lib/facelock/models/, where `sudo facelock setup` puts them. The
+#      models are 0644 under a 0755 dir, so reading them needs no sudo — but
+#      /var/lib/facelock itself is 0710 root:facelock, so getting in needs the
+#      facelock group (or root).
+#
+# Hardlink, never symlink: test/Containerfile does `COPY models/ /build/models/`
+# and podman's COPY does not follow a symlink pointing outside the build
+# context, so a symlinked models/ would build a clean-looking image with no
+# models in it — the exact failure this recipe exists to prevent. Hardlinks
+# fall back to a copy when the source is on another filesystem; /var/lib
+# usually is, and btrfs refuses links across subvolumes even on one device.
+#
+# Every file is checked against the sha256 in models/manifest.toml before it
+# lands, and lands via a temp name, so an interrupted copy cannot leave a
+# truncated model behind for the daemon to reject later.
+#
+# Populate models/*.onnx from an existing checkout or install tree
+link-models src="": (_link-models "explicit" src)
+
+# mode=explicit (`just link-models`) — try every mechanism, report each file,
+#   and fail if a required model is still missing at the end.
+# mode=auto (dependency of _require-models) — hardlink only, say nothing when
+#   there is nothing to do, and never fail. A copy can be 435MB; that is worth
+#   opting into, not something `just test-arch-integration` should spend behind
+#   your back. When auto cannot finish the job it stays quiet and leaves the
+#   diagnosis to _require-models, which owns that message.
+_link-models mode="explicit" src="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "{{mode}}" = "explicit" ]; then explicit=1; else explicit=0; fi
+
+    manifest=models/manifest.toml
+    if [ ! -f "$manifest" ]; then
+        echo "error: $manifest is missing — it is tracked, so this is not a fresh-checkout problem" >&2
+        exit 1
+    fi
+
+    # filename <TAB> sha256 <TAB> required(1|0), read straight out of the
+    # manifest so adding a model there does not need a second list updated here.
+    models_meta="$(awk '
+        /^\[\[models\]\]/ { if (fn != "") print fn "\t" sha "\t" req; fn = ""; sha = ""; req = 1 }
+        $1 == "filename" { gsub(/"/, "", $3); fn = $3 }
+        $1 == "sha256" { gsub(/"/, "", $3); sha = $3 }
+        $1 == "optional" && $3 == "true" { req = 0 }
+        END { if (fn != "") print fn "\t" sha "\t" req }
+    ' "$manifest")"
+
+    # need: missing and required — the set that decides which source is usable.
+    # wanted: what we will actually place. auto only ever chases `need`.
+    declare -A sha_of=()
+    need=()
+    optional_missing=()
+    while IFS=$'\t' read -r fn sha req; do
+        if [ -z "$fn" ]; then continue; fi
+        sha_of["$fn"]="$sha"
+        if [ -f "models/$fn" ]; then continue; fi
+        if [ "$req" = "1" ]; then need+=("$fn"); else optional_missing+=("$fn"); fi
+    done <<< "$models_meta"
+
+    wanted=("${need[@]}")
+    if [ "$explicit" = 1 ]; then wanted+=("${optional_missing[@]}"); fi
+
+    if [ ${#wanted[@]} -eq 0 ]; then
+        if [ "$explicit" = 1 ]; then echo "models/ already has every model in $manifest — nothing to do"; fi
+        exit 0
+    fi
+
+    candidates=()
+    if [ -n "{{src}}" ]; then
+        candidates+=("{{src}}")
+    else
+        # `git worktree list` prints the main worktree first. That is the
+        # checkout a worktree can hardlink from for free.
+        main_checkout="$(git worktree list --porcelain 2>/dev/null | sed -n '1s/^worktree //p' || true)"
+        if [ -n "$main_checkout" ] && [ "$(realpath -m "$main_checkout")" != "$(realpath .)" ]; then
+            candidates+=("$main_checkout/models")
+        fi
+        candidates+=(/var/lib/facelock/models)
+    fi
+
+    # A usable source has every required model we are missing, and at least one
+    # file we actually want (so we do not "pick" a source with nothing to give).
+    source_dir=""
+    for c in "${candidates[@]}"; do
+        if [ ! -d "$c" ]; then continue; fi
+        usable=1
+        for fn in "${need[@]}"; do
+            if [ ! -r "$c/$fn" ]; then usable=0; break; fi
+        done
+        if [ "$usable" = 0 ]; then continue; fi
+        for fn in "${wanted[@]}"; do
+            if [ -r "$c/$fn" ]; then source_dir="$c"; break; fi
+        done
+        if [ -n "$source_dir" ]; then break; fi
+    done
+
+    if [ -z "$source_dir" ]; then
+        # auto: _require-models is about to say the same thing, better.
+        if [ "$explicit" = 0 ]; then exit 0; fi
+        if [ ${#need[@]} -eq 0 ]; then
+            # Both required models are here and only the optional ones are not,
+            # with nothing around that has them. The test tiers do not need
+            # them, so this is a note, not a failure — and re-running stays a
+            # no-op instead of turning into an error the second time.
+            echo "models/ has both required models; no candidate source has the optional ones:"
+            for fn in "${optional_missing[@]}"; do echo "  $fn"; done
+            exit 0
+        fi
+        echo "error: found no source holding the required models that models/ is missing:" >&2
+        for fn in "${need[@]}"; do echo "         $fn" >&2; done
+        echo "       Looked in:" >&2
+        for c in "${candidates[@]}"; do
+            if [ -d "$c" ]; then
+                echo "         $c (exists, but does not have them all — or is not readable)" >&2
+            else
+                echo "         $c (no such directory)" >&2
+            fi
+        done
+        echo "       Download them once, then re-run this:" >&2
+        echo "         sudo facelock setup      # downloads to /var/lib/facelock/models" >&2
+        echo "       Or point at a directory that already has them:" >&2
+        echo "         just link-models /path/to/models" >&2
+        exit 1
+    fi
+
+    if [ "$explicit" = 1 ]; then echo "source: $source_dir"; fi
+
+    # A partially written model is worse than a missing one: it satisfies the
+    # `[ -f ]` guards and then fails sha256 verification inside the container.
+    tmp=""
+    cleanup() { if [ -n "$tmp" ]; then rm -f "$tmp"; fi; }
+    trap cleanup EXIT
+
+    linked=0
+    copied=0
+    copied_bytes=0
+    for fn in "${wanted[@]}"; do
+        if [ ! -r "$source_dir/$fn" ]; then continue; fi
+        size="$(stat -c %s "$source_dir/$fn")"
+        tmp="models/.$fn.tmp.$$"
+        rm -f "$tmp"
+        if [ "$explicit" = 1 ]; then
+            printf '  %-24s %6s  ' "$fn" "$(numfmt --to=iec "$size")"
+        fi
+        if ln "$source_dir/$fn" "$tmp" 2>/dev/null; then
+            method=hardlink
+        elif [ "$explicit" = 1 ]; then
+            # Another filesystem, or fs.protected_hardlinks refusing a link to a
+            # file we do not own. Copying is what is left, and it is not free.
+            printf 'copying (hardlink not possible)'
+            cp -- "$source_dir/$fn" "$tmp"
+            method=copy
+        else
+            rm -f "$tmp"
+            tmp=""
+            continue
+        fi
+
+        want_sha="${sha_of[$fn]}"
+        got_sha="$(sha256sum "$tmp" | cut -d' ' -f1)"
+        if [ "$want_sha" != "$got_sha" ]; then
+            rm -f "$tmp"
+            tmp=""
+            if [ "$explicit" = 1 ]; then printf '\n'; fi
+            echo "warning: $source_dir/$fn does not match its sha256 in $manifest — skipped" >&2
+            echo "           expected $want_sha" >&2
+            echo "           got      $got_sha" >&2
+            continue
+        fi
+
+        mv -f "$tmp" "models/$fn"
+        tmp=""
+        if [ "$method" = hardlink ]; then
+            linked=$((linked + 1))
+            if [ "$explicit" = 1 ]; then printf 'hardlink\n'; fi
+        else
+            copied=$((copied + 1))
+            copied_bytes=$((copied_bytes + size))
+            printf ' done\n'
+        fi
+    done
+
+    still_missing=()
+    for fn in "${need[@]}"; do
+        if [ ! -f "models/$fn" ]; then still_missing+=("$fn"); fi
+    done
+    if [ ${#still_missing[@]} -gt 0 ]; then
+        if [ "$explicit" = 0 ]; then exit 0; fi
+        echo "error: models/ is still missing a required model after linking from $source_dir:" >&2
+        for fn in "${still_missing[@]}"; do echo "         $fn" >&2; done
+        exit 1
+    fi
+
+    if [ "$explicit" = 1 ]; then
+        echo "models/ has both required models — $linked hardlinked (no extra disk), $copied copied ($(numfmt --to=iec "$copied_bytes"))"
+        left_out=()
+        for fn in "${optional_missing[@]}"; do
+            if [ ! -f "models/$fn" ]; then left_out+=("$fn"); fi
+        done
+        if [ ${#left_out[@]} -gt 0 ]; then
+            echo "optional models not at $source_dir (no test tier needs them): ${left_out[*]}"
+        fi
+    elif [ "$linked" -gt 0 ]; then
+        # Never silent: hardlinks cost nothing but they are still a change to
+        # the working tree, made on the way to a test the caller asked for.
+        echo "hardlinked $linked model(s) into models/ from $source_dir (just link-models)"
+    fi
+
 # Guard for every tier that needs a daemon which can actually load the face
 # engine: the camera tiers (the Containerfile bakes models/ into the image with
 # a tolerant `|| true`, so a checkout without the ONNX models produces an image
@@ -102,7 +319,12 @@ test-arch-layout: _build-test-container
 # turn the refusal into a warning: those tiers still validate packaging without
 # models, and pkg-validate.sh then *counts* what it skipped. The camera tiers
 # pass "0" — without models they have nothing left to test.
-_require-models allow_opt_out="0":
+#
+# The _link-models dependency makes the common case not happen at all: a fresh
+# worktree hardlinks from the main checkout on the way in, so neither the
+# refusal nor the opt-out is reached. It only ever uses free mechanisms, so when
+# it declines, everything below still applies unchanged.
+_require-models allow_opt_out="0": (_link-models "auto")
     #!/usr/bin/env bash
     set -euo pipefail
     missing=()
@@ -118,10 +340,12 @@ _require-models allow_opt_out="0":
     fi
     echo "error: missing required ONNX models — this test tier needs them baked into the image:" >&2
     for m in "${missing[@]}"; do echo "         $m" >&2; done
-    echo "       They are downloaded, not tracked. Copy them from the install tree" >&2
-    echo "       ('sudo facelock setup' downloads them to /var/lib/facelock/models):" >&2
-    echo "         sudo cp /var/lib/facelock/models/*.onnx models/" >&2
-    echo "       (models/*.onnx is gitignored, so this cannot be committed by accident.)" >&2
+    echo "       They are downloaded, not tracked. Populate models/ from a checkout" >&2
+    echo "       or install tree that already has them:" >&2
+    echo "         just link-models" >&2
+    echo "       It names what it looked at, and how to get the models, if it finds" >&2
+    echo "       no source. (models/*.onnx is gitignored, so nothing you link in can" >&2
+    echo "       be committed by accident.)" >&2
     if [ "{{allow_opt_out}}" = "1" ]; then
         echo "       To validate packaging only, with the daemon-start assertions counted" >&2
         echo "       as skipped: FACELOCK_ALLOW_MISSING_MODELS=1 just <recipe>" >&2


### PR DESCRIPTION
## Summary

- add `just link-models` to populate `models/*.onnx` from the main checkout, `/var/lib/facelock/models/`, or a directory passed as an argument
- hardlink where possible and fall back to a copy across filesystems, reporting which happened and what it cost
- verify each file against the sha256 in `models/manifest.toml` and place it via a temp name, so an interrupted copy cannot leave a truncated model behind
- point `_require-models` at the recipe instead of `sudo cp /var/lib/facelock/models/*.onnx models/`
- take `_link-models` as a hardlink-only `auto` dependency of `_require-models`, so the camera and package tiers self-provision and only fail when nothing is linkable
- `test-deb-pkg` and `test-rpm-pkg` inherit that through `(_require-models "1")`, making `FACELOCK_ALLOW_MISSING_MODELS=1` an escape hatch rather than the usual path
- document the recipe in `CONTRIBUTING.md`, `book/src/testing.md`, and `docs/testing-safety.md`

## Why

`models/*.onnx` is gitignored, so every `git worktree add` starts without models and the camera and package tiers are unavailable until 435MB is hand-copied with `sudo`. A worktree shares a filesystem with its main checkout, so a hardlink is free and instant; nothing offered one. Hardlink rather than symlink because `test/Containerfile` does `COPY models/ /build/models/` and podman's `COPY` does not follow a symlink out of the build context, which would bake a dangling link into the image. The hardlink from `/var/lib/facelock/models/` that #155 suggests is refused by `fs.protected_hardlinks=1` and by btrfs across subvolumes, so the copy path is what runs from an install tree — without `sudo` either way, since the models are 0644.

## Validation

- `cargo test --workspace` (882 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `shellcheck` and `bash -n` on both recipe bodies
- `just --summary` at each commit
- fresh `git worktree add`: guard fails on `e3bc8d0`, hardlinks and passes here, no-op on repeat, sha256s matching `models/manifest.toml`
- ten scenarios against fake checkouts spanning tmpfs and btrfs: no source available, same-filesystem hardlink, cross-filesystem copy, sha256 mismatch refused with no leftover temp file, and the three `auto` paths
- podman `COPY` probe confirming a hardlink arrives with its bytes and a symlink-to-outside arrives dangling, exit 0 either way
- `just _build-test-container` from a hardlinked `models/`, with all four models in the image at `/var/lib/facelock/models/`
- GitHub CI: build/test/lint, cargo-audit, translation freshness, TPM tests, and container PAM smoke test

Not run: `test-arch-integration` and `test-arch-oneshot`, which need a live camera and a human in frame.

Closes #155
