### PR TITLE
fix(cli): Default the CLI to warn and add -v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The CLI defaults to `warn`, and the daemon still logs at `info`.** Every
+  command used to emit INFO on stderr, so the setup wizard's questions arrived
+  interleaved with timestamped log lines and a run that was succeeding looked
+  broken. Diagnostics now start at `warn`, and the new global `-v` raises them
+  one step per repeat (`-v` info, `-vv` debug, `-vvv` trace). `facelock daemon
+  run` is unchanged at `info`, because it writes to the journal, where nothing
+  competes with it. `RUST_LOG` still outranks both, and unlike the environment
+  variable, `-v` survives `sudo`. Exit codes and stdout payloads are untouched
+  at every level, and every degradation worth acting on was already WARN or
+  above.
 - **`--quiet` has one implementation and one meaning** (#179/#193): it
   suppresses informational stdout and, on a command whose stdout is the payload,
   the payload too, so `facelock --quiet devices --json` writes nothing and the

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -12,9 +12,17 @@ either side of the subcommand name — `facelock -c X daemon` and
 |------|-------------|
 | `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
 | `-q`, `--quiet` | Suppress informational stdout; errors, prompts and exit codes are unchanged. |
+| `-v`, `--verbose` | Raise diagnostic verbosity on stderr, one level per repeat. The CLI starts at `warn`, `daemon run` at `info`. `RUST_LOG` overrides it. |
 
-No subcommand re-declares either one. Flag spelling in general is pinned by the
-`cli_flag_conformance` test — see [Contracts](contracts.md), "CLI Flag
+Diagnostics default to `warn`, so stderr carries warnings and errors and
+nothing quieter. `-v` raises the level one step per repeat, `facelock daemon
+run` keeps `info` because it writes to the journal, and `RUST_LOG` outranks
+both. The level changes output volume only: exit codes and stdout payloads are
+identical at every level. `--quiet` and `-v` govern different streams, so
+`--quiet -v` gives a silent report with loud diagnostics.
+
+No subcommand re-declares any of the three. Flag spelling in general is pinned
+by the `cli_flag_conformance` test — see [Contracts](contracts.md), "CLI Flag
 Spelling", for the invariants and the short-letter registry.
 
 ## facelock setup
@@ -668,4 +676,4 @@ For commands that accept `--user`:
 | Variable | Purpose |
 |----------|---------|
 | `FACELOCK_CONFIG` | Override config file path for unprivileged CLI commands. Ignored by privileged PAM/root auth flows; use `--config` there. |
-| `RUST_LOG` | Control log verbosity (e.g., `facelock_daemon=debug`) |
+| `RUST_LOG` | Control log verbosity (e.g., `facelock_daemon=debug`). Outranks both the built-in default and `-v`. An unparseable value is reported at `warn` and ignored. |

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -206,9 +206,24 @@ busctl status org.facelock.Daemon
 systemctl status facelock-daemon.service
 ```
 
+## Turning up the log level
+
+Commands print warnings and errors only. `-v` adds the informational lines,
+`-vv` debug, `-vvv` trace:
+
+```bash
+facelock -v test
+sudo facelock -vv daemon run
+```
+
+The flag is part of the command line, so it survives `sudo`, which strips
+`RUST_LOG` from the environment.
+
 ## Debugging with RUST_LOG
 
-Facelock uses the `tracing` crate with `RUST_LOG` env-filter syntax.
+Facelock uses the `tracing` crate with `RUST_LOG` env-filter syntax, which
+picks a level per crate rather than one level for all of them. It outranks
+`-v`.
 
 ```bash
 # Verbose output for all facelock crates:

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -18,7 +18,7 @@ use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 use tracing::{debug, error, info};
 
-pub fn run(user: String, config_path: Option<String>) -> i32 {
+pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
     // Deliberate parse (D7): `facelock auth` is its own one-shot process
     // spawned by PAM, so this is its top-of-process read — not a re-read.
     let config = match config_path {
@@ -35,7 +35,13 @@ pub fn run(user: String, config_path: Option<String>) -> i32 {
 
     // See crate::logging's module doc for why this must not build its own
     // subscriber by hand: it owns both the filter and the stderr writer.
-    crate::logging::init_stderr(false);
+    //
+    // `Program::Cli`, not `Daemon`: this process is spawned by
+    // `pam_facelock.so` with its stderr on a pipe nothing ever drains, and is
+    // otherwise something a person ran in a terminal. Neither reader wants
+    // INFO by default, and `facelock -v auth --user X` is how a run being
+    // debugged asks for it.
+    crate::logging::init_stderr(crate::logging::Program::Cli, verbose);
 
     // Loaded once, up front: auto-detection and the interrogation below must
     // be decided by the SAME quirk set, or the device picked and the device

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -287,21 +287,25 @@ pub fn restart() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `verbose` is the count of the global `-v`, and raises this process's log
+/// level one rung per repeat from the daemon's own INFO default.
+///
 /// `--config` is honored through the process-level override `main` installs
 /// before dispatch, which is what `Config::load()` and
 /// `paths::config_path()` both read — so startup, the live reload and the
 /// mtime watch cannot disagree about which file is the config.
-pub fn run(notifier_factory: NotifierFactory) -> anyhow::Result<()> {
+pub fn run(notifier_factory: NotifierFactory, verbose: u8) -> anyhow::Result<()> {
     crate::ipc_client::require_root("sudo facelock daemon run")?;
 
-    // Init tracing (the daemon is the one caller that wants targets rendered).
-    // See crate::logging's module doc for why this must not build its own
-    // subscriber by hand. The writer is stderr rather than the previous
+    // Init tracing (the daemon is the one caller that wants targets rendered,
+    // and the one that keeps INFO by default: the journal is its reader, and
+    // nothing competes with it there). See crate::logging's module doc for why
+    // this must not build its own subscriber by hand. The writer is stderr rather than the previous
     // stdout: the shipped unit sets `StandardOutput=journal` *and*
     // `StandardError=journal`, so the journal sees exactly what it saw before,
     // and a daemon run in the foreground now behaves like every other
     // subcommand.
-    crate::logging::init_stderr(true);
+    crate::logging::init_stderr(crate::logging::Program::Daemon, verbose);
 
     info!("facelock daemon starting");
 

--- a/crates/facelock-cli/src/conformance/flags.rs
+++ b/crates/facelock-cli/src/conformance/flags.rs
@@ -440,6 +440,48 @@ fn top_level_commands_match_the_registry() {
     }
 }
 
+/// `-v` on every side of every command, and what it counts to.
+///
+/// Its own table rather than rows in `legacy_invocations_still_parse`: that
+/// one pins what parsed *before* the flag existed, and this flag is new.
+///
+/// The row a reader would expect to be a contradiction is the one that must
+/// not be: `--quiet -v` is a legitimate pair. They are two knobs on two
+/// streams — `--quiet` silences the stdout report, `-v` raises the stderr
+/// diagnostics — so neither cancels the other (docs/contracts.md, "CLI Output
+/// Streams").
+#[test]
+fn verbose_invocations_parse_and_count_repeats() {
+    for (argv, expected) in [
+        (&["facelock", "status"][..], 0u8),
+        (&["facelock", "-v", "status"], 1),
+        (&["facelock", "status", "-v"], 1),
+        (&["facelock", "--verbose", "status"], 1),
+        (&["facelock", "-vv", "status"], 2),
+        (&["facelock", "status", "-vvv"], 3),
+        (&["facelock", "--verbose", "--verbose", "status"], 2),
+        // The three init sites, each reached with the flag: the shared CLI
+        // path, the one-shot PAM helper, and the daemon.
+        (&["facelock", "-v", "setup", "--non-interactive"], 1),
+        (&["facelock", "auth", "--user", "alice", "-vv"], 2),
+        (&["facelock", "daemon", "run", "-v"], 1),
+    ] {
+        let cli = Cli::try_parse_from(argv)
+            .unwrap_or_else(|e| panic!("`{}` must parse: {e}", argv.join(" ")));
+        assert_eq!(
+            cli.verbose,
+            expected,
+            "`{}`: -v must count its repeats",
+            argv.join(" ")
+        );
+    }
+
+    let cli = Cli::try_parse_from(["facelock", "--quiet", "-v", "list", "--json"])
+        .expect("`--quiet -v` must parse: quiet stdout and loud stderr are not a contradiction");
+    assert!(cli.quiet);
+    assert_eq!(cli.verbose, 1);
+}
+
 /// The short-letter registry.
 ///
 /// Short letters are a single namespace shared by every subcommand: once
@@ -451,9 +493,9 @@ fn top_level_commands_match_the_registry() {
 /// effect of adding a flag.
 ///
 /// `l` maps to two names because `enroll --label` and `audit --lines` both
-/// ship today and both must keep working. `v` has no site at all — it is a
-/// reservation for `--verbose`, held so the letter cannot be spent on
-/// something else first.
+/// ship today and both must keep working. `v` was held here as a reservation
+/// before `--verbose` existed, so that the letter could not be spent on
+/// something else first; the global flag now claims it.
 const SHORT_REGISTRY: &[(char, &[&str])] = &[
     ('u', &["user"]),
     ('y', &["yes"]),
@@ -577,6 +619,21 @@ fn cli_flag_conformance() {
                         "`{path} --quiet` must spell `-q`"
                     );
                     assert_eq!(long, Some("quiet"), "`{path}`: quiet arg spelled oddly");
+                }
+                "verbose" => {
+                    assert_eq!(
+                        arg.get_short(),
+                        Some('v'),
+                        "`{path} --verbose` must spell `-v`"
+                    );
+                    assert_eq!(long, Some("verbose"), "`{path}`: verbose arg spelled oddly");
+                    // Repeatable or the rungs above info are unreachable: a
+                    // `SetTrue` here would leave `-vv` a parse error and
+                    // debug/trace with no spelling at all.
+                    assert!(
+                        matches!(arg.get_action(), clap::ArgAction::Count),
+                        "`{path} --verbose` must count repeats"
+                    );
                 }
                 _ => {}
             }

--- a/crates/facelock-cli/src/logging.rs
+++ b/crates/facelock-cli/src/logging.rs
@@ -1,8 +1,9 @@
 //! The one tracing-subscriber init site for the `facelock` binary (gap E9,
 //! issue #149).
 //!
-//! Two contracts live here. Both have been broken by a hand-rolled init before,
-//! and both are invisible until something downstream reads the output:
+//! Three contracts live here. The first two have been broken by a hand-rolled
+//! init before, and both are invisible until something downstream reads the
+//! output:
 //!
 //! **1. The filter targets the bin name.** `RUST_LOG` filters by target, and
 //! this binary's own diagnostic events carry the target `facelock` — the
@@ -14,42 +15,112 @@
 //! `tracing_subscriber::fmt()` defaults its writer to **stdout** — the same
 //! stream the machine-readable payloads are printed on (`devices --json`,
 //! `list --json`, `is-enrolled --json`, and every human-readable renderer).
-//! Any event that passed the filter was therefore prepended to the JSON and the
-//! output stopped parsing (#149: with `daemon.mode = "daemon"` and the daemon
-//! stopped, `facelock devices --json | jq .` failed on the D-Bus fallback WARN
-//! that `backend::select` emits). The split is per-process and per-stream, so
-//! it cannot be fixed at the `println!` call sites one at a time — it is fixed
-//! once, here.
+//! Any event that passed the filter was therefore prepended to the JSON and
+//! the output stopped parsing (#149: with `daemon.mode = "daemon"` and the
+//! daemon stopped, `facelock devices --json | jq .` failed on the D-Bus
+//! fallback WARN that `backend::select` emits). The split is per-process and
+//! per-stream, so it cannot be fixed at the `println!` call sites one at a
+//! time — it is fixed once, here.
+//!
+//! **3. How loud the process is depends on who is reading.** The CLI's stderr
+//! shares a terminal with the wizard's own prompts, so an INFO default
+//! interleaved timestamped log lines with the questions and left a succeeding
+//! run looking broken. [`Program::Cli`] therefore starts at `warn` and `-v`
+//! climbs from there. [`Program::Daemon`] keeps `info`: it writes to the
+//! journal, where nothing competes with it and INFO is what
+//! `journalctl -u facelock` is expected to show. `RUST_LOG` outranks both.
 //!
 //! [`init_stderr`] is the only sanctioned way to install this process's
 //! subscriber. `no_init_site_outside_this_module_builds_its_own_subscriber`
 //! enforces that no other file under `src/` touches `tracing_subscriber` at
 //! all, which is what keeps a copy-pasted `tracing_subscriber::fmt()` from
-//! reintroducing either failure.
+//! reintroducing any of the three.
 
 /// The environment variable `tracing_subscriber` reads its filter from.
 const ENV_LOG: &str = "RUST_LOG";
 
-/// Fallback `EnvFilter` directive string used when `RUST_LOG` is unset.
-/// Enables `info` level on `facelock` (this crate's bin target) and
-/// `facelock_daemon` (the library every auth-path command pulls in) — the
-/// two targets that carry the diagnostics operators care about by default.
-pub const DEFAULT_LOG_FILTER: &str = "facelock=info,facelock_daemon=info";
+/// Which program this process is running as.
+///
+/// The two differ in exactly two ways — where they start on [`LADDER`], and
+/// whether each event's target is rendered — and both differences follow from
+/// the one fact that a call site knows: who reads this stream. So it is one
+/// argument rather than two booleans a site could set inconsistently.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Program {
+    /// Every subcommand a person types, `facelock auth` included: its stderr
+    /// is either a terminal someone is reading or the pipe `pam_facelock.so`
+    /// opens and never drains, and neither wants INFO by default.
+    Cli,
+    /// `facelock daemon run`, whose stderr the shipped unit points at the
+    /// journal.
+    Daemon,
+}
+
+impl Program {
+    /// Where this program sits on [`LADDER`] before `-v` is counted.
+    fn base_rung(self) -> usize {
+        match self {
+            Program::Cli => 0,
+            Program::Daemon => 1,
+        }
+    }
+
+    /// Whether each event's target (module path) is rendered on the line. The
+    /// daemon wants it; the CLI does not.
+    fn renders_target(self) -> bool {
+        self == Program::Daemon
+    }
+}
+
+/// The CLI's filter when `RUST_LOG` is unset and no `-v` was given: warnings
+/// and errors, and nothing else.
+///
+/// Every degradation an operator has to act on is already WARN or above — the
+/// D-Bus fallback in `backend::select`, an ONNX Runtime that would not load, a
+/// provider that could not be queried, an unreadable quirks file, an ignored
+/// `RUST_LOG` — so this hides progress reports, not findings.
+pub const DEFAULT_CLI_LOG_FILTER: &str = "facelock=warn,facelock_daemon=warn";
+
+/// The daemon's filter, and — one `-v` up — the CLI's. It is also what every
+/// command emitted before the CLI default moved, so a user who wants the old
+/// output back types one flag rather than learning a filter.
+pub const DEFAULT_DAEMON_LOG_FILTER: &str = "facelock=info,facelock_daemon=info";
+
+/// One filter per rung of loudness, quietest first. Each `-v` climbs one rung
+/// from the program's [`base_rung`](Program::base_rung); repeats past the top
+/// stay at `trace` rather than being an error, because a wrapper script that
+/// passes `-vvvv` means "as loud as it goes".
+///
+/// Every rung names `facelock` — the `[[bin]]` target, per contract 1 above —
+/// and `facelock_daemon`, the library the auth path pulls in. `EnvFilter`
+/// matches a directive's target as a plain string prefix, so `facelock=` also
+/// governs `facelock_camera`, `facelock_face` and every other workspace crate:
+/// one rung is what silences, or restores, the camera-negotiation and
+/// quirks-loading lines this default was changed for.
+const LADDER: [&str; 4] = [
+    DEFAULT_CLI_LOG_FILTER,
+    DEFAULT_DAEMON_LOG_FILTER,
+    "facelock=debug,facelock_daemon=debug",
+    "facelock=trace,facelock_daemon=trace",
+];
 
 /// Install this process's tracing subscriber, writing every event to
 /// **stderr**.
 ///
-/// `with_target` includes each event's target (module path) in the rendered
-/// line: the daemon wants it, the CLI does not.
+/// `verbose` is the count of `-v` on the command line (0 when the flag is
+/// absent). It moves this process up [`LADDER`]; `RUST_LOG` overrides the
+/// result outright.
 ///
 /// Panics only in the way `tracing_subscriber`'s own `init()` does — being
 /// called twice in one process.
-pub fn init_stderr(with_target: bool) {
-    let (filter, rejected) = env_filter();
+pub fn init_stderr(program: Program, verbose: u8) {
+    let fallback = filter_for(program, verbose);
+    let (directives, rejected) =
+        chosen_directives(std::env::var(ENV_LOG).ok().as_deref(), fallback);
 
     tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_target(with_target)
+        .with_env_filter(tracing_subscriber::EnvFilter::new(&directives))
+        .with_target(program.renders_target())
         // #149. Not a style preference: stdout carries this binary's payloads.
         .with_writer(std::io::stderr)
         .init();
@@ -57,71 +128,170 @@ pub fn init_stderr(with_target: bool) {
     // Reportable only now that a subscriber exists — the filter has to be
     // built before it can be installed. Silently ignoring a `RUST_LOG` the
     // operator deliberately set is its own papercut: the symptom is "my filter
-    // did nothing", which is indistinguishable from "nothing logged".
+    // did nothing", which is indistinguishable from "nothing logged". It is a
+    // WARN so that it survives the CLI's own default.
     if let Some(reason) = rejected {
         tracing::warn!(
             reason = %reason,
-            fallback = DEFAULT_LOG_FILTER,
+            fallback = fallback,
             "RUST_LOG could not be parsed and was ignored"
         );
     }
 }
 
-/// The `EnvFilter` to install, plus the reason `RUST_LOG` was rejected when it
-/// was set but unparseable.
+/// The rung `program` filters at after `verbose` repeats of `-v`, when
+/// `RUST_LOG` says nothing: `facelock` → warn, `-v` → info, `-vv` → debug,
+/// `-vvv` → trace, and one rung louder throughout for the daemon, which starts
+/// at info.
+fn filter_for(program: Program, verbose: u8) -> &'static str {
+    let rung = program.base_rung() + usize::from(verbose);
+    LADDER[rung.min(LADDER.len() - 1)]
+}
+
+/// The directive string this process filters with, plus the reason a
+/// `RUST_LOG` that *was* set had to be ignored.
 ///
-/// `RUST_LOG` unset and `RUST_LOG` invalid both fall back to
-/// [`DEFAULT_LOG_FILTER`] — the same outcome the previous
-/// `try_from_default_env().unwrap_or_else(..)` produced — but only the second
-/// is worth telling the operator about, which is why they are distinguished
-/// here rather than collapsed.
-fn env_filter() -> (tracing_subscriber::EnvFilter, Option<String>) {
-    match std::env::var(ENV_LOG) {
-        Ok(raw) => classify_filter(&raw),
-        Err(_) => (fallback_filter(), None),
-    }
-}
-
-/// [`env_filter`] for one already-read `RUST_LOG` value, split out so the
-/// accept/reject classification is testable without mutating the process
-/// environment (which every other test in this binary shares).
-fn classify_filter(raw: &str) -> (tracing_subscriber::EnvFilter, Option<String>) {
+/// **`RUST_LOG` outranks `-v`, which outranks the program's default.** An
+/// operator who exported a filter has said what they want, including when what
+/// they want is quieter than the flags a wrapper script passes; a `-vvv` that
+/// could shout over `RUST_LOG=facelock=error` would make the environment
+/// variable unreliable, which is the one thing an override cannot be.
+///
+/// An unset `RUST_LOG` and an unparseable one both fall back to `fallback` —
+/// the same outcome the previous `try_from_default_env().unwrap_or_else(..)`
+/// produced — but only the second is worth telling the operator about, which
+/// is why they are distinguished here rather than collapsed.
+///
+/// Pure, and takes the already-read variable rather than reading it, so
+/// precedence is testable without mutating the process environment (which
+/// every other test in this binary shares). The filter `try_new` builds is
+/// discarded and the accepted string parsed once more in [`init_stderr`]: one
+/// extra parse of a short string, once per process, for a decision function
+/// that is a plain `&str` in and `String` out.
+fn chosen_directives(rust_log: Option<&str>, fallback: &'static str) -> (String, Option<String>) {
+    let Some(raw) = rust_log else {
+        return (fallback.to_string(), None);
+    };
     match tracing_subscriber::EnvFilter::try_new(raw) {
-        Ok(filter) => (filter, None),
-        Err(e) => (fallback_filter(), Some(e.to_string())),
+        Ok(_) => (raw.to_string(), None),
+        Err(e) => (fallback.to_string(), Some(e.to_string())),
     }
-}
-
-fn fallback_filter() -> tracing_subscriber::EnvFilter {
-    tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
 
     #[test]
-    fn default_log_filter_targets_the_bin_name_not_the_crate_directory_name() {
+    fn every_rung_targets_the_bin_name_not_the_crate_directory_name() {
         // The crate directory is `facelock-cli` (which underscores to
         // `facelock_cli`), but the `[[bin]]` target — and therefore every
         // tracing event's target in this binary — is `facelock`.
         // `facelock_cli=...` matches nothing and silently drops every event.
-        assert!(DEFAULT_LOG_FILTER.contains("facelock="));
-        assert!(!DEFAULT_LOG_FILTER.contains("facelock_cli"));
-        assert!(DEFAULT_LOG_FILTER.contains("facelock_daemon="));
+        for rung in LADDER {
+            assert!(rung.contains("facelock="), "`{rung}` names no bin target");
+            assert!(!rung.contains("facelock_cli"), "`{rung}` filters nothing");
+            assert!(
+                rung.contains("facelock_daemon="),
+                "`{rung}` drops the auth-path library"
+            );
+        }
     }
 
+    /// Both defaults verbatim. Changing either is a deliberate edit here, not
+    /// a side effect of an edit somewhere else.
     #[test]
-    fn default_log_filter_pinned() {
-        assert_eq!(DEFAULT_LOG_FILTER, "facelock=info,facelock_daemon=info");
+    fn default_log_filters_pinned() {
+        assert_eq!(DEFAULT_CLI_LOG_FILTER, "facelock=warn,facelock_daemon=warn");
+        assert_eq!(
+            DEFAULT_DAEMON_LOG_FILTER,
+            "facelock=info,facelock_daemon=info"
+        );
     }
 
-    /// The fallback string has to actually parse — it is what an operator gets
+    /// Every rung has to actually parse — one of them is what an operator gets
     /// when their own `RUST_LOG` did not.
     #[test]
-    fn the_fallback_filter_parses() {
-        assert!(tracing_subscriber::EnvFilter::try_new(DEFAULT_LOG_FILTER).is_ok());
+    fn every_rung_parses() {
+        for rung in LADDER {
+            assert!(
+                tracing_subscriber::EnvFilter::try_new(rung).is_ok(),
+                "`{rung}` does not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn the_cli_starts_quiet_and_the_daemon_starts_at_info() {
+        assert_eq!(filter_for(Program::Cli, 0), DEFAULT_CLI_LOG_FILTER);
+        assert_eq!(filter_for(Program::Daemon, 0), DEFAULT_DAEMON_LOG_FILTER);
+    }
+
+    /// The documented mapping, plus the top of the ladder: `-v` past `trace`
+    /// saturates rather than panicking on an out-of-range index.
+    #[test]
+    fn each_v_climbs_one_rung_and_the_ladder_saturates() {
+        assert_eq!(
+            filter_for(Program::Cli, 1),
+            "facelock=info,facelock_daemon=info"
+        );
+        assert_eq!(
+            filter_for(Program::Cli, 2),
+            "facelock=debug,facelock_daemon=debug"
+        );
+        assert_eq!(
+            filter_for(Program::Cli, 3),
+            "facelock=trace,facelock_daemon=trace"
+        );
+        assert_eq!(
+            filter_for(Program::Cli, u8::MAX),
+            "facelock=trace,facelock_daemon=trace"
+        );
+
+        assert_eq!(
+            filter_for(Program::Daemon, 1),
+            "facelock=debug,facelock_daemon=debug"
+        );
+        assert_eq!(
+            filter_for(Program::Daemon, u8::MAX),
+            "facelock=trace,facelock_daemon=trace"
+        );
+    }
+
+    /// One `-v` is exactly the volume every command had before the CLI default
+    /// moved, which is what makes the upgrade note a flag rather than a filter
+    /// to learn.
+    #[test]
+    fn one_v_restores_the_volume_the_cli_used_to_have() {
+        assert_eq!(filter_for(Program::Cli, 1), DEFAULT_DAEMON_LOG_FILTER);
+    }
+
+    #[test]
+    fn an_unset_rust_log_takes_the_programs_own_rung() {
+        assert_eq!(
+            chosen_directives(None, filter_for(Program::Cli, 0)).0,
+            DEFAULT_CLI_LOG_FILTER
+        );
+        assert_eq!(
+            chosen_directives(None, filter_for(Program::Daemon, 0)).0,
+            DEFAULT_DAEMON_LOG_FILTER
+        );
+    }
+
+    #[test]
+    fn rust_log_outranks_both_the_default_and_the_v_count() {
+        let (chosen, rejected) =
+            chosen_directives(Some("facelock=info"), filter_for(Program::Cli, 0));
+        assert_eq!(chosen, "facelock=info");
+        assert!(rejected.is_none());
+
+        // The direction that is easy to get backwards: `RUST_LOG` wins even
+        // when it is the quieter of the two.
+        let (chosen, _) = chosen_directives(Some("facelock=error"), filter_for(Program::Cli, 3));
+        assert_eq!(chosen, "facelock=error");
     }
 
     /// `tests/json_stream_split.rs` forces a guaranteed WARN by handing the
@@ -131,20 +301,162 @@ mod tests {
     /// classifies it.
     #[test]
     fn the_stream_split_tests_bad_rust_log_fixture_really_is_unparseable() {
-        let (_, rejected) = classify_filter("facelock=notalevel");
+        let (chosen, rejected) =
+            chosen_directives(Some("facelock=notalevel"), DEFAULT_CLI_LOG_FILTER);
         assert!(
             rejected.is_some(),
             "`facelock=notalevel` must be rejected: it is the fixture \
              tests/json_stream_split.rs uses to force a WARN"
         );
+        assert_eq!(chosen, DEFAULT_CLI_LOG_FILTER);
     }
 
     /// A valid `RUST_LOG` is honored and reported as such; an unset one falls
     /// back without complaint.
     #[test]
     fn a_valid_rust_log_is_honored_without_a_complaint() {
-        assert!(classify_filter("facelock=trace").1.is_none());
-        assert!(classify_filter(DEFAULT_LOG_FILTER).1.is_none());
+        assert!(
+            chosen_directives(Some("facelock=trace"), DEFAULT_CLI_LOG_FILTER)
+                .1
+                .is_none()
+        );
+        assert!(
+            chosen_directives(Some(DEFAULT_CLI_LOG_FILTER), DEFAULT_CLI_LOG_FILTER)
+                .1
+                .is_none()
+        );
+    }
+
+    // -- What the streams actually carry ---------------------------------
+    //
+    // The tests above pin which directive string is chosen. These pin what
+    // that string does to real events, which is the thing the gap is about:
+    // a `facelock status` run that no longer interleaves INFO with its
+    // report, and a `-v` that brings it back.
+
+    /// A `tracing_subscriber::fmt` layer built the way [`init_stderr`] builds
+    /// it, but writing into a buffer.
+    ///
+    /// It rebuilds rather than calling `init_stderr`, which installs a
+    /// *process-global* subscriber and so can run at most once per test
+    /// binary. What it must share with the real thing is the filter, and that
+    /// it takes from [`filter_for`] — the same function `init_stderr` calls.
+    fn rendered_events(directives: &str) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new(directives))
+            .with_writer(Capture(Arc::clone(&buffer)))
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            // The targets are the real ones, spelled as the emitting crates
+            // spell them: `facelock` is this binary, `facelock_camera` is the
+            // crate whose format-negotiation lines landed on top of the
+            // wizard's prompts, and neither is named by any directive except
+            // through the `facelock=` prefix.
+            tracing::warn!(target: "facelock", "a warning worth reading");
+            tracing::info!(target: "facelock", "an informational line");
+            tracing::info!(target: "facelock_camera", "camera format negotiated");
+            tracing::debug!(target: "facelock", "a debug line");
+        });
+
+        let captured = buffer.lock().expect("capture buffer poisoned").clone();
+        String::from_utf8(captured).expect("the fmt layer writes UTF-8")
+    }
+
+    /// A `MakeWriter` over a shared buffer, so the events can be read back
+    /// after the subscriber that wrote them is gone. `Arc<Mutex<Vec<u8>>>` is
+    /// not itself a `MakeWriter` — the blanket impl for `Arc<W>` wants
+    /// `&W: Write`, which a `Mutex` is not — so this is the one line of glue.
+    #[derive(Clone)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for Capture {
+        type Writer = Capture;
+        fn make_writer(&self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    impl Write for Capture {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// **The gap.** At the default, a CLI run carries warnings and nothing
+    /// below them — including from the workspace crates the `facelock=`
+    /// prefix reaches, which is where the noise came from.
+    #[test]
+    fn the_cli_default_carries_warnings_and_no_progress_reports() {
+        let rendered = rendered_events(filter_for(Program::Cli, 0));
+
+        assert!(
+            rendered.contains("a warning worth reading"),
+            "a WARN must survive the default, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("an informational line"),
+            "INFO must not reach stderr by default, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("camera format negotiated"),
+            "a workspace crate's INFO must not reach stderr by default \
+             (the `facelock=` directive is a target *prefix*), got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn v_restores_info_and_vv_adds_debug() {
+        let one = rendered_events(filter_for(Program::Cli, 1));
+        assert!(one.contains("an informational line"), "got:\n{one}");
+        assert!(one.contains("camera format negotiated"), "got:\n{one}");
+        assert!(
+            !one.contains("a debug line"),
+            "`-v` is info, not debug, got:\n{one}"
+        );
+
+        let two = rendered_events(filter_for(Program::Cli, 2));
+        assert!(two.contains("a debug line"), "got:\n{two}");
+    }
+
+    /// The daemon is unaffected by the CLI's new default: `journalctl -u
+    /// facelock` shows what it always showed.
+    #[test]
+    fn the_daemon_still_carries_info() {
+        let rendered = rendered_events(filter_for(Program::Daemon, 0));
+        assert!(
+            rendered.contains("an informational line"),
+            "got:\n{rendered}"
+        );
+    }
+
+    /// `RUST_LOG=info` still wins over the quiet default, end to end rather
+    /// than as a string comparison.
+    #[test]
+    fn a_rust_log_of_info_beats_the_quiet_default_on_the_stream() {
+        let (directives, rejected) =
+            chosen_directives(Some("facelock=info"), filter_for(Program::Cli, 0));
+        assert!(rejected.is_none());
+
+        let rendered = rendered_events(&directives);
+        assert!(
+            rendered.contains("an informational line"),
+            "got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("camera format negotiated"),
+            "got:\n{rendered}"
+        );
     }
 
     /// Walks this crate's `src/` tree at test time and asserts that no file

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -22,6 +22,7 @@ use facelock_cli::commands::config::ConfigCommand;
 use facelock_cli::commands::daemon::DaemonCommand;
 use facelock_cli::commands::hyprlock::HyprlockCommand;
 use facelock_cli::commands::setup::{SetupArgs, resolve_setup_plan};
+use facelock_cli::logging::Program;
 use facelock_cli::{commands, logging, message, notifications, resolved};
 
 use args::{ConfirmArg, JsonArg, PamCli, SetupCli, UserArg};
@@ -35,6 +36,19 @@ struct Cli {
     /// Suppress informational stdout; errors, prompts and exit codes are unchanged
     #[arg(short = 'q', long, global = true)]
     quiet: bool,
+    /// Raise diagnostic verbosity on stderr, one level per repeat (the CLI starts at warn, the daemon at info)
+    //
+    // The help text names the starting points rather than a fixed
+    // level-per-repeat mapping, because there are two: `-v` is info on a CLI
+    // command and debug on `daemon run`, which starts a rung higher.
+    //
+    // Counted rather than a bool so the levels above the base are reachable
+    // without a second flag, and separate from `--quiet` on purpose: that one
+    // governs stdout, this one stderr, so `--quiet --verbose` is a legitimate
+    // pair (silent report, loud diagnostics) rather than a contradiction.
+    // `RUST_LOG` outranks it; see `logging::chosen_directives`.
+    #[arg(short = 'v', long, global = true, action = clap::ArgAction::Count)]
+    verbose: u8,
     #[command(subcommand)]
     command: Commands,
 }
@@ -176,6 +190,7 @@ fn main() -> anyhow::Result<()> {
     let Cli {
         config,
         quiet,
+        verbose,
         command,
     } = Cli::parse();
 
@@ -215,21 +230,23 @@ fn main() -> anyhow::Result<()> {
         // and setup.rs's `ExecStart` marker all invoke the bare form (ADR 009 §4).
         Commands::Daemon { command } => match command {
             None | Some(DaemonCommand::Run) => {
-                commands::daemon::run(notifications::daemon_notifier_factory())
+                commands::daemon::run(notifications::daemon_notifier_factory(), verbose)
             }
             // `restart` only talks to systemd: no parsed Config, and nothing
             // from the D7 block it used to sit in except this tracing init
             // (`message::init` already ran at the top of `main`, for every
-            // command alike).
+            // command alike). It inits as `Program::Cli` — the daemon it
+            // restarts is a different process, and this one is answering the
+            // person who typed the verb.
             Some(DaemonCommand::Restart) => {
-                logging::init_stderr(false);
+                logging::init_stderr(Program::Cli, verbose);
                 commands::daemon::restart()
             }
         },
         Commands::Auth { user } => {
             // `auth` is its own one-shot process and loads the config itself,
             // so it takes the explicit path rather than re-deriving it.
-            let exit_code = commands::auth::run(user, config);
+            let exit_code = commands::auth::run(user, config, verbose);
             std::process::exit(exit_code);
         }
         other => {
@@ -237,7 +254,7 @@ fn main() -> anyhow::Result<()> {
             // stderr, which is what leaves stdout free for the payload these
             // commands print — `devices --json`, `list --json`,
             // `is-enrolled --json` (#149). See `crate::logging`.
-            logging::init_stderr(false);
+            logging::init_stderr(Program::Cli, verbose);
 
             match other {
                 // -- Dispatched before the shared config parse (D7). --

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,18 @@ The following flags are accepted by every subcommand (declared `global = true`):
 |------|-------------|
 | `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
 | `-q`, `--quiet` | Suppress stdout: informational text, and on commands whose stdout is the payload, the payload too. Errors (stderr), prompts and exit codes are unaffected. |
+| `-v`, `--verbose` | Raise diagnostic verbosity on stderr, one level per repeat. The CLI starts at `warn`, `daemon run` at `info`. `RUST_LOG` overrides it. |
+
+Diagnostics default to `warn`, so a command prints warnings and errors on
+stderr and nothing quieter. The setup wizard's questions and the `status`
+report are readable again, rather than interleaved with timestamped log lines.
+`-v` raises the level one step per repeat; `facelock daemon run` keeps `info`,
+because it writes to the journal, where nothing competes with it. `RUST_LOG`
+outranks both, and the level changes output volume only: exit codes and stdout
+payloads are identical at every level.
+
+`--quiet` and `-v` are separate knobs on separate streams, so `--quiet -v` is a
+real combination (silent report, loud diagnostics) rather than a contradiction.
 
 `--quiet` is complete for every command whose output goes through the message
 seam: `setup`, `enroll`, `test`, `remove`, `clear`, `is-enrolled`,
@@ -706,4 +718,4 @@ For commands that accept `--user`:
 | Variable | Purpose |
 |----------|---------|
 | `FACELOCK_CONFIG` | Override config file path for unprivileged CLI commands. Ignored by privileged PAM/root auth flows; use `--config` there. |
-| `RUST_LOG` | Control log verbosity (e.g., `facelock_daemon=debug`) |
+| `RUST_LOG` | Control log verbosity (e.g., `facelock_daemon=debug`). Outranks both the built-in default and `-v`. An unparseable value is reported at `warn` and ignored. |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -122,10 +122,14 @@ The invariants it pins:
   fall back to the process owner. Every other `--user` defaults to the current user
 - `--yes` is `-y` and accepts `--no-confirm` everywhere (it was `setup`-only)
 - `--json` and `--dry-run` take no short letter
-- `--config` (`-c`) and `--quiet` (`-q`) are declared once, `global = true`, and
-  are accepted on either side of the subcommand name. No command re-declares
-  them. `facelock daemon -c X` and `facelock -c X daemon` are equivalent, as are
-  `facelock is-enrolled --quiet` and `facelock --quiet is-enrolled`
+- `--config` (`-c`), `--quiet` (`-q`) and `--verbose` (`-v`) are declared once,
+  `global = true`, and are accepted on either side of the subcommand name. No
+  command re-declares them. `facelock daemon -c X` and `facelock -c X daemon`
+  are equivalent, as are `facelock is-enrolled --quiet` and
+  `facelock --quiet is-enrolled`
+- `--verbose` counts its repeats, one level per `-v` from the program's own
+  starting level (`warn` for the CLI, `info` for `daemon run`). `RUST_LOG`
+  outranks it
 - every subcommand has non-empty `about` text
 
 `legacy_invocations_still_parse`, alongside it, is a table of real argv — the PAM
@@ -148,6 +152,22 @@ JSON (#149).
 
 An unparseable `RUST_LOG` is reported at WARN (on stderr) and the built-in
 filter is used, rather than the value being silently discarded.
+
+**Diagnostics default to `warn` in the CLI and `info` in the daemon.** Someone
+typing a command reads its prompts and its report on the same terminal these
+events land on, so the CLI prints warnings and errors and nothing quieter.
+`facelock daemon run` keeps `info`, because the journal is its reader and
+nothing competes with it there. `-v` raises the level one step per repeat from
+whichever of the two this process started at. `RUST_LOG` outranks both,
+including when it is the quieter of them: an override a flag can shout over is
+not an override.
+
+The level governs output volume and nothing else. Exit codes and stdout
+payloads are identical at every level, so a consumer needs no flag it did not
+need before. Every degradation an operator has to act on is WARN or above and
+so survives the default: the D-Bus fallback in `backend::select`, an ONNX
+Runtime that would not load, a provider that could not be queried, an
+unreadable quirks file, an ignored `RUST_LOG`.
 
 **`--quiet` suppresses informational chatter, and on commands whose stdout is
 the payload, the payload too; errors, prompts and exit codes are unchanged.** A

--- a/docs/testing-safety.md
+++ b/docs/testing-safety.md
@@ -116,7 +116,7 @@ kill %1             # stop daemon
 Control via `RUST_LOG` environment variable:
 ```bash
 RUST_LOG=facelock_daemon=debug facelock daemon    # verbose daemon
-RUST_LOG=facelock_cli=debug facelock test         # verbose CLI
+RUST_LOG=facelock=debug facelock test             # verbose CLI (or: facelock -vv test)
 ```
 
 ## Dev Config

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -231,9 +231,24 @@ busctl status org.facelock.Daemon
 systemctl status facelock-daemon.service
 ```
 
+## Turning up the log level
+
+Commands print warnings and errors only. `-v` adds the informational lines,
+`-vv` debug, `-vvv` trace:
+
+```bash
+facelock -v test
+sudo facelock -vv daemon run
+```
+
+The flag is part of the command line, so it survives `sudo`, which strips
+`RUST_LOG` from the environment.
+
 ## Debugging with RUST_LOG
 
-Facelock uses the `tracing` crate with `RUST_LOG` env-filter syntax.
+Facelock uses the `tracing` crate with `RUST_LOG` env-filter syntax, which
+picks a level per crate rather than one level for all of them. It outranks
+`-v`.
 
 ```bash
 # Verbose output for all facelock crates:

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -30,6 +30,16 @@ Path to the config file. Takes precedence over
 .TP
 .B \-q\fR, \fB\-\-quiet
 Suppress informational stdout; errors, prompts and exit codes are unchanged.
+.TP
+.B \-v\fR, \fB\-\-verbose
+Raise diagnostic verbosity on stderr, one level per repeat. A command starts at
+.BR warn ,
+so it prints warnings and errors and nothing quieter;
+.B facelock daemon run
+starts at info, because it writes to the journal.
+.B RUST_LOG
+outranks both. The level changes output volume only: exit codes and the
+payloads on stdout are identical at every level.
 .SH COMMANDS
 .TP
 .B setup
@@ -507,6 +517,9 @@ Number of recent entries to show (default: 20).
 .B RUST_LOG
 Controls log verbosity via the tracing/env_filter crate. Example:
 .BR RUST_LOG=debug .
+Outranks both the built-in default and
+.BR \-\-verbose ;
+a value that cannot be parsed is reported at warn level and ignored.
 .TP
 .B FACELOCK_CONFIG
 Override path to the configuration file.


### PR DESCRIPTION
## Summary

- default the CLI's stderr diagnostics to `warn`; `facelock daemon run` keeps `info` (it writes to the journal)
- add global, repeatable `-v/--verbose`: one level per repeat from the program's own starting level; `RUST_LOG` outranks both
- keep `--quiet` (stdout) and `-v` (stderr) as separate seams; `--quiet -v` is a legitimate pair
- `facelock auth` follows the CLI default: its stderr under PAM is a pipe `pam_facelock.so` never reads, and `RUST_LOG` is stripped from that child anyway
- no exit code or stdout payload changes

## Why

Every command emitted timestamped INFO lines by default, so the setup wizard's prompts were interleaved with `camera format negotiated …` and `loaded hardware quirks` and a user could not tell whether the run was succeeding. Every degradation an operator acts on (`DirectByFallback`, an unparseable `RUST_LOG`, Y16 fail-open, IR emitter failure) was already WARN, so nothing an operator needs disappears at the new default.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`
- `-v`/`-vv`/`-vvv`/`-vvvvvv` ladder read off the real binary's installed filter, on both sides of the subcommand
- `RUST_LOG=facelock=error -vvv` (env wins downward too)
- `--quiet -v is-enrolled --json`: stdout payload and exit code unchanged
- `is-enrolled --json` payload byte-identical at every level
- `man --warnings` on the updated man page
