### PR TITLE
fix(camera): require IR-typical quirk evidence

### DIFF
--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -19,7 +19,9 @@
 #   emitter_xu_guid         - UVC Extension Unit GUID for IR emitter control
 #   emitter_xu_selector     - UVC XU control selector for emitter toggle
 #   warmup_frames           - override device.warmup_frames for this camera
-#   format_preference       - preferred pixel format (e.g. "GREY", "Y16 ", "YUYV")
+#   format_preference       - preferred pixel format (e.g. "GREY", "Y16 ", "YUYV");
+#                             counts as IR evidence only when IR-typical and
+#                             actually advertised by the capture node
 #   y16_bit_depth           - effective bit depth of this sensor's Y16 samples
 #                             (8..=16, e.g. 10 for a 10-bit sensor). Pins the
 #                             Y16 -> 8-bit scale from hardware truth instead of

--- a/crates/facelock-camera/src/device.rs
+++ b/crates/facelock-camera/src/device.rs
@@ -103,7 +103,7 @@ pub fn ir_source(device: &DeviceInfo) -> IrSource {
 /// space-padded to 4 chars by the V4L2 API; compare trimmed.
 const IR_TYPICAL_FOURCCS: [&str; 5] = ["GREY", "Y16", "Y12", "Y10", "Y8"];
 
-fn is_ir_typical_fourcc(fourcc: &str) -> bool {
+pub(crate) fn is_ir_typical_fourcc(fourcc: &str) -> bool {
     IR_TYPICAL_FOURCCS.contains(&fourcc.trim())
 }
 
@@ -276,11 +276,13 @@ fn ir_source_with_quirks_and_ids(
 /// V4L2 nodes sharing the same VID:PID — e.g. the Logitech BRIO (046d:085e) has
 /// an RGB node (YUYV/MJPG) *and* an IR node (native GREY). When multiple nodes
 /// share one quirk-matched USB identity AND at least one of them exposes an
-/// IR-like format (GREY/Y16, or the quirk's `format_preference`), only the
-/// node(s) with that format are IR; siblings without it fall back to the
-/// quirk-free heuristic. If NO node has an IR-like format there is no evidence
-/// to disambiguate with, so `force_ir` is trusted for all nodes (some quirk
-/// entries exist precisely because the camera advertises no IR-like format).
+/// IR-typical format (GREY/Y8/Y10/Y12/Y16), only the node(s) with that format
+/// are IR; siblings without it fall back to the quirk-free heuristic. A
+/// quirk's `format_preference` counts as this evidence only when the preference
+/// is itself IR-typical and the node advertises it. If NO node has an IR-like
+/// format there is no evidence to disambiguate with, so `force_ir` is trusted
+/// for all nodes (some quirk entries exist precisely because the camera
+/// advertises no IR-like format).
 pub fn classify_ir_sources(
     devices: &[DeviceInfo],
     quirks: Option<&crate::quirks::QuirksDb>,
@@ -325,7 +327,8 @@ fn classify_ir_sources_with_ids(
             continue;
         }
 
-        // IR-like formats: GREY/Y16 plus the quirk's format_preference, if any.
+        // IR-like formats: native GREY/Y8/Y10/Y12/Y16, including the quirk's
+        // format_preference only when the preference is itself IR-typical.
         let pref = quirks
             .and_then(|db| db.find_match_with_ids(&devices[i], Some(ids)))
             .and_then(|q| q.format_preference.clone());
@@ -338,10 +341,11 @@ fn classify_ir_sources_with_ids(
         let node_has_ir_format = |j: usize| {
             has_native_ir_format(&devices[j])
                 || pref.as_deref().is_some_and(|p| {
-                    devices[j]
-                        .formats
-                        .iter()
-                        .any(|f| f.fourcc.trim() == p.trim())
+                    is_ir_typical_fourcc(p)
+                        && devices[j]
+                            .formats
+                            .iter()
+                            .any(|f| f.fourcc.trim() == p.trim())
                 })
         };
 
@@ -843,6 +847,30 @@ mod tests {
 
         let sources = classify_ir_sources_with_ids(&devices, Some(&db), &ids);
         assert_eq!(sources[0], IrSource::None);
+        assert_eq!(sources[1], IrSource::Quirk);
+    }
+
+    #[test]
+    fn rgb_format_preference_does_not_exempt_rgb_sibling_from_demotion() {
+        // Regression #164: format_preference is node-level IR evidence only
+        // when the preferred format is itself IR-typical. An RGB preference
+        // such as MJPG must not let the RGB sibling keep force_ir when a GREY
+        // sibling provides real evidence for disambiguation.
+        let mut db = crate::quirks::QuirksDb::default();
+        db.push_quirk_for_test(brio_quirk(Some("MJPG")));
+
+        let devices = [
+            device_at("/dev/video0", "Logitech BRIO", &["YUYV", "MJPG"]),
+            device_at("/dev/video2", "Logitech BRIO", &["GREY"]),
+        ];
+        let ids = vec![brio_ids(), brio_ids()];
+
+        let sources = classify_ir_sources_with_ids(&devices, Some(&db), &ids);
+        assert_eq!(
+            sources[0],
+            IrSource::None,
+            "an RGB format preference must not preserve force_ir on the RGB sibling"
+        );
         assert_eq!(sources[1], IrSource::Quirk);
     }
 

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -830,7 +830,8 @@ notes = "Full test quirk"
     }
 
     /// Every `format_preference` shipped in `config/quirks.d/00-defaults.toml`
-    /// must be a format facelock can actually decode.
+    /// must be both a format facelock can actually decode and an IR-typical
+    /// format that may safely act as node-level IR evidence.
     ///
     /// This is the coupling #90 introduced and nothing else guards: the file
     /// writes the padded V4L2 spelling (`"Y16 "`), `load_file` normalizes it,
@@ -839,7 +840,7 @@ notes = "Full test quirk"
     /// A shipped preference that fails this check does not fail loudly at
     /// runtime — it silently stops selecting the RealSense IR sensor node.
     #[test]
-    fn shipped_quirk_format_preferences_are_decodable() {
+    fn shipped_quirk_format_preferences_are_decodable_and_ir_typical() {
         let Some(quirks) = shipped_default_quirks() else {
             return;
         };
@@ -853,6 +854,12 @@ notes = "Full test quirk"
                 crate::capture::DECODABLE_FORMATS.contains(&pref.trim()),
                 "shipped quirk {:?} prefers {pref:?}, which facelock cannot decode — \
                  it would be dropped at open with a warning",
+                q.notes
+            );
+            assert!(
+                crate::device::is_ir_typical_fourcc(pref),
+                "shipped quirk {:?} prefers {pref:?}, which is not IR-typical — \
+                 it must not act as node-level IR evidence",
                 q.notes
             );
         }

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1481,8 +1481,10 @@ When `device.path` is omitted:
    (GREY/Y8/Y10/Y12/Y16, with no color format mixed in). The device name never
    classifies a node on its own. Node-level disambiguation for multi-node USB
    devices: when several nodes share one quirk-matched VID:PID and at least one
-   has an IR-like format (GREY/Y16 or the quirk's `format_preference`), only the
-   format-bearing node(s) are IR
+   has an IR-typical format (GREY/Y8/Y10/Y12/Y16), only the format-bearing
+   node(s) are IR. A quirk's `format_preference` counts as node-level IR
+   evidence only when it is itself IR-typical and the node actually advertises
+   it
 4. Exclude devices that advertise no decodable pixel format
    (GREY/Y16/YUYV/NV12/MJPG) — e.g. raw Bayer sensor nodes (Intel IPU6/IPU7).
    This filter runs *after* step 3 and never feeds back into it: it changes
@@ -1804,7 +1806,10 @@ evidence or a real USB identity). The free-text device name never classifies a
 device on its own, and a GREY/Y16 format offered *alongside* a color format is
 not treated as IR. A `force_ir` quirk is device-level ("this USB device has an
 IR sensor"): when the device exposes multiple capture nodes and at least one has
-an IR-like format, only the format-bearing node(s) classify IR (see
+an IR-typical format, only the format-bearing node(s) classify IR. A quirk's
+`format_preference` participates in that decision only when the preferred
+format is itself IR-typical and actually advertised; an RGB preference such as
+MJPG cannot exempt an RGB sibling from demotion (see
 `docs/security.md` §A). Frame variance is passive
 anti-photo only (does not stop video replay); it is evaluated over a sliding window
 of the most recent `min_auth_frames` matched frames (see `docs/security.md` §B), with

--- a/docs/security.md
+++ b/docs/security.md
@@ -64,11 +64,13 @@ pub fn ir_source_with_quirks(device, quirks) -> IrSource { ... }
 // physical camera can expose several V4L2 nodes under one VID:PID (Logitech
 // BRIO 046d:085e: /dev/video0 = RGB YUYV/MJPG, /dev/video2 = IR native GREY).
 // When multiple nodes share a quirk-matched USB identity AND at least one has
-// an IR-like format (GREY/Y16, or the quirk's format_preference), only the
-// node(s) with that format classify IR; siblings fall back to the quirk-free
-// heuristic. If NO node has an IR-like format, force_ir is trusted for all
-// (some quirk entries exist precisely because the camera advertises no
-// IR-like format). Anything gating require_ir uses these sibling-aware forms:
+// an IR-typical format (GREY/Y8/Y10/Y12/Y16), only the node(s) with that
+// format classify IR; siblings fall back to the quirk-free heuristic. A
+// quirk's format_preference counts as this evidence only when it is itself
+// IR-typical and the node actually advertises it. If NO node has an IR-like
+// format, force_ir is trusted for all (some quirk entries exist precisely
+// because the camera advertises no IR-like format). Anything gating require_ir
+// uses these sibling-aware forms:
 pub fn classify_ir_sources(devices, quirks) -> Vec<IrSource> { ... }
 pub fn ir_source_resolved(device, quirks) -> IrSource { ... } // enumerates siblings
 
@@ -88,7 +90,7 @@ if config.security.require_ir && !device_is_ir {
 
 **Honest residual — format evidence is not unforgeable**: deriving IR-ness from queried formats raises the attacker's cost from "set a free-text `CARD_LABEL` string" to "also negotiate a mono-**only** pixel format", and removes the old path where a bare name token (or a name-only quirk) could escalate a device to IR. It does **not** make the evidence unforgeable. A `v4l2loopback` device (loading the module requires **root**) or a programmable USB gadget can present a mono-only (GREY/Y16/…) format set and **will** classify as IR — the format check cannot distinguish a genuine IR sensor from a device that merely advertises IR-typical formats. The remaining backstops against a fabricated IR device are the **liveness / frame-variance checks** (§B) and the **privilege required to create such a device** in the first place (root to load `v4l2loopback`, or physical access to attach USB-gadget hardware). `require_ir` is one layer of a layered defense, not a standalone attestation of a real IR sensor.
 
-**Why `force_ir` is device-level, not node-level (hardware-verified regression)**: on a real Logitech BRIO, treating every quirk-matched node as IR made *both* `/dev/video0` (the RGB sensor) and `/dev/video2` (the IR sensor) classify IR — so setup stopped auto-selecting and auto-detect captured from the RGB sensor (white LED) instead of the IR sensor. The sibling-format disambiguation above restores per-node honesty: exactly one BRIO node is `[IR]`, and auto-detection prefers the format-corroborated IR node.
+**Why `force_ir` is device-level, not node-level (hardware-verified regression)**: on a real Logitech BRIO, treating every quirk-matched node as IR made *both* `/dev/video0` (the RGB sensor) and `/dev/video2` (the IR sensor) classify IR — so setup stopped auto-selecting and auto-detect captured from the RGB sensor (white LED) instead of the IR sensor. The sibling-format disambiguation above restores per-node honesty: exactly one BRIO node is `[IR]`, and auto-detection prefers the format-corroborated IR node. A quirk preference for an RGB format such as MJPG may still guide capture negotiation, but it is not IR evidence and cannot exempt an RGB sibling from demotion.
 
 **Limitation**: classification is capability-based, not a hardware allow-list. A genuine IR camera that exposes its IR and color streams on a *single* V4L2 node (so its format set is not mono-only) and is not covered by a shipped quirk will not auto-classify as IR. Add a quirks `force_ir` entry keyed by **USB vendor:product ID** (`/etc/facelock/quirks.d/`) for such hardware — a VID:PID match is authoritative — and set `format_preference` to the IR node's native format (e.g. `"GREY"`) when the camera exposes multiple capture nodes. Prefer a USB-ID quirk over a name-only one: a name-only `force_ir` is trusted only when corroborated by the device's own mono-format evidence or a real USB identity, so it is not a reliable override on its own. The `facelock devices` command displays whether each camera is detected as IR. Device *identity* pinning (rather than capability heuristics) is implemented as its robust successor — see §1.D Device Coupling (Plan 02).
 


### PR DESCRIPTION
## Why

A quirk's RGB format preference could incorrectly preserve IR classification on an RGB sibling. This weakens the intended IR-typical evidence contract.

## Changes

- require IR-typical advertised preference evidence
- demote RGB siblings despite RGB format preferences
- guard shipped quirk preferences
- update camera security and behavior contracts
- resolve #164

## Validation

- cargo test -p facelock-camera
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- just test-arch-oneshot BRIO discovery and GREY negotiation
