### PR TITLE
docs(skills): Add release and packaging-test project skills

### DIFF
--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: packaging-test
+description: Pick and run the right facelock packaging or container test for a change. Use after touching dist/, debian/, the spec, PKGBUILDs, systemd units, D-Bus policy, polkit, the PAM module, or CI packaging jobs. Triggers on "test the packaging", "will this break the deb", "check the rpm", "test the AUR package", "which container test should I run".
+---
+
+# Packaging and container tests
+
+CI runs exactly one container job — `container-pam-test` in `ci.yml`. Every
+`.deb`, `.rpm`, COPR and APT-repo path is **local only**. If you changed
+packaging and did not run one of these yourself, it is untested until a release
+tag fires `release.yml`, which is the worst place to find out.
+
+All recipes need `podman`. None of the ones in the routing table need a camera.
+
+## Routing — what you touched, what to run
+
+| Changed | Run |
+|---|---|
+| `dist/debian/**`, `dist/facelock.spec` shared install logic | `just test-deb-pkg` and `just test-rpm-pkg` |
+| `dist/debian/**` only | `just test-deb-pkg` |
+| `dist/facelock.spec`, `dist/facelock.install` | `just test-rpm-pkg` |
+| TPM packaging or `facelock-tpm` build features | `just test-deb-tpm-pkg` (builds the trixie TPM `.deb`) |
+| `dist/PKGBUILD*` | `just test-arch-pam`, then a release shell (below) |
+| `.packit.yaml`, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
+| APT repo generation, `publish-apt` workflow | `just test-apt-repo` — needs `reprepro` and `gpg` |
+| `systemd/`, `dbus/`, `polkit/`, install paths | `just test-deb-pkg` or `just test-rpm-pkg` — both validate under booted systemd |
+| `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
+| File layout, installed paths | `just test-arch-layout` |
+
+Quick syntax-level checks, weaker than the `-pkg` variants: `just test-rpm`
+(Fedora container), `just test-deb` (Ubuntu container). They exercise packaging
+but do not install and boot.
+
+## The `-pkg` recipes are the real ones
+
+`test-deb-pkg`, `test-deb-tpm-pkg` and `test-rpm-pkg` build a real package,
+install it with `dpkg` or `dnf`, and validate under **booted systemd**. That is
+the only path that catches unit-file, D-Bus policy, polkit and post-install
+scriptlet problems. Prefer them over `test-deb` / `test-rpm` whenever the change
+could affect installed state rather than just packaging syntax.
+
+## Camera-gated tests
+
+These need a real camera and a person in frame, so neither CI nor an agent can
+run them:
+
+- `just test-arch-integration` — daemon-mode end to end
+- `just test-arch-oneshot` — daemonless end to end
+- `just test-arch-dev-shell`, `test-arch-release-shell`, `test-deb-dev-shell`, `test-rpm-dev-shell`, `test-deb-release-shell`, `test-rpm-release-shell`
+
+**Do not attempt these.** When a change needs one, say so plainly and name the
+recipe so a human can run it. Never report a change as validated on the strength
+of tests that were skipped.
+
+Dev shells mount host models for fast iteration; release shells are clean-room
+and reproduce the real first-run user experience. Reach for a release shell when
+the question is "does a fresh install work", a dev shell when iterating.
+
+## Before claiming packaging works
+
+- `just check` covers test, lint, format, audit and the PAM standalone surface — it does **not** cover packaging
+- Name which packaging recipe you ran; if none, say so
+- Report camera-gated tests as not run, never as passed
+
+## Cost
+
+`test-copr` is self-described as slow and opt-in. The `-pkg` recipes boot a
+container under systemd. Run the narrowest recipe the routing table allows
+rather than the whole set.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -96,11 +96,12 @@ Only after explicit confirmation. No AI attribution in the commit or tag message
 
 ## Step 6: Watch the publish
 
-The `v*` tag triggers `.github/workflows/release.yml`, which has eight jobs:
+The `v*` tag triggers `.github/workflows/release.yml`, which has 9 jobs:
 
 ```
