### PR TITLE
feat(cli): Add facelock capabilities, a machine-readable feature probe

### DIFF
--- a/crates/facelock-cli/src/commands/capabilities.rs
+++ b/crates/facelock-cli/src/commands/capabilities.rs
@@ -1,0 +1,256 @@
+//! `facelock capabilities` — what *this* build can do, as capability names.
+//!
+//! ```text
+//! facelock capabilities [--json] [--quiet]
+//! ```
+//!
+//! # What it replaces
+//!
+//! Integrations branch on features today by grepping help text —
+//! `facelock setup --help 2>/dev/null | grep -q -- "--no-pam"` is the shape in
+//! the wild. **Help text is not an API**: it breaks on a reworded flag
+//! description, a line wrap, a translated help template, or a flag that moved
+//! to a subcommand. This command is the supported probe, so a wrapper script
+//! can ask a direct question and get a stable answer.
+//!
+//! Bare form prints one name per line; `--json` prints
+//! `{"version": "...", "capabilities": [...]}`. Both exit 0 — there is no
+//! failure path — and `--quiet` suppresses stdout entirely, leaving the exit
+//! code as the whole answer, as it does for [`crate::commands::is_enrolled`].
+//! A build predating the command answers with clap's usage error on stderr and
+//! exit 2, which a caller reads as "no capabilities at all".
+//!
+//! # Hard requirements
+//!
+//! The answer comes from this binary's own clap tree and compiled-in
+//! constants. Nothing here may read a config file, open the database, activate
+//! the daemon over D-Bus, or touch a camera — a probe that needed root or a
+//! working install to answer "what can you do?" would be useless to the
+//! user-level setup script that is its consumer. That is also why it is
+//! dispatched ahead of every config-consuming command in `main`.
+//!
+//! Output is **not** localized. A capability name is an identifier, not prose,
+//! so it goes out through `println!` and never through the message seam
+//! (`message/mod.rs`, §"What must NOT come through here") — the same rule
+//! `is-enrolled` follows for its state words.
+//!
+//! # Why the list has to be provable
+//!
+//! A hand-maintained feature list rots the moment a flag is renamed, and a
+//! stale list is worse than no list: a consumer that trusts it invokes
+//! something that is not there. So [`CAPABILITIES`] is not documentation —
+//! `capability_names_are_all_implemented` in `main.rs` maps every name to the
+//! clap subcommand or argument that declares the surface it names, and a name
+//! nothing backs fails the build rather than shipping.
+
+/// The capability names this build emits. Sorted and deduplicated — the
+/// contract says the array is, and a const that is already sorted is the
+/// cheapest way to keep it so.
+///
+/// Adding a name here is a promise. `capability_names_are_all_implemented`
+/// in `main.rs` refuses to build a name that nothing in the clap tree backs.
+pub const CAPABILITIES: &[&str] = &[
+    "capabilities",
+    "devices-json",
+    "is-enrolled",
+    "is-enrolled-json",
+    "pam-dry-run",
+    "pam-if-present",
+    "pam-json",
+    "pam-multi-service",
+    "pam-status",
+    "quiet",
+    "setup-if-present",
+    "setup-no-pam",
+    "setup-systemd",
+];
+
+/// This binary's version — the string `facelock --version` prints.
+///
+/// Read from the same place `#[command(version)]` reads it, so the two cannot
+/// disagree. It is for humans and bug reports: consumers branch on names, not
+/// on this (a git or distro build carries a version that says nothing about
+/// what is in it, and a backport can add a feature without moving the number).
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// `{"version": "...", "capabilities": [...]}` — the documented shape.
+///
+/// Serialized through `serde_json` rather than `format!` so the array is
+/// escaped by the serializer, as `is_enrolled::enrolled_json` does. Key order
+/// is whatever the serializer picks and is explicitly not contractual.
+fn payload_json() -> String {
+    serde_json::json!({
+        "version": VERSION,
+        "capabilities": CAPABILITIES,
+    })
+    .to_string()
+}
+
+/// What [`run`] prints, or `None` under `--quiet`. The whole of this command's
+/// logic, with the printing left to the caller so a test can assert on it
+/// without capturing stdout (the `is_enrolled::report` split).
+fn rendered(json: bool, quiet: bool) -> Option<String> {
+    if quiet {
+        return None;
+    }
+    Some(if json {
+        payload_json()
+    } else {
+        CAPABILITIES.join("\n")
+    })
+}
+
+/// Run `facelock capabilities`. Infallible by construction: no file, no
+/// socket, no camera, so there is no error to return and no exit code but 0.
+pub fn run(json: bool, quiet: bool) {
+    if let Some(text) = rendered(json, quiet) {
+        println!("{text}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every name this binary has ever emitted. Contract: names are added,
+    /// never removed or repurposed. This list is append-only history — do not
+    /// edit a name out of it, ever; if a name here is missing from
+    /// `CAPABILITIES` the contract has been broken, not the test.
+    ///
+    /// **When you add a name to `CAPABILITIES`, add it here in the same
+    /// commit.** The two lists are identical today and stay identical unless
+    /// the contract is violated; this one exists so that a later deletion has
+    /// something to fail against.
+    const CAPABILITIES_EVER_EMITTED: &[&str] = &[
+        "capabilities",
+        "devices-json",
+        "is-enrolled",
+        "is-enrolled-json",
+        "pam-dry-run",
+        "pam-if-present",
+        "pam-json",
+        "pam-multi-service",
+        "pam-status",
+        "quiet",
+        "setup-if-present",
+        "setup-no-pam",
+        "setup-systemd",
+    ];
+
+    /// The half of the contract no clap predicate can see: a consumer that
+    /// branched on a name must keep working against every later build.
+    #[test]
+    fn capability_names_are_never_removed() {
+        for name in CAPABILITIES_EVER_EMITTED {
+            assert!(
+                CAPABILITIES.contains(name),
+                "`{name}` has been emitted by a released build and is gone: \
+                 names are added, never removed"
+            );
+        }
+    }
+
+    /// Strict `<` proves sorted and deduplicated in one pass — the contract
+    /// promises the array is both.
+    #[test]
+    fn capability_list_is_sorted_and_deduplicated() {
+        for pair in CAPABILITIES.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "CAPABILITIES must be sorted and deduplicated: `{}` precedes `{}`",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    /// Lowercase and hyphenated: `[a-z0-9]+(-[a-z0-9]+)*`. Hand-checked rather
+    /// than by regex — this crate has no regex dependency and does not want one
+    /// for a rule this small.
+    #[test]
+    fn capability_names_follow_the_naming_rule() {
+        for name in CAPABILITIES {
+            assert!(!name.is_empty(), "a capability name must not be empty");
+            assert!(
+                name.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'),
+                "`{name}` must be lowercase alphanumeric and hyphens only"
+            );
+            assert!(
+                !name.starts_with('-') && !name.ends_with('-'),
+                "`{name}` must not start or end with a hyphen"
+            );
+            assert!(!name.contains("--"), "`{name}` must not contain `--`");
+        }
+    }
+
+    /// Every emitted name has a row in the contract saying what it means.
+    ///
+    /// `capability_names_are_all_implemented` in `main.rs` proves a name is
+    /// backed by a real surface; this proves the same name is *documented*,
+    /// which is the other half of a promise — a consumer cannot branch on a
+    /// name whose meaning is written down nowhere. `include_str!` reaches out
+    /// of the crate the way `setup.rs` embeds the systemd unit and D-Bus
+    /// policy, so deleting a row breaks the build rather than the contract.
+    #[test]
+    fn capabilities_are_all_documented_in_contracts() {
+        const CONTRACTS: &str = include_str!("../../../../docs/contracts.md");
+
+        for name in CAPABILITIES {
+            let row = format!("| `{name}` |");
+            assert!(
+                CONTRACTS.contains(&row),
+                "`{name}` is emitted but has no `{row}` row in docs/contracts.md"
+            );
+        }
+    }
+
+    #[test]
+    fn capabilities_json_matches_the_documented_shape() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload_json()).expect("the payload must be JSON");
+        let object = parsed.as_object().expect("the payload must be an object");
+
+        assert_eq!(
+            object.len(),
+            2,
+            "the document has exactly `version` and `capabilities`, got {:?}",
+            object.keys().collect::<Vec<_>>()
+        );
+
+        // Only that it is this binary's own version. The *shape* of the string
+        // is Cargo's problem: `VERSION` is `env!("CARGO_PKG_VERSION")`, which
+        // Cargo already refuses to build unless it is valid semver — and a
+        // stricter check here would reject the prerelease versions
+        // `docs/releasing.md` documents (`v0.2.0-rc1`).
+        assert_eq!(
+            object["version"].as_str(),
+            Some(VERSION),
+            "`version` is this binary's own version, as a string"
+        );
+
+        let names = object["capabilities"]
+            .as_array()
+            .expect("`capabilities` is an array");
+        assert_eq!(names.len(), CAPABILITIES.len());
+        for (emitted, expected) in names.iter().zip(CAPABILITIES) {
+            assert_eq!(
+                emitted.as_str(),
+                Some(*expected),
+                "every element is a string, in CAPABILITIES order"
+            );
+        }
+    }
+
+    #[test]
+    fn capabilities_output_modes() {
+        for json in [false, true] {
+            assert!(
+                rendered(json, true).is_none(),
+                "`--quiet` prints nothing, whatever `--json` says"
+            );
+        }
+        assert_eq!(rendered(false, false), Some(CAPABILITIES.join("\n")));
+        assert_eq!(rendered(true, false), Some(payload_json()));
+    }
+}

--- a/crates/facelock-cli/src/commands/mod.rs
+++ b/crates/facelock-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit;
 pub mod auth;
 pub mod bench;
+pub mod capabilities;
 pub mod clear;
 pub mod config;
 pub mod daemon;

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -41,6 +41,11 @@ enum Commands {
         #[command(flatten)]
         json: JsonArg,
     },
+    /// Report what this build can do, as capability names (--json for a machine-readable document)
+    Capabilities {
+        #[command(flatten)]
+        json: JsonArg,
+    },
     /// Capture and store a face
     Enroll {
         #[command(flatten)]
@@ -218,6 +223,14 @@ fn main() -> anyhow::Result<()> {
                 // dotfiles, `config` operates on the config file itself, and
                 // `restart` only talks to systemd — none consume a parsed
                 // Config.
+                //
+                // `capabilities` reports on the binary itself — its own clap
+                // tree and constants. It reads no file at all, so it sits
+                // ahead even of `is-enrolled`, which at least opens a marker.
+                Commands::Capabilities { json } => {
+                    commands::capabilities::run(json.json, quiet);
+                    Ok(())
+                }
                 Commands::IsEnrolled { user, json } => {
                     std::process::exit(commands::is_enrolled::run(user.user, json.json, quiet))
                 }
@@ -288,6 +301,7 @@ fn main() -> anyhow::Result<()> {
                         Commands::Daemon
                         | Commands::Auth { .. }
                         | Commands::IsEnrolled { .. }
+                        | Commands::Capabilities { .. }
                         | Commands::Pam { .. }
                         | Commands::Hyprlock { .. }
                         | Commands::Config { .. }
@@ -715,6 +729,7 @@ mod tests {
     /// the flag `--text-only`, which survives as a hidden alias.
     const JSON_COMMANDS: &[&str] = &[
         "facelock is-enrolled",
+        "facelock capabilities",
         "facelock list",
         "facelock devices",
         "facelock preview",
@@ -739,6 +754,35 @@ mod tests {
             walk(sub, &path, out);
         }
         out.push((path, command));
+    }
+
+    /// Descend by subcommand name, naming the missing command on failure.
+    fn sub<'a>(command: &'a clap::Command, name: &str) -> &'a clap::Command {
+        command
+            .get_subcommands()
+            .find(|c| c.get_name() == name)
+            .unwrap_or_else(|| panic!("no `{name}` subcommand"))
+    }
+
+    /// Look an argument up by its clap **id**, which the derive takes from the
+    /// Rust field name (`no_pam`), not from the long spelling (`--no-pam`).
+    fn arg<'a>(command: &'a clap::Command, id: &str) -> &'a clap::Arg {
+        command
+            .get_arguments()
+            .find(|a| a.get_id().as_str() == id)
+            .unwrap_or_else(|| panic!("`{}` has no `{id}` argument", command.get_name()))
+    }
+
+    /// Assert both halves: the id exists *and* it spells the long name a
+    /// caller types. Asserting the id alone would let a rename of the
+    /// spelling pass.
+    fn assert_long(command: &clap::Command, id: &str, long: &str) {
+        assert_eq!(
+            arg(command, id).get_long(),
+            Some(long),
+            "`{}`: the `{id}` arg must spell `--{long}`",
+            command.get_name()
+        );
     }
 
     /// Pins flag spelling across the whole command tree.
@@ -1133,6 +1177,120 @@ mod tests {
             assert!(
                 Cli::try_parse_from(argv).is_err(),
                 "`{}` must not parse",
+                argv.join(" ")
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // `facelock capabilities` (#165)
+    // -----------------------------------------------------------------------
+
+    /// Every emitted capability name is backed by the clap surface it names.
+    ///
+    /// This is what makes the list a probe rather than documentation: a name
+    /// that nothing declares is a lie a consumer would act on. It lives in the
+    /// binary's test module because only the binary can call `Cli::command()`.
+    ///
+    /// Each predicate proves the **surface** exists — the subcommand, the
+    /// argument, its long spelling. What a surface *means* is pinned by the
+    /// section of `docs/contracts.md` that owns it and by that command's own
+    /// tests; duplicating semantics here would only make both places drift.
+    ///
+    /// `&str` patterns cannot be exhaustive, so the wildcard arm **is** the
+    /// exhaustiveness check: it must panic, so that adding a name to
+    /// `CAPABILITIES` without adding a predicate fails the build.
+    #[test]
+    fn capability_names_are_all_implemented() {
+        use facelock_cli::commands::capabilities::CAPABILITIES;
+
+        let root = Cli::command();
+        let pam = sub(&root, "pam");
+        let setup = sub(&root, "setup");
+
+        for name in CAPABILITIES {
+            match *name {
+                "capabilities" => {
+                    sub(&root, "capabilities");
+                }
+                "devices-json" => assert_long(sub(&root, "devices"), "json", "json"),
+                "is-enrolled" => {
+                    sub(&root, "is-enrolled");
+                }
+                "is-enrolled-json" => assert_long(sub(&root, "is-enrolled"), "json", "json"),
+                "pam-dry-run" => {
+                    for verb in ["add", "remove"] {
+                        assert_long(sub(pam, verb), "dry_run", "dry-run");
+                    }
+                }
+                "pam-if-present" => {
+                    for verb in ["add", "remove"] {
+                        assert_long(sub(pam, verb), "if_present", "if-present");
+                    }
+                }
+                "pam-json" => {
+                    for verb in ["add", "remove", "status"] {
+                        assert_long(sub(pam, verb), "json", "json");
+                    }
+                }
+                "pam-multi-service" => {
+                    for verb in ["add", "remove", "status"] {
+                        let verb_command = sub(pam, verb);
+                        assert_long(verb_command, "service", "service");
+                        // "multi" is the whole promise: a single `Option` here
+                        // is what forced one process per service.
+                        assert!(
+                            matches!(
+                                arg(verb_command, "service").get_action(),
+                                clap::ArgAction::Append
+                            ),
+                            "`pam {verb} --service` must be repeatable"
+                        );
+                    }
+                }
+                "pam-status" => {
+                    sub(pam, "status");
+                }
+                "quiet" => {
+                    assert_long(&root, "quiet", "quiet");
+                    assert!(
+                        arg(&root, "quiet").is_global_set(),
+                        "`--quiet` must be global — every command honours it"
+                    );
+                }
+                "setup-if-present" => assert_long(setup, "if_present", "if-present"),
+                "setup-no-pam" => assert_long(setup, "no_pam", "no-pam"),
+                "setup-systemd" => assert_long(setup, "systemd", "systemd"),
+                other => {
+                    panic!("capability `{other}` has no predicate: a name nothing backs is a lie")
+                }
+            }
+        }
+    }
+
+    /// Nothing legacy invokes this command, so these are their own table
+    /// rather than rows in `legacy_invocations_still_parse`.
+    #[test]
+    fn capabilities_invocations_parse() {
+        for argv in [
+            &["facelock", "capabilities"][..],
+            &["facelock", "capabilities", "--json"],
+            &["facelock", "--quiet", "capabilities", "--json"],
+            &["facelock", "capabilities", "--quiet"],
+        ] {
+            let cli = Cli::try_parse_from(argv)
+                .unwrap_or_else(|e| panic!("`{}` must parse: {e}", argv.join(" ")));
+            assert!(
+                matches!(cli.command, Commands::Capabilities { .. }),
+                "`{}` must reach the Capabilities variant",
+                argv.join(" ")
+            );
+            // The global flag on either side of the subcommand name reaches
+            // the same field — the `CLI Flag Spelling` invariant.
+            assert_eq!(
+                cli.quiet,
+                argv.contains(&"--quiet"),
+                "`{}`: global --quiet must land on Cli::quiet wherever it sits",
                 argv.join(" ")
             );
         }

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -23,6 +23,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock setup` choice flags | `--camera <PATH\|auto>`, `--models <standard\|balanced\|high>`, `--execution-provider <cpu\|cuda\|rocm\|openvino\|auto>`, `--encryption <tpm\|keyfile\|none\|auto>`. Precedence: CLI flag > config file > built-in default |
 | `facelock setup` action opt-outs | `--no-pam`, `--no-systemd`, `--no-enroll` decline an action outright (and their `--pam`/`--systemd`/`--enroll` counterparts force it). Later flag wins |
 | `facelock is-enrolled` | Report whether face auth is operational for a user. Exit code is the contract; no daemon activation, no camera. Requires `facelock` group membership to answer `enrolled` — a caller outside the group reports `not-enrolled`, which is correct: the group is required to reach the daemon at all |
+| `facelock capabilities` | Report what this build can do: one capability name per line, or `--json` for `{"version", "capabilities"}`. Unprivileged, reads no config, activates no daemon. The feature probe to branch on instead of grepping `--help` |
 | `facelock enroll` | Capture and store a face |
 | `facelock test` | Test face recognition |
 | `facelock list` | List enrolled face models |
@@ -121,6 +122,7 @@ Adding a row is the moment someone states who parses the output.
 | Command | Payload |
 |---------|---------|
 | `facelock is-enrolled --json` | one object. See "facelock is-enrolled Exit Codes" |
+| `facelock capabilities --json` | one object. See "facelock capabilities" |
 | `facelock list --json` | array of enrolled models |
 | `facelock devices --json` | array of `IpcDeviceInfo` (`facelock_core::ipc`): `path`, `name`, `driver`, `is_ir`, `formats` (empty whenever the daemon answers, which carries no format detail). Serde-derived, so it is a typed schema rather than a scrape of the human renderer, whose columns and `[IR]` tag are free to change |
 | `facelock preview --json` | one object per line, one per frame |
@@ -326,9 +328,85 @@ missing trailing newline stays missing; a backup is taken before every edit and
 never before a no-op. Golden fixtures captured from the pre-refactor code pin
 all of it.
 
+### facelock capabilities
+
+`facelock capabilities` answers "what can *this* build do?" — from the binary's
+own clap tree and compiled-in constants, without reading a config file,
+activating the daemon, or opening a camera. It is what replaces
+`facelock setup --help 2>/dev/null | grep -q -- "--no-pam"` in a wrapper
+script: **help text is not an API**, and a grep against it breaks on a reworded
+flag description, a line wrap, or a translated help template.
+
+Bare `capabilities` prints one name per line on stdout. `--json` prints one
+document on stdout. Both exit 0 — the command has no failure mode — and
+`--quiet` suppresses stdout entirely, leaving the exit code as the whole
+answer, as it does for `is-enrolled`. Neither form localizes: a capability name
+is an identifier, not prose.
+
+The `--json` document, with the array elided — the names this build emits are
+the table at the end of this section:
+
+```json
+{"version": "0.1.4", "capabilities": ["capabilities", "devices-json", "is-enrolled"]}
+```
+
+`version` is this binary's own version — byte for byte the one `facelock
+--version` prints. `capabilities` is a **sorted, deduplicated** array of
+strings.
+
+**Probe by name, not by version.** A version comparison is the wrong test
+twice over: a git or distro build can carry a version that says nothing about
+what is in it (`facelock-git` is exactly that case, and is why a downstream
+package pin cannot express "needs the `pam` verb"), and a backport can add a
+feature without moving the number. The name list cannot drift from the binary
+it came out of — a unit test maps every name to the clap argument, subcommand
+or constant that declares the surface it names, and a name with no such proof
+fails the build. What each surface *means* is pinned by the section of this
+document that owns it, and by that command's own tests. `version` is for
+humans and bug reports.
+
+**A build that predates the command** answers by failing: clap's
+"unrecognized subcommand" error, usage text on stderr, exit 2, nothing on
+stdout. A caller reads any non-zero exit as "no capabilities at all", which is
+the true answer for that build.
+
+**Stability.** The names are a contract of the same kind as the `pam --json`
+`action` vocabulary, one degree stronger:
+
+- a name, once emitted, never changes meaning
+- names are **added**; none is ever removed or repurposed
+- `version` and `capabilities` are always present, and a new top-level field is
+  additive — a consumer ignores fields it does not know
+- a consumer tolerates a **name** it does not know rather than treating it as
+  an error
+- key order within the JSON document is **not** part of the contract — parse
+  the document, do not string-match it
+
+**Naming.** Lowercase, hyphenated. A bare name (`quiet`, `is-enrolled`) means
+the command or global flag itself exists; `<command>-<feature>` names one
+feature of one command, and where the command's own name is hyphenated the
+suffix simply appends (`is-enrolled-json`). One name promises one thing: a flag
+that is not on this list is not being denied, only not yet promised.
+
+| Name | Meaning |
+|------|---------|
+| `capabilities` | this command exists, so a consumer's membership test is uniform across every name |
+| `devices-json` | `devices --json` |
+| `is-enrolled` | `is-enrolled` exists — the unprivileged enrollment probe whose exit code is the contract |
+| `is-enrolled-json` | `is-enrolled --json` |
+| `pam-dry-run` | `pam add`/`pam remove` accept `--dry-run` |
+| `pam-if-present` | `pam add`/`pam remove` accept `--if-present` |
+| `pam-json` | `pam add`/`pam remove`/`pam status` accept `--json` |
+| `pam-multi-service` | `pam add`/`pam remove`/`pam status` take a repeatable `--service` — several services in one process, one root check |
+| `pam-status` | `pam status` exists — the unprivileged `/etc/pam.d` read (DEC-6 below) |
+| `quiet` | the global `--quiet` |
+| `setup-if-present` | `setup --pam --remove --if-present` |
+| `setup-no-pam` | `setup --no-pam` |
+| `setup-systemd` | `setup --systemd` |
+
 ### CLI Privilege Model (DEC-6)
 
-The CLI is root by default: every subcommand requires root except the five
+The CLI is root by default: every subcommand requires root except the six
 listed below, which are unprivileged by design, not by omission.
 
 | Command | Why unprivileged |
@@ -337,6 +415,7 @@ listed below, which are unprivileged by design, not by omission.
 | `facelock hyprlock …` | Edits the user's own dotfile — root would write root-owned files into `$HOME`, which is wrong, not just unnecessary |
 | `facelock pam status` | Reads `0644` files under `/etc/pam.d` and writes nothing. Same role as `is-enrolled`: the probe an integration runs without `sudo`, replacing a hand-rolled `grep -q pam_facelock.so /etc/pam.d/<service>`. A file it cannot read reports `unknown` and exits 2 rather than reporting it as missing |
 | `facelock config` (display, no `--edit`) | Reads a `0644` file |
+| `facelock capabilities` | Reports what the *binary* can do, derived from its own clap tree and compiled-in constants — no file, no D-Bus, no camera, no per-user state, so there is nothing to protect. Unprivileged because the consumer is a user-level setup script deciding whether to invoke `sudo facelock …` at all: a probe that needed root to answer "do I need root?" would be useless |
 | `--help`, `--version` | — |
 
 Every other command requires root. Two escalation behaviors apply, and each


### PR DESCRIPTION
## Summary

- add `facelock capabilities [--json]`: one capability name per line, or `{"version", "capabilities"}`; unprivileged, reads no config, activates no daemon, exits 0
- name the 13 initial capabilities in `docs/contracts.md` as a stability contract: names added, never removed or repurposed; probe by name, not by version
- add a DEC-6 row saying why the probe is unprivileged by design
- prove the list from the binary: `capability_names_are_all_implemented` maps every name to the clap surface that declares it (panicking wildcard), `capabilities_are_all_documented_in_contracts` requires a contracts row, `capability_names_are_never_removed` freezes the append-only history
- register `capabilities` in `JSON_COMMANDS` per the rule in #181

## Why

`omarchy-setup-security-face` greps `facelock setup --help` for `--no-pam`, and
Omarchy PR #7040 pins `facelock-git` because it cannot express "needs ≥ 0.1.5".
Help text is not an API and a git package version says nothing about content;
a name list that a test derives from the same clap tree the flags come out of
cannot drift from the binary.

## Validation

- `just check`
- as uid 1000: `capabilities`, `capabilities --json | jq -e .`, `--quiet` on either side; unknown-subcommand exit 2 as the pre-command probe answer
- mutation checks: an unbacked name, a removed name, a renamed long spelling, a non-repeatable `--service`, and a missing contracts row each fail their test
- `just pot` msgid-clean (nothing enters the seam); a `0.2.0-rc1` workspace version keeps the suite green

Stacked on #181.

Closes #165
