### PR TITLE
fix(cli): Require root for tpm status and pcr-baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`facelock tpm status` and `facelock tpm pcr-baseline` now require root**,
+  like every other `tpm` verb. Neither checked, which left `status` failing
+  with a raw sqlite "unable to open database file" error when it reached the
+  root-only face database, and left `pcr-baseline` printing its header
+  and PCR values and exiting **0** for an unprivileged caller — that
+  invocation now refuses with `Root required.` and exits **1**. `tpm status`
+  reports key and embedding state read from the face database, so it belongs
+  with `seal-key`/`unseal-key`, not with the world-readable-file probes
+  `pam status` and `capabilities`.
 - **An authentication at an empty chair ends early and costs no rate-limit
   budget** (ADR 008 §3/§4). A new `recognition.no_face_timeout_secs` (default
   **2**) ends an attempt once that many seconds have passed with no face

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -422,7 +422,7 @@ TPM integration status and management.
 Report TPM availability and configuration.
 
 ```bash
-facelock tpm status
+sudo facelock tpm status
 ```
 
 ### facelock tpm seal-key
@@ -430,7 +430,7 @@ facelock tpm status
 Seal the AES encryption key with the TPM, migrating from a plaintext keyfile to TPM-backed storage.
 
 ```bash
-facelock tpm seal-key
+sudo facelock tpm seal-key
 ```
 
 ### facelock tpm unseal-key
@@ -438,7 +438,7 @@ facelock tpm seal-key
 Unseal the AES key from the TPM back to a plaintext keyfile, migrating from TPM-backed to keyfile storage.
 
 ```bash
-facelock tpm unseal-key
+sudo facelock tpm unseal-key
 ```
 
 ### facelock tpm unseal-check
@@ -454,7 +454,7 @@ sudo facelock tpm unseal-check
 Display the current PCR values for all configured PCR indices.
 
 ```bash
-facelock tpm pcr-baseline
+sudo facelock tpm pcr-baseline
 ```
 
 ## facelock bench

--- a/book/src/contracts.md
+++ b/book/src/contracts.md
@@ -28,7 +28,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock config` | Show/edit configuration |
 | `facelock daemon` | Run persistent daemon |
 | `facelock auth --user X` | One-shot auth (PAM helper). `--user` is required here and only here; `--config` is the global flag, not a per-command one |
-| `facelock tpm status` | TPM status |
+| `facelock tpm status` | TPM status, sealed-key presence and encrypted/plaintext embedding counts. Root, like every `tpm` verb |
 | `facelock encrypt` | Encrypt face database |
 | `facelock decrypt` | Decrypt face database |
 | `facelock audit` | View audit log |

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -63,6 +63,8 @@ fn unseal_check(config: &Config) -> Result<()> {
 }
 
 fn status(config: &Config) -> Result<()> {
+    crate::ipc_client::require_root("sudo facelock tpm status")?;
+
     // Extract device path from TCTI string (e.g., "device:/dev/tpmrm0" -> "/dev/tpmrm0")
     let device_path = config
         .tpm
@@ -385,6 +387,8 @@ pub fn run_reseal(config: &Config) -> Result<()> {
 }
 
 fn pcr_baseline(config: &Config) -> Result<()> {
+    crate::ipc_client::require_root("sudo facelock tpm pcr-baseline")?;
+
     println!("PCR Baseline (indices: {:?})", config.tpm.pcr_indices);
     println!("----------");
 

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -145,6 +145,29 @@ fn pam_remove_refuses_before_touching_pam_d_non_root() {
 }
 
 #[test]
+fn tpm_status_refuses_before_opening_database_non_root() {
+    // `tpm status` had no root check at all, so a non-root caller reached
+    // `FaceStore::open_readonly` on the root-only database and got a sqlite
+    // "unable to open database file" error instead of the refusal. The
+    // forbidden list includes that error text: reaching it means the check
+    // is gone again, not merely late.
+    assert_refuses_before_output(
+        &["tpm", "status"],
+        &["TPM Status", "TPM device", "failed to open face database"],
+    );
+}
+
+#[test]
+fn tpm_pcr_baseline_refuses_before_output_non_root() {
+    // `tpm pcr-baseline` also had no root check: it printed its header and
+    // the PCR values and exited 0 for any user. It now refuses and exits 1.
+    assert_refuses_before_output(
+        &["tpm", "pcr-baseline"],
+        &["PCR Baseline", "TPM support not compiled in"],
+    );
+}
+
+#[test]
 fn help_exits_successfully() {
     let output = facelock_bin()
         .arg("--help")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -298,7 +298,7 @@ TPM integration status and management.
 Report TPM availability and configuration.
 
 ```bash
-facelock tpm status
+sudo facelock tpm status
 ```
 
 ### facelock tpm seal-key
@@ -306,7 +306,7 @@ facelock tpm status
 Seal the AES encryption key with the TPM, migrating from a plaintext keyfile to TPM-backed storage.
 
 ```bash
-facelock tpm seal-key
+sudo facelock tpm seal-key
 ```
 
 ### facelock tpm unseal-key
@@ -314,7 +314,7 @@ facelock tpm seal-key
 Unseal the AES key from the TPM back to a plaintext keyfile, migrating from TPM-backed to keyfile storage.
 
 ```bash
-facelock tpm unseal-key
+sudo facelock tpm unseal-key
 ```
 
 ### facelock tpm unseal-check
@@ -332,7 +332,7 @@ sudo facelock tpm unseal-check
 Display the current PCR values for all configured PCR indices.
 
 ```bash
-facelock tpm pcr-baseline
+sudo facelock tpm pcr-baseline
 ```
 
 ## facelock bench

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -35,7 +35,7 @@ Stable contracts. Do not change without updating this document.
 | `facelock config` | Show/edit configuration |
 | `facelock daemon` | Run persistent daemon |
 | `facelock auth --user X` | One-shot auth (PAM helper). `--user` is required here and only here; `--config` is the global flag, not a per-command one |
-| `facelock tpm status` | TPM status |
+| `facelock tpm status` | TPM status, sealed-key presence and encrypted/plaintext embedding counts. Root, like every `tpm` verb |
 | `facelock hyprlock enable\|disable\|status` | Manage hyprlock lock-screen integration (user, no root); `enable` accepts `--no-icon` to skip the cosmetic face glyph |
 | `facelock encrypt` | Encrypt face database |
 | `facelock decrypt` | Decrypt face database |


### PR DESCRIPTION
- require root in `tpm status` and `tpm pcr-baseline`, as every other `tpm` verb already does; add C6 smoke rows for both
- show every `tpm` verb with `sudo` in the CLI reference and book; mark the `tpm status` row root in `contracts.md`
- CHANGELOG line for the exit-code change

## Why

Neither verb checked for root. Non-root `facelock tpm status` died on
`cannot access database … (sqlite code 14)` (the database is root-only), and
`pcr-baseline` printed its report and exited 0 for any user; now both refuse
with `Root required` and exit 1. `tpm status` opens the face database and
reports key and embedding state, so it belongs with `seal-key`/`unseal-*`
(DEC-6's interactive `tpm` class), not with the world-readable-file probes
`pam status` and `capabilities`; making it an unprivileged probe would need
the counts to become "unknown", which is a separate design.
