### PR TITLE
fix(cli): Configure the daemon before enrolling in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ just install              # build + install binaries, systemd, D-Bus, PAM
 
 ```bash
 sudo facelock setup       # interactive wizard: camera, models, encryption,
-                          # enrollment, daemon, and PAM for sudo + screen lock
+                          # daemon, enrollment, and PAM for sudo + screen lock
 ```
 
 That's it. Open a new terminal and run `sudo echo "ok"` to confirm face auth fires. Keep a root shell open until you've verified it works.

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -31,6 +31,8 @@ Interactive setup wizard. Walks through camera selection, model quality, inferen
 
 The daemon is configured before enrollment on purpose. `enroll` and `test` select their transport once, when they start, so on a first install a daemon configured after them would never be the one they used: enrollment would fall back to direct camera access and the recognition test would validate a transport no later authentication takes. It stays after the model download and encryption steps, because the daemon loads the models and opens the embedding key at startup.
 
+The step starts the daemon, or restarts it if one is already running. The encryption method, the model preset and the inference device are read once at daemon startup, so on a re-run of `setup` a daemon left running would answer enrollment and the recognition test with the configuration from before the wizard. A restart interrupts any authentication that daemon is mid-way through, which on a `sudo` prompt in another terminal means one password fallback.
+
 ```bash
 facelock setup                          # interactive wizard
 facelock setup --non-interactive        # base setup, no prompts, no PAM/systemd/enroll

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -27,7 +27,9 @@ Spelling", for the invariants and the short-letter registry.
 
 ## facelock setup
 
-Interactive setup wizard. Walks through camera selection, model quality, inference device (CPU / CUDA / ROCm / OpenVINO), model downloads, encryption, enrollment, systemd, and PAM configuration. Every step can also be answered — or declined — from the command line.
+Interactive setup wizard. Walks through camera selection, model quality, inference device (CPU / CUDA / ROCm / OpenVINO), model downloads, encryption, the daemon, enrollment, and PAM configuration. Every step can also be answered — or declined — from the command line.
+
+The daemon is configured before enrollment on purpose. `enroll` and `test` select their transport once, when they start, so on a first install a daemon configured after them would never be the one they used: enrollment would fall back to direct camera access and the recognition test would validate a transport no later authentication takes. It stays after the model download and encryption steps, because the daemon loads the models and opens the embedding key at startup.
 
 ```bash
 facelock setup                          # interactive wizard
