### PR TITLE
feat(setup): Accept --if-present on setup --pam, not only on --remove

### DIFF
--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -29,7 +29,8 @@ facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
 facelock setup --pam --service polkit-1 # install to a specific service
 facelock setup --pam --remove           # remove the PAM line
-facelock setup --pam --remove --if-present  # a missing service file is success
+facelock setup --pam --service hyprlock --if-present  # a missing service file is success
+facelock setup --pam --remove --if-present  # ...on removal too
 facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
 facelock setup --no-pam                 # wizard, but never touch /etc/pam.d
 facelock setup --camera /dev/video2     # answer step 1 from the command line
@@ -111,7 +112,7 @@ Two details worth knowing:
 |------|----------|---------|
 | `--service <name>` | `--pam` | Target PAM service. Default `sudo`. |
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
-| `--if-present` | `--remove` | Treat an absent service file as success rather than an error. Read, parse and write failures stay fatal. |
+| `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
 | `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
 
 These `requires` relationships are enforced by the parser. `facelock setup --remove` is a clear error naming the missing `--pam`, not a silently ignored flag.

--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -113,8 +113,8 @@ pub struct SetupCli {
     /// Used with --pam: remove the PAM line instead of adding it
     #[arg(long, requires = "pam")]
     pub remove: bool,
-    /// Used with --pam --remove: treat an absent service file as success
-    #[arg(long = "if-present", requires = "remove")]
+    /// Used with --pam: treat an absent service file as success
+    #[arg(long = "if-present", requires = "pam")]
     pub if_present: bool,
 
     // -- Choice flags. Supplying a value answers the question, and so skips

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -2356,7 +2356,18 @@ pub(crate) fn remove_for_setup(request: &PamRequest) -> anyhow::Result<()> {
 /// already *is* the per-service consent, and the module check already ran, so
 /// neither is repeated here — nor is the closing hint, which the wizard emits
 /// itself once, after step 9, whatever that step decided.
-pub(crate) fn install_one_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Result<()> {
+///
+/// `Ok(true)` means the service carries a facelock line now. The wizard needs
+/// that answer and cannot get it from `Ok(())`: it names the configured
+/// services in its closing summary and offers the hyprlock handoff off the
+/// same list, and both are claims about the file rather than about the call
+/// having not failed. `absent` and `declined` are successes that configured
+/// nothing.
+///
+/// The wizard's request names exactly one service, so the fold below reads it
+/// off a single row; `any` rather than `all` so a future empty request answers
+/// "nothing was configured" instead of "everything was".
+pub(crate) fn install_one_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Result<bool> {
     debug_assert_eq!(request.action, PamAction::Add);
     let write = WriteRequest {
         action: WriteAction::Add,
@@ -2365,7 +2376,31 @@ pub(crate) fn install_one_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Re
     };
     let sink = Sink::human();
     let reports = apply_all(&plan_writes(dirs, &write)?, &write, &sink);
-    first_failure(&reports)
+    first_failure(&reports)?;
+    Ok(reports
+        .iter()
+        .any(|report| add_left_the_line(&report.outcome)))
+}
+
+/// Whether `add` left the service carrying a facelock line.
+///
+/// `overridden` is `true`: the `/etc/pam.d` copy that now exists carries it.
+/// `absent` and `declined` are `false` — neither is a failure, and neither
+/// configured anything. Every other word belongs to `remove` or `status`, or
+/// is `failed`, which [`first_failure`] has already turned into an `Err`
+/// before this is consulted.
+fn add_left_the_line(outcome: &Outcome) -> bool {
+    match outcome {
+        Outcome::Installed | Outcome::Overridden | Outcome::Unchanged => true,
+        Outcome::Absent
+        | Outcome::Declined
+        | Outcome::Removed
+        | Outcome::VendorOnly
+        | Outcome::Failed(_)
+        | Outcome::Present
+        | Outcome::Missing
+        | Outcome::Unknown(_) => false,
+    }
 }
 
 #[cfg(test)]
@@ -3497,6 +3532,90 @@ mod tests {
         assert_eq!(status(&["sudo", "not-a-service"], true), STATUS_MISSING);
         // ...and it converts absence only.
         assert_eq!(status(&["../escape"], true), STATUS_ERROR);
+    }
+
+    /// The alias honours `--if-present` on `add`, and forgives absence only.
+    ///
+    /// The verb's own coverage is `if_present_turns_a_missing_service_into_a_no_op_on_both_verbs`
+    /// above; this is the alias entry point, which is where the bool used to
+    /// stop. `install_one_in` rather than `install_for_setup` because the
+    /// latter refuses non-root before it reaches phase one — the two differ by
+    /// that check and the module check, and hand `plan_writes` the same
+    /// request.
+    #[test]
+    fn the_alias_honours_if_present_on_add() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let request = PamRequest {
+            no_confirm: true,
+            if_present: true,
+            ..add(&["omarchy-lock-face"])
+        };
+        assert!(
+            !install_one_in(&only(dir.path()), &request).unwrap(),
+            "an absent service configured nothing, so it is not a configured service"
+        );
+        assert!(
+            fs::read_dir(dir.path()).unwrap().next().is_none(),
+            "an absent service must leave the directory empty"
+        );
+
+        // The positive control: the same call on a service that is there
+        // answers `true`, so the bool tracks the file and not the flag.
+        let real = seeded(&[("omarchy-lock-face", OMARCHY_REMOVED)]);
+        assert!(install_one_in(&only(real.path()), &request).unwrap());
+        assert_eq!(read(&real, "omarchy-lock-face"), OMARCHY_PRESENT);
+
+        // Without the flag the same call is a failure, so the default still
+        // catches a typo'd `--service`.
+        let error = install_one_in(&only(dir.path()), &add(&["omarchy-lock-face"]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("PAM service file not found:"),
+            "got: {error}"
+        );
+
+        // ...and the flag converts absence and nothing else: an unreadable
+        // target is still fatal through the alias, exactly as through the verb.
+        fs::create_dir(dir.path().join("sudo")).unwrap();
+        let error = install_one_in(
+            &only(dir.path()),
+            &PamRequest {
+                no_confirm: true,
+                if_present: true,
+                allow_sensitive: true,
+                ..add(&["sudo"])
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("failed to read"), "got: {error}");
+    }
+
+    /// The decision table behind `install_one_in`'s bool, every word given a
+    /// verdict on purpose.
+    ///
+    /// `Declined` is reachable no other way from a test: it needs a terminal
+    /// answering "no" at the per-file confirmation. It is the second word that
+    /// is a success having configured nothing, so the wizard's summary and its
+    /// hyprlock handoff must treat it the way they treat `absent`.
+    #[test]
+    fn only_the_add_words_that_leave_a_line_count_as_configured() {
+        for outcome in [Outcome::Installed, Outcome::Overridden, Outcome::Unchanged] {
+            assert!(add_left_the_line(&outcome), "{}", outcome.word());
+        }
+        for outcome in [
+            Outcome::Absent,
+            Outcome::Declined,
+            Outcome::Removed,
+            Outcome::VendorOnly,
+            Outcome::Failed("e".to_string()),
+            Outcome::Present,
+            Outcome::Missing,
+            Outcome::Unknown("e".to_string()),
+        ] {
+            assert!(!add_left_the_line(&outcome), "{}", outcome.word());
+        }
     }
 
     /// `install_for_setup` edits `/etc/pam.d` and `run_with_plan` reaches it

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -114,8 +114,14 @@ pub enum SystemdPref {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PamPref {
     Ask,
-    Install { service: Option<String> },
-    Remove { service: String, if_present: bool },
+    Install {
+        service: Option<String>,
+        if_present: bool,
+    },
+    Remove {
+        service: String,
+        if_present: bool,
+    },
     Skip,
 }
 
@@ -228,6 +234,7 @@ pub fn resolve_setup_plan(args: SetupArgs) -> SetupPlan {
     } else if args.pam {
         PamPref::Install {
             service: args.service.clone(),
+            if_present: args.if_present,
         }
     } else if args.no_pam {
         PamPref::Skip
@@ -412,7 +419,10 @@ pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
             PamKnobs::default(),
             *if_present,
         ))?,
-        PamPref::Install { service } => {
+        PamPref::Install {
+            service,
+            if_present,
+        } => {
             // The wizard's step 9 already applied `--pam`; installing again here
             // would be a second, unasked-for edit of the same file.
             if !wizard_ran {
@@ -421,7 +431,7 @@ pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
                     PamAction::Add,
                     service,
                     setup_pam_knobs(&plan),
-                    false,
+                    *if_present,
                 ))?;
             }
         }
@@ -1899,10 +1909,16 @@ fn systemd_step_for(plan: &SetupPlan) -> SystemdStep {
 enum PamStep {
     /// No flag: today's multi-select over the detected candidates.
     Ask,
-    /// `--pam [--service X]`: exactly this one service. Deliberately *not* the
-    /// candidates' five `default_enabled` entries — `--pam` already means "sudo"
-    /// in standalone mode, so a scripter gets one consistent meaning everywhere.
-    Install(String),
+    /// `--pam [--service X] [--if-present]`: exactly this one service.
+    /// Deliberately *not* the candidates' five `default_enabled` entries —
+    /// `--pam` already means "sudo" in standalone mode, so a scripter gets one
+    /// consistent meaning everywhere.
+    ///
+    /// `if_present` rides along because this arm is `--pam` under a *wizard*
+    /// base — `setup --pam --service X --if-present --enroll` reaches step 9
+    /// rather than [`run_with_plan`]'s alias call, and a flag the operator
+    /// typed must not be decided differently by which other flags they typed.
+    Install { service: String, if_present: bool },
     /// `--no-pam`: declined. Nothing under the PAM directory is written or
     /// backed up.
     Skip,
@@ -1913,7 +1929,7 @@ enum PamStep {
 impl PamStep {
     /// Whether step 9 modifies anything under the PAM directory.
     fn touches_pam_d(&self) -> bool {
-        matches!(self, PamStep::Ask | PamStep::Install(_))
+        matches!(self, PamStep::Ask | PamStep::Install { .. })
     }
 }
 
@@ -1921,11 +1937,15 @@ fn pam_step_for(plan: &SetupPlan) -> PamStep {
     match &plan.pam {
         PamPref::Ask => PamStep::Ask,
         PamPref::Skip => PamStep::Skip,
-        PamPref::Install { service } => PamStep::Install(
-            service
+        PamPref::Install {
+            service,
+            if_present,
+        } => PamStep::Install {
+            service: service
                 .clone()
                 .unwrap_or_else(|| DEFAULT_PAM_SERVICE.to_string()),
-        ),
+            if_present: *if_present,
+        },
         PamPref::Remove { .. } => PamStep::Deferred,
     }
 }
@@ -2037,7 +2057,10 @@ fn pam_step_in(
     }
 
     match step {
-        PamStep::Install(service) => {
+        PamStep::Install {
+            service,
+            if_present,
+        } => {
             Terminal.info(&PamMessage::ConfiguringPamFor {
                 service: service.clone(),
             });
@@ -2045,11 +2068,22 @@ fn pam_step_in(
             // `--non-interactive`, so `setup_pam_knobs` reduces to `plan.yes`
             // on both knobs here. Splitting them would make `--pam --service X
             // --yes` start prompting where it never did.
-            super::pam::install_one_in(
+            //
+            // The returned bool, not the absence of an `Err`, decides whether
+            // this service is named in the closing summary and whether the
+            // hyprlock handoff fires. Under `--if-present` an absent service
+            // is a success that configured nothing, and reporting it as
+            // configured would have offered to wire `hyprlock.conf` up to a
+            // PAM service that has no facelock line.
+            let configured = super::pam::install_one_in(
                 dirs,
-                &pam_request(PamAction::Add, &service, setup_pam_knobs(plan), false),
+                &pam_request(PamAction::Add, &service, setup_pam_knobs(plan), if_present),
             )?;
-            Ok(vec![service])
+            Ok(if configured {
+                vec![service]
+            } else {
+                Vec::new()
+            })
         }
         PamStep::Ask => wizard_pam_setup_in(dirs, theme),
         // Both returned above; repeated here to keep the match exhaustive.
@@ -2106,9 +2140,17 @@ fn wizard_pam_setup_in(dirs: &PamDirs, theme: &ColorfulTheme) -> anyhow::Result<
             no_confirm: true,
             allow_sensitive: true,
         };
+        // `false`, not the plan's `--if-present`: the multi-select only ever
+        // offers services whose file it just found, so there is no absence to
+        // forgive, and these are not the service the operator named.
         match super::pam::install_one_in(dirs, &pam_request(PamAction::Add, &service, knobs, false))
         {
-            Ok(()) => configured.push(service),
+            Ok(true) => configured.push(service),
+            // Unreachable as written — the multi-select offers only services
+            // whose file it just found, and `no_confirm` suppresses the
+            // decline — but the list must carry what was configured, not what
+            // was attempted.
+            Ok(false) => {}
             Err(e) => {
                 Terminal.info(&PamMessage::PamConfigureFailed {
                     service: service.clone(),
@@ -3786,6 +3828,7 @@ mod action_tests {
             yes: true,
             ..pam_plan(PamPref::Install {
                 service: Some("sudo".to_string()),
+                if_present: false,
             })
         };
         let configured =
@@ -3832,6 +3875,7 @@ mod action_tests {
             yes: true,
             ..pam_plan(PamPref::Install {
                 service: Some("hyprlock".to_string()),
+                if_present: false,
             })
         };
         let configured =
@@ -3842,6 +3886,75 @@ mod action_tests {
         assert_ne!(before["hyprlock"], after["hyprlock"]);
         assert_eq!(before["sudo"], after["sudo"]);
         assert_eq!(before["polkit-1"], after["polkit-1"]);
+    }
+
+    /// `--if-present` reaches the writer through step 9, not only through the
+    /// alias call in [`run_with_plan`].
+    ///
+    /// `setup --pam --service X --if-present --enroll` resolves to a *wizard*
+    /// base, so `run_with_plan` skips its own `install_for_setup` and step 9
+    /// performs the install instead. Step 9 used to hand the writer a
+    /// hard-coded `false`, which made the flag mean one thing on
+    /// `--pam --if-present` and nothing at all as soon as any base-forcing flag
+    /// was typed beside it.
+    #[test]
+    fn pam_if_present_survives_into_step_nine() {
+        let dir = fake_pam_d();
+        let before = hash_dir(dir.path());
+
+        let plan = SetupPlan {
+            yes: true,
+            ..pam_plan(PamPref::Install {
+                service: Some("facelock-absent".to_string()),
+                if_present: true,
+            })
+        };
+        assert_eq!(
+            pam_step_for(&plan),
+            PamStep::Install {
+                service: "facelock-absent".to_string(),
+                if_present: true,
+            }
+        );
+
+        let configured =
+            pam_step_in(&only(dir.path()), &plan, &ColorfulTheme::default(), true).unwrap();
+        assert!(
+            configured.is_empty(),
+            "an absent service configured nothing, so the closing summary must not \
+             name it and the hyprlock handoff must not fire for it: {configured:?}"
+        );
+        assert_eq!(
+            before,
+            hash_dir(dir.path()),
+            "an absent service under --if-present must write nothing"
+        );
+    }
+
+    /// The default stays a hard error: without the flag, a service that is not
+    /// there fails the step rather than being skipped. This is what catches
+    /// `--service polkti-1`.
+    #[test]
+    fn an_absent_service_without_if_present_still_fails_step_nine() {
+        let dir = fake_pam_d();
+        let before = hash_dir(dir.path());
+
+        let plan = SetupPlan {
+            yes: true,
+            ..pam_plan(PamPref::Install {
+                service: Some("facelock-absent".to_string()),
+                if_present: false,
+            })
+        };
+
+        let error = pam_step_in(&only(dir.path()), &plan, &ColorfulTheme::default(), true)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("PAM service file not found:"),
+            "got: {error}"
+        );
+        assert_eq!(before, hash_dir(dir.path()));
     }
 
     /// Bare `--pam` means `sudo`, not the candidates' `default_enabled` set.
@@ -3855,11 +3968,17 @@ mod action_tests {
     fn pam_without_service_means_sudo_not_the_default_enabled_set() {
         let plan = SetupPlan {
             yes: true,
-            ..pam_plan(PamPref::Install { service: None })
+            ..pam_plan(PamPref::Install {
+                service: None,
+                if_present: false,
+            })
         };
         assert_eq!(
             pam_step_for(&plan),
-            PamStep::Install(DEFAULT_PAM_SERVICE.to_string())
+            PamStep::Install {
+                service: DEFAULT_PAM_SERVICE.to_string(),
+                if_present: false,
+            }
         );
 
         let dir = fake_pam_d();

--- a/crates/facelock-cli/src/conformance/docs.rs
+++ b/crates/facelock-cli/src/conformance/docs.rs
@@ -449,6 +449,7 @@ fn docs_cli_examples_never_install_into_a_gated_service() {
                     }
                     let PamPref::Install {
                         service: Some(service),
+                        ..
                     } = &plan.pam
                     else {
                         continue;

--- a/crates/facelock-cli/src/conformance/flags.rs
+++ b/crates/facelock-cli/src/conformance/flags.rs
@@ -38,6 +38,7 @@ fn parse_error(args: &[&str]) -> clap::Error {
 fn install(service: Option<&str>) -> PamPref {
     PamPref::Install {
         service: service.map(str::to_string),
+        if_present: false,
     }
 }
 
@@ -203,6 +204,34 @@ fn pam_remove_if_present_reaches_the_resolved_plan() {
     );
 }
 
+/// The add side of the same flag.
+///
+/// `setup --pam --if-present` used to be a parse error, and the alias handed
+/// the writer a hard-coded `false` even so — two independent places for the
+/// bool to stop, which is why the row is here as well as in
+/// `commands::setup`'s step-9 tests. What a caller wants out of it is one
+/// thing: configure this set of optional integrations, skipping the services
+/// this machine does not have.
+#[test]
+fn pam_add_if_present_reaches_the_resolved_plan() {
+    assert_eq!(
+        plan(&["--pam", "--service", "omarchy-lock-face", "--if-present"]).pam,
+        PamPref::Install {
+            service: Some("omarchy-lock-face".to_string()),
+            if_present: true,
+        }
+    );
+    // Bare `--pam --if-present` too: the service default is applied later, and
+    // the flag must survive that.
+    assert_eq!(
+        plan(&["--pam", "--if-present"]).pam,
+        PamPref::Install {
+            service: None,
+            if_present: true,
+        }
+    );
+}
+
 #[test]
 fn systemd_disable_is_standalone() {
     let p = plan(&["--systemd", "--disable"]);
@@ -305,19 +334,31 @@ fn remove_without_pam_is_a_parse_error() {
     );
 }
 
+/// `--if-present` requires `--pam`, and nothing else.
+///
+/// Was `if_present_requires_remove_and_pam`, back when the flag was gated to
+/// removal. The two cases that must keep failing are the same two it held
+/// then, kept here rather than dropped: `--if-present` on its own is still a
+/// parse error naming the action it modifies, and `--remove --if-present`
+/// still fails on `--remove`'s own `requires = "pam"`. Only the middle case
+/// moved, from a parse error to a resolved plan.
 #[test]
-fn if_present_requires_remove_and_pam() {
-    for args in [
-        &["--if-present"][..],
-        &["--pam", "--if-present"],
-        &["--remove", "--if-present"],
-    ] {
+fn if_present_requires_pam() {
+    for args in [&["--if-present"][..], &["--remove", "--if-present"]] {
         assert_eq!(
             parse_error(args).kind(),
             clap::error::ErrorKind::MissingRequiredArgument,
             "unexpected error kind for {args:?}"
         );
     }
+    // ...and the case that used to be here as a third failure.
+    assert_eq!(
+        plan(&["--pam", "--if-present"]).pam,
+        PamPref::Install {
+            service: None,
+            if_present: true,
+        }
+    );
 }
 
 #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,8 @@ facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
 facelock setup --pam --service polkit-1 # install to a specific service
 facelock setup --pam --remove           # remove the PAM line
-facelock setup --pam --remove --if-present  # a missing service file is success
+facelock setup --pam --service hyprlock --if-present  # a missing service file is success
+facelock setup --pam --remove --if-present  # ...on removal too
 facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
 facelock setup --no-pam                 # wizard, but never touch /etc/pam.d
 facelock setup --camera /dev/video2     # answer step 1 from the command line
@@ -130,7 +131,7 @@ forcing the step, so it runs unattended.
 |------|----------|---------|
 | `--service <NAME>` | `--pam` | Target PAM service. Default `sudo`. |
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
-| `--if-present` | `--remove` | Treat an absent service file as success rather than an error. Read, parse and write failures stay fatal. |
+| `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
 | `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
 
 The parser enforces these, so `facelock setup --remove` is an error naming the

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -228,12 +228,20 @@ Consequently `setup --systemd --pam` now runs both (it previously dropped
 `--remove` and `--service` require `--pam`, and `--disable` requires `--systemd`,
 so a dropped flag is now a parse error rather than silence.
 
-`--if-present` requires `--remove` (and therefore `--pam`). It changes only a
-missing target service file from an error into a successful no-op; read, parse
-and write failures remain fatal, and `--remove` without the flag retains its
-historical missing-file error. (On `facelock pam` the same flag is offered on
-**both** `add` and `remove`, since "configure hyprlock if this machine has
-hyprlock" is the same question in either direction.)
+`--if-present` requires `--pam` and applies to the add side as well as
+`--remove`. "Configure hyprlock if this machine has hyprlock" is the same
+question in either direction, and it is what a provisioning script over a set
+of optional integrations is asking. The flag turns a missing target service
+file from an error into a successful no-op and does nothing else; read, parse
+and write failures remain fatal, and without it both directions keep their
+historical missing-file error. The exit code is `facelock pam`'s and identical
+on both: an absent service is reported `absent` and the alias exits 0.
+
+The flag is not a way around a service that *should* resolve. Since the search
+path took in the vendor directories, `--service polkit-1` finds
+`/usr/lib/pam.d/polkit-1` on a stock Arch box without it. Reserve
+`--if-present` for services a machine may genuinely not have. The default stays
+a hard error, which is what catches `--service polkti-1`.
 
 **`--pam` is an alias onto `facelock pam add` / `facelock pam remove`.** The
 plan resolution above stays on `setup` — `--pam`, `--no-pam`, `--service`,
@@ -653,7 +661,7 @@ that is not on this list is not being denied, only not yet promised.
 | `pam-multi-service` | `pam add`/`pam remove`/`pam status` take a repeatable `--service` — several services in one process, one root check |
 | `pam-status` | `pam status` exists — the unprivileged `/etc/pam.d` read (DEC-6 below) |
 | `quiet` | the global `--quiet` |
-| `setup-if-present` | `setup --pam --remove --if-present` |
+| `setup-if-present` | `setup --pam --if-present`, on add and on `--remove` alike |
 | `setup-no-pam` | `setup --no-pam` |
 | `setup-systemd` | `setup --systemd` |
 | `tpm-decrypt` | `tpm decrypt` exists — the verb ADR 009 moved under `tpm` from the top-level `decrypt` |

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -259,6 +259,22 @@ run_test "setup --pam --remove --if-present succeeds on an absent service file" 
     "facelock setup --pam --service facelock-scratch --remove --yes --if-present" \
     0
 
+# The add side of the same flag. A provisioning script configures a set of
+# optional integrations in one pass; before this, the alias could only say
+# "add", so a machine without hyprlock failed the whole run. Absence must be a
+# successful no-op that creates nothing. Both halves are asserted: a `setup
+# --pam` that reached exit 0 by writing a service file out of thin air would
+# satisfy an exit-code-only row.
+run_test "setup --pam --if-present succeeds on an absent service file" \
+    "facelock setup --pam --service facelock-scratch --yes --if-present > /dev/null 2>&1; test \$? -eq 0 && ! test -e /etc/pam.d/facelock-scratch" \
+    0
+
+# ...and the default is still a hard error, which is what catches a typo'd
+# --service rather than silently configuring nothing.
+run_test "setup --pam without --if-present still fails on an absent service file" \
+    "facelock setup --pam --service facelock-scratch --yes > /dev/null 2>&1; test \$? -ne 0 && ! test -e /etc/pam.d/facelock-scratch" \
+    0
+
 # --- P1: vendor pam.d resolution ---
 #
 # Linux-PAM reads /etc/pam.d first and /usr/lib/pam.d second, and packages have


### PR DESCRIPTION
## Summary

- accept `--if-present` on `setup --pam` (add), not only on `--pam --remove`; the clap gate becomes `requires = "pam"`
- thread the flag through `PamPref::Install` and `PamStep::Install`, so it survives a wizard base (`--pam --service X --if-present --enroll`) as well as the standalone alias; the wizard's own multi-select still passes `false`
- absent service → exit 0 with a note; permission denied, malformed file and failed writes stay fatal with and without the flag; the default stays a hard error (it catches `--service polkti-1`)
- `install_one_in` now reports whether the service carries a line afterwards, so a skipped or declined service is not listed in the closing summary and cannot trigger the hyprlock handoff
- `docs/cli.md` `--if-present` row: Requires `--pam` (was `--remove`); contracts §Flag Composition and the capability row updated

## Why

Provisioning scripts configure a set of optional services through the alias and had no way to say "do these if they exist" on the add side; the alternatives were pre-checking each file (duplicating the resolver P1 just centralised) or swallowing every error. After #201 `polkit-1` resolves on Arch, so this is for genuinely optional services, not a workaround.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`
- clap gate: `--if-present` bare and `--remove --if-present` still fail, `--pam --if-present` parses
- `just test-arch-pam`: two new rows (`setup --pam --if-present` on an absent service exits 0 and writes nothing; without the flag still non-zero)

Stacked on #201.
