### PR TITLE
ci: Add Claude Code Action workflows for @claude and PR review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,45 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,24 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # No `synchronize`: PRs here iterate through many pushes (stacked PRs,
+    # iterate-pr loops), and a full review per push is mostly noise. Review
+    # once when the PR is ready; ask for another with `@claude review`.
+    # `opened` is kept for the rare PR that opens non-draft.
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Same-repo, non-draft PRs only.
+    #   - Fork PRs get no secrets on `pull_request`, and the action rejects
+    #     actors without write access anyway; skip them cleanly instead of
+    #     failing red on the contributor's PR. Never switch this workflow to
+    #     `pull_request_target` to "fix" that: it would hand secrets to forks.
+    #   - PRs open as drafts by convention; reviewing the draft on `opened`
+    #     and again on `ready_for_review` doubles the spend for nothing.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
     permissions:
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -39,7 +42,15 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # The code-review skill hunts for bugs. AGENTS.md is loaded from the
+          # checkout, but it describes how to build the project, not what a
+          # reviewer should treat as a defect. Spell that out here.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --append-system-prompt "This repository is a Linux PAM face-authentication module; a bug here is a security defect.
+            Read AGENTS.md, docs/security.md, and docs/contracts.md before reviewing.
+            Treat changes under crates/facelock-daemon/src (auth, handler, rate limiting, liveness, audit), crates/pam-facelock, crates/facelock-tpm, dbus/, systemd/, and polkit/ as security-sensitive and review them adversarially.
+            Report as findings: any weakening of the security.require_ir default or of frame-variance/liveness checks in the auth path; any change to binary names, install paths, config keys, the D-Bus interface, the database schema, or auth semantics that does not also update docs/contracts.md; any new dependency in pam-facelock beyond libc, toml, serde, zbus; unwrap()/expect()/panic paths in library crates; embedding comparisons that are not constant-time; loosened file permissions, D-Bus policy, or systemd hardening; error paths that fail open.
+            Docs are part of the product: review docs/**, book/**, website/**, man/, and CHANGELOG.md for accuracy against the code, stale contracts, and broken cross-references, not only the Rust."
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,16 @@ Supported providers: `cpu` (default), `cuda` (NVIDIA), `rocm` (AMD), `openvino` 
 - Tag `vX.Y.Z` triggers CI to build binaries, .deb, and .rpm.
 - Update `CHANGELOG.md` before committing the release.
 - See `docs/releasing.md` for full process and versioning contract.
+
+## Commits, PRs, and Issues
+
+Applies to anything an agent authors in this repository, including runs
+triggered from GitHub (`@claude` in a comment or issue).
+
+- Titles: `<type>(<scope>): <subject>`. Types: `feat` `fix` `refactor` `polish` `docs` `test` `ci` `chore` `perf` `build` `style` `revert`.
+- No AI attribution anywhere: no "Generated with Claude Code" footer, no `Co-Authored-By` trailer, no mention of Claude, AI, agents, or assistants in a title, body, commit message, or changelog entry.
+- Open PRs as drafts. The maintainer marks them ready.
+- PR and issue bodies are bullets: verb-first fragments, lowercase, no terminal period. Prose only for the `Why`, capped at four sentences. A small PR is two or three bullets with no headings.
+- Never paste command output, CI logs, or pass/fail tables into a PR. Naming a check under `Validation` is fine; reporting its result is not.
+- Every PR says why the change exists. If it cannot be derived, ask; never invent one.
+- Docs are part of the deliverable. A change to paths, config keys, CLI flags, D-Bus interface, or behavior updates `docs/` (and `docs/contracts.md` where it applies) in the same PR.


### PR DESCRIPTION
## Summary

- add `claude.yml`: run Claude Code Action on `@claude` in issues, PR comments, and reviews; write access required, bots refused
- add `claude-code-review.yml`: `/code-review --comment` on same-repo, non-draft PRs at `opened`, `ready_for_review`, `reopened`; no `synchronize`, re-review on demand with `@claude review`
- skip fork PRs cleanly instead of failing red; never `pull_request_target`
- append a reviewer brief: security-sensitive paths, what counts as a finding, docs reviewed for accuracy against the code
- record commit, PR, and issue conventions in `AGENTS.md` (no attribution, `type(scope): subject`, draft PRs, bullet bodies) so runs from the GitHub runner follow them

## Why

The installer's defaults review every push to every PR, including drafts and forks. PRs here open as drafts and iterate through many pushes, so that reviews the same PR repeatedly and burns tokens on nothing. Fork PRs get no secrets on `pull_request`, so the job failed red on the contributor's PR. The runner has no global instructions, so anything an agent authored from a GitHub trigger carried attribution footers.

## Validation

- `actionlint` on both workflows
- tokenized `claude_args` with the action's `shell-quote` parser to confirm the multi-line `--append-system-prompt` value survives as one argument
