### PR TITLE
docs(contracts): Name all eight gated PAM services and pin the list

### DIFF
--- a/crates/facelock-cli/src/conformance/docs.rs
+++ b/crates/facelock-cli/src/conformance/docs.rs
@@ -25,6 +25,12 @@ const BOOK_CLI_DOC: &str = include_str!("../../../../book/src/cli-reference.md")
 /// The man page. Matched only through [`unescaped_man_page`].
 const MAN_PAGE: &str = include_str!("../../../../man/facelock.1");
 
+/// The contract document. Not a CLI reference — it is the normative copy of
+/// the rules the references paraphrase, so a list that decides behaviour
+/// (which PAM services the sensitive gate covers) is checked against it
+/// rather than against prose that is allowed to summarize.
+const CONTRACTS_DOC: &str = include_str!("../../../../docs/contracts.md");
+
 /// Both prose copies of the CLI reference, by repository path so a failure
 /// names the file that is missing the entry rather than just the entry.
 const MARKDOWN_REFERENCES: &[(&str, &str)] = &[
@@ -51,6 +57,26 @@ fn section_of<'a>(doc: &'a str, heading: &str) -> &'a str {
         Some(end) => &body[..end],
         None => body,
     }
+}
+
+/// The body of one `###` subsection, ending at the next heading of the same
+/// level or higher.
+///
+/// [`section_of`] stops only at a `##`, which is right for `docs/cli.md` and
+/// wrong here: `### facelock pam Semantics` would run on through
+/// `### facelock capabilities` and two more subsections, and a check scoped
+/// to it could be satisfied by text describing a different command.
+fn subsection_of<'a>(doc: &'a str, heading: &str) -> &'a str {
+    let start = doc
+        .find(heading)
+        .unwrap_or_else(|| panic!("`{}` is missing from the document", heading.trim()));
+    let body = &doc[start + heading.len()..];
+    let end = [body.find("\n## "), body.find("\n### ")]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(body.len());
+    &body[..end]
 }
 
 /// Every subcommand the binary offers is written down.
@@ -321,6 +347,56 @@ fn docs_references_name_every_gated_service() {
             );
         }
     }
+}
+
+/// The contract's own list of gated services is the whole list.
+///
+/// `docs/contracts.md` is where an operator looks up which service names
+/// need `--allow-sensitive`, and it enumerates them rather than pointing at
+/// the code — so a name missing from the sentence reads as a name that does
+/// not need the flag. The list has already grown once past what the prose
+/// said: `system-auth-ac` and `password-auth-ac` joined
+/// [`SENSITIVE_SERVICES`] for the files RHEL's older `authconfig` leaves
+/// behind, and the section went on claiming six for both.
+///
+/// Stricter than [`docs_references_name_every_gated_service`] in the two
+/// ways that matter for a normative document: the name must appear inside
+/// `### facelock pam Semantics` rather than anywhere in the file, and it
+/// must be marked up as code, so "logins are audited" cannot stand in for
+/// `login`.
+#[test]
+fn contracts_name_every_gated_service() {
+    use facelock_cli::commands::pam::SENSITIVE_SERVICES;
+
+    let section = subsection_of(CONTRACTS_DOC, "\n### facelock pam Semantics\n");
+
+    for service in SENSITIVE_SERVICES {
+        assert!(
+            section.contains(&format!("`{service}`")),
+            "`{service}` is gated by SENSITIVE_SERVICES but the \
+             `### facelock pam Semantics` section of docs/contracts.md never \
+             names it"
+        );
+    }
+
+    // The names alone would not have caught the rot this test was written
+    // for. `system-auth-ac` and `password-auth-ac` were already named a few
+    // paragraphs up, in the symlink rule that explains why they are on the
+    // list, while the sentence that enumerates the gate went on saying six.
+    // So the size is pinned too, in the one spelling the section uses.
+    const COUNTS: &[&str] = &[
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+    ];
+    let count = COUNTS
+        .get(SENSITIVE_SERVICES.len())
+        .expect("SENSITIVE_SERVICES outgrew the numerals this check spells");
+    assert!(
+        section.contains(&format!("of the {count}")),
+        "SENSITIVE_SERVICES holds {} services but the `### facelock pam \
+         Semantics` section of docs/contracts.md never says \"of the {count}\" \
+         — the count in the prose is stale",
+        SENSITIVE_SERVICES.len()
+    );
 }
 
 /// No example installs into a gated PAM service without the flag that

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -319,13 +319,17 @@ edit, which nothing in this command deletes.
 
 **`--no-confirm` never implies `--allow-sensitive`.** They are separate
 authorizations: "do not ask me" and "yes, edit the shared auth stack". The
-gated services are `common-auth`, `login`, `password-auth`, `sshd`,
-`system-auth` and `system-login`. Four of the six are *shared stacks* — files
-that other service files `include`, so one edit reaches `su`, `passwd`, `chsh`
-and the display manager at once — and which name a distribution uses is the
-only difference between them (`system-auth`/`password-auth` on Fedora, RHEL and
-Arch, `common-auth` on Debian and Ubuntu, `system-login` on Arch). Gating one
-spelling made the gate depend on the operator's distribution. `--yes` and
+gated services are `common-auth`, `login`, `password-auth`,
+`password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac` and
+`system-login`. Six of the eight are *shared stacks* — files that other
+service files `include`, so one edit reaches `su`, `passwd`, `chsh` and the
+display manager at once — and which name a distribution uses is the only
+difference between them (`system-auth`/`password-auth` on Fedora, RHEL and
+Arch, the `-ac` spellings where `authconfig` wrote the real file,
+`common-auth` on Debian and Ubuntu, `system-login` on Arch). Gating one
+spelling made the gate depend on the operator's distribution. `login` and
+`sshd` are the two that are not: each locks one specific door — the TTY, the
+network — rather than every one at once. `--yes` and
 `--no-confirm` are the same flag (the shared `ConfirmArg` spelling, so "skip
 prompts" reads the same on `pam add` as on `remove` and `clear`) and neither
 unlocks the gate. `setup --yes` keeps the combined meaning and is the sole


### PR DESCRIPTION
- name all eight gated PAM services in `contracts.md` (one sentence still said six after #194)
- pin the list and the count word with `contracts_name_every_gated_service`
