### PR TITLE
polish(cli): Give --quiet one implementation via a payload sink

### DIFF
--- a/crates/facelock-cli/src/commands/capabilities.rs
+++ b/crates/facelock-cli/src/commands/capabilities.rs
@@ -30,9 +30,11 @@
 //! dispatched ahead of every config-consuming command in `main`.
 //!
 //! Output is **not** localized. A capability name is an identifier, not prose,
-//! so it goes out through `println!` and never through the message seam
-//! (`message/mod.rs`, §"What must NOT come through here") — the same rule
-//! `is-enrolled` follows for its state words.
+//! so it goes out through `message::payload` — the seam's machine sink, which
+//! consults no catalog (`message/mod.rs`, §"What must NOT come through
+//! here") — and never through `Terminal::info`. That is the same rule
+//! `is-enrolled` follows for its state words, and it is what makes `--quiet`
+//! one implementation instead of a `bool` threaded through this file.
 //!
 //! # Why the list has to be provable
 //!
@@ -42,6 +44,8 @@
 //! `capability_names_are_all_implemented` in `main.rs` maps every name to the
 //! clap subcommand or argument that declares the surface it names, and a name
 //! nothing backs fails the build rather than shipping.
+
+use crate::message;
 
 /// The capability names this build emits. Sorted and deduplicated — the
 /// contract says the array is, and a const that is already sorted is the
@@ -91,26 +95,24 @@ fn payload_json() -> String {
     .to_string()
 }
 
