### PR TITLE
docs(cli): Sync the CLI reference and man page with what ships

### DIFF
--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -27,9 +27,10 @@ facelock setup --non-interactive        # base setup, no prompts, no PAM/systemd
 facelock setup --systemd                # install systemd units
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
-facelock setup --pam --service login    # install to specific service
-facelock setup --pam --remove           # remove PAM line
-facelock setup --pam --service sshd -y  # skip confirmation for sensitive services
+facelock setup --pam --service polkit-1 # install to a specific service
+facelock setup --pam --remove           # remove the PAM line
+facelock setup --pam --remove --if-present  # a missing service file is success
+facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
 facelock setup --no-pam                 # wizard, but never touch /etc/pam.d
 facelock setup --camera /dev/video2     # answer step 1 from the command line
 ```
@@ -101,6 +102,7 @@ Each pair is a clap override pair: **a later flag wins over an earlier one.** `-
 Two details worth knowing:
 
 - `--pam` inside the wizard configures **exactly one service** — `--service`, defaulting to `sudo`. It does not apply the multi-select's pre-checked candidates. `--pam` means the same thing everywhere, whether or not the base setup is also running.
+- `--pam` is an alias onto [`facelock pam add`](#facelock-pam) / `facelock pam remove`, which is the primary spelling and the one that takes several services in one process. Every `setup --pam` invocation keeps parsing and keeps its behaviour, including that `-y` is what unlocks a sensitive service here where `--allow-sensitive` does it on `facelock pam add`.
 - `--enroll` answers the "would you like to enroll a face now?" confirmation as well as forcing the step, so it runs unattended. Combined with `--non-interactive` it enrolls without any prompt at all.
 
 ### Action modifiers
@@ -109,6 +111,7 @@ Two details worth knowing:
 |------|----------|---------|
 | `--service <name>` | `--pam` | Target PAM service. Default `sudo`. |
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
+| `--if-present` | `--remove` | Treat an absent service file as success rather than an error. Read, parse and write failures stay fatal. |
 | `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
 
 These `requires` relationships are enforced by the parser. `facelock setup --remove` is a clear error naming the missing `--pam`, not a silently ignored flag.
@@ -243,7 +246,28 @@ The database is `600 root:root` — encrypted biometric templates are read by th
 
 **PAM at auth time remains authoritative.** Nothing in the authentication path consults the marker.
 
-Markers are maintained by `enroll`, `remove`, and `clear`, and reconciled from the database on every `setup` run.
+Markers are maintained by `enroll`, `remove`, and `clear`, and reconciled from the database on every `setup` run. See `docs/contracts.md`, "facelock is-enrolled Exit Codes", for the stability promise and for how the scope of that reconciliation differs between `setup`, daemon startup and the one-shot `facelock auth` path.
+
+## facelock capabilities
+
+Report what this build can do, as capability names. Unprivileged: it answers from the binary's own clap tree and compiled-in constants, reading no config file, activating no daemon and opening no camera.
+
+```bash
+facelock capabilities                   # one name per line
+facelock capabilities --json            # {"version", "capabilities"}
+```
+
+With the name array elided:
+
+```json
+{"capabilities":["capabilities","devices-json","is-enrolled"],"version":"0.1.4"}
+```
+
+This is what replaces grepping `--help` in a wrapper script: **help text is not an API**, and a grep against it breaks on a reworded flag description, a line wrap, or a translated help template.
+
+Both forms exit 0 — the command has no failure mode — and `--quiet` suppresses stdout, leaving the exit code as the whole answer. A build that predates the command answers by failing: clap's unrecognized-subcommand error on stderr, exit 2, nothing on stdout. A caller reads any non-zero exit as "no capabilities at all", which is the true answer for that build.
+
+**Probe by name, never by version.** A version comparison is the wrong test twice over: a git or distro build can carry a version that says nothing about what is in it, and a backport can add a feature without moving the number. The names this build emits, what each one promises, and the stability rules that govern them are in `docs/contracts.md`, "facelock capabilities".
 
 ## facelock enroll
 
@@ -317,11 +341,12 @@ Live camera preview with face detection overlay.
 
 ```bash
 facelock preview                        # Wayland graphical window
-facelock preview --text-only            # JSON output to stdout
+facelock preview --json                 # one JSON object per frame on stdout
 facelock preview --user alice           # match against specific user
 ```
 
-Text-only mode outputs one JSON object per frame:
+`--json` shipped as `--text-only`, which stays a hidden alias and keeps parsing; the payload is unchanged. One object per line, one per frame:
+
 ```json
 {"frame":1,"fps":15.2,"width":640,"height":480,"recognized":1,"unrecognized":0,"faces":[...]}
 ```
@@ -331,10 +356,15 @@ Text-only mode outputs one JSON object per frame:
 List available V4L2 video capture devices.
 
 ```bash
-facelock devices
+facelock devices                        # human-readable listing
+facelock devices --json                 # JSON output
 ```
 
 Shows device path, name, driver, formats, resolutions, and IR status.
+
+`--json` emits an array of device objects with `path`, `name`, `driver`, `is_ir`, and `formats`; each format carries `fourcc`, `description`, and `sizes`, a list of `[width, height]` pairs. It is a typed schema derived from the device struct, so a script reads it rather than parsing the listing above, whose columns, indentation and `[IR]` tag are free to change.
+
+`formats` is empty whenever the daemon answers: the D-Bus device type does not carry format detail, so only the direct (oneshot) backend fills it in. The human listing omits the section for the same reason.
 
 ## facelock status
 
@@ -411,6 +441,14 @@ Unseal the AES key from the TPM back to a plaintext keyfile, migrating from TPM-
 facelock tpm unseal-key
 ```
 
+### facelock tpm unseal-check
+
+Read-only check that the sealed AES key still unseals under the current PCR values. Writes nothing, and exits non-zero when it does not — which is the signal to run [`facelock reseal`](#facelock-reseal).
+
+```bash
+sudo facelock tpm unseal-check
+```
+
 ### facelock tpm pcr-baseline
 
 Display the current PCR values for all configured PCR indices.
@@ -445,6 +483,94 @@ reports the per-phase median. That total is what `device.camera_release_secs`
 trades LED-on time against -- holding the stream warm after a failed attempt
 buys a retry exactly this much (ADR 008).
 
+## facelock pam
+
+Manage the facelock line in `/etc/pam.d` service files. This command owns every write to `/etc/pam.d`; `setup --pam` is an alias onto it, and the setup wizard's step 9 calls the same writer, so there is one implementation of the edit and one set of rules.
+
+`--service` is repeatable on all three verbs and defaults to `sudo`, so several services are configured in one process, under one root check. That is the defect the verb exists to fix: the old `setup --pam --service X` took a single value, so configuring three services meant three processes.
+
+`add` and `remove` require root and never offer to re-exec under `sudo` — silently re-running an `/etc/pam.d` edit on a wrapper script's behalf is a surprise, not a convenience. `status` reads only and needs no root.
+
+### facelock pam add
+
+```bash
+sudo facelock pam add                                        # /etc/pam.d/sudo
+sudo facelock pam add --service polkit-1 --service hyprlock  # several at once
+sudo facelock pam add --service sshd --allow-sensitive       # unlock a gated service
+sudo facelock pam add --service hyprlock --if-present        # a missing file is success
+sudo facelock pam add --service sudo --dry-run               # print the plan, write nothing
+sudo facelock pam add --service sudo --json                  # machine-readable result
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--service <NAME>` | Service to act on; repeat for several (default: `sudo`). |
+| `-y`, `--yes` (alias `--no-confirm`) | Skip the per-file confirmation, and nothing else. |
+| `--allow-sensitive` | Also permit the gated services `system-auth`, `login`, `sshd`. |
+| `--if-present` | Treat a missing service file as success instead of an error. |
+| `--dry-run` | Print the resolved plan, write nothing, exit 0. |
+| `--json` | Emit one JSON document instead of human text. |
+
+**`--yes` never implies `--allow-sensitive`.** They are separate authorizations: "do not ask me" and "yes, edit `system-auth`". Locking yourself out of a machine should take two decisions, not one.
+
+Every service is validated — name, existence, the sensitive gate, and what the edit would be — before **any** file is written, so a typo'd or gated service name leaves every other service untouched. With no TTY on stdin the per-file confirmation is skipped as if `--yes` were given, which is what has always made this work from a provisioning script; the gate is decided in the validation phase, before any prompt exists, so an unattended `pam add --service system-auth` still refuses.
+
+`--dry-run` is honoured after the root check, so it still needs root. `pam status` is the unprivileged read to reach for instead.
+
+### facelock pam remove
+
+```bash
+sudo facelock pam remove                                     # /etc/pam.d/sudo
+sudo facelock pam remove --service login                     # removal is never gated
+sudo facelock pam remove --service hyprlock --if-present     # a missing file is success
+sudo facelock pam remove --service sudo --dry-run --json
+```
+
+Takes the same flags as `add` except `--allow-sensitive`, which it does not offer: removal can only take away a way to authenticate, so there is nothing to gate. It never prompts either, and the `.facelock-backup` file written by `add` is left in place.
+
+### facelock pam status
+
+```bash
+facelock pam status                                          # /etc/pam.d/sudo
+facelock pam status --service sudo --service polkit-1
+facelock pam status --service sudo --json
+```
+
+Unprivileged, and the probe to branch on instead of grepping `/etc/pam.d` yourself: it answers from the same file, without root, and reports "absent" and "unreadable" as themselves rather than as "not configured". It offers `--service` and `--json` and neither `--dry-run` nor `--allow-sensitive` — there is no write to preview or gate.
+
+The exit code is the answer, on the same 0/1/2 scale as `is-enrolled` and `grep`:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Every requested service carries the line |
+| `1` | At least one exists without it |
+| `2` | At least one is absent, unreadable, or misnamed |
+
+Across several services the worst outcome wins. `--json` emits one document:
+
+```json
+{"command":"status","dry_run":false,"services":[{"action":"present","backup":null,"path":"/etc/pam.d/sudo","service":"sudo"}]}
+```
+
+The document's shape and the `action` vocabulary are a stability contract, including the rule that a consumer must tolerate an `action` it does not recognize rather than treat it as an error. See `docs/contracts.md`, "facelock pam Semantics", for that, for the `add`/`remove` exit codes, and for what `--json` does on a validation failure.
+
+## facelock hyprlock
+
+Manage hyprlock lock-screen integration: the face glyph in `placeholder_text`, and the `ignore_empty_input = false` setting that lets a bare Enter submit to PAM.
+
+```bash
+facelock hyprlock enable                # face icon, and allow the empty-Enter submit
+facelock hyprlock enable --no-icon      # only set ignore_empty_input = false
+facelock hyprlock disable               # undo
+facelock hyprlock status                # report the current state
+```
+
+Runs as your normal user and refuses to run as root, since it edits `~/.config/hypr/hyprlock.conf` and root would leave root-owned files in `$HOME`. A backup is taken before the first edit.
+
+`--no-icon` is for a hyprlock font with no Nerd Font glyphs; it flips the functional setting and leaves any existing icon alone. `disable` restores `ignore_empty_input` only when no fingerprint icon coexists, so a machine using both keeps working.
+
+Wiring `/etc/pam.d/hyprlock` itself is a separate, root step — see [`facelock pam`](#facelock-pam). This command touches no file outside `$HOME`.
+
 ## facelock encrypt
 
 Encrypt all unencrypted embeddings in the database with AES-256-GCM.
@@ -463,6 +589,18 @@ Decrypt all software-encrypted embeddings in the database (reverting AES-256-GCM
 ```bash
 facelock decrypt
 ```
+
+## facelock reseal
+
+Re-seal the TPM AES key under the current PCR values. This is the recovery step after a firmware or kernel change moves a measured PCR and the sealed key stops unsealing.
+
+```bash
+sudo facelock reseal
+```
+
+Requires root, and applies only when `encryption.method = "tpm"` — under any other method it errors rather than quietly doing nothing.
+
+It prefers unsealing the existing blob, which still works while the PCR policy is satisfied, so it is safe to run proactively before a firmware update; once the PCRs have moved it falls back to the plaintext key backup. With neither available there is nothing to re-seal and it fails. Run `facelock tpm unseal-check` to find out which of those you are in.
 
 ## facelock audit
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -94,7 +94,7 @@ No daemon needed -- the CLI auto-falls back to direct mode when no daemon is run
 ```bash
 sudo facelock devices            # list cameras
 sudo facelock list               # see enrolled models
-sudo facelock preview --text-only  # live detection output
+sudo facelock preview --json     # live detection output, one JSON object per frame
 sudo facelock status             # check system status
 sudo facelock bench warm-auth    # measure auth latency
 ```

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -1295,4 +1295,307 @@ mod tests {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Reference-doc coverage (#172)
+    // -----------------------------------------------------------------------
+
+    /// `docs/cli.md` is the user-facing CLI reference. Reached the way
+    /// `commands/capabilities.rs` reaches `docs/contracts.md` and `setup.rs`
+    /// reaches the systemd unit: embedded, so a doc that stops describing the
+    /// binary breaks the build rather than the reader.
+    const CLI_DOC: &str = include_str!("../../../docs/cli.md");
+
+    /// The book ships a second copy of the same reference. It is a near-copy,
+    /// not a generated one, so it rots independently — `docs/cli.md` gained
+    /// `is-enrolled` long before this file did.
+    const BOOK_CLI_DOC: &str = include_str!("../../../book/src/cli-reference.md");
+
+    /// The man page. Matched only through [`unescaped_man_page`].
+    const MAN_PAGE: &str = include_str!("../../../man/facelock.1");
+
+    /// Both prose copies of the CLI reference, by repository path so a failure
+    /// names the file that is missing the entry rather than just the entry.
+    const MARKDOWN_REFERENCES: &[(&str, &str)] = &[
+        ("docs/cli.md", CLI_DOC),
+        ("book/src/cli-reference.md", BOOK_CLI_DOC),
+    ];
+
+    /// `man(7)` writes a literal hyphen as `\-`, so `system-auth` is on disk as
+    /// `system\-auth` and a plain substring search for it fails. Undoing that
+    /// one escape is the whole normalization these checks need; nothing here
+    /// looks at roff structure.
+    fn unescaped_man_page() -> String {
+        MAN_PAGE.replace(r"\-", "-")
+    }
+
+    /// The body of one `##` section, so a check scoped to a section cannot be
+    /// satisfied by matching text somewhere else in the file.
+    fn section_of<'a>(doc: &'a str, heading: &str) -> &'a str {
+        let start = doc
+            .find(heading)
+            .unwrap_or_else(|| panic!("`{}` is missing from the document", heading.trim()));
+        let body = &doc[start + heading.len()..];
+        match body.find("\n## ") {
+            Some(end) => &body[..end],
+            None => body,
+        }
+    }
+
+    /// Every subcommand the binary offers is written down.
+    ///
+    /// The rot this exists to stop was real: `is-enrolled`, `hyprlock`,
+    /// `reseal`, `pam` and `capabilities` all shipped without ever reaching
+    /// the reference, and `is-enrolled` is the one command Omarchy's
+    /// integration depends on.
+    ///
+    /// **Top-level commands get a `## facelock <name>` heading of their own.**
+    /// A nested verb (`bench camera-reopen`, `tpm unseal-check`, `pam status`,
+    /// `hyprlock enable`) does *not*: it is documented under its parent's
+    /// section, which is how the file already reads and how a reader looks one
+    /// up. So the assertion for a nested verb is weaker on purpose — the full
+    /// invocation must appear somewhere in the file — but it is still enough
+    /// to catch a whole verb going undocumented, which is what happened to
+    /// `tpm unseal-check`.
+    ///
+    /// Clap's built-in `help` pseudo-command is skipped at every level.
+    ///
+    /// Both prose copies are checked. The book's is a hand-maintained near-copy
+    /// rather than a generated one, so holding only `docs/cli.md` to this would
+    /// leave the copy that rots more freely unpinned.
+    #[test]
+    fn docs_cli_documents_every_subcommand() {
+        let root = Cli::command();
+
+        for (doc_path, doc) in MARKDOWN_REFERENCES {
+            for command in root.get_subcommands() {
+                let name = command.get_name();
+                if name == "help" {
+                    continue;
+                }
+                let heading = format!("\n## facelock {name}\n");
+                assert!(
+                    doc.contains(&heading),
+                    "`facelock {name}` ships but `{doc_path}` has no \
+                     `## facelock {name}` heading"
+                );
+
+                for nested in command.get_subcommands() {
+                    let nested_name = nested.get_name();
+                    if nested_name == "help" {
+                        continue;
+                    }
+                    let invocation = format!("facelock {name} {nested_name}");
+                    assert!(
+                        doc.contains(&invocation),
+                        "`{invocation}` ships but is not mentioned anywhere in \
+                         `{doc_path}`; document it under the `## facelock {name}` section"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The `## Machine-readable output` section names every command that
+    /// offers `--json`.
+    ///
+    /// That section is a third copy of a list the binary already holds twice —
+    /// the `JSON_COMMANDS` registry above, and the table in
+    /// `docs/contracts.md`. Prose is the copy that rots silently, because
+    /// nothing fails when a newly added `--json` never reaches it.
+    /// `JSON_COMMANDS` is pinned against the clap tree and not against this
+    /// text, so the two checks do not prop each other up: the walk below is the
+    /// clap tree, and a command satisfies it only by being written down.
+    ///
+    /// One direction only. Asserting that nothing *else* is named there would
+    /// mean parsing prose for command names, and the reverse direction is
+    /// already covered — a command named here that binds no `--json` fails
+    /// `cli_flag_conformance` against `JSON_COMMANDS` first.
+    #[test]
+    fn docs_cli_machine_output_section_names_every_json_command() {
+        let root = Cli::command();
+        let mut commands = Vec::new();
+        walk(&root, "", &mut commands);
+
+        let section = section_of(CLI_DOC, "\n## Machine-readable output\n");
+
+        for (path, command) in &commands {
+            if !command.get_arguments().any(|arg| arg.get_id() == "json") {
+                continue;
+            }
+            assert!(
+                section.contains(path.as_str()),
+                "`{path}` offers `--json` but the `## Machine-readable output` \
+                 section of docs/cli.md does not name it"
+            );
+        }
+    }
+
+    /// Every `facelock …` line the reference shows must actually parse.
+    ///
+    /// A reference example is a promise that the command line works, and the
+    /// cheapest way to break that promise is to document a flag that was
+    /// renamed or never existed. This does not prove an example *succeeds* —
+    /// most need root, a camera or a TPM — only that clap accepts it, which is
+    /// the half a unit test can own.
+    ///
+    /// Extraction rules, and why each one is what it is:
+    ///
+    /// - only ```` ```bash ```` blocks, so prose that names a flag inline is
+    ///   left alone (the `setup` section deliberately cites the invocation
+    ///   that *refuses*, as prose, to explain the sensitive-service gate);
+    /// - a leading `sudo ` is stripped, since half the examples need root;
+    /// - a trailing ` # …` comment is stripped;
+    /// - the invocation ends at the first shell operator (`|`, `||`, `&&`,
+    ///   `;`, `&`), so a piped example documents a real pipeline and still
+    ///   gets its `facelock` half checked;
+    /// - **no placeholders.** A `<user>` or `<model_id>` in an example is
+    ///   rejected outright rather than substituted, because a reference
+    ///   example should be runnable as written — and a substituted
+    ///   placeholder would make `--user <user>` pass while `remove <id>`
+    ///   failed, which is an arbitrary line. Angle brackets are used for
+    ///   metavariables in the flag *tables*, which are not bash blocks.
+    fn documented_invocations() -> Vec<Vec<String>> {
+        const OPERATORS: &[&str] = &["|", "||", "&&", ";", "&"];
+
+        let mut invocations = Vec::new();
+        let mut in_bash = false;
+
+        for line in CLI_DOC.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("```") {
+                in_bash = !in_bash && trimmed == "```bash";
+                continue;
+            }
+            if !in_bash {
+                continue;
+            }
+
+            let command = trimmed.strip_prefix("sudo ").unwrap_or(trimmed).trim();
+            if command != "facelock" && !command.starts_with("facelock ") {
+                continue;
+            }
+            // ` #` rather than `#`: a `#` can legitimately open an argument.
+            let command = match command.split_once(" #") {
+                Some((before, _)) => before.trim(),
+                None => command,
+            };
+
+            let argv: Vec<String> = command
+                .split_whitespace()
+                .take_while(|token| !OPERATORS.contains(token))
+                .map(str::to_string)
+                .collect();
+
+            for token in &argv {
+                assert!(
+                    !token.contains('<') && !token.contains('>'),
+                    "`{command}` in docs/cli.md carries a placeholder or redirect \
+                     (`{token}`); a reference example must be runnable as written"
+                );
+            }
+            invocations.push(argv);
+        }
+
+        assert!(
+            invocations.len() > 20,
+            "extracted only {} invocations from docs/cli.md — the extractor is \
+             probably broken, not the doc",
+            invocations.len()
+        );
+        invocations
+    }
+
+    #[test]
+    fn docs_cli_examples_all_parse() {
+        for argv in documented_invocations() {
+            Cli::try_parse_from(&argv)
+                .unwrap_or_else(|e| panic!("`{}` in docs/cli.md must parse: {e}", argv.join(" ")));
+        }
+    }
+
+    /// No example installs into a gated PAM service without the flag that
+    /// unlocks it.
+    ///
+    /// This is the bug that motivated the gap: `docs/cli.md` documented
+    /// `facelock setup --pam --service login`, and `login` is in
+    /// `SENSITIVE_SERVICES`, so the command as written **fails**. Parsing
+    /// cannot catch it — the gate is a runtime refusal, not a parse error —
+    /// so the check has to resolve the invocation the way `main` does and ask
+    /// the writer's own question.
+    ///
+    /// Only the add direction is gated. `pam remove --service login` is a
+    /// documented example precisely because removal is never gated.
+    #[test]
+    fn docs_cli_examples_never_install_into_a_gated_service() {
+        use facelock_cli::commands::pam::{PamAction, SENSITIVE_SERVICES};
+
+        // Which services are gated is enumerated in prose in every reference,
+        // and a reader who cannot look the list up has to discover it by being
+        // refused. `SENSITIVE_SERVICES` is the only copy that decides anything,
+        // so every other copy is checked against it.
+        //
+        // Containment is a deliberately loose test: `login` would also match
+        // "login managers". It still catches the failure that matters, which is
+        // a name added to `SENSITIVE_SERVICES` and written down nowhere.
+        let man = unescaped_man_page();
+        let mut references = MARKDOWN_REFERENCES.to_vec();
+        references.push(("man/facelock.1", &man));
+        for (doc_path, doc) in &references {
+            for service in SENSITIVE_SERVICES {
+                assert!(
+                    doc.contains(service),
+                    "`{doc_path}` never names the gated service `{service}`"
+                );
+            }
+        }
+
+        let gated = |services: &[String]| -> Option<String> {
+            services
+                .iter()
+                .find(|s| SENSITIVE_SERVICES.contains(&s.as_str()))
+                .cloned()
+        };
+
+        for argv in documented_invocations() {
+            let rendered = argv.join(" ");
+            let cli = Cli::try_parse_from(&argv).expect("checked by docs_cli_examples_all_parse");
+
+            match cli.command {
+                Commands::Pam { command } => {
+                    let request: facelock_cli::commands::pam::PamRequest = command.into();
+                    if request.action != PamAction::Add || request.allow_sensitive {
+                        continue;
+                    }
+                    if let Some(service) = gated(&request.services) {
+                        panic!(
+                            "`{rendered}` in docs/cli.md installs into the gated service \
+                             `{service}` without --allow-sensitive, so it fails as written"
+                        );
+                    }
+                }
+                Commands::Setup(setup) => {
+                    let plan = resolve_setup_plan(SetupArgs::from(setup));
+                    // `setup --yes` is the documented exception: it maps onto
+                    // --allow-sensitive as well as --no-confirm.
+                    if plan.yes {
+                        continue;
+                    }
+                    let PamPref::Install {
+                        service: Some(service),
+                    } = &plan.pam
+                    else {
+                        continue;
+                    };
+                    if let Some(service) = gated(std::slice::from_ref(service)) {
+                        panic!(
+                            "`{rendered}` in docs/cli.md installs into the gated service \
+                             `{service}` without -y, so it fails as written"
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,26 @@ rest of that region. Other commands still print some output directly rather than
 through the message seam the flag gates, so they stay partly noisy until
 [#140](https://github.com/tyvsmith/facelock/issues/140) is finished.
 
+## Machine-readable output
+
+Every command whose output a script would parse takes `--json`, and spells it
+exactly that — one flag family, no short letter, no `--output json`. It is not
+offered everywhere: a command gains it when it has a named consumer, which
+today means `facelock is-enrolled`, `facelock capabilities`, `facelock list`,
+`facelock devices`, `facelock preview`, `facelock pam add`,
+`facelock pam remove` and `facelock pam status`. Each payload is described in
+that command's section below; the rule behind the flag, and the promise each
+payload carries, are in [`contracts.md`](contracts.md) under "CLI Machine
+Output".
+
+The payload goes to stdout and nothing else does — diagnostics are on stderr
+whatever `RUST_LOG` says — so `facelock devices --json` is safe to pipe at any
+log level. On `is-enrolled`, `capabilities` and `pam`, `--quiet` suppresses the
+payload too, leaving the exit code as the whole answer; `list`, `devices` and
+`preview` still print theirs directly rather than through the seam the flag
+gates, so they stay noisy until
+[#140](https://github.com/tyvsmith/facelock/issues/140) is finished.
+
 ## facelock setup
 
 Interactive setup wizard. Walks through camera selection, model quality, inference device (CPU / CUDA / ROCm / OpenVINO), model downloads, encryption, enrollment, and PAM configuration. Can also be run with flags for individual setup tasks.
@@ -27,10 +47,93 @@ facelock setup --non-interactive        # run wizard without prompts
 facelock setup --systemd                # install systemd units
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
-facelock setup --pam --service login    # install to specific service
-facelock setup --pam --remove           # remove PAM line
-facelock setup --pam --service sshd -y  # skip confirmation for sensitive services
+facelock setup --pam --service polkit-1 # install to a specific service
+facelock setup --pam --remove           # remove the PAM line
+facelock setup --pam --remove --if-present  # a missing service file is success
+facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
 ```
+
+`--pam` is an alias onto [`facelock pam add | remove`](#facelock-pam), which is
+the primary spelling and the one that takes several services in one process.
+Every `setup --pam` invocation keeps parsing and keeps its behaviour.
+
+`system-auth`, `login` and `sshd` are gated: `facelock setup --pam --service login`
+refuses until `-y` is added, and on `facelock pam add` the same gate is
+`--allow-sensitive`. `--if-present` requires `--remove` and turns a missing
+service file into a successful no-op — read, parse and write failures stay
+fatal.
+
+## facelock is-enrolled
+
+Report whether a user has a usable face enrollment. Unprivileged and cheap
+enough to call repeatedly from a lock screen: it reads one marker file under
+`/var/lib/facelock/enrolled/` and never activates the daemon, opens a camera,
+or reads the face database.
+
+It never errors merely because the caller is outside the `facelock` group, but
+it cannot report `enrolled` for one either: the marker sits under two
+`0710 root:facelock` directories, so a non-member reads `EACCES` and is
+reported `not-enrolled`. That is the correct answer — the group is required to
+reach the daemon at all, so face auth genuinely is not operational for that
+caller yet.
+
+```bash
+facelock is-enrolled                    # prints enrolled / not-enrolled
+facelock is-enrolled --user alice       # specific user
+facelock is-enrolled --json             # machine-readable
+facelock is-enrolled --quiet            # no stdout; the exit code is the answer
+```
+
+The exit code is the contract — branch on it rather than parsing stdout:
+
+| Code | Meaning |
+|------|---------|
+| 0 | the user has a usable enrollment |
+| 1 | not enrolled; an absent or unreadable marker reports this way |
+| 2 | error — an invalid `--user`, or a marker that exists but cannot be parsed |
+
+`--json` emits one object and does not change the exit code:
+
+```json
+{"enrolled":true,"models":2,"updated":"2026-08-12T00:00:00Z"}
+```
+
+`models` is `0` and `updated` is `null` when the user is not enrolled. The
+error case prints its reason on stderr and no payload at all.
+
+The marker is a hint for deciding whether to offer a face-auth affordance; PAM
+at authentication time remains authoritative and nothing in the auth path
+consults it. See [`contracts.md`](contracts.md), "facelock is-enrolled Exit
+Codes", for the stability promise and for how markers are reconciled with the
+database.
+
+## facelock capabilities
+
+Report what this build can do, as capability names. Unprivileged: it answers
+from the binary's own clap tree and compiled-in constants, reading no config
+file, activating no daemon and opening no camera. It is what replaces grepping
+`--help` in a wrapper script.
+
+```bash
+facelock capabilities                   # one name per line
+facelock capabilities --json            # {"version", "capabilities"}
+```
+
+With the name array elided:
+
+```json
+{"capabilities":["capabilities","devices-json","is-enrolled"],"version":"0.1.4"}
+```
+
+Both forms exit 0 — the command has no failure mode — and `--quiet` suppresses
+stdout, leaving the exit code as the whole answer. A build that predates the
+command answers by failing: clap's unrecognized-subcommand error on stderr,
+exit 2, nothing on stdout. A caller reads any non-zero exit as "no capabilities
+at all", which is the true answer for that build.
+
+Probe by name, never by version. The names this build emits, what each one
+promises, and the stability rules that govern them are in
+[`contracts.md`](contracts.md), "facelock capabilities".
 
 ## facelock enroll
 
@@ -214,6 +317,16 @@ Unseal the AES key from the TPM back to a plaintext keyfile, migrating from TPM-
 facelock tpm unseal-key
 ```
 
+### facelock tpm unseal-check
+
+Read-only check that the sealed AES key still unseals under the current PCR
+values. Writes nothing, and exits non-zero when it does not — which is the
+signal to run [`facelock reseal`](#facelock-reseal).
+
+```bash
+sudo facelock tpm unseal-check
+```
+
 ### facelock tpm pcr-baseline
 
 Display the current PCR values for all configured PCR indices.
@@ -248,6 +361,117 @@ reports the per-phase median. That total is what `device.camera_release_secs`
 trades LED-on time against — holding the stream warm after a failed attempt
 buys a retry exactly this much (ADR 008).
 
+## facelock pam
+
+Manage the facelock line in `/etc/pam.d` service files. This command owns every
+write to `/etc/pam.d`; `setup --pam` is an alias onto it, and the setup wizard
+calls the same writer.
+
+`--service` is repeatable on all three verbs and defaults to `sudo`, so several
+services are configured in one process, under one root check. `add` and
+`remove` require root and never offer to re-exec under `sudo`; `status` reads
+only and needs no root.
+
+### facelock pam add
+
+```bash
+sudo facelock pam add                                        # /etc/pam.d/sudo
+sudo facelock pam add --service polkit-1 --service hyprlock  # several at once
+sudo facelock pam add --service sshd --allow-sensitive       # unlock a gated service
+sudo facelock pam add --service hyprlock --if-present        # a missing file is success
+sudo facelock pam add --service sudo --dry-run               # print the plan, write nothing
+sudo facelock pam add --service sudo --json                  # machine-readable result
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--service <NAME>` | service to act on; repeat for several (default: `sudo`) |
+| `-y`, `--yes` (alias `--no-confirm`) | skip the per-file confirmation, and nothing else |
+| `--allow-sensitive` | also permit the gated services `system-auth`, `login`, `sshd` |
+| `--if-present` | treat a missing service file as success instead of an error |
+| `--dry-run` | print the resolved plan, write nothing, exit 0 |
+| `--json` | emit one JSON document instead of human text |
+
+`--yes` never implies `--allow-sensitive`: they are separate authorizations,
+"do not ask me" and "yes, edit `system-auth`". Every service is validated before
+any file is written, so a rejected service name leaves the rest untouched.
+With no TTY on stdin the per-file confirmation is skipped as if `--yes` were
+given — the gate is decided before any prompt exists, so an unattended
+`pam add --service system-auth` still refuses.
+
+`--dry-run` is honoured after the root check, so it still needs root.
+`pam status` is the unprivileged read to reach for instead.
+
+### facelock pam remove
+
+```bash
+sudo facelock pam remove                                     # /etc/pam.d/sudo
+sudo facelock pam remove --service login                     # removal is never gated
+sudo facelock pam remove --service hyprlock --if-present     # a missing file is success
+sudo facelock pam remove --service sudo --dry-run --json
+```
+
+Takes the same flags as `add` except `--allow-sensitive`, which it does not
+offer: removal can only take away a way to authenticate, so there is nothing to
+gate. It never prompts either, and the `.facelock-backup` file written by `add`
+is left in place.
+
+### facelock pam status
+
+```bash
+facelock pam status                                          # /etc/pam.d/sudo
+facelock pam status --service sudo --service polkit-1
+facelock pam status --service sudo --json
+```
+
+Unprivileged, and the probe to branch on instead of grepping `/etc/pam.d`
+yourself: it answers from the same file, without root, and reports "absent" and
+"unreadable" as themselves rather than as "not configured". It offers
+`--service` and `--json` and neither `--dry-run` nor `--allow-sensitive` —
+there is no write to preview or gate. The exit code is the answer, on the same
+0/1/2 scale as `is-enrolled` and `grep`:
+
+| Code | Meaning |
+|------|---------|
+| 0 | every requested service carries the line |
+| 1 | at least one exists without it |
+| 2 | at least one is absent, unreadable, or misnamed |
+
+Across several services the worst outcome wins. `--json` emits one document:
+
+```json
+{"command":"status","dry_run":false,"services":[{"action":"present","backup":null,"path":"/etc/pam.d/sudo","service":"sudo"}]}
+```
+
+The document's shape, the `action` vocabulary, and the rule that a consumer
+must tolerate an `action` it does not recognize rather than treat it as an
+error, are a stability contract — see [`contracts.md`](contracts.md), "facelock
+pam Semantics", along with the exit codes for `add` and `remove` and what
+`--json` does on a validation failure.
+
+## facelock hyprlock
+
+Manage hyprlock lock-screen integration: the face glyph in `placeholder_text`,
+and the `ignore_empty_input = false` setting that lets a bare Enter submit to
+PAM. Runs as your normal user and refuses to run as root, since it edits
+`~/.config/hypr/hyprlock.conf` and root would leave root-owned files in `$HOME`.
+A backup is taken before the first edit.
+
+```bash
+facelock hyprlock enable                # face icon, and allow the empty-Enter submit
+facelock hyprlock enable --no-icon      # only set ignore_empty_input = false
+facelock hyprlock disable               # undo
+facelock hyprlock status                # report the current state
+```
+
+`--no-icon` is for a hyprlock font with no Nerd Font glyphs; it flips the
+functional setting and leaves any existing icon alone. `disable` restores
+`ignore_empty_input` only when no fingerprint icon coexists, so a machine using
+both keeps working.
+
+Wiring `/etc/pam.d/hyprlock` itself is a separate, root step — see
+[`facelock pam`](#facelock-pam). This command touches no file outside `$HOME`.
+
 ## facelock encrypt
 
 Encrypt all unencrypted embeddings in the database with AES-256-GCM.
@@ -266,6 +490,23 @@ Decrypt all software-encrypted embeddings in the database (reverting AES-256-GCM
 ```bash
 facelock decrypt
 ```
+
+## facelock reseal
+
+Re-seal the TPM AES key under the current PCR values. This is the recovery step
+after a firmware or kernel change moves a measured PCR and the sealed key stops
+unsealing. Requires root, and applies only when `encryption.method = "tpm"` —
+under any other method it errors rather than quietly doing nothing.
+
+```bash
+sudo facelock reseal
+```
+
+It prefers unsealing the existing blob, which still works while the PCR policy
+is satisfied, so it is safe to run proactively before a firmware update; once
+the PCRs have moved it falls back to the plaintext key backup. With neither
+available there is nothing to re-seal and it fails. Run
+`facelock tpm unseal-check` to find out which of those you are in.
 
 ## facelock audit
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -559,7 +559,9 @@ the codes themselves match `grep`'s 0 = match / 1 = no match / 2 = error.
 Default stdout is `enrolled` / `not-enrolled` — the state word, as `systemctl
 is-active` prints `active`. `--quiet` suppresses stdout and leaves only the exit
 code; it is the global `-q` flag, so `facelock --quiet is-enrolled` is the same
-invocation. `--json` emits `{"enrolled": bool, "models": N, "updated": "<ISO8601>"}`.
+invocation. `--json` emits `{"enrolled": bool, "models": N, "updated": "<ISO8601>"}`;
+when the user is not enrolled there is no marker to read a timestamp from, so
+`models` is `0` and `updated` is `null`.
 
 `is-enrolled` answers from `/var/lib/facelock/enrolled/<user>` alone. It never
 activates the daemon over D-Bus, never opens a camera, and never reads the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ No daemon needed — the CLI auto-falls back to direct mode when no daemon is ru
 ```bash
 sudo facelock devices            # list cameras
 sudo facelock list               # see enrolled models
-sudo facelock preview --text-only  # live detection output
+sudo facelock preview --json     # live detection output, one JSON object per frame
 sudo facelock status             # check system status
 sudo facelock bench warm-auth    # measure auth latency
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,7 +65,7 @@
    refuses to open it with an error listing the advertised formats. Point
    `device.path` at a processed camera instead — see "Intel IPU6/IPU7 MIPI
    cameras" in `docs/compatibility.md`.
-3. **Verify frames are usable**: run `facelock preview --text-only` (or
+3. **Verify frames are usable**: run `facelock preview --json` (or
    `facelock preview`) and check that you see a live image with your face
    detected.
 4. Run with `RUST_LOG=facelock_daemon=debug` to see per-frame rejection

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -94,6 +94,11 @@ Used with \fB\-\-pam\fR: target PAM service (default: sudo). Requires
 Used with \fB\-\-pam\fR: remove the facelock PAM line instead of adding it.
 Requires \fB\-\-pam\fR.
 .TP
+.B \-\-if\-present
+Used with \fB\-\-pam \-\-remove\fR: treat an absent service file as success
+rather than an error. Read, parse and write failures remain fatal. Requires
+\fB\-\-remove\fR.
+.TP
 .B \-\-camera \fIpath\fR|\fBauto\fR
 Camera device path, or \fBauto\fR to re-detect the IR camera from the attached
 hardware. \fBauto\fR fails if zero or more than one IR-capable device is found;
@@ -123,6 +128,16 @@ that action; any flag that only makes sense while the base setup runs
 \fB\-\-no\-systemd\fR, \fB\-\-enroll\fR, \fB\-\-no\-enroll\fR) forces the base
 setup, and the requested actions run in addition to it. For an action pair, the
 later flag on the command line wins.
+.IP
+\fB\-\-pam\fR is an alias onto
+.B "facelock pam add"
+and
+.BR "facelock pam remove" ,
+which is the primary spelling and the one that takes several services in one
+process. Every \fBsetup \-\-pam\fR invocation keeps parsing and keeps its
+behaviour, including the rule that \fB\-y\fR is what unlocks a sensitive
+service here where \fB\-\-allow\-sensitive\fR does it on
+.BR "facelock pam add" .
 .TP
 .B is\-enrolled
 Report whether a user has a usable face enrollment. The exit status is the
@@ -136,11 +151,19 @@ See
 .B EXIT STATUS
 below. It reads only the per-user marker file under
 .IR /var/lib/facelock/enrolled/ ;
-it does not activate the daemon over D-Bus, does not open a camera, does not
-read the face database, and does not require membership of the
+it does not activate the daemon over D-Bus, does not open a camera, and does
+not read the face database. It never errors merely because the caller is
+outside the
 .B facelock
-group. The marker is a hint for deciding whether to offer a face-auth
-affordance \(em PAM at authentication time remains authoritative.
+group, but it cannot report
+.B enrolled
+for one either: the marker sits under two 0710 root:facelock directories, so a
+non-member reads EACCES and is reported
+.BR not\-enrolled .
+That is the correct answer \(em the group is required to reach the daemon at
+all, so face auth genuinely is not operational for that caller yet. The marker
+is a hint for deciding whether to offer a face-auth affordance \(em PAM at
+authentication time remains authoritative.
 .RS
 .TP
 .B \-u\fR, \fB\-\-user \fIusername\fR
@@ -148,14 +171,40 @@ Username (default: current user).
 .TP
 .B \-\-json
 Output a JSON object with the keys \fBenrolled\fR (boolean), \fBmodels\fR
-(integer) and \fBupdated\fR (ISO 8601 timestamp, or null) instead of
-\fByes\fR/\fBno\fR. Does not change the exit status.
+(integer) and \fBupdated\fR (ISO 8601 timestamp, or null) instead of the state
+word. \fBmodels\fR is 0 and \fBupdated\fR is null when the user is not
+enrolled. Does not change the exit status.
 .TP
 .B \-q\fR, \fB\-\-quiet
 Suppress stdout and report only via the exit status. Errors are still written
 to stderr. This is the global flag (see GLOBAL OPTIONS), so
 \fBfacelock \-\-quiet is\-enrolled\fR is the same invocation.
 .RE
+.TP
+.B capabilities
+Report what this build can do, as capability names \(em one per line on stdout.
+Answers from the binary's own clap tree and compiled-in constants: it reads no
+config file, activates no daemon and opens no camera, and so needs no root. It
+is what replaces grepping \fB\-\-help\fR in a wrapper script, since help text
+is not an API. Probe by name, never by version: a distro or git build can carry
+a version that says nothing about what is in it.
+.RS
+.TP
+.B \-\-json
+Emit one JSON object with the keys \fBversion\fR (this binary's own version)
+and \fBcapabilities\fR (a sorted, deduplicated array of names) instead of the
+plain list.
+.TP
+.B \-q\fR, \fB\-\-quiet
+Suppress stdout, leaving the exit status as the whole answer. This is the
+global flag (see GLOBAL OPTIONS).
+.RE
+.IP
+Both forms exit 0; the command has no failure mode. A build that predates the
+command answers by failing \(em unrecognized subcommand on stderr, exit 2 \(em
+which a caller reads as "no capabilities at all". See
+.B EXIT STATUS
+below.
 .TP
 .B enroll
 Capture and store a face embedding for authentication.
@@ -213,8 +262,10 @@ Username (default: current user).
 Live camera preview with face detection overlay.
 .RS
 .TP
-.B \-\-text\-only
-Print detection results to stdout instead of graphical preview.
+.B \-\-json
+Print one JSON object per frame on stdout instead of opening the graphical
+preview. This flag shipped as \fB\-\-text\-only\fR, which survives as a
+hidden alias and keeps parsing; the per-frame payload is unchanged.
 .TP
 .B \-u\fR, \fB\-\-user \fIusername\fR
 User to match faces against (defaults to current user).
@@ -282,6 +333,10 @@ Measure ONNX model load time.
 .B calibrate
 Sweep thresholds and measure FAR/FRR.
 .TP
+.B camera\-reopen
+Measure what reopening the camera costs, reporting the open / STREAMON / warmup
+split. Needs no enrolled face and loads no models.
+.TP
 .B report
 Generate a comprehensive benchmark report.
 .RE
@@ -299,8 +354,78 @@ Seal the AES encryption key with TPM (migrate keyfile to TPM).
 .B unseal\-key
 Unseal the AES key from TPM back to a plaintext keyfile (migrate TPM to keyfile).
 .TP
+.B unseal\-check
+Read-only check that the sealed AES key currently unseals, verifying the PCR
+policy is still satisfied. Writes nothing and exits non-zero if the unseal
+fails, which is the signal to run
+.BR "facelock reseal" .
+.TP
 .B pcr\-baseline
 Display current PCR values for configured indices.
+.RE
+.TP
+.B pam \fIsubcommand\fR
+Manage the facelock line in
+.I /etc/pam.d
+service files. This command owns every write to that directory;
+\fBsetup \-\-pam\fR is an alias onto it. \fB\-\-service\fR is repeatable on
+all three verbs and defaults to \fBsudo\fR, so several services are configured
+in one process under one root check.
+.RS
+.TP
+.B add
+Add the facelock line to one or more service files. Root. Accepts
+\fB\-\-service \fIname\fR (repeatable), \fB\-y\fR, \fB\-\-yes\fR
+(alias \fB\-\-no\-confirm\fR) to skip the per-file confirmation,
+\fB\-\-allow\-sensitive\fR to also permit \fBsystem\-auth\fR,
+\fBlogin\fR and \fBsshd\fR, \fB\-\-if\-present\fR to treat a missing
+service file as success, \fB\-\-dry\-run\fR to print the resolved plan
+without writing, and \fB\-\-json\fR. \fB\-\-yes\fR never implies
+\fB\-\-allow\-sensitive\fR: they are separate authorizations. Every service
+is validated before any file is written.
+.TP
+.B remove
+Remove the facelock line. Root. Same flags as \fBadd\fR except
+\fB\-\-allow\-sensitive\fR, which it does not offer \(em removal can only
+take away a way to authenticate, so there is nothing to gate. It never prompts,
+and the \fI.facelock\-backup\fR file written by \fBadd\fR is left in place.
+.TP
+.B status
+Report whether services carry the line. Reads only and needs
+.B no
+root: this is the probe to branch on instead of grepping
+.I /etc/pam.d
+yourself. Offers \fB\-\-service\fR and \fB\-\-json\fR, and neither
+\fB\-\-dry\-run\fR nor \fB\-\-allow\-sensitive\fR \(em there is no write
+to preview or gate. The exit status is the answer; see
+.B EXIT STATUS
+below.
+.RE
+.TP
+.B hyprlock \fIsubcommand\fR
+Manage hyprlock lock-screen integration: the face glyph in
+\fBplaceholder_text\fR and the \fBignore_empty_input = false\fR setting that
+lets a bare Enter submit to PAM. Runs as your normal user and refuses to run as
+root, since it edits
+.I ~/.config/hypr/hyprlock.conf
+and root would leave root-owned files under
+.IR $HOME .
+A backup is taken before the first edit. Wiring
+.I /etc/pam.d/hyprlock
+itself is a separate, root step \(em see \fBpam add\fR above.
+.RS
+.TP
+.B enable
+Add the face icon and set \fBignore_empty_input = false\fR. \fB\-\-no\-icon\fR
+sets only the functional flag, for a hyprlock font with no Nerd Font glyphs, and
+leaves any existing icon alone.
+.TP
+.B disable
+Remove the face icon, and restore \fBignore_empty_input\fR only when no
+fingerprint icon coexists, so a machine using both keeps working.
+.TP
+.B status
+Show the current hyprlock integration state.
 .RE
 .TP
 .B encrypt
@@ -313,6 +438,17 @@ Generate a new encryption key without encrypting embeddings.
 .TP
 .B decrypt
 Decrypt all software-encrypted embeddings in the database.
+.TP
+.B reseal
+Re-seal the TPM AES key under the current PCR values \(em the recovery step
+after a firmware or kernel change moves a measured PCR and the sealed key stops
+unsealing. Requires root, and applies only when \fBencryption.method\fR is
+\fBtpm\fR; under any other method it errors rather than quietly doing nothing.
+It prefers unsealing the existing blob, which still works while the PCR policy
+is satisfied, so it is safe to run proactively before a firmware update; once
+the PCRs have moved it falls back to the plaintext key backup. Use
+.B "facelock tpm unseal\-check"
+to find out which of those applies.
 .TP
 .B restart
 Restart the facelock daemon via systemd.
@@ -413,6 +549,24 @@ unreadable one are both reported this way.
 Error: an invalid
 .BR \-\-user ,
 or a marker that exists but cannot be parsed.
+.PP
+.B facelock pam status
+uses the same 0/1/2 scale, for the same reason \(em it is a boolean query whose
+exit status is the answer. Across several services the worst outcome wins:
+.TP
+.B 0
+Every requested service carries the facelock line.
+.TP
+.B 1
+At least one requested service exists without it.
+.TP
+.B 2
+At least one is absent, unreadable, or misnamed.
+.PP
+.B facelock capabilities
+always exits 0 \(em it has no failure mode. A build too old to have the command
+exits 2 with clap's unrecognized-subcommand error on stderr and nothing on
+stdout, which a caller reads as "no capabilities at all".
 .PP
 .B facelock auth
 exits 0 when the face matched, 1 when it did not, and 2 on error.


### PR DESCRIPTION
## Summary

- add reference entries for `is-enrolled`, `capabilities`, `pam add|remove|status`, `hyprlock`, `reseal`, `setup --if-present`, `tpm unseal-check` to `docs/cli.md`, `man/facelock.1`, and `book/src/cli-reference.md`; document the global `--quiet`, the `--json` rule, `--dry-run`
- replace the `setup --pam --service login` example, which failed as written (`login` is gated), with `polkit-1`; keep `sshd -y` as the sensitive illustration; name `pam add` primary and `setup --pam` the alias
- point the four stale `--text-only` mentions at `preview --json`
- correct the man page's `is-enrolled` group sentence and its `--json` description; add the not-enrolled `models: 0` / `updated: null` clause to `contracts.md`
- add four `docs_*` conformance tests: every subcommand has a heading in both markdown references (nested verbs by mention); every `facelock …` line in `cli.md`'s bash blocks parses; no example installs into a gated service without `--allow-sensitive`/`setup --yes`, and every gated name is written down in all three references; every `--json` command is named in the machine-output section

## Why

`is-enrolled`, the one command Omarchy branches on, appeared in neither the CLI
reference nor the man page, and the reference's own PAM example failed when
run. Text alone rots; the tests make the reference fail the build the next time
a command lands undocumented.

## Validation

- `just check`, `groff -man -ww man/facelock.1`
- all 81 documented invocations run against the built binary with `--help`
- mutation checks: a removed heading, a placeholder token, `--service login`, a dropped `--json` mention, and a gated name missing from any of the three files each fail their test

Stacked on #182.

Closes #172
