### PR TITLE
refactor(cli): Spell machine output --json and write the rule down

### DIFF
--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -10,7 +10,7 @@ use crate::backend::{Backend, BackendKind};
 use crate::ipc_client;
 use crate::message::{AccessMessage, Terminal};
 
-pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Result<()> {
+pub fn run(config: &Config, json: bool, user: Option<String>) -> anyhow::Result<()> {
     // DEC-6/N13: `PreviewDetectFrame` is root-only now — it was the last
     // unprivileged consumer of a per-frame similarity score (the
     // hill-climbing oracle N12/N13 close by construction).
@@ -29,13 +29,13 @@ pub fn run(config: &Config, text_only: bool, user: Option<String>) -> anyhow::Re
         // is unavailable depends on the kind: a stopped daemon is a degraded
         // state, not a configuration choice (the old single message blamed
         // "oneshot mode" for both).
-        if !text_only {
+        if !json {
             Terminal.error(&graphical_unavailable_message(backend.kind()));
         }
         return text_only::run_direct(config, &user);
     }
 
-    if text_only {
+    if json {
         return text_only::run(&user);
     }
 

--- a/crates/facelock-cli/src/commands/preview/text_only.rs
+++ b/crates/facelock-cli/src/commands/preview/text_only.rs
@@ -47,25 +47,27 @@ pub fn run(user: &str) -> anyhow::Result<()> {
         }
 
         let (width, height) = jpeg_dimensions(&jpeg_data);
-        let recognized = faces.iter().filter(|f| f.recognized).count();
-        let unrecognized = faces.len() - recognized;
-
-        let output = serde_json::json!({
-            "frame": frame_count,
-            "fps": (current_fps * 10.0).round() / 10.0,
-            "jpeg_size": jpeg_data.len(),
-            "width": width,
-            "height": height,
-            "recognized": recognized,
-            "unrecognized": unrecognized,
-            "faces": faces.iter().map(|f| serde_json::json!({
-                "x": f.x, "y": f.y,
-                "width": f.width, "height": f.height,
-                "confidence": (f.confidence * 1000.0).round() / 1000.0,
-                "similarity": (f.similarity * 1000.0).round() / 1000.0,
-                "recognized": f.recognized,
-            })).collect::<Vec<_>>(),
-        });
+        let output = frame_json(
+            frame_count,
+            current_fps,
+            Some(jpeg_data.len()),
+            width,
+            height,
+            faces
+                .iter()
+                .map(|f| {
+                    face_json(
+                        f.x,
+                        f.y,
+                        f.width,
+                        f.height,
+                        f.confidence,
+                        f.similarity,
+                        f.recognized,
+                    )
+                })
+                .collect(),
+        );
 
         let mut handle = stdout.lock();
         if writeln!(handle, "{output}").is_err() {
@@ -98,7 +100,11 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
     let stored = match crate::direct::open_store_existing(config) {
         Ok(store) => crate::direct::load_user_embeddings(&store, config, user)?,
         Err(facelock_store::StoreError::Absent { .. }) => {
-            Terminal.info(&FaceMessage::NoModelsEnrolled {
+            // stderr, not the informational sink: stdout here is the frame
+            // stream, and this loop cannot see whether `--json` was passed.
+            // As stdout chatter this localized sentence prefixed the stream
+            // on any fresh oneshot install, so `jq` failed on line 1.
+            Terminal.error(&FaceMessage::NoModelsEnrolled {
                 user: user.to_string(),
             });
             Vec::new()
@@ -133,7 +139,7 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
         let faces_result = engine.process(&frame);
         let faces = faces_result.unwrap_or_default();
 
-        let face_json: Vec<serde_json::Value> = faces
+        let faces_json: Vec<serde_json::Value> = faces
             .iter()
             .map(|(det, embedding)| {
                 let mut best_sim: f32 = 0.0;
@@ -143,26 +149,26 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
                         best_sim = sim;
                     }
                 }
-                serde_json::json!({
-                    "x": det.bbox.x, "y": det.bbox.y,
-                    "width": det.bbox.width, "height": det.bbox.height,
-                    "confidence": (det.confidence * 1000.0).round() / 1000.0,
-                    "similarity": (best_sim * 1000.0).round() / 1000.0,
-                    "recognized": best_sim >= threshold,
-                })
+                face_json(
+                    det.bbox.x,
+                    det.bbox.y,
+                    det.bbox.width,
+                    det.bbox.height,
+                    det.confidence,
+                    best_sim,
+                    best_sim >= threshold,
+                )
             })
             .collect();
 
-        let recognized = face_json.iter().filter(|f| f["recognized"] == true).count();
-        let output = serde_json::json!({
-            "frame": frame_count,
-            "fps": (current_fps * 10.0).round() / 10.0,
-            "width": frame.width,
-            "height": frame.height,
-            "recognized": recognized,
-            "unrecognized": faces.len() - recognized,
-            "faces": face_json,
-        });
+        let output = frame_json(
+            frame_count,
+            current_fps,
+            None,
+            frame.width,
+            frame.height,
+            faces_json,
+        );
 
         let mut handle = stdout.lock();
         if writeln!(handle, "{output}").is_err() {
@@ -171,6 +177,67 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
     }
 
     Ok(())
+}
+
+/// One face, as `--json` reports it.
+///
+/// The two loops above build a face row from different sources (a
+/// `PreviewFace` off the bus; a `FaceDetection` plus a locally computed
+/// similarity in direct mode), so the field set and the rounding live here
+/// rather than twice. Coordinates are pixels in the original, pre-JPEG frame.
+///
+/// `confidence` and `similarity` are rounded to three decimals **in `f32`**,
+/// and JSON numbers are `f64`, so the widening puts the trailing digits back:
+/// `0.988f32` serializes as `0.9879999756813049`. That is what this has always
+/// emitted and the pins below record it. A consumer compares numbers, never
+/// the rendered text.
+fn face_json(
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    confidence: f32,
+    similarity: f32,
+    recognized: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "x": x, "y": y,
+        "width": width, "height": height,
+        "confidence": (confidence * 1000.0).round() / 1000.0,
+        "similarity": (similarity * 1000.0).round() / 1000.0,
+        "recognized": recognized,
+    })
+}
+
+/// One frame, as `--json` emits it: a document per line on stdout.
+///
+/// `jpeg_size` is `Some` only on the daemon path, the only one holding a JPEG
+/// to measure; the direct loop has never reported it, and this keeps that
+/// difference stated instead of implied by two copies of the payload. The
+/// counts are derived from `faces` rather than passed alongside them, so they
+/// cannot disagree with the rows they summarize.
+fn frame_json(
+    frame: u64,
+    fps: f32,
+    jpeg_size: Option<usize>,
+    width: u32,
+    height: u32,
+    faces: Vec<serde_json::Value>,
+) -> serde_json::Value {
+    let recognized = faces.iter().filter(|f| f["recognized"] == true).count();
+    let mut output = serde_json::json!({
+        "frame": frame,
+        "fps": (fps * 10.0).round() / 10.0,
+        "width": width,
+        "height": height,
+        "recognized": recognized,
+        "unrecognized": faces.len() - recognized,
+        "faces": faces,
+    });
+    if let Some(bytes) = jpeg_size {
+        output["jpeg_size"] = serde_json::json!(bytes);
+    }
+    output
 }
 
 /// Try to extract JPEG dimensions without full decode.
@@ -193,5 +260,115 @@ mod tests {
     fn jpeg_dimensions_returns_zero_for_invalid() {
         let (w, h) = jpeg_dimensions(&[0, 1, 2, 3]);
         assert_eq!((w, h), (0, 0));
+    }
+
+    // Both loops need a daemon or a camera, so the payload is pinned one
+    // level down, at the builders they share — the lowest seam here that
+    // does no I/O. `preview --json` was `preview --text-only` and emitted
+    // exactly these bytes; the rename must not have moved a key or a digit.
+
+    #[test]
+    fn daemon_frame_is_the_documented_json_line() {
+        let frame = frame_json(
+            7,
+            15.24,
+            Some(4096),
+            640,
+            480,
+            vec![face_json(10.0, 20.0, 100.0, 120.0, 0.98765, 0.61234, true)],
+        );
+
+        assert_eq!(
+            frame.to_string(),
+            concat!(
+                r#"{"faces":[{"confidence":0.9879999756813049,"height":120.0,"#,
+                r#""recognized":true,"similarity":0.6119999885559082,"#,
+                r#""width":100.0,"x":10.0,"y":20.0}],"#,
+                r#""fps":15.199999809265137,"frame":7,"height":480,"#,
+                r#""jpeg_size":4096,"recognized":1,"unrecognized":0,"width":640}"#,
+            )
+        );
+    }
+
+    /// The direct loop has no JPEG, so it reports no `jpeg_size`. Every other
+    /// key is the same one, which is the half a consumer branches on.
+    #[test]
+    fn direct_frame_omits_jpeg_size_and_keeps_every_other_key() {
+        let frame = frame_json(1, 0.0, None, 1280, 720, Vec::new());
+
+        let object = frame.as_object().expect("a frame is a JSON object");
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "faces",
+                "fps",
+                "frame",
+                "height",
+                "recognized",
+                "unrecognized",
+                "width",
+            ]
+        );
+    }
+
+    /// stdout in this module is the frame stream and nothing else.
+    ///
+    /// `--json` is parsed one level up, so neither loop here knows whether a
+    /// human or `jq` is reading, and both must keep stdout clean either way.
+    /// The regression this catches shipped: the no-enrollment notice in
+    /// `run_direct` went through `Terminal::info`, which writes to stdout, so
+    /// a fresh oneshot install prefixed the stream with a localized sentence
+    /// and a consumer failed on the first line. Human text goes to stderr.
+    ///
+    /// A source scan is the only seam available: both loops need a daemon or
+    /// a camera to run. Needles are assembled at runtime so this test does
+    /// not match itself, following `backend.rs`'s single-siting pins.
+    #[test]
+    fn nothing_beside_the_frame_stream_writes_to_stdout() {
+        let source = include_str!("text_only.rs");
+        let info_sink = format!("Terminal{}info(", ".");
+        let bare_stdout = format!("{}!(", String::from("print") + "ln");
+
+        for (index, line) in source.lines().enumerate() {
+            let code = line.trim_start();
+            if code.starts_with("//") {
+                continue;
+            }
+            let number = index + 1;
+            assert!(
+                !code.contains(&info_sink),
+                "line {number}: the informational sink writes to stdout, which \
+                 here is the frame stream; use Terminal::error"
+            );
+            // `eprint` is masked first so only the stdout macro can match.
+            assert!(
+                !code.replace("eprint", "eprint_").contains(&bare_stdout),
+                "line {number}: bare stdout printing beside the frame stream; \
+                 human text belongs on stderr"
+            );
+        }
+    }
+
+    /// The counts summarize the rows, so they are read off them. A face row
+    /// that says `recognized: false` cannot end up inside `recognized: 1`.
+    #[test]
+    fn counts_are_derived_from_the_face_rows() {
+        let frame = frame_json(
+            1,
+            30.0,
+            None,
+            640,
+            480,
+            vec![
+                face_json(0.0, 0.0, 1.0, 1.0, 0.9, 0.7, true),
+                face_json(0.0, 0.0, 1.0, 1.0, 0.9, 0.1, false),
+                face_json(0.0, 0.0, 1.0, 1.0, 0.9, 0.2, false),
+            ],
+        );
+
+        assert_eq!(frame["recognized"], 1);
+        assert_eq!(frame["unrecognized"], 2);
     }
 }

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -81,10 +81,18 @@ enum Commands {
         user: UserArg,
     },
     /// Live camera preview with detection overlay
+    // `--text-only` is the name this flag shipped under, and it always
+    // emitted JSON — one object per frame. `mut_arg` re-labels the shared
+    // `JsonArg` here rather than a second declaration of the flag, so the
+    // spelling still comes from one struct and `cli_flag_conformance` still
+    // sees an arg with id `json`. The alias is hidden: it parses forever, and
+    // `--help` teaches the one spelling.
+    #[command(mut_arg("json", |arg: clap::Arg| arg
+        .alias("text-only")
+        .help("Print one JSON object per frame instead of the graphical preview")))]
     Preview {
-        /// Print detection results to stdout instead of graphical preview
-        #[arg(long)]
-        text_only: bool,
+        #[command(flatten)]
+        json: JsonArg,
         #[command(flatten)]
         user: UserArg,
     },
