### PR TITLE
refactor(cli): Route setup output through the sink and add quiet verbosity

### DIFF
--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -613,7 +613,7 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     } else {
         Terminal.info(&SetupMessage::SummaryFaceNotEnrolled);
     }
-    println!();
+    Terminal.info(&SetupMessage::BlankLine);
 
     let manifest: ModelManifest =
         toml::from_str(MANIFEST_TOML).context("failed to parse model manifest")?;
@@ -857,13 +857,12 @@ fn preset_of_models(detector: &str, embedder: &str) -> Option<ModelPreset> {
         .find(|p| preset_models(*p) == (detector, embedder))
 }
 
-fn preset_summary(preset: ModelPreset) -> &'static str {
+/// What the wizard says once a preset is chosen.
+fn preset_summary(preset: ModelPreset) -> DeviceMessage {
     match preset {
-        ModelPreset::Standard => "Selected standard models (fast, good accuracy).",
-        ModelPreset::Balanced => {
-            "Selected balanced models (fast detection, high-accuracy embedding)."
-        }
-        ModelPreset::High => "Selected high-accuracy models (larger, ~40-50ms slower).",
+        ModelPreset::Standard => DeviceMessage::SelectedModelsStandard,
+        ModelPreset::Balanced => DeviceMessage::SelectedModelsBalanced,
+        ModelPreset::High => DeviceMessage::SelectedModelsHigh,
     }
 }
 
@@ -885,7 +884,7 @@ fn set_model_preset(config: &mut Config, preset: ModelPreset) -> anyhow::Result<
 /// `--models`, so the two cannot disagree about what a preset means.
 fn apply_model_preset(config: &mut Config, preset: ModelPreset) -> anyhow::Result<()> {
     set_model_preset(config, preset)?;
-    println!("  {}", preset_summary(preset));
+    Terminal.info(&preset_summary(preset));
     update_config_models(config)?;
     Ok(())
 }
@@ -957,13 +956,15 @@ fn wizard_execution_provider(theme: &ColorfulTheme, config: &mut Config) -> anyh
 fn resolve_execution_provider_auto() -> anyhow::Result<String> {
     match facelock_face::detect_execution_provider() {
         Ok(detection) => {
-            println!("  Detected: {}", detection.explain());
+            Terminal.info(&DeviceMessage::DetectedProvider {
+                detail: detection.explain(),
+            });
             Ok(detection.provider.as_str().to_string())
         }
         Err(e) => {
-            println!("  \u{26a0} Could not query the ONNX Runtime for available providers: {e}");
-            println!("    Selecting cpu. Re-run with an explicit --execution-provider once the");
-            println!("    runtime is installed if you need GPU inference.");
+            Terminal.info(&DeviceMessage::ProviderQueryFailed {
+                error: e.to_string(),
+            });
             Ok("cpu".to_string())
         }
     }
@@ -993,12 +994,10 @@ fn warn_provider_preflight(provider: &str) {
         .any(|p| Path::new(p).exists());
 
     if !has_nvidia_driver {
-        println!("  \u{26a0} NVIDIA driver not detected. Install the NVIDIA driver package");
-        println!("    before starting the daemon.");
+        Terminal.info(&DeviceMessage::NvidiaDriverMissing);
     }
     if !has_cuda_ort {
-        println!("  \u{26a0} CUDA-enabled ONNX Runtime not found. Install onnxruntime-opt-cuda");
-        println!("    before starting the daemon, or inference will fall back to CPU.");
+        Terminal.info(&DeviceMessage::CudaRuntimeMissing);
     }
 }
 
@@ -1219,13 +1218,9 @@ fn handle_orphan_models_before_keygen(
         ),
     }
 
