### PR TITLE
ci: run the CI workflow on pull requests against any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No base-branch filter: a PR stacked on another PR's branch gets the same
+  # gate as one targeting main. GitHub retargets it to main when its base
+  # merges, so it would otherwise run CI for the first time only then.
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- drop the `branches: [main]` filter from the `pull_request` trigger; `push` stays main-only
- a PR stacked on another PR's branch now runs CI on open instead of only after GitHub retargets it to `main`; the CLI flags work (#175) opens its PRs that way

Refs #175