@@ -262,8 +270,8 @@ fn main() -> anyhow::Result<()> {
                             commands::list::run(&config, user.user, json.json)
                         }
                         Commands::Test { user } => commands::test_cmd::run(&config, user.user),
-                        Commands::Preview { text_only, user } => {
-                            commands::preview::run(&config, text_only, user.user)
+                        Commands::Preview { json, user } => {
+                            commands::preview::run(&config, json.json, user.user)
                         }
                         Commands::Devices { json } => commands::devices::run(&config, json.json),
                         Commands::Bench { command } => commands::bench::run(&config, command),
@@ -695,6 +703,26 @@ mod tests {
         ('v', &["verbose"]),
     ];
 
+    /// Every command that offers `--json`, by full invocation path.
+    ///
+    /// The list is the contract, in both directions: a command here without a
+    /// `json` arg fails, and a `json` arg on a command not here fails too. So
+    /// `--json` cannot appear because a matrix looked incomplete — adding a
+    /// row is the moment someone states who parses the output, which is the
+    /// rule `docs/contracts.md` records under "CLI Machine Output".
+    ///
+    /// `preview` is on the list because it always emitted JSON; it just spelled
+    /// the flag `--text-only`, which survives as a hidden alias.
+    const JSON_COMMANDS: &[&str] = &[
+        "facelock is-enrolled",
+        "facelock list",
+        "facelock devices",
+        "facelock preview",
+        "facelock pam add",
+        "facelock pam remove",
+        "facelock pam status",
+    ];
+
     /// Collect every command in the tree, keyed by its full invocation path
     /// (`facelock bench camera-reopen`), so a failure names the offender.
     fn walk<'a>(
@@ -830,6 +858,79 @@ mod tests {
                 }
             }
         }