-build · download-ort · build-deb · build-deb-tpm · build-rpm
-build-nix · publish-aur · publish-apt · trigger-pages
+build · download-ort · build-deb
+build-deb-tpm · build-rpm · build-nix
+publish-aur · publish-apt · trigger-pages
 ```
 
 ```bash

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: release
+description: Cut a facelock release. Overrides the generic releasing skill with this repo's known procedure — just release-preflight, just release, the six version files, and the tag-triggered publish workflow. Use for "cut a release", "release vX.Y.Z", "ship a release", "bump the version", "tag a release".
+---
+
+# Releasing facelock
+
+This is the repo-local override of the global `releasing` skill. That skill
+discovers a project's release procedure; here the answer is known, so skip
+discovery and use what follows. Keep its two habits regardless: preflight
+before touching anything, and verify every version file actually changed.
+
+Authoritative reference: `docs/releasing.md`. Read it if anything below
+disagrees with the tree — the doc wins and this skill is stale.
+
+## Step 1: Preflight
+
+```bash
+just release-preflight v<X.Y.Z>
+```
+
+Pass the tag. The recipe is **prerelease-aware**: a tag matching
+`alpha|beta|rc` relaxes the secret requirements, a final tag does not. Running
+it bare skips that branch, so always pass the tag you intend to push.
+
+It checks local tools (`git`, `cargo`, `just`, `podman`), the packaging files,
+and release secrets. Fix every `MISSING` before continuing.
+
+Then confirm independently:
+
+- working tree clean (`just release` also enforces this and aborts)
+- on `main`, in sync with `origin/main`
+- CI green **on the exact commit being released** — compare `gh run list --branch main --limit 1 --json conclusion,headSha` against `git rev-parse HEAD`
+
+## Step 2: Bump
+
+```bash
+just release <X.Y.Z>
+```
+
+Semver only, no `v` prefix — the recipe rejects anything else.
+
+It rewrites **six** files with `sed -i`:
+
+| File | Note |
+|---|---|
+| `Cargo.toml` | workspace version, inherited by all crates |
+| `dist/PKGBUILD` | |
+| `dist/PKGBUILD-bin` | per-binary sha256sums are filled in by CI, not here |
+| `dist/PKGBUILD-git` | the runtime `pkgver()` computes the real version; this is the fallback |
+| `dist/facelock.spec` | |
+| `dist/debian/changelog` | prepends a new entry |
+
+Then it runs `cargo check --workspace` and **stops**. It does not commit, tag,
+or push — it prints those as instructions. Steps 3 to 5 are yours.
+
+## Step 3: Verify all six changed
+
+The recipe runs six independent `sed -i` calls and checks none of them. A
+pattern that fails to match leaves that file at the old version, silently, and
+the mismatch does not surface until a package ships wrong.
+
+```bash
+git diff --stat
+```
+
+All six files above must appear. Then confirm each carries the new version:
+
+```bash
+git diff -U0 | rg -n '^\+' | rg '<X.Y.Z>'
+```
+
+Any file missing from the diff is a stop. Fix the bump before going further.
+
+## Step 4: CHANGELOG.md
+
+Hand-written, not generated. Draft from commits since the last tag:
+
+```bash
+git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
+```
+
+Write for someone deciding whether to upgrade. Apply `~/.claude/PROSE.md`.
+Never edit an entry for an already-released version.
+
+## Step 5: Commit, tag, push
+
+```bash
+git add -A
+git commit -m "chore: release v<X.Y.Z>"
+git tag v<X.Y.Z>
+git push origin main --tags
+```
+
+Only after explicit confirmation. No AI attribution in the commit or tag message.
+
+## Step 6: Watch the publish
+
+The `v*` tag triggers `.github/workflows/release.yml`, which has eight jobs:
+
+```
+build · download-ort · build-deb · build-deb-tpm · build-rpm
+build-nix · publish-aur · publish-apt · trigger-pages
+```
+
+```bash
+gh run watch
+gh release view v<X.Y.Z> --json assets --jq '.assets[].name'
+```
+
+`publish-aur` and `publish-apt` push to external package repositories. A failure
+after those succeed is only partially recoverable — check them first when
+triaging a bad release.
+
+## Guardrails
+
+- Never tag or push without explicit confirmation.
+- Never proceed when CI is not green on the exact release commit.
+- Never hand-edit a version file as a workaround for a failed `just release` — fix the recipe.
+- Never edit a changelog entry for a released version.
+- Prereleases: use an `alpha`/`beta`/`rc` tag so preflight applies the right secret rules.


### PR DESCRIPTION
## Summary

- add `.claude/skills/release/` — facelock's known release procedure, overriding the generic discovery-based one
- add `.claude/skills/packaging-test/` — routing table from what changed to which container test to run
- document the six files `just release` rewrites, and that it verifies none of them
- document that `just release` stops after `cargo check`; commit, tag and push are manual
- mark the camera-gated recipes as unrunnable by CI or an agent, never to be reported as passed

## Why

Both procedures exist only as justfile recipes today, so an agent rediscovers
them each time or improvises. `just release` runs six independent `sed -i` calls
and checks none, which is silent until a package ships the wrong version. CI runs
exactly one container job, so every `.deb`, `.rpm`, COPR and APT path is local-only
and untested until a release tag fires the publish workflow.

## Validation

- rebased on main; every claim re-checked against the current tree rather than the tree at authoring time
- every `just <recipe>` referenced resolved against `just --list`
- the six version files confirmed to still exist and to still be what the recipe rewrites
- release workflow job list regenerated from `release.yml` rather than transcribed
- YAML frontmatter parsed; skill name matches directory name
