### PR TITLE
docs(agents): Scope path-specific rules to .claude/rules

### DIFF
--- a/.claude/rules/pam-boundary.md
+++ b/.claude/rules/pam-boundary.md
@@ -12,3 +12,19 @@ Why: this keeps the shared library small and avoids dragging heavy dependencies
 into every PAM-using process. The module is a thin client that either connects
 to the daemon or spawns `facelock auth`, so inference and camera code belong on
 the other side of that boundary, never linked into `pam_facelock.so`.
+
+## zbus must use the tokio backend
+
+The crate list above is not the whole constraint. `just check-pam-standalone`
+fails the build if the dependency tree contains any of:
+
+    async-io  async-signal  async-executor  async-fs  async-lock  polling
+
+Those are the `async-io` backend. zbus must be built with the tokio backend and
+without default features. Satisfying the four-crate ceiling above while pulling
+in the wrong zbus feature set still fails CI — this has already cost two fixes
+(#107, #123), because the ceiling was documented and the backend was not.
+
+Run `just check-pam-standalone` after any change to `crates/pam-facelock/Cargo.toml`.
+CI runs the same guard as the "Verify pam-facelock dependency surface" step in
+`build-and-test`.

--- a/.claude/rules/pam-boundary.md
+++ b/.claude/rules/pam-boundary.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "crates/pam-facelock/**"
+---
+
+# PAM Dependency Ceiling
+
+`pam-facelock` depends on **libc, toml, serde, zbus ONLY**. No ort, no v4l, no
+facelock-core.
+
+Why: this keeps the shared library small and avoids dragging heavy dependencies
+into every PAM-using process. The module is a thin client that either connects
+to the daemon or spawns `facelock auth`, so inference and camera code belong on
+the other side of that boundary, never linked into `pam_facelock.so`.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "crates/facelock-daemon/**/*.rs"
+  - "crates/pam-facelock/**/*.rs"
+  - "crates/facelock-tpm/**/*.rs"
+  - "crates/facelock-cli/src/commands/auth.rs"
+---
+
+# Security Rules
+
+Read `docs/security.md` before implementing any auth-related code. The ADR
+directory under `docs/adr/` records why these are what they are; ADR 010 is the
+most recent to change them.
+
+- **Read `docs/security.md`** before implementing any auth-related code.
+- `security.require_ir` defaults to **true**. Never weaken this default.
+- Frame variance checks must be in the auth path.
+- Model files SHA256-verified at load time.
+- D-Bus system bus policy: deny-all default; every local user may send `Authenticate` only (daemon checks caller UID == target user), root gets the whole interface incl. signals; no group policy (ADR 010).
+- D-Bus daemon verifies caller UID via `GetConnectionUnixUser` before executing methods.
+- D-Bus message size limits enforced by the bus daemon.
+- PAM module logs all auth attempts to syslog.
+- Database is 0600 root:root, model files 0644 under a 0755 root:root directory; the state directory is 0711 root:root (ADR 010).
+- Rate limiting enforced in daemon (5 attempts/user/60s default).
+- Constant-time embedding comparison via `subtle` crate (prevents timing side-channels).
+- systemd service hardened with ProtectSystem=strict, NoNewPrivileges, InaccessiblePaths, etc.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "test/**"
+  - "justfile"
+  - "crates/**/tests/**"
+  - ".github/workflows/**"
+---
+
+# Testing Strategy
+
+| Tier | What | How |
+|------|------|-----|
+| 1 | Unit tests | `cargo test --workspace` |
+| 2 | Hardware tests | `cargo test --workspace -- --ignored` |
+| 3 | Arch container PAM smoke | `just test-arch-pam` |
+| 3b | Arch container E2E (daemon) | `just test-arch-integration` |
+| 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
+| 4 | VM testing | Disposable VM with snapshots |
+| 5 | Host PAM | After tiers 3-4, with root shell backup |
+
+**Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` 
 ## Core Rules
 
 - Do not change binary names, paths, config keys, database schema, or auth semantics without updating `docs/contracts.md`.
+- Keep the PAM module free of heavy dependencies (no ort, no v4l, no facelock-core). `pam_facelock.so` loads into every PAM-using process, `sshd` and `login` included. Full ceiling in `.claude/rules/pam-boundary.md`.
 - Keep all inference local. No cloud services, no runtime model downloads in the auth path.
 - Prefer minimal dependencies and clear crate boundaries.
-- PAM module dependency ceiling: `.claude/rules/pam-boundary.md`.
 
 ## Security Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,24 +4,6 @@
 
 Facelock is a Linux face authentication PAM module written in Rust. Single unified binary (`facelock`) handles CLI, daemon, one-shot auth, and benchmarks. The PAM module (`pam_facelock.so`) is a thin client that either connects to the daemon or spawns `facelock auth`. IPC uses the D-Bus system bus (`org.facelock.Daemon`), not Unix sockets.
 
-## Repository Structure
-
-Cargo workspace with 11 crates:
-
-| Crate | Type | Purpose |
-|-------|------|---------|
-| `facelock-core` | lib | Config, types, errors, D-Bus interface, traits |
-| `facelock-camera` | lib | V4L2 capture, auto-detection, preprocessing |
-| `facelock-face` | lib | ONNX inference (SCRFD + ArcFace) |
-| `facelock-store` | lib | SQLite face embedding storage |
-| `facelock-daemon` | lib | Auth/enroll logic, rate limiting, liveness, audit, D-Bus server |
-| `facelock-cli` | bin | Unified CLI (`facelock` binary, includes `bench` subcommand) |
-| `facelock-bench` | bin | Standalone benchmark and calibration utility |
-| `pam-facelock` | cdylib | PAM module (libc + toml + serde + zbus only) |
-| `facelock-tpm` | lib | TPM-sealed key encryption, software AES-256-GCM |
-| `facelock-polkit` | bin | Polkit authentication agent |
-| `facelock-test-support` | lib | Mocks and fixtures for testing |
-
 ## Build & Verify
 
 ```bash
@@ -46,24 +28,13 @@ Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` 
 ## Core Rules
 
 - Do not change binary names, paths, config keys, database schema, or auth semantics without updating `docs/contracts.md`.
-- Keep the PAM module free of heavy dependencies (no ort, no v4l, no facelock-core).
 - Keep all inference local. No cloud services, no runtime model downloads in the auth path.
 - Prefer minimal dependencies and clear crate boundaries.
+- PAM module dependency ceiling: `.claude/rules/pam-boundary.md`.
 
 ## Security Rules
 
-- **Read `docs/security.md`** before implementing any auth-related code.
-- `security.require_ir` defaults to **true**. Never weaken this default.
-- Frame variance checks must be in the auth path.
-- Model files SHA256-verified at load time.
-- D-Bus system bus policy: deny-all default; every local user may send `Authenticate` only (daemon checks caller UID == target user), root gets the whole interface incl. signals; no group policy (ADR 010).
-- D-Bus daemon verifies caller UID via `GetConnectionUnixUser` before executing methods.
-- D-Bus message size limits enforced by the bus daemon.
-- PAM module logs all auth attempts to syslog.
-- Database is 0600 root:root, model files 0644 under a 0755 root:root directory; the state directory is 0711 root:root (ADR 010).
-- Rate limiting enforced in daemon (5 attempts/user/60s default).
-- Constant-time embedding comparison via `subtle` crate (prevents timing side-channels).
-- systemd service hardened with ProtectSystem=strict, NoNewPrivileges, InaccessiblePaths, etc.
+See `.claude/rules/security.md`, which loads when you open daemon, PAM, TPM, or auth-path sources.
 
 ## Code Style
 
@@ -72,34 +43,9 @@ Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` 
 - `tracing` for structured logging. Control verbosity via `RUST_LOG` env filter.
 - `#[cfg(test)]` modules in each source file for tests.
 
-## Dependency Rules
-
-| Crate | Dependencies |
-|-------|-------------|
-| facelock-core | serde, toml, thiserror, tracing, subtle, zeroize, zvariant |
-| facelock-camera | facelock-core, v4l, image, tracing |
-| facelock-face | facelock-core, ort, ndarray, image, sha2 |
-| facelock-store | facelock-core, rusqlite (bundled), bytemuck, thiserror |
-| facelock-daemon | facelock-core, facelock-camera, facelock-face, facelock-store, facelock-tpm, signal-hook, nix, zbus (tokio), tokio |
-| facelock-cli | facelock-core + all above, clap, reqwest, zbus, tokio, dialoguer |
-| facelock-bench | facelock-core, facelock-camera, facelock-face, facelock-store, clap, anyhow, tracing |
-| pam-facelock | **libc, toml, serde, zbus ONLY** |
-| facelock-tpm | facelock-core, tracing, aes-gcm, rand, zeroize, tss-esapi (optional) |
-| facelock-polkit | facelock-core, zbus, tokio, nix, anyhow |
-
 ## Testing Strategy
 
-| Tier | What | How |
-|------|------|-----|
-| 1 | Unit tests | `cargo test --workspace` |
-| 2 | Hardware tests | `cargo test --workspace -- --ignored` |
-| 3 | Arch container PAM smoke | `just test-arch-pam` |
-| 3b | Arch container E2E (daemon) | `just test-arch-integration` |
-| 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
-| 4 | VM testing | Disposable VM with snapshots |
-| 5 | Host PAM | After tiers 3-4, with root shell backup |
-
-**Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.
+See `.claude/rules/testing.md`, which loads when you open the justfile, `test/`, crate integration tests, or CI workflows.
 
 ## Workspace Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,24 @@
 
 Facelock is a Linux face authentication PAM module written in Rust. Single unified binary (`facelock`) handles CLI, daemon, one-shot auth, and benchmarks. The PAM module (`pam_facelock.so`) is a thin client that either connects to the daemon or spawns `facelock auth`. IPC uses the D-Bus system bus (`org.facelock.Daemon`), not Unix sockets.
 
+## Crates
+
+Cargo workspace, 11 crates. What each is for — the manifests carry no `description`, so this is the only map.
+
+- `facelock-core` — config, types, errors, D-Bus interface, traits
+- `facelock-camera` — V4L2 capture, auto-detection, preprocessing
+- `facelock-face` — ONNX inference (SCRFD + ArcFace)
+- `facelock-store` — SQLite face embedding storage
+- `facelock-daemon` — auth/enroll logic, rate limiting, liveness, audit, D-Bus server
+- `facelock-cli` — the `facelock` binary, plus a library target so the domain layer is testable
+- `facelock-bench` — standalone benchmark and calibration utility
+- `pam-facelock` — the PAM module, a thin client to the daemon
+- `facelock-tpm` — TPM-sealed key encryption, software AES-256-GCM
+- `facelock-polkit` — polkit authentication agent
+- `facelock-test-support` — mocks and fixtures
+
+Dependencies are whatever the manifests say; there is no separate allowed-list to keep in sync. The one enforced boundary is the PAM ceiling below.
+
 ## Build & Verify
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Version is declared once in the root `Cargo.toml` and inherited via `version.wor
 
 The PAM module (`pam-facelock`) must stay lightweight: **libc, toml, serde, zbus only**. No ort, no v4l, no facelock-core. This keeps the shared library small and avoids dragging heavy dependencies into every PAM-using process.
 
-Each crate has a defined dependency boundary. See `AGENTS.md` for the full table.
+Each crate has a defined dependency boundary. See each crate's `Cargo.toml` for its actual dependencies.
 
 ### Supply-chain auditing
 


### PR DESCRIPTION
## Summary

- move security and testing rules into `.claude/rules/*.md` with `paths:` frontmatter, scoped to the files they govern
- add `.claude/rules/pam-boundary.md` for the PAM dependency ceiling, scoped to `crates/pam-facelock/**`
- document there that zbus must use the tokio backend, which `just check-pam-standalone` enforces but no doc stated
- keep the one-line PAM ceiling in Core Rules as an unconditional tripwire, deliberately duplicating the rule file
- delete the per-crate dependency table
- replace the crate-structure table with a compact crate map, dropping the Type column
- repoint CONTRIBUTING.md at each crate's `Cargo.toml` for dependency boundaries

## Why

AGENTS.md is symlinked as CLAUDE.md, so it loads in full every session. Rules
that only matter while editing the daemon or the justfile spend context on every
unrelated task; path-scoped rules load when a matching file is opened instead.
The dependency table went because it had drifted, not merely because Cargo.toml
restates it: `facelock-cli` documented 5 dependencies against 29 actual, and the
table stayed accurate only where CI enforces it. The crate map stayed because no
manifest carries a `description`, so nothing else says what each crate is for.

## Validation

- rebased on main after ADR 009 and ADR 010; `security.md` re-derived from the current AGENTS.md rather than the pre-ADR-010 text it first copied
- every normative line in the current AGENTS.md accounted for across the new file set
- testing tier table compared row for row against main
- crate map checked against `crates/` on disk, 11 for 11, no stale entries
- `Commits, PRs, and Issues` confirmed retained and unconditional, since GitHub-triggered runs have no file path to scope on
- YAML frontmatter parsed for each rule file, glob targets resolved against real paths