+
+        // -- `--json` coverage (#169) ------------------------------------
+        //
+        // Spelling is pinned above; these pin *where* the flag appears, and
+        // that nothing else spells machine output a second way.
+
+        let offers_json = |path: &str| {
+            commands
+                .iter()
+                .find(|(p, _)| p == path)
+                .unwrap_or_else(|| panic!("`{path}` is in JSON_COMMANDS but not in the tree"))
+                .1
+                .get_arguments()
+                .any(|arg| arg.get_id() == "json")
+        };
+        for path in JSON_COMMANDS {
+            assert!(
+                offers_json(path),
+                "`{path}` is in JSON_COMMANDS but binds no `--json`"
+            );
+        }
+        for (path, command) in &commands {
+            if command.get_arguments().any(|arg| arg.get_id() == "json") {
+                assert!(
+                    JSON_COMMANDS.contains(&path.as_str()),
+                    "`{path}` offers `--json` without a row in JSON_COMMANDS; add one \
+                     naming the consumer that asked for it"
+                );
+            }
+        }
+
+        // A flag that advertises JSON is named `json`. Without this, a later
+        // `--output json` or a second `--text-only` would satisfy every rule
+        // above by never being called `json` in the first place. Clap aliases
+        // are not `Arg`s and carry no help, so a hidden historical spelling is
+        // exempt by construction.
+        //
+        // Everything a user could read on the flag counts, concatenated
+        // rather than one-or-the-other: short help, long help, and the
+        // possible values with their own help. A `--format <FORMAT>` over
+        // `{json, text}` documented as "Output format" says JSON nowhere in
+        // its help text and only the value list gives it away.
+        //
+        // This is deliberately over-broad. A future *input* flag such as
+        // `--from-json <path>` would trip it despite emitting nothing. Rename
+        // that arg rather than relaxing the rule: the tripwire is worth more
+        // than the one name it costs.
+        for (path, command) in &commands {
+            for arg in command.get_arguments() {
+                let mut advertised = String::new();
+                for text in [arg.get_help(), arg.get_long_help()].into_iter().flatten() {
+                    advertised.push_str(&text.to_string());
+                    advertised.push(' ');
+                }
+                for value in arg.get_possible_values() {
+                    advertised.push_str(value.get_name());
+                    advertised.push(' ');
+                    if let Some(text) = value.get_help() {
+                        advertised.push_str(&text.to_string());
+                        advertised.push(' ');
+                    }
+                }
+                if advertised.to_lowercase().contains("json") {
+                    assert_eq!(
+                        arg.get_id().as_str(),
+                        "json",
+                        "`{path} --{}` advertises JSON but is not the shared \
+                         `json` arg; machine output has one spelling",
+                        arg.get_long().unwrap_or_else(|| arg.get_id().as_str())
+                    );
+                }
+            }
+        }
     }
 
     /// Every invocation that parsed before the shared arg structs landed must
