### PR TITLE
feat(cli): Add facelock pam add|remove|status, aliasing setup --pam

### DIFF
--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -11,8 +11,9 @@
 //! These types are deliberately bin-private (declared by `main.rs`, absent from
 //! `lib.rs`). Nothing outside the binary consumes clap types.
 
-use clap::Args;
+use clap::{Args, Subcommand};
 
+use facelock_cli::commands::pam::{PamAction, PamRequest};
 use facelock_cli::commands::setup::{
     EncryptionChoice, ExecutionProviderChoice, ModelPreset, SetupArgs,
 };
@@ -72,7 +73,7 @@ pub struct SetupCli {
     // Not a shared `ConfirmArg`: on `setup` the flag means more than it does
     // elsewhere. It skips the per-file "Proceed?" prompt *and* unlocks the
     // gate that otherwise refuses to write into a sensitive PAM service
-    // (`SENSITIVE_SERVICES` in commands/setup.rs). Rendering that as plain
+    // (`SENSITIVE_SERVICES` in commands/pam.rs). Rendering that as plain
     // prompt suppression would understate what the user is authorizing.
     // Spelling still cannot drift: `cli_flag_conformance` pins `-y` and the
     // `no-confirm` alias on every arg named `yes`, wherever it is declared.
@@ -168,6 +169,122 @@ impl From<SetupCli> for SetupArgs {
             models,
             execution_provider,
             encryption,
+        }
+    }
+}
+
+/// The services a `facelock pam` verb acts on.
+///
+/// Repeatable, which is the point: the old `setup --pam --service X` took one
+/// `Option<String>`, so configuring three services meant three processes, three
+/// root checks and no atomicity across them. Empty means `sudo`, preserving
+/// what bare `--pam` has always meant.
+#[derive(Args)]
+pub struct PamServiceArg {
+    /// PAM service to act on; repeat for several (default: sudo)
+    #[arg(long, num_args = 1, action = clap::ArgAction::Append, value_name = "SERVICE")]
+    pub service: Vec<String>,
+}
+
+/// `facelock pam add | remove | status`.
+///
+/// Becomes a [`PamRequest`], the same way [`SetupCli`] becomes a [`SetupArgs`]:
+/// clap types stay in the binary, and the library sees plain data it can also
+/// construct in a test.
+#[derive(Subcommand)]
+pub enum PamCli {
+    /// Add the facelock line to one or more /etc/pam.d service files
+    #[command(after_help = "\
+--yes/--no-confirm only skips the per-file confirmation. Editing the sensitive \
+services system-auth, login or sshd additionally requires --allow-sensitive; \
+neither flag implies the other. Every service is validated before any file is \
+written, so a rejected service leaves the rest untouched.")]
+    Add {
+        #[command(flatten)]
+        service: PamServiceArg,
+        #[command(flatten)]
+        confirm: ConfirmArg,
+        /// Also permit the sensitive services: system-auth, login, sshd
+        #[arg(long)]
+        allow_sensitive: bool,
+        /// Treat a missing service file as success instead of an error
+        #[arg(long = "if-present")]
+        if_present: bool,
+        #[command(flatten)]
+        dry_run: DryRunArg,
+        #[command(flatten)]
+        json: JsonArg,
+    },
+    /// Remove the facelock line from one or more /etc/pam.d service files
+    #[command(after_help = "\
+Removal is never gated by the sensitive-service list and never prompts — it can \
+only take away a way to authenticate, and the .facelock-backup file written by \
+`add` is left in place. --yes/--no-confirm is accepted for symmetry with `add`.")]
+    Remove {
+        #[command(flatten)]
+        service: PamServiceArg,
+        #[command(flatten)]
+        confirm: ConfirmArg,
+        /// Treat a missing service file as success instead of an error
+        #[arg(long = "if-present")]
+        if_present: bool,
+        #[command(flatten)]
+        dry_run: DryRunArg,
+        #[command(flatten)]
+        json: JsonArg,
+    },
+    /// Report whether services carry the facelock line (exit 0 = all do, 1 = one does not, 2 = error)
+    #[command(after_help = "\
+Reads only; needs no root. This is the probe to branch on instead of grepping \
+/etc/pam.d yourself.")]
+    Status {
+        #[command(flatten)]
+        service: PamServiceArg,
+        #[command(flatten)]
+        json: JsonArg,
+    },
+}
+
+impl From<PamCli> for PamRequest {
+    fn from(cli: PamCli) -> Self {
+        match cli {
+            PamCli::Add {
+                service,
+                confirm,
+                allow_sensitive,
+                if_present,
+                dry_run,
+                json,
+            } => PamRequest {
+                action: PamAction::Add,
+                services: service.service,
+                no_confirm: confirm.yes,
+                allow_sensitive,
+                if_present,
+                dry_run: dry_run.dry_run,
+                json: json.json,
+            },
+            PamCli::Remove {
+                service,
+                confirm,
+                if_present,
+                dry_run,
+                json,
+            } => PamRequest {
+                action: PamAction::Remove,
+                services: service.service,
+                no_confirm: confirm.yes,
+                allow_sensitive: false,
+                if_present,
+                dry_run: dry_run.dry_run,
+                json: json.json,
+            },
+            PamCli::Status { service, json } => PamRequest {
+                action: PamAction::Status,
+                services: service.service,
+                json: json.json,
+                ..PamRequest::default()
+            },
         }
     }
 }

--- a/crates/facelock-cli/src/commands/mod.rs
+++ b/crates/facelock-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod enrollment_marker;
 pub mod hyprlock;
 pub mod is_enrolled;
 pub mod list;