@@ -103,8 +105,8 @@ Under `--non-interactive`, a choice flag applies before the model download, so `
 | Pair | Without either flag (wizard) | Without either flag (`--non-interactive`) |
 |------|------------------------------|-------------------------------------------|
 | `--pam` / `--no-pam` | prompt (step 9) | off |
-| `--systemd` / `--no-systemd` | prompt (step 8) | off |
-| `--enroll` / `--no-enroll` | prompt (step 6) | off — enrollment needs a human in front of the camera |
+| `--systemd` / `--no-systemd` | prompt (step 6) | off |
+| `--enroll` / `--no-enroll` | prompt (step 7) | off — enrollment needs a human in front of the camera |
 
 Each pair is a clap override pair: **a later flag wins over an earlier one.** `--pam --no-pam` declines PAM; `--no-pam --pam` installs it. This matters when a wrapper script appends an override to a command line it did not construct.
 
@@ -133,7 +135,7 @@ Flags **compose**; they are not mutually exclusive. The rule is:
 
 `-y` on its own does not force the base setup, so `facelock setup -y --pam` is still PAM-only.
 
-When the base setup does run alongside an action, the order is: base setup, then systemd, then PAM — the same order the wizard uses for steps 8 and 9. A wizard run that already configured PAM at step 9 is not asked to do it a second time.
+When the base setup does run alongside an action, the actions run inside it, at the step that owns them: `--systemd` at step 6 and `--pam` at step 9. `--systemd` used to be applied after the whole base setup had finished, which put it after enrollment; it is now applied where the wizard would have prompted for it. Standalone `--systemd` and `--pam`, with no base setup to host them, run in that same order afterwards. A wizard run that already configured PAM at step 9 is not asked to do it a second time.
 
 ### Compatibility matrix
 

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -25,7 +25,7 @@ pub fn run(
                 if !marker.exists() {
                     return Err(fail(FaceMessage::SetupDidNotComplete));
                 }
-                // Setup includes face enrollment (Step 4), so we're done
+                // Setup includes face enrollment (Step 7), so we're done
                 return Ok(());
             } else {
                 Terminal.info(&FaceMessage::RunSetupWhenReady);

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -3132,6 +3132,23 @@ const DAEMON_READY_POLL: std::time::Duration = std::time::Duration::from_millis(
 /// Bring the daemon up so the enrollment and test steps that follow select it
 /// instead of falling back to direct camera access.
 ///
+/// A stopped unit is started; one that is already running is restarted. The
+/// daemon reads the encryption method (step 5), the model preset (step 2) and
+/// the inference device (step 3) once, at startup, so on a second `setup` run
+/// leaving the running instance alone would enroll and test through a daemon
+/// holding the configuration the wizard has just replaced.
+///
+/// A restart needs more than a `Ping` to be believed. `--no-block` returns
+/// when systemd has queued the job, not when it has run it, so the first
+/// probe would be answered by the process being replaced — and step 7, with
+/// no prompt in front of it under `--enroll`, would then select its backend
+/// during the window where the old instance has exited and the new one is
+/// still loading its models, falling back to direct camera access under a
+/// line claiming the opposite. So the unit's main PID is read before the
+/// restart and the wait requires a *different* non-zero PID as well as a
+/// responding daemon ([`daemon_ready`]). The `start` branch needs none of
+/// that: there is no outgoing instance for an answer to have come from.
+///
 /// Every failure here is survivable and none of them are fatal: [`run_systemd`]
 /// has already installed and enabled the unit, which is what the user asked
 /// for, and a daemon that does not come up leaves exactly the direct-access
@@ -3147,19 +3164,162 @@ fn start_daemon_for_setup(config: &Config) {
         return;
     }
 
-    // `--no-block` because `Type=dbus` makes a blocking start wait on bus-name
-    // acquisition under systemd's start timeout. The wait below is ours, and
-    // bounded by us.
-    if let Err(e) = run_cmd("systemctl", &["start", "--no-block", SERVICE_FILENAME]) {
-        tracing::warn!("could not start {SERVICE_FILENAME}: {e}");
+    let bring_up = daemon_bring_up_for(daemon_unit_is_active());
+    // Read before the job is queued, so it names the instance being replaced.
+    let outgoing_pid = bring_up.main_pid();
+
+    // `--no-block` because `Type=dbus` makes a blocking start or restart wait
+    // on bus-name acquisition under systemd's start timeout. The wait below is
+    // ours, and bounded by us.
+    let issued = run_cmd(
+        "systemctl",
+        &[bring_up.verb(), "--no-block", SERVICE_FILENAME],
+    );
+    if let Err(e) = &issued {
+        tracing::warn!("could not {} {SERVICE_FILENAME}: {e}", bring_up.verb());
+    }
+    if restart_announced(bring_up, issued.is_ok()) {
+        Terminal.info(&SystemMessage::DaemonRestarted);
     }
 
-    if wait_for_daemon(DAEMON_READY_TIMEOUT) {
+    if wait_for_daemon(DAEMON_READY_TIMEOUT, bring_up, outgoing_pid) {
         Terminal.info(&SystemMessage::DaemonRunning);
     } else {
         Terminal.info(&SystemMessage::DaemonNotReady {
             seconds: DAEMON_READY_TIMEOUT.as_secs(),
         });
+    }
+}
+
+/// How the wizard brings the unit up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaemonBringUp {
+    /// Nothing is running: `systemctl start`.
+    Start,
+    /// Something is running, on the configuration from before the wizard:
+    /// `systemctl try-restart`.
+    Restart,
+}
+
+impl DaemonBringUp {
+    /// The two verbs differ in which starting state they do nothing for, and
+    /// that is the whole reason both exist here: `start` is a no-op on an
+    /// already-running unit — the stale daemon this pairing exists to replace
+    /// — and `try-restart` is a no-op on a stopped one.
+    ///
+    /// Both directions of the race between the check and the call therefore
+    /// end somewhere survivable. A unit that stops in that window is left
+    /// down, rather than started by a verb whose branch never checked for
+    /// that. A unit that starts in it — a concurrent D-Bus activation — takes
+    /// `Start`, which is then the no-op: the freshly activated daemon
+    /// survives with the pre-wizard configuration, and no restart is
+    /// announced, because none happened. Milliseconds wide, and the readiness
+    /// wait reports whatever is actually there either way.
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Restart => "try-restart",
+        }
+    }
+
+    /// The unit's main PID, on the branch whose acceptance rule reads one.
+    ///
+    /// `Start` has no outgoing instance to tell a successor from, so it never
+    /// consults a PID and does not pay a `systemctl show` per poll for one.
+    fn main_pid(self) -> Option<u32> {
+        match self {
+            Self::Restart => daemon_main_pid(),
+            Self::Start => None,
+        }
+    }
+}
+
+/// Which verb the unit's current state calls for. Pure, so the choice is
+/// testable without systemd; [`daemon_unit_is_active`] is the part that is not.
+fn daemon_bring_up_for(unit_active: bool) -> DaemonBringUp {
+    if unit_active {
+        DaemonBringUp::Restart
+    } else {
+        DaemonBringUp::Start
+    }
+}
+
+/// Whether systemd reports the unit as already running.
+///
+/// `systemctl is-active` exits non-zero for every state that is not active, so
+/// a stopped unit, a failed one, and a systemd that is not there at all all
+/// read as inactive: the [`DaemonBringUp::Start`] branch, whose own failure is
+/// already best effort.
+///
+/// The `Err` is the *answer*, not a fault — do not propagate it with `?`, or a
+/// stopped unit becomes a fatal setup.
+fn daemon_unit_is_active() -> bool {
+    run_cmd("systemctl", &["is-active", "--quiet", SERVICE_FILENAME]).is_ok()
+}
+
+/// The PID of the running instance, or `None` when there is not one.
+///
+/// `systemctl show -p MainPID --value` prints `0` for a unit that is not
+/// running; a systemd that is absent or that fails the query prints nothing
+/// usable. All three mean the same thing here — no instance to tell apart from
+/// its successor — so all three answer `None`, which [`daemon_ready`] treats
+/// as "cannot prove a restart happened" on the restart branch and ignores
+/// entirely on the start branch.
+fn daemon_main_pid() -> Option<u32> {
+    let out = Command::new("systemctl")
+        .args(["show", "-p", "MainPID", "--value", SERVICE_FILENAME])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let pid: u32 = String::from_utf8_lossy(&out.stdout).trim().parse().ok()?;
+    (pid != 0).then_some(pid)
+}
+
+/// Whether the step announces the restart it asked for.
+///
+/// Only a restart systemd accepted: a rejected one replaced nothing, so the
+/// daemon the wait goes on to find is the same one that was already there, and
+/// saying otherwise would be the lie the notice exists to prevent.
+fn restart_announced(bring_up: DaemonBringUp, systemctl_ok: bool) -> bool {
+    systemctl_ok && matches!(bring_up, DaemonBringUp::Restart)
+}
+
+/// Whether a poll of the unit means the daemon the wizard asked for is up.
+///
+/// The two branches accept different evidence, because they have different
+/// things to prove:
+///
+/// - `Start` had nothing running, so any daemon answering is the one it
+///   started. A `Ping` is the whole test.
+/// - `Restart` had something running, and that something answers `Ping` until
+///   systemd gets round to stopping it. So the answer only counts once the
+///   unit reports a *different*, non-zero main PID: systemd runs a restart as
+///   stop-then-start, so a changed PID means the process that could have
+///   answered falsely is gone.
+///
+/// `current_pid` of `None` — a stopped unit, or a systemd that would not say —
+/// is never proof of a restart. It fails the wait rather than passing it,
+/// which costs at worst a bounded 20s and the direct-access fallback the whole
+/// step is best-effort about. An `old_pid` of `None` is the one soft spot: the
+/// wizard could not name the outgoing instance, so any running one is accepted
+/// and the branch degrades to the `Start` rule.
+fn daemon_ready(
+    bring_up: DaemonBringUp,
+    old_pid: Option<u32>,
+    current_pid: Option<u32>,
+    ping_ok: bool,
+) -> bool {
+    if !ping_ok {
+        return false;
+    }
+    match bring_up {
+        DaemonBringUp::Start => true,
+        DaemonBringUp::Restart => match current_pid {
+            None => false,
+            Some(pid) => Some(pid) != old_pid,
+        },
     }
 }
 
@@ -3174,24 +3334,36 @@ fn daemon_start_wanted(mode: &facelock_core::config::DaemonMode) -> bool {
     matches!(mode, DaemonMode::Daemon)
 }
 
-/// Poll until the daemon answers, or `timeout` elapses.
+/// Poll until the daemon the wizard asked for answers, or `timeout` elapses.
 ///
-/// Through the seam's [`crate::backend::probe_daemon`], which is the full
-/// `Ping` round-trip rather than the non-activating `name_has_owner` that
-/// backend selection uses. "The daemon answers method calls" is the property
-/// the next two steps need, and activating one systemd has not got to yet is a
-/// success here rather than the hazard it would be at selection time.
-fn wait_for_daemon(timeout: std::time::Duration) -> bool {
+/// The probe is the seam's [`crate::backend::probe_daemon`], the full `Ping`
+/// round-trip rather than the non-activating `name_has_owner` that backend
+/// selection uses. "The daemon answers method calls" is the property the next
+/// two steps need, and activating one systemd has not got to yet is a success
+/// here rather than the hazard it would be at selection time.
+///
+/// [`daemon_ready`] decides what a poll proves; `old_pid` is the main PID read
+/// before the restart was queued. The PID is read *before* the ping, and only
+/// on the branch that needs it: a PID that is already the successor's cannot
+/// then be paired with a ping the outgoing instance answered a moment earlier:
+/// systemd runs a restart as stop-then-start, so the old process has exited by
+/// the time its PID stops being the unit's.
+fn wait_for_daemon(
+    timeout: std::time::Duration,
+    bring_up: DaemonBringUp,
+    old_pid: Option<u32>,
+) -> bool {
     use crate::backend::DaemonPing;
     use facelock_core::config::DaemonMode;
 
     let deadline = std::time::Instant::now() + timeout;
     loop {
-        let responding = matches!(
+        let current_pid = bring_up.main_pid();
+        let ping_ok = matches!(
             crate::backend::probe_daemon(&DaemonMode::Daemon).known(),
             Some(DaemonPing::Responding)
         );
-        if responding {
+        if daemon_ready(bring_up, old_pid, current_pid, ping_ok) {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -4266,6 +4438,82 @@ mod action_tests {
         use facelock_core::config::DaemonMode;
         assert!(daemon_start_wanted(&DaemonMode::Daemon));
         assert!(!daemon_start_wanted(&DaemonMode::Oneshot));
+    }
+
+    /// A second `setup` run must not enroll through the daemon the first run
+    /// left behind: the config the wizard just wrote is only read at startup.
+    /// The verbs are pinned because each is a no-op in the other's state —
+    /// `start` on a running unit is the stale daemon, `try-restart` on a
+    /// stopped one is no daemon at all.
+    #[test]
+    fn an_already_running_daemon_is_restarted_rather_than_left_alone() {
+        assert_eq!(daemon_bring_up_for(true), DaemonBringUp::Restart);
+        assert_eq!(daemon_bring_up_for(true).verb(), "try-restart");
+
+        assert_eq!(daemon_bring_up_for(false), DaemonBringUp::Start);
+        assert_eq!(daemon_bring_up_for(false).verb(), "start");
+    }
+
+    /// `try-restart --no-block` returns when systemd has *queued* the job, so
+    /// the outgoing daemon goes on answering `Ping` for as long as it takes to
+    /// stop it. On the restart branch a ping alone is therefore not evidence:
+    /// the unit's main PID has to have become a different, non-zero one.
+    #[test]
+    fn a_restart_is_only_ready_once_a_different_process_answers() {
+        // The outgoing instance answering its own replacement's wait.
+        assert!(!daemon_ready(
+            DaemonBringUp::Restart,
+            Some(4242),
+            Some(4242),
+            true
+        ));
+
+        // The successor: a different PID, and answering.
+        assert!(daemon_ready(
+            DaemonBringUp::Restart,
+            Some(4242),
+            Some(9001),
+            true
+        ));
+
+        // MainPID 0 — nothing is running, whatever answered the bus.
+        assert!(!daemon_ready(
+            DaemonBringUp::Restart,
+            Some(4242),
+            None,
+            true
+        ));
+
+        // A new process that is not answering yet: still loading its models.
+        assert!(!daemon_ready(
+            DaemonBringUp::Restart,
+            Some(4242),
+            Some(9001),
+            false
+        ));
+
+        // No outgoing PID to tell apart: degrades to the `Start` rule rather
+        // than waiting out the timeout on a daemon that is plainly up.
+        assert!(daemon_ready(DaemonBringUp::Restart, None, Some(9001), true));
+    }
+
+    /// The start branch has no outgoing instance an answer could have come
+    /// from, so the ping is the whole test and the PIDs are not consulted.
+    #[test]
+    fn a_start_is_ready_as_soon_as_the_daemon_answers() {
+        assert!(daemon_ready(DaemonBringUp::Start, None, None, true));
+        assert!(daemon_ready(DaemonBringUp::Start, Some(1), Some(1), true));
+        assert!(!daemon_ready(DaemonBringUp::Start, None, Some(9001), false));
+    }
+
+    /// The notice claims a replacement happened. A `systemctl` that refused
+    /// the job replaced nothing, and a start was never a replacement.
+    #[test]
+    fn only_a_restart_systemd_accepted_is_announced() {
+        assert!(restart_announced(DaemonBringUp::Restart, true));
+        assert!(!restart_announced(DaemonBringUp::Restart, false));
+        assert!(!restart_announced(DaemonBringUp::Start, true));
+        assert!(!restart_announced(DaemonBringUp::Start, false));
     }
 
     // -- `--no-enroll` ------------------------------------------------------

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -374,7 +374,7 @@ fn pam_request(action: PamAction, service: &str, knobs: PamKnobs, if_present: bo
 }
 
 /// Execute a resolved plan: base setup first (if any), then the standalone
-/// systemd and PAM actions, in that order — the wizard runs systemd (step 8)
+/// systemd and PAM actions, in that order — the wizard runs systemd (step 6)
 /// before PAM (step 9), and `--systemd --pam` must match.
 pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
     if needs_root_precheck(&plan) {
@@ -396,9 +396,16 @@ pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
     }
 
     match plan.systemd {
-        SystemdPref::Install => run_systemd(false)?,
-        SystemdPref::Disable => run_systemd(true)?,
-        // Under a wizard base `Ask` is step 8; everywhere else it means nothing.
+        // Only the standalone `--systemd` / `--systemd --disable` are applied
+        // here. A base flow applies its own, at step 6, because it has to
+        // land before enrollment: `enroll` and `test` select their transport
+        // at entry, so a daemon installed after them is never the one they
+        // used — both would run direct-by-fallback and the recognition test
+        // would validate a transport no later authentication takes.
+        SystemdPref::Install if plan.base.is_none() => run_systemd(false)?,
+        SystemdPref::Disable if plan.base.is_none() => run_systemd(true)?,
+        SystemdPref::Install | SystemdPref::Disable => {}
+        // Under a base flow `Ask` is step 6; everywhere else it means nothing.
         SystemdPref::Ask | SystemdPref::Skip => {}
     }
 
@@ -547,7 +554,59 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
         },
     }
 
-    // -- Step 6: Face enrollment --
+    // -- Step 6: Daemon configuration --
+    //
+    // Ahead of enrollment on purpose. Both steps below select their transport
+    // once, at entry (`backend::Backend::select`), so a daemon installed after
+    // them is never the one they used: enrollment would run direct-by-fallback
+    // and the recognition test would validate a transport that no later
+    // authentication takes. Still after model download and encryption — the
+    // daemon loads the models and opens the embedding key at startup, so it
+    // has nothing to start from before those two steps have run.
+    Terminal.info(&SetupMessage::SetupStepDaemon);
+    let systemd_step = systemd_step_for(plan);
+    let systemd_enabled = match systemd_step {
+        SystemdStep::Ask => match wizard_systemd_setup(&theme, plan.yes) {
+            Ok(enabled) => enabled,
+            Err(e) => {
+                Terminal.info(&SetupMessage::SystemdStepFailed {
+                    error: e.to_string(),
+                });
+                false
+            }
+        },
+        // Answered on the command line. Applied here rather than after the
+        // whole base flow, for the ordering reason above; the error it can
+        // raise is the one `run_with_plan` used to raise, only earlier.
+        SystemdStep::Install => {
+            Terminal.info(&SystemMessage::SystemdFromCommandLine);
+            run_systemd(false)?;
+            true
+        }
+        SystemdStep::Disable => {
+            Terminal.info(&SystemMessage::SystemdFromCommandLine);
+            run_systemd(true)?;
+            false
+        }
+        SystemdStep::Skip => {
+            Terminal.info(&SystemMessage::SystemdSkippedFlag);
+            false
+        }
+    };
+
+    // Group membership: without it, the first daemon command a normal user
+    // runs after setup fails with a bare D-Bus AccessDenied (issue #89).
+    if let Err(e) = setup_group_membership(Some(&theme)) {
+        Terminal.info(&SetupMessage::GroupStepFailed {
+            error: e.to_string(),
+        });
+    }
+
+    if systemd_enabled {
+        start_daemon_for_setup(&config);
+    }
+
+    // -- Step 7: Face enrollment --
     let enroll_steps = enroll_steps_for(plan);
     let enrolled = if enroll_steps.enroll {
         Terminal.info(&SetupMessage::SetupStepEnrollment);
@@ -565,7 +624,7 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
         false
     };
 
-    // -- Step 7: Test recognition --
+    // -- Step 8: Test recognition --
     if test_recognition_runs(enroll_steps, enrolled) {
         Terminal.info(&SetupMessage::SetupStepTest);
         match wizard_test_recognition(&config, &theme, plan.yes) {
@@ -578,36 +637,6 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
         }
     } else {
         Terminal.info(&SetupMessage::SetupStepTestSkipped);
-    }
-
-    // -- Step 8: Systemd setup --
-    Terminal.info(&SetupMessage::SetupStepDaemon);
-    let systemd_step = systemd_step_for(plan);
-    let systemd_enabled = if systemd_step.wizard_may_install() {
-        match wizard_systemd_setup(&theme, plan.yes) {
-            Ok(enabled) => enabled,
-            Err(e) => {
-                Terminal.info(&SetupMessage::SystemdStepFailed {
-                    error: e.to_string(),
-                });
-                false
-            }
-        }
-    } else {
-        if systemd_step == SystemdStep::Skip {
-            Terminal.info(&SystemMessage::SystemdSkippedFlag);
-        } else {
-            Terminal.info(&SystemMessage::SystemdDeferred);
-        }
-        false
-    };
-
-    // Group membership: without it, the first daemon command a normal user
-    // runs after setup fails with a bare D-Bus AccessDenied (issue #89).
-    if let Err(e) = setup_group_membership(Some(&theme)) {
-        Terminal.info(&SetupMessage::GroupStepFailed {
-            error: e.to_string(),
-        });
     }
 
     // -- Step 9: PAM configuration --
@@ -676,7 +705,9 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     Terminal.info(&SetupMessage::SummaryDaemon {
         status: match systemd_step {
             SystemdStep::Skip => SetupMessage::DaemonStatusNotConfiguredNoSystemd,
-            SystemdStep::Deferred => SetupMessage::DaemonStatusDeferred,
+            SystemdStep::Install | SystemdStep::Disable => {
+                SetupMessage::DaemonStatusFromCommandLine
+            }
             SystemdStep::Ask if systemd_enabled => SetupMessage::DaemonStatusEnabled,
             SystemdStep::Ask => SetupMessage::DaemonStatusNotConfigured,
         }
@@ -1841,13 +1872,13 @@ fn resolve_configured_model_sha256(
 // not configure the candidate set's five `default_enabled` services.
 // ---------------------------------------------------------------------------
 
-/// Steps 6 and 7, decided up front. Step 7 exists only to exercise the
-/// enrollment step 6 produced, so `--no-enroll` suppresses both.
+/// Steps 7 and 8, decided up front. Step 8 exists only to exercise the
+/// enrollment step 7 produced, so `--no-enroll` suppresses both.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EnrollSteps {
-    /// Step 6 runs at all.
+    /// Step 7 runs at all.
     enroll: bool,
-    /// Step 6 proceeds without its confirmation prompt.
+    /// Step 7 proceeds without its confirmation prompt.
     assume_yes: bool,
 }
 
@@ -1871,36 +1902,37 @@ fn enroll_steps_for(plan: &SetupPlan) -> EnrollSteps {
     }
 }
 
-/// Step 7 runs only when step 6 actually enrolled a face.
+/// Step 8 runs only when step 7 actually enrolled a face.
 fn test_recognition_runs(steps: EnrollSteps, enrolled: bool) -> bool {
     steps.enroll && enrolled
 }
 
-/// What step 8 does.
+/// What step 6 does.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SystemdStep {
     /// No flag: prompt, then install if accepted.
     Ask,
     /// `--no-systemd`: declined. No unit files, no `systemctl`.
     Skip,
-    /// `--systemd` / `--systemd --disable`: already answered, and
-    /// [`run_with_plan`] performs the action after the base flow — the wizard
-    /// must not do it a second time.
-    Deferred,
+    /// `--systemd`: already answered — install without prompting.
+    Install,
+    /// `--systemd --disable`: already answered — disable without prompting.
+    Disable,
 }
 
-impl SystemdStep {
-    /// Whether the wizard itself may write unit files or invoke `systemctl`.
-    fn wizard_may_install(self) -> bool {
-        matches!(self, SystemdStep::Ask)
-    }
-}
-
+/// Which [`SystemdStep`] a plan's `--systemd` / `--no-systemd` answer means.
+///
+/// `Install` and `Disable` used to collapse into one `Deferred` variant, on
+/// the rule that [`run_with_plan`] applied both after the base flow. It now
+/// applies them only when there is no base flow: inside one, the daemon has to
+/// be configured before enrollment, so step 6 performs them and the two
+/// answers need to be told apart.
 fn systemd_step_for(plan: &SetupPlan) -> SystemdStep {
     match plan.systemd {
         SystemdPref::Ask => SystemdStep::Ask,
         SystemdPref::Skip => SystemdStep::Skip,
-        SystemdPref::Install | SystemdPref::Disable => SystemdStep::Deferred,
+        SystemdPref::Install => SystemdStep::Install,
+        SystemdPref::Disable => SystemdStep::Disable,
     }
 }
 
@@ -2337,6 +2369,20 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
 
     secure_setup_paths(&config, Some(&manifest))?;
     write_setup_marker()?;
+
+    // Daemon configuration, before enrollment and for the same reason the
+    // wizard puts step 6 there: `enroll::run` selects its transport at entry,
+    // so a daemon installed after it is never the one it used. `Ask` and
+    // `Skip` mean "do nothing here", exactly as before — this flow has never
+    // prompted about systemd.
+    match plan.systemd {
+        SystemdPref::Install => {
+            run_systemd(false)?;
+            start_daemon_for_setup(&config);
+        }
+        SystemdPref::Disable => run_systemd(true)?,
+        SystemdPref::Ask | SystemdPref::Skip => {}
+    }
 
     // Enrollment only happens here when it was explicitly asked for: `None` and
     // `--no-enroll` both mean "do nothing", which is what this flow has always
@@ -3051,6 +3097,16 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         run_cmd("systemctl", &["daemon-reload"])?;
         Terminal.info(&SystemMessage::SystemctlDaemonReloadDone);
 
+        // The bus half of the same reload. Until the bus re-reads the policy
+        // written above, nothing may own `org.facelock.Daemon` — the system
+        // bus denies `own` by default and root is not exempt. Bus
+        // implementations differ on whether they pick the directory up over
+        // inotify, so ask; where it was unnecessary this is a no-op, and a
+        // failure is not worth failing an install over.
+        if let Err(e) = run_cmd("systemctl", &["reload", "dbus"]) {
+            tracing::debug!("could not reload the D-Bus configuration: {e}");
+        }
+
         run_cmd("systemctl", &["enable", SERVICE_FILENAME])?;
         Terminal.info(&SystemMessage::SystemctlEnableDone {
             unit: SERVICE_FILENAME.to_string(),
@@ -3060,6 +3116,89 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// How long a base flow waits for a freshly installed daemon to answer.
+///
+/// Bounded on purpose, and deliberately shorter than systemd's 90s start
+/// timeout: the daemon is a convenience for the two steps that follow, not a
+/// precondition for them, so a wizard must not stall a minute and a half on
+/// one that is never coming up.
+const DAEMON_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Gap between readiness probes.
+const DAEMON_READY_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Bring the daemon up so the enrollment and test steps that follow select it
+/// instead of falling back to direct camera access.
+///
+/// Every failure here is survivable and none of them are fatal: [`run_systemd`]
+/// has already installed and enabled the unit, which is what the user asked
+/// for, and a daemon that does not come up leaves exactly the direct-access
+/// fallback those steps used before this ordering existed. Reported, not
+/// raised.
+///
+/// Only reached from a base flow — a standalone `facelock setup --systemd`
+/// installs and enables as it always has, and starts on the next boot or on
+/// the next D-Bus activation. The bus-config reload the daemon needs before it
+/// can own its name is [`run_systemd`]'s, next to the policy file it serves.
+fn start_daemon_for_setup(config: &Config) {
+    if !daemon_start_wanted(&config.daemon.mode) {
+        return;
+    }
+
+    // `--no-block` because `Type=dbus` makes a blocking start wait on bus-name
+    // acquisition under systemd's start timeout. The wait below is ours, and
+    // bounded by us.
+    if let Err(e) = run_cmd("systemctl", &["start", "--no-block", SERVICE_FILENAME]) {
+        tracing::warn!("could not start {SERVICE_FILENAME}: {e}");
+    }
+
+    if wait_for_daemon(DAEMON_READY_TIMEOUT) {
+        Terminal.info(&SystemMessage::DaemonRunning);
+    } else {
+        Terminal.info(&SystemMessage::DaemonNotReady {
+            seconds: DAEMON_READY_TIMEOUT.as_secs(),
+        });
+    }
+}
+
+/// Whether a running daemon is any use to the steps that follow.
+///
+/// `mode = "oneshot"` is the configuration, not a degraded state: backend
+/// selection never probes the bus under it, so enrollment and the test would
+/// take direct camera access whether or not a daemon were running. Starting
+/// one would cost the wizard a spurious wait and win it nothing.
+fn daemon_start_wanted(mode: &facelock_core::config::DaemonMode) -> bool {
+    use facelock_core::config::DaemonMode;
+    matches!(mode, DaemonMode::Daemon)
+}
+
+/// Poll until the daemon answers, or `timeout` elapses.
+///
+/// Through the seam's [`crate::backend::probe_daemon`], which is the full
+/// `Ping` round-trip rather than the non-activating `name_has_owner` that
+/// backend selection uses. "The daemon answers method calls" is the property
+/// the next two steps need, and activating one systemd has not got to yet is a
+/// success here rather than the hazard it would be at selection time.
+fn wait_for_daemon(timeout: std::time::Duration) -> bool {
+    use crate::backend::DaemonPing;
+    use facelock_core::config::DaemonMode;
+
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let responding = matches!(
+            crate::backend::probe_daemon(&DaemonMode::Daemon).known(),
+            Some(DaemonPing::Responding)
+        );
+        if responding {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(DAEMON_READY_POLL);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4040,44 +4179,108 @@ mod action_tests {
         let step = systemd_step_for(&plan);
         assert_eq!(step, SystemdStep::Skip);
 
-        // `wizard_systemd_setup` is the wizard's only path to unit files and
-        // `systemctl`, and it runs only when `wizard_may_install()` holds.
-        assert!(!step.wizard_may_install());
-        // `run_with_plan` acts only on Install/Disable.
+        // `Skip` is the one step-6 arm with no `run_systemd` behind it —
+        // the other three all reach it, by prompt or by flag. And
+        // `run_with_plan`'s standalone arms act only on Install/Disable.
         assert!(!matches!(
             plan.systemd,
             SystemdPref::Install | SystemdPref::Disable
         ));
     }
 
-    /// `--systemd` is applied by `run_with_plan`, so step 8 must defer rather
-    /// than install a second time.
+    /// `--systemd` and `--systemd --disable` are answers, not deferrals: step
+    /// 6 applies them itself so the daemon is configured before enrollment.
+    /// They used to share one `Deferred` variant, which is why the step could
+    /// not tell an install from a disable.
     #[test]
-    fn systemd_flag_is_deferred_to_run_with_plan() {
-        for pref in [SystemdPref::Install, SystemdPref::Disable] {
+    fn systemd_flags_are_applied_by_the_daemon_step() {
+        for (pref, expected) in [
+            (SystemdPref::Install, SystemdStep::Install),
+            (SystemdPref::Disable, SystemdStep::Disable),
+        ] {
             let plan = SetupPlan {
                 systemd: pref,
                 ..SetupPlan::default()
             };
-            let step = systemd_step_for(&plan);
-            assert_eq!(step, SystemdStep::Deferred);
-            assert!(!step.wizard_may_install());
+            assert_eq!(systemd_step_for(&plan), expected);
         }
+    }
+
+    /// The other half of that move: `run_with_plan` must not repeat what the
+    /// base flow's step 6 already did. Its `--systemd` arms are guarded on
+    /// `plan.base.is_none()`, which only a standalone `facelock setup
+    /// --systemd` satisfies.
+    #[test]
+    fn run_with_plan_applies_systemd_only_without_a_base_flow() {
+        // Standalone: no base flow exists to run step 6.
+        let standalone = resolve_setup_plan(SetupArgs {
+            systemd: true,
+            ..SetupArgs::default()
+        });
+        assert_eq!(standalone.base, None);
+        assert_eq!(standalone.systemd, SystemdPref::Install);
+
+        // Any flag that forces the base flow hands the action to step 6.
+        for args in [
+            SetupArgs {
+                systemd: true,
+                enroll: true,
+                ..SetupArgs::default()
+            },
+            SetupArgs {
+                systemd: true,
+                non_interactive: true,
+                ..SetupArgs::default()
+            },
+        ] {
+            let plan = resolve_setup_plan(args);
+            assert!(plan.base.is_some());
+            assert_eq!(plan.systemd, SystemdPref::Install);
+            assert_eq!(systemd_step_for(&plan), SystemdStep::Install);
+        }
+    }
+
+    /// A daemon-less install enrolls exactly as it did before the reorder.
+    /// `--no-systemd` declines step 6 and nothing else: steps 7 and 8 still
+    /// run, on the direct-access fallback they have always used.
+    #[test]
+    fn no_systemd_still_reaches_enrollment_and_the_test() {
+        let plan = resolve_setup_plan(SetupArgs {
+            no_systemd: true,
+            enroll: true,
+            ..SetupArgs::default()
+        });
+        assert_eq!(plan.base, Some(BaseMode::Wizard));
+        assert_eq!(systemd_step_for(&plan), SystemdStep::Skip);
+
+        let steps = enroll_steps_for(&plan);
+        assert!(steps.enroll, "step 7 runs without a daemon");
+        assert!(steps.assume_yes);
+        assert!(test_recognition_runs(steps, true), "step 8 runs too");
+    }
+
+    /// Oneshot mode wants no daemon started: backend selection never probes
+    /// the bus under it, so the wait would buy the steps below nothing.
+    #[test]
+    fn the_daemon_is_only_started_for_daemon_mode() {
+        use facelock_core::config::DaemonMode;
+        assert!(daemon_start_wanted(&DaemonMode::Daemon));
+        assert!(!daemon_start_wanted(&DaemonMode::Oneshot));
     }
 
     // -- `--no-enroll` ------------------------------------------------------
 