@@ -861,6 +962,7 @@ mod tests {
             &["facelock", "setup", "--no-pam", "--systemd", "--enroll"],
             &["facelock", "setup", "--pam", "--no-confirm"],
             &["facelock", "preview", "--text-only"],
+            &["facelock", "preview", "--json"],
             &["facelock", "remove", "1", "-y"],
             &["facelock", "clear", "-u", "alice", "--yes"],
             &["facelock", "enroll", "-u", "alice", "-l", "laptop"],

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -63,8 +63,13 @@ impl Message for AccessMessage {
             DaemonUnreachableFallback => translate(
                 "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\nStart the facelock-daemon service to use it.",
             ),
+            // The flag is `--json` since #169; `--text-only` is a hidden
+            // alias that `preview --help` no longer lists, so naming it here
+            // taught a spelling the program had stopped showing. "text-only
+            // mode" in the second sentence describes the mode, not the flag,
+            // and stays.
             PreviewGraphicalNeedsDaemonOneshot => translate(
-                "Graphical preview requires the daemon. In oneshot mode, use --text-only.\nFalling back to text-only mode.\n",
+                "Graphical preview requires the daemon. In oneshot mode, use --json.\nFalling back to text-only mode.\n",
             ),
             PreviewGraphicalDaemonUnreachable => translate(
                 "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the facelock-daemon service to use it.\n",

--- a/crates/facelock-cli/src/message/mod.rs
+++ b/crates/facelock-cli/src/message/mod.rs
@@ -514,6 +514,16 @@ mod tests {
              To rollback:\n  sudo cp /etc/pam.d/sudo.facelock-backup /etc/pam.d/sudo\n\
              \u{20} # or: sudo facelock pam remove --service sudo"
         );
+        // Not a historical pin either: #169 renamed `preview --text-only` to
+        // `preview --json`, and this is the one runtime string that tells an
+        // operator which flag to reach for, so it was changed on purpose.
+        // Pinned so the next change to it is also on purpose. The second
+        // sentence says "text-only mode" about the mode, not the flag.
+        assert_eq!(
+            AccessMessage::PreviewGraphicalNeedsDaemonOneshot.localized(),
+            "Graphical preview requires the daemon. In oneshot mode, use --json.\n\
+             Falling back to text-only mode.\n"
+        );
         // The module-missing refusal was an inline `bail!` on the same path.
         assert_eq!(
             PamMessage::PamModuleNotInstalled {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,24 +104,44 @@ Live camera preview with face detection overlay.
 
 ```bash
 facelock preview                        # Wayland graphical window
-facelock preview --text-only            # JSON output to stdout
+facelock preview --json                 # one JSON object per frame on stdout
 facelock preview --user alice           # match against specific user
 ```
 
-Text-only mode outputs one JSON object per frame:
+`--json` shipped as `--text-only`, which stays a hidden alias and keeps
+parsing; the payload is unchanged. One object per line, one per frame:
+
 ```json
-{"frame":1,"fps":15.2,"width":640,"height":480,"recognized":1,"unrecognized":0,"faces":[...]}
+{"faces":[{"confidence":0.5,"height":180.0,"recognized":true,"similarity":0.75,"width":180.0,"x":112.0,"y":88.0}],"fps":15.0,"frame":1,"height":480,"jpeg_size":24576,"recognized":1,"unrecognized":0,"width":640}
 ```
+
+Keys come out sorted, which is `serde_json`'s doing and not a promise.
+`jpeg_size` is present only when the daemon serves the frames; the direct
+(oneshot) path has no JPEG and omits that key, and every other key is on both.
+Numbers are `f32` rounded then widened to `f64`, so a rounded `0.988` reaches
+you as `0.9879999756813049`: compare numerically, never as text.
 
 ## facelock devices
 
 List available V4L2 video capture devices.
 
 ```bash
-facelock devices
+facelock devices                        # human-readable listing
+facelock devices --json                 # JSON output
 ```
 
 Shows device path, name, driver, formats, resolutions, and IR status.
+
+`--json` emits an array of device objects with `path`, `name`, `driver`,
+`is_ir`, and `formats`; each format carries `fourcc`, `description`, and
+`sizes`, a list of `[width, height]` pairs. It is a typed schema derived from
+the device struct, so a script reads it rather than parsing the listing above,
+whose columns, indentation and `[IR]` tag are free to change.
+
+`formats` is empty whenever the daemon answers: the D-Bus device type does not
+carry format detail, so only the direct (oneshot) backend fills it in. The
+human listing omits the section for the same reason. Read `formats` for
+capability detection only when you know you are on the direct path.
 
 ## facelock status
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -103,6 +103,45 @@ quieter program. This generalizes `is-enrolled --quiet`, which has always meant
 through that seam; commands still printing directly are tracked by
 [#140](https://github.com/tyvsmith/facelock/issues/140).
 
+### CLI Machine Output
+
+**Every command whose output a script would parse takes `--json`, and spells it
+`--json`.** One flag family (the shared `JsonArg` in
+`crates/facelock-cli/src/args.rs`), no short letter, no `--output json`, no
+per-command invention. `cli_flag_conformance` pins both halves: an arg whose
+help advertises JSON must carry the id `json`, so a second spelling fails the
+build instead of shipping.
+
+**A command gains `--json` when it has a named consumer, not to complete a
+matrix.** The coverage list is the `JSON_COMMANDS` registry inside that test,
+and it is checked in both directions: a command on the list that binds no
+`--json` fails, and a `--json` on a command absent from the list fails too.
+Adding a row is the moment someone states who parses the output.
+
+| Command | Payload |
+|---------|---------|
+| `facelock is-enrolled --json` | one object. See "facelock is-enrolled Exit Codes" |
+| `facelock list --json` | array of enrolled models |
+| `facelock devices --json` | array of `IpcDeviceInfo` (`facelock_core::ipc`): `path`, `name`, `driver`, `is_ir`, `formats` (empty whenever the daemon answers, which carries no format detail). Serde-derived, so it is a typed schema rather than a scrape of the human renderer, whose columns and `[IR]` tag are free to change |
+| `facelock preview --json` | one object per line, one per frame |
+| `facelock pam add\|remove\|status --json` | one object, whose shape is a stability contract. See "facelock pam Semantics" |
+
+`preview` is on the list because it always emitted JSON. It shipped calling the
+flag `--text-only`, which survives as a hidden alias and keeps parsing; the
+per-frame payload is byte for byte what it was.
+
+Two commands were considered and declined. `facelock test` is an interactive
+diagnostic, and `facelock audit` already has a structured log format; neither
+has a consumer asking, which under the rule above settles it. `facelock status`
+is a schema question rather than a flag question, since nothing in `health.rs`
+derives `Serialize` yet, and it is tracked separately.
+
+Machine output does not pass through the translation seam: every `--json`
+payload is built with `serde_json` and is C-locale by construction. The one
+documented exception is `pam`'s `error` field, which can interpolate a
+`strerror` string (see "facelock pam Semantics"), and which is a diagnostic
+rather than something to branch on.
+
 ### facelock setup Flag Composition
 
 Flags **compose**; they are not mutually exclusive. The rule:

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 13:37-0700\n"
+"POT-Creation-Date: 2026-08-17 14:05-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,13 +60,13 @@ msgid ""
 "Start the facelock-daemon service to use it."
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:67
+#: crates/facelock-cli/src/message/access.rs:72
 msgid ""
-"Graphical preview requires the daemon. In oneshot mode, use --text-only.\n"
+"Graphical preview requires the daemon. In oneshot mode, use --json.\n"
 "Falling back to text-only mode.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:70
+#: crates/facelock-cli/src/message/access.rs:75
 msgid ""
 "Graphical preview requires the daemon, which is configured but not reachable.\n"
 "Falling back to text-only mode. Start the facelock-daemon service to use it.\n"


### PR DESCRIPTION
## Summary

- write the machine-output rule into `docs/contracts.md`: a command whose output a script parses takes `--json`, spelled `--json`, via the shared `JsonArg`; a command gains it when it has a named consumer, not to fill a matrix
- rename `preview --text-only` to `preview --json`; `--text-only` stays as a hidden alias; per-frame payload byte-identical, now built by shared `face_json`/`frame_json` and pinned by test
- route `preview`'s oneshot "no models enrolled" line to stderr so `--json` stdout is only the frame stream
- extend `cli_flag_conformance` with a `JSON_COMMANDS` registry (checked both ways) and a tripwire: any arg whose help or value list says JSON must be the shared `json` arg
- document `devices --json` (`sizes` key; `formats` is `[]` over the daemon backend) and the preview rename in `docs/cli.md`
- update the oneshot hint string to name `--json` (deliberate string change, pinned; pot regenerated)

## Why

`preview --text-only` was JSON under another name, and nothing stopped the next
command from picking a third spelling. Writing the rule down with the consumer
clause keeps `--json` from spreading on speculation; the registry and tripwire
make the rule a test instead of a convention.

## Validation

- `just check`
- payload byte-identity: old inline `json!` construction compared against the new builders for both the daemon and direct loops
- `preview --help`, `preview --text-only` (alias), `is-enrolled --json | jq -e .`, `pam status --json | jq -e .`
- conformance mutations: dropping a registry row, adding a rival `--output-json`, and a `--format {json,text}` value enum all fail the test

Stacked on #180.

Closes #169