+pub mod pam;
 pub mod preview;
 pub mod remove;
 pub mod setup;

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -1,0 +1,1708 @@
+//! `facelock pam add | remove | status` — the `/etc/pam.d` writer.
+//!
+//! This is the most dangerous text the CLI writes: a bad line in
+//! `/etc/pam.d/sudo` costs a `sudo`, a bad line in `/etc/pam.d/system-auth`
+//! costs the machine. The module is built around that.
+//!
+//! # Why a verb
+//!
+//! The writer used to be reachable only as `setup --pam [--service X]
+//! [--remove] [--yes] [--if-present]` — two `requires = "pam"` modifiers
+//! hanging off a flag, which is what a missing verb looks like. Four defects
+//! came out of that shape, and they are one refactor rather than four:
+//!
+//! 1. **Flag-on-flag.** `--service`/`--remove` only meant anything with
+//!    `--pam`, so the action lived in a flag and its object in another flag.
+//! 2. **One service per process.** `--service` was an `Option<String>`, so a
+//!    wrapper wanting three services ran three processes: three root checks,
+//!    three module checks, three previews, three copies of the closing hint —
+//!    and no atomicity, since a failure on the third left the first two
+//!    written.
+//! 3. **`--yes` meant two things.** It suppressed the per-file confirmation
+//!    *and* unlocked [`SENSITIVE_SERVICES`], so there was no way to say
+//!    "unattended, and still refuse `system-auth`". [`PamRequest::no_confirm`]
+//!    and [`PamRequest::allow_sensitive`] are now separate, and
+//!    **`--no-confirm` never implies `--allow-sensitive`**. `setup --yes`
+//!    keeps its combined meaning and is the one documented exception; the
+//!    alias maps it onto both.
+//! 4. **A no-op was indistinguishable from an action.** The old writer
+//!    returned `Ok(())` for *installed*, *already present* and *declined*
+//!    alike, which is why integrations pre-grepped `/etc/pam.d/<service>` for
+//!    `pam_facelock.so` — a shell reimplementation of
+//!    [`is_facelock_pam_line`]. [`Outcome`] is that answer, and
+//!    `pam status --json` is the probe that replaces the grep.
+//!
+//! # Two-phase, and what that does and does not promise
+//!
+//! [`plan_writes`] validates **every** requested service — name well-formed,
+//! file present (subject to `--if-present`), sensitive-gate, and what the edit
+//! would be — before [`apply_add`]/[`apply_remove`] touches anything. A
+//! validation failure therefore writes nothing at all, which is what gives a
+//! caller's `set -e` loop real all-or-nothing semantics for the failure mode
+//! that actually happens: a typo'd or gated service name.
+//!
+//! It is **not** a transaction. A write-phase I/O error on service N — a full
+//! disk, a read-only mount — leaves services 1..N-1 written. Those are
+//! reported per service ([`Outcome::Failed`]) and the process exits non-zero;
+//! the remaining services are still attempted, because each is an independent
+//! file with its own backup and a half-reported plan is harder to recover from
+//! than a fully-reported one. The rollback is the `.facelock-backup` file the
+//! write phase makes before each edit, and nothing here deletes it.
+//!
+//! # Confinement
+//!
+//! A service name is **one path component** ([`confined`]), rejected before
+//! any I/O on every verb. `base.join(service)` is not a confinement
+//! primitive: an absolute `service` *replaces* `base` outright.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io::IsTerminal;
+use std::path::{Component, Path, PathBuf};
+
+use dialoguer::Confirm;
+
+use crate::message::{Message, PamMessage, Terminal, fail};
+
+/// The real PAM configuration directory. Every engine function takes it as a
+/// parameter so tests drive the whole writer against a tempdir, unprivileged.
+pub const PAM_DIR: &str = "/etc/pam.d";
+
+/// The line this command adds and removes. Matching is by module name rather
+/// than by these bytes — see [`is_facelock_pam_line`].
+pub const PAM_LINE: &str = "auth      sufficient pam_facelock.so";
+
+/// Where the PAM module has to be for the line to mean anything.
+pub const PAM_MODULE_PATH: &str = "/lib/security/pam_facelock.so";
+
+/// Services whose stacks can lock the machine, or the network, out. Adding
+/// face auth here needs `--allow-sensitive` (`--yes` on the `setup` alias);
+/// **removing** it needs no gate, because removal can only take away a way to
+/// authenticate.
+pub const SENSITIVE_SERVICES: &[&str] = &["system-auth", "login", "sshd"];
+
+/// The service a bare `pam add` / `setup --pam` means.
+pub const DEFAULT_PAM_SERVICE: &str = "sudo";
+
+/// Suffix of the copy taken before any edit. Never deleted by this module.
+const BACKUP_SUFFIX: &str = ".facelock-backup";
+
+/// The `--json` `error` value for a service name confinement rejected.
+///
+/// A fixed C-locale string, deliberately **not** the rendered
+/// [`PamMessage::PamInvalidServiceName`]: that goes through
+/// [`crate::message::Message::localized`], and `--json` output must never
+/// localize (see the "What must NOT come through here" list in
+/// `crate::message`). `message::init` sets `LC_MESSAGES` from the environment,
+/// so routing the localized text here would make a documented machine field
+/// change with the operator's locale. The human still gets the localized
+/// message, on stderr.
+const INVALID_SERVICE_NAME: &str = "invalid service name";
+
+// ---------------------------------------------------------------------------
+// Exit codes
+// ---------------------------------------------------------------------------
+
+/// `pam status`: every requested service carries the facelock line.
+const STATUS_PRESENT: i32 = 0;
+/// `pam status`: a requested service file exists without the line.
+const STATUS_MISSING: i32 = 1;
+/// `pam status`: a requested service file is absent, unreadable, or misnamed.
+const STATUS_ERROR: i32 = 2;
+
+/// `pam add` / `pam remove`: every service reached its requested state.
+const WRITE_OK: i32 = 0;
+/// `pam add` / `pam remove`: at least one service could not be written.
+const WRITE_FAILED: i32 = 1;
+
+// ---------------------------------------------------------------------------
+// Request
+// ---------------------------------------------------------------------------
+
+/// Which verb ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PamAction {
+    Add,
+    Remove,
+    /// The default, so that a [`PamRequest`] built field by field reads and
+    /// never writes until something names a verb on purpose.
+    #[default]
+    Status,
+}
+
+impl PamAction {
+    /// The word this action reports as `"command"` in `--json`. Part of the
+    /// output contract, so it is spelled here once rather than at the call
+    /// site.
+    fn word(self) -> &'static str {
+        match self {
+            PamAction::Add => "add",
+            PamAction::Remove => "remove",
+            PamAction::Status => "status",
+        }
+    }
+}
+
+/// A resolved `facelock pam` invocation.
+///
+/// Plain data, like [`crate::commands::setup::SetupArgs`]: the clap types stay
+/// in the binary (`args.rs`), so this is what the library sees and what tests
+/// construct. Fields that do not apply to an action are ignored by it —
+/// `allow_sensitive` by `remove` and `status`, `dry_run` by `status`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PamRequest {
+    pub action: PamAction,
+    /// Requested services, in the order given. Empty means
+    /// [`DEFAULT_PAM_SERVICE`].
+    pub services: Vec<String>,
+    /// Suppress prompts. **Never** unlocks [`SENSITIVE_SERVICES`].
+    pub no_confirm: bool,
+    /// Accept the risk of editing a [`SENSITIVE_SERVICES`] entry.
+    pub allow_sensitive: bool,
+    /// Treat a missing service file as success rather than an error.
+    pub if_present: bool,
+    /// Report the resolved plan and write nothing.
+    pub dry_run: bool,
+    /// Emit one JSON document on stdout instead of human text.
+    pub json: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Outcomes — the `--json` vocabulary
+// ---------------------------------------------------------------------------
+
+/// What happened to one service.
+///
+/// The `action` string of a `--json` service object. **These words are a
+/// stability contract**: existing words keep their meaning and new ones may be
+/// added, so a consumer must tolerate a word it does not know rather than
+/// treat it as an error. They are spelled in one place on purpose — the whole
+/// vocabulary is visible in [`Outcome::word`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Outcome {
+    /// `add`: the line was written (or, under `--dry-run`, would be).
+    Installed,
+    /// `remove`: the line was deleted (or would be).
+    Removed,
+    /// The service was already in the requested state.
+    Unchanged,
+    /// The service file does not exist, and `--if-present` allowed that.
+    Absent,
+    /// The operator answered no at the per-file confirmation.
+    Declined,
+    /// The write failed. Carries the error for the `"error"` field.
+    ///
+    /// That field is a diagnostic, not a contract: `Failed` and `Unknown` both
+    /// interpolate an `io::Error`, whose text comes from the C library's
+    /// `strerror` and therefore follows `LC_MESSAGES` like any other OS
+    /// string. A consumer branches on `action`; it must not match on `error`.
+    Failed(String),
+    /// `status`: the file exists and carries a facelock line.
+    Present,
+    /// `status`: the file exists and carries no facelock line.
+    Missing,
+    /// `status`: the file exists but could not be read.
+    Unknown(String),
+}
+
+impl Outcome {
+    fn word(&self) -> &'static str {
+        match self {
+            Outcome::Installed => "installed",
+            Outcome::Removed => "removed",
+            Outcome::Unchanged => "unchanged",
+            Outcome::Absent => "absent",
+            Outcome::Declined => "declined",
+            Outcome::Failed(_) => "failed",
+            Outcome::Present => "present",
+            Outcome::Missing => "missing",
+            Outcome::Unknown(_) => "unknown",
+        }
+    }
+
+    /// The `"error"` field, when this outcome carries one.
+    fn error(&self) -> Option<&str> {
+        match self {
+            Outcome::Failed(error) | Outcome::Unknown(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// One row of the report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ServiceReport {
+    service: String,
+    path: String,
+    outcome: Outcome,
+    /// The `.facelock-backup` path, when one exists on disk after the
+    /// operation. `null` otherwise — including for every `--dry-run` service,
+    /// which writes no backup.
+    backup: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Planning
+// ---------------------------------------------------------------------------
+
+/// What a service is planned to become.
+///
+/// The variants that rewrite the file carry the bytes they were derived from,
+/// so "there is an edit to make" and "here is what it is being made from"
+/// cannot disagree. Holding them apart — a plan beside an `Option<String>` —
+/// made two representations of one fact, and every consumer had to re-check
+/// the pairing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Plan {
+    /// Insert the line. `at_top` records that the file has no `auth` line, so
+    /// the preview and the dry-run report can say where it lands.
+    Add { at_top: bool, content: String },
+    /// Delete the line.
+    Remove { content: String },
+    /// Already in the requested state.
+    NoChange,
+    /// No service file, and `--if-present` said that is fine.
+    Absent,
+}
+
+/// A validated service, with the file already read.
+#[derive(Debug, Clone)]
+struct Target {
+    service: String,
+    path: PathBuf,
+    backup: PathBuf,
+    plan: Plan,
+}
+
+impl Target {
+    fn path_string(&self) -> String {
+        self.path.display().to_string()
+    }
+
+    fn backup_string(&self) -> String {
+        self.backup.display().to_string()
+    }
+
+    /// The backup path if it exists on disk, for the report's `backup` field.
+    fn existing_backup(&self) -> Option<String> {
+        self.backup.exists().then(|| self.backup_string())
+    }
+}
+
+/// A PAM service name is **one path component** under [`PAM_DIR`].
+///
+/// Rejected before any I/O, on `add`, `remove` and `status` alike: empty,
+/// containing `/`, equal to `.` or `..`, or carrying an interior NUL. This is
+/// the check the old writer did not have — `pam_install_in` did a bare
+/// `base.join(service)`, and an absolute `service` *replaces* `base`, so
+/// `--service /etc/shadow` resolved to `/etc/shadow`; `pam_remove_in` stripped
+/// a leading `/` and nothing else, which left `..` intact.
+fn confined(service: &str) -> anyhow::Result<()> {
+    let mut components = Path::new(service).components();
+    // A trailing slash is dropped by `components`, so the round-trip
+    // comparison is what rejects `sudo/` as well as `a/b` and `/etc/shadow`.
+    let single_component = matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(name)), None) if name == OsStr::new(service)
+    );
+    if single_component && !service.contains('\0') {
+        return Ok(());
+    }
+    Err(fail(PamMessage::PamInvalidServiceName {
+        service: service.to_string(),
+    }))
+}
+
+/// Requested services, defaulted and de-duplicated, in the order given.
+///
+/// De-duplication is not cosmetic: `--service sudo --service sudo` would
+/// otherwise emit two report rows for one file, the second of them
+/// `unchanged` because the first had just written it.
+fn requested_services(services: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for service in services {
+        if !out.iter().any(|seen| seen == service) {
+            out.push(service.clone());
+        }
+    }
+    if out.is_empty() {
+        out.push(DEFAULT_PAM_SERVICE.to_string());
+    }
+    out
+}
+
+/// Phase one: validate and read every service, or fail having written nothing.
+///
+/// Every rejection here is an `Err`, not a report row, and the caller performs
+/// no writes on `Err` — that is the whole point of the phase. Errors render on
+/// stderr as text and never as a JSON document, the same contract
+/// `is-enrolled` has for its unanswerable case.
+fn plan_writes(
+    base: &Path,
+    action: PamAction,
+    services: &[String],
+    request: &PamRequest,
+    sensitive_remedy: &str,
+) -> anyhow::Result<Vec<Target>> {
+    let mut targets = Vec::with_capacity(services.len());
+
+    for service in services {
+        confined(service)?;
+
+        if action == PamAction::Add
+            && SENSITIVE_SERVICES.contains(&service.as_str())
+            && !request.allow_sensitive
+        {
+            return Err(fail(PamMessage::PamSensitiveRefused {
+                service: service.clone(),
+                remedy: sensitive_remedy.to_string(),
+            }));
+        }
+
+        let path = base.join(service);
+        let backup = backup_path(&path);
+        let display = path.display().to_string();
+
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => Some(content),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if !request.if_present {
+                    return Err(fail(PamMessage::PamFileNotFound { path: display }));
+                }
+                None
+            }
+            // `--if-present` converts a missing file into a no-op and nothing
+            // else: a permission or I/O failure stays fatal.
+            Err(error) => {
+                return Err(anyhow::Error::new(error).context(format!("failed to read {display}")));
+            }
+        };
+
+        let plan = match (content, action) {
+            (None, _) => Plan::Absent,
+            (Some(content), PamAction::Add) => {
+                if content.lines().any(is_facelock_pam_line) {
+                    Plan::NoChange
+                } else {
+                    Plan::Add {
+                        at_top: !content.lines().any(has_auth_keyword),
+                        content,
+                    }
+                }
+            }
+            (Some(content), PamAction::Remove) => {
+                if content.lines().any(is_facelock_pam_line) {
+                    Plan::Remove { content }
+                } else {
+                    Plan::NoChange
+                }
+            }
+            (Some(_), PamAction::Status) => Plan::NoChange,
+        };
+
+        targets.push(Target {
+            service: service.clone(),
+            path,
+            backup,
+            plan,
+        });
+    }
+
+    Ok(targets)
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    // Built by appending to the string rather than with `set_extension`, which
+    // would replace a service name's existing suffix.
+    PathBuf::from(format!("{}{BACKUP_SUFFIX}", path.display()))
+}
+
+/// Whether a PAM config line references pam_facelock, regardless of spacing.
+///
+/// Matches on the module name, not on [`PAM_LINE`]'s bytes, so a hand-edited
+/// line with different spacing is still recognized — and a commented-out one
+/// is not.
+pub fn is_facelock_pam_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    !trimmed.starts_with('#') && trimmed.contains("pam_facelock.so")
+}
+
+/// Whether a line begins a PAM `auth` rule, which is where the facelock line
+/// has to go above.
+fn has_auth_keyword(line: &str) -> bool {
+    line.trim_start().starts_with("auth")
+}
+
+/// Insert [`PAM_LINE`] above the first `auth` line, or at the very top if
+/// there is none. Trailing-newline behavior of the original is preserved.
+fn with_line_inserted(content: &str) -> String {
+    let mut new_lines: Vec<String> = Vec::new();
+    let mut inserted = false;
+
+    for line in content.lines() {
+        if !inserted && has_auth_keyword(line) {
+            new_lines.push(PAM_LINE.to_string());
+            inserted = true;
+        }
+        new_lines.push(line.to_string());
+    }
+
+    if !inserted {
+        new_lines.insert(0, PAM_LINE.to_string());
+    }
+
+    let mut output = new_lines.join("\n");
+    if content.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+/// Drop every facelock line, preserving the original's trailing newline.
+fn with_line_removed(content: &str) -> String {
+    let mut output = content
+        .lines()
+        .filter(|line| !is_facelock_pam_line(line))
+        .collect::<Vec<&str>>()
+        .join("\n");
+    if content.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+// ---------------------------------------------------------------------------
+// Output routing
+// ---------------------------------------------------------------------------
+
+/// Where this invocation's human text goes.
+///
+/// `--json` replaces the human rendering of the payload, so [`Sink::info`] is
+/// silenced under it — but [`Sink::error`] is not. stdout is the answer and
+/// stderr is everything else (contracts.md, "CLI Output Streams"), so a
+/// diagnostic belongs on stderr whether or not a JSON document is being
+/// written to stdout. `--quiet` is handled one layer down, by the message
+/// seam, which silences `Terminal::info` and never `Terminal::error`.
+#[derive(Clone, Copy)]
+struct Sink {
+    json: bool,
+}
+
+impl Sink {
+    fn info(&self, msg: &dyn Message) {
+        if !self.json {
+            Terminal.info(msg);
+        }
+    }
+
+    fn error(&self, msg: &dyn Message) {
+        Terminal.error(msg);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Applying
+// ---------------------------------------------------------------------------
+
+/// Phase two for `add`: preview, confirm, back up, write — one service.
+///
+/// Message order is the old `pam_install_in`'s, byte for byte: the
+/// already-present notice, or the preview, the confirmation, the backup line
+/// and the installed line with its rollback instructions.
+fn apply_add(target: &Target, no_confirm: bool, sink: &Sink) -> Outcome {
+    let path = target.path_string();
+
+    let (at_top, content) = match &target.plan {
+        Plan::NoChange => {
+            sink.info(&PamMessage::PamLineAlreadyPresent { path });
+            return Outcome::Unchanged;
+        }
+        Plan::Absent => {
+            sink.info(&PamMessage::PamServiceAbsentSkipped { path });
+            return Outcome::Absent;
+        }
+        Plan::Add { at_top, content } => (*at_top, content.as_str()),
+        // `plan_writes` is the only thing that builds a plan, and it never
+        // hands an add a removal. Reported as a failure rather than as
+        // "nothing to do" so a bug in this file cannot exit 0 having done
+        // nothing while claiming the service is configured.
+        Plan::Remove { .. } => return Outcome::Failed(internal_plan_mismatch(&path)),
+    };
+    let backup = target.backup_string();
+
+    // The insertion point is decided before prompting, so the preview is
+    // accurate rather than a guess the write could contradict.
+    let hint = if at_top {
+        PamMessage::PamInsertAtTopHint
+    } else {
+        PamMessage::PamInsertBeforeAuthHint
+    };
+    sink.info(&PamMessage::PamModifyPreview {
+        path: path.clone(),
+        line: PAM_LINE.to_string(),
+        hint: hint.localized(),
+        backup: backup.clone(),
+    });
+
+    // A closed or piped stdin proceeds rather than hanging on a question
+    // nobody can answer. This predates the verb and is preserved deliberately:
+    // it is what makes `setup --pam` work from a provisioning script.
+    let proceed = if no_confirm || !std::io::stdin().is_terminal() {
+        true
+    } else {
+        match Confirm::new()
+            .with_prompt(PamMessage::ConfirmProceed.localized())
+            .default(true)
+            .interact()
+        {
+            Ok(answer) => answer,
+            Err(error) => return Outcome::Failed(format!("failed to read confirmation: {error}")),
+        }
+    };
+
+    if !proceed {
+        sink.info(&PamMessage::PamSkippedFile { path });
+        return Outcome::Declined;
+    }
+
+    if let Err(error) = fs::copy(&target.path, &target.backup) {
+        return Outcome::Failed(format!("failed to back up {path} to {backup}: {error}"));
+    }
+    sink.info(&PamMessage::PamBackedUp {
+        path: path.clone(),
+        backup: backup.clone(),
+    });
+
+    if let Err(error) = fs::write(&target.path, with_line_inserted(content)) {
+        return Outcome::Failed(format!("failed to write {path}: {error}"));
+    }
+
+    sink.info(&PamMessage::PamInstalled {
+        path,
+        backup,
+        service: target.service.clone(),
+    });
+    Outcome::Installed
+}
+
+/// Phase two for `remove` — one service.
+///
+/// No confirmation and no new backup, which is what the old `pam_remove_in`
+/// did: removal only takes away a way to authenticate, so there is nothing to
+/// be talked out of, and `setup --pam --remove` has never prompted. An
+/// existing backup is reported so the operator knows a full restore is
+/// available.
+fn apply_remove(target: &Target, sink: &Sink) -> Outcome {
+    let path = target.path_string();
+
+    let outcome = match &target.plan {
+        Plan::Absent => {
+            sink.info(&PamMessage::PamServiceAbsent { path });
+            // Returns before the backup notice, as the old writer did.
+            return Outcome::Absent;
+        }
+        Plan::NoChange => {
+            sink.info(&PamMessage::PamNoLineFound { path: path.clone() });
+            Outcome::Unchanged
+        }
+        Plan::Remove { content } => match fs::write(&target.path, with_line_removed(content)) {
+            Ok(()) => {
+                sink.info(&PamMessage::PamRemoved { path: path.clone() });
+                Outcome::Removed
+            }
+            Err(error) => Outcome::Failed(format!("failed to write {path}: {error}")),
+        },
+        // See `apply_add`: an impossible plan is a bug here, not a no-op.
+        Plan::Add { .. } => Outcome::Failed(internal_plan_mismatch(&path)),
+    };
+
+    if let Some(backup) = target.existing_backup() {
+        sink.info(&PamMessage::PamBackupExists { path, backup });
+    }
+
+    outcome
+}
+
+/// A plan that does not match the verb applying it. Unreachable — `plan_writes`
+/// builds every plan and builds it for the verb that asked — and phrased as a
+/// failure rather than a panic, so the process reports it and exits non-zero
+/// instead of aborting mid-way through a multi-service run.
+fn internal_plan_mismatch(path: &str) -> String {
+    format!("internal error: plan for {path} does not match the requested action")
+}
+
+/// Render the resolved plan for `--dry-run`, writing nothing.
+fn report_plan(target: &Target, sink: &Sink) -> Outcome {
+    let path = target.path_string();
+    match &target.plan {
+        Plan::Add { at_top, .. } => {
+            let at_top = *at_top;
+            let hint = if at_top {
+                PamMessage::PamInsertAtTopHint
+            } else {
+                PamMessage::PamInsertBeforeAuthHint
+            };
+            sink.info(&PamMessage::PamPlanAdd {
+                path,
+                hint: hint.localized(),
+            });
+            Outcome::Installed
+        }
+        Plan::Remove { .. } => {
+            sink.info(&PamMessage::PamPlanRemove { path });
+            Outcome::Removed
+        }
+        Plan::NoChange => {
+            sink.info(&PamMessage::PamPlanNoChange { path });
+            Outcome::Unchanged
+        }
+        Plan::Absent => {
+            sink.info(&PamMessage::PamPlanAbsent { path });
+            Outcome::Absent
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON
+// ---------------------------------------------------------------------------
+
+/// `{"command", "dry_run", "services": [{"service", "path", "action",
+/// "backup"}]}`, with `"error"` present on a `failed` or `unknown` service.
+///
+/// An object rather than a bare array so a later top-level field is an
+/// additive change instead of a document-type change. Built through
+/// `serde_json::json!` rather than `format!` (E10, the same reason as
+/// `commands::list::list_json`): a service name reaches here from argv, and
+/// confinement rejects `/` but not `"`, so `--service 'a"b'` would otherwise
+/// emit invalid JSON.
+fn report_json(action: PamAction, dry_run: bool, reports: &[ServiceReport]) -> String {
+    let services: Vec<serde_json::Value> = reports
+        .iter()
+        .map(|report| {
+            let mut value = serde_json::json!({
+                "service": report.service,
+                "path": report.path,
+                "action": report.outcome.word(),
+                "backup": report.backup,
+            });
+            if let (Some(error), Some(object)) = (report.outcome.error(), value.as_object_mut()) {
+                object.insert("error".to_string(), serde_json::Value::String(error.into()));
+            }
+            value
+        })
+        .collect();
+
+    serde_json::json!({
+        "command": action.word(),
+        "dry_run": dry_run,
+        "services": services,
+    })
+    .to_string()
+}
+
+/// Emit the machine document, unless `--quiet` said the exit code is the whole
+/// answer. That is `is-enrolled --quiet --json`'s existing rule, generalized:
+/// `--quiet` leaves only the exit code, whatever the format.
+fn emit_json(action: PamAction, dry_run: bool, reports: &[ServiceReport], quiet: bool) {
+    if !quiet {
+        println!("{}", report_json(action, dry_run, reports));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// Run `facelock pam …`, returning the process exit code.
+///
+/// **C6 ordering.** `add` and `remove` check root as their first statement,
+/// before any output, any read of `/etc/pam.d`, and `--dry-run`. A dry run
+/// that succeeded unprivileged would be a misleading preview of a command that
+/// cannot run, and making the check conditional on a flag is exactly the
+/// ordering subtlety C6 exists to prevent. `pam status` needs no root and
+/// takes none.
+///
+/// The refusal is the hard-error kind (`require_root_scripted`), not the
+/// interactive sudo re-exec: standalone `setup --pam` has never re-execed —
+/// `setup::needs_root_precheck` says so and a test pins it — and silently
+/// re-running a `/etc/pam.d` edit under `sudo` from a wrapper script is a
+/// surprise, not a convenience.
+pub fn run(request: PamRequest, quiet: bool) -> anyhow::Result<i32> {
+    if request.action == PamAction::Status {
+        return Ok(status_in(Path::new(PAM_DIR), &request, quiet));
+    }
+
+    crate::ipc_client::require_root_scripted(&format!(
+        "sudo facelock pam {}",
+        request.action.word()
+    ))?;
+
+    if request.action == PamAction::Add {
+        require_module_installed()?;
+    }
+
+    write_in(Path::new(PAM_DIR), &request, quiet)
+}
+
+/// The precondition the line is useless without. Hoisted out of the per-service
+/// loop: it is a property of the machine, not of a service.
+fn require_module_installed() -> anyhow::Result<()> {
+    if Path::new(PAM_MODULE_PATH).exists() {
+        return Ok(());
+    }
+    Err(fail(PamMessage::PamModuleNotInstalled {
+        path: PAM_MODULE_PATH.to_string(),
+    }))
+}
+
+/// `add` / `remove` against `base`. The engine tests drive this directly, so
+/// it performs no root or module check — [`run`] owns those.
+fn write_in(base: &Path, request: &PamRequest, quiet: bool) -> anyhow::Result<i32> {
+    let action = request.action;
+    if action == PamAction::Status {
+        // `run` routes `status` to `status_in` and never gets here. Delegating
+        // rather than falling through is what stops a future caller from
+        // getting a *removal* out of a request that asked to read.
+        return Ok(status_in(base, request, quiet));
+    }
+    let services = requested_services(&request.services);
+    let sink = Sink { json: request.json };
+
+    // Phase one. An `Err` here has written nothing, by construction.
+    let targets = plan_writes(base, action, &services, request, "--allow-sensitive")?;
+
+    // Phase two.
+    let mut reports = Vec::with_capacity(targets.len());
+    for target in &targets {
+        let outcome = if request.dry_run {
+            report_plan(target, &sink)
+        } else if action == PamAction::Add {
+            apply_add(target, request.no_confirm, &sink)
+        } else {
+            apply_remove(target, &sink)
+        };
+
+        if let Outcome::Failed(error) = &outcome {
+            sink.error(&PamMessage::PamConfigureFailed {
+                service: target.service.clone(),
+                error: error.clone(),
+            });
+        }
+
+        reports.push(ServiceReport {
+            service: target.service.clone(),
+            path: target.path_string(),
+            outcome,
+            backup: (!request.dry_run)
+                .then(|| target.existing_backup())
+                .flatten(),
+        });
+    }
+
+    // One hint per invocation, after every service — not once per service, as
+    // a shell loop over the old one-service-per-process CLI produced. It is
+    // human-facing text, so `--json` and `--quiet` both drop it; `--dry-run`
+    // keeps it, so a dry run is a faithful preview of what the real run prints.
+    if action == PamAction::Add {
+        sink.info(&PamMessage::PamExtensionHint {
+            line: PAM_LINE.to_string(),
+        });
+    }
+
+    if request.json {
+        emit_json(action, request.dry_run, &reports, quiet);
+    }
+
+    Ok(
+        if reports
+            .iter()
+            .any(|report| matches!(report.outcome, Outcome::Failed(_)))
+        {
+            WRITE_FAILED
+        } else {
+            WRITE_OK
+        },
+    )
+}
+
+/// `pam status` against `base`.
+///
+/// Unprivileged by design (DEC-6): `/etc/pam.d/*` is `0644`, this never
+/// writes, and it is the probe an integration wants without `sudo` — the one
+/// that replaces `grep -q pam_facelock.so /etc/pam.d/<service>`. An unreadable
+/// file reports `unknown` and exits 2 rather than pretending it is missing.
+///
+/// The exit code is the answer, on `grep`'s scale and `is-enrolled`'s: 0 every
+/// service has the line, 1 at least one does not, 2 at least one could not be
+/// answered. The worst outcome wins.
+fn status_in(base: &Path, request: &PamRequest, quiet: bool) -> i32 {
+    let sink = Sink { json: request.json };
+    let reports = status_reports(base, &requested_services(&request.services), &sink);
+
+    if request.json {
+        emit_json(PamAction::Status, false, &reports, quiet);
+    }
+
+    reports
+        .iter()
+        .map(|report| status_code(&report.outcome))
+        .max()
+        .unwrap_or(STATUS_PRESENT)
+}
+
+/// One report row per service. Split out from [`status_in`] so the rows —
+/// which are the `--json` payload — are assertable without capturing stdout.
+fn status_reports(base: &Path, services: &[String], sink: &Sink) -> Vec<ServiceReport> {
+    services
+        .iter()
+        .map(|service| {
+            let path = base.join(service);
+            let display = path.display().to_string();
+
+            // A rejected name is answered without touching the filesystem —
+            // including the backup probe below, which would otherwise `stat`
+            // `/etc/pam.d/../escape.facelock-backup` for a name the whole
+            // point of `confined` is to not act on.
+            if confined(service).is_err() {
+                // Not an `Err` return: `status` owns its exit codes, and a
+                // usage error is exit 2 rather than the generic exit 1 `main`
+                // gives an `anyhow` failure. The human rendering is the
+                // invalid-name message rather than `PamStatusUnknown`, which
+                // would report a path this never went near as "unreadable".
+                sink.error(&PamMessage::PamInvalidServiceName {
+                    service: service.clone(),
+                });
+                return ServiceReport {
+                    service: service.clone(),
+                    path: display,
+                    outcome: Outcome::Unknown(INVALID_SERVICE_NAME.to_string()),
+                    backup: None,
+                };
+            }
+
+            let outcome = match fs::read_to_string(&path) {
+                Ok(content) if content.lines().any(is_facelock_pam_line) => {
+                    sink.info(&PamMessage::PamStatusPresent {
+                        path: display.clone(),
+                    });
+                    Outcome::Present
+                }
+                Ok(_) => {
+                    sink.info(&PamMessage::PamStatusMissing {
+                        path: display.clone(),
+                    });
+                    Outcome::Missing
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    sink.info(&PamMessage::PamStatusAbsent {
+                        path: display.clone(),
+                    });
+                    Outcome::Absent
+                }
+                Err(error) => {
+                    sink.error(&PamMessage::PamStatusUnknown {
+                        path: display.clone(),
+                        error: error.to_string(),
+                    });
+                    Outcome::Unknown(error.to_string())
+                }
+            };
+
+            let backup = backup_path(&path);
+            ServiceReport {
+                service: service.clone(),
+                path: display,
+                outcome,
+                backup: backup.exists().then(|| backup.display().to_string()),
+            }
+        })
+        .collect()
+}
+
+/// `grep`'s scale, and `is-enrolled`'s. The worst outcome across the requested
+/// services wins, which is why this is a function of one outcome and the
+/// caller takes the max.
+fn status_code(outcome: &Outcome) -> i32 {
+    match outcome {
+        Outcome::Present => STATUS_PRESENT,
+        Outcome::Missing => STATUS_MISSING,
+        _ => STATUS_ERROR,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The `setup --pam` alias
+// ---------------------------------------------------------------------------
+
+/// `setup --pam [--service X]`, routed through the same engine.
+///
+/// `setup --yes` keeps its combined meaning — it is the documented exception
+/// to the flag split — so the caller maps it onto **both** knobs, and the
+/// refusal names `--yes` rather than `--allow-sensitive` because that is the
+/// flag this surface actually honours.
+///
+/// Root is re-checked here rather than only at the `setup` entry point:
+/// `run_with_plan` reaches this directly for a standalone `--pam`, which does
+/// not take the base setup's root pre-check.
+pub fn install_for_setup(
+    services: &[String],
+    no_confirm: bool,
+    allow_sensitive: bool,
+) -> anyhow::Result<()> {
+    crate::ipc_client::require_root_scripted("sudo facelock setup --pam")?;
+    require_module_installed()?;
+
+    let request = PamRequest {
+        action: PamAction::Add,
+        services: services.to_vec(),
+        no_confirm,
+        allow_sensitive,
+        ..PamRequest::default()
+    };
+    let targets = plan_writes(
+        Path::new(PAM_DIR),
+        PamAction::Add,
+        &requested_services(services),
+        &request,
+        "--yes",
+    )?;
+
+    let sink = Sink { json: false };
+    for target in &targets {
+        if let Outcome::Failed(error) = apply_add(target, request.no_confirm, &sink) {
+            return Err(anyhow::anyhow!(error));
+        }
+    }
+    sink.info(&PamMessage::PamExtensionHint {
+        line: PAM_LINE.to_string(),
+    });
+    Ok(())
+}
+
+/// `setup --pam --remove [--if-present]`, routed through the same engine.
+pub fn remove_for_setup(services: &[String], if_present: bool) -> anyhow::Result<()> {
+    crate::ipc_client::require_root_scripted("sudo facelock setup --pam --remove")?;
+
+    let request = PamRequest {
+        action: PamAction::Remove,
+        services: services.to_vec(),
+        if_present,
+        ..PamRequest::default()
+    };
+    let targets = plan_writes(
+        Path::new(PAM_DIR),
+        PamAction::Remove,
+        &requested_services(services),
+        &request,
+        "--yes",
+    )?;
+
+    let sink = Sink { json: false };
+    for target in &targets {
+        if let Outcome::Failed(error) = apply_remove(target, &sink) {
+            return Err(anyhow::anyhow!(error));
+        }
+    }
+    Ok(())
+}
+
+/// One service, against `base`, with the wizard's semantics: the multi-select
+/// already *is* the per-service consent, and the module check already ran, so
+/// neither is repeated here.
+pub(crate) fn install_one_in(
+    base: &Path,
+    service: &str,
+    allow_sensitive: bool,
+    no_confirm: bool,
+) -> anyhow::Result<()> {
+    let request = PamRequest {
+        action: PamAction::Add,
+        allow_sensitive,
+        no_confirm,
+        ..PamRequest::default()
+    };
+    let services = vec![service.to_string()];
+    let targets = plan_writes(base, PamAction::Add, &services, &request, "--yes")?;
+
+    let sink = Sink { json: false };
+    for target in &targets {
+        // `request.no_confirm`, never the parameter: one value reaches both
+        // phases, so the request cannot describe a run the apply does not do.
+        if let Outcome::Failed(error) = apply_add(target, request.no_confirm, &sink) {
+            return Err(anyhow::anyhow!(error));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    // -----------------------------------------------------------------------
+    // Goldens captured from `main` (4c8cf28) before the extraction.
+    //
+    // Produced by running that commit's `pam_install_in` / `pam_remove_in`
+    // against a tempdir and dumping the resulting bytes — not written by hand.
+    // They are the regression guard the whole refactor turns on: the file this
+    // command leaves behind must be the file the old one left behind, byte for
+    // byte, including where the line lands and whether a trailing newline
+    // survives.
+    // -----------------------------------------------------------------------
+
+    /// A service whose first `auth` line is not its first line.
+    const SUDO_BEFORE: &str = "#%PAM-1.0\nauth\t\tinclude\t\tsystem-auth\naccount\t\tinclude\t\tsystem-auth\nsession\t\tinclude\t\tsystem-auth\n";
+    const SUDO_AFTER: &str = "#%PAM-1.0\nauth      sufficient pam_facelock.so\nauth\t\tinclude\t\tsystem-auth\naccount\t\tinclude\t\tsystem-auth\nsession\t\tinclude\t\tsystem-auth\n";
+
+    /// A service with no `auth` line at all: the line goes to the very top,
+    /// *above* the `#%PAM-1.0` header. That is what `main` did, so that is
+    /// what the golden says.
+    const POLKIT_BEFORE: &str =
+        "#%PAM-1.0\naccount\t\tinclude\t\tsystem-auth\npassword\tinclude\t\tsystem-auth\n";
+    const POLKIT_AFTER: &str = "auth      sufficient pam_facelock.so\n#%PAM-1.0\naccount\t\tinclude\t\tsystem-auth\npassword\tinclude\t\tsystem-auth\n";
+
+    /// A service that already carries the line: untouched, and no backup.
+    const OMARCHY_PRESENT: &str = "#%PAM-1.0\nauth      sufficient pam_facelock.so\nauth\t\tinclude\t\tsystem-auth\naccount\t\tinclude\t\tsystem-auth\n";
+    const OMARCHY_REMOVED: &str =
+        "#%PAM-1.0\nauth\t\tinclude\t\tsystem-auth\naccount\t\tinclude\t\tsystem-auth\n";
+
+    /// A file with no trailing newline keeps not having one.
+    const NO_NEWLINE_BEFORE: &str = "#%PAM-1.0\nauth\t\tinclude\t\tsystem-auth";
+    const NO_NEWLINE_AFTER: &str =
+        "#%PAM-1.0\nauth      sufficient pam_facelock.so\nauth\t\tinclude\t\tsystem-auth";
+
+    fn seeded(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        for (name, content) in files {
+            fs::write(dir.path().join(name), content).unwrap();
+        }
+        dir
+    }
+
+    /// Every entry under `dir` and its exact bytes. Enumerating the directory
+    /// rather than the files we wrote is what catches a stray
+    /// `.facelock-backup` appearing where none should.
+    fn snapshot(dir: &Path) -> BTreeMap<String, Vec<u8>> {
+        fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    fs::read(entry.path()).unwrap_or_default(),
+                )
+            })
+            .collect()
+    }
+
+    fn add(services: &[&str]) -> PamRequest {
+        PamRequest {
+            action: PamAction::Add,
+            services: services.iter().map(|s| s.to_string()).collect(),
+            no_confirm: true,
+            ..PamRequest::default()
+        }
+    }
+
+    fn remove(services: &[&str]) -> PamRequest {
+        PamRequest {
+            action: PamAction::Remove,
+            services: services.iter().map(|s| s.to_string()).collect(),
+            no_confirm: true,
+            ..PamRequest::default()
+        }
+    }
+
+    fn read(dir: &tempfile::TempDir, name: &str) -> String {
+        fs::read_to_string(dir.path().join(name)).unwrap()
+    }
+
+    // -- byte identity with `main` ------------------------------------------
+
+    #[test]
+    fn add_reproduces_main_byte_for_byte() {
+        for (service, before, after) in [
+            ("sudo", SUDO_BEFORE, SUDO_AFTER),
+            ("polkit-1", POLKIT_BEFORE, POLKIT_AFTER),
+            ("omarchy-lock-face", OMARCHY_PRESENT, OMARCHY_PRESENT),
+            ("sudo", NO_NEWLINE_BEFORE, NO_NEWLINE_AFTER),
+        ] {
+            let dir = seeded(&[(service, before)]);
+            let code = write_in(dir.path(), &add(&[service]), false).unwrap();
+
+            assert_eq!(code, WRITE_OK, "{service}");
+            assert_eq!(read(&dir, service), after, "{service} content");
+        }
+    }
+
+    /// The backup is a byte copy of the original, and it only appears when
+    /// something was actually written.
+    #[test]
+    fn add_backup_is_the_original_and_only_exists_on_a_real_write() {
+        let dir = seeded(&[("sudo", SUDO_BEFORE)]);
+        write_in(dir.path(), &add(&["sudo"]), false).unwrap();
+        assert_eq!(read(&dir, "sudo.facelock-backup"), SUDO_BEFORE);
+
+        let untouched = seeded(&[("omarchy-lock-face", OMARCHY_PRESENT)]);
+        let before = snapshot(untouched.path());
+        write_in(untouched.path(), &add(&["omarchy-lock-face"]), false).unwrap();
+        assert_eq!(
+            before,
+            snapshot(untouched.path()),
+            "an already-configured service must not gain a backup"
+        );
+    }
+
+    #[test]
+    fn remove_reproduces_main_byte_for_byte() {
+        let dir = seeded(&[
+            ("omarchy-lock-face", OMARCHY_PRESENT),
+            ("sudo", SUDO_BEFORE),
+        ]);
+        let code = write_in(dir.path(), &remove(&["omarchy-lock-face", "sudo"]), false).unwrap();
+
+        assert_eq!(code, WRITE_OK);
+        assert_eq!(read(&dir, "omarchy-lock-face"), OMARCHY_REMOVED);
+        assert_eq!(read(&dir, "sudo"), SUDO_BEFORE, "no line, no rewrite");
+    }
+
+    /// The `setup --pam` alias reaches the writer through `install_one_in`,
+    /// not through `write_in`, so the goldens have to cover it too — the two
+    /// entry points sharing an engine is the claim, and this is what makes it
+    /// a checked one rather than a comment.
+    #[test]
+    fn the_setup_alias_writes_the_same_bytes_as_the_verb() {
+        for (service, before, after) in [
+            ("sudo", SUDO_BEFORE, SUDO_AFTER),
+            ("polkit-1", POLKIT_BEFORE, POLKIT_AFTER),
+            ("omarchy-lock-face", OMARCHY_PRESENT, OMARCHY_PRESENT),
+            ("sudo", NO_NEWLINE_BEFORE, NO_NEWLINE_AFTER),
+        ] {
+            let via_alias = seeded(&[(service, before)]);
+            install_one_in(via_alias.path(), service, true, true).unwrap();
+
+            let via_verb = seeded(&[(service, before)]);
+            write_in(via_verb.path(), &add(&[service]), false).unwrap();
+
+            assert_eq!(read(&via_alias, service), after, "{service} via the alias");
+            assert_eq!(
+                snapshot(via_alias.path()),
+                snapshot(via_verb.path()),
+                "{service}: the alias and the verb must leave the same directory"
+            );
+        }
+    }
+
+    /// `add` then `remove` is a round trip, which is the property that makes
+    /// the rollback advice in `PamInstalled` true.
+    #[test]
+    fn add_then_remove_restores_the_original_bytes() {
+        for before in [SUDO_BEFORE, POLKIT_BEFORE, NO_NEWLINE_BEFORE] {
+            let dir = seeded(&[("sudo", before)]);
+            write_in(dir.path(), &add(&["sudo"]), false).unwrap();
+            write_in(dir.path(), &remove(&["sudo"]), false).unwrap();
+            assert_eq!(read(&dir, "sudo"), before);
+        }
+    }
+
+    // -- confinement --------------------------------------------------------
+
+    #[test]
+    fn one_path_component_is_the_whole_rule() {
+        for good in ["sudo", "polkit-1", "omarchy-lock-face", "..x", "a\"b"] {
+            assert!(confined(good).is_ok(), "{good} must be accepted");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "/",
+            "/etc/shadow",
+            "../shadow",
+            "a/b",
+            "sudo/",
+            "./sudo",
+            "sudo\0",
+        ] {
+            assert!(confined(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    /// The property `pam_remove_absolute_service_stays_anchored_under_base`
+    /// protected — never touch a file outside `base` — now holds by rejecting
+    /// the name before any I/O rather than by re-anchoring it. The old writer
+    /// stripped a leading `/` on removal and stripped nothing on install, so
+    /// `--service /etc/shadow` resolved to `/etc/shadow` on the install side.
+    #[test]
+    fn an_absolute_service_is_rejected_before_any_io() {
+        for action in [PamAction::Add, PamAction::Remove] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let base = dir.path().join("pam.d");
+            fs::create_dir(&base).unwrap();
+            let outside = dir.path().join("outside-service");
+            fs::write(&outside, OMARCHY_PRESENT).unwrap();
+
+            let request = PamRequest {
+                action,
+                services: vec![outside.to_str().unwrap().to_string()],
+                no_confirm: true,
+                if_present: true,
+                ..PamRequest::default()
+            };
+            let error = write_in(&base, &request, false).unwrap_err().to_string();
+
+            assert!(error.contains("Invalid PAM service name"), "got: {error}");
+            assert_eq!(fs::read_to_string(&outside).unwrap(), OMARCHY_PRESENT);
+            assert!(fs::read_dir(&base).unwrap().next().is_none());
+        }
+    }
+
+    #[test]
+    fn a_parent_traversal_is_rejected_before_any_io() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let base = dir.path().join("pam.d");
+        fs::create_dir(&base).unwrap();
+        fs::write(dir.path().join("shadow"), "root:!:1::::::\n").unwrap();
+
+        for action in [PamAction::Add, PamAction::Remove] {
+            let request = PamRequest {
+                action,
+                services: vec!["../shadow".to_string()],
+                no_confirm: true,
+                if_present: true,
+                ..PamRequest::default()
+            };
+            assert!(write_in(&base, &request, false).is_err());
+        }
+        assert_eq!(
+            fs::read_to_string(dir.path().join("shadow")).unwrap(),
+            "root:!:1::::::\n"
+        );
+    }
+
+    // -- two-phase ----------------------------------------------------------
+
+    /// The plan's acceptance criterion: a validation failure on service two
+    /// leaves service one byte-identical and makes no backup. Without the
+    /// phase split, `sudo` would already be written by the time `sshd` was
+    /// rejected.
+    #[test]
+    fn a_validation_failure_writes_nothing_at_all() {
+        for second in ["sshd", "does-not-exist", "../escape"] {
+            let dir = seeded(&[("sudo", SUDO_BEFORE), ("sshd", SUDO_BEFORE)]);
+            let before = snapshot(dir.path());
+
+            let error = write_in(dir.path(), &add(&["sudo", second]), false).unwrap_err();
+
+            assert_eq!(
+                before,
+                snapshot(dir.path()),
+                "`{second}` was rejected, so `sudo` must be untouched: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_valid_multi_service_add_writes_every_service() {
+        let dir = seeded(&[("sudo", SUDO_BEFORE), ("polkit-1", POLKIT_BEFORE)]);
+
+        let code = write_in(dir.path(), &add(&["sudo", "polkit-1"]), false).unwrap();
+
+        assert_eq!(code, WRITE_OK);
+        assert_eq!(read(&dir, "sudo"), SUDO_AFTER);
+        assert_eq!(read(&dir, "polkit-1"), POLKIT_AFTER);
+    }
+
+    // -- the flag split -----------------------------------------------------
+
+    /// The defect the split exists to fix: unattended and "allowed to edit
+    /// system-auth" are different authorizations, and the first must never
+    /// imply the second.
+    #[test]
+    fn no_confirm_does_not_unlock_a_sensitive_service() {
+        for service in SENSITIVE_SERVICES {
+            let dir = seeded(&[(service, SUDO_BEFORE)]);
+            let before = snapshot(dir.path());
+
+            let error = write_in(dir.path(), &add(&[service]), false)
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                error.contains(&format!("Refusing to modify '{service}'")),
+                "got: {error}"
+            );
+            assert!(
+                error.contains("--allow-sensitive"),
+                "the refusal must name the flag that unlocks it: {error}"
+            );
+            assert_eq!(before, snapshot(dir.path()));
+        }
+    }
+
+    #[test]
+    fn allow_sensitive_unlocks_it() {
+        let dir = seeded(&[("sshd", SUDO_BEFORE)]);
+        let request = PamRequest {
+            allow_sensitive: true,
+            ..add(&["sshd"])
+        };
+
+        assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+        assert_eq!(read(&dir, "sshd"), SUDO_AFTER);
+    }
+
+    /// Removal is the safe direction, so it is not gated at all: a user who
+    /// wired `system-auth` must be able to unwire it without arguing with the
+    /// CLI about it.
+    #[test]
+    fn remove_is_never_gated_by_the_sensitive_list() {
+        let dir = seeded(&[("system-auth", OMARCHY_PRESENT)]);
+
+        assert_eq!(
+            write_in(dir.path(), &remove(&["system-auth"]), false).unwrap(),
+            WRITE_OK
+        );
+        assert_eq!(read(&dir, "system-auth"), OMARCHY_REMOVED);
+    }
+
+    // -- --if-present -------------------------------------------------------
+
+    #[test]
+    fn if_present_turns_a_missing_service_into_a_no_op_on_both_verbs() {
+        for action in [PamAction::Add, PamAction::Remove] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let request = PamRequest {
+                action,
+                services: vec!["omarchy-lock-face".to_string()],
+                no_confirm: true,
+                if_present: true,
+                ..PamRequest::default()
+            };
+
+            assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+            assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
+        }
+    }
+
+    #[test]
+    fn a_missing_service_without_if_present_still_errors() {
+        for request in [add(&["omarchy-lock-face"]), remove(&["omarchy-lock-face"])] {
+            let dir = tempfile::TempDir::new().unwrap();
+
+            let error = write_in(dir.path(), &request, false)
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                error.contains("PAM service file not found:"),
+                "got: {error}"
+            );
+            assert!(error.contains("omarchy-lock-face"), "got: {error}");
+            assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
+        }
+    }
+
+    /// `--if-present` converts a missing file into success and nothing else.
+    /// A directory where a service file should be is a read failure, not an
+    /// absence, and stays fatal. (The old test used `.` for this; `.` is now
+    /// rejected as a service name before any I/O, so the unreadable target has
+    /// to be a validly-named one.)
+    #[test]
+    fn if_present_does_not_suppress_other_read_errors() {
+        for request in [add(&["sudo"]), remove(&["sudo"])] {
+            let dir = tempfile::TempDir::new().unwrap();
+            fs::create_dir(dir.path().join("sudo")).unwrap();
+            let request = PamRequest {
+                if_present: true,
+                ..request
+            };
+
+            let error = write_in(dir.path(), &request, false)
+                .unwrap_err()
+                .to_string();
+
+            assert!(error.contains("failed to read"), "got: {error}");
+        }
+    }
+
+    // -- --dry-run ----------------------------------------------------------
+
+    #[test]
+    fn dry_run_writes_nothing_and_succeeds() {
+        let dir = seeded(&[
+            ("sudo", SUDO_BEFORE),
+            ("omarchy-lock-face", OMARCHY_PRESENT),
+        ]);
+        let before = snapshot(dir.path());
+
+        for action in [PamAction::Add, PamAction::Remove] {
+            let request = PamRequest {
+                action,
+                services: vec!["sudo".to_string(), "omarchy-lock-face".to_string()],
+                dry_run: true,
+                no_confirm: true,
+                ..PamRequest::default()
+            };
+            assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+        }
+
+        assert_eq!(before, snapshot(dir.path()));
+    }
+
+    #[test]
+    fn dry_run_reports_the_action_it_would_take() {
+        let dir = seeded(&[
+            ("sudo", SUDO_BEFORE),
+            ("omarchy-lock-face", OMARCHY_PRESENT),
+        ]);
+        let request = PamRequest {
+            dry_run: true,
+            json: true,
+            ..add(&["sudo", "omarchy-lock-face"])
+        };
+        let services = requested_services(&request.services);
+        let targets = plan_writes(dir.path(), PamAction::Add, &services, &request, "--x").unwrap();
+
+        let sink = Sink { json: true };
+        let words: Vec<&str> = targets
+            .iter()
+            .map(|t| report_plan(t, &sink).word())
+            .collect();
+
+        assert_eq!(words, ["installed", "unchanged"]);
+    }
+
+    // -- status -------------------------------------------------------------
+
+    #[test]
+    fn status_exit_codes_follow_grep() {
+        let dir = seeded(&[
+            ("omarchy-lock-face", OMARCHY_PRESENT),
+            ("sudo", SUDO_BEFORE),
+        ]);
+        let status = |services: &[&str]| {
+            status_in(
+                dir.path(),
+                &PamRequest {
+                    action: PamAction::Status,
+                    services: services.iter().map(|s| s.to_string()).collect(),
+                    ..PamRequest::default()
+                },
+                false,
+            )
+        };
+
+        assert_eq!(status(&["omarchy-lock-face"]), STATUS_PRESENT);
+        assert_eq!(status(&["sudo"]), STATUS_MISSING);
+        assert_eq!(status(&["not-a-service"]), STATUS_ERROR);
+        assert_eq!(status(&["../escape"]), STATUS_ERROR, "usage error");
+        // The worst outcome wins across services.
+        assert_eq!(status(&["omarchy-lock-face", "sudo"]), STATUS_MISSING);
+        assert_eq!(
+            status(&["omarchy-lock-face", "not-a-service"]),
+            STATUS_ERROR
+        );
+    }
+
+    /// `status` never writes, whatever it is asked about.
+    #[test]
+    fn status_writes_nothing() {
+        let dir = seeded(&[("sudo", SUDO_BEFORE)]);
+        let before = snapshot(dir.path());
+
+        status_in(
+            dir.path(),
+            &PamRequest {
+                action: PamAction::Status,
+                services: vec!["sudo".into(), "absent".into(), "../escape".into()],
+                ..PamRequest::default()
+            },
+            false,
+        );
+
+        assert_eq!(before, snapshot(dir.path()));
+    }
+
+    // -- JSON ---------------------------------------------------------------
+
+    #[test]
+    fn json_document_shape_is_the_contract() {
+        let reports = [ServiceReport {
+            service: "sudo".into(),
+            path: "/etc/pam.d/sudo".into(),
+            outcome: Outcome::Installed,
+            backup: Some("/etc/pam.d/sudo.facelock-backup".into()),
+        }];
+        let value: serde_json::Value =
+            serde_json::from_str(&report_json(PamAction::Add, false, &reports)).unwrap();
+
+        assert_eq!(value["command"], "add");
+        assert_eq!(value["dry_run"], false);
+        assert_eq!(value["services"][0]["service"], "sudo");
+        assert_eq!(value["services"][0]["path"], "/etc/pam.d/sudo");
+        assert_eq!(value["services"][0]["action"], "installed");
+        assert_eq!(
+            value["services"][0]["backup"],
+            "/etc/pam.d/sudo.facelock-backup"
+        );
+        assert!(value["services"][0].get("error").is_none());
+    }
+
+    #[test]
+    fn json_carries_the_error_only_when_there_is_one() {
+        let reports = [
+            ServiceReport {
+                service: "sudo".into(),
+                path: "/etc/pam.d/sudo".into(),
+                outcome: Outcome::Failed("disk full".into()),
+                backup: None,
+            },
+            ServiceReport {
+                service: "polkit-1".into(),
+                path: "/etc/pam.d/polkit-1".into(),
+                outcome: Outcome::Unchanged,
+                backup: None,
+            },
+        ];
+        let value: serde_json::Value =
+            serde_json::from_str(&report_json(PamAction::Add, false, &reports)).unwrap();
+
+        assert_eq!(value["services"][0]["action"], "failed");
+        assert_eq!(value["services"][0]["error"], "disk full");
+        assert_eq!(value["services"][0]["backup"], serde_json::Value::Null);
+        assert!(value["services"][1].get("error").is_none());
+    }
+
+    /// **The `--json` `error` field must never carry localized text.** The
+    /// human gets `PamInvalidServiceName` through the seam, on stderr, where
+    /// gettext belongs; the machine field gets a fixed C-locale string. Pinned
+    /// to that exact string, so re-routing `confined`'s localized error back
+    /// into the row fails here instead of silently making a documented field
+    /// change with `LC_MESSAGES`.
+    #[test]
+    fn a_rejected_name_reports_a_locale_independent_reason() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sink = Sink { json: true };
+
+        let reports = status_reports(dir.path(), &["../escape".to_string()], &sink);
+
+        assert_eq!(
+            reports[0].outcome,
+            Outcome::Unknown(INVALID_SERVICE_NAME.to_string())
+        );
+        assert_eq!(INVALID_SERVICE_NAME, "invalid service name");
+        // ...and it is what lands in the document.
+        let value: serde_json::Value =
+            serde_json::from_str(&report_json(PamAction::Status, false, &reports)).unwrap();
+        assert_eq!(value["services"][0]["error"], "invalid service name");
+        assert_eq!(value["services"][0]["action"], "unknown");
+        // N3: a name that was rejected is never resolved, so nothing — not
+        // even the backup probe — goes near the filesystem for it.
+        assert_eq!(reports[0].backup, None);
+    }
+
+    /// E10: a service name reaches here from argv and confinement rejects `/`
+    /// but not `"`, so the document has to be built by a serializer rather
+    /// than by `format!`.
+    #[test]
+    fn json_escapes_a_service_name_containing_a_quote() {
+        let reports = [ServiceReport {
+            service: "a\"b".into(),
+            path: "/etc/pam.d/a\"b".into(),
+            outcome: Outcome::Missing,
+            backup: None,
+        }];
+        let rendered = report_json(PamAction::Status, false, &reports);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(value["services"][0]["service"], "a\"b");
+    }
+
+    /// Every word in the vocabulary is distinct and stable; this is the list
+    /// `docs/contracts.md` documents.
+    #[test]
+    fn outcome_vocabulary_is_pinned() {
+        let words: Vec<&str> = [
+            Outcome::Installed,
+            Outcome::Removed,
+            Outcome::Unchanged,
+            Outcome::Absent,
+            Outcome::Declined,
+            Outcome::Failed(String::new()),
+            Outcome::Present,
+            Outcome::Missing,
+            Outcome::Unknown(String::new()),
+        ]
+        .iter()
+        .map(Outcome::word)
+        .collect();
+
+        assert_eq!(
+            words,
+            [
+                "installed",
+                "removed",
+                "unchanged",
+                "absent",
+                "declined",
+                "failed",
+                "present",
+                "missing",
+                "unknown",
+            ]
+        );
+    }
+
+    // -- misc ---------------------------------------------------------------
+
+    #[test]
+    fn no_service_means_sudo_and_duplicates_collapse() {
+        assert_eq!(requested_services(&[]), [DEFAULT_PAM_SERVICE]);
+        assert_eq!(
+            requested_services(&["sudo".into(), "polkit-1".into(), "sudo".into()]),
+            ["sudo", "polkit-1"]
+        );
+    }
+
+    #[test]
+    fn facelock_line_detection_ignores_spacing_and_comments() {
+        assert!(is_facelock_pam_line(PAM_LINE));
+        assert!(is_facelock_pam_line("auth  sufficient  pam_facelock.so"));
+        assert!(!is_facelock_pam_line("#auth sufficient pam_facelock.so"));
+        assert!(!is_facelock_pam_line("auth include system-login"));
+    }
+
+    #[test]
+    fn sensitive_services_are_the_three_that_can_lock_you_out() {
+        assert!(SENSITIVE_SERVICES.contains(&"system-auth"));
+        assert!(SENSITIVE_SERVICES.contains(&"login"));
+        assert!(SENSITIVE_SERVICES.contains(&"sshd"));
+        assert!(!SENSITIVE_SERVICES.contains(&"sudo"));
+    }
+
+    /// `install_for_setup` edits `/etc/pam.d` and `run_with_plan` reaches it
+    /// directly for a standalone `--pam`, so it must refuse non-root itself
+    /// (C6: before any other check and any output). Regression: routing
+    /// standalone `--pam` through it once let an unprivileged `facelock setup
+    /// --pam` read and report on `/etc/pam.d/sudo`.
+    #[test]
+    fn setup_alias_refuses_without_root() {
+        if nix::unistd::Uid::current().is_root() {
+            return; // the check cannot fire; nothing to assert
+        }
+        for error in [
+            install_for_setup(&["sudo".to_string()], true, true).unwrap_err(),
+            remove_for_setup(&["sudo".to_string()], true).unwrap_err(),
+        ] {
+            let error = error.to_string();
+            assert!(
+                error.contains("Root required"),
+                "expected the root refusal before any other check, got: {error}"
+            );
+        }
+    }
+}

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -18,6 +18,14 @@ use crate::message::{
     fail,
 };
 
+// The `/etc/pam.d` writer lives in `commands/pam.rs` (#174) — `facelock pam
+// add|remove|status` is its command, and `setup --pam` is an alias onto it.
+// What stays here is the wizard's *menu* (`PAM_CANDIDATES`, `candidates_in`):
+// it is the list of services setup offers to configure, which is a property of
+// the setup flow rather than of the writer, and moving it would have split the
+// multi-select from the entries it renders for no gain.
+use super::pam::{PAM_DIR, PAM_LINE, PAM_MODULE_PATH, is_facelock_pam_line};
+
 /// Embedded systemd unit file.
 const SERVICE_UNIT: &str = include_str!("../../../../systemd/facelock-daemon.service");
 
@@ -33,8 +41,9 @@ const MANIFEST_TOML: &str = include_str!("../../../../models/manifest.toml");
 /// Marker file written on successful setup completion.
 pub const SETUP_COMPLETE_MARKER: &str = "/etc/facelock/.setup-complete";
 
-/// PAM service targeted by `--pam` when `--service` is not given.
-pub const DEFAULT_PAM_SERVICE: &str = "sudo";
+/// PAM service targeted by `--pam` when `--service` is not given. Declared by
+/// the writer and re-exported so `setup::DEFAULT_PAM_SERVICE` keeps resolving.
+pub use super::pam::DEFAULT_PAM_SERVICE;
 
 // ---------------------------------------------------------------------------
 // CLI argument resolution
@@ -300,11 +309,27 @@ pub fn run(non_interactive: bool) -> anyhow::Result<()> {
 ///
 /// Only when a base setup runs. `ipc_client::require_root` prompts and re-execs
 /// under `sudo` on a TTY, and standalone `--pam` / `--systemd` never did that:
-/// they bail immediately from their own root checks (`run_pam`, `check_root`).
+/// they bail immediately from their own root checks (`commands::pam`,
+/// `check_root`).
 /// Escalating there would be a new, surprising behavior for exactly the
 /// scripted invocations that must stay byte-compatible.
 pub fn needs_root_precheck(plan: &SetupPlan) -> bool {
     plan.base.is_some()
+}
+
+/// How `setup`'s flags map onto the writer's two independent knobs
+/// (`--no-confirm`, `--allow-sensitive`).
+///
+/// A pure function rather than an expression inline in [`run_with_plan`]
+/// because it *is* the security property: `--non-interactive` promises no
+/// prompts, so it suppresses the per-file "Proceed?" confirmation, and it
+/// deliberately does **not** bypass the sensitive-service gate. `setup --yes`
+/// is the one flag that still means both halves — "skip the prompt" *and*
+/// "unlock system-auth/login/sshd" — and so maps onto both. On `facelock pam
+/// add` the two are separate flags and neither implies the other.
+fn setup_pam_knobs(plan: &SetupPlan) -> (bool, bool) {
+    let no_prompt = plan.base == Some(BaseMode::NonInteractive);
+    (plan.yes || no_prompt, plan.yes)
 }
 
 /// Execute a resolved plan: base setup first (if any), then the standalone
@@ -336,22 +361,23 @@ pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
         SystemdPref::Ask | SystemdPref::Skip => {}
     }
 
+    // `--pam` is an alias onto `facelock pam add|remove` (#174): the plan and
+    // its precedence rules stay here, the execution is the writer's.
     match &plan.pam {
         PamPref::Remove {
             service,
             if_present,
-        } => run_pam(service, true, *if_present, plan.yes)?,
+        } => super::pam::remove_for_setup(std::slice::from_ref(service), *if_present)?,
         PamPref::Install { service } => {
             // The wizard's step 9 already applied `--pam`; installing again here
             // would be a second, unasked-for edit of the same file.
             if !wizard_ran {
-                let service = service.as_deref().unwrap_or(DEFAULT_PAM_SERVICE);
-                // `--non-interactive` promises no prompts, so the per-file
-                // "Proceed?" confirmation is suppressed. It deliberately does
-                // *not* bypass the SENSITIVE_SERVICES gate, which checks `--yes`.
-                let no_prompt = plan.base == Some(BaseMode::NonInteractive);
-                pam_install(service, plan.yes, no_prompt)?;
-                print_pam_extension_hint();
+                let service = service
+                    .as_deref()
+                    .unwrap_or(DEFAULT_PAM_SERVICE)
+                    .to_string();
+                let (no_confirm, allow_sensitive) = setup_pam_knobs(&plan);
+                super::pam::install_for_setup(&[service], no_confirm, allow_sensitive)?;
             }
         }
         PamPref::Ask | PamPref::Skip => {}
@@ -550,7 +576,11 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
         wizard_hyprlock_handoff(&theme);
     }
 
-    print_pam_extension_hint();
+    // The closing hint fires once per wizard run, whatever step 9 decided —
+    // it is advice about extending PAM by hand, not a report of what happened.
+    Terminal.info(&PamMessage::PamExtensionHint {
+        line: PAM_LINE.to_string(),
+    });
 
     // -- Summary --
     Terminal.info(&SetupMessage::SetupCompleteHeader);
@@ -1927,7 +1957,7 @@ fn wizard_systemd_setup(theme: &ColorfulTheme, assume_yes: bool) -> anyhow::Resu
 /// every file byte-identical" is testable against a tempdir.
 ///
 /// `module_present` is the caller's answer to "is `pam_facelock.so` installed?".
-/// It is hoisted out of [`pam_install_in`] so the check happens once, before any
+/// It is hoisted out of the writer so the check happens once, before any
 /// prompt or write, and so tests can drive the write path on a machine that has
 /// no PAM module installed.
 fn pam_step_in(
@@ -1959,7 +1989,12 @@ fn pam_step_in(
             Terminal.info(&PamMessage::ConfiguringPamFor {
                 service: service.clone(),
             });
-            pam_install_in(base, &service, plan.yes, false)?;
+            // Step 9 runs only under a wizard base, never
+            // `--non-interactive`, so `setup_pam_knobs` reduces to `plan.yes`
+            // on both knobs here. Splitting them would make `--pam --service X
+            // --yes` start prompting where it never did.
+            let (no_confirm, allow_sensitive) = setup_pam_knobs(plan);
+            super::pam::install_one_in(base, &service, allow_sensitive, no_confirm)?;
             Ok(vec![service])
         }
         PamStep::Ask => wizard_pam_setup_in(base, theme),
@@ -1985,34 +2020,34 @@ fn wizard_pam_setup_in(base: &Path, theme: &ColorfulTheme) -> anyhow::Result<Vec
     let labels: Vec<&str> = candidates.iter().map(|c| c.description).collect();
     let defaults: Vec<bool> = candidates.iter().map(|c| c.default_enabled).collect();
 
-    let selected_services: Vec<String> = if !is_interactive() {
-        // Non-TTY / non-interactive: auto-select per defaults.
-        candidates
-            .iter()
-            .zip(defaults.iter())
-            .filter(|(_, d)| **d)
-            .map(|(c, _)| c.service.to_string())
-            .collect()
-    } else {
-        let selections = MultiSelect::with_theme(theme)
-            .with_prompt(PamMessage::PromptSelectPamServices.localized())
-            .items(&labels)
-            .defaults(&defaults)
-            .interact()?;
-        selections
-            .into_iter()
-            .map(|i| candidates[i].service.to_string())
-            .collect()
-    };
+    // The multi-select is the only thing that can select a service here, and
+    // it needs a terminal. There used to be a `!is_interactive()` arm that
+    // auto-selected every `default_enabled` candidate instead — hyprlock,
+    // swaylock, kscreenlocker_greet and lightdm, written with no consent from
+    // anyone. It could not fire in production (`run_with_plan` demotes a
+    // non-TTY wizard base to `run_non_interactive` under the same
+    // `is_interactive()` test, so `run_wizard` — this function's only caller —
+    // never runs headless), and the one test that reached it did so by calling
+    // step 9 directly.
+    let selections = MultiSelect::with_theme(theme)
+        .with_prompt(PamMessage::PromptSelectPamServices.localized())
+        .items(&labels)
+        .defaults(&defaults)
+        .interact()?;
+    let selected_services: Vec<String> = selections
+        .into_iter()
+        .map(|i| candidates[i].service.to_string())
+        .collect();
 
     let mut configured = Vec::new();
     for service in selected_services {
         Terminal.info(&PamMessage::ConfiguringPamFor {
             service: service.clone(),
         });
-        // `yes = true`: the multi-select above *is* the per-service consent, and
-        // no candidate is in SENSITIVE_SERVICES.
-        match pam_install_in(base, &service, true, false) {
+        // The multi-select above *is* the per-service consent, so no
+        // confirmation is asked for again; no candidate is in
+        // SENSITIVE_SERVICES, so the gate is moot either way.
+        match super::pam::install_one_in(base, &service, true, true) {
             Ok(()) => configured.push(service),
             Err(e) => {
                 Terminal.info(&PamMessage::PamConfigureFailed {
@@ -2747,253 +2782,12 @@ const PAM_CANDIDATES: &[PamCandidate] = &[
     },
 ];
 
-/// The real PAM configuration directory. `candidates_in` and `pam_install_in`
-/// take it as a parameter so tests can point them at a tempdir instead.
-const PAM_DIR: &str = "/etc/pam.d";
-
 /// Returns candidates from `PAM_CANDIDATES` whose service file exists under `base`.
 fn candidates_in(base: &Path) -> Vec<&'static PamCandidate> {
     PAM_CANDIDATES
         .iter()
         .filter(|c| base.join(c.service).exists())
         .collect()
-}
-
-// The four prints below are the last in this file that still write to stdout
-// directly instead of going through the message sink, and they stay that way
-// on purpose: this whole region moves to `commands/pam.rs` (#174), which
-// converts them during the move. Converting them here would only make that
-// move a conflict.
-
-// --- PAM installation ---
-
-const PAM_LINE: &str = "auth      sufficient pam_facelock.so";
-
-/// Print a copy-pasteable hint so users can extend PAM integration to any service.
-fn print_pam_extension_hint() {
-    println!();
-    println!("==> facelock PAM line for manual extension to other services:");
-    println!("==>   {PAM_LINE}");
-    println!(
-        "==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
-    );
-}
-
-const PAM_MODULE_PATH: &str = "/lib/security/pam_facelock.so";
-const SENSITIVE_SERVICES: &[&str] = &["system-auth", "login", "sshd"];
-
-/// Check if a PAM config line references pam_facelock, regardless of spacing.
-fn is_facelock_pam_line(line: &str) -> bool {
-    let trimmed = line.trim();
-    !trimmed.starts_with('#') && trimmed.contains("pam_facelock.so")
-}
-
-pub fn run_pam(service: &str, remove: bool, if_present: bool, yes: bool) -> anyhow::Result<()> {
-    // 1. Check root
-    if !nix::unistd::Uid::current().is_root() {
-        bail!("PAM configuration requires root. Run with sudo.");
-    }
-
-    if remove {
-        pam_remove(service, if_present)
-    } else {
-        pam_install(service, yes, false)?;
-        print_pam_extension_hint();
-        Ok(())
-    }
-}
-
-/// [`pam_install_in`] against the real [`PAM_DIR`], plus the module-presence
-/// precondition that the parameterized form leaves to its caller.
-///
-/// Root is re-checked here rather than only in [`run_pam`]: this function edits
-/// `/etc/pam.d`, and it is reachable both from `run_pam` and directly from
-/// `run_with_plan`. The parameterized [`pam_install_in`] deliberately does not
-/// check, so tests can drive the write path against a tempdir unprivileged.
-fn pam_install(service: &str, yes: bool, no_prompt: bool) -> anyhow::Result<()> {
-    // 1. Check root
-    if !nix::unistd::Uid::current().is_root() {
-        bail!("PAM configuration requires root. Run with sudo.");
-    }
-
-    // 2. Check PAM module exists
-    if !Path::new(PAM_MODULE_PATH).exists() {
-        bail!(
-            "PAM module not found at {PAM_MODULE_PATH}.\n\
-             Install it first: cargo build --release -p pam-facelock && \
-             sudo cp target/release/libpam_facelock.so {PAM_MODULE_PATH}"
-        );
-    }
-
-    pam_install_in(Path::new(PAM_DIR), service, yes, no_prompt)
-}
-
-/// Insert the facelock PAM line into `<base>/<service>`.
-///
-/// `yes` gates [`SENSITIVE_SERVICES`]; `no_prompt` only suppresses the per-file
-/// "Proceed?" confirmation, because `--non-interactive` promises no prompts but
-/// must not weaken the sensitive-service gate.
-///
-/// The caller is responsible for checking that the PAM module is installed.
-fn pam_install_in(base: &Path, service: &str, yes: bool, no_prompt: bool) -> anyhow::Result<()> {
-    // 3. Refuse sensitive services without --yes
-    if SENSITIVE_SERVICES.contains(&service) && !yes {
-        bail!(
-            "Refusing to modify '{service}' without --yes flag.\n\
-             This is a sensitive PAM service. Use: facelock setup --pam --service {service} --yes"
-        );
-    }
-
-    let pam_file = base.join(service);
-    let pam_path = pam_file.display().to_string();
-    let pam_file = pam_file.as_path();
-
-    if !pam_file.exists() {
-        bail!("PAM service file not found: {pam_path}");
-    }
-
-    // Read existing content
-    let content =
-        fs::read_to_string(pam_file).with_context(|| format!("failed to read {pam_path}"))?;
-
-    // Check idempotency — match on the module name, not exact spacing
-    if content.lines().any(is_facelock_pam_line) {
-        Terminal.info(&PamMessage::PamLineAlreadyPresent {
-            path: pam_path.clone(),
-        });
-        return Ok(());
-    }
-
-    // 4. Preview change and confirm before any modification
-    let backup_path = format!("{pam_path}.facelock-backup");
-
-    // Decide where the line will go BEFORE prompting, so the preview is accurate.
-    let insertion_hint = if content.lines().any(|l| l.trim_start().starts_with("auth")) {
-        PamMessage::PamInsertBeforeAuthHint
-    } else {
-        PamMessage::PamInsertAtTopHint
-    };
-
-    Terminal.info(&PamMessage::PamModifyPreview {
-        path: pam_path.clone(),
-        line: PAM_LINE.to_string(),
-        hint: insertion_hint.localized(),
-        backup: backup_path.clone(),
-    });
-
-    let proceed = if yes || no_prompt || !std::io::stdin().is_terminal() {
-        true
-    } else {
-        Confirm::new()
-            .with_prompt(PamMessage::ConfirmProceed.localized())
-            .default(true)
-            .interact()
-            .context("failed to read confirmation")?
-    };
-
-    if !proceed {
-        Terminal.info(&PamMessage::PamSkippedFile {
-            path: pam_path.clone(),
-        });
-        return Ok(());
-    }
-
-    // 4b. Create backup (always, before any modification)
-    fs::copy(pam_file, &backup_path)
-        .with_context(|| format!("failed to back up {pam_path} to {backup_path}"))?;
-    Terminal.info(&PamMessage::PamBackedUp {
-        path: pam_path.clone(),
-        backup: backup_path.clone(),
-    });
-
-    // 5. Prepend PAM line before first auth line
-    let mut new_lines: Vec<String> = Vec::new();
-    let mut inserted = false;
-
-    for line in content.lines() {
-        if !inserted && line.trim_start().starts_with("auth") {
-            new_lines.push(PAM_LINE.to_string());
-            inserted = true;
-        }
-        new_lines.push(line.to_string());
-    }
-
-    if !inserted {
-        // No auth line found; append at the top
-        new_lines.insert(0, PAM_LINE.to_string());
-    }
-
-    // Preserve trailing newline
-    let mut output = new_lines.join("\n");
-    if content.ends_with('\n') {
-        output.push('\n');
-    }
-
-    fs::write(pam_file, &output).with_context(|| format!("failed to write {pam_path}"))?;
-
-    Terminal.info(&PamMessage::PamInstalled {
-        path: pam_path.clone(),
-        backup: backup_path.clone(),
-        service: service.to_string(),
-    });
-
-    Ok(())
-}
-
-fn pam_remove(service: &str, if_present: bool) -> anyhow::Result<()> {
-    pam_remove_in(Path::new(PAM_DIR), service, if_present)
-}
-
-fn pam_remove_in(base: &Path, service: &str, if_present: bool) -> anyhow::Result<()> {
-    let pam_file = base.join(service.trim_start_matches('/'));
-    let pam_path = pam_file.display().to_string();
-
-    let content = match fs::read_to_string(&pam_file) {
-        Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            if if_present {
-                Terminal.info(&PamMessage::PamServiceAbsent {
-                    path: pam_path.clone(),
-                });
-                return Ok(());
-            }
-            bail!("PAM service file not found: {pam_path}");
-        }
-        Err(error) => return Err(error).with_context(|| format!("failed to read {pam_path}")),
-    };
-
-    let original_count = content.lines().count();
-    let new_lines: Vec<&str> = content
-        .lines()
-        .filter(|line| !is_facelock_pam_line(line))
-        .collect();
-
-    if new_lines.len() == original_count {
-        Terminal.info(&PamMessage::PamNoLineFound {
-            path: pam_path.clone(),
-        });
-    } else {
-        let mut output = new_lines.join("\n");
-        if content.ends_with('\n') {
-            output.push('\n');
-        }
-
-        fs::write(&pam_file, &output).with_context(|| format!("failed to write {pam_path}"))?;
-        Terminal.info(&PamMessage::PamRemoved {
-            path: pam_path.clone(),
-        });
-    }
-
-    // Offer backup restore
-    let backup_path = format!("{pam_path}.facelock-backup");
-    if Path::new(&backup_path).exists() {
-        Terminal.info(&PamMessage::PamBackupExists {
-            path: pam_path.clone(),
-            backup: backup_path.clone(),
-        });
-    }
-
-    Ok(())
 }
 
 fn verify_after_download(path: &Path, expected_sha256: &str, name: &str) -> anyhow::Result<()> {
@@ -3561,73 +3355,6 @@ mod tests {
     }
 
     #[test]
-    fn pam_insert_before_first_auth_line() {
-        let original = "\
-#%PAM-1.0
-auth    include   system-local-login
-auth    include   system-login
-account include   system-login
-";
-        // Simulate the insertion logic
-        let mut new_lines: Vec<String> = Vec::new();
-        let mut inserted = false;
-        for line in original.lines() {
-            if !inserted && line.trim_start().starts_with("auth") {
-                new_lines.push(PAM_LINE.to_string());
-                inserted = true;
-            }
-            new_lines.push(line.to_string());
-        }
-        let mut output = new_lines.join("\n");
-        if original.ends_with('\n') {
-            output.push('\n');
-        }
-
-        assert!(inserted);
-        let lines: Vec<&str> = output.lines().collect();
-        assert_eq!(lines[0], "#%PAM-1.0");
-        assert_eq!(lines[1], PAM_LINE);
-        assert_eq!(lines[2], "auth    include   system-local-login");
-    }
-
-    #[test]
-    fn pam_idempotent_detection() {
-        // Exact match
-        let content = format!("#%PAM-1.0\n{PAM_LINE}\nauth    include   system-login\n");
-        assert!(content.lines().any(is_facelock_pam_line));
-
-        // Different spacing should still match
-        let content2 =
-            "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\n";
-        assert!(content2.lines().any(is_facelock_pam_line));
-
-        // Commented-out line should not match
-        let content3 =
-            "#%PAM-1.0\n#auth sufficient pam_facelock.so\nauth    include   system-login\n";
-        assert!(!content3.lines().any(is_facelock_pam_line));
-    }
-
-    #[test]
-    fn pam_remove_filters_line() {
-        // Should remove regardless of spacing
-        let content = "#%PAM-1.0\nauth  sufficient  pam_facelock.so\nauth    include   system-login\naccount include   system-login\n";
-        let new_lines: Vec<&str> = content
-            .lines()
-            .filter(|line| !is_facelock_pam_line(line))
-            .collect();
-        assert_eq!(new_lines.len(), 3);
-        assert!(!new_lines.iter().any(|l| is_facelock_pam_line(l)));
-    }
-
-    #[test]
-    fn sensitive_services_detected() {
-        assert!(SENSITIVE_SERVICES.contains(&"system-auth"));
-        assert!(SENSITIVE_SERVICES.contains(&"login"));
-        assert!(SENSITIVE_SERVICES.contains(&"sshd"));
-        assert!(!SENSITIVE_SERVICES.contains(&"sudo"));
-    }
-
-    #[test]
     fn detect_candidates_filters_by_presence() {
         let tmp = tempfile::TempDir::new().unwrap();
         std::fs::write(tmp.path().join("sudo"), "").unwrap();
@@ -3912,6 +3639,13 @@ mod action_tests {
 
     /// The plan's acceptance criterion: declining PAM leaves every file under
     /// the PAM directory byte-identical, and adds none.
+    ///
+    /// `hash_harness_detects_a_real_pam_write` below is the foil that keeps
+    /// this honest. It used to be `default_plan_still_configures_pam`, which
+    /// drove the default (`Ask`) plan and relied on step 9 auto-selecting every
+    /// `default_enabled` candidate when stdin was not a terminal. That branch
+    /// is gone (#174) and the test with it — `cargo test` from a terminal gets
+    /// a tty on stdin, so it was already blocking on the multi-select there.
     #[test]
     fn no_pam_leaves_every_pam_file_byte_identical() {
         let dir = fake_pam_d();
@@ -3977,85 +3711,6 @@ mod action_tests {
         assert_eq!(before, hash_dir(dir.path()));
     }
 
-    #[test]
-    fn pam_remove_if_present_missing_service_is_a_noop() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let before = hash_dir(dir.path());
-
-        pam_remove_in(dir.path(), "omarchy-lock-face", true).unwrap();
-
-        assert_eq!(before, hash_dir(dir.path()));
-        assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
-    }
-
-    #[test]
-    fn pam_remove_missing_service_without_if_present_still_errors() {
-        let dir = tempfile::TempDir::new().unwrap();
-
-        let error = pam_remove_in(dir.path(), "omarchy-lock-face", false).unwrap_err();
-
-        let rendered = error.to_string();
-        assert!(rendered.contains("PAM service file not found:"));
-        assert!(rendered.contains("omarchy-lock-face"));
-        assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
-    }
-
-    #[test]
-    fn pam_remove_if_present_removes_an_existing_facelock_line() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let pam_file = dir.path().join("omarchy-lock-face");
-        fs::write(
-            &pam_file,
-            format!("#%PAM-1.0\n{PAM_LINE}\nauth include system-auth\n"),
-        )
-        .unwrap();
-
-        pam_remove_in(dir.path(), "omarchy-lock-face", true).unwrap();
-
-        assert_eq!(
-            fs::read_to_string(pam_file).unwrap(),
-            "#%PAM-1.0\nauth include system-auth\n"
-        );
-    }
-
-    #[test]
-    fn pam_remove_if_present_preserves_a_file_without_a_facelock_line() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let pam_file = dir.path().join("omarchy-lock-face");
-        let original = b"#%PAM-1.0\nauth include system-auth\n";
-        fs::write(&pam_file, original).unwrap();
-
-        pam_remove_in(dir.path(), "omarchy-lock-face", true).unwrap();
-
-        assert_eq!(fs::read(pam_file).unwrap(), original);
-    }
-
-    #[test]
-    fn pam_remove_if_present_does_not_suppress_other_read_errors() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let before = hash_dir(dir.path());
-
-        let error = pam_remove_in(dir.path(), ".", true).unwrap_err();
-
-        assert!(error.to_string().contains("failed to read"));
-        assert_eq!(before, hash_dir(dir.path()));
-    }
-
-    #[test]
-    fn pam_remove_absolute_service_stays_anchored_under_base() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let base = dir.path().join("pam.d");
-        fs::create_dir(&base).unwrap();
-        let absolute_target = dir.path().join("outside-service");
-        let original = format!("#%PAM-1.0\n{PAM_LINE}\nauth include system-auth\n");
-        fs::write(&absolute_target, &original).unwrap();
-
-        pam_remove_in(&base, absolute_target.to_str().unwrap(), true).unwrap();
-
-        assert_eq!(fs::read_to_string(absolute_target).unwrap(), original);
-        assert!(fs::read_dir(base).unwrap().next().is_none());
-    }
-
     // -- `--pam` in a wizard base -------------------------------------------
 
     /// `--pam --service hyprlock` configures exactly `hyprlock`.
@@ -4080,9 +3735,18 @@ mod action_tests {
     }
 
     /// Bare `--pam` means `sudo`, not the candidates' `default_enabled` set.
+    ///
+    /// `yes` is set for the same reason its sibling tests set it: without it
+    /// the write reaches the per-file "Proceed?" confirmation, and `cargo test`
+    /// run from a terminal hands the test a real tty on stdin, so the prompt
+    /// blocks the suite rather than failing it. The assertion is about *which*
+    /// service is configured; prompting is not part of it.
     #[test]
     fn pam_without_service_means_sudo_not_the_default_enabled_set() {
-        let plan = pam_plan(PamPref::Install { service: None });
+        let plan = SetupPlan {
+            yes: true,
+            ..pam_plan(PamPref::Install { service: None })
+        };
         assert_eq!(
             pam_step_for(&plan),
             PamStep::Install(DEFAULT_PAM_SERVICE.to_string())
@@ -4099,22 +3763,27 @@ mod action_tests {
         assert_eq!(before["polkit-1"], after["polkit-1"]);
     }
 
-    /// The sensitive-service gate still requires `--yes`, and refusing it
-    /// writes nothing.
+    /// The `setup --yes` mapping is the security property the flag split has
+    /// to preserve, and it is the one part of it that lives on this side of
+    /// the seam. `commands::pam` pins that the engine honours the knobs;
+    /// this pins that `setup` sets them right.
     #[test]
-    fn sensitive_service_refused_without_yes() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::write(
-            dir.path().join("sshd"),
-            "#%PAM-1.0\nauth\t\tinclude\t\tsystem-auth\n",
-        )
-        .unwrap();
-        let before = hash_dir(dir.path());
+    fn setup_maps_yes_to_both_knobs_and_non_interactive_to_only_one() {
+        let with = |base, yes| {
+            setup_pam_knobs(&SetupPlan {
+                base,
+                yes,
+                ..SetupPlan::default()
+            })
+        };
 
-        // `no_prompt` (what `--non-interactive` sets) must not weaken the gate.
-        let err = pam_install_in(dir.path(), "sshd", false, true).unwrap_err();
-        assert!(err.to_string().contains("Refusing to modify 'sshd'"));
-        assert_eq!(before, hash_dir(dir.path()));
+        // Standalone `--pam`: ask, and refuse the sensitive services.
+        assert_eq!(with(None, false), (false, false));
+        // `--non-interactive --pam`: no prompts, and *still* refuse them.
+        assert_eq!(with(Some(BaseMode::NonInteractive), false), (true, false));
+        // `--pam --yes`: the documented combined meaning — both halves.
+        assert_eq!(with(None, true), (true, true));
+        assert_eq!(with(Some(BaseMode::NonInteractive), true), (true, true));
     }
 
     // -- `--no-systemd` -----------------------------------------------------
@@ -4203,22 +3872,6 @@ mod action_tests {
         assert!(pam_step_for(&plan).touches_pam_d());
     }
 
-    /// ...and step 9 under a default plan really does write. Under `cargo test`
-    /// stdin is not a terminal, so it falls back to the candidates'
-    /// `default_enabled` set — which is exactly what `--no-pam` must prevent.
-    #[test]
-    fn default_plan_still_configures_pam() {
-        let dir = fake_pam_d();
-        let before = hash_dir(dir.path());
-
-        let plan = SetupPlan::default();
-        let configured = pam_step_in(dir.path(), &plan, &ColorfulTheme::default(), true).unwrap();
-
-        assert!(configured.contains(&"sudo".to_string()));
-        assert!(configured.contains(&"hyprlock".to_string()));
-        assert_ne!(before, hash_dir(dir.path()));
-    }
-
     /// `-y` makes the step 6/7/8 confirmations take their default instead of
     /// prompting. `cargo test` gives us a non-tty stdin, so a real prompt here
     /// would fail — `Ok(true)` is proof it was suppressed.
@@ -4243,7 +3896,7 @@ mod action_tests {
     }
 
     /// A PAM module that is not installed short-circuits step 9 before any
-    /// write — the check the tests above hoist out of `pam_install_in`.
+    /// write — the check the tests above hoist out of the writer.
     #[test]
     fn missing_pam_module_writes_nothing() {
         let dir = fake_pam_d();
@@ -4254,21 +3907,5 @@ mod action_tests {
 
         assert!(configured.is_empty());
         assert_eq!(before, hash_dir(dir.path()));
-    }
-
-    /// `pam_install` edits `/etc/pam.d` and is reachable from `run_with_plan`
-    /// without going through `run_pam`, so it must refuse non-root itself.
-    /// Regression: routing standalone `--pam` through `pam_install` once let an
-    /// unprivileged `facelock setup --pam` read and report on `/etc/pam.d/sudo`.
-    #[test]
-    fn pam_install_refuses_without_root() {
-        if nix::unistd::Uid::current().is_root() {
-            return; // the check cannot fire; nothing to assert
-        }
-        let err = pam_install("sudo", true, true).unwrap_err().to_string();
-        assert!(
-            err.contains("requires root"),
-            "expected the root refusal before any other check, got: {err}"
-        );
     }
 }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -15,7 +15,7 @@ use facelock_cli::commands::hyprlock::HyprlockCommand;
 use facelock_cli::commands::setup::{SetupArgs, resolve_setup_plan};
 use facelock_cli::{commands, logging, message, notifications, resolved};
 
-use args::{ConfirmArg, JsonArg, SetupCli, UserArg};
+use args::{ConfirmArg, JsonArg, PamCli, SetupCli, UserArg};
 
 #[derive(Parser)]
 #[command(name = "facelock", about = "Linux face authentication", version)]
@@ -123,6 +123,11 @@ enum Commands {
         #[command(subcommand)]
         command: TpmCommand,
     },
+    /// Manage the facelock line in /etc/pam.d service files
+    Pam {
+        #[command(subcommand)]
+        command: PamCli,
+    },
     /// Manage hyprlock lock-screen integration (no root required)
     Hyprlock {
         #[command(subcommand)]
@@ -208,6 +213,14 @@ fn main() -> anyhow::Result<()> {
                 Commands::IsEnrolled { user, json } => {
                     std::process::exit(commands::is_enrolled::run(user.user, json.json, quiet))
                 }
+                // `pam` consumes no `Config` either: `add`/`remove` edit
+                // `/etc/pam.d` and `status` reads it, and neither wants a
+                // missing or broken config file to be the thing that stops
+                // them. Its exit code is its own — `status` answers on grep's
+                // 0/1/2 scale — so it exits here rather than returning `()`.
+                Commands::Pam { command } => {
+                    std::process::exit(commands::pam::run(command.into(), quiet)?)
+                }
                 Commands::Hyprlock { command } => commands::hyprlock::run(command),
                 Commands::Config { edit } => commands::config::run(edit),
                 Commands::Restart => commands::config::restart(),
@@ -267,6 +280,7 @@ fn main() -> anyhow::Result<()> {
                         Commands::Daemon
                         | Commands::Auth { .. }
                         | Commands::IsEnrolled { .. }
+                        | Commands::Pam { .. }
                         | Commands::Hyprlock { .. }
                         | Commands::Config { .. }
                         | Commands::Restart
@@ -853,6 +867,46 @@ mod tests {
             &["facelock", "audit", "-f", "-l", "5"],
             &["facelock", "list", "-u", "alice", "--json"],
             &["facelock", "devices", "--json"],
+            // `facelock pam` (#174). The new verb is additive: every row above
+            // is what `setup --pam` accepted before it existed, and both
+            // spellings keep working.
+            &["facelock", "pam", "add"],
+            &["facelock", "pam", "add", "--service", "sudo"],
+            &[
+                "facelock",
+                "pam",
+                "add",
+                "--service",
+                "sudo",
+                "--service",
+                "polkit-1",
+                "--no-confirm",
+                "--dry-run",
+                "--json",
+            ],
+            &[
+                "facelock",
+                "pam",
+                "add",
+                "--service",
+                "system-auth",
+                "--allow-sensitive",
+                "-y",
+            ],
+            &["facelock", "pam", "add", "--service", "x", "--if-present"],
+            &["facelock", "pam", "remove"],
+            &[
+                "facelock",
+                "pam",
+                "remove",
+                "--service",
+                "sudo",
+                "--if-present",
+                "--no-confirm",
+            ],
+            &["facelock", "pam", "status"],
+            &["facelock", "pam", "status", "--service", "sudo", "--json"],
+            &["facelock", "--quiet", "pam", "status", "--json"],
         ] {
             Cli::try_parse_from(argv)
                 .unwrap_or_else(|e| panic!("`{}` must still parse: {e}", argv.join(" ")));
@@ -908,5 +962,77 @@ mod tests {
             panic!("expected the Clear variant");
         };
         assert!(confirm.yes);
+    }
+
+    // -----------------------------------------------------------------------
+    // `facelock pam` (#174)
+    // -----------------------------------------------------------------------
+
+    fn pam_request(args: &[&str]) -> facelock_cli::commands::pam::PamRequest {
+        let argv: Vec<&str> = ["facelock", "pam"].iter().chain(args).copied().collect();
+        let cli = Cli::try_parse_from(argv).expect("expected these args to parse");
+        let Commands::Pam { command } = cli.command else {
+            panic!("expected the Pam variant");
+        };
+        command.into()
+    }
+
+    /// The defect the verb exists to fix: one process, several services. The
+    /// old surface took a single `Option<String>`, so a wrapper wanting three
+    /// services ran three of them.
+    #[test]
+    fn pam_service_is_repeatable_and_ordered() {
+        assert_eq!(
+            pam_request(&["add", "--service", "sudo", "--service", "polkit-1"]).services,
+            ["sudo", "polkit-1"]
+        );
+        // Empty is not "no services" — it is `sudo`, resolved in the command.
+        assert!(pam_request(&["add"]).services.is_empty());
+    }
+
+    /// **`--no-confirm` must never imply `--allow-sensitive`.** They are
+    /// separate authorizations: "do not ask me" and "yes, edit system-auth".
+    /// `setup --yes` keeps the combined meaning and is the sole exception.
+    #[test]
+    fn no_confirm_and_allow_sensitive_are_independent() {
+        for skip_prompts in [
+            &["add", "--no-confirm"][..],
+            &["add", "--yes"],
+            &["add", "-y"],
+        ] {
+            let request = pam_request(skip_prompts);
+            assert!(request.no_confirm, "{skip_prompts:?}");
+            assert!(
+                !request.allow_sensitive,
+                "{skip_prompts:?} must not unlock the sensitive services"
+            );
+        }
+
+        let request = pam_request(&["add", "--allow-sensitive"]);
+        assert!(request.allow_sensitive);
+        assert!(
+            !request.no_confirm,
+            "--allow-sensitive accepts a risk; it does not skip the question"
+        );
+
+        // `setup --yes` is the documented exception, unchanged.
+        assert!(plan(&["--pam", "--yes"]).yes);
+    }
+
+    /// `--allow-sensitive` is an `add`-only flag: removal can only take away a
+    /// way to authenticate, so there is nothing to gate.
+    #[test]
+    fn remove_and_status_do_not_offer_allow_sensitive() {
+        for argv in [
+            &["facelock", "pam", "remove", "--allow-sensitive"][..],
+            &["facelock", "pam", "status", "--allow-sensitive"],
+            &["facelock", "pam", "status", "--dry-run"],
+        ] {
+            assert!(
+                Cli::try_parse_from(argv).is_err(),
+                "`{}` must not parse",
+                argv.join(" ")
+            );
+        }
     }
 }

--- a/crates/facelock-cli/src/message/mod.rs
+++ b/crates/facelock-cli/src/message/mod.rs
@@ -485,6 +485,45 @@ mod tests {
             .localized(),
             "PAM service file absent: /etc/pam.d/omarchy-lock-face. Nothing to remove."
         );
+        // The closing hint of `facelock pam add` was four bare `println!`s in
+        // `commands/setup.rs` until #174 folded them into one message. These
+        // are those four lines' exact bytes, captured from the commit before
+        // the move: a leading blank line, three `==>` lines, and no trailing
+        // newline (the sink's `println!` supplies it).
+        assert_eq!(
+            PamMessage::PamExtensionHint {
+                line: "auth      sufficient pam_facelock.so".into()
+            }
+            .localized(),
+            "\n==> facelock PAM line for manual extension to other services:\n\
+             ==>   auth      sufficient pam_facelock.so\n\
+             ==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
+        );
+        // Not a historical pin: #174 changed this text on purpose, from
+        // `setup --pam --remove --service X` to the verb that now owns the
+        // undo. Pinned so the next change to it is also on purpose — this is
+        // the one message that tells a locked-out operator how to get back in.
+        assert_eq!(
+            PamMessage::PamInstalled {
+                path: "/etc/pam.d/sudo".into(),
+                backup: "/etc/pam.d/sudo.facelock-backup".into(),
+                service: "sudo".into()
+            }
+            .localized(),
+            "Installed facelock PAM line into /etc/pam.d/sudo\n\n\
+             To rollback:\n  sudo cp /etc/pam.d/sudo.facelock-backup /etc/pam.d/sudo\n\
+             \u{20} # or: sudo facelock pam remove --service sudo"
+        );
+        // The module-missing refusal was an inline `bail!` on the same path.
+        assert_eq!(
+            PamMessage::PamModuleNotInstalled {
+                path: "/lib/security/pam_facelock.so".into()
+            }
+            .localized(),
+            "PAM module not found at /lib/security/pam_facelock.so.\n\
+             Install it first: cargo build --release -p pam-facelock && \
+             sudo cp target/release/libpam_facelock.so /lib/security/pam_facelock.so"
+        );
     }
 
     /// `--quiet` gates informational stdout and nothing else.

--- a/crates/facelock-cli/src/message/pam.rs
+++ b/crates/facelock-cli/src/message/pam.rs
@@ -75,6 +75,57 @@ pub enum PamMessage {
         path: String,
         backup: String,
     },
+
+    // -- `facelock pam` (#174) ---------------------------------------------
+    /// The closing copy-pasteable hint. One variant carrying the whole block,
+    /// because it is one paragraph a translator has to be able to reflow, not
+    /// four independent sentences.
+    PamExtensionHint {
+        line: String,
+    },
+    PamInvalidServiceName {
+        service: String,
+    },
+    /// `remedy` is the flag that unlocks this surface: `--allow-sensitive` on
+    /// `pam add`, `--yes` on the `setup --pam` alias, which keeps its
+    /// combined meaning. Carrying it as data is what lets one message be
+    /// truthful on both.
+    PamSensitiveRefused {
+        service: String,
+        remedy: String,
+    },
+    PamModuleNotInstalled {
+        path: String,
+    },
+    PamServiceAbsentSkipped {
+        path: String,
+    },
+    PamPlanAdd {
+        path: String,
+        hint: String,
+    },
+    PamPlanRemove {
+        path: String,
+    },
+    PamPlanNoChange {
+        path: String,
+    },
+    PamPlanAbsent {
+        path: String,
+    },
+    PamStatusPresent {
+        path: String,
+    },
+    PamStatusMissing {
+        path: String,
+    },
+    PamStatusAbsent {
+        path: String,
+    },
+    PamStatusUnknown {
+        path: String,
+        error: String,
+    },
 }
 
 impl Message for PamMessage {
@@ -157,7 +208,7 @@ impl Message for PamMessage {
                 service,
             } => fill(
                 translate(
-                    "Installed facelock PAM line into {path}\n\nTo rollback:\n  sudo cp {backup} {path}\n  # or: sudo facelock setup --pam --remove --service {service}",
+                    "Installed facelock PAM line into {path}\n\nTo rollback:\n  sudo cp {backup} {path}\n  # or: sudo facelock pam remove --service {service}",
                 ),
                 &[
                     ("path", path.clone()),
@@ -180,6 +231,66 @@ impl Message for PamMessage {
             PamBackupExists { path, backup } => fill(
                 translate("Backup exists at {backup}\nTo restore: sudo cp {backup} {path}"),
                 &[("path", path.clone()), ("backup", backup.clone())],
+            ),
+            PamExtensionHint { line } => fill(
+                translate(
+                    "\n==> facelock PAM line for manual extension to other services:\n==>   {line}\n==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file.",
+                ),
+                &[("line", line.clone())],
+            ),
+            PamInvalidServiceName { service } => fill(
+                translate(
+                    "Invalid PAM service name '{service}': a service is one file name under /etc/pam.d, so it may not be empty, contain '/', or be '.' or '..'.",
+                ),
+                &[("service", service.clone())],
+            ),
+            PamSensitiveRefused { service, remedy } => fill(
+                translate(
+                    "Refusing to modify '{service}': this is a sensitive PAM service.\nRe-run with {remedy} to accept the risk of locking yourself out.",
+                ),
+                &[("service", service.clone()), ("remedy", remedy.clone())],
+            ),
+            PamModuleNotInstalled { path } => fill(
+                translate(
+                    "PAM module not found at {path}.\nInstall it first: cargo build --release -p pam-facelock && sudo cp target/release/libpam_facelock.so {path}",
+                ),
+                &[("path", path.clone())],
+            ),
+            PamServiceAbsentSkipped { path } => fill(
+                translate("PAM service file absent: {path}. Nothing to add."),
+                &[("path", path.clone())],
+            ),
+            PamPlanAdd { path, hint } => fill(
+                translate("Would add the facelock PAM line to {path} ({hint})."),
+                &[("path", path.clone()), ("hint", hint.clone())],
+            ),
+            PamPlanRemove { path } => fill(
+                translate("Would remove the facelock PAM line from {path}."),
+                &[("path", path.clone())],
+            ),
+            PamPlanNoChange { path } => fill(
+                translate("No change needed for {path}."),
+                &[("path", path.clone())],
+            ),
+            PamPlanAbsent { path } => fill(
+                translate("PAM service file absent: {path}. Nothing to do."),
+                &[("path", path.clone())],
+            ),
+            PamStatusPresent { path } => fill(
+                translate("{path}: facelock PAM line present"),
+                &[("path", path.clone())],
+            ),
+            PamStatusMissing { path } => fill(
+                translate("{path}: no facelock PAM line"),
+                &[("path", path.clone())],
+            ),
+            PamStatusAbsent { path } => fill(
+                translate("{path}: service file absent"),
+                &[("path", path.clone())],
+            ),
+            PamStatusUnknown { path, error } => fill(
+                translate("{path}: unreadable ({error})"),
+                &[("path", path.clone()), ("error", error.clone())],
             ),
         }
     }
@@ -240,7 +351,31 @@ impl super::Samples for PamMessage {
                 path: s("/p"),
                 backup: s("/b"),
             },
-            PamBackupExists { .. } => return None,
+            PamBackupExists { .. } => PamExtensionHint {
+                line: s("auth ..."),
+            },
+            PamExtensionHint { .. } => PamInvalidServiceName { service: s("../x") },
+            PamInvalidServiceName { .. } => PamSensitiveRefused {
+                service: s("sshd"),
+                remedy: s("--allow-sensitive"),
+            },
+            PamSensitiveRefused { .. } => PamModuleNotInstalled { path: s("/p") },
+            PamModuleNotInstalled { .. } => PamServiceAbsentSkipped { path: s("/p") },
+            PamServiceAbsentSkipped { .. } => PamPlanAdd {
+                path: s("/p"),
+                hint: s("h"),
+            },
+            PamPlanAdd { .. } => PamPlanRemove { path: s("/p") },
+            PamPlanRemove { .. } => PamPlanNoChange { path: s("/p") },
+            PamPlanNoChange { .. } => PamPlanAbsent { path: s("/p") },
+            PamPlanAbsent { .. } => PamStatusPresent { path: s("/p") },
+            PamStatusPresent { .. } => PamStatusMissing { path: s("/p") },
+            PamStatusMissing { .. } => PamStatusAbsent { path: s("/p") },
+            PamStatusAbsent { .. } => PamStatusUnknown {
+                path: s("/p"),
+                error: s("e"),
+            },
+            PamStatusUnknown { .. } => return None,
         })
     }
 }

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -119,6 +119,32 @@ fn clear_refuses_before_confirmation_prompt_non_root() {
 }
 
 #[test]
+fn pam_add_refuses_before_touching_pam_d_non_root() {
+    // C6: the root check is the first statement in `commands::pam::run`, ahead
+    // of the module-presence check, the plan, and `--dry-run`. A dry run that
+    // succeeded unprivileged would be a preview of a command that cannot run.
+    assert_refuses_before_output(
+        &["pam", "add", "--service", "sudo", "--dry-run"],
+        &[
+            "About to modify",
+            "Would add the facelock PAM line",
+            "==> facelock PAM line",
+        ],
+    );
+}
+
+#[test]
+fn pam_remove_refuses_before_touching_pam_d_non_root() {
+    assert_refuses_before_output(
+        &["pam", "remove", "--service", "sudo", "--dry-run"],
+        &[
+            "Would remove the facelock PAM line",
+            "Removed facelock PAM line",
+        ],
+    );
+}
+
+#[test]
 fn help_exits_successfully() {
     let output = facelock_bin()
         .arg("--help")

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -16,7 +16,10 @@ Stable contracts. Do not change without updating this document.
 |---------|---------|
 | `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, enrollment, PAM); also manages `facelock` group membership (creates the group if missing, adds the invoking user) |
 | `facelock setup --systemd` | Install/enable systemd units |
-| `facelock setup --pam` | Install PAM module to `/etc/pam.d/` |
+| `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
+| `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |
+| `facelock pam remove` | Remove it. Root |
+| `facelock pam status` | Report whether services carry the line. Reads only, **no root** — the probe to branch on instead of grepping `/etc/pam.d` |
 | `facelock setup` choice flags | `--camera <PATH\|auto>`, `--models <standard\|balanced\|high>`, `--execution-provider <cpu\|cuda\|rocm\|openvino\|auto>`, `--encryption <tpm\|keyfile\|none\|auto>`. Precedence: CLI flag > config file > built-in default |
 | `facelock setup` action opt-outs | `--no-pam`, `--no-systemd`, `--no-enroll` decline an action outright (and their `--pam`/`--systemd`/`--enroll` counterparts force it). Later flag wins |
 | `facelock is-enrolled` | Report whether face auth is operational for a user. Exit code is the contract; no daemon activation, no camera. Requires `facelock` group membership to answer `enrolled` — a caller outside the group reports `not-enrolled`, which is correct: the group is required to reach the daemon at all |
@@ -120,22 +123,180 @@ so a dropped flag is now a parse error rather than silence.
 `--if-present` requires `--remove` (and therefore `--pam`). It changes only a
 missing target service file from an error into a successful no-op; read, parse
 and write failures remain fatal, and `--remove` without the flag retains its
-historical missing-file error.
+historical missing-file error. (On `facelock pam` the same flag is offered on
+**both** `add` and `remove`, since "configure hyprlock if this machine has
+hyprlock" is the same question in either direction.)
+
+**`--pam` is an alias onto `facelock pam add` / `facelock pam remove`.** The
+plan resolution above stays on `setup` — `--pam`, `--no-pam`, `--service`,
+`--remove`, `--if-present` and their precedence rules are unchanged — and only
+the execution moved. The alias is exact, including the two things that make it
+not a plain forward:
+
+- **`setup --yes` keeps its combined meaning** and is the one documented
+  exception to the flag split below. It maps onto *both* of the writer's knobs:
+  `--no-confirm` (skip the per-file question) **and** `--allow-sensitive`
+  (accept `system-auth`/`login`/`sshd`). `--non-interactive` maps onto
+  `--no-confirm` alone, as it always has.
+- **The root refusal is a hard error, not a `sudo` re-exec.** Standalone
+  `--pam` never offered the interactive escalation (`needs_root_precheck`), and
+  `facelock pam add|remove` does not either.
 
 Supplying a choice flag suppresses the corresponding wizard step. `auto` means
 "re-derive from hardware", **not** "use the default" — omitting the flag already
 gives the default. Under `--non-interactive`, an unresolvable choice is an error,
 never a prompt.
 
+### facelock pam Semantics
+
+`facelock pam add | remove | status` owns every write to `/etc/pam.d`.
+`setup --pam` is an alias onto it (above), and the wizard's step 9 calls the
+same writer, so there is one implementation of the edit and one set of rules.
+
+**Confinement.** A service name is **one path component**: not empty, no `/`,
+not `.` or `..`, no interior NUL. Rejected before any I/O, on `add`, `remove`
+and `status` alike. `base.join(service)` is not a confinement primitive — an
+absolute name *replaces* the base — so this is the check, not the join.
+Anything else is accepted: `PAM_CANDIDATES` is the wizard's menu, **not** an
+allowlist, and a service that is not on it must keep working.
+
+**Two-phase.** Every requested service is validated — name, existence
+(subject to `--if-present`), the sensitive gate, and what the edit would be —
+before **any** file is written. A validation failure writes nothing at all,
+which is what makes a caller's loop all-or-nothing for the failure that
+actually happens: a typo'd or gated service name. It is **not** a transaction:
+a write-phase I/O error on service N leaves 1..N-1 written. Those are reported
+per service and the exit code is non-zero; the remaining services are still
+attempted. The rollback is the `.facelock-backup` file written before each
+edit, which nothing in this command deletes.
+
+**`--no-confirm` never implies `--allow-sensitive`.** They are separate
+authorizations: "do not ask me" and "yes, edit `system-auth`". `--yes` and
+`--no-confirm` are the same flag (the shared `ConfirmArg` spelling, so "skip
+prompts" reads the same on `pam add` as on `remove` and `clear`) and neither
+unlocks the gate. `setup --yes` keeps the combined meaning and is the sole
+exception. `remove` is never gated at all — removal can only take away a way
+to authenticate — and never prompts, which is what `setup --pam --remove` has
+always done; `--yes`/`--no-confirm` is accepted there for symmetry and has
+nothing to suppress today.
+
+**With no TTY on stdin, `pam add` proceeds as if `--no-confirm` were given.**
+A question nobody can answer is a hang, not a safeguard, and this is what has
+always made `setup --pam` work from a provisioning script — so
+`sudo facelock pam add --service sudo < /dev/null` writes without the flag.
+The prompt this skips defaults to yes, so the flag changes nothing about the
+outcome on a TTY either; what it changes is whether you are asked. This never
+touches `--allow-sensitive`: the sensitive-service gate is decided in the
+validation phase, before any prompt exists to skip, so an unattended
+`pam add --service system-auth` still refuses.
+
+**Exit codes.**
+
+| Command | Code | Meaning |
+|---------|------|---------|
+| `pam status` | 0 | every requested service carries the line |
+| `pam status` | 1 | at least one requested service exists without it |
+| `pam status` | 2 | at least one is absent, unreadable, or misnamed |
+| `pam add`, `pam remove` | 0 | every service reached its requested state — including `unchanged`, `absent` under `--if-present`, and `declined` |
+| `pam add`, `pam remove` | non-zero | a validation failure (nothing written) or a write failure |
+
+`pam status` is on `grep`'s scale and `is-enrolled`'s, deliberately: it is a
+boolean query whose exit code is the answer, and an absent file is exit 2 for
+the same reason `grep` gives 2 for one. Across several services the worst
+outcome wins. A **declined** confirmation is exit 0 — the command did what the
+operator asked — and `--json` is how a script tells it from an install.
+
+**`--dry-run`** prints the resolved plan, writes nothing, and exits 0. It is
+honoured *after* the root check (see DEC-6 above).
+
+**`--json`** emits exactly one document on stdout and no human text; `--quiet`
+suppresses even that, leaving the exit code as the whole answer, as it does for
+`is-enrolled`. Diagnostics stay on stderr either way.
+
+On `add` and `remove`, a validation failure produces **no** JSON document: it
+is reported as text on stderr and the process exits non-zero, matching
+`is-enrolled`, whose unanswerable case prints a reason and no payload. The
+phase that rejects is the phase that would have decided every row, so there is
+no partial document to emit.
+
+`pam status` is the other way round and **always** emits a document: it has no
+all-or-nothing phase to fail, so a rejected service name becomes an `unknown`
+row inside the document (with the reason in `error`) alongside the rows for
+every other requested service, and the invalid-name message is *also* written
+to stderr for a human. Exit 2 either way.
+
+```json
+{
+  "command": "add",
+  "dry_run": false,
+  "services": [
+    {
+      "service": "sudo",
+      "path": "/etc/pam.d/sudo",
+      "action": "installed",
+      "backup": "/etc/pam.d/sudo.facelock-backup"
+    }
+  ]
+}
+```
+
+**This shape is a stability contract.** An object rather than a bare array so a
+new top-level field is additive. Field names do not change and are not removed;
+`service`, `path`, `action` and `backup` are always present on every service
+object, and `error` is present when `action` is `failed` or `unknown`. **`error` is a
+diagnostic, not a contract** — branch on `action`, never on `error`'s text. A
+rejected service name reports the fixed C-locale string `invalid service name`,
+but the OS-level failures (`failed` on a write, `unknown` on an unreadable
+file) interpolate a `strerror` string, which follows the operator's
+`LC_MESSAGES` like any other C library message. Nothing else in a `--json`
+document is locale-dependent. `backup`
+is the `.facelock-backup` path when one exists on disk after the operation and
+`null` otherwise — always `null` under `--dry-run`, which writes none. When
+`action` is `unknown` because the *name* was rejected, `path` is the path that
+name would have resolved to (which is why it was rejected) and is not a path
+anything read or wrote.
+
+The `action` vocabulary — **new words may be added, so a consumer must tolerate
+one it does not know rather than treat it as an error**:
+
+| `action` | Verb | Meaning |
+|----------|------|---------|
+| `installed` | `add` | the line was written (under `--dry-run`, would be) |
+| `removed` | `remove` | the line was deleted (under `--dry-run`, would be) |
+| `unchanged` | `add`, `remove` | already in the requested state |
+| `absent` | all three | the service file does not exist |
+| `declined` | `add` | the operator answered no at the per-file confirmation |
+| `failed` | `add`, `remove` | the write failed; see `error` |
+| `present` | `status` | the file exists and carries a facelock line |
+| `missing` | `status` | the file exists and carries none |
+| `unknown` | `status` | the file could not be read; see `error` |
+
+`pam status --json` is what replaces `grep -q pam_facelock.so
+/etc/pam.d/<service>` in an integration script: it answers from the same file,
+without root, and reports "absent" and "unreadable" as themselves rather than
+as "not configured".
+
+**Repeatable `--service`.** `--service a --service b` acts on both in one
+process, one root check and one closing hint. Duplicates collapse. No
+`--service` means `sudo`, which is what bare `setup --pam` has always meant.
+
+**The `/etc/pam.d` bytes are unchanged from before the verb existed.** The line
+goes above the first `auth` line, or at the very top of the file when there is
+none (above the `#%PAM-1.0` header, which is where it has always gone); a
+missing trailing newline stays missing; a backup is taken before every edit and
+never before a no-op. Golden fixtures captured from the pre-refactor code pin
+all of it.
+
 ### CLI Privilege Model (DEC-6)
 
-The CLI is root by default: every subcommand requires root except the four
+The CLI is root by default: every subcommand requires root except the five
 listed below, which are unprivileged by design, not by omission.
 
 | Command | Why unprivileged |
 |---------|-------------------|
 | `facelock is-enrolled` | Answers from the caller's own `0600` marker file; the unprivileged integration point (see Exit Codes above). Never probes D-Bus |
 | `facelock hyprlock …` | Edits the user's own dotfile — root would write root-owned files into `$HOME`, which is wrong, not just unnecessary |
+| `facelock pam status` | Reads `0644` files under `/etc/pam.d` and writes nothing. Same role as `is-enrolled`: the probe an integration runs without `sudo`, replacing a hand-rolled `grep -q pam_facelock.so /etc/pam.d/<service>`. A file it cannot read reports `unknown` and exits 2 rather than reporting it as missing |
 | `facelock config` (display, no `--edit`) | Reads a `0644` file |
 | `--help`, `--version` | — |
 
@@ -150,11 +311,21 @@ command uses exactly one:
   they hard-error instead — `Root required.\n  Run: sudo facelock <cmd>` —
   rather than hang waiting for input that will never arrive
   (`ipc_client::require_root`).
-- **Hard error only.** `facelock audit` (and `facelock daemon`, whose own
-  root check predates this table) never offer the interactive prompt at all,
+- **Hard error only.** `facelock pam add`, `facelock pam remove`, `facelock
+  audit` (and `facelock daemon`, whose own root check predates this table)
+  never offer the interactive prompt at all,
   even with a TTY attached — both are typically invoked non-interactively or
   as a long-running service, where a stray confirmation prompt is a hang, not
   a convenience (`ipc_client::require_root_scripted`).
+
+`facelock pam add|remove` are in the hard-error class because the surface they
+replace was: standalone `setup --pam` bailed from its own root check rather
+than prompting, and silently re-running an `/etc/pam.d` edit under `sudo` on
+behalf of a wrapper script is a surprise, not a convenience. The check runs
+**before `--dry-run` is honoured** — a dry run that succeeded unprivileged
+would be a misleading preview of a command that cannot run — and `pam status`
+is the unprivileged read that covers the case `--dry-run` might otherwise be
+reached for.
 
 `facelock auth` is not user-facing — PAM spawns it directly, and it is not
 part of this table.
@@ -263,6 +434,9 @@ the codes themselves match `grep`'s 0 = match / 1 = no match / 2 = error.
 | 0 | User has a usable enrollment |
 | 1 | Not enrolled / not usable (includes an unreadable or absent marker) |
 | 2 | Error — bad arguments, or a marker that exists but cannot be parsed |
+
+`facelock pam status` uses the same 0/1/2 scale for the same reason; see
+"facelock pam Semantics" above.
 
 Default stdout is `enrolled` / `not-enrolled` — the state word, as `systemctl
 is-active` prints `active`. `--quiet` suppresses stdout and leaves only the exit

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 12:31-0700\n"
+"POT-Creation-Date: 2026-08-17 13:37-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -399,29 +399,29 @@ msgstr ""
 msgid "Face auth failed: {reason}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:86
+#: crates/facelock-cli/src/message/pam.rs:137
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:92
+#: crates/facelock-cli/src/message/pam.rs:143
 msgid ""
 "  PAM module not found at {path}.\n"
 "  Install it first, then run: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:97
+#: crates/facelock-cli/src/message/pam.rs:148
 #, python-brace-format
 msgid "  Configuring PAM for {service}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:101
+#: crates/facelock-cli/src/message/pam.rs:152
 #, python-brace-format
 msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:106
+#: crates/facelock-cli/src/message/pam.rs:157
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -432,38 +432,38 @@ msgid ""
 "  to confirm each file individually.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:111
+#: crates/facelock-cli/src/message/pam.rs:162
 msgid "Select services to enable face authentication for"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:114
+#: crates/facelock-cli/src/message/pam.rs:165
 #, python-brace-format
 msgid "  Failed to configure {service}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:117
+#: crates/facelock-cli/src/message/pam.rs:168
 msgid "  No PAM services selected."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:119
+#: crates/facelock-cli/src/message/pam.rs:170
 #, python-brace-format
 msgid "PAM service file not found: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:123
+#: crates/facelock-cli/src/message/pam.rs:174
 #, python-brace-format
 msgid "PAM line already present in {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:126
+#: crates/facelock-cli/src/message/pam.rs:177
 msgid "inserted before the first 'auth' line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:128
+#: crates/facelock-cli/src/message/pam.rs:179
 msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:137
+#: crates/facelock-cli/src/message/pam.rs:188
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -473,48 +473,118 @@ msgid ""
 "(To configure manually instead, add the line above to each service yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:146
+#: crates/facelock-cli/src/message/pam.rs:197
 msgid "Proceed?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:148
+#: crates/facelock-cli/src/message/pam.rs:199
 #, python-brace-format
 msgid "Skipped {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:151
+#: crates/facelock-cli/src/message/pam.rs:202
 #, python-brace-format
 msgid "Backed up {path} -> {backup}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:160
+#: crates/facelock-cli/src/message/pam.rs:211
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
 "To rollback:\n"
 "  sudo cp {backup} {path}\n"
-"  # or: sudo facelock setup --pam --remove --service {service}"
+"  # or: sudo facelock pam remove --service {service}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:169
+#: crates/facelock-cli/src/message/pam.rs:220
 #, python-brace-format
 msgid "Removed facelock PAM line from {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:173
+#: crates/facelock-cli/src/message/pam.rs:224
 #, python-brace-format
 msgid "No facelock PAM line found in {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:177
+#: crates/facelock-cli/src/message/pam.rs:228
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:181
+#: crates/facelock-cli/src/message/pam.rs:232
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:237
+msgid ""
+"\n"
+"==> facelock PAM line for manual extension to other services:\n"
+"==>   {line}\n"
+"==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:243
+#, python-brace-format
+msgid "Invalid PAM service name '{service}': a service is one file name under /etc/pam.d, so it may not be empty, contain '/', or be '.' or '..'."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:249
+msgid ""
+"Refusing to modify '{service}': this is a sensitive PAM service.\n"
+"Re-run with {remedy} to accept the risk of locking yourself out."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:255
+msgid ""
+"PAM module not found at {path}.\n"
+"Install it first: cargo build --release -p pam-facelock && sudo cp target/release/libpam_facelock.so {path}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:260
+#, python-brace-format
+msgid "PAM service file absent: {path}. Nothing to add."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:264
+#, python-brace-format
+msgid "Would add the facelock PAM line to {path} ({hint})."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:268
+#, python-brace-format
+msgid "Would remove the facelock PAM line from {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:272
+#, python-brace-format
+msgid "No change needed for {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:276
+#, python-brace-format
+msgid "PAM service file absent: {path}. Nothing to do."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:280
+#, python-brace-format
+msgid "{path}: facelock PAM line present"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:284
+#, python-brace-format
+msgid "{path}: no facelock PAM line"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:288
+#, python-brace-format
+msgid "{path}: service file absent"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:292
+#, python-brace-format
+msgid "{path}: unreadable ({error})"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:191

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -70,6 +70,139 @@ run_test "facelock daemon requires root" \
     "su -s /bin/bash testuser -c 'facelock daemon 2>&1' | grep -q 'Root required'" \
     0
 
+# --- #174: `facelock pam add | remove | status` against the real /etc/pam.d ---
+#
+# The verb is the only writer of /etc/pam.d, and everything that decides
+# whether it writes is machine state a tempdir test cannot stand in for: the
+# root check, the pam_facelock.so-is-installed check, the hard-coded
+# /etc/pam.d base, and the C-locale text of the refusals. This block proves
+# the whole path as root on a live system — install, idempotence, the status
+# probe's 0/1 scale, the sensitive-service gate, two-phase validation, name
+# confinement, removal, and the `setup --pam` alias landing in the same file.
+#
+# It writes only to service files it creates itself (facelock-scratch*) and
+# removes them at the end, so it is safe to run twice; sudo, system-auth,
+# login and sshd are read and never written. jq is not in the image, so the
+# --json documents are asserted with python.
+
+PAM_LINE_TEXT='auth      sufficient pam_facelock.so'
+
+# The `action` word for the first service in a `facelock pam --json` document.
+cat > /tmp/pam-action.py <<'EOF'
+import json, sys
+print(json.load(open(sys.argv[1]))["services"][0]["action"])
+EOF
+
+# Exit 0 only if the facelock line is present AND is the file's first `auth`
+# line — the placement contract, asserted by index rather than by eyeball.
+cat > /tmp/pam-first-auth.py <<'EOF'
+import sys
+line = "auth      sufficient pam_facelock.so"
+lines = open(sys.argv[1]).read().splitlines()
+auth = [i for i, text in enumerate(lines) if text.lstrip().startswith("auth")]
+sys.exit(0 if line in lines and auth and lines[auth[0]] == line else 1)
+EOF
+
+# Two throwaway service files with a realistic body. Nothing consumes them.
+rm -f /etc/pam.d/facelock-scratch /etc/pam.d/facelock-scratch2 \
+      /etc/pam.d/facelock-scratch.facelock-backup \
+      /etc/pam.d/facelock-scratch2.facelock-backup
+cat > /etc/pam.d/facelock-scratch <<'EOF'
+#%PAM-1.0
+auth       include        system-auth
+account    include        system-auth
+session    include        system-auth
+EOF
+chmod 644 /etc/pam.d/facelock-scratch
+cp /etc/pam.d/facelock-scratch /etc/pam.d/facelock-scratch2
+
+run_test "pam status: existing file without the line is 'missing', exit 1" \
+    "facelock pam status --service facelock-scratch --json > /tmp/pam-status.json 2>/dev/null; test \$? -eq 1 && python3 /tmp/pam-action.py /tmp/pam-status.json | grep -qx missing" \
+    0
+
+run_test "pam add: 'installed', backup written, line is the first auth line" \
+    "facelock pam add --service facelock-scratch --json > /tmp/pam-add.json 2>/dev/null; test \$? -eq 0 && python3 /tmp/pam-action.py /tmp/pam-add.json | grep -qx installed && test -f /etc/pam.d/facelock-scratch.facelock-backup && python3 /tmp/pam-first-auth.py /etc/pam.d/facelock-scratch" \
+    0
+
+sha256sum /etc/pam.d/facelock-scratch > /tmp/pam-scratch.sha
+
+run_test "pam add is idempotent: 'unchanged' and the file is byte-identical" \
+    "facelock pam add --service facelock-scratch --json > /tmp/pam-add2.json 2>/dev/null; test \$? -eq 0 && python3 /tmp/pam-action.py /tmp/pam-add2.json | grep -qx unchanged && sha256sum -c --status /tmp/pam-scratch.sha" \
+    0
+
+run_test "pam status exits 0 once the line is present" \
+    "facelock pam status --service facelock-scratch" \
+    0
+
+# The sensitive-service gate. Arch's `pam` package ships /etc/pam.d/system-auth,
+# so that is what this normally runs against; the loop keeps the row honest if
+# the base image ever changes which of the three exists. The refusal is decided
+# in the validation phase, before any prompt, so --no-confirm cannot unlock it.
+PAM_SENSITIVE=""
+for svc in system-auth login sshd; do
+    if [ -f "/etc/pam.d/$svc" ]; then
+        PAM_SENSITIVE="$svc"
+        break
+    fi
+done
+
+if [ -n "$PAM_SENSITIVE" ]; then
+    # Belt and braces: the sha256 below detects a regression, and the copy
+    # taken here undoes one. This is the container's own auth stack, and every
+    # row after this one runs through it, so a failure must not be allowed to
+    # leak into them as a second, mystifying failure.
+    cp -p "/etc/pam.d/$PAM_SENSITIVE" /tmp/pam-sensitive.orig
+    sha256sum "/etc/pam.d/$PAM_SENSITIVE" > /tmp/pam-sensitive.sha
+    run_test "pam add refuses sensitive service $PAM_SENSITIVE under --no-confirm" \
+        "facelock pam add --service $PAM_SENSITIVE --no-confirm > /tmp/pam-sensitive.out 2>&1; test \$? -ne 0 && grep -q 'sensitive PAM service' /tmp/pam-sensitive.out && sha256sum -c --status /tmp/pam-sensitive.sha" \
+        0
+    cp -p /tmp/pam-sensitive.orig "/etc/pam.d/$PAM_SENSITIVE"
+    rm -f "/etc/pam.d/$PAM_SENSITIVE.facelock-backup" /tmp/pam-sensitive.orig
+else
+    echo "SKIP: no system-auth/login/sshd in the image to test the sensitive gate"
+fi
+
+sha256sum /etc/pam.d/facelock-scratch2 > /tmp/pam-scratch2.sha
+
+# Two-phase: the second service is rejected in validation, so the first one —
+# which would otherwise have been written by the time the failure happened —
+# is untouched, has no backup, and no JSON document is emitted at all.
+run_test "pam add validates every service before writing any" \
+    "facelock pam add --service facelock-scratch2 --service facelock-does-not-exist --json > /tmp/pam-twophase.out 2>&1; test \$? -ne 0 && sha256sum -c --status /tmp/pam-scratch2.sha && ! test -e /etc/pam.d/facelock-scratch2.facelock-backup && ! grep -q '\"services\"' /tmp/pam-twophase.out" \
+    0
+
+# The message grep is what makes this row mean anything: without `confined`,
+# `../facelock-escape` resolves to /etc/facelock-escape, which does not exist,
+# so the command would still exit non-zero (file-not-found) and --dry-run would
+# still write nothing — every `! test -e` would hold on the broken path too.
+run_test "pam add rejects a service name that escapes /etc/pam.d" \
+    "facelock pam add --service ../facelock-escape --dry-run > /tmp/pam-escape.out 2>&1; test \$? -ne 0 && grep -q 'Invalid PAM service name' /tmp/pam-escape.out && ! test -e /etc/facelock-escape && ! test -e /etc/facelock-escape.facelock-backup && ! test -e /etc/pam.d/facelock-escape" \
+    0
+
+run_test "pam remove: 'removed' and no facelock line left" \
+    "facelock pam remove --service facelock-scratch --json > /tmp/pam-remove.json 2>/dev/null; test \$? -eq 0 && python3 /tmp/pam-action.py /tmp/pam-remove.json | grep -qx removed && ! grep -q pam_facelock.so /etc/pam.d/facelock-scratch" \
+    0
+
+# The `setup --pam` alias must reach the same writer and the same bytes.
+run_test "setup --pam alias installs the line" \
+    "facelock setup --pam --service facelock-scratch --yes > /dev/null 2>&1; test \$? -eq 0 && grep -qxF '$PAM_LINE_TEXT' /etc/pam.d/facelock-scratch" \
+    0
+
+run_test "setup --pam --remove alias removes the line" \
+    "facelock setup --pam --service facelock-scratch --remove --yes --if-present > /dev/null 2>&1; test \$? -eq 0 && ! grep -q pam_facelock.so /etc/pam.d/facelock-scratch" \
+    0
+
+rm -f /etc/pam.d/facelock-scratch
+
+run_test "setup --pam --remove --if-present succeeds on an absent service file" \
+    "facelock setup --pam --service facelock-scratch --remove --yes --if-present" \
+    0
+
+rm -f /etc/pam.d/facelock-scratch /etc/pam.d/facelock-scratch2 \
+      /etc/pam.d/facelock-scratch.facelock-backup \
+      /etc/pam.d/facelock-scratch2.facelock-backup \
+      /tmp/pam-action.py /tmp/pam-first-auth.py
+
 # --- Spec 29: Smart PAM skip (no enrolled faces) ---
 
 # In oneshot mode with no enrolled faces, facelock auth should exit 2 (PAM_IGNORE)


### PR DESCRIPTION
## Summary

- add `facelock pam add | remove | status` in a new `commands/pam.rs`; `--service` repeats, empty means `sudo`
- validate every service (name, existence, confinement, sensitive gate, module) before writing any; a rejected service leaves the rest untouched
- confine a service to one path component on both verbs, before I/O (`/`, `.`, `..`, empty, absolute all refused)
- split `--no-confirm` (skip the per-file prompt) from `--allow-sensitive` (system-auth/login/sshd); neither implies the other; `setup --yes` keeps its combined meaning as the documented exception
- `--json` per-service `action` vocabulary (`installed unchanged declined absent failed present missing unknown …`) as a stability contract; `--dry-run` reports and writes nothing; `--if-present` on both verbs
- `pam status` is unprivileged (DEC-6 row); `add`/`remove` are root, hard-error class, root check first (C6)
- `setup --pam …` is now a thin alias onto the same engine; `PamPref` unchanged
- delete the unreachable non-TTY auto-select branch in `wizard_pam_setup_in` and the test that could only reach it (it hung `cargo test` under a real pty)
- extension hint fires once per invocation; its four raw prints move into the message seam, byte-pinned
- `setup.rs` now has zero raw `println!`

## Why

`setup --pam --service X --remove --yes` is a verb hiding behind three
modifiers, one service per process, and its `Ok(())` cannot tell "installed"
from "already there" from "declined". Omarchy's wizard therefore loops the
command three times and pre-greps `/etc/pam.d` in bash. A real verb with a
per-service report, all-or-nothing validation, and a separate sensitive-service
switch removes both workarounds and closes the path-confinement gap #148 left
on the install side.

## Validation

- `just check`, `just test-arch-pam` (the Arch tier now runs `pam status|add|remove` and the `setup --pam` alias as root against scratch service files: install placement, idempotence, exit codes, the sensitive gate with the real `system-auth` byte-identical, two-phase validation, name confinement, `--if-present`)
- golden files captured from `main`'s `pam_install_in`/`pam_remove_in`; both `pam add` and the `setup --pam` alias asserted byte-identical to them, backups included
- two-phase property: a bad second service leaves the first byte-identical with no backup created
- confinement cases on both verbs; `--no-confirm` vs `--allow-sensitive` on the verb and on the alias mapping (`setup_pam_knobs`)
- `cli_smoke` C6 rows for `pam add`/`pam remove`; live `pam status --json` and rejected-name JSON under a non-C locale
- `cargo test -p facelock-cli` under a pty (no interactive hang)

## Reviewer notes

- **Non-TTY auto-proceed is preserved and now documented**: `pam add` with no TTY on stdin proceeds as if `--no-confirm` were given, as `setup --pam` always has; the sensitive gate is decided in validation, so this never widens it.
- **`PAM_MODULE_PATH` is still `/lib/security`** (pre-existing); Fedora installs to `%{_libdir}/security`, so `pam add` hard-refuses there. Follow-up, not this PR.

Stacked on #179.

Closes #174