-    println!();
-    println!(
-        "  WARNING: encrypted face models already exist in {} but the",
-        config.storage.db_path
-    );
-    println!("  encryption key is missing. Generating a new key would make them unreadable.");
-    println!();
+    Terminal.info(&SetupMessage::OrphanModelsWarning {
+        db_path: config.storage.db_path.clone(),
+    });
 
     let Some(theme) = theme.filter(|_| is_interactive()) else {
         bail!(
@@ -1246,7 +1241,7 @@ fn handle_orphan_models_before_keygen(
     let removed = store
         .clear_all()
         .map_err(|e| anyhow::anyhow!("failed to clear orphaned models: {e}"))?;
-    println!("  Removed {removed} orphaned model(s).");
+    Terminal.info(&SetupMessage::OrphanModelsRemoved { count: removed });
     Ok(())
 }
 
@@ -1361,7 +1356,7 @@ mod orphan_guard_tests {
 }
 
 fn wizard_encryption_setup(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
-    println!("  Setting up AES-256-GCM encryption for face embeddings.");
+    Terminal.info(&SetupMessage::EncryptionIntro);
 
     // Detect TPM availability
     let tpm_available = detect_tpm(config);
@@ -1395,13 +1390,12 @@ fn setup_encryption_tpm_key(
 
     let sealed_path = Path::new(&config.encryption.sealed_key_path);
     if sealed_path.exists() {
-        println!(
-            "  TPM-sealed key already exists at {}.",
-            sealed_path.display()
-        );
+        Terminal.info(&SetupMessage::TpmSealedKeyPresent {
+            path: sealed_path.display().to_string(),
+        });
     } else {
         handle_orphan_models_before_keygen(config, theme)?;
-        println!("  Generating and sealing AES key with TPM...");
+        Terminal.info(&SetupMessage::GeneratingTpmSealedKey);
         let pcr = if config.tpm.pcr_binding {
             Some(config.tpm.pcr_indices.as_slice())
         } else {
@@ -1413,10 +1407,9 @@ fn setup_encryption_tpm_key(
                 .context("failed to initialize TPM")?;
             facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
                 .context("failed to generate and seal key")?;
-            println!(
-                "  TPM-sealed key written to {} (permissions: 0600).",
-                sealed_path.display()
-            );
+            Terminal.info(&SetupMessage::TpmSealedKeyWritten {
+                path: sealed_path.display().to_string(),
+            });
         }
         #[cfg(not(feature = "tpm"))]
         {
@@ -1426,7 +1419,7 @@ fn setup_encryption_tpm_key(
     }
     config.encryption.method = EncryptionMethod::Tpm;
     update_config_encryption(config, "tpm")?;
-    println!("  Encryption enabled (TPM-sealed key).");
+    Terminal.info(&SetupMessage::EncryptionEnabledTpm);
     Ok(())
 }
 
@@ -1439,21 +1432,22 @@ fn setup_encryption_keyfile(
 
     let key_path = Path::new(&config.encryption.key_path);
     if key_path.exists() {
-        println!("  Encryption key already exists at {}.", key_path.display());
+        Terminal.info(&SetupMessage::KeyfilePresent {
+            path: key_path.display().to_string(),
+        });
     } else {
         handle_orphan_models_before_keygen(config, theme)?;
-        println!("  Generating encryption key...");
+        Terminal.info(&SetupMessage::GeneratingKeyfile);
         facelock_tpm::SoftwareSealer::generate_key_file(key_path)
             .context("failed to generate encryption key")?;
-        println!(
-            "  Key written to {} (permissions: 0600).",
-            key_path.display()
-        );
+        Terminal.info(&SetupMessage::KeyfileWritten {
+            path: key_path.display().to_string(),
+        });
     }
 
     config.encryption.method = EncryptionMethod::Keyfile;
     update_config_encryption(config, "keyfile")?;
-    println!("  Encryption enabled.");
+    Terminal.info(&SetupMessage::EncryptionEnabledKeyfile);
 
     Ok(())
 }
@@ -1465,10 +1459,7 @@ fn setup_encryption_none(config: &mut Config) -> anyhow::Result<()> {
     config.encryption.method = EncryptionMethod::None;
     update_config_encryption(config, "none")?;
 
-    println!("  \u{26a0} WARNING: encryption disabled (--encryption=none).");
-    println!("    Biometric templates will be stored UNENCRYPTED in the database.");
-    println!("    `facelock enroll` refuses to write plaintext embeddings unless");
-    println!("    security.allow_plaintext is also set in the config.");
+    Terminal.info(&SetupMessage::EncryptionDisabledWarning);
     Ok(())
 }
 
@@ -1538,7 +1529,7 @@ fn detect_tpm(config: &Config) -> bool {
     {
         match facelock_tpm::TpmSealer::new(&config.tpm.tcti) {
             Ok(_) => {
-                println!("  TPM 2.0 detected and functional.");
+                Terminal.info(&SetupMessage::TpmDetected);
                 true
             }
             Err(e) => {
@@ -2044,9 +2035,7 @@ fn wizard_pam_setup_in(base: &Path, theme: &ColorfulTheme) -> anyhow::Result<Vec
 // ---------------------------------------------------------------------------
 
 fn print_hyprlock_hint() {
-    println!();
-    println!("==> To finish hyprlock integration, run as your normal user:");
-    println!("==>     facelock hyprlock enable");
+    Terminal.info(&SetupMessage::HyprlockHint);
 }
 
 fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
@@ -2074,7 +2063,7 @@ fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
         return;
     }
 
-    println!();
+    Terminal.info(&SetupMessage::BlankLine);
     let proceed = Confirm::with_theme(theme)
         .with_prompt(format!(
             "Apply hyprlock face-unlock integration for {sudo_user}? (face icon + empty-Enter submit)"
@@ -2094,7 +2083,7 @@ fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
 
     match status {
         Ok(s) if s.success() => {
-            println!("  hyprlock integration applied for {sudo_user}.");
+            Terminal.info(&SetupMessage::HyprlockApplied { user: sudo_user });
         }
         _ => {
             print_hyprlock_hint();
@@ -2167,25 +2156,32 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
 
         match status {
             ModelStatus::Present => {
-                println!("  [ok] {} ({})", entry.name, entry.purpose);
+                Terminal.info(&DownloadMessage::ModelPresentOk {
+                    name: entry.name.clone(),
+                    purpose: entry.purpose.clone(),
+                });
             }
             ModelStatus::Missing => {
-                println!(
-                    "  [download] {} (~{}MB) - {}",
-                    entry.name, entry.size_mb, entry.purpose
-                );
+                Terminal.info(&DownloadMessage::ModelDownloadPending {
+                    name: entry.name.clone(),
+                    size_mb: entry.size_mb,
+                    purpose: entry.purpose.clone(),
+                });
                 download_model(entry, &model_path)?;
                 verify_after_download(&model_path, &entry.sha256, &entry.name)?;
-                println!("  [ok] {} downloaded and verified", entry.name);
+                Terminal.info(&DownloadMessage::ModelDownloaded {
+                    name: entry.name.clone(),
+                });
             }
             ModelStatus::BadChecksum => {
-                println!(
-                    "  [redownload] {} - checksum mismatch, re-downloading",
-                    entry.name
-                );
+                Terminal.info(&DownloadMessage::ModelRedownloading {
+                    name: entry.name.clone(),
+                });
                 download_model(entry, &model_path)?;
                 verify_after_download(&model_path, &entry.sha256, &entry.name)?;
-                println!("  [ok] {} re-downloaded and verified", entry.name);
+                Terminal.info(&DownloadMessage::ModelRedownloaded {
+                    name: entry.name.clone(),
+                });
             }
         }
     }
@@ -2211,7 +2207,7 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     // the setup marker exists.
     let enrolled = plan.enroll == Some(true);
     if enrolled {
-        println!("\nEnrolling face...");
+        Terminal.info(&SetupMessage::EnrollingFace);
         super::enroll::run(&config, None, None, true)?;
     }
 
@@ -2241,10 +2237,12 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
 
     // Skip if already configured
     if config.encryption.method != EncryptionMethod::None {
-        println!(
-            "  Encryption already configured ({:?}).",
-            config.encryption.method
-        );
+        Terminal.info(&SetupMessage::EncryptionAlreadyConfigured {
+            // Pre-formatted: `Debug` here is the config enum's own spelling
+            // (`Tpm`/`Keyfile`), and formatting before the seam keeps the
+            // rendering locale-independent.
+            method: format!("{:?}", config.encryption.method),
+        });
         return Ok(());
     }
 
@@ -2263,15 +2261,14 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
                     .context("failed to initialize TPM")?;
                 facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
                     .context("failed to generate and seal key")?;
-                println!(
-                    "  [ok] Generated TPM-sealed encryption key at {}",
-                    sealed_path.display()
-                );
+                Terminal.info(&SetupMessage::GeneratedTpmKeyAt {
+                    path: sealed_path.display().to_string(),
+                });
             }
             let mut config = config.clone();
             config.encryption.method = EncryptionMethod::Tpm;
             update_config_encryption(&config, "tpm")?;
-            println!("  [ok] AES-256-GCM encryption enabled (TPM-sealed key).");
+            Terminal.info(&SetupMessage::EncryptionEnabledTpmAuto);
             return Ok(());
         }
     }
@@ -2281,13 +2278,15 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
     if !key_path.exists() {
         facelock_tpm::SoftwareSealer::generate_key_file(key_path)
             .context("failed to generate encryption key")?;
-        println!("  [ok] Generated encryption key at {}", key_path.display());
+        Terminal.info(&SetupMessage::GeneratedKeyfileAt {
+            path: key_path.display().to_string(),
+        });
     }
 
     let mut config = config.clone();
     config.encryption.method = EncryptionMethod::Keyfile;
     update_config_encryption(&config, "keyfile")?;
-    println!("  [ok] AES-256-GCM encryption enabled.");
+    Terminal.info(&SetupMessage::EncryptionEnabledKeyfileAuto);
     Ok(())
 }
 
@@ -2534,7 +2533,7 @@ fn create_directories(config: &Config) -> anyhow::Result<()> {
         tracing::debug!("ensured directory: {}", dir.display());
     }
 
-    println!("  Directories created.");
+    Terminal.info(&SetupMessage::DirectoriesCreated);
     Ok(())
 }
 
@@ -2557,7 +2556,9 @@ path = "/dev/video0"
             config_path.display()
         )
     })?;
-    println!("  Created default config at {}", config_path.display());
+    Terminal.info(&SetupMessage::CreatedDefaultConfig {
+        path: config_path.display().to_string(),
+    });
     Ok(())
 }
 
@@ -2757,6 +2758,12 @@ fn candidates_in(base: &Path) -> Vec<&'static PamCandidate> {
         .filter(|c| base.join(c.service).exists())
         .collect()
 }
+
+// The four prints below are the last in this file that still write to stdout
+// directly instead of going through the message sink, and they stay that way
+// on purpose: this whole region moves to `commands/pam.rs` (#174), which
+// converts them during the move. Converting them here would only make that
+// move a conflict.
 
 // --- PAM installation ---
 
@@ -3067,7 +3074,9 @@ fn refresh_legacy_copy_if_present(path: &Path, contents: &str, marker: &str) -> 
 
     write_file(path, contents.as_bytes(), 0o644)
         .with_context(|| format!("failed to refresh {}", path.display()))?;
-    println!("  Refreshed legacy {}", path.display());
+    Terminal.info(&SystemMessage::RefreshedLegacyFile {
+        path: path.display().to_string(),
+    });
     Ok(())
 }
 
@@ -3076,11 +3085,11 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
     check_systemd()?;
 
     if disable {
-        println!("Disabling facelock-daemon systemd units...");
+        Terminal.info(&SystemMessage::DisablingSystemdUnits);
         run_cmd("systemctl", &["disable", "--now", "facelock-daemon"])?;
-        println!("facelock-daemon service disabled and stopped.");
+        Terminal.info(&SystemMessage::SystemdUnitsDisabled);
     } else {
-        println!("Installing facelock-daemon systemd and D-Bus units...");
+        Terminal.info(&SystemMessage::InstallingSystemdUnits);
 
         // Install systemd service unit
         let unit_dir = Path::new(SYSTEMD_UNIT_DIR);
@@ -3090,7 +3099,9 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         let service_path = unit_dir.join(SERVICE_FILENAME);
         write_file(&service_path, SERVICE_UNIT.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", service_path.display()))?;
-        println!("  Wrote {}", service_path.display());
+        Terminal.info(&SystemMessage::WroteFile {
+            path: service_path.display().to_string(),
+        });
         refresh_legacy_copy_if_present(
             Path::new(LEGACY_SYSTEMD_UNIT_PATH),
             SERVICE_UNIT,
@@ -3105,7 +3116,9 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         let policy_path = conf_dir.join(DBUS_POLICY_FILENAME);
         write_file(&policy_path, DBUS_POLICY.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", policy_path.display()))?;
-        println!("  Wrote {}", policy_path.display());
+        Terminal.info(&SystemMessage::WroteFile {
+            path: policy_path.display().to_string(),
+        });
         refresh_legacy_copy_if_present(
             Path::new(LEGACY_DBUS_SYSTEM_CONF_PATH),
             DBUS_POLICY,
@@ -3120,7 +3133,9 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         let dbus_svc_path = svc_dir.join(DBUS_SERVICE_FILENAME);
         write_file(&dbus_svc_path, DBUS_SERVICE.as_bytes(), 0o644)
             .with_context(|| format!("failed to write {}", dbus_svc_path.display()))?;
-        println!("  Wrote {}", dbus_svc_path.display());
+        Terminal.info(&SystemMessage::WroteFile {
+            path: dbus_svc_path.display().to_string(),
+        });
         refresh_legacy_copy_if_present(
             Path::new(LEGACY_DBUS_SYSTEM_SERVICE_PATH),
             DBUS_SERVICE,
@@ -3128,12 +3143,14 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         )?;
 
         run_cmd("systemctl", &["daemon-reload"])?;
-        println!("  systemctl daemon-reload done.");
+        Terminal.info(&SystemMessage::SystemctlDaemonReloadDone);
 
         run_cmd("systemctl", &["enable", SERVICE_FILENAME])?;
-        println!("  systemctl enable {SERVICE_FILENAME} done.");
+        Terminal.info(&SystemMessage::SystemctlEnableDone {
+            unit: SERVICE_FILENAME.to_string(),
+        });
 
-        println!("\nfacelock-daemon D-Bus activation is now enabled.");
+        Terminal.info(&SystemMessage::DbusActivationEnabled);
     }
 
     Ok(())

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -170,6 +170,15 @@ fn main() -> anyhow::Result<()> {
         facelock_core::paths::set_process_config_override(PathBuf::from(path));
     }
 
+    // `--quiet` is likewise global, and lands at the message sink rather than
+    // at any call site: it silences `Terminal::info` and nothing else, so
+    // errors, prompts, exit codes and the `RUST_LOG` event stream are
+    // unchanged. `is-enrolled` reads the same flag directly for its
+    // exit-code-only mode, which predates the sink.
+    if quiet {
+        message::set_verbosity(message::Verbosity::Quiet);
+    }
+
     match command {
         // Daemon and auth init their own tracing, so handle them separately
         Commands::Daemon => commands::daemon::run(notifications::daemon_notifier_factory()),

--- a/crates/facelock-cli/src/message/device.rs
+++ b/crates/facelock-cli/src/message/device.rs
@@ -28,6 +28,19 @@ pub enum DeviceMessage {
     // -- model quality / inference device --
     PromptSelectModelQuality,
     PromptSelectInferenceDevice,
+    SelectedModelsStandard,
+    SelectedModelsBalanced,
+    SelectedModelsHigh,
+    DetectedProvider { detail: String },
+
+    // The three warnings below reach `Terminal::info`, so `--quiet` suppresses
+    // them. Deliberate: they have always gone to stdout, and routing them to
+    // `error` to make them unsuppressible would move them to stderr, breaking
+    // both the byte-identity pins and any script reading setup's stdout.
+    // Stream fidelity won; do not "fix" these into `error`.
+    ProviderQueryFailed { error: String },
+    NvidiaDriverMissing,
+    CudaRuntimeMissing,
 }
 
 impl Message for DeviceMessage {
@@ -77,6 +90,31 @@ impl Message for DeviceMessage {
             ),
             PromptSelectModelQuality => translate("Select model quality"),
             PromptSelectInferenceDevice => translate("Select inference device"),
+            SelectedModelsStandard => {
+                translate("  Selected standard models (fast, good accuracy).")
+            }
+            SelectedModelsBalanced => {
+                translate("  Selected balanced models (fast detection, high-accuracy embedding).")
+            }
+            SelectedModelsHigh => {
+                translate("  Selected high-accuracy models (larger, ~40-50ms slower).")
+            }
+            DetectedProvider { detail } => fill(
+                translate("  Detected: {detail}"),
+                &[("detail", detail.clone())],
+            ),
+            ProviderQueryFailed { error } => fill(
+                translate(
+                    "  ⚠ Could not query the ONNX Runtime for available providers: {error}\n    Selecting cpu. Re-run with an explicit --execution-provider once the\n    runtime is installed if you need GPU inference.",
+                ),
+                &[("error", error.clone())],
+            ),
+            NvidiaDriverMissing => translate(
+                "  ⚠ NVIDIA driver not detected. Install the NVIDIA driver package\n    before starting the daemon.",
+            ),
+            CudaRuntimeMissing => translate(
+                "  ⚠ CUDA-enabled ONNX Runtime not found. Install onnxruntime-opt-cuda\n    before starting the daemon, or inference will fall back to CPU.",
+            ),
         }
     }
 }
@@ -119,7 +157,63 @@ impl super::Samples for DeviceMessage {
             AutoCameraManyIr { .. } => CameraDeviceMissing { path: s("/d") },
             CameraDeviceMissing { .. } => PromptSelectModelQuality,
             PromptSelectModelQuality => PromptSelectInferenceDevice,
-            PromptSelectInferenceDevice => return None,
+            PromptSelectInferenceDevice => SelectedModelsStandard,
+            SelectedModelsStandard => SelectedModelsBalanced,
+            SelectedModelsBalanced => SelectedModelsHigh,
+            SelectedModelsHigh => DetectedProvider { detail: s("d") },
+            DetectedProvider { .. } => ProviderQueryFailed { error: s("e") },
+            ProviderQueryFailed { .. } => NvidiaDriverMissing,
+            NvidiaDriverMissing => CudaRuntimeMissing,
+            CudaRuntimeMissing => return None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The strings this domain took over from `commands/setup.rs`, pinned to
+    /// the bytes those `println!` call sites printed. See the same test in
+    /// [`super::super::setup`] for why a failing pin is fixed by restoring
+    /// the string, never by editing the expectation.
+    #[test]
+    fn english_fallback_is_byte_identical() {
+        use DeviceMessage::*;
+
+        assert_eq!(
+            SelectedModelsStandard.localized(),
+            "  Selected standard models (fast, good accuracy)."
+        );
+        assert_eq!(
+            SelectedModelsBalanced.localized(),
+            "  Selected balanced models (fast detection, high-accuracy embedding)."
+        );
+        assert_eq!(
+            SelectedModelsHigh.localized(),
+            "  Selected high-accuracy models (larger, ~40-50ms slower)."
+        );
+        assert_eq!(
+            DetectedProvider {
+                detail: "cuda (available: cpu, cuda)".into()
+            }
+            .localized(),
+            "  Detected: cuda (available: cpu, cuda)"
+        );
+        assert_eq!(
+            ProviderQueryFailed {
+                error: "libonnxruntime.so not found".into()
+            }
+            .localized(),
+            "  \u{26a0} Could not query the ONNX Runtime for available providers: libonnxruntime.so not found\n    Selecting cpu. Re-run with an explicit --execution-provider once the\n    runtime is installed if you need GPU inference."
+        );
+        assert_eq!(
+            NvidiaDriverMissing.localized(),
+            "  \u{26a0} NVIDIA driver not detected. Install the NVIDIA driver package\n    before starting the daemon."
+        );
+        assert_eq!(
+            CudaRuntimeMissing.localized(),
+            "  \u{26a0} CUDA-enabled ONNX Runtime not found. Install onnxruntime-opt-cuda\n    before starting the daemon, or inference will fall back to CPU."
+        );
     }
 }

--- a/crates/facelock-cli/src/message/download.rs
+++ b/crates/facelock-cli/src/message/download.rs
@@ -32,6 +32,19 @@ pub enum DownloadMessage {
     ModelDownloaded {
         name: String,
     },
+
+    // -- the non-interactive flow, which narrates each file as it goes --
+    ModelDownloadPending {
+        name: String,
+        size_mb: u64,
+        purpose: String,
+    },
+    ModelRedownloading {
+        name: String,
+    },
+    ModelRedownloaded {
+        name: String,
+    },
 }
 
 impl Message for DownloadMessage {
@@ -70,6 +83,26 @@ impl Message for DownloadMessage {
                 translate("  [ok] {name} downloaded and verified"),
                 &[("name", name.clone())],
             ),
+            ModelDownloadPending {
+                name,
+                size_mb,
+                purpose,
+            } => fill(
+                translate("  [download] {name} (~{size_mb}MB) - {purpose}"),
+                &[
+                    ("name", name.clone()),
+                    ("size_mb", size_mb.to_string()),
+                    ("purpose", purpose.clone()),
+                ],
+            ),
+            ModelRedownloading { name } => fill(
+                translate("  [redownload] {name} - checksum mismatch, re-downloading"),
+                &[("name", name.clone())],
+            ),
+            ModelRedownloaded { name } => fill(
+                translate("  [ok] {name} re-downloaded and verified"),
+                &[("name", name.clone())],
+            ),
         }
     }
 }
@@ -104,7 +137,67 @@ impl super::Samples for DownloadMessage {
             ConfirmDownloadRequiredModels => SkippingModelDownload,
             SkippingModelDownload => DownloadingModel { name: s("n") },
             DownloadingModel { .. } => ModelDownloaded { name: s("n") },
-            ModelDownloaded { .. } => return None,
+            ModelDownloaded { .. } => ModelDownloadPending {
+                name: s("n"),
+                size_mb: 1,
+                purpose: s("p"),
+            },
+            ModelDownloadPending { .. } => ModelRedownloading { name: s("n") },
+            ModelRedownloading { .. } => ModelRedownloaded { name: s("n") },
+            ModelRedownloaded { .. } => return None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The model-progress lines, pinned to the bytes `commands/setup.rs`
+    /// printed. The first two are pinned even though they predate this
+    /// change: the non-interactive flow now renders them too, so they are
+    /// load-bearing on both paths.
+    #[test]
+    fn english_fallback_is_byte_identical() {
+        use DownloadMessage::*;
+
+        assert_eq!(
+            ModelPresentOk {
+                name: "SCRFD 2.5G".into(),
+                purpose: "face detection".into()
+            }
+            .localized(),
+            "  [ok] SCRFD 2.5G (face detection)"
+        );
+        assert_eq!(
+            ModelDownloaded {
+                name: "SCRFD 2.5G".into()
+            }
+            .localized(),
+            "  [ok] SCRFD 2.5G downloaded and verified"
+        );
+        assert_eq!(
+            ModelDownloadPending {
+                name: "ArcFace R50".into(),
+                size_mb: 166,
+                purpose: "face embedding".into()
+            }
+            .localized(),
+            "  [download] ArcFace R50 (~166MB) - face embedding"
+        );
+        assert_eq!(
+            ModelRedownloading {
+                name: "ArcFace R50".into()
+            }
+            .localized(),
+            "  [redownload] ArcFace R50 - checksum mismatch, re-downloading"
+        );
+        assert_eq!(
+            ModelRedownloaded {
+                name: "ArcFace R50".into()
+            }
+            .localized(),
+            "  [ok] ArcFace R50 re-downloaded and verified"
+        );
     }
 }

--- a/crates/facelock-cli/src/message/mod.rs
+++ b/crates/facelock-cli/src/message/mod.rs
@@ -22,6 +22,11 @@
 //! sink, not the string — `bail!` text a human reads on stderr localizes,
 //! the same event written to audit/syslog/tracing does not.
 //!
+//! `--quiet` acts here rather than at the call sites: [`set_verbosity`]
+//! silences [`Terminal::info`] and nothing else, so converting a `println!`
+//! into a message is also what makes it quietable — no caller ever asks
+//! whether it should be printing.
+//!
 //! # The vocabulary is split by domain
 //!
 //! There is no single `Message` enum. Each domain owns its own, and this
@@ -213,6 +218,81 @@ pub trait Message: std::fmt::Debug {
 }
 
 // ---------------------------------------------------------------------------
+// Verbosity
+// ---------------------------------------------------------------------------
+
+/// How much the human sink says.
+///
+/// **`--quiet` suppresses informational stdout only; errors and exit codes are
+/// unchanged.** [`Terminal::error`] is never suppressed, so a quiet run that
+/// fails still says why on stderr and still exits non-zero. That is
+/// `is-enrolled --quiet`'s existing semantics (see
+/// [`crate::commands::is_enrolled`]) and it is the house rule for every
+/// command. Prompts ([`Terminal::confirm`]) are unaffected too — a silenced
+/// question is a hang, not a quieter program. The debug side channel
+/// (`trace`) also keeps firing: the machine event stream is not user-facing
+/// output, so `RUST_LOG=facelock=debug` works the same either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Verbosity {
+    #[default]
+    Normal,
+    Quiet,
+}
+
+/// Process-global verbosity. Written once, from the parsed global `--quiet`
+/// flag, before any other thread exists; `Relaxed` is therefore enough — no
+/// other state is published through it.
+static VERBOSITY: std::sync::atomic::AtomicU8 =
+    std::sync::atomic::AtomicU8::new(Verbosity::Normal as u8);
+
+/// Set the process verbosity. Call once, early in `main`, next to [`init`].
+pub fn set_verbosity(verbosity: Verbosity) {
+    VERBOSITY.store(verbosity as u8, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The process verbosity ([`Verbosity::Normal`] until [`set_verbosity`] runs).
+///
+/// The decode names every level rather than testing for `Quiet` and defaulting,
+/// so the next one to be added is visible here instead of quietly demoting to
+/// `Normal`. Rust cannot check a `u8` match against the enum, so the guarantee
+/// is a test: `every_level_round_trips_through_the_stored_byte` walks a
+/// wildcard-free `match` over [`Verbosity`] — a new level does not compile
+/// until it joins that walk, and then fails the round trip until it is listed
+/// below. The trailing arm is unreachable ([`set_verbosity`] is the only
+/// writer) and resolves to `Normal`, the setting that hides nothing.
+pub fn verbosity() -> Verbosity {
+    let stored = VERBOSITY.load(std::sync::atomic::Ordering::Relaxed);
+    match stored {
+        v if v == Verbosity::Normal as u8 => Verbosity::Normal,
+        v if v == Verbosity::Quiet as u8 => Verbosity::Quiet,
+        _ => Verbosity::Normal,
+    }
+}
+
+/// The walk that holds [`verbosity`]'s decode to this enum.
+///
+/// Wildcard-free on purpose, the same discipline as the [`Samples`] walks: a
+/// level added without a line here does not compile.
+#[cfg(test)]
+impl Verbosity {
+    fn next_level(self) -> Option<Self> {
+        match self {
+            Verbosity::Normal => Some(Verbosity::Quiet),
+            Verbosity::Quiet => None,
+        }
+    }
+}
+
+/// Whether [`Terminal::info`] writes anything to stdout.
+///
+/// The decision is a pure function of the global so it can be tested without
+/// capturing stdout — the test that matters is *what the sink decides*, not
+/// what a captured pipe received.
+fn info_enabled() -> bool {
+    verbosity() == Verbosity::Normal
+}
+
+// ---------------------------------------------------------------------------
 // Sinks
 // ---------------------------------------------------------------------------
 
@@ -228,13 +308,19 @@ fn trace(msg: &dyn Message) {
 pub struct Terminal;
 
 impl Terminal {
-    /// Informational message to stdout.
+    /// Informational message to stdout — the half [`Verbosity::Quiet`]
+    /// silences. The machine rendering is emitted either way.
     pub fn info(&self, msg: &dyn Message) {
         trace(msg);
-        println!("{}", msg.localized());
+        if info_enabled() {
+            println!("{}", msg.localized());
+        }
     }
 
     /// Warning/error message to stderr (the process continues).
+    ///
+    /// Never suppressed: `--quiet` is about informational chatter, and a
+    /// program that hid the reason it failed would be a worse one.
     pub fn error(&self, msg: &dyn Message) {
         trace(msg);
         eprintln!("{}", msg.localized());
@@ -400,6 +486,55 @@ mod tests {
             "PAM service file absent: /etc/pam.d/omarchy-lock-face. Nothing to remove."
         );
     }
+
+    /// `--quiet` gates informational stdout and nothing else.
+    ///
+    /// Asserted on `info_enabled` rather than on captured stdout: the sink's
+    /// decision is the contract, and a capture test would prove the same thing
+    /// while making every future sink change a plumbing exercise. What the
+    /// other three sinks do is structural — `error`, `confirm` and
+    /// `confirm_default_yes` never call `info_enabled`, so there is no state
+    /// in which they could go quiet.
+    #[test]
+    fn quiet_suppresses_info_only() {
+        let _guard = VERBOSITY_MUTATION.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(verbosity(), Verbosity::Normal, "default must be Normal");
+        assert!(info_enabled());
+
+        set_verbosity(Verbosity::Quiet);
+        assert_eq!(verbosity(), Verbosity::Quiet);
+        assert!(!info_enabled(), "Quiet must silence Terminal::info");
+
+        set_verbosity(Verbosity::Normal);
+        assert!(info_enabled(), "Normal must restore informational output");
+    }
+
+    /// Every level survives the `u8` the global stores it in.
+    ///
+    /// This is what makes `verbosity`'s `u8` match honest. The walk is
+    /// wildcard-free, so a new level cannot compile without joining it; once
+    /// it has, this fails until `verbosity` decodes it too. Without the pair,
+    /// an unlisted level would read back as `Normal` and silently un-quiet
+    /// the program.
+    #[test]
+    fn every_level_round_trips_through_the_stored_byte() {
+        let _guard = VERBOSITY_MUTATION.lock().unwrap_or_else(|e| e.into_inner());
+        let mut level = Some(Verbosity::Normal);
+        while let Some(current) = level {
+            set_verbosity(current);
+            assert_eq!(
+                verbosity(),
+                current,
+                "{current:?} must survive the u8 round trip"
+            );
+            level = current.next_level();
+        }
+        set_verbosity(Verbosity::Normal);
+    }
+
+    /// Held by every test that writes the process-global verbosity, so two of
+    /// them cannot interleave their mutate/restore sequences.
+    static VERBOSITY_MUTATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// The answer hint is appended by the sink and the question alone is the
     /// msgid, so a translator cannot advertise an answer `read_answer` will

--- a/crates/facelock-cli/src/message/setup.rs
+++ b/crates/facelock-cli/src/message/setup.rs
@@ -16,7 +16,9 @@ use super::{Message, fill, translate};
 #[derive(Debug, Clone, PartialEq)]
 pub enum SetupMessage {
     // -- wizard spine --
-    SetupIntro { version: String },
+    SetupIntro {
+        version: String,
+    },
     SetupStepCamera,
     SetupStepModelQuality,
     SetupStepInferenceDevice,
@@ -31,16 +33,39 @@ pub enum SetupMessage {
     SetupCompleteHeader,
 
     // -- step-level failures (error + retry hint, one event) --
-    CameraStepFailed { error: String, current: String },
-    ModelQualityStepFailed { error: String, current: String },
-    InferenceStepFailed { error: String, current: String },
-    ModelDownloadStepFailed { error: String },
-    EncryptionStepFailed { error: String },
-    EnrollStepFailed { error: String },
-    TestStepFailed { error: String },
-    SystemdStepFailed { error: String },
-    GroupStepFailed { error: String },
-    PamStepFailed { error: String },
+    CameraStepFailed {
+        error: String,
+        current: String,
+    },
+    ModelQualityStepFailed {
+        error: String,
+        current: String,
+    },
+    InferenceStepFailed {
+        error: String,
+        current: String,
+    },
+    ModelDownloadStepFailed {
+        error: String,
+    },
+    EncryptionStepFailed {
+        error: String,
+    },
+    EnrollStepFailed {
+        error: String,
+    },
+    TestStepFailed {
+        error: String,
+    },
+    SystemdStepFailed {
+        error: String,
+    },
+    GroupStepFailed {
+        error: String,
+    },
+    PamStepFailed {
+        error: String,
+    },
 
     // -- enrollment and test steps --
     ConfirmEnrollNow,
@@ -49,17 +74,32 @@ pub enum SetupMessage {
     TestSkipped,
 
     // -- closing summary --
-    SummaryCamera { value: String },
-    SummaryModels { dir: String, quality: String },
-    SummaryInference { value: String },
-    SummaryDatabase { value: String },
-    SummaryEncryption { value: String },
-    SummaryDaemon { status: String },
+    SummaryCamera {
+        value: String,
+    },
+    SummaryModels {
+        dir: String,
+        quality: String,
+    },
+    SummaryInference {
+        value: String,
+    },
+    SummaryDatabase {
+        value: String,
+    },
+    SummaryEncryption {
+        value: String,
+    },
+    SummaryDaemon {
+        status: String,
+    },
     DaemonStatusNotConfiguredNoSystemd,
     DaemonStatusDeferred,
     DaemonStatusEnabled,
     DaemonStatusNotConfigured,
-    SummaryPam { services: String },
+    SummaryPam {
+        services: String,
+    },
     SummaryPamSkipped,
     SummaryPamNone,
     SummaryFaceEnrolled,
@@ -68,9 +108,78 @@ pub enum SetupMessage {
 
     // -- non-interactive --
     NonInteractivePreparing,
-    CheckingModels { count: usize },
+    CheckingModels {
+        count: usize,
+    },
     SetupCompleteShort,
     SetupCompleteEnroll,
+
+    // -- bootstrap --
+    DirectoriesCreated,
+    CreatedDefaultConfig {
+        path: String,
+    },
+    EnrollingFace,
+
+    // -- embedding encryption (step 5, and the non-interactive auto policy) --
+    EncryptionIntro,
+    TpmDetected,
+    TpmSealedKeyPresent {
+        path: String,
+    },
+    GeneratingTpmSealedKey,
+    TpmSealedKeyWritten {
+        path: String,
+    },
+    EncryptionEnabledTpm,
+    KeyfilePresent {
+        path: String,
+    },
+    GeneratingKeyfile,
+    KeyfileWritten {
+        path: String,
+    },
+    EncryptionEnabledKeyfile,
+
+    /// The plaintext-storage warning. It reaches [`super::Terminal::info`],
+    /// so `--quiet` suppresses it — chosen knowingly: this text has always
+    /// gone to stdout, and moving it to `error` to make it unsuppressible
+    /// would relocate it to stderr and break the byte-identity pin. Nothing
+    /// is gated on it either way; `--encryption=none` is an explicit request,
+    /// and `enroll` still refuses to write plaintext embeddings unless
+    /// `security.allow_plaintext` is set. Do not "fix" this into `error`.
+    EncryptionDisabledWarning,
+    EncryptionAlreadyConfigured {
+        method: String,
+    },
+    GeneratedTpmKeyAt {
+        path: String,
+    },
+    EncryptionEnabledTpmAuto,
+    GeneratedKeyfileAt {
+        path: String,
+    },
+    EncryptionEnabledKeyfileAuto,
+    OrphanModelsWarning {
+        db_path: String,
+    },
+    OrphanModelsRemoved {
+        count: u32,
+    },
+
+    // -- hyprlock handoff --
+    HyprlockHint,
+    HyprlockApplied {
+        user: String,
+    },
+
+    /// A spacer between blocks, and the one variant that says nothing.
+    ///
+    /// It goes through the sink rather than staying a bare `println!()` so
+    /// that `--quiet` silences the spacing along with the block it spaces —
+    /// a quiet run that still emitted blank lines would be a stray newline
+    /// on an otherwise empty stdout.
+    BlankLine,
 }
 
 impl Message for SetupMessage {
@@ -209,6 +318,76 @@ impl Message for SetupMessage {
             SetupCompleteEnroll => {
                 translate("\nSetup complete. Run `facelock enroll` to register your face.")
             }
+            DirectoriesCreated => translate("  Directories created."),
+            CreatedDefaultConfig { path } => fill(
+                translate("  Created default config at {path}"),
+                &[("path", path.clone())],
+            ),
+            EnrollingFace => translate("\nEnrolling face..."),
+            EncryptionIntro => {
+                translate("  Setting up AES-256-GCM encryption for face embeddings.")
+            }
+            TpmDetected => translate("  TPM 2.0 detected and functional."),
+            TpmSealedKeyPresent { path } => fill(
+                translate("  TPM-sealed key already exists at {path}."),
+                &[("path", path.clone())],
+            ),
+            GeneratingTpmSealedKey => translate("  Generating and sealing AES key with TPM..."),
+            TpmSealedKeyWritten { path } => fill(
+                translate("  TPM-sealed key written to {path} (permissions: 0600)."),
+                &[("path", path.clone())],
+            ),
+            EncryptionEnabledTpm => translate("  Encryption enabled (TPM-sealed key)."),
+            KeyfilePresent { path } => fill(
+                translate("  Encryption key already exists at {path}."),
+                &[("path", path.clone())],
+            ),
+            GeneratingKeyfile => translate("  Generating encryption key..."),
+            KeyfileWritten { path } => fill(
+                translate("  Key written to {path} (permissions: 0600)."),
+                &[("path", path.clone())],
+            ),
+            EncryptionEnabledKeyfile => translate("  Encryption enabled."),
+            EncryptionDisabledWarning => translate(
+                "  ⚠ WARNING: encryption disabled (--encryption=none).\n    Biometric templates will be stored UNENCRYPTED in the database.\n    `facelock enroll` refuses to write plaintext embeddings unless\n    security.allow_plaintext is also set in the config.",
+            ),
+            EncryptionAlreadyConfigured { method } => fill(
+                translate("  Encryption already configured ({method})."),
+                &[("method", method.clone())],
+            ),
+            GeneratedTpmKeyAt { path } => fill(
+                translate("  [ok] Generated TPM-sealed encryption key at {path}"),
+                &[("path", path.clone())],
+            ),
+            EncryptionEnabledTpmAuto => {
+                translate("  [ok] AES-256-GCM encryption enabled (TPM-sealed key).")
+            }
+            GeneratedKeyfileAt { path } => fill(
+                translate("  [ok] Generated encryption key at {path}"),
+                &[("path", path.clone())],
+            ),
+            EncryptionEnabledKeyfileAuto => translate("  [ok] AES-256-GCM encryption enabled."),
+            OrphanModelsWarning { db_path } => fill(
+                translate(
+                    "\n  WARNING: encrypted face models already exist in {db_path} but the\n  encryption key is missing. Generating a new key would make them unreadable.\n",
+                ),
+                &[("db_path", db_path.clone())],
+            ),
+            OrphanModelsRemoved { count } => fill(
+                translate("  Removed {count} orphaned model(s)."),
+                &[("count", count.to_string())],
+            ),
+            HyprlockHint => translate(
+                "\n==> To finish hyprlock integration, run as your normal user:\n==>     facelock hyprlock enable",
+            ),
+            HyprlockApplied { user } => fill(
+                translate("  hyprlock integration applied for {user}."),
+                &[("user", user.clone())],
+            ),
+            // Never `translate("")`: gettext answers an empty msgid with the
+            // catalog's own metadata header, so an "empty" translation would
+            // print the .mo file's Content-Type block.
+            BlankLine => String::new(),
         }
     }
 }
@@ -288,7 +467,188 @@ impl super::Samples for SetupMessage {
             NonInteractivePreparing => CheckingModels { count: 2 },
             CheckingModels { .. } => SetupCompleteShort,
             SetupCompleteShort => SetupCompleteEnroll,
-            SetupCompleteEnroll => return None,
+            SetupCompleteEnroll => DirectoriesCreated,
+            DirectoriesCreated => CreatedDefaultConfig { path: s("/c") },
+            CreatedDefaultConfig { .. } => EnrollingFace,
+            EnrollingFace => EncryptionIntro,
+            EncryptionIntro => TpmDetected,
+            TpmDetected => TpmSealedKeyPresent { path: s("/k") },
+            TpmSealedKeyPresent { .. } => GeneratingTpmSealedKey,
+            GeneratingTpmSealedKey => TpmSealedKeyWritten { path: s("/k") },
+            TpmSealedKeyWritten { .. } => EncryptionEnabledTpm,
+            EncryptionEnabledTpm => KeyfilePresent { path: s("/k") },
+            KeyfilePresent { .. } => GeneratingKeyfile,
+            GeneratingKeyfile => KeyfileWritten { path: s("/k") },
+            KeyfileWritten { .. } => EncryptionEnabledKeyfile,
+            EncryptionEnabledKeyfile => EncryptionDisabledWarning,
+            EncryptionDisabledWarning => EncryptionAlreadyConfigured { method: s("Tpm") },
+            EncryptionAlreadyConfigured { .. } => GeneratedTpmKeyAt { path: s("/k") },
+            GeneratedTpmKeyAt { .. } => EncryptionEnabledTpmAuto,
+            EncryptionEnabledTpmAuto => GeneratedKeyfileAt { path: s("/k") },
+            GeneratedKeyfileAt { .. } => EncryptionEnabledKeyfileAuto,
+            EncryptionEnabledKeyfileAuto => OrphanModelsWarning { db_path: s("/db") },
+            OrphanModelsWarning { .. } => OrphanModelsRemoved { count: 2 },
+            OrphanModelsRemoved { .. } => HyprlockHint,
+            HyprlockHint => HyprlockApplied { user: s("u") },
+            HyprlockApplied { .. } => BlankLine,
+            BlankLine => return None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every string this domain took over from a `println!` in
+    /// `commands/setup.rs`, pinned to the bytes that call site printed.
+    ///
+    /// The pins are the contract, not a snapshot: a failing assertion means
+    /// the *string* changed, and the fix is to restore the string. Editing
+    /// the expectation to match new output inverts the test — a wording
+    /// change is a separate decision with its own review, because container
+    /// suites and downstream integrations grep this output.
+    #[test]
+    fn english_fallback_is_byte_identical() {
+        use SetupMessage::*;
+
+        // -- bootstrap --
+        assert_eq!(DirectoriesCreated.localized(), "  Directories created.");
+        assert_eq!(
+            CreatedDefaultConfig {
+                path: "/etc/facelock/config.toml".into()
+            }
+            .localized(),
+            "  Created default config at /etc/facelock/config.toml"
+        );
+        assert_eq!(EnrollingFace.localized(), "\nEnrolling face...");
+
+        // -- encryption, interactive --
+        assert_eq!(
+            EncryptionIntro.localized(),
+            "  Setting up AES-256-GCM encryption for face embeddings."
+        );
+        assert_eq!(
+            TpmDetected.localized(),
+            "  TPM 2.0 detected and functional."
+        );
+        assert_eq!(
+            TpmSealedKeyPresent {
+                path: "/etc/facelock/sealed.key".into()
+            }
+            .localized(),
+            "  TPM-sealed key already exists at /etc/facelock/sealed.key."
+        );
+        assert_eq!(
+            GeneratingTpmSealedKey.localized(),
+            "  Generating and sealing AES key with TPM..."
+        );
+        assert_eq!(
+            TpmSealedKeyWritten {
+                path: "/etc/facelock/sealed.key".into()
+            }
+            .localized(),
+            "  TPM-sealed key written to /etc/facelock/sealed.key (permissions: 0600)."
+        );
+        assert_eq!(
+            EncryptionEnabledTpm.localized(),
+            "  Encryption enabled (TPM-sealed key)."
+        );
+        assert_eq!(
+            KeyfilePresent {
+                path: "/etc/facelock/facelock.key".into()
+            }
+            .localized(),
+            "  Encryption key already exists at /etc/facelock/facelock.key."
+        );
+        assert_eq!(
+            GeneratingKeyfile.localized(),
+            "  Generating encryption key..."
+        );
+        assert_eq!(
+            KeyfileWritten {
+                path: "/etc/facelock/facelock.key".into()
+            }
+            .localized(),
+            "  Key written to /etc/facelock/facelock.key (permissions: 0600)."
+        );
+        assert_eq!(
+            EncryptionEnabledKeyfile.localized(),
+            "  Encryption enabled."
+        );
+        assert_eq!(
+            EncryptionDisabledWarning.localized(),
+            "  \u{26a0} WARNING: encryption disabled (--encryption=none).\n    Biometric templates will be stored UNENCRYPTED in the database.\n    `facelock enroll` refuses to write plaintext embeddings unless\n    security.allow_plaintext is also set in the config."
+        );
+
+        // -- encryption, the non-interactive auto policy --
+        assert_eq!(
+            EncryptionAlreadyConfigured {
+                method: "Tpm".into()
+            }
+            .localized(),
+            "  Encryption already configured (Tpm)."
+        );
+        assert_eq!(
+            GeneratedTpmKeyAt {
+                path: "/etc/facelock/sealed.key".into()
+            }
+            .localized(),
+            "  [ok] Generated TPM-sealed encryption key at /etc/facelock/sealed.key"
+        );
+        assert_eq!(
+            EncryptionEnabledTpmAuto.localized(),
+            "  [ok] AES-256-GCM encryption enabled (TPM-sealed key)."
+        );
+        assert_eq!(
+            GeneratedKeyfileAt {
+                path: "/etc/facelock/facelock.key".into()
+            }
+            .localized(),
+            "  [ok] Generated encryption key at /etc/facelock/facelock.key"
+        );
+        assert_eq!(
+            EncryptionEnabledKeyfileAuto.localized(),
+            "  [ok] AES-256-GCM encryption enabled."
+        );
+
+        // -- the orphaned-template guard --
+        assert_eq!(
+            OrphanModelsWarning {
+                db_path: "/var/lib/facelock/facelock.db".into()
+            }
+            .localized(),
+            "\n  WARNING: encrypted face models already exist in /var/lib/facelock/facelock.db but the\n  encryption key is missing. Generating a new key would make them unreadable.\n"
+        );
+        assert_eq!(
+            OrphanModelsRemoved { count: 3 }.localized(),
+            "  Removed 3 orphaned model(s)."
+        );
+
+        // -- hyprlock handoff --
+        assert_eq!(
+            HyprlockHint.localized(),
+            "\n==> To finish hyprlock integration, run as your normal user:\n==>     facelock hyprlock enable"
+        );
+        assert_eq!(
+            HyprlockApplied {
+                user: "alice".into()
+            }
+            .localized(),
+            "  hyprlock integration applied for alice."
+        );
+    }
+
+    /// The spacer renders as nothing, so the sink's trailing newline is the
+    /// whole line — the bytes `println!()` produced.
+    ///
+    /// It must never reach gettext: `dgettext` answers an empty msgid with
+    /// the catalog's metadata header, so a translated build would print the
+    /// `.mo` file's `Content-Type` block where a blank line belongs. Under a
+    /// real catalog this test would fail if the arm ever grew a
+    /// `translate("")`, because the C locale used here returns the msgid.
+    #[test]
+    fn blank_line_is_empty_and_never_translated() {
+        assert_eq!(SetupMessage::BlankLine.localized(), "");
     }
 }

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -24,6 +24,16 @@ pub enum SystemMessage {
     ConfirmAddToGroup { user: String },
     GroupAddSkipped { user: String },
     AddedToGroup { user: String },
+
+    // -- installing and removing the unit files --
+    DisablingSystemdUnits,
+    SystemdUnitsDisabled,
+    InstallingSystemdUnits,
+    WroteFile { path: String },
+    RefreshedLegacyFile { path: String },
+    SystemctlDaemonReloadDone,
+    SystemctlEnableDone { unit: String },
+    DbusActivationEnabled,
 }
 
 impl Message for SystemMessage {
@@ -67,6 +77,24 @@ impl Message for SystemMessage {
                 ),
                 &[("user", user.clone())],
             ),
+            DisablingSystemdUnits => translate("Disabling facelock-daemon systemd units..."),
+            SystemdUnitsDisabled => translate("facelock-daemon service disabled and stopped."),
+            InstallingSystemdUnits => {
+                translate("Installing facelock-daemon systemd and D-Bus units...")
+            }
+            WroteFile { path } => fill(translate("  Wrote {path}"), &[("path", path.clone())]),
+            RefreshedLegacyFile { path } => fill(
+                translate("  Refreshed legacy {path}"),
+                &[("path", path.clone())],
+            ),
+            SystemctlDaemonReloadDone => translate("  systemctl daemon-reload done."),
+            SystemctlEnableDone { unit } => fill(
+                translate("  systemctl enable {unit} done."),
+                &[("unit", unit.clone())],
+            ),
+            DbusActivationEnabled => {
+                translate("\nfacelock-daemon D-Bus activation is now enabled.")
+            }
         }
     }
 }
@@ -96,7 +124,72 @@ impl super::Samples for SystemMessage {
             AlreadyInGroup { .. } => ConfirmAddToGroup { user: s("u") },
             ConfirmAddToGroup { .. } => GroupAddSkipped { user: s("u") },
             GroupAddSkipped { .. } => AddedToGroup { user: s("u") },
-            AddedToGroup { .. } => return None,
+            AddedToGroup { .. } => DisablingSystemdUnits,
+            DisablingSystemdUnits => SystemdUnitsDisabled,
+            SystemdUnitsDisabled => InstallingSystemdUnits,
+            InstallingSystemdUnits => WroteFile { path: s("/p") },
+            WroteFile { .. } => RefreshedLegacyFile { path: s("/p") },
+            RefreshedLegacyFile { .. } => SystemctlDaemonReloadDone,
+            SystemctlDaemonReloadDone => SystemctlEnableDone {
+                unit: s("u.service"),
+            },
+            SystemctlEnableDone { .. } => DbusActivationEnabled,
+            DbusActivationEnabled => return None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The unit-install narration, pinned to the bytes `run_systemd`
+    /// printed. `facelock setup --systemd` is a scripted entry point
+    /// (packaging, Omarchy), so these lines are read by more than humans.
+    #[test]
+    fn english_fallback_is_byte_identical() {
+        use SystemMessage::*;
+
+        assert_eq!(
+            DisablingSystemdUnits.localized(),
+            "Disabling facelock-daemon systemd units..."
+        );
+        assert_eq!(
+            SystemdUnitsDisabled.localized(),
+            "facelock-daemon service disabled and stopped."
+        );
+        assert_eq!(
+            InstallingSystemdUnits.localized(),
+            "Installing facelock-daemon systemd and D-Bus units..."
+        );
+        assert_eq!(
+            WroteFile {
+                path: "/etc/systemd/system/facelock-daemon.service".into()
+            }
+            .localized(),
+            "  Wrote /etc/systemd/system/facelock-daemon.service"
+        );
+        assert_eq!(
+            RefreshedLegacyFile {
+                path: "/usr/lib/systemd/system/facelock-daemon.service".into()
+            }
+            .localized(),
+            "  Refreshed legacy /usr/lib/systemd/system/facelock-daemon.service"
+        );
+        assert_eq!(
+            SystemctlDaemonReloadDone.localized(),
+            "  systemctl daemon-reload done."
+        );
+        assert_eq!(
+            SystemctlEnableDone {
+                unit: "facelock-daemon.service".into()
+            }
+            .localized(),
+            "  systemctl enable facelock-daemon.service done."
+        );
+        assert_eq!(
+            DbusActivationEnabled.localized(),
+            "\nfacelock-daemon D-Bus activation is now enabled."
+        );
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,11 +4,18 @@ All commands are subcommands of the `facelock` binary.
 
 ## Global flags
 
-The following flag is accepted by every subcommand (declared `global = true`):
+The following flags are accepted by every subcommand (declared `global = true`):
 
 | Flag | Description |
 |------|-------------|
-| `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
+| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
+| `-q`, `--quiet` | Suppress informational output on stdout. Errors (stderr), prompts and exit codes are unaffected. |
+
+`--quiet` is complete for `facelock setup` except the PAM extension hint, which
+[#174](https://github.com/tyvsmith/facelock/issues/174) converts along with the
+rest of that region. Other commands still print some output directly rather than
+through the message seam the flag gates, so they stay partly noisy until
+[#140](https://github.com/tyvsmith/facelock/issues/140) is finished.
 
 ## facelock setup
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -91,6 +91,15 @@ JSON (#149).
 An unparseable `RUST_LOG` is reported at WARN (on stderr) and the built-in
 filter is used, rather than the value being silently discarded.
 
+**`--quiet` suppresses informational stdout only; errors and exit codes are
+unchanged.** A quiet run that fails still says why on stderr and still exits
+non-zero, and prompts are unaffected — a silenced question is a hang, not a
+quieter program. This generalizes `is-enrolled --quiet`, which has always meant
+"leave only the exit code". The flag is read once at the message sink
+(`message::set_verbosity`), so it covers every command whose output goes
+through that seam; commands still printing directly are tracked by
+[#140](https://github.com/tyvsmith/facelock/issues/140).
+
 ### facelock setup Flag Composition
 
 Flags **compose**; they are not mutually exclusive. The rule:

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 17:26-0700\n"
+"POT-Creation-Date: 2026-08-17 12:31-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,106 +72,157 @@ msgid ""
 "Falling back to text-only mode. Start the facelock-daemon service to use it.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:38
+#: crates/facelock-cli/src/message/device.rs:51
 msgid ""
 "  No video devices found.\n"
 "  Check that your camera is connected and the v4l2 module is loaded."
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:41
+#: crates/facelock-cli/src/message/device.rs:54
 #, python-brace-format
 msgid "  Auto-selected IR camera: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:45
+#: crates/facelock-cli/src/message/device.rs:58
 #, python-brace-format
 msgid "  Auto-selected IR camera: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:49
+#: crates/facelock-cli/src/message/device.rs:62
 #, python-brace-format
 msgid "  Selected: {path} ({name})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:53
+#: crates/facelock-cli/src/message/device.rs:66
 #, python-brace-format
 msgid "  Selected: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:56
+#: crates/facelock-cli/src/message/device.rs:69
 msgid "Select camera device"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:58
+#: crates/facelock-cli/src/message/device.rs:71
 msgid "--camera=auto found no video devices; check that the camera is connected and the v4l2 module is loaded"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:62
+#: crates/facelock-cli/src/message/device.rs:75
 msgid ""
 "--camera=auto found no IR-capable camera among the detected devices:\n"
 "{listed}\n"
 "  Pass an explicit device path, e.g. --camera={example}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:68
+#: crates/facelock-cli/src/message/device.rs:81
 msgid ""
 "--camera=auto found {count} IR-capable cameras:\n"
 "{listed}\n"
 "  Pass an explicit device path to choose one."
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:74
+#: crates/facelock-cli/src/message/device.rs:87
 #, python-brace-format
 msgid "camera device {path} does not exist; pass a valid /dev/video* path or --camera=auto"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:78
+#: crates/facelock-cli/src/message/device.rs:91
 msgid "Select model quality"
 msgstr ""
 
-#: crates/facelock-cli/src/message/device.rs:79
+#: crates/facelock-cli/src/message/device.rs:92
 msgid "Select inference device"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:42
+#: crates/facelock-cli/src/message/device.rs:94
+msgid "  Selected standard models (fast, good accuracy)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:97
+msgid "  Selected balanced models (fast detection, high-accuracy embedding)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:100
+msgid "  Selected high-accuracy models (larger, ~40-50ms slower)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:103
+#, python-brace-format
+msgid "  Detected: {detail}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:108
+msgid ""
+"  ⚠ Could not query the ONNX Runtime for available providers: {error}\n"
+"    Selecting cpu. Re-run with an explicit --execution-provider once the\n"
+"    runtime is installed if you need GPU inference."
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:113
+msgid ""
+"  ⚠ NVIDIA driver not detected. Install the NVIDIA driver package\n"
+"    before starting the daemon."
+msgstr ""
+
+#: crates/facelock-cli/src/message/device.rs:116
+msgid ""
+"  ⚠ CUDA-enabled ONNX Runtime not found. Install onnxruntime-opt-cuda\n"
+"    before starting the daemon, or inference will fall back to CPU."
+msgstr ""
+
+#: crates/facelock-cli/src/message/download.rs:55
 #, python-brace-format
 msgid "  [ok] {name} ({purpose})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:45
+#: crates/facelock-cli/src/message/download.rs:58
 msgid "  All models are already present and verified."
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:46
+#: crates/facelock-cli/src/message/download.rs:59
 msgid "  Models to download:"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:52
+#: crates/facelock-cli/src/message/download.rs:65
 #, python-brace-format
 msgid "    - {name} (~{size_mb}MB) - {purpose}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:60
+#: crates/facelock-cli/src/message/download.rs:73
 #, python-brace-format
 msgid "  Total download size: ~{mb}MB"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:63
+#: crates/facelock-cli/src/message/download.rs:76
 msgid "Download required models?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:64
+#: crates/facelock-cli/src/message/download.rs:77
 msgid "  Skipping model download."
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:66
+#: crates/facelock-cli/src/message/download.rs:79
 #, python-brace-format
 msgid "  Downloading {name}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/download.rs:70
+#: crates/facelock-cli/src/message/download.rs:83
 #, python-brace-format
 msgid "  [ok] {name} downloaded and verified"
+msgstr ""
+
+#: crates/facelock-cli/src/message/download.rs:91
+#, python-brace-format
+msgid "  [download] {name} (~{size_mb}MB) - {purpose}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/download.rs:99
+#, python-brace-format
+msgid "  [redownload] {name} - checksum mismatch, re-downloading"
+msgstr ""
+
+#: crates/facelock-cli/src/message/download.rs:103
+#, python-brace-format
+msgid "  [ok] {name} re-downloaded and verified"
 msgstr ""
 
 #: crates/facelock-cli/src/message/face.rs:109
@@ -466,7 +517,7 @@ msgid ""
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:82
+#: crates/facelock-cli/src/message/setup.rs:191
 msgid ""
 "\n"
 "  Facelock v{version}\n"
@@ -481,245 +532,359 @@ msgid ""
 "    - Daemon and PAM configuration\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:86
+#: crates/facelock-cli/src/message/setup.rs:195
 msgid ""
 "\n"
 "--- Step 1: Camera Selection ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:87
+#: crates/facelock-cli/src/message/setup.rs:196
 msgid ""
 "\n"
 "--- Step 2: Model Quality ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:88
+#: crates/facelock-cli/src/message/setup.rs:197
 msgid ""
 "\n"
 "--- Step 3: Inference Device ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:89
+#: crates/facelock-cli/src/message/setup.rs:198
 msgid ""
 "\n"
 "--- Step 4: Model Download ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:90
+#: crates/facelock-cli/src/message/setup.rs:199
 msgid ""
 "\n"
 "--- Step 5: Embedding Encryption ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:91
+#: crates/facelock-cli/src/message/setup.rs:200
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:93
+#: crates/facelock-cli/src/message/setup.rs:202
 msgid ""
 "\n"
 "--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:95
+#: crates/facelock-cli/src/message/setup.rs:204
 msgid ""
 "\n"
 "--- Step 7: Test Recognition ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:97
+#: crates/facelock-cli/src/message/setup.rs:206
 msgid ""
 "\n"
 "--- Step 7: Test Recognition (skipped, no face enrolled) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:99
+#: crates/facelock-cli/src/message/setup.rs:208
 msgid ""
 "\n"
 "--- Step 8: Daemon Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:100
+#: crates/facelock-cli/src/message/setup.rs:209
 msgid ""
 "\n"
 "--- Step 9: PAM Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:101
+#: crates/facelock-cli/src/message/setup.rs:210
 msgid ""
 "\n"
 "--- Setup Complete ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:104
+#: crates/facelock-cli/src/message/setup.rs:213
 msgid ""
 "  Camera detection failed: {error}\n"
 "  You can configure the camera later in the config file.\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:110
+#: crates/facelock-cli/src/message/setup.rs:219
 msgid ""
 "  Model quality selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:116
+#: crates/facelock-cli/src/message/setup.rs:225
 msgid ""
 "  Inference device selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:122
+#: crates/facelock-cli/src/message/setup.rs:231
 msgid ""
 "  Model download failed: {error}\n"
 "  You can retry later with: sudo facelock setup --non-interactive"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:128
+#: crates/facelock-cli/src/message/setup.rs:237
 msgid ""
 "  Encryption setup failed: {error}\n"
 "  You can configure encryption later with: sudo facelock encrypt --generate-key"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:134
+#: crates/facelock-cli/src/message/setup.rs:243
 msgid ""
 "  Enrollment failed: {error}\n"
 "  You can enroll later with: facelock enroll"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:139
+#: crates/facelock-cli/src/message/setup.rs:248
 msgid ""
 "  Test failed: {error}\n"
 "  You can test later with: facelock test"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:144
+#: crates/facelock-cli/src/message/setup.rs:253
 msgid ""
 "  Systemd setup failed: {error}\n"
 "  You can enable it later with: sudo facelock setup --systemd"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:150
+#: crates/facelock-cli/src/message/setup.rs:259
 msgid ""
 "  Group setup failed: {error}\n"
 "  Add manually: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:156
+#: crates/facelock-cli/src/message/setup.rs:265
 msgid ""
 "  PAM setup failed: {error}\n"
 "  You can configure PAM later with: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:160
+#: crates/facelock-cli/src/message/setup.rs:269
 msgid "Would you like to enroll a face now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:161
+#: crates/facelock-cli/src/message/setup.rs:270
 msgid "  Skipping face enrollment."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:162
+#: crates/facelock-cli/src/message/setup.rs:271
 msgid "Would you like to test recognition?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:163
+#: crates/facelock-cli/src/message/setup.rs:272
 msgid "  Skipping recognition test."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:165
+#: crates/facelock-cli/src/message/setup.rs:274
 #, python-brace-format
 msgid "  Camera:     {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:169
+#: crates/facelock-cli/src/message/setup.rs:278
 #, python-brace-format
 msgid "  Models:     {dir} ({quality})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:173
+#: crates/facelock-cli/src/message/setup.rs:282
 #, python-brace-format
 msgid "  Inference:  {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:177
+#: crates/facelock-cli/src/message/setup.rs:286
 #, python-brace-format
 msgid "  Database:   {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:181
+#: crates/facelock-cli/src/message/setup.rs:290
 #, python-brace-format
 msgid "  Encryption: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:185
+#: crates/facelock-cli/src/message/setup.rs:294
 #, python-brace-format
 msgid "  Daemon:   {status}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:188
+#: crates/facelock-cli/src/message/setup.rs:297
 msgid "not configured (--no-systemd)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:189
+#: crates/facelock-cli/src/message/setup.rs:298
 msgid "configured from the command line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:190
+#: crates/facelock-cli/src/message/setup.rs:299
 msgid "enabled (D-Bus activation)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:191
+#: crates/facelock-cli/src/message/setup.rs:300
 msgid "not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:193
+#: crates/facelock-cli/src/message/setup.rs:302
 #, python-brace-format
 msgid "  PAM:      {services}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:196
+#: crates/facelock-cli/src/message/setup.rs:305
 msgid "  PAM:      not configured (--no-pam)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:197
+#: crates/facelock-cli/src/message/setup.rs:306
 msgid "  PAM:      not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:198
+#: crates/facelock-cli/src/message/setup.rs:307
 msgid "  Face:     enrolled"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:200
+#: crates/facelock-cli/src/message/setup.rs:309
 msgid "  Face:     not enrolled (--no-enroll; run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:202
+#: crates/facelock-cli/src/message/setup.rs:311
 msgid "  Face:     not enrolled (run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:203
+#: crates/facelock-cli/src/message/setup.rs:312
 msgid "facelock setup: preparing system...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:205
+#: crates/facelock-cli/src/message/setup.rs:314
 #, python-brace-format
 msgid "Checking {count} model(s)...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:208
+#: crates/facelock-cli/src/message/setup.rs:317
 msgid ""
 "\n"
 "Setup complete."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:210
+#: crates/facelock-cli/src/message/setup.rs:319
 msgid ""
 "\n"
 "Setup complete. Run `facelock enroll` to register your face."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:321
+msgid "  Directories created."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:323
+#, python-brace-format
+msgid "  Created default config at {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:326
+msgid ""
+"\n"
+"Enrolling face..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:328
+msgid "  Setting up AES-256-GCM encryption for face embeddings."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:330
+msgid "  TPM 2.0 detected and functional."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:332
+#, python-brace-format
+msgid "  TPM-sealed key already exists at {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:335
+msgid "  Generating and sealing AES key with TPM..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:337
+#, python-brace-format
+msgid "  TPM-sealed key written to {path} (permissions: 0600)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:340
+msgid "  Encryption enabled (TPM-sealed key)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:342
+#, python-brace-format
+msgid "  Encryption key already exists at {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:345
+msgid "  Generating encryption key..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:347
+#, python-brace-format
+msgid "  Key written to {path} (permissions: 0600)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:350
+msgid "  Encryption enabled."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:352
+msgid ""
+"  ⚠ WARNING: encryption disabled (--encryption=none).\n"
+"    Biometric templates will be stored UNENCRYPTED in the database.\n"
+"    `facelock enroll` refuses to write plaintext embeddings unless\n"
+"    security.allow_plaintext is also set in the config."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:355
+#, python-brace-format
+msgid "  Encryption already configured ({method})."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:359
+#, python-brace-format
+msgid "  [ok] Generated TPM-sealed encryption key at {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:363
+msgid "  [ok] AES-256-GCM encryption enabled (TPM-sealed key)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:366
+#, python-brace-format
+msgid "  [ok] Generated encryption key at {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:369
+msgid "  [ok] AES-256-GCM encryption enabled."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:372
+msgid ""
+"\n"
+"  WARNING: encrypted face models already exist in {db_path} but the\n"
+"  encryption key is missing. Generating a new key would make them unreadable.\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:377
+#, python-brace-format
+msgid "  Removed {count} orphaned model(s)."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:381
+msgid ""
+"\n"
+"==> To finish hyprlock integration, run as your normal user:\n"
+"==>     facelock hyprlock enable"
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:384
+#, python-brace-format
+msgid "  hyprlock integration applied for {user}."
 msgstr ""
 
 #: crates/facelock-cli/src/message/status.rs:115
@@ -959,57 +1124,94 @@ msgstr ""
 msgid "not configured for facelock"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:33
+#: crates/facelock-cli/src/message/system.rs:43
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:35
+#: crates/facelock-cli/src/message/system.rs:45
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:38
+#: crates/facelock-cli/src/message/system.rs:48
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:41
+#: crates/facelock-cli/src/message/system.rs:51
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:44
+#: crates/facelock-cli/src/message/system.rs:54
 msgid "  Answered on the command line; applied once setup finishes."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:46
+#: crates/facelock-cli/src/message/system.rs:56
 msgid "  Creating 'facelock' system group..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:48
+#: crates/facelock-cli/src/message/system.rs:58
 msgid ""
 "  Note: running daemon commands (preview/test) as a normal user requires\n"
 "  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:51
+#: crates/facelock-cli/src/message/system.rs:61
 #, python-brace-format
 msgid "  User '{user}' is already in the 'facelock' group."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:56
+#: crates/facelock-cli/src/message/system.rs:66
 #, python-brace-format
 msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:61
+#: crates/facelock-cli/src/message/system.rs:71
 #, python-brace-format
 msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:66
+#: crates/facelock-cli/src/message/system.rs:76
 msgid ""
 "  Added '{user}' to the 'facelock' group.\n"
 "  NOTE: log out and back in for the new group membership to take effect."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:80
+msgid "Disabling facelock-daemon systemd units..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:81
+msgid "facelock-daemon service disabled and stopped."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:83
+msgid "Installing facelock-daemon systemd and D-Bus units..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:85
+#, python-brace-format
+msgid "  Wrote {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:87
+#, python-brace-format
+msgid "  Refreshed legacy {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:90
+msgid "  systemctl daemon-reload done."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:92
+#, python-brace-format
+msgid "  systemctl enable {unit} done."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:96
+msgid ""
+"\n"
+"facelock-daemon D-Bus activation is now enabled."
 msgstr ""


### PR DESCRIPTION
## Summary

- add `message::Verbosity` (`Normal | Quiet`); `Terminal::info` is silent under `Quiet`, `Terminal::error` and prompts never are; the `RUST_LOG` event stream keeps firing
- wire the global `-q/--quiet` from #178 to the sink, once, at the top of `main`
- move `setup.rs`'s raw prints into the message seam: 61 → 4, the 4 being `print_pam_extension_hint`, which #174 moves with the rest of the PAM region
- pin every moved string byte-exact in per-domain `english_fallback_is_byte_identical` tests; multi-line blocks are one variant each
- state in `docs/cli.md` that `--quiet` is complete for `setup` (bar the PAM hint) and partial elsewhere until #140
- regenerate `po/facelock.pot`

## Why

A `--quiet` flag with no verbosity at the sink is a no-op, and a verbosity at the
sink with callers still printing directly is a half-implementation. `setup` is
the command integration scripts drive, so it converts first; the rest of the
conversion stays with #140, one domain per PR. Container suites grep some of
this output, which is why nothing is reworded and every string carries a pin.

## Validation

- `just check`
- moved strings cross-checked against `main`'s `setup.rs` literals in both directions
- `--quiet is-enrolled`, `--quiet devices` (unprivileged: error still on stderr, exit 1), `RUST_LOG=facelock=debug` under `--quiet`
- `msgen po/facelock.pot | msgfmt --check-format`

Stacked on #178.

Closes #168
Refs #140