-/// What [`run`] prints, or `None` under `--quiet`. The whole of this command's
-/// logic, with the printing left to the caller so a test can assert on it
-/// without capturing stdout (the `is_enrolled::report` split).
-fn rendered(json: bool, quiet: bool) -> Option<String> {
-    if quiet {
-        return None;
-    }
-    Some(if json {
+/// What [`run`] prints. The whole of this command's logic, with the printing
+/// left to the caller so a test can assert on it without capturing stdout (the
+/// `is_enrolled::report` split).
+///
+/// `--quiet` is not consulted here: both forms are machine output, so they go
+/// out through [`message::payload`], which is where the flag acts.
+fn rendered(json: bool) -> String {
+    if json {
         payload_json()
     } else {
         CAPABILITIES.join("\n")
-    })
+    }
 }
 
 /// Run `facelock capabilities`. Infallible by construction: no file, no
 /// socket, no camera, so there is no error to return and no exit code but 0.
-pub fn run(json: bool, quiet: bool) {
-    if let Some(text) = rendered(json, quiet) {
-        println!("{text}");
-    }
+pub fn run(json: bool) {
+    message::payload(&rendered(json));
 }
 
 #[cfg(test)]
@@ -252,15 +254,12 @@ mod tests {
         }
     }
 
+    /// The two rendering modes. `--quiet` is absent on purpose: it is the
+    /// payload sink's business now, pinned in `message::mod`'s
+    /// `quiet_silences_stdout_except_notice`.
     #[test]
     fn capabilities_output_modes() {
-        for json in [false, true] {
-            assert!(
-                rendered(json, true).is_none(),
-                "`--quiet` prints nothing, whatever `--json` says"
-            );
-        }
-        assert_eq!(rendered(false, false), Some(CAPABILITIES.join("\n")));
-        assert_eq!(rendered(true, false), Some(payload_json()));
+        assert_eq!(rendered(false), CAPABILITIES.join("\n"));
+        assert_eq!(rendered(true), payload_json());
     }
 }

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -67,7 +67,9 @@ pub fn run(config: &Config, json: bool) -> anyhow::Result<()> {
 /// breaking anything that reads `--json`.
 fn print_json(devices: &[IpcDeviceInfo]) {
     let json = serde_json::to_string(devices).unwrap_or_else(|_| "[]".to_string());
-    println!("{json}");
+    // The seam's machine sink: never localized, and silenced by `--quiet`
+    // like every other payload (before #140 this command ignored the flag).
+    crate::message::payload(&json);
 }
 
 #[cfg(test)]

--- a/crates/facelock-cli/src/commands/is_enrolled.rs
+++ b/crates/facelock-cli/src/commands/is_enrolled.rs
@@ -6,8 +6,8 @@
 //!
 //! Named after systemd's `is-*` family (`systemctl is-active`, `is-enabled`),
 //! which is the established idiom for this exact shape: a boolean query whose
-//! exit code is the contract, printing the state word on stdout and taking a
-//! `--quiet` to suppress it.
+//! exit code is the contract, printing the state word on stdout and taking the
+//! global `--quiet` to suppress it.
 //!
 //! **The exit code is the contract**, so this drops into a shell one-liner:
 //!
@@ -54,6 +54,7 @@
 use std::path::Path;
 
 use crate::commands::enrollment_marker::{self, MarkerState};
+use crate::message;
 
 /// Exit code: the user has a usable enrollment.
 const EXIT_ENROLLED: i32 = 0;
@@ -63,11 +64,11 @@ const EXIT_NOT_ENROLLED: i32 = 1;
 const EXIT_ERROR: i32 = 2;
 
 /// Run `facelock is-enrolled`, returning the process exit code.
-pub fn run(user: Option<String>, json: bool, quiet: bool) -> i32 {
+pub fn run(user: Option<String>, json: bool) -> i32 {
     // Pure `$SUDO_USER`/`$USER`/`getpwuid` resolution — no D-Bus, no database.
     let user = crate::ipc_client::resolve_user(user.as_deref());
     let base = enrollment_marker::marker_dir_or_default();
-    report(state_in(&base, &user), json, quiet)
+    report(state_in(&base, &user), json)
 }
 
 /// Read one user's marker from `base`. The whole of this command's logic, with
@@ -78,23 +79,25 @@ fn state_in(base: &Path, user: &str) -> MarkerState {
 
 /// Print the result and map it to an exit code.
 ///
-/// `quiet` suppresses stdout only — a genuine error still explains itself on
-/// stderr, since a silent exit 2 is indistinguishable from a broken invocation.
-fn report(state: MarkerState, json: bool, quiet: bool) -> i32 {
+/// Everything printed here is machine-facing — a JSON document or a state
+/// word — so it goes out through [`message::payload`], which is also where
+/// `--quiet` acts: under it this command prints nothing on stdout and the exit
+/// code is the whole answer. A genuine error still explains itself on stderr,
+/// since a silent exit 2 is indistinguishable from a broken invocation.
+fn report(state: MarkerState, json: bool) -> i32 {
     match &state {
         MarkerState::Unreadable(reason) => {
             eprintln!("facelock is-enrolled: {reason}");
         }
-        _ if quiet => {}
         MarkerState::Enrolled(marker) if json => {
-            println!("{}", enrolled_json(Some(marker)));
+            message::payload(&enrolled_json(Some(marker)));
         }
         MarkerState::Absent if json => {
-            println!("{}", enrolled_json(None));
+            message::payload(&enrolled_json(None));
         }
         // The state word, as `systemctl is-active` prints `active`.
-        MarkerState::Enrolled(_) => println!("enrolled"),
-        MarkerState::Absent => println!("not-enrolled"),
+        MarkerState::Enrolled(_) => message::payload("enrolled"),
+        MarkerState::Absent => message::payload("not-enrolled"),
     }
 
     exit_code(&state)
@@ -221,15 +224,20 @@ mod tests {
         assert_eq!(exit_code(&state_in(&base, "alice")), 0);
     }
 
+    /// The exit code is the contract, and `--json` does not touch it.
+    ///
+    /// `--quiet` is not a parameter any more — it acts at the payload sink —
+    /// so what is left to pin here is that the two rendering modes agree on
+    /// the answer.
     #[test]
-    fn quiet_and_json_still_produce_the_contract_exit_codes() {
+    fn json_still_produces_the_contract_exit_codes() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join("enrolled");
         write_marker_in(&base, "alice", 1, None).unwrap();
 
-        for (json, quiet) in [(false, false), (true, false), (false, true), (true, true)] {
-            assert_eq!(report(state_in(&base, "alice"), json, quiet), 0);
-            assert_eq!(report(state_in(&base, "nobody"), json, quiet), 1);
+        for json in [false, true] {
+            assert_eq!(report(state_in(&base, "alice"), json), 0);
+            assert_eq!(report(state_in(&base, "nobody"), json), 1);
         }
     }
 

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -65,8 +65,11 @@ fn print_table(user: &str, models: &[FaceModelInfo]) {
     println!("\n  Total: {} model(s)", models.len());
 }
 
+/// The `--json` payload, through the seam's machine sink: never localized,
+/// and silenced by `--quiet` like every other payload (before #140 this
+/// command ignored the flag outright).
 fn print_json(models: &[FaceModelInfo]) {
-    println!("{}", list_json(models));
+    crate::message::payload(&list_json(models));
 }
 
 /// `[{"id", "label", "user", "created_at", "embedder_model", "device_id"}, ...]`.

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -701,13 +701,14 @@ fn report_json(action: PamAction, dry_run: bool, reports: &[ServiceReport]) -> S
     .to_string()
 }
 
-/// Emit the machine document, unless `--quiet` said the exit code is the whole
-/// answer. That is `is-enrolled --quiet --json`'s existing rule, generalized:
-/// `--quiet` leaves only the exit code, whatever the format.
-fn emit_json(action: PamAction, dry_run: bool, reports: &[ServiceReport], quiet: bool) {
-    if !quiet {
-        println!("{}", report_json(action, dry_run, reports));
-    }
+/// Emit the machine document on stdout.
+///
+/// Through [`message::payload`], so `--quiet` reaches it without this function
+/// knowing the flag exists: under it the document is dropped and the exit code
+/// is the whole answer, which is `is-enrolled --quiet --json`'s rule
+/// generalized to every payload.
+fn emit_json(action: PamAction, dry_run: bool, reports: &[ServiceReport]) {
+    crate::message::payload(&report_json(action, dry_run, reports));
 }
 
 // ---------------------------------------------------------------------------
@@ -728,9 +729,9 @@ fn emit_json(action: PamAction, dry_run: bool, reports: &[ServiceReport], quiet:
 /// `setup::needs_root_precheck` says so and a test pins it — and silently
 /// re-running a `/etc/pam.d` edit under `sudo` from a wrapper script is a
 /// surprise, not a convenience.
-pub fn run(request: PamRequest, quiet: bool) -> anyhow::Result<i32> {
+pub fn run(request: PamRequest) -> anyhow::Result<i32> {
     if request.action == PamAction::Status {
-        return Ok(status_in(Path::new(PAM_DIR), &request, quiet));
+        return Ok(status_in(Path::new(PAM_DIR), &request));
     }
 
     crate::ipc_client::require_root_scripted(&format!(
@@ -742,7 +743,7 @@ pub fn run(request: PamRequest, quiet: bool) -> anyhow::Result<i32> {
         require_module_installed()?;
     }
 
-    write_in(Path::new(PAM_DIR), &request, quiet)
+    write_in(Path::new(PAM_DIR), &request)
 }
 
 /// The precondition the line is useless without. Hoisted out of the per-service
@@ -758,13 +759,13 @@ fn require_module_installed() -> anyhow::Result<()> {
 
 /// `add` / `remove` against `base`. The engine tests drive this directly, so
 /// it performs no root or module check — [`run`] owns those.
-fn write_in(base: &Path, request: &PamRequest, quiet: bool) -> anyhow::Result<i32> {
+fn write_in(base: &Path, request: &PamRequest) -> anyhow::Result<i32> {
     let action = request.action;
     if action == PamAction::Status {
         // `run` routes `status` to `status_in` and never gets here. Delegating
         // rather than falling through is what stops a future caller from
         // getting a *removal* out of a request that asked to read.
-        return Ok(status_in(base, request, quiet));
+        return Ok(status_in(base, request));
     }
     let services = requested_services(&request.services);
     let sink = Sink { json: request.json };
@@ -811,7 +812,7 @@ fn write_in(base: &Path, request: &PamRequest, quiet: bool) -> anyhow::Result<i3
     }
 
     if request.json {
-        emit_json(action, request.dry_run, &reports, quiet);
+        emit_json(action, request.dry_run, &reports);
     }
 
     Ok(
@@ -836,12 +837,12 @@ fn write_in(base: &Path, request: &PamRequest, quiet: bool) -> anyhow::Result<i3
 /// The exit code is the answer, on `grep`'s scale and `is-enrolled`'s: 0 every
 /// service has the line, 1 at least one does not, 2 at least one could not be
 /// answered. The worst outcome wins.
-fn status_in(base: &Path, request: &PamRequest, quiet: bool) -> i32 {
+fn status_in(base: &Path, request: &PamRequest) -> i32 {
     let sink = Sink { json: request.json };
     let reports = status_reports(base, &requested_services(&request.services), &sink);
 
     if request.json {
-        emit_json(PamAction::Status, false, &reports, quiet);
+        emit_json(PamAction::Status, false, &reports);
     }
 
     reports
@@ -1131,7 +1132,7 @@ mod tests {
             ("sudo", NO_NEWLINE_BEFORE, NO_NEWLINE_AFTER),
         ] {
             let dir = seeded(&[(service, before)]);
-            let code = write_in(dir.path(), &add(&[service]), false).unwrap();
+            let code = write_in(dir.path(), &add(&[service])).unwrap();
 
             assert_eq!(code, WRITE_OK, "{service}");
             assert_eq!(read(&dir, service), after, "{service} content");
@@ -1143,12 +1144,12 @@ mod tests {
     #[test]
     fn add_backup_is_the_original_and_only_exists_on_a_real_write() {
         let dir = seeded(&[("sudo", SUDO_BEFORE)]);
-        write_in(dir.path(), &add(&["sudo"]), false).unwrap();
+        write_in(dir.path(), &add(&["sudo"])).unwrap();
         assert_eq!(read(&dir, "sudo.facelock-backup"), SUDO_BEFORE);
 
         let untouched = seeded(&[("omarchy-lock-face", OMARCHY_PRESENT)]);
         let before = snapshot(untouched.path());
-        write_in(untouched.path(), &add(&["omarchy-lock-face"]), false).unwrap();
+        write_in(untouched.path(), &add(&["omarchy-lock-face"])).unwrap();
         assert_eq!(
             before,
             snapshot(untouched.path()),
@@ -1162,7 +1163,7 @@ mod tests {
             ("omarchy-lock-face", OMARCHY_PRESENT),
             ("sudo", SUDO_BEFORE),
         ]);
-        let code = write_in(dir.path(), &remove(&["omarchy-lock-face", "sudo"]), false).unwrap();
+        let code = write_in(dir.path(), &remove(&["omarchy-lock-face", "sudo"])).unwrap();
 
         assert_eq!(code, WRITE_OK);
         assert_eq!(read(&dir, "omarchy-lock-face"), OMARCHY_REMOVED);
@@ -1185,7 +1186,7 @@ mod tests {
             install_one_in(via_alias.path(), service, true, true).unwrap();
 
             let via_verb = seeded(&[(service, before)]);
-            write_in(via_verb.path(), &add(&[service]), false).unwrap();
+            write_in(via_verb.path(), &add(&[service])).unwrap();
 
             assert_eq!(read(&via_alias, service), after, "{service} via the alias");
             assert_eq!(
@@ -1202,8 +1203,8 @@ mod tests {
     fn add_then_remove_restores_the_original_bytes() {
         for before in [SUDO_BEFORE, POLKIT_BEFORE, NO_NEWLINE_BEFORE] {
             let dir = seeded(&[("sudo", before)]);
-            write_in(dir.path(), &add(&["sudo"]), false).unwrap();
-            write_in(dir.path(), &remove(&["sudo"]), false).unwrap();
+            write_in(dir.path(), &add(&["sudo"])).unwrap();
+            write_in(dir.path(), &remove(&["sudo"])).unwrap();
             assert_eq!(read(&dir, "sudo"), before);
         }
     }
@@ -1252,7 +1253,7 @@ mod tests {
                 if_present: true,
                 ..PamRequest::default()
             };
-            let error = write_in(&base, &request, false).unwrap_err().to_string();
+            let error = write_in(&base, &request).unwrap_err().to_string();
 
             assert!(error.contains("Invalid PAM service name"), "got: {error}");
             assert_eq!(fs::read_to_string(&outside).unwrap(), OMARCHY_PRESENT);
@@ -1275,7 +1276,7 @@ mod tests {
                 if_present: true,
                 ..PamRequest::default()
             };
-            assert!(write_in(&base, &request, false).is_err());
+            assert!(write_in(&base, &request).is_err());
         }
         assert_eq!(
             fs::read_to_string(dir.path().join("shadow")).unwrap(),
@@ -1295,7 +1296,7 @@ mod tests {
             let dir = seeded(&[("sudo", SUDO_BEFORE), ("sshd", SUDO_BEFORE)]);
             let before = snapshot(dir.path());
 
-            let error = write_in(dir.path(), &add(&["sudo", second]), false).unwrap_err();
+            let error = write_in(dir.path(), &add(&["sudo", second])).unwrap_err();
 
             assert_eq!(
                 before,
@@ -1309,7 +1310,7 @@ mod tests {
     fn a_valid_multi_service_add_writes_every_service() {
         let dir = seeded(&[("sudo", SUDO_BEFORE), ("polkit-1", POLKIT_BEFORE)]);
 
-        let code = write_in(dir.path(), &add(&["sudo", "polkit-1"]), false).unwrap();
+        let code = write_in(dir.path(), &add(&["sudo", "polkit-1"])).unwrap();
 
         assert_eq!(code, WRITE_OK);
         assert_eq!(read(&dir, "sudo"), SUDO_AFTER);
@@ -1327,7 +1328,7 @@ mod tests {
             let dir = seeded(&[(service, SUDO_BEFORE)]);
             let before = snapshot(dir.path());
 
-            let error = write_in(dir.path(), &add(&[service]), false)
+            let error = write_in(dir.path(), &add(&[service]))
                 .unwrap_err()
                 .to_string();
 
@@ -1351,7 +1352,7 @@ mod tests {
             ..add(&["sshd"])
         };
 
-        assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+        assert_eq!(write_in(dir.path(), &request).unwrap(), WRITE_OK);
         assert_eq!(read(&dir, "sshd"), SUDO_AFTER);
     }
 
@@ -1363,7 +1364,7 @@ mod tests {
         let dir = seeded(&[("system-auth", OMARCHY_PRESENT)]);
 
         assert_eq!(
-            write_in(dir.path(), &remove(&["system-auth"]), false).unwrap(),
+            write_in(dir.path(), &remove(&["system-auth"])).unwrap(),
             WRITE_OK
         );
         assert_eq!(read(&dir, "system-auth"), OMARCHY_REMOVED);
@@ -1383,7 +1384,7 @@ mod tests {
                 ..PamRequest::default()
             };
 
-            assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+            assert_eq!(write_in(dir.path(), &request).unwrap(), WRITE_OK);
             assert!(fs::read_dir(dir.path()).unwrap().next().is_none());
         }
     }
@@ -1393,9 +1394,7 @@ mod tests {
         for request in [add(&["omarchy-lock-face"]), remove(&["omarchy-lock-face"])] {
             let dir = tempfile::TempDir::new().unwrap();
 
-            let error = write_in(dir.path(), &request, false)
-                .unwrap_err()
-                .to_string();
+            let error = write_in(dir.path(), &request).unwrap_err().to_string();
 
             assert!(
                 error.contains("PAM service file not found:"),
@@ -1421,9 +1420,7 @@ mod tests {
                 ..request
             };
 
-            let error = write_in(dir.path(), &request, false)
-                .unwrap_err()
-                .to_string();
+            let error = write_in(dir.path(), &request).unwrap_err().to_string();
 
             assert!(error.contains("failed to read"), "got: {error}");
         }
@@ -1447,7 +1444,7 @@ mod tests {
                 no_confirm: true,
                 ..PamRequest::default()
             };
-            assert_eq!(write_in(dir.path(), &request, false).unwrap(), WRITE_OK);
+            assert_eq!(write_in(dir.path(), &request).unwrap(), WRITE_OK);
         }
 
         assert_eq!(before, snapshot(dir.path()));
@@ -1492,7 +1489,6 @@ mod tests {
                     services: services.iter().map(|s| s.to_string()).collect(),
                     ..PamRequest::default()
                 },
-                false,
             )
         };
 
@@ -1521,7 +1517,6 @@ mod tests {
                 services: vec!["sudo".into(), "absent".into(), "../escape".into()],
                 ..PamRequest::default()
             },
-            false,
         );
 
         assert_eq!(before, snapshot(dir.path()));

--- a/crates/facelock-cli/src/commands/preview/text_only.rs
+++ b/crates/facelock-cli/src/commands/preview/text_only.rs
@@ -1,10 +1,41 @@
+//! `preview --json`: one JSON document per frame, on stdout, until Ctrl+C.
+//!
+//! **stdout here is the frame stream and nothing else.** `--json` is parsed one
+//! level up, so neither loop below knows whether a human or `jq` is reading,
+//! and both must keep stdout clean either way. The regression this rule exists
+//! for shipped: the no-enrollment notice went through `Terminal::info`, which
+//! writes to stdout, so a fresh oneshot install prefixed the stream with a
+//! localized sentence and a consumer failed on the first line.
+//!
+//! Two checks enforce it, one per way in. `#![deny(clippy::print_stdout)]`
+//! below refuses a bare `println!` — CI runs clippy with `-D warnings` — while
+//! leaving the frame loops' `writeln!` alone. The seam's stdout sinks are
+//! invisible to that lint, so `no_stdout_sink_of_the_seam_is_used_here`
+//! scans this file for them; [`warn`] is the convenience that makes the right
+//! thing the short thing, not a barrier, since a fully-qualified call to
+//! `crate::message::Terminal`'s informational sink needs no import to compile
+//! here.
+//!
+//! The frame stream is the one payload in the CLI that does not go through
+//! `message::payload`: it runs until interrupted, so a `--quiet` that silenced
+//! it would leave a command that produces nothing forever.
+#![deny(clippy::print_stdout)]
+
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use crate::ipc_client;
-use crate::message::{FaceMessage, Terminal};
+use crate::message::FaceMessage;
+
+/// This module's route for human text: stderr, never stdout.
+///
+/// A convenience, not an enforcement — see the module docs for what actually
+/// checks that the stdout sinks stay out of this file.
+fn warn(msg: &dyn crate::message::Message) {
+    crate::message::Terminal.error(msg);
+}
 
 /// Run the text-only preview mode.
 ///
@@ -100,11 +131,9 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
     let stored = match crate::direct::open_store_existing(config) {
         Ok(store) => crate::direct::load_user_embeddings(&store, config, user)?,
         Err(facelock_store::StoreError::Absent { .. }) => {
-            // stderr, not the informational sink: stdout here is the frame
-            // stream, and this loop cannot see whether `--json` was passed.
-            // As stdout chatter this localized sentence prefixed the stream
-            // on any fresh oneshot install, so `jq` failed on line 1.
-            Terminal.error(&FaceMessage::NoModelsEnrolled {
+            // stderr, not stdout: this is the notice that used to corrupt
+            // the frame stream (see the module docs).
+            warn(&FaceMessage::NoModelsEnrolled {
                 user: user.to_string(),
             });
             Vec::new()
@@ -313,41 +342,28 @@ mod tests {
         );
     }
 
-    /// stdout in this module is the frame stream and nothing else.
+    /// The seam's stdout sinks, which no lint can see.
     ///
-    /// `--json` is parsed one level up, so neither loop here knows whether a
-    /// human or `jq` is reading, and both must keep stdout clean either way.
-    /// The regression this catches shipped: the no-enrollment notice in
-    /// `run_direct` went through `Terminal::info`, which writes to stdout, so
-    /// a fresh oneshot install prefixed the stream with a localized sentence
-    /// and a consumer failed on the first line. Human text goes to stderr.
-    ///
-    /// A source scan is the only seam available: both loops need a daemon or
-    /// a camera to run. Needles are assembled at runtime so this test does
-    /// not match itself, following `backend.rs`'s single-siting pins.
+    /// `#![deny(clippy::print_stdout)]` catches a bare `println!`. It cannot
+    /// catch either sink that writes to stdout through the seam: the
+    /// informational one, which is what shipped as the bug, and the notice
+    /// one, which `--quiet` does not even suppress. Neither needs an import
+    /// to reach from here. So this scans the source, which is the only seam
+    /// available — both frame loops need a daemon or a camera to run. The
+    /// needles are assembled at runtime so the test does not match itself,
+    /// following `backend.rs`'s single-siting pins.
     #[test]
-    fn nothing_beside_the_frame_stream_writes_to_stdout() {
+    fn no_stdout_sink_of_the_seam_is_used_here() {
         let source = include_str!("text_only.rs");
-        let info_sink = format!("Terminal{}info(", ".");
-        let bare_stdout = format!("{}!(", String::from("print") + "ln");
-
-        for (index, line) in source.lines().enumerate() {
-            let code = line.trim_start();
-            if code.starts_with("//") {
-                continue;
+        for sink in ["info", "notice"] {
+            for sep in [".", "::"] {
+                let needle = format!("Terminal{sep}{sink}(");
+                assert!(
+                    !source.contains(&needle),
+                    "`{needle}` writes to stdout, which here is the frame \
+                     stream; human text goes to stderr through `warn`"
+                );
             }
-            let number = index + 1;
-            assert!(
-                !code.contains(&info_sink),
-                "line {number}: the informational sink writes to stdout, which \
-                 here is the frame stream; use Terminal::error"
-            );
-            // `eprint` is masked first so only the stdout macro can match.
-            assert!(
-                !code.replace("eprint", "eprint_").contains(&bare_stdout),
-                "line {number}: bare stdout printing beside the frame stream; \
-                 human text belongs on stderr"
-            );
         }
     }
 

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -181,13 +181,16 @@ fn main() -> anyhow::Result<()> {
     }
 
     // `--quiet` is likewise global, and lands at the message sink rather than
-    // at any call site: it silences `Terminal::info` and nothing else, so
-    // errors, prompts, exit codes and the `RUST_LOG` event stream are
-    // unchanged. `is-enrolled` reads the same flag directly for its
-    // exit-code-only mode, which predates the sink.
-    if quiet {
-        message::set_verbosity(message::Verbosity::Quiet);
-    }
+    // at any call site: it silences the two suppressible stdout sinks
+    // (`Terminal::info` for human text, `message::payload` for machine
+    // output) and nothing else, so errors, prompts, exit codes and the
+    // `RUST_LOG` event stream are unchanged. Written unconditionally so the
+    // global is initialised exactly once, on either branch.
+    message::set_verbosity(if quiet {
+        message::Verbosity::Quiet
+    } else {
+        message::Verbosity::Normal
+    });
 
     match command {
         // Daemon and auth init their own tracing, so handle them separately.
@@ -243,11 +246,11 @@ fn main() -> anyhow::Result<()> {
                 // tree and constants. It reads no file at all, so it sits
                 // ahead even of `is-enrolled`, which at least opens a marker.
                 Commands::Capabilities { json } => {
-                    commands::capabilities::run(json.json, quiet);
+                    commands::capabilities::run(json.json);
                     Ok(())
                 }
                 Commands::IsEnrolled { user, json } => {
-                    std::process::exit(commands::is_enrolled::run(user.user, json.json, quiet))
+                    std::process::exit(commands::is_enrolled::run(user.user, json.json))
                 }
                 // `pam` consumes no `Config` either: `add`/`remove` edit
                 // `/etc/pam.d` and `status` reads it, and neither wants a
@@ -255,7 +258,7 @@ fn main() -> anyhow::Result<()> {
                 // them. Its exit code is its own — `status` answers on grep's
                 // 0/1/2 scale — so it exits here rather than returning `()`.
                 Commands::Pam { command } => {
-                    std::process::exit(commands::pam::run(command.into(), quiet)?)
+                    std::process::exit(commands::pam::run(command.into())?)
                 }
                 Commands::Hyprlock { command } => commands::hyprlock::run(command),
                 // `config show` (and bare `config`) is the unprivileged read

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -78,34 +78,32 @@ impl Message for AccessMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for AccessMessage {
-    fn first_sample() -> Self {
-        use AccessMessage::*;
-        NoConfigFile { path: s("/p") }
-    }
+    const VARIANT_COUNT: usize = 10;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use AccessMessage::*;
-        Some(match self {
-            NoConfigFile { .. } => InvalidConfig {
+        vec![
+            NoConfigFile { path: s("/p") },
+            InvalidConfig {
                 path: s("/p"),
                 error: s("e"),
             },
-            InvalidConfig { .. } => RootRequired { hint: s("h") },
-            RootRequired { .. } => SudoReexecPrompt,
-            SudoReexecPrompt => AccessDeniedRootHint,
-            AccessDeniedRootHint => AccessDeniedGroupHint,
-            AccessDeniedGroupHint => EnrollTimedOutClientSide,
-            EnrollTimedOutClientSide => DaemonUnreachableFallback,
-            DaemonUnreachableFallback => PreviewGraphicalNeedsDaemonOneshot,
-            PreviewGraphicalNeedsDaemonOneshot => PreviewGraphicalDaemonUnreachable,
-            PreviewGraphicalDaemonUnreachable => return None,
-        })
+            RootRequired { hint: s("h") },
+            SudoReexecPrompt,
+            AccessDeniedRootHint,
+            AccessDeniedGroupHint,
+            EnrollTimedOutClientSide,
+            DaemonUnreachableFallback,
+            PreviewGraphicalNeedsDaemonOneshot,
+            PreviewGraphicalDaemonUnreachable,
+        ]
     }
 }

--- a/crates/facelock-cli/src/message/device.rs
+++ b/crates/facelock-cli/src/message/device.rs
@@ -119,53 +119,51 @@ impl Message for DeviceMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for DeviceMessage {
-    fn first_sample() -> Self {
-        use DeviceMessage::*;
-        NoVideoDevices
-    }
+    const VARIANT_COUNT: usize = 19;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use DeviceMessage::*;
-        Some(match self {
-            NoVideoDevices => AutoSelectedIrCamera {
+        vec![
+            NoVideoDevices,
+            AutoSelectedIrCamera {
                 path: s("/d"),
                 name: s("n"),
             },
-            AutoSelectedIrCamera { .. } => AutoSelectedIrCameraPath { path: s("/d") },
-            AutoSelectedIrCameraPath { .. } => SelectedCamera {
+            AutoSelectedIrCameraPath { path: s("/d") },
+            SelectedCamera {
                 path: s("/d"),
                 name: s("n"),
             },
-            SelectedCamera { .. } => SelectedValue { value: s("v") },
-            SelectedValue { .. } => PromptSelectCameraDevice,
-            PromptSelectCameraDevice => AutoCameraNoDevices,
-            AutoCameraNoDevices => AutoCameraNoIr {
+            SelectedValue { value: s("v") },
+            PromptSelectCameraDevice,
+            AutoCameraNoDevices,
+            AutoCameraNoIr {
                 listed: s("l"),
                 example: s("/d"),
             },
-            AutoCameraNoIr { .. } => AutoCameraManyIr {
+            AutoCameraManyIr {
                 count: 2,
                 listed: s("l"),
             },
-            AutoCameraManyIr { .. } => CameraDeviceMissing { path: s("/d") },
-            CameraDeviceMissing { .. } => PromptSelectModelQuality,
-            PromptSelectModelQuality => PromptSelectInferenceDevice,
-            PromptSelectInferenceDevice => SelectedModelsStandard,
-            SelectedModelsStandard => SelectedModelsBalanced,
-            SelectedModelsBalanced => SelectedModelsHigh,
-            SelectedModelsHigh => DetectedProvider { detail: s("d") },
-            DetectedProvider { .. } => ProviderQueryFailed { error: s("e") },
-            ProviderQueryFailed { .. } => NvidiaDriverMissing,
-            NvidiaDriverMissing => CudaRuntimeMissing,
-            CudaRuntimeMissing => return None,
-        })
+            CameraDeviceMissing { path: s("/d") },
+            PromptSelectModelQuality,
+            PromptSelectInferenceDevice,
+            SelectedModelsStandard,
+            SelectedModelsBalanced,
+            SelectedModelsHigh,
+            DetectedProvider { detail: s("d") },
+            ProviderQueryFailed { error: s("e") },
+            NvidiaDriverMissing,
+            CudaRuntimeMissing,
+        ]
     }
 }
 
@@ -178,7 +176,7 @@ mod tests {
     /// [`super::super::setup`] for why a failing pin is fixed by restoring
     /// the string, never by editing the expectation.
     #[test]
-    fn english_fallback_is_byte_identical() {
+    fn device_fallback_is_byte_identical() {
         use DeviceMessage::*;
 
         assert_eq!(

--- a/crates/facelock-cli/src/message/download.rs
+++ b/crates/facelock-cli/src/message/download.rs
@@ -107,45 +107,43 @@ impl Message for DownloadMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for DownloadMessage {
-    fn first_sample() -> Self {
-        use DownloadMessage::*;
-        ModelPresentOk {
-            name: s("n"),
-            purpose: s("p"),
-        }
-    }
+    const VARIANT_COUNT: usize = 12;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use DownloadMessage::*;
-        Some(match self {
-            ModelPresentOk { .. } => AllModelsPresent,
-            AllModelsPresent => ModelsToDownloadHeader,
-            ModelsToDownloadHeader => ModelToDownloadEntry {
+        vec![
+            ModelPresentOk {
+                name: s("n"),
+                purpose: s("p"),
+            },
+            AllModelsPresent,
+            ModelsToDownloadHeader,
+            ModelToDownloadEntry {
                 name: s("n"),
                 size_mb: 1,
                 purpose: s("p"),
             },
-            ModelToDownloadEntry { .. } => TotalDownloadSize { mb: 1 },
-            TotalDownloadSize { .. } => ConfirmDownloadRequiredModels,
-            ConfirmDownloadRequiredModels => SkippingModelDownload,
-            SkippingModelDownload => DownloadingModel { name: s("n") },
-            DownloadingModel { .. } => ModelDownloaded { name: s("n") },
-            ModelDownloaded { .. } => ModelDownloadPending {
+            TotalDownloadSize { mb: 1 },
+            ConfirmDownloadRequiredModels,
+            SkippingModelDownload,
+            DownloadingModel { name: s("n") },
+            ModelDownloaded { name: s("n") },
+            ModelDownloadPending {
                 name: s("n"),
                 size_mb: 1,
                 purpose: s("p"),
             },
-            ModelDownloadPending { .. } => ModelRedownloading { name: s("n") },
-            ModelRedownloading { .. } => ModelRedownloaded { name: s("n") },
-            ModelRedownloaded { .. } => return None,
-        })
+            ModelRedownloading { name: s("n") },
+            ModelRedownloaded { name: s("n") },
+        ]
     }
 }
 
@@ -158,7 +156,7 @@ mod tests {
     /// change: the non-interactive flow now renders them too, so they are
     /// load-bearing on both paths.
     #[test]
-    fn english_fallback_is_byte_identical() {
+    fn download_fallback_is_byte_identical() {
         use DownloadMessage::*;
 
         assert_eq!(

--- a/crates/facelock-cli/src/message/face.rs
+++ b/crates/facelock-cli/src/message/face.rs
@@ -248,89 +248,87 @@ impl Message for FaceMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for FaceMessage {
-    fn first_sample() -> Self {
-        use FaceMessage::*;
-        SetupNotCompleted
-    }
+    const VARIANT_COUNT: usize = 32;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use FaceMessage::*;
-        Some(match self {
-            SetupNotCompleted => ConfirmRunSetupNow,
-            ConfirmRunSetupNow => SetupDidNotComplete,
-            SetupDidNotComplete => RunSetupWhenReady,
-            RunSetupWhenReady => PlaintextEnrollWarning,
-            PlaintextEnrollWarning => ModelsMissing { dir: s("/m") },
-            ModelsMissing { .. } => StaleEmbedderNote { embedder: s("e") },
-            StaleEmbedderNote { .. } => Enrolling {
+        vec![
+            SetupNotCompleted,
+            ConfirmRunSetupNow,
+            SetupDidNotComplete,
+            RunSetupWhenReady,
+            PlaintextEnrollWarning,
+            ModelsMissing { dir: s("/m") },
+            StaleEmbedderNote { embedder: s("e") },
+            Enrolling {
                 user: s("u"),
                 label: s("l"),
             },
-            Enrolling { .. } => EnrollLookAtCamera,
-            EnrollLookAtCamera => EnrollComplete {
+            EnrollLookAtCamera,
+            EnrollComplete {
                 model_id: 1,
                 count: 2,
                 label: s("l"),
             },
-            EnrollComplete { .. } => TooManyModels {
+            TooManyModels {
                 user: s("u"),
                 count: 6,
             },
-            TooManyModels { .. } => ModelsNotFoundOfferSetup,
-            ModelsNotFoundOfferSetup => ConfirmDownloadModels,
-            ConfirmDownloadModels => ModelsStillMissingAfterSetup,
-            ModelsStillMissingAfterSetup => ModelsRequired,
-            ModelsRequired => NoModelsEnrolled { user: s("u") },
-            NoModelsEnrolled { .. } => RunEnrollFirst,
-            RunEnrollFirst => NoMatchingEmbedder { embedder: s("e") },
-            NoMatchingEmbedder { .. } => ReenrollHint,
-            ReenrollHint => TestingUser { user: s("u") },
-            TestingUser { .. } => TestLookAtCamera,
-            TestLookAtCamera => TestMatched {
+            ModelsNotFoundOfferSetup,
+            ConfirmDownloadModels,
+            ModelsStillMissingAfterSetup,
+            ModelsRequired,
+            NoModelsEnrolled { user: s("u") },
+            RunEnrollFirst,
+            NoMatchingEmbedder { embedder: s("e") },
+            ReenrollHint,
+            TestingUser { user: s("u") },
+            TestLookAtCamera,
+            TestMatched {
                 similarity: 0.5,
                 seconds: 1.0,
             },
-            TestMatched { .. } => TestMatchedModel {
+            TestMatchedModel {
                 model_id: 1,
                 label: s("l"),
                 similarity: 0.5,
                 seconds: 1.0,
             },
-            TestMatchedModel { .. } => TestVarianceBlocked {
+            TestVarianceBlocked {
                 similarity: 0.5,
                 seconds: 1.0,
             },
-            TestVarianceBlocked { .. } => TestNoMatch {
+            TestNoMatch {
                 similarity: 0.5,
                 seconds: 1.0,
             },
-            TestNoMatch { .. } => ConfirmRemoveModel {
+            ConfirmRemoveModel {
                 model_id: 1,
                 user: s("u"),
             },
-            ConfirmRemoveModel { .. } => Cancelled,
-            Cancelled => RemovedModel {
+            Cancelled,
+            RemovedModel {
                 model_id: 1,
                 user: s("u"),
             },
-            RemovedModel { .. } => ModelNotFound {
+            ModelNotFound {
                 model_id: 1,
                 user: s("u"),
             },
-            ModelNotFound { .. } => ConfirmClearAll { user: s("u") },
-            ConfirmClearAll { .. } => ClearedModels {
+            ConfirmClearAll { user: s("u") },
+            ClearedModels {
                 count: 1,
                 user: s("u"),
             },
-            ClearedModels { .. } => AllModelsRemoved { user: s("u") },
-            AllModelsRemoved { .. } => return None,
-        })
+            AllModelsRemoved { user: s("u") },
+        ]
     }
 }

--- a/crates/facelock-cli/src/message/mod.rs
+++ b/crates/facelock-cli/src/message/mod.rs
@@ -22,10 +22,29 @@
 //! sink, not the string — `bail!` text a human reads on stderr localizes,
 //! the same event written to audit/syslog/tracing does not.
 //!
-//! `--quiet` acts here rather than at the call sites: [`set_verbosity`]
-//! silences [`Terminal::info`] and nothing else, so converting a `println!`
-//! into a message is also what makes it quietable — no caller ever asks
-//! whether it should be printing.
+//! # Three sinks write to stdout, and `--quiet` knows all three
+//!
+//! `--quiet` acts here rather than at the call sites: [`set_verbosity`] is
+//! read by the sinks themselves, so no caller ever asks whether it should be
+//! printing.
+//!
+//! | Sink | Renders | Under `--quiet` |
+//! |---|---|---|
+//! | [`Terminal::info`] | localized | silenced |
+//! | [`payload`] | never localized | silenced |
+//! | [`Terminal::notice`] | localized | still prints |
+//!
+//! [`payload`] is the machine half of stdout: `--json` documents, `is-enrolled`'s
+//! state word, `capabilities`' name list. It takes an already-rendered `&str`,
+//! so no catalog is consulted on the way out — a payload cannot pick up a
+//! translation by being routed through the seam. [`Terminal::notice`] is for
+//! the rare human line that must be seen and must stay on stdout for byte
+//! compatibility.
+//!
+//! One rule follows: **`--quiet` suppresses stdout, and on a command whose
+//! stdout *is* the payload that means the payload too — the exit code is the
+//! answer.** Errors, prompts, exit codes and the `RUST_LOG` event stream are
+//! unchanged.
 //!
 //! # The vocabulary is split by domain
 //!
@@ -58,9 +77,10 @@
 //!    translators can reorder them. Pre-format numbers that need precision
 //!    (`format!("{similarity:.2}")`) before filling — Rust formatting is
 //!    locale-independent, so numbers stay stable across locales.
-//! 3. Link a sample into that domain's [`Samples`] walk. The compiler asks
-//!    for this: the walk is a wildcard-free `match`, so a new variant does
-//!    not build until the placeholder sweep can reach it.
+//! 3. Add a sample to that domain's [`Samples`] list and bump its
+//!    [`Samples::VARIANT_COUNT`]. The compiler forces step 2 (the `localized`
+//!    match is wildcard-free); the count is what forces this step, and the
+//!    sweep says so when the two disagree.
 //! 4. Replace the `println!`/`eprintln!`/`bail!` site with
 //!    `Terminal.info(&msg)` / `Terminal.error(&msg)` / `return Err(fail(msg))`.
 //!
@@ -75,6 +95,10 @@
 //! strings (PAM substring-matches those on the wire — see
 //! `pam_code_for_daemon_error` in `pam-facelock`). Route none of them
 //! through [`Message::localized`].
+//!
+//! The first two still belong on stdout, and still have to obey `--quiet`, so
+//! they go through [`payload`] instead: same global, no gettext. The rest are
+//! not stdout at all and do not come through this module.
 //!
 //! # Why this lives in `facelock-cli`
 //!
@@ -221,17 +245,20 @@ pub trait Message: std::fmt::Debug {
 // Verbosity
 // ---------------------------------------------------------------------------
 
-/// How much the human sink says.
+/// How much the stdout sinks say.
 ///
-/// **`--quiet` suppresses informational stdout only; errors and exit codes are
+/// **`--quiet` suppresses stdout; errors, prompts and exit codes are
 /// unchanged.** [`Terminal::error`] is never suppressed, so a quiet run that
 /// fails still says why on stderr and still exits non-zero. That is
 /// `is-enrolled --quiet`'s existing semantics (see
 /// [`crate::commands::is_enrolled`]) and it is the house rule for every
-/// command. Prompts ([`Terminal::confirm`]) are unaffected too — a silenced
-/// question is a hang, not a quieter program. The debug side channel
-/// (`trace`) also keeps firing: the machine event stream is not user-facing
-/// output, so `RUST_LOG=facelock=debug` works the same either way.
+/// command: on a command whose stdout is a machine payload, `--quiet` takes
+/// the payload with it and the exit code is the whole answer. Prompts
+/// ([`Terminal::confirm`]) are unaffected — a silenced question is a hang, not
+/// a quieter program — and so is [`Terminal::notice`], the sink that exists
+/// for the lines that must be seen. The debug side channel (`trace`) also
+/// keeps firing: the machine event stream is not user-facing output, so
+/// `RUST_LOG=facelock=debug` works the same either way.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Verbosity {
     #[default]
@@ -239,57 +266,59 @@ pub enum Verbosity {
     Quiet,
 }
 
-/// Process-global verbosity. Written once, from the parsed global `--quiet`
-/// flag, before any other thread exists; `Relaxed` is therefore enough — no
-/// other state is published through it.
-static VERBOSITY: std::sync::atomic::AtomicU8 =
-    std::sync::atomic::AtomicU8::new(Verbosity::Normal as u8);
+/// Process-global verbosity, written once from the parsed global `--quiet`
+/// flag before any other thread exists.
+static VERBOSITY: std::sync::OnceLock<Verbosity> = std::sync::OnceLock::new();
 
 /// Set the process verbosity. Call once, early in `main`, next to [`init`].
+///
+/// A second call is a programming error — the flag is parsed once and the
+/// sinks are allowed to assume the answer does not change under them. The
+/// second write is dropped rather than refused, since returning a `Result` to
+/// a caller three lines into `main` buys nothing; the `debug_assert` is what
+/// makes the drop visible to a test binary that calls this twice instead of
+/// leaving it to be discovered as a `--quiet` that stopped working.
+///
+/// The write is a `let` binding, not the assert's argument: `debug_assert!`
+/// compiles its condition out of a release build, which would take the write
+/// with it.
 pub fn set_verbosity(verbosity: Verbosity) {
-    VERBOSITY.store(verbosity as u8, std::sync::atomic::Ordering::Relaxed);
+    let first_write = VERBOSITY.set(verbosity).is_ok();
+    debug_assert!(
+        first_write,
+        "set_verbosity called twice; the global is written once, from main"
+    );
 }
 
 /// The process verbosity ([`Verbosity::Normal`] until [`set_verbosity`] runs).
-///
-/// The decode names every level rather than testing for `Quiet` and defaulting,
-/// so the next one to be added is visible here instead of quietly demoting to
-/// `Normal`. Rust cannot check a `u8` match against the enum, so the guarantee
-/// is a test: `every_level_round_trips_through_the_stored_byte` walks a
-/// wildcard-free `match` over [`Verbosity`] — a new level does not compile
-/// until it joins that walk, and then fails the round trip until it is listed
-/// below. The trailing arm is unreachable ([`set_verbosity`] is the only
-/// writer) and resolves to `Normal`, the setting that hides nothing.
-pub fn verbosity() -> Verbosity {
-    let stored = VERBOSITY.load(std::sync::atomic::Ordering::Relaxed);
-    match stored {
-        v if v == Verbosity::Normal as u8 => Verbosity::Normal,
-        v if v == Verbosity::Quiet as u8 => Verbosity::Quiet,
-        _ => Verbosity::Normal,
-    }
+pub(crate) fn verbosity() -> Verbosity {
+    VERBOSITY.get().copied().unwrap_or_default()
 }
 
-/// The walk that holds [`verbosity`]'s decode to this enum.
+/// What [`Terminal::info`] writes at this verbosity, or `None` when silenced.
 ///
-/// Wildcard-free on purpose, the same discipline as the [`Samples`] walks: a
-/// level added without a line here does not compile.
-#[cfg(test)]
-impl Verbosity {
-    fn next_level(self) -> Option<Self> {
-        match self {
-            Verbosity::Normal => Some(Verbosity::Quiet),
-            Verbosity::Quiet => None,
-        }
-    }
+/// The decision is a pure function of the level rather than of the global, so
+/// the rule is testable without mutating process state or capturing stdout —
+/// what matters is *what the sink decides*, not what a pipe received.
+fn info_at(msg: &dyn Message, verbosity: Verbosity) -> Option<String> {
+    (verbosity == Verbosity::Normal).then(|| msg.localized())
 }
 
-/// Whether [`Terminal::info`] writes anything to stdout.
+/// What [`Terminal::notice`] writes at this verbosity: always the message.
 ///
-/// The decision is a pure function of the global so it can be tested without
-/// capturing stdout — the test that matters is *what the sink decides*, not
-/// what a captured pipe received.
-fn info_enabled() -> bool {
-    verbosity() == Verbosity::Normal
+/// The unused level is the contract, stated in the signature so a test can
+/// hold it: this sink is offered the verbosity and ignores it.
+fn notice_at(msg: &dyn Message, _verbosity: Verbosity) -> Option<String> {
+    Some(msg.localized())
+}
+
+/// What [`payload`] writes at this verbosity, or `None` when silenced.
+///
+/// Borrowed through unchanged: no gettext, no formatting, no allocation. A
+/// payload is bytes a script parses, and this sink's whole job is to keep them
+/// that way while still answering to `--quiet`.
+fn payload_at(text: &str, verbosity: Verbosity) -> Option<&str> {
+    (verbosity == Verbosity::Normal).then_some(text)
 }
 
 // ---------------------------------------------------------------------------
@@ -312,8 +341,25 @@ impl Terminal {
     /// silences. The machine rendering is emitted either way.
     pub fn info(&self, msg: &dyn Message) {
         trace(msg);
-        if info_enabled() {
-            println!("{}", msg.localized());
+        if let Some(line) = info_at(msg, verbosity()) {
+            println!("{line}");
+        }
+    }
+
+    /// Human message to stdout that `--quiet` does **not** silence.
+    ///
+    /// For the few lines that must be seen and must stay on stdout, where
+    /// [`Terminal::error`]'s stderr would change the stream a caller reads:
+    /// [`PamMessage::PamInstalled`]'s rollback instructions (the one message
+    /// that tells a locked-out operator how to get back in),
+    /// [`SetupMessage::EncryptionDisabledWarning`], and the context a prompt
+    /// needs to be answerable. Everything else informational is
+    /// [`Terminal::info`] — a `notice` that did not have to be seen is just an
+    /// unquietable one.
+    pub fn notice(&self, msg: &dyn Message) {
+        trace(msg);
+        if let Some(line) = notice_at(msg, verbosity()) {
+            println!("{line}");
         }
     }
 
@@ -338,6 +384,38 @@ impl Terminal {
         trace(msg);
         eprint!("{}", prompt_line(msg, "[Y/n]"));
         Ok(!matches!(read_answer()?.as_str(), "n" | "no"))
+    }
+}
+
+/// The machine sink: one line of payload on stdout, C-locale, `--quiet`-aware.
+///
+/// This is what a script parses — a `--json` document, `is-enrolled`'s state
+/// word, `capabilities`' name list — so it takes an already-rendered `&str`
+/// and prints it. Nothing here consults gettext: there is no [`Message`] to
+/// call [`Message::localized`] on, so routing a payload through the seam
+/// cannot translate it. That is the "boundary is the sink" trick that keeps
+/// logs English (D2), pointed the other way — weaker in one direction, since
+/// a caller is free to hand this sink text it localized itself.
+///
+/// It reads the same [`Verbosity`] as [`Terminal::info`], which is the whole
+/// point: before this existed `--quiet` had three implementations and a silent
+/// no-op — this global, three `quiet: bool` parameters each gating a bare
+/// `println!`, and two commands that took the flag and ignored it. One sink,
+/// one rule: `--quiet` suppresses stdout and the exit code is the answer.
+///
+/// Nothing is traced. A payload is not an event: it is already on stdout in a
+/// stable form, and copying a JSON document into the debug stream would say
+/// nothing the reader cannot see.
+///
+/// **The one payload that does not come through here** is `preview --json`'s
+/// frame stream (`commands/preview/text_only.rs`): it emits a document per
+/// frame until the operator interrupts it, so a `--quiet` that silenced it
+/// would leave a command that produces nothing forever. That module denies
+/// `clippy::print_stdout` and scans itself for the seam's stdout sinks, so the
+/// exception cannot spread past the frame loops it was made for.
+pub fn payload(text: &str) {
+    if let Some(line) = payload_at(text, verbosity()) {
+        println!("{line}");
     }
 }
 
@@ -386,31 +464,37 @@ pub fn fail(msg: impl Message) -> anyhow::Error {
 }
 
 // ---------------------------------------------------------------------------
-// Test support: the sample walk that feeds the placeholder sweep
+// Test support: the sample list that feeds the sweeps
 // ---------------------------------------------------------------------------
 
-/// A walk over every variant of a domain, one constructed sample each.
+/// One constructed sample per variant of a domain, for the sweeps below.
 ///
-/// Implementations write [`Samples::next_sample`] as a wildcard-free `match`,
-/// which is what keeps the walk honest: a variant added without a sample does
-/// not compile.
+/// # What holds this to the vocabulary
+///
+/// Three things, and it is worth being exact about which is which, because an
+/// earlier version of this trait claimed the first one covered all three:
+///
+/// - **The compiler** proves every variant has a `localized` arm: that `match`
+///   is wildcard-free, so a new variant does not build until it renders.
+/// - **[`VARIANT_COUNT`](Samples::VARIANT_COUNT)** proves [`samples`](Samples::samples)
+///   has not fallen behind: `every_variant_has_a_sample` fails when the list and
+///   the count disagree, and fails again if two entries are the same variant.
+///   Adding a variant therefore touches the enum, the rendering, the sample
+///   list and the count, and the count is the one that says so out loud.
+/// - **Nothing** can prove the count itself: stable Rust cannot count enum
+///   variants, so a variant added while touching neither the list nor the
+///   count is invisible here. What is *not* possible any more is the failure
+///   this replaced: a linked-list walk whose arms were compiler-checked while
+///   its results were not, so `Foo => Bar` beside `Prev => Bar` compiled,
+///   dropped `Foo` from the sweep, and could route the walk into a cycle (the
+///   old `assert!(out.len() < 10_000)` was the tell).
 #[cfg(test)]
 pub(crate) trait Samples: Sized {
-    /// The first sample, in enum order.
-    fn first_sample() -> Self;
-
-    /// The sample after `self`, or `None` at the end of the vocabulary.
-    fn next_sample(&self) -> Option<Self>;
+    /// How many variants this domain has. Bumped with the sample below it.
+    const VARIANT_COUNT: usize;
 
     /// Every variant of this domain, exactly once, in enum order.
-    fn samples() -> Vec<Self> {
-        let mut out = vec![Self::first_sample()];
-        while let Some(next) = out[out.len() - 1].next_sample() {
-            out.push(next);
-            assert!(out.len() < 10_000, "sample walk does not terminate");
-        }
-        out
-    }
+    fn samples() -> Vec<Self>;
 }
 
 /// Placeholder-sized string for sample values.
@@ -427,8 +511,11 @@ mod tests {
     /// so `localized()` is the English fallback — these pins are exactly the
     /// bytes the historical inline strings produced (container tests grep
     /// some of them).
+    ///
+    /// The strings pinned here are `face`, `access` and `pam` ones; each
+    /// domain module pins its own alongside its `Samples` list.
     #[test]
-    fn english_fallback_is_byte_identical() {
+    fn face_access_and_pam_fallback_is_byte_identical() {
         assert_eq!(
             FaceMessage::EnrollComplete {
                 model_id: 3,
@@ -536,54 +623,48 @@ mod tests {
         );
     }
 
-    /// `--quiet` gates informational stdout and nothing else.
+    /// `--quiet` silences the two suppressible stdout sinks, and only those.
     ///
-    /// Asserted on `info_enabled` rather than on captured stdout: the sink's
+    /// Asserted on the sinks' decisions rather than on captured stdout: the
     /// decision is the contract, and a capture test would prove the same thing
-    /// while making every future sink change a plumbing exercise. What the
-    /// other three sinks do is structural — `error`, `confirm` and
-    /// `confirm_default_yes` never call `info_enabled`, so there is no state
-    /// in which they could go quiet.
-    #[test]
-    fn quiet_suppresses_info_only() {
-        let _guard = VERBOSITY_MUTATION.lock().unwrap_or_else(|e| e.into_inner());
-        assert_eq!(verbosity(), Verbosity::Normal, "default must be Normal");
-        assert!(info_enabled());
-
-        set_verbosity(Verbosity::Quiet);
-        assert_eq!(verbosity(), Verbosity::Quiet);
-        assert!(!info_enabled(), "Quiet must silence Terminal::info");
-
-        set_verbosity(Verbosity::Normal);
-        assert!(info_enabled(), "Normal must restore informational output");
-    }
-
-    /// Every level survives the `u8` the global stores it in.
+    /// while making every future sink change a plumbing exercise. The
+    /// decisions are pure functions of the level, so nothing here touches the
+    /// process global — which is why this test can exist beside a `OnceLock`
+    /// that `main` writes exactly once.
     ///
-    /// This is what makes `verbosity`'s `u8` match honest. The walk is
-    /// wildcard-free, so a new level cannot compile without joining it; once
-    /// it has, this fails until `verbosity` decodes it too. Without the pair,
-    /// an unlisted level would read back as `Normal` and silently un-quiet
-    /// the program.
+    /// `error`, `confirm` and `confirm_default_yes` are absent because they
+    /// are not offered a level at all: they are on stderr, where `--quiet`
+    /// has never reached.
     #[test]
-    fn every_level_round_trips_through_the_stored_byte() {
-        let _guard = VERBOSITY_MUTATION.lock().unwrap_or_else(|e| e.into_inner());
-        let mut level = Some(Verbosity::Normal);
-        while let Some(current) = level {
-            set_verbosity(current);
-            assert_eq!(
-                verbosity(),
-                current,
-                "{current:?} must survive the u8 round trip"
-            );
-            level = current.next_level();
-        }
-        set_verbosity(Verbosity::Normal);
+    fn quiet_silences_stdout_except_notice() {
+        let msg = FaceMessage::ModelsRequired;
+        let text = "Models required. Run `facelock setup` to download them.";
+
+        assert_eq!(info_at(&msg, Verbosity::Normal), Some(text.to_string()));
+        assert_eq!(info_at(&msg, Verbosity::Quiet), None);
+
+        assert_eq!(payload_at("{}", Verbosity::Normal), Some("{}"));
+        assert_eq!(payload_at("{}", Verbosity::Quiet), None);
+
+        // The unsuppressible one: same text at either level.
+        assert_eq!(notice_at(&msg, Verbosity::Normal), Some(text.to_string()));
+        assert_eq!(
+            notice_at(&msg, Verbosity::Quiet),
+            Some(text.to_string()),
+            "notice exists to be seen; --quiet must not reach it"
+        );
     }
 
-    /// Held by every test that writes the process-global verbosity, so two of
-    /// them cannot interleave their mutate/restore sequences.
-    static VERBOSITY_MUTATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// An unwritten global reads as `Normal`, so a `main` that forgot
+    /// [`set_verbosity`] hides nothing rather than everything.
+    ///
+    /// Nothing in this crate's tests writes the `OnceLock`; if that changes,
+    /// this is the test that says the default stopped being observable.
+    #[test]
+    fn unset_verbosity_reads_as_normal() {
+        assert_eq!(Verbosity::default(), Verbosity::Normal);
+        assert_eq!(verbosity(), Verbosity::Normal);
+    }
 
     /// The answer hint is appended by the sink and the question alone is the
     /// msgid, so a translator cannot advertise an answer `read_answer` will
@@ -605,11 +686,25 @@ mod tests {
         );
     }
 
+    /// The domain list the sweeps below run over. Single-sited because it is
+    /// the one list here that no compiler checks: a new domain module joins
+    /// the seam by being added to this macro.
+    macro_rules! every_domain {
+        ($sweep:ident) => {{
+            $sweep::<AccessMessage>();
+            $sweep::<FaceMessage>();
+            $sweep::<StatusMessage>();
+            $sweep::<NotifyMessage>();
+            $sweep::<SetupMessage>();
+            $sweep::<DeviceMessage>();
+            $sweep::<DownloadMessage>();
+            $sweep::<SystemMessage>();
+            $sweep::<PamMessage>();
+        }};
+    }
+
     /// Every message in every domain renders with all placeholders
     /// substituted — a leftover `{name}` means a template/argument mismatch.
-    ///
-    /// The per-domain walks are compiler-checked for completeness; this list
-    /// of domains is the one thing that is not, so a new module goes here.
     #[test]
     fn no_unfilled_placeholders() {
         fn sweep<M: Message + Samples>() {
@@ -621,15 +716,40 @@ mod tests {
                 );
             }
         }
-        sweep::<AccessMessage>();
-        sweep::<FaceMessage>();
-        sweep::<StatusMessage>();
-        sweep::<NotifyMessage>();
-        sweep::<SetupMessage>();
-        sweep::<DeviceMessage>();
-        sweep::<DownloadMessage>();
-        sweep::<SystemMessage>();
-        sweep::<PamMessage>();
+        every_domain!(sweep);
+    }
+
+    /// Each domain's sample list holds one sample per variant.
+    ///
+    /// Two failures, which together are the whole of what [`Samples`]
+    /// guarantees (its doc comment says what is left over): a list that has
+    /// drifted from `VARIANT_COUNT`, and a list that names the same variant
+    /// twice — the copy-paste mistake that used to hide a variant from the
+    /// sweep above while still compiling.
+    #[test]
+    fn every_variant_has_a_sample() {
+        fn sweep<M: Message + Samples>() {
+            let samples = M::samples();
+            assert_eq!(
+                samples.len(),
+                M::VARIANT_COUNT,
+                "{} samples for {} variants — add the missing sample, or fix \
+                 VARIANT_COUNT if a variant was removed: {samples:?}",
+                samples.len(),
+                M::VARIANT_COUNT,
+            );
+            for (index, sample) in samples.iter().enumerate() {
+                for other in &samples[index + 1..] {
+                    assert_ne!(
+                        std::mem::discriminant(sample),
+                        std::mem::discriminant(other),
+                        "{sample:?} is sampled twice, so some variant is not \
+                         sampled at all"
+                    );
+                }
+            }
+        }
+        every_domain!(sweep);
     }
 
     /// The machine rendering names the variant and its data, and never goes

--- a/crates/facelock-cli/src/message/notify.rs
+++ b/crates/facelock-cli/src/message/notify.rs
@@ -65,26 +65,24 @@ impl From<&NotifyEvent> for NotifyMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for NotifyMessage {
-    fn first_sample() -> Self {
-        use NotifyMessage::*;
-        NotifyScanning
-    }
+    const VARIANT_COUNT: usize = 4;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use NotifyMessage::*;
-        Some(match self {
-            NotifyScanning => NotifyWelcome { label: s("l") },
-            NotifyWelcome { .. } => NotifyRecognized { similarity: 0.5 },
-            NotifyRecognized { .. } => NotifyAuthFailed { reason: s("r") },
-            NotifyAuthFailed { .. } => return None,
-        })
+        vec![
+            NotifyScanning,
+            NotifyWelcome { label: s("l") },
+            NotifyRecognized { similarity: 0.5 },
+            NotifyAuthFailed { reason: s("r") },
+        ]
     }
 }
 #[cfg(test)]

--- a/crates/facelock-cli/src/message/pam.rs
+++ b/crates/facelock-cli/src/message/pam.rs
@@ -296,86 +296,84 @@ impl Message for PamMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for PamMessage {
-    fn first_sample() -> Self {
-        use PamMessage::*;
-        PamSkippedFlag { dir: s("/d") }
-    }
+    const VARIANT_COUNT: usize = 34;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use PamMessage::*;
-        Some(match self {
-            PamSkippedFlag { .. } => PamModuleMissing { path: s("/p") },
-            PamModuleMissing { .. } => ConfiguringPamFor { service: s("sudo") },
-            ConfiguringPamFor { .. } => NoPamCandidates { dir: s("/d") },
-            NoPamCandidates { .. } => PamLinePreview {
+        vec![
+            PamSkippedFlag { dir: s("/d") },
+            PamModuleMissing { path: s("/p") },
+            ConfiguringPamFor { service: s("sudo") },
+            NoPamCandidates { dir: s("/d") },
+            PamLinePreview {
                 line: s("auth ..."),
             },
-            PamLinePreview { .. } => PromptSelectPamServices,
-            PromptSelectPamServices => PamConfigureFailed {
+            PromptSelectPamServices,
+            PamConfigureFailed {
                 service: s("sudo"),
                 error: s("e"),
             },
-            PamConfigureFailed { .. } => NoPamServicesSelected,
-            NoPamServicesSelected => PamFileNotFound { path: s("/p") },
-            PamFileNotFound { .. } => PamLineAlreadyPresent { path: s("/p") },
-            PamLineAlreadyPresent { .. } => PamInsertBeforeAuthHint,
-            PamInsertBeforeAuthHint => PamInsertAtTopHint,
-            PamInsertAtTopHint => PamModifyPreview {
+            NoPamServicesSelected,
+            PamFileNotFound { path: s("/p") },
+            PamLineAlreadyPresent { path: s("/p") },
+            PamInsertBeforeAuthHint,
+            PamInsertAtTopHint,
+            PamModifyPreview {
                 path: s("/p"),
                 line: s("auth"),
                 hint: s("h"),
                 backup: s("/b"),
             },
-            PamModifyPreview { .. } => ConfirmProceed,
-            ConfirmProceed => PamSkippedFile { path: s("/p") },
-            PamSkippedFile { .. } => PamBackedUp {
+            ConfirmProceed,
+            PamSkippedFile { path: s("/p") },
+            PamBackedUp {
                 path: s("/p"),
                 backup: s("/b"),
             },
-            PamBackedUp { .. } => PamInstalled {
+            PamInstalled {
                 path: s("/p"),
                 backup: s("/b"),
                 service: s("sudo"),
             },
-            PamInstalled { .. } => PamRemoved { path: s("/p") },
-            PamRemoved { .. } => PamNoLineFound { path: s("/p") },
-            PamNoLineFound { .. } => PamServiceAbsent { path: s("/p") },
-            PamServiceAbsent { .. } => PamBackupExists {
+            PamRemoved { path: s("/p") },
+            PamNoLineFound { path: s("/p") },
+            PamServiceAbsent { path: s("/p") },
+            PamBackupExists {
                 path: s("/p"),
                 backup: s("/b"),
             },
-            PamBackupExists { .. } => PamExtensionHint {
+            PamExtensionHint {
                 line: s("auth ..."),
             },
-            PamExtensionHint { .. } => PamInvalidServiceName { service: s("../x") },
-            PamInvalidServiceName { .. } => PamSensitiveRefused {
+            PamInvalidServiceName { service: s("../x") },
+            PamSensitiveRefused {
                 service: s("sshd"),
                 remedy: s("--allow-sensitive"),
             },
-            PamSensitiveRefused { .. } => PamModuleNotInstalled { path: s("/p") },
-            PamModuleNotInstalled { .. } => PamServiceAbsentSkipped { path: s("/p") },
-            PamServiceAbsentSkipped { .. } => PamPlanAdd {
+            PamModuleNotInstalled { path: s("/p") },
+            PamServiceAbsentSkipped { path: s("/p") },
+            PamPlanAdd {
                 path: s("/p"),
                 hint: s("h"),
             },
-            PamPlanAdd { .. } => PamPlanRemove { path: s("/p") },
-            PamPlanRemove { .. } => PamPlanNoChange { path: s("/p") },
-            PamPlanNoChange { .. } => PamPlanAbsent { path: s("/p") },
-            PamPlanAbsent { .. } => PamStatusPresent { path: s("/p") },
-            PamStatusPresent { .. } => PamStatusMissing { path: s("/p") },
-            PamStatusMissing { .. } => PamStatusAbsent { path: s("/p") },
-            PamStatusAbsent { .. } => PamStatusUnknown {
+            PamPlanRemove { path: s("/p") },
+            PamPlanNoChange { path: s("/p") },
+            PamPlanAbsent { path: s("/p") },
+            PamStatusPresent { path: s("/p") },
+            PamStatusMissing { path: s("/p") },
+            PamStatusAbsent { path: s("/p") },
+            PamStatusUnknown {
                 path: s("/p"),
                 error: s("e"),
             },
-            PamStatusUnknown { .. } => return None,
-        })
+        ]
     }
 }

--- a/crates/facelock-cli/src/message/setup.rs
+++ b/crates/facelock-cli/src/message/setup.rs
@@ -396,107 +396,105 @@ impl Message for SetupMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SetupMessage {
-    fn first_sample() -> Self {
-        use SetupMessage::*;
-        SetupIntro { version: s("1.0") }
-    }
+    const VARIANT_COUNT: usize = 71;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use SetupMessage::*;
-        Some(match self {
-            SetupIntro { .. } => SetupStepCamera,
-            SetupStepCamera => SetupStepModelQuality,
-            SetupStepModelQuality => SetupStepInferenceDevice,
-            SetupStepInferenceDevice => SetupStepModelDownload,
-            SetupStepModelDownload => SetupStepEncryption,
-            SetupStepEncryption => SetupStepEnrollment,
-            SetupStepEnrollment => SetupStepEnrollmentSkipped,
-            SetupStepEnrollmentSkipped => SetupStepTest,
-            SetupStepTest => SetupStepTestSkipped,
-            SetupStepTestSkipped => SetupStepDaemon,
-            SetupStepDaemon => SetupStepPam,
-            SetupStepPam => SetupCompleteHeader,
-            SetupCompleteHeader => CameraStepFailed {
+        vec![
+            SetupIntro { version: s("1.0") },
+            SetupStepCamera,
+            SetupStepModelQuality,
+            SetupStepInferenceDevice,
+            SetupStepModelDownload,
+            SetupStepEncryption,
+            SetupStepEnrollment,
+            SetupStepEnrollmentSkipped,
+            SetupStepTest,
+            SetupStepTestSkipped,
+            SetupStepDaemon,
+            SetupStepPam,
+            SetupCompleteHeader,
+            CameraStepFailed {
                 error: s("e"),
                 current: s("c"),
             },
-            CameraStepFailed { .. } => ModelQualityStepFailed {
+            ModelQualityStepFailed {
                 error: s("e"),
                 current: s("c"),
             },
-            ModelQualityStepFailed { .. } => InferenceStepFailed {
+            InferenceStepFailed {
                 error: s("e"),
                 current: s("c"),
             },
-            InferenceStepFailed { .. } => ModelDownloadStepFailed { error: s("e") },
-            ModelDownloadStepFailed { .. } => EncryptionStepFailed { error: s("e") },
-            EncryptionStepFailed { .. } => EnrollStepFailed { error: s("e") },
-            EnrollStepFailed { .. } => TestStepFailed { error: s("e") },
-            TestStepFailed { .. } => SystemdStepFailed { error: s("e") },
-            SystemdStepFailed { .. } => GroupStepFailed { error: s("e") },
-            GroupStepFailed { .. } => PamStepFailed { error: s("e") },
-            PamStepFailed { .. } => ConfirmEnrollNow,
-            ConfirmEnrollNow => EnrollSkipped,
-            EnrollSkipped => ConfirmTestRecognition,
-            ConfirmTestRecognition => TestSkipped,
-            TestSkipped => SummaryCamera { value: s("v") },
-            SummaryCamera { .. } => SummaryModels {
+            ModelDownloadStepFailed { error: s("e") },
+            EncryptionStepFailed { error: s("e") },
+            EnrollStepFailed { error: s("e") },
+            TestStepFailed { error: s("e") },
+            SystemdStepFailed { error: s("e") },
+            GroupStepFailed { error: s("e") },
+            PamStepFailed { error: s("e") },
+            ConfirmEnrollNow,
+            EnrollSkipped,
+            ConfirmTestRecognition,
+            TestSkipped,
+            SummaryCamera { value: s("v") },
+            SummaryModels {
                 dir: s("/d"),
                 quality: s("q"),
             },
-            SummaryModels { .. } => SummaryInference { value: s("v") },
-            SummaryInference { .. } => SummaryDatabase { value: s("v") },
-            SummaryDatabase { .. } => SummaryEncryption { value: s("v") },
-            SummaryEncryption { .. } => SummaryDaemon { status: s("st") },
-            SummaryDaemon { .. } => DaemonStatusNotConfiguredNoSystemd,
-            DaemonStatusNotConfiguredNoSystemd => DaemonStatusDeferred,
-            DaemonStatusDeferred => DaemonStatusEnabled,
-            DaemonStatusEnabled => DaemonStatusNotConfigured,
-            DaemonStatusNotConfigured => SummaryPam {
+            SummaryInference { value: s("v") },
+            SummaryDatabase { value: s("v") },
+            SummaryEncryption { value: s("v") },
+            SummaryDaemon { status: s("st") },
+            DaemonStatusNotConfiguredNoSystemd,
+            DaemonStatusDeferred,
+            DaemonStatusEnabled,
+            DaemonStatusNotConfigured,
+            SummaryPam {
                 services: s("sudo"),
             },
-            SummaryPam { .. } => SummaryPamSkipped,
-            SummaryPamSkipped => SummaryPamNone,
-            SummaryPamNone => SummaryFaceEnrolled,
-            SummaryFaceEnrolled => SummaryFaceNotEnrolledNoEnroll,
-            SummaryFaceNotEnrolledNoEnroll => SummaryFaceNotEnrolled,
-            SummaryFaceNotEnrolled => NonInteractivePreparing,
-            NonInteractivePreparing => CheckingModels { count: 2 },
-            CheckingModels { .. } => SetupCompleteShort,
-            SetupCompleteShort => SetupCompleteEnroll,
-            SetupCompleteEnroll => DirectoriesCreated,
-            DirectoriesCreated => CreatedDefaultConfig { path: s("/c") },
-            CreatedDefaultConfig { .. } => EnrollingFace,
-            EnrollingFace => EncryptionIntro,
-            EncryptionIntro => TpmDetected,
-            TpmDetected => TpmSealedKeyPresent { path: s("/k") },
-            TpmSealedKeyPresent { .. } => GeneratingTpmSealedKey,
-            GeneratingTpmSealedKey => TpmSealedKeyWritten { path: s("/k") },
-            TpmSealedKeyWritten { .. } => EncryptionEnabledTpm,
-            EncryptionEnabledTpm => KeyfilePresent { path: s("/k") },
-            KeyfilePresent { .. } => GeneratingKeyfile,
-            GeneratingKeyfile => KeyfileWritten { path: s("/k") },
-            KeyfileWritten { .. } => EncryptionEnabledKeyfile,
-            EncryptionEnabledKeyfile => EncryptionDisabledWarning,
-            EncryptionDisabledWarning => EncryptionAlreadyConfigured { method: s("Tpm") },
-            EncryptionAlreadyConfigured { .. } => GeneratedTpmKeyAt { path: s("/k") },
-            GeneratedTpmKeyAt { .. } => EncryptionEnabledTpmAuto,
-            EncryptionEnabledTpmAuto => GeneratedKeyfileAt { path: s("/k") },
-            GeneratedKeyfileAt { .. } => EncryptionEnabledKeyfileAuto,
-            EncryptionEnabledKeyfileAuto => OrphanModelsWarning { db_path: s("/db") },
-            OrphanModelsWarning { .. } => OrphanModelsRemoved { count: 2 },
-            OrphanModelsRemoved { .. } => HyprlockHint,
-            HyprlockHint => HyprlockApplied { user: s("u") },
-            HyprlockApplied { .. } => BlankLine,
-            BlankLine => return None,
-        })
+            SummaryPamSkipped,
+            SummaryPamNone,
+            SummaryFaceEnrolled,
+            SummaryFaceNotEnrolledNoEnroll,
+            SummaryFaceNotEnrolled,
+            NonInteractivePreparing,
+            CheckingModels { count: 2 },
+            SetupCompleteShort,
+            SetupCompleteEnroll,
+            DirectoriesCreated,
+            CreatedDefaultConfig { path: s("/c") },
+            EnrollingFace,
+            EncryptionIntro,
+            TpmDetected,
+            TpmSealedKeyPresent { path: s("/k") },
+            GeneratingTpmSealedKey,
+            TpmSealedKeyWritten { path: s("/k") },
+            EncryptionEnabledTpm,
+            KeyfilePresent { path: s("/k") },
+            GeneratingKeyfile,
+            KeyfileWritten { path: s("/k") },
+            EncryptionEnabledKeyfile,
+            EncryptionDisabledWarning,
+            EncryptionAlreadyConfigured { method: s("Tpm") },
+            GeneratedTpmKeyAt { path: s("/k") },
+            EncryptionEnabledTpmAuto,
+            GeneratedKeyfileAt { path: s("/k") },
+            EncryptionEnabledKeyfileAuto,
+            OrphanModelsWarning { db_path: s("/db") },
+            OrphanModelsRemoved { count: 2 },
+            HyprlockHint,
+            HyprlockApplied { user: s("u") },
+            BlankLine,
+        ]
     }
 }
 
@@ -513,7 +511,7 @@ mod tests {
     /// change is a separate decision with its own review, because container
     /// suites and downstream integrations grep this output.
     #[test]
-    fn english_fallback_is_byte_identical() {
+    fn setup_fallback_is_byte_identical() {
         use SetupMessage::*;
 
         // -- bootstrap --

--- a/crates/facelock-cli/src/message/status.rs
+++ b/crates/facelock-cli/src/message/status.rs
@@ -222,81 +222,79 @@ impl Message for StatusMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for StatusMessage {
-    fn first_sample() -> Self {
-        use StatusMessage::*;
-        StatusHeader
-    }
+    const VARIANT_COUNT: usize = 56;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use StatusMessage::*;
-        Some(match self {
-            StatusHeader => StatusLabelConfigFile,
-            StatusLabelConfigFile => StatusLabelDaemon,
-            StatusLabelDaemon => StatusLabelOneshotFallback,
-            StatusLabelOneshotFallback => StatusLabelCameraDevice,
-            StatusLabelCameraDevice => StatusLabelModelDirectory,
-            StatusLabelModelDirectory => StatusLabelExecutionProvider,
-            StatusLabelExecutionProvider => StatusLabelEncryption,
-            StatusLabelEncryption => StatusLabelEnrolledFaces,
-            StatusLabelEnrolledFaces => StatusLabelSecurity,
-            StatusLabelSecurity => StatusLabelNotifications,
-            StatusLabelNotifications => StatusLabelPamModule,
-            StatusLabelPamModule => StatusUnknown { why: s("w") },
-            StatusUnknown { .. } => StatusWhyConfigNotAvailable,
-            StatusWhyConfigNotAvailable => StatusConfigValid,
-            StatusConfigValid => StatusConfigNotFound,
-            StatusConfigNotFound => StatusConfigInvalid { error: s("e") },
-            StatusConfigInvalid { .. } => StatusDaemonOneshot,
-            StatusDaemonOneshot => StatusDaemonResponding,
-            StatusDaemonResponding => StatusDaemonNotResponding { error: s("e") },
-            StatusDaemonNotResponding { .. } => StatusFallbackUsable,
-            StatusFallbackUsable => StatusFallbackNotUsable,
-            StatusFallbackNotUsable => StatusCameraDeviceExists,
-            StatusCameraDeviceExists => StatusCameraDeviceNotFound,
-            StatusCameraDeviceNotFound => StatusCameraAutoDetect,
-            StatusCameraAutoDetect => StatusModelsDirNotFound,
-            StatusModelsDirNotFound => StatusModelsAllPresent,
-            StatusModelsAllPresent => StatusModelsSomeMissing,
-            StatusModelsSomeMissing => StatusPresent,
-            StatusPresent => StatusMissing,
-            StatusMissing => StatusEpSupported,
-            StatusEpSupported => StatusEpNotBuiltIn,
-            StatusEpNotBuiltIn => StatusEpUnknownName,
-            StatusEpUnknownName => StatusEpUnqueryable { error: s("e") },
-            StatusEpUnqueryable { .. } => StatusSealedKey { path: s("/p") },
-            StatusSealedKey { .. } => StatusSealedKeyMissing { path: s("/p") },
-            StatusSealedKeyMissing { .. } => StatusTpmDeviceMissing { path: s("/p") },
-            StatusTpmDeviceMissing { .. } => StatusKeyFile { path: s("/p") },
-            StatusKeyFile { .. } => StatusKeyFileMissing { path: s("/p") },
-            StatusKeyFileMissing { .. } => StatusPlaintextEmbeddings,
-            StatusPlaintextEmbeddings => StatusNoFacesEnrolled,
-            StatusNoFacesEnrolled => StatusModelCount { count: 2 },
-            StatusModelCount { .. } => StatusMarkerMismatch {
+        vec![
+            StatusHeader,
+            StatusLabelConfigFile,
+            StatusLabelDaemon,
+            StatusLabelOneshotFallback,
+            StatusLabelCameraDevice,
+            StatusLabelModelDirectory,
+            StatusLabelExecutionProvider,
+            StatusLabelEncryption,
+            StatusLabelEnrolledFaces,
+            StatusLabelSecurity,
+            StatusLabelNotifications,
+            StatusLabelPamModule,
+            StatusUnknown { why: s("w") },
+            StatusWhyConfigNotAvailable,
+            StatusConfigValid,
+            StatusConfigNotFound,
+            StatusConfigInvalid { error: s("e") },
+            StatusDaemonOneshot,
+            StatusDaemonResponding,
+            StatusDaemonNotResponding { error: s("e") },
+            StatusFallbackUsable,
+            StatusFallbackNotUsable,
+            StatusCameraDeviceExists,
+            StatusCameraDeviceNotFound,
+            StatusCameraAutoDetect,
+            StatusModelsDirNotFound,
+            StatusModelsAllPresent,
+            StatusModelsSomeMissing,
+            StatusPresent,
+            StatusMissing,
+            StatusEpSupported,
+            StatusEpNotBuiltIn,
+            StatusEpUnknownName,
+            StatusEpUnqueryable { error: s("e") },
+            StatusSealedKey { path: s("/p") },
+            StatusSealedKeyMissing { path: s("/p") },
+            StatusTpmDeviceMissing { path: s("/p") },
+            StatusKeyFile { path: s("/p") },
+            StatusKeyFileMissing { path: s("/p") },
+            StatusPlaintextEmbeddings,
+            StatusNoFacesEnrolled,
+            StatusModelCount { count: 2 },
+            StatusMarkerMismatch {
                 marker: 3,
                 store: 2,
             },
-            StatusMarkerMismatch { .. } => StatusMarkerUnreadable { why: s("w") },
-            StatusMarkerUnreadable { .. } => StatusSecurityDisabled,
-            StatusSecurityDisabled => StatusYes,
-            StatusYes => StatusNo,
-            StatusNo => StatusNotifyOff,
-            StatusNotifyOff => StatusNotifyTerminal,
-            StatusNotifyTerminal => StatusNotifyDesktop,
-            StatusNotifyDesktop => StatusNotifyBoth,
-            StatusNotifyBoth => StatusPamInstalled,
-            StatusPamInstalled => StatusPamInstalledAt { path: s("/p") },
-            StatusPamInstalledAt { .. } => StatusPamNotInstalled,
-            StatusPamNotInstalled => StatusPamSudoConfigured,
-            StatusPamSudoConfigured => StatusPamSudoNotConfigured,
-            StatusPamSudoNotConfigured => return None,
-        })
+            StatusMarkerUnreadable { why: s("w") },
+            StatusSecurityDisabled,
+            StatusYes,
+            StatusNo,
+            StatusNotifyOff,
+            StatusNotifyTerminal,
+            StatusNotifyDesktop,
+            StatusNotifyBoth,
+            StatusPamInstalled,
+            StatusPamInstalledAt { path: s("/p") },
+            StatusPamNotInstalled,
+            StatusPamSudoConfigured,
+            StatusPamSudoNotConfigured,
+        ]
     }
 }
 

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -99,43 +99,41 @@ impl Message for SystemMessage {
     }
 }
 
-/// One sample per variant, in enum order, for the placeholder sweep.
+/// One sample per variant, in enum order, for the sweeps in [`super::Samples`].
 ///
-/// [`Self::next_sample`] is an exhaustive `match` with no wildcard arm, so a
-/// new variant stops this compiling until it is given a sample and linked
-/// into the walk — the sweep cannot silently fall behind the vocabulary.
+/// The list is flat, so it cannot cycle and cannot name a variant twice
+/// without saying so; `VARIANT_COUNT` is what fails the sweep when a new
+/// variant is not sampled at all. The compiler's share of this is `localized`
+/// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    fn first_sample() -> Self {
-        use SystemMessage::*;
-        ConfirmDaemonMode
-    }
+    const VARIANT_COUNT: usize = 19;
 
-    fn next_sample(&self) -> Option<Self> {
+    fn samples() -> Vec<Self> {
         use SystemMessage::*;
-        Some(match self {
-            ConfirmDaemonMode => SystemdNotDetected,
-            SystemdNotDetected => SystemdDeclined,
-            SystemdDeclined => SystemdSkippedFlag,
-            SystemdSkippedFlag => SystemdDeferred,
-            SystemdDeferred => CreatingFacelockGroup,
-            CreatingFacelockGroup => GroupMembershipNote,
-            GroupMembershipNote => AlreadyInGroup { user: s("u") },
-            AlreadyInGroup { .. } => ConfirmAddToGroup { user: s("u") },
-            ConfirmAddToGroup { .. } => GroupAddSkipped { user: s("u") },
-            GroupAddSkipped { .. } => AddedToGroup { user: s("u") },
-            AddedToGroup { .. } => DisablingSystemdUnits,
-            DisablingSystemdUnits => SystemdUnitsDisabled,
-            SystemdUnitsDisabled => InstallingSystemdUnits,
-            InstallingSystemdUnits => WroteFile { path: s("/p") },
-            WroteFile { .. } => RefreshedLegacyFile { path: s("/p") },
-            RefreshedLegacyFile { .. } => SystemctlDaemonReloadDone,
-            SystemctlDaemonReloadDone => SystemctlEnableDone {
+        vec![
+            ConfirmDaemonMode,
+            SystemdNotDetected,
+            SystemdDeclined,
+            SystemdSkippedFlag,
+            SystemdDeferred,
+            CreatingFacelockGroup,
+            GroupMembershipNote,
+            AlreadyInGroup { user: s("u") },
+            ConfirmAddToGroup { user: s("u") },
+            GroupAddSkipped { user: s("u") },
+            AddedToGroup { user: s("u") },
+            DisablingSystemdUnits,
+            SystemdUnitsDisabled,
+            InstallingSystemdUnits,
+            WroteFile { path: s("/p") },
+            RefreshedLegacyFile { path: s("/p") },
+            SystemctlDaemonReloadDone,
+            SystemctlEnableDone {
                 unit: s("u.service"),
             },
-            SystemctlEnableDone { .. } => DbusActivationEnabled,
-            DbusActivationEnabled => return None,
-        })
+            DbusActivationEnabled,
+        ]
     }
 }
 
@@ -147,7 +145,7 @@ mod tests {
     /// printed. `facelock setup --systemd` is a scripted entry point
     /// (packaging, Omarchy), so these lines are read by more than humans.
     #[test]
-    fn english_fallback_is_byte_identical() {
+    fn system_fallback_is_byte_identical() {
         use SystemMessage::*;
 
         assert_eq!(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,13 +9,17 @@ The following flags are accepted by every subcommand (declared `global = true`):
 | Flag | Description |
 |------|-------------|
 | `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
-| `-q`, `--quiet` | Suppress informational output on stdout. Errors (stderr), prompts and exit codes are unaffected. |
+| `-q`, `--quiet` | Suppress stdout: informational text, and on commands whose stdout is the payload, the payload too. Errors (stderr), prompts and exit codes are unaffected. |
 
-`--quiet` is complete for `facelock setup` except the PAM extension hint, which
-[#174](https://github.com/tyvsmith/facelock/issues/174) converts along with the
-rest of that region. Other commands still print some output directly rather than
-through the message seam the flag gates, so they stay partly noisy until
-[#140](https://github.com/tyvsmith/facelock/issues/140) is finished.
+`--quiet` is complete for every command whose output goes through the message
+seam: `setup`, `status`, `enroll`, `test`, `remove`, `clear`, `is-enrolled`,
+`capabilities`, `pam`, and the `--json` payloads of `list` and `devices`. Nine
+commands still print human text directly and stay noisy under it until
+[#140](https://github.com/tyvsmith/facelock/issues/140) is finished — `bench`,
+`tpm`, `reseal`, `encrypt`, `decrypt`, `config`, `restart`, `hyprlock` and
+`audit` — as do the human tables of `list` and `devices`. `preview --json` is
+not on either list: its frame stream is stdout by design and `--quiet` is
+documented not to reach it.
 
 ## Machine-readable output
 
@@ -31,11 +35,11 @@ Output".
 
 The payload goes to stdout and nothing else does — diagnostics are on stderr
 whatever `RUST_LOG` says — so `facelock devices --json` is safe to pipe at any
-log level. On `is-enrolled`, `capabilities` and `pam`, `--quiet` suppresses the
-payload too, leaving the exit code as the whole answer; `list`, `devices` and
-`preview` still print theirs directly rather than through the seam the flag
-gates, so they stay noisy until
-[#140](https://github.com/tyvsmith/facelock/issues/140) is finished.
+log level. `--quiet` suppresses the payload, leaving the exit code as the whole
+answer, on every one of these except `preview`, whose frame stream runs until
+interrupted and would otherwise become a command that prints nothing forever.
+**This changed:** `list --json --quiet` and `devices --json --quiet` used to
+print their payload and now print nothing; the exit code is unchanged.
 
 ## facelock setup
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -116,14 +116,27 @@ JSON (#149).
 An unparseable `RUST_LOG` is reported at WARN (on stderr) and the built-in
 filter is used, rather than the value being silently discarded.
 
-**`--quiet` suppresses informational stdout only; errors and exit codes are
-unchanged.** A quiet run that fails still says why on stderr and still exits
-non-zero, and prompts are unaffected — a silenced question is a hang, not a
-quieter program. This generalizes `is-enrolled --quiet`, which has always meant
-"leave only the exit code". The flag is read once at the message sink
-(`message::set_verbosity`), so it covers every command whose output goes
-through that seam; commands still printing directly are tracked by
-[#140](https://github.com/tyvsmith/facelock/issues/140).
+**`--quiet` suppresses informational chatter, and on commands whose stdout is
+the payload, the payload too; errors, prompts and exit codes are unchanged.** A
+quiet run that fails still says why on stderr and still exits non-zero, and a
+prompt still asks — a silenced question is a hang, not a quieter program. This
+is `is-enrolled --quiet`'s rule ("leave only the exit code") generalized to
+every payload: `facelock --quiet devices --json` writes nothing on stdout, and
+the exit code is the answer. `list --json` and `devices --json` printed their
+payload under `--quiet` before this rule; they no longer do.
+
+The flag is read once, by the two suppressible stdout sinks of the message seam
+— `Terminal::info` for human text, `message::payload` for machine output — so
+no command implements it and no command can forget it. There is a third stdout
+sink, `Terminal::notice`, which `--quiet` deliberately does not reach: it is
+for the human lines that must be seen and must stay on stdout (rollback
+instructions, the plaintext-embeddings warning). The messages that belong on it
+move across as part of [#140](https://github.com/tyvsmith/facelock/issues/140),
+which also tracks the commands still printing human text directly.
+
+`preview --json` is the one payload outside this rule: it emits a document per
+frame until interrupted, so silencing it would leave a command that produces
+nothing forever.
 
 ### CLI Machine Output
 
@@ -160,10 +173,13 @@ is a schema question rather than a flag question, since nothing in `health.rs`
 derives `Serialize` yet, and it is tracked separately.
 
 Machine output does not pass through the translation seam: every `--json`
-payload is built with `serde_json` and is C-locale by construction. The one
-documented exception is `pam`'s `error` field, which can interpolate a
-`strerror` string (see "facelock pam Semantics"), and which is a diagnostic
-rather than something to branch on.
+payload is built with `serde_json` and is C-locale by construction. It reaches
+stdout through `message::payload`, which takes an already-rendered `&str` and
+consults no catalog, so routing a payload through the seam to pick up `--quiet`
+cannot translate it on the way. The one documented exception to the C-locale
+rule is `pam`'s `error` field, which can interpolate a `strerror` string (see
+"facelock pam Semantics"), and which is a diagnostic rather than something to
+branch on.
 
 ### facelock setup Flag Composition
 


### PR DESCRIPTION
## Summary

- add `message::payload(&str)`: the one stdout sink for machine output, unlocalized, silenced by `--quiet`; route `is-enrolled`, `capabilities`, `pam --json`, `list --json`, `devices --json` through it and drop their `quiet` parameters
- add `Terminal::notice`: stdout, localized, never suppressed (no call sites yet; the stacked PAM PR moves the rollback advice and prompt context onto it)
- replace the `Samples` linked-list walk with a flat `samples()` + `VARIANT_COUNT`, checked for count and duplicate discriminants; state the real guarantee in the docs
- store `Verbosity` in a `OnceLock`, make the stdout gates pure functions, drop the decode/round-trip/mutex machinery
- `preview/text_only.rs`: `#![deny(clippy::print_stdout)]` plus a scan that no seam stdout sink is used there; the frame stream is the documented `--quiet` exception (runs until interrupted)
- **behaviour change:** `list --json -q` and `devices --json -q` now print nothing; one rule: `--quiet` suppresses stdout, the exit code is the answer

## Why

`--quiet` was implemented three times and skipped twice, and #140's remedy
("route through the seam") could not apply to payloads because the seam
localizes. The `Samples` walk's comments promised a compile-time guarantee the
linked list did not give.

## Validation

- `just check`
- byte comparison against `main` for `capabilities`, `is-enrolled`, `pam status` (human and `--json`, with and without `-q`): identical rc, stdout, stderr
- every `*_fallback_is_byte_identical` pin unchanged; `just pot` msgid-clean
- `VARIANT_COUNT` cross-checked against the nine enum declarations

Refs #140