-    /// `--no-enroll` suppresses step 6 *and* step 7, which depends on it.
+    /// `--no-enroll` suppresses step 7 *and* step 8, which depends on it.
     #[test]
-    fn no_enroll_suppresses_steps_6_and_7() {
+    fn no_enroll_suppresses_steps_7_and_8() {
         let plan = SetupPlan {
             enroll: Some(false),
             ..SetupPlan::default()
         };
         let steps = enroll_steps_for(&plan);
 
-        assert!(!steps.enroll, "step 6 must not run");
-        // Step 7 is gated on step 6, so it cannot run whatever `enrolled` says.
+        assert!(!steps.enroll, "step 7 must not run");
+        // Step 8 is gated on step 7, so it cannot run whatever `enrolled` says.
         assert!(!test_recognition_runs(steps, true));
         assert!(!test_recognition_runs(steps, false));
     }
@@ -4104,11 +4307,10 @@ mod action_tests {
         let plan = SetupPlan::default();
 
         let steps = enroll_steps_for(&plan);
-        assert!(steps.enroll, "step 6");
-        assert!(!steps.assume_yes, "step 6 still prompts");
-        assert!(test_recognition_runs(steps, true), "step 7");
-        assert_eq!(systemd_step_for(&plan), SystemdStep::Ask, "step 8");
-        assert!(systemd_step_for(&plan).wizard_may_install());
+        assert_eq!(systemd_step_for(&plan), SystemdStep::Ask, "step 6");
+        assert!(steps.enroll, "step 7");
+        assert!(!steps.assume_yes, "step 7 still prompts");
+        assert!(test_recognition_runs(steps, true), "step 8");
         assert_eq!(pam_step_for(&plan), PamStep::Ask, "step 9");
         assert!(pam_step_for(&plan).touches_pam_d());
     }
@@ -4127,7 +4329,7 @@ mod action_tests {
             assert!(confirm_step(&theme, prompt, true).unwrap());
         }
 
-        // `-y` is what feeds `assume_yes` at the step 6 call site; steps 7 and 8
+        // `-y` is what feeds `assume_yes` at the step 7 call site; steps 6 and 8
         // are passed `plan.yes` directly.
         let plan = SetupPlan {
             yes: true,

--- a/crates/facelock-cli/src/message/setup.rs
+++ b/crates/facelock-cli/src/message/setup.rs
@@ -24,11 +24,11 @@ pub enum SetupMessage {
     SetupStepInferenceDevice,
     SetupStepModelDownload,
     SetupStepEncryption,
+    SetupStepDaemon,
     SetupStepEnrollment,
     SetupStepEnrollmentSkipped,
     SetupStepTest,
     SetupStepTestSkipped,
-    SetupStepDaemon,
     SetupStepPam,
     SetupCompleteHeader,
 
@@ -94,7 +94,7 @@ pub enum SetupMessage {
         status: String,
     },
     DaemonStatusNotConfiguredNoSystemd,
-    DaemonStatusDeferred,
+    DaemonStatusFromCommandLine,
     DaemonStatusEnabled,
     DaemonStatusNotConfigured,
     SummaryPam {
@@ -193,7 +193,7 @@ impl Message for SetupMessage {
         match self {
             SetupIntro { version } => fill(
                 translate(
-                    "\n  Facelock v{version}\n  Linux face authentication\n\n  This wizard will walk you through initial setup:\n    - Camera detection\n    - Model quality and inference device\n    - Model downloads\n    - Embedding encryption (TPM or software)\n    - Face enrollment\n    - Daemon and PAM configuration\n",
+                    "\n  Facelock v{version}\n  Linux face authentication\n\n  This wizard will walk you through initial setup:\n    - Camera detection\n    - Model quality and inference device\n    - Model downloads\n    - Embedding encryption (TPM or software)\n    - Daemon configuration\n    - Face enrollment\n    - PAM configuration\n",
                 ),
                 &[("version", version.clone())],
             ),
@@ -202,15 +202,15 @@ impl Message for SetupMessage {
             SetupStepInferenceDevice => translate("\n--- Step 3: Inference Device ---\n"),
             SetupStepModelDownload => translate("\n--- Step 4: Model Download ---\n"),
             SetupStepEncryption => translate("\n--- Step 5: Embedding Encryption ---\n"),
-            SetupStepEnrollment => translate("\n--- Step 6: Face Enrollment ---\n"),
+            SetupStepDaemon => translate("\n--- Step 6: Daemon Configuration ---\n"),
+            SetupStepEnrollment => translate("\n--- Step 7: Face Enrollment ---\n"),
             SetupStepEnrollmentSkipped => {
-                translate("\n--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n")
+                translate("\n--- Step 7: Face Enrollment (skipped, --no-enroll) ---\n")
             }
-            SetupStepTest => translate("\n--- Step 7: Test Recognition ---\n"),
+            SetupStepTest => translate("\n--- Step 8: Test Recognition ---\n"),
             SetupStepTestSkipped => {
-                translate("\n--- Step 7: Test Recognition (skipped, no face enrolled) ---\n")
+                translate("\n--- Step 8: Test Recognition (skipped, no face enrolled) ---\n")
             }
-            SetupStepDaemon => translate("\n--- Step 8: Daemon Configuration ---\n"),
             SetupStepPam => translate("\n--- Step 9: PAM Configuration ---\n"),
             SetupCompleteHeader => translate("\n--- Setup Complete ---\n"),
             CameraStepFailed { error, current } => fill(
@@ -304,7 +304,7 @@ impl Message for SetupMessage {
                 &[("status", status.clone())],
             ),
             DaemonStatusNotConfiguredNoSystemd => translate("not configured (--no-systemd)"),
-            DaemonStatusDeferred => translate("configured from the command line"),
+            DaemonStatusFromCommandLine => translate("configured from the command line"),
             DaemonStatusEnabled => translate("enabled (D-Bus activation)"),
             DaemonStatusNotConfigured => translate("not configured"),
             SummaryPam { services } => fill(
@@ -420,11 +420,11 @@ impl super::Samples for SetupMessage {
             SetupStepInferenceDevice,
             SetupStepModelDownload,
             SetupStepEncryption,
+            SetupStepDaemon,
             SetupStepEnrollment,
             SetupStepEnrollmentSkipped,
             SetupStepTest,
             SetupStepTestSkipped,
-            SetupStepDaemon,
             SetupStepPam,
             SetupCompleteHeader,
             CameraStepFailed {
@@ -460,7 +460,7 @@ impl super::Samples for SetupMessage {
             SummaryEncryption { value: s("v") },
             SummaryDaemon { status: s("st") },
             DaemonStatusNotConfiguredNoSystemd,
-            DaemonStatusDeferred,
+            DaemonStatusFromCommandLine,
             DaemonStatusEnabled,
             DaemonStatusNotConfigured,
             SummaryPam {
@@ -506,6 +506,65 @@ impl super::Samples for SetupMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The wizard's step banners, in the order `run_wizard` prints them.
+    ///
+    /// The numbering is the whole point of the list: the daemon is configured
+    /// at step 6, ahead of enrollment and the recognition test, so that both
+    /// run against the transport every later authentication uses instead of
+    /// against the direct-camera fallback. A banner whose number no longer
+    /// matches its position is the symptom of a step that moved without the
+    /// steps around it being renumbered.
+    #[test]
+    fn step_banners_are_numbered_in_the_order_the_wizard_runs_them() {
+        use SetupMessage::*;
+
+        let expected = [
+            (SetupStepCamera, "\n--- Step 1: Camera Selection ---\n"),
+            (SetupStepModelQuality, "\n--- Step 2: Model Quality ---\n"),
+            (
+                SetupStepInferenceDevice,
+                "\n--- Step 3: Inference Device ---\n",
+            ),
+            (SetupStepModelDownload, "\n--- Step 4: Model Download ---\n"),
+            (
+                SetupStepEncryption,
+                "\n--- Step 5: Embedding Encryption ---\n",
+            ),
+            (SetupStepDaemon, "\n--- Step 6: Daemon Configuration ---\n"),
+            (SetupStepEnrollment, "\n--- Step 7: Face Enrollment ---\n"),
+            (SetupStepTest, "\n--- Step 8: Test Recognition ---\n"),
+            (SetupStepPam, "\n--- Step 9: PAM Configuration ---\n"),
+        ];
+        for (step, banner) in &expected {
+            assert_eq!(&step.localized(), banner);
+        }
+
+        // The skipped twins carry their unskipped twin's number, so they
+        // renumber with it rather than drifting into a second numbering.
+        assert_eq!(
+            SetupStepEnrollmentSkipped.localized(),
+            "\n--- Step 7: Face Enrollment (skipped, --no-enroll) ---\n"
+        );
+        assert_eq!(
+            SetupStepTestSkipped.localized(),
+            "\n--- Step 8: Test Recognition (skipped, no face enrolled) ---\n"
+        );
+    }
+
+    /// The intro promises the same order the steps run in.
+    #[test]
+    fn the_intro_lists_the_daemon_before_enrollment() {
+        let intro = SetupMessage::SetupIntro {
+            version: "0.0.0".into(),
+        }
+        .localized();
+        let daemon = intro.find("Daemon configuration").expect("daemon bullet");
+        let enrollment = intro.find("Face enrollment").expect("enrollment bullet");
+        let pam = intro.find("PAM configuration").expect("pam bullet");
+        assert!(daemon < enrollment, "daemon is configured before enrolling");
+        assert!(enrollment < pam);
+    }
 
     /// Every string this domain took over from a `println!` in
     /// `commands/setup.rs`, pinned to the bytes that call site printed.

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -18,6 +18,7 @@ pub enum SystemMessage {
     SystemdFromCommandLine,
 
     // -- bringing the daemon up --
+    DaemonRestarted,
     DaemonRunning,
     DaemonNotReady { seconds: u64 },
 
@@ -55,6 +56,9 @@ impl Message for SystemMessage {
                 "  Skipping daemon configuration (--no-systemd).\n  No unit files are written and systemctl is not invoked.",
             ),
             SystemdFromCommandLine => translate("  Answered on the command line."),
+            DaemonRestarted => translate(
+                "  facelock-daemon was already running; restarted so enrollment uses\n  the new configuration.",
+            ),
             DaemonRunning => translate("  facelock-daemon is running."),
             DaemonNotReady { seconds } => fill(
                 translate(
@@ -116,7 +120,7 @@ impl Message for SystemMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    const VARIANT_COUNT: usize = 21;
+    const VARIANT_COUNT: usize = 22;
 
     fn samples() -> Vec<Self> {
         use SystemMessage::*;
@@ -126,6 +130,7 @@ impl super::Samples for SystemMessage {
             SystemdDeclined,
             SystemdSkippedFlag,
             SystemdFromCommandLine,
+            DaemonRestarted,
             DaemonRunning,
             DaemonNotReady { seconds: 20 },
             CreatingFacelockGroup,

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -15,7 +15,11 @@ pub enum SystemMessage {
     SystemdNotDetected,
     SystemdDeclined,
     SystemdSkippedFlag,
-    SystemdDeferred,
+    SystemdFromCommandLine,
+
+    // -- bringing the daemon up --
+    DaemonRunning,
+    DaemonNotReady { seconds: u64 },
 
     // -- group membership --
     CreatingFacelockGroup,
@@ -50,9 +54,14 @@ impl Message for SystemMessage {
             SystemdSkippedFlag => translate(
                 "  Skipping daemon configuration (--no-systemd).\n  No unit files are written and systemctl is not invoked.",
             ),
-            SystemdDeferred => {
-                translate("  Answered on the command line; applied once setup finishes.")
-            }
+            SystemdFromCommandLine => translate("  Answered on the command line."),
+            DaemonRunning => translate("  facelock-daemon is running."),
+            DaemonNotReady { seconds } => fill(
+                translate(
+                    "  facelock-daemon did not answer within {seconds}s.\n  Continuing with direct camera access; check: systemctl status facelock-daemon",
+                ),
+                &[("seconds", seconds.to_string())],
+            ),
             CreatingFacelockGroup => translate("  Creating 'facelock' system group..."),
             GroupMembershipNote => translate(
                 "  Note: running daemon commands (preview/test) as a normal user requires\n  membership in the 'facelock' group: sudo usermod -aG facelock <user>",
@@ -107,7 +116,7 @@ impl Message for SystemMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    const VARIANT_COUNT: usize = 19;
+    const VARIANT_COUNT: usize = 21;
 
     fn samples() -> Vec<Self> {
         use SystemMessage::*;
@@ -116,7 +125,9 @@ impl super::Samples for SystemMessage {
             SystemdNotDetected,
             SystemdDeclined,
             SystemdSkippedFlag,
-            SystemdDeferred,
+            SystemdFromCommandLine,
+            DaemonRunning,
+            DaemonNotReady { seconds: 20 },
             CreatingFacelockGroup,
             GroupMembershipNote,
             AlreadyInGroup { user: s("u") },

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,8 +61,14 @@ print their payload and now print nothing; the exit code is unchanged.
 
 Interactive setup wizard. Walks through camera selection, model quality,
 inference device (CPU / CUDA / ROCm / OpenVINO), model downloads, encryption,
-enrollment, systemd and PAM configuration. Every step can also be answered, or
-declined, from the command line.
+the daemon, enrollment and PAM configuration. Every step can also be answered,
+or declined, from the command line.
+
+The daemon is configured before enrollment on purpose. `enroll` and `test`
+select their transport once, when they start, so on a first install a daemon
+configured after them would never be the one they used: enrollment would fall
+back to direct camera access and the recognition test would validate a
+transport no later authentication takes.
 
 ```bash
 facelock setup                          # interactive wizard
@@ -127,8 +133,8 @@ Model presets:
 | Pair | Without either flag (wizard) | Without either flag (`--non-interactive`) |
 |------|------------------------------|-------------------------------------------|
 | `--pam` / `--no-pam` | prompt (step 9) | off |
-| `--systemd` / `--no-systemd` | prompt (step 8) | off |
-| `--enroll` / `--no-enroll` | prompt (step 6) | off; enrollment needs a human in front of the camera |
+| `--systemd` / `--no-systemd` | prompt (step 6) | off |
+| `--enroll` / `--no-enroll` | prompt (step 7) | off; enrollment needs a human in front of the camera |
 
 Each pair is a clap override pair, so **a later flag wins over an earlier
 one**: `--pam --no-pam` declines PAM, `--no-pam --pam` installs it. That

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,13 @@ The daemon is configured before enrollment on purpose. `enroll` and `test`
 select their transport once, when they start, so on a first install a daemon
 configured after them would never be the one they used: enrollment would fall
 back to direct camera access and the recognition test would validate a
-transport no later authentication takes.
+transport no later authentication takes. The step starts the daemon, or
+restarts it if one is already running, because the daemon reads the encryption
+method, the model preset and the inference device once at startup: on a re-run
+of `setup` an untouched daemon would hold the answers from before the wizard.
+A restart interrupts any authentication that daemon is mid-way through, so a
+`sudo` prompt waiting on a face in another terminal falls back to a password
+that once.
 
 ```bash
 facelock setup                          # interactive wizard

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -50,7 +50,7 @@ follow it.
 
 | Command | Purpose |
 |---------|---------|
-| `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, enrollment, PAM); also manages `facelock` group membership (creates the group if missing, adds the invoking user) |
+| `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, daemon, enrollment, PAM — the daemon before enrollment, so enrollment and the recognition test run on the transport later authentications use); also manages `facelock` group membership (creates the group if missing, adds the invoking user) |
 | `facelock setup --systemd` | Install/enable systemd units |
 | `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
 | `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 12:19-0700\n"
+"POT-Creation-Date: 2026-08-18 12:20-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1288,103 +1288,109 @@ msgstr ""
 msgid "{path} ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:47
+#: crates/facelock-cli/src/message/system.rs:48
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:49
+#: crates/facelock-cli/src/message/system.rs:50
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:52
+#: crates/facelock-cli/src/message/system.rs:53
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:55
+#: crates/facelock-cli/src/message/system.rs:56
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:57
+#: crates/facelock-cli/src/message/system.rs:58
 msgid "  Answered on the command line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:58
+#: crates/facelock-cli/src/message/system.rs:60
+msgid ""
+"  facelock-daemon was already running; restarted so enrollment uses\n"
+"  the new configuration."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:62
 msgid "  facelock-daemon is running."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:61
+#: crates/facelock-cli/src/message/system.rs:65
 msgid ""
 "  facelock-daemon did not answer within {seconds}s.\n"
 "  Continuing with direct camera access; check: systemctl status facelock-daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:65
+#: crates/facelock-cli/src/message/system.rs:69
 msgid "  Creating 'facelock' system group..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:67
+#: crates/facelock-cli/src/message/system.rs:71
 msgid ""
 "  Note: running daemon commands (preview/test) as a normal user requires\n"
 "  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:70
+#: crates/facelock-cli/src/message/system.rs:74
 #, python-brace-format
 msgid "  User '{user}' is already in the 'facelock' group."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:75
+#: crates/facelock-cli/src/message/system.rs:79
 #, python-brace-format
 msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:80
+#: crates/facelock-cli/src/message/system.rs:84
 #, python-brace-format
 msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:85
+#: crates/facelock-cli/src/message/system.rs:89
 msgid ""
 "  Added '{user}' to the 'facelock' group.\n"
 "  NOTE: log out and back in for the new group membership to take effect."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:89
+#: crates/facelock-cli/src/message/system.rs:93
 msgid "Disabling facelock-daemon systemd units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:90
+#: crates/facelock-cli/src/message/system.rs:94
 msgid "facelock-daemon service disabled and stopped."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:92
+#: crates/facelock-cli/src/message/system.rs:96
 msgid "Installing facelock-daemon systemd and D-Bus units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:94
+#: crates/facelock-cli/src/message/system.rs:98
 #, python-brace-format
 msgid "  Wrote {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:96
+#: crates/facelock-cli/src/message/system.rs:100
 #, python-brace-format
 msgid "  Refreshed legacy {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:99
+#: crates/facelock-cli/src/message/system.rs:103
 msgid "  systemctl daemon-reload done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:101
+#: crates/facelock-cli/src/message/system.rs:105
 #, python-brace-format
 msgid "  systemctl enable {unit} done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:105
+#: crates/facelock-cli/src/message/system.rs:109
 msgid ""
 "\n"
 "facelock-daemon D-Bus activation is now enabled."

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-17 23:08-0700\n"
+"POT-Creation-Date: 2026-08-18 12:19-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -676,8 +676,9 @@ msgid ""
 "    - Model quality and inference device\n"
 "    - Model downloads\n"
 "    - Embedding encryption (TPM or software)\n"
+"    - Daemon configuration\n"
 "    - Face enrollment\n"
-"    - Daemon and PAM configuration\n"
+"    - PAM configuration\n"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:200
@@ -713,31 +714,31 @@ msgstr ""
 #: crates/facelock-cli/src/message/setup.rs:205
 msgid ""
 "\n"
-"--- Step 6: Face Enrollment ---\n"
+"--- Step 6: Daemon Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:207
+#: crates/facelock-cli/src/message/setup.rs:206
 msgid ""
 "\n"
-"--- Step 6: Face Enrollment (skipped, --no-enroll) ---\n"
+"--- Step 7: Face Enrollment ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:209
+#: crates/facelock-cli/src/message/setup.rs:208
 msgid ""
 "\n"
-"--- Step 7: Test Recognition ---\n"
+"--- Step 7: Face Enrollment (skipped, --no-enroll) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:211
+#: crates/facelock-cli/src/message/setup.rs:210
 msgid ""
 "\n"
-"--- Step 7: Test Recognition (skipped, no face enrolled) ---\n"
+"--- Step 8: Test Recognition ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:213
+#: crates/facelock-cli/src/message/setup.rs:212
 msgid ""
 "\n"
-"--- Step 8: Daemon Configuration ---\n"
+"--- Step 8: Test Recognition (skipped, no face enrolled) ---\n"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:214
@@ -1287,93 +1288,103 @@ msgstr ""
 msgid "{path} ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:43
+#: crates/facelock-cli/src/message/system.rs:47
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:45
+#: crates/facelock-cli/src/message/system.rs:49
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:48
+#: crates/facelock-cli/src/message/system.rs:52
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:51
+#: crates/facelock-cli/src/message/system.rs:55
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:54
-msgid "  Answered on the command line; applied once setup finishes."
-msgstr ""
-
-#: crates/facelock-cli/src/message/system.rs:56
-msgid "  Creating 'facelock' system group..."
+#: crates/facelock-cli/src/message/system.rs:57
+msgid "  Answered on the command line."
 msgstr ""
 
 #: crates/facelock-cli/src/message/system.rs:58
+msgid "  facelock-daemon is running."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:61
+msgid ""
+"  facelock-daemon did not answer within {seconds}s.\n"
+"  Continuing with direct camera access; check: systemctl status facelock-daemon"
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:65
+msgid "  Creating 'facelock' system group..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:67
 msgid ""
 "  Note: running daemon commands (preview/test) as a normal user requires\n"
 "  membership in the 'facelock' group: sudo usermod -aG facelock <user>"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:61
+#: crates/facelock-cli/src/message/system.rs:70
 #, python-brace-format
 msgid "  User '{user}' is already in the 'facelock' group."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:66
+#: crates/facelock-cli/src/message/system.rs:75
 #, python-brace-format
 msgid "Add user '{user}' to the 'facelock' group? (required to run facelock preview/test without sudo)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:71
+#: crates/facelock-cli/src/message/system.rs:80
 #, python-brace-format
 msgid "  Skipped. Add later with: sudo usermod -aG facelock {user}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:76
+#: crates/facelock-cli/src/message/system.rs:85
 msgid ""
 "  Added '{user}' to the 'facelock' group.\n"
 "  NOTE: log out and back in for the new group membership to take effect."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:80
+#: crates/facelock-cli/src/message/system.rs:89
 msgid "Disabling facelock-daemon systemd units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:81
+#: crates/facelock-cli/src/message/system.rs:90
 msgid "facelock-daemon service disabled and stopped."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:83
+#: crates/facelock-cli/src/message/system.rs:92
 msgid "Installing facelock-daemon systemd and D-Bus units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:85
+#: crates/facelock-cli/src/message/system.rs:94
 #, python-brace-format
 msgid "  Wrote {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:87
+#: crates/facelock-cli/src/message/system.rs:96
 #, python-brace-format
 msgid "  Refreshed legacy {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:90
+#: crates/facelock-cli/src/message/system.rs:99
 msgid "  systemctl daemon-reload done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:92
+#: crates/facelock-cli/src/message/system.rs:101
 #, python-brace-format
 msgid "  systemctl enable {unit} done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:96
+#: crates/facelock-cli/src/message/system.rs:105
 msgid ""
 "\n"
 "facelock-daemon D-Bus activation is now enabled."


### PR DESCRIPTION
## Summary

- move the wizard's daemon step ahead of enrollment: Camera → Model quality → Inference device → Model download → Encryption → Daemon → Enrollment → Test → PAM
- start the daemon in that step (`systemctl start --no-block` + a 20 s readiness probe through `backend::probe_daemon`) instead of only enabling it; reload the bus config right after the policy file is written so the daemon can own its name
- when the unit is already running (a `setup` re-run), `try-restart` it so enrollment and the test go through a daemon holding the wizard's config; readiness then requires a changed MainPID plus a responding ping, so the outgoing instance cannot answer for the new one
- apply `--systemd`/`--systemd --disable` inside the daemon step when a base flow runs (wizard and `--non-interactive`); standalone `setup --systemd` is unchanged
- keep `--no-systemd` and oneshot installs on today's direct-camera fallback
- renumber the step banners (Daemon 8→6, Enrollment 6→7, Test 7→8; PAM stays 9); `SetupMessage::VARIANT_COUNT` unchanged

## Why

On a first install enrollment and the recognition test ran before the daemon existed, so both fell back to direct camera access with a `DirectByFallback` warning, and step 7 validated a code path no later authentication uses. Reordering alone was not enough: `run_systemd` never started the unit and `--systemd` was deferred until after the whole flow, so `setup --systemd --enroll` would still have enrolled daemon-less.

## Reviewer notes

- **failing `--systemd` now aborts at step 6** instead of after enrollment, PAM and the summary; exit code unchanged. Swallowing it to keep the old completion point would turn a broken `--systemd` into exit 0.
- **the readiness wait bounds the poll loop, not wall time**: one hung D-Bus probe can outlast the 20 s the `DaemonNotReady` line promises. Not seen in practice; a zbus method timeout is the fix if a real box shows it.
- **the restart can interrupt an authentication in flight** in another terminal (one-time password fallback); accepted against a stale daemon silently holding the wrong key or model until someone restarts it
- `backend.rs` and `ipc_client.rs` untouched

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check`
- banner order, `--systemd` plan split, `--no-systemd` still reaching enrollment, daemon start gated on `daemon.mode` — all unit-pinned
- root run with a camera: `sudo facelock setup --systemd --enroll` twice (second run prints the restart notice) with no `DirectByFallback`, and `--no-systemd --enroll` still enrolling with the fallback
