### PR TITLE
build(release): define prerelease versions and the supported distro matrix

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -19,9 +19,9 @@ disagrees with the tree — the doc wins and this skill is stale.
 just release-preflight v<X.Y.Z>
 ```
 
-Pass the tag. The recipe is **prerelease-aware**: a tag matching
-`alpha|beta|rc` relaxes the secret requirements, a final tag does not. Running
-it bare skips that branch, so always pass the tag you intend to push.
+Pass the tag you intend to push. Tags are parsed strictly as `vX.Y.Z` or `vX.Y.Z-{alpha,beta,rc}.N`.
+A validated prerelease relaxes the stable secret requirements; a final version
+does not. A bare invocation derives the version from `Cargo.toml` and classifies it with the same parser.
 
 It checks local tools (`git`, `cargo`, `just`, `podman`), the packaging files,
 and release secrets. Fix every `MISSING` before continuing.
@@ -99,8 +99,8 @@ Only after explicit confirmation. No AI attribution in the commit or tag message
 The `v*` tag triggers `.github/workflows/release.yml`, which has 9 jobs:
 
 ```
-build · download-ort · build-deb
-build-deb-tpm · build-rpm · build-nix
+metadata · build · download-ort
+build-deb · build-rpm · build-nix
 publish-aur · publish-apt · trigger-pages
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
   build-and-test:
     name: Build, Test, Lint
     runs-on: ubuntu-latest
-    container: archlinux:base-devel
+    container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
     steps:
       - name: Install system dependencies
         run: |
+          printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
             git \
             rust \
@@ -103,7 +104,7 @@ jobs:
   cargo-audit:
     name: Supply-chain Audit (cargo-audit)
     runs-on: ubuntu-latest
-    container: archlinux:base-devel
+    container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
     # Override the workflow-level -Dwarnings: this job compiles cargo-audit's
     # own third-party dependency tree, which we don't control. A future
     # warning upstream shouldn't fail this job for reasons unrelated to the
@@ -113,6 +114,7 @@ jobs:
     steps:
       - name: Install system dependencies
         run: |
+          printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
             git \
             rust
@@ -134,11 +136,12 @@ jobs:
   tpm-tests:
     name: TPM Tests (swtpm)
     runs-on: ubuntu-latest
-    container: archlinux:base-devel
+    container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
     needs: build-and-test
     steps:
       - name: Install dependencies
         run: |
+          printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
             git \
             rust \
@@ -174,10 +177,11 @@ jobs:
   agent-docs:
     name: Agent Docs Consistency
     runs-on: ubuntu-latest
-    container: archlinux:base-devel
+    container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
     steps:
       - name: Install system dependencies
         run: |
+          printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
             git \
             just \
@@ -193,13 +197,20 @@ jobs:
       - name: Verify agent docs still describe the tree
         run: just check-agent-docs "${{ github.event.pull_request.base.sha }}"
 
+      - name: Verify release target declarations
+        run: python3 test/check-release-matrix.py
+
+      - name: Compare live production release channels with checked-in authority
+        run: python3 test/check-live-release-channels.py
+
   catalog-check:
     name: Translation Catalog Freshness
     runs-on: ubuntu-latest
-    container: archlinux:base-devel
+    container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
     steps:
       - name: Install system dependencies
         run: |
+          printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
             git \
             gettext \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,33 @@ env:
   ORT_VERSION: "1.20.1"
 
 jobs:
+  metadata:
+    name: Validate Release Identity
+    runs-on: ubuntu-latest
+    outputs:
+      cargo-version: ${{ steps.release.outputs.cargo-version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      arch-pkgver: ${{ steps.release.outputs.arch-pkgver }}
+      debian-upstream: ${{ steps.release.outputs.debian-upstream }}
+      debian-revision: ${{ steps.release.outputs.debian-revision }}
+      rpm-version: ${{ steps.release.outputs.rpm-version }}
+      rpm-counter: ${{ steps.release.outputs.rpm-counter }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate tag, package metadata, channels, and target matrix
+        id: release
+        run: |
+          set -euo pipefail
+          source scripts/release-versions.sh
+          release_check_metadata "$GITHUB_REF_NAME"
+          release_write_github_outputs "$GITHUB_REF_NAME" "$GITHUB_OUTPUT"
+          RELEASE_MATRIX_VERSION="${GITHUB_REF_NAME#v}" python3 test/check-release-matrix.py
+
   build:
     name: Build Release Binaries
     runs-on: ubuntu-latest
+    needs: metadata
     steps:
       - uses: actions/checkout@v7
 
@@ -65,10 +89,12 @@ jobs:
             release/facelock-polkit-agent-x86_64-linux-gnu
             release/SHA256SUMS
           generate_release_notes: true
+          prerelease: ${{ needs.metadata.outputs.prerelease }}
 
   download-ort:
     name: Download ONNX Runtime
     runs-on: ubuntu-latest
+    needs: metadata
     steps:
       - name: Download ONNX Runtime for bundling
         run: |
@@ -87,67 +113,41 @@ jobs:
           path: onnxruntime/
 
   build-deb:
-    name: Build Debian Package
+    name: Build ${{ matrix.suite }} Debian Package
     runs-on: ubuntu-latest
-    needs: [build, download-ort]
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install system dependencies
-        run: .github/workflows/scripts/install-ubuntu-deps.sh
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release
-        run: cargo build --release --workspace
-
-      - name: Download ORT bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: onnxruntime-bundle
-          path: onnxruntime
-
-      - name: Verify ORT bundle exists
-        run: test -s onnxruntime/lib/libonnxruntime.so
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Build .deb package (legacy)
-        run: .github/workflows/scripts/build-deb.sh "${{ steps.version.outputs.VERSION }}" "legacy"
-
-      - name: Validate .deb contents
-        run: .github/workflows/scripts/validate-deb.sh facelock_*.deb
-
-      - name: Upload .deb artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-deb-legacy
-          path: facelock_*.deb
-
-      - name: Upload .deb to release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: facelock_*.deb
-
-  build-deb-tpm:
-    name: Build Debian Package (TPM)
-    runs-on: ubuntu-latest
-    needs: [build, download-ort]
+    needs: [metadata, build, download-ort]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: trixie
+            variant: tpm
+            architecture: amd64
+            image: docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958
+          - suite: bookworm
+            variant: legacy
+            architecture: amd64
+            image: docker.io/library/debian:12@sha256:813017f3d62be4b5891a7acca6a01bdcd4b8513daa81b1ab99d3a50385b26931
+          - suite: resolute
+            variant: tpm
+            architecture: amd64
+            image: docker.io/library/ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6
+          - suite: noble
+            variant: legacy
+            architecture: amd64
+            image: docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb
     container:
-      image: debian:13
+      image: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Install system dependencies
         run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -y \
+            ca-certificates \
             build-essential \
             curl \
             pkg-config \
@@ -156,32 +156,42 @@ jobs:
             libv4l-dev \
             libpam0g-dev \
             libxkbcommon-dev \
-            libwayland-dev \
-            libtss2-dev \
-            libtss2-tcti-tabrmd-dev
+            libwayland-dev
+          if [ "${{ matrix.variant }}" = tpm ]; then
+            apt-get install -y libtss2-dev
+          fi
 
       - name: Detect libtss2-esys package name and version
         id: tss
         run: |
-          TSS_PKG=$(dpkg -l 'libtss2-esys*' 2>/dev/null | awk '/^ii/{print $2}' | head -1)
-          TSS_VER=$(dpkg -l 'libtss2-esys*' 2>/dev/null | awk '/^ii/{print $3}' | head -1)
-          if [ -z "$TSS_PKG" ]; then
-            echo "ERROR: No libtss2-esys package found"
-            exit 1
+          set -euo pipefail
+          if [ "${{ matrix.variant }}" = tpm ]; then
+            TSS_PKG=$(dpkg -l 'libtss2-esys*' 2>/dev/null | awk '/^ii/{print $2}' | head -1)
+            TSS_VER=$(dpkg -l 'libtss2-esys*' 2>/dev/null | awk '/^ii/{print $3}' | head -1)
+            if [ -z "$TSS_PKG" ]; then
+              echo "ERROR: No libtss2-esys package found"
+              exit 1
+            fi
+            echo "TSS_DEPENDS=${TSS_PKG} (>= ${TSS_VER})" >> "$GITHUB_OUTPUT"
+            echo "Found: ${TSS_PKG} ${TSS_VER}"
+          else
+            echo "TSS_DEPENDS=" >> "$GITHUB_OUTPUT"
           fi
-          echo "TSS_PKG=${TSS_PKG}" >> "$GITHUB_OUTPUT"
-          echo "TSS_VER=${TSS_VER}" >> "$GITHUB_OUTPUT"
-          echo "Found: ${TSS_PKG} ${TSS_VER}"
 
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Build release with TPM
+      - name: Build release for suite variant
         run: |
+          set -euo pipefail
           . "$HOME/.cargo/env"
-          cargo build --release --workspace --features tpm
+          if [ "${{ matrix.variant }}" = tpm ]; then
+            cargo build --release --workspace --features tpm
+          else
+            cargo build --release --workspace
+          fi
 
       - name: Download ORT bundle
         uses: actions/download-artifact@v8
@@ -192,14 +202,14 @@ jobs:
       - name: Verify ORT bundle exists
         run: test -s onnxruntime/lib/libonnxruntime.so
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Build .deb package (TPM)
+      - name: Build suite-specific .deb package
         run: |
           . "$HOME/.cargo/env"
-          .github/workflows/scripts/build-deb.sh "${{ steps.version.outputs.VERSION }}" "tpm" "${{ steps.tss.outputs.TSS_PKG }} (>= ${{ steps.tss.outputs.TSS_VER }})"
+          .github/workflows/scripts/build-deb.sh \
+            "${{ needs.metadata.outputs.cargo-version }}" \
+            "${{ matrix.suite }}" \
+            "${{ needs.metadata.outputs.debian-revision }}" \
+            "${{ steps.tss.outputs.TSS_DEPENDS }}"
 
       - name: Validate .deb contents
         run: .github/workflows/scripts/validate-deb.sh facelock_*.deb
@@ -207,7 +217,7 @@ jobs:
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v7
         with:
-          name: release-deb-tpm
+          name: release-deb-${{ matrix.suite }}
           path: facelock_*.deb
 
       - name: Upload .deb to release
@@ -218,9 +228,9 @@ jobs:
   build-rpm:
     name: Build RPM Package
     runs-on: ubuntu-latest
-    needs: [build, download-ort]
+    needs: [metadata, build, download-ort]
     container:
-      image: fedora:latest
+      image: registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
     steps:
       - uses: actions/checkout@v7
 
@@ -243,15 +253,11 @@ jobs:
       - name: Verify ORT bundle exists
         run: test -s onnxruntime/lib/libonnxruntime.so
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Build release
         run: cargo build --release --workspace --features tpm
 
       - name: Build RPM
-        run: .github/workflows/scripts/build-rpm.sh "${{ steps.version.outputs.VERSION }}"
+        run: .github/workflows/scripts/build-rpm.sh "${{ needs.metadata.outputs.cargo-version }}" "${{ needs.metadata.outputs.rpm-counter }}"
 
       - name: Copy RPM to workspace
         run: cp ~/rpmbuild/RPMS/x86_64/*.rpm ./ 2>/dev/null || cp ~/rpmbuild/RPMS/**/*.rpm ./ 2>/dev/null || true
@@ -267,6 +273,7 @@ jobs:
   build-nix:
     name: Validate Nix Build
     runs-on: ubuntu-latest
+    needs: metadata
     steps:
       - uses: actions/checkout@v7
 
@@ -289,14 +296,10 @@ jobs:
   publish-aur:
     name: Publish to AUR
     runs-on: ubuntu-latest
-    needs: [build, build-deb, build-deb-tpm, build-rpm]
-    if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    needs: [metadata, build, build-deb, build-rpm]
+    if: ${{ needs.metadata.outputs.prerelease == 'false' }}
     steps:
       - uses: actions/checkout@v7
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Compute source tarball checksum
         id: checksum
@@ -307,39 +310,54 @@ jobs:
       - name: Publish to AUR
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
-        run: .github/workflows/scripts/publish-aur.sh "${{ steps.version.outputs.VERSION }}" "${{ steps.checksum.outputs.SHA256 }}"
+        run: .github/workflows/scripts/publish-aur.sh "${{ needs.metadata.outputs.cargo-version }}" "${{ steps.checksum.outputs.SHA256 }}"
 
   publish-apt:
     name: Publish APT Repository
     runs-on: ubuntu-latest
-    needs: [build-deb, build-deb-tpm]
-    if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    needs: [metadata, build-deb]
+    if: ${{ needs.metadata.outputs.prerelease == 'false' }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y reprepro gnupg
 
-      - name: Download TPM .deb artifact
+      - name: Download trixie .deb artifact
         uses: actions/download-artifact@v8
         with:
-          name: release-deb-tpm
-          path: debs/tpm
+          name: release-deb-trixie
+          path: debs/trixie
 
-      - name: Download legacy .deb artifact
+      - name: Download bookworm .deb artifact
         uses: actions/download-artifact@v8
         with:
-          name: release-deb-legacy
-          path: debs/legacy
+          name: release-deb-bookworm
+          path: debs/bookworm
+
+      - name: Download resolute .deb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-deb-resolute
+          path: debs/resolute
+
+      - name: Download noble .deb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-deb-noble
+          path: debs/noble
 
       - name: Build APT repository
         env:
           APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
           APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
         run: |
-          TPM_DEB=$(ls debs/tpm/facelock_*.deb)
-          LEGACY_DEB=$(ls debs/legacy/facelock_*.deb)
-          .github/workflows/scripts/publish-apt.sh "${TPM_DEB}" "${LEGACY_DEB}" "$(pwd)/apt-repo"
+          set -euo pipefail
+          .github/workflows/scripts/publish-apt.sh "$(pwd)/apt-repo" \
+            "trixie=$(ls debs/trixie/facelock_*.deb)" \
+            "bookworm=$(ls debs/bookworm/facelock_*.deb)" \
+            "resolute=$(ls debs/resolute/facelock_*.deb)" \
+            "noble=$(ls debs/noble/facelock_*.deb)"
 
       - name: Package APT repo artifact
         run: |

--- a/.github/workflows/scripts/build-deb.sh
+++ b/.github/workflows/scripts/build-deb.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${1:?Usage: build-deb.sh <VERSION> <VARIANT> [EXTRA_DEPENDS]}"
-VARIANT="${2:?Usage: build-deb.sh <VERSION> <VARIANT> [EXTRA_DEPENDS]}"
-EXTRA_DEPENDS="${3:-}"
+VERSION="${1:?Usage: build-deb.sh <VERSION> <SUITE> <REVISION> [EXTRA_DEPENDS]}"
+SUITE="${2:?Usage: build-deb.sh <VERSION> <SUITE> <REVISION> [EXTRA_DEPENDS]}"
+REVISION="${3:?Usage: build-deb.sh <VERSION> <SUITE> <REVISION> [EXTRA_DEPENDS]}"
+EXTRA_DEPENDS="${4:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+source "$SCRIPT_DIR/../../../scripts/release-versions.sh"
+
+VARIANT="$(release_debian_variant "$SUITE")"
+PKG_VERSION="$(release_debian_version "$VERSION" "$REVISION" "$SUITE")"
+SOURCE_BASENAME="$(release_debian_source_basename "$VERSION" "$REVISION" "$SUITE")"
 
 # Set version suffix and description based on variant
 case "$VARIANT" in
   legacy)
-    PKG_VERSION="${VERSION}-1~legacy1"
     DESCRIPTION="Face authentication for Linux PAM (legacy, no TPM)"
     DESCRIPTION_LONG=" Facelock provides Windows Hello-style face authentication for Linux
  using IR anti-spoofing, ONNX inference, and PAM integration.
@@ -21,7 +28,6 @@ case "$VARIANT" in
     DEPENDS="libpam-runtime, dbus"
     ;;
   tpm)
-    PKG_VERSION="${VERSION}-1"
     DESCRIPTION="Face authentication for Linux PAM (TPM enabled)"
     DESCRIPTION_LONG=" Facelock provides Windows Hello-style face authentication for Linux
  using IR anti-spoofing, ONNX inference, and PAM integration.
@@ -42,9 +48,10 @@ case "$VARIANT" in
     ;;
 esac
 
-PKG_DIR="facelock_${PKG_VERSION}_amd64"
-echo "=== Building .deb package (${VARIANT}) ==="
+PKG_DIR="$(release_debian_binary_basename "$VERSION" "$REVISION" "$SUITE" amd64)"
+echo "=== Building .deb package (${SUITE}, ${VARIANT}) ==="
 echo "Version: ${PKG_VERSION}"
+echo "Source package: ${SOURCE_BASENAME}"
 echo "Package dir: ${PKG_DIR}"
 
 # Create directory tree

--- a/.github/workflows/scripts/build-rpm.sh
+++ b/.github/workflows/scripts/build-rpm.sh
@@ -1,22 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PKG_VERSION_RAW="${1:?Usage: build-rpm.sh <VERSION_RAW>}"
-PKG_VERSION="$PKG_VERSION_RAW"
-PKG_RELEASE='1%{?dist}'
+PKG_VERSION_RAW="${1:?Usage: build-rpm.sh <VERSION_RAW> <PRERELEASE_COUNTER>}"
+PRERELEASE_COUNTER="${2:?Usage: build-rpm.sh <VERSION_RAW> <PRERELEASE_COUNTER>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+source "$SCRIPT_DIR/../../../scripts/release-versions.sh"
+PKG_VERSION="$(release_rpm_version "$PKG_VERSION_RAW")"
+PKG_RELEASE="$(release_rpm_release "$PKG_VERSION_RAW" "$PRERELEASE_COUNTER")%{?dist}"
 
 echo "=== Building RPM package ==="
 echo "Raw version: ${PKG_VERSION_RAW}"
-
-# RPM Version cannot contain '-'. For prereleases, keep the base
-# version and move the prerelease marker into Release so it sorts
-# before final releases.
-if [ "${PKG_VERSION_RAW#*-}" != "$PKG_VERSION_RAW" ]; then
-  PRERELEASE_SUFFIX="${PKG_VERSION_RAW#*-}"
-  PKG_VERSION="${PKG_VERSION_RAW%%-*}"
-  PRERELEASE_SUFFIX="${PRERELEASE_SUFFIX//-/.}"
-  PKG_RELEASE="0.${PRERELEASE_SUFFIX}%{?dist}"
-fi
 
 echo "RPM Version: ${PKG_VERSION}"
 echo "RPM Release: ${PKG_RELEASE}"

--- a/.github/workflows/scripts/publish-apt.sh
+++ b/.github/workflows/scripts/publish-apt.sh
@@ -1,9 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TPM_DEB="${1:?Usage: publish-apt.sh <TPM_DEB> <LEGACY_DEB> <REPO_DIR>}"
-LEGACY_DEB="${2:?Usage: publish-apt.sh <TPM_DEB> <LEGACY_DEB> <REPO_DIR>}"
-REPO_DIR="${3:?Usage: publish-apt.sh <TPM_DEB> <LEGACY_DEB> <REPO_DIR>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+source "$SCRIPT_DIR/../../../scripts/release-versions.sh"
+
+REPO_DIR="${1:?Usage: publish-apt.sh <REPO_DIR> <SUITE=DEB>...}"
+shift
+if [ "$#" -eq 0 ]; then
+  echo "publish-apt.sh requires at least one SUITE=DEB input" >&2
+  exit 1
+fi
+
+declare -a SUITES=()
+declare -a DEBS=()
+declare -A SEEN_SUITES=()
+for suite_deb in "$@"; do
+  SUITE="${suite_deb%%=*}"
+  DEB="${suite_deb#*=}"
+  case "$SUITE" in
+    trixie|bookworm|resolute|noble) ;;
+    *) echo "refusing unknown stable APT suite '$SUITE'" >&2; exit 1 ;;
+  esac
+  if [ -n "${SEEN_SUITES[$SUITE]:-}" ]; then
+    echo "duplicate stable APT suite '$SUITE'" >&2
+    exit 1
+  fi
+  if [ "$DEB" = "$suite_deb" ] || [ ! -f "$DEB" ]; then
+    echo "invalid APT input '$suite_deb'" >&2
+    exit 1
+  fi
+  SEEN_SUITES[$SUITE]=1
+  SUITES+=("$SUITE")
+  DEBS+=("$DEB")
+done
+
+if [ "${#SUITES[@]}" -ne 4 ]; then
+  echo "publish-apt.sh requires exactly one package for each stable suite: trixie, bookworm, resolute, noble" >&2
+  exit 1
+fi
+
+for index in "${!DEBS[@]}"; do
+  SUITE="${SUITES[index]}"
+  DEB="${DEBS[index]}"
+  EXPECTED_SUFFIX="$(release_debian_suite_suffix "$SUITE")"
+  DEB_VERSION="$(dpkg-deb -f "$DEB" Version)"
+  if [[ "$DEB_VERSION" =~ ~(alpha|beta|rc)\. ]]; then
+    echo "refusing prerelease $DEB_VERSION in stable APT suite $SUITE" >&2
+    exit 1
+  fi
+  if [[ "$DEB_VERSION" != *"$EXPECTED_SUFFIX" ]]; then
+    echo "package version $DEB_VERSION does not match stable APT suite $SUITE ($EXPECTED_SUFFIX)" >&2
+    exit 1
+  fi
+done
 
 echo "=== Building APT repository ==="
 
@@ -44,13 +94,12 @@ echo "GPG key imported and passphrase preset: ${KEY_FPR}"
 mkdir -p "${REPO_DIR}/conf"
 cp dist/apt/conf/distributions "${REPO_DIR}/conf/distributions"
 
-# Add TPM .deb to 'main' suite
-echo "Adding TPM .deb to main: ${TPM_DEB}"
-reprepro -b "${REPO_DIR}" includedeb main "${TPM_DEB}"
-
-# Add legacy .deb to 'legacy' suite
-echo "Adding legacy .deb to legacy: ${LEGACY_DEB}"
-reprepro -b "${REPO_DIR}" includedeb legacy "${LEGACY_DEB}"
+for index in "${!DEBS[@]}"; do
+  SUITE="${SUITES[index]}"
+  DEB="${DEBS[index]}"
+  echo "Adding ${DEB} to ${SUITE}"
+  reprepro -b "${REPO_DIR}" includedeb "$SUITE" "$DEB"
+done
 
 # Export only the signing key (not the entire keyring)
 gpg --export "${KEY_FPR}" > "${REPO_DIR}/tysmith-archive-keyring.gpg"
@@ -59,7 +108,7 @@ echo "Public keyring exported ($(du -h "${REPO_DIR}/tysmith-archive-keyring.gpg"
 echo "=== APT repo structure ==="
 find "${REPO_DIR}" -type f | sort
 echo ""
-echo "=== Release file (main) ==="
-cat "${REPO_DIR}/dists/main/Release" || true
+echo "=== Release file (trixie) ==="
+cat "${REPO_DIR}/dists/trixie/Release" || true
 
 echo "=== APT repository built ==="

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 VERSION="${1:?Usage: publish-aur.sh <VERSION> <CHECKSUM>}"
 CHECKSUM="${2:?Usage: publish-aur.sh <VERSION> <CHECKSUM>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+source "$SCRIPT_DIR/../../../scripts/release-versions.sh"
+release_validate_cargo_version "$VERSION"
+if release_is_prerelease "$VERSION"; then
+  echo "refusing to publish prerelease $VERSION to stable AUR packages" >&2
+  exit 1
+fi
+ARCH_VERSION="$(release_arch_pkgver "$VERSION")"
 
 echo "=== Publishing to AUR ==="
 
@@ -41,7 +50,8 @@ RUNNER_GID="$(id -g)"
 
 generate_srcinfo() {
   local dir="$1"
-  ( cd "$dir" && docker run --rm -v "$(pwd):/pkg" -w /pkg archlinux:base-devel bash -c "
+  ( cd "$dir" && docker run --rm -v "$(pwd):/pkg" -w /pkg docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b bash -c "
+      printf '%s\\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/\$repo/os/\$arch' > /etc/pacman.d/mirrorlist
       pacman -Sy --noconfirm pacman-contrib >/dev/null
       useradd -m builder
       chown -R builder:builder /pkg
@@ -101,7 +111,7 @@ publish_facelock() {
   get_or_init_repo "$dir" facelock
   cp dist/PKGBUILD "$dir/PKGBUILD"
   cp dist/facelock.install "$dir/facelock.install"
-  sed -i "s/^pkgver=.*/pkgver=${VERSION}/" "$dir/PKGBUILD"
+  sed -i "s/^_tag=.*/_tag=${VERSION}/; s/^pkgver=.*/pkgver=${ARCH_VERSION}/" "$dir/PKGBUILD"
   sed -i "s/sha256sums=('SKIP')/sha256sums=('${CHECKSUM}')/" "$dir/PKGBUILD"
   generate_srcinfo "$dir"
   commit_and_push "$dir" "Update to v${VERSION}"
@@ -113,7 +123,7 @@ publish_facelock_bin() {
   get_or_init_repo "$dir" facelock-bin
   cp dist/PKGBUILD-bin "$dir/PKGBUILD"
   cp dist/facelock.install "$dir/facelock.install"
-  sed -i "s/^pkgver=.*/pkgver=${VERSION}/" "$dir/PKGBUILD"
+  sed -i "s/^_tag=.*/_tag=${VERSION}/; s/^pkgver=.*/pkgver=${ARCH_VERSION}/" "$dir/PKGBUILD"
   sed -i "s/__SRC_SHA256__/${CHECKSUM}/" "$dir/PKGBUILD"
   sed -i "s/__FACELOCK_SHA256__/${SHA_FACELOCK}/" "$dir/PKGBUILD"
   sed -i "s/__PAM_SHA256__/${SHA_PAM}/" "$dir/PKGBUILD"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,17 +1,19 @@
-# Packit configuration — https://packit.dev/docs/configuration
-# Release-only COPR builds: stable git tags (vX.Y.Z) are built into the
-# existing COPR project tyvsmith/facelock. Packit generates the SRPM itself.
-specfile_path: dist/facelock.spec
-upstream_package_name: facelock
-downstream_package_name: facelock
-upstream_tag_template: "v{version}"
-
-jobs:
-  - job: copr_build
-    trigger: release
-    owner: tyvsmith
-    project: facelock
-    targets:
-      - fedora-rawhide-x86_64
-      - fedora-42-x86_64
-      - fedora-43-x86_64
+{
+  "specfile_path": "dist/facelock.spec",
+  "upstream_package_name": "facelock",
+  "downstream_package_name": "facelock",
+  "upstream_tag_template": "v{version}",
+  "jobs": [
+    {
+      "job": "copr_build",
+      "trigger": "ignore",
+      "owner": "tyvsmith",
+      "project": "facelock",
+      "targets": [
+        "fedora-43-x86_64",
+        "fedora-44-x86_64",
+        "fedora-45-x86_64"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ sudo install -d -m 0755 /etc/apt/keyrings
 curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
   | sudo tee /etc/apt/keyrings/tysmith-archive-keyring.gpg >/dev/null
 
-# Add repository — pick ONE:
-# Modern (Debian trixie+, Ubuntu 25.04+) — TPM enabled:
-echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt main facelock" \
+# Set APT_SUITE to the exact suite for your host:
+# Debian 13 — trixie — TPM
+# Debian 12 — bookworm — legacy
+# Ubuntu 26.04 — resolute — TPM
+# Ubuntu 24.04 — noble — legacy
+APT_SUITE=trixie  # Debian 13 example
+echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt ${APT_SUITE} facelock" \
   | sudo tee /etc/apt/sources.list.d/facelock.list
-
-# Legacy (Ubuntu 24.04, Debian bookworm) — no TPM:
-# echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt legacy facelock" \
-#   | sudo tee /etc/apt/sources.list.d/facelock.list
 
 sudo apt update && sudo apt install facelock
 ```
@@ -238,7 +238,12 @@ just release 0.2.0        # bump version across all packaging files
 git push origin main --tags  # trigger CI release workflow
 ```
 
-Tagging `vX.Y.Z` builds release binaries, `.deb` (TPM + legacy), `.rpm`, publishes to AUR/COPR/APT via GitHub Actions. See [docs/releasing.md](docs/releasing.md) for the full process and versioning contract.
+Tagging `vX.Y.Z` builds release binaries, four suite-specific `.deb` artifacts
+(trixie, bookworm, resolute, and noble), and the direct Fedora `.rpm` artifact.
+Stable tags publish the stable AUR and APT channels; Packit handles production
+COPR builds. Prerelease tags create a GitHub prerelease without entering those
+stable channels. See [docs/releasing.md](docs/releasing.md) for the full process
+and versioning contract.
 
 ## License
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -12,7 +12,14 @@ yay -S facelock           # or paru -S facelock
 
 ### Debian / Ubuntu (APT)
 
-For **modern systems** (Debian trixie+, Ubuntu 25.04+) with TPM support:
+Use the exact suite and package variant for your platform:
+
+| Platform | Suite | Variant |
+|----------|-------|---------|
+| Debian 13 | trixie | TPM |
+| Debian 12 | bookworm | legacy |
+| Ubuntu 26.04 | resolute | TPM |
+| Ubuntu 24.04 | noble | legacy |
 
 ```bash
 # Add signing key
@@ -20,25 +27,9 @@ sudo install -d -m 0755 /etc/apt/keyrings
 curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
   | sudo tee /etc/apt/keyrings/tysmith-archive-keyring.gpg >/dev/null
 
-# Add repository (main = TPM enabled)
-echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt main facelock" \
-  | sudo tee /etc/apt/sources.list.d/facelock.list
-
-# Install
-sudo apt update
-sudo apt install facelock
-```
-
-For **older systems** (Ubuntu 24.04, Debian bookworm) without TPM:
-
-```bash
-# Add signing key (same as above)
-sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
-  | sudo tee /etc/apt/keyrings/tysmith-archive-keyring.gpg >/dev/null
-
-# Add repository (legacy = non-TPM)
-echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt legacy facelock" \
+# Set this to the suite in the table above; trixie is the Debian 13 example.
+APT_SUITE=trixie
+echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt ${APT_SUITE} facelock" \
   | sudo tee /etc/apt/sources.list.d/facelock.list
 
 # Install

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: facelock contributors
 pkgname=facelock
+_tag=0.1.4
 pkgver=0.1.4
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux"
@@ -15,30 +16,30 @@ optdepends=(
 backup=('etc/facelock/config.toml')
 install=facelock.install
 options=(!lto)
-source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+source=("$pkgname-$_tag.tar.gz::$url/archive/v$_tag.tar.gz")
 sha256sums=('SKIP')
 
 prepare() {
-    cd "$pkgname-$pkgver"
+    cd "$pkgname-$_tag"
     export RUSTUP_TOOLCHAIN=stable
     cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-    cd "$pkgname-$pkgver"
+    cd "$pkgname-$_tag"
     export RUSTUP_TOOLCHAIN=stable
     cargo build --frozen --release --workspace
     cargo build --frozen --release -p facelock-cli --features tpm
 }
 
 check() {
-    cd "$pkgname-$pkgver"
+    cd "$pkgname-$_tag"
     export RUSTUP_TOOLCHAIN=stable
     cargo test --frozen --workspace
 }
 
 package() {
-    cd "$pkgname-$pkgver"
+    cd "$pkgname-$_tag"
 
     # Binaries
     install -Dm755 target/release/facelock "$pkgdir/usr/bin/facelock"

--- a/dist/PKGBUILD-bin
+++ b/dist/PKGBUILD-bin
@@ -1,6 +1,7 @@
 # Maintainer: facelock contributors
 pkgname=facelock-bin
 _pkgname=facelock
+_tag=0.1.4
 pkgver=0.1.4
 pkgrel=1
 pkgdesc="Face authentication PAM module for Linux (prebuilt binaries)"
@@ -17,20 +18,20 @@ conflicts=('facelock' 'facelock-git')
 backup=('etc/facelock/config.toml')
 install=facelock.install
 source=(
-    "$_pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
-    "facelock-$pkgver-x86_64::$url/releases/download/v$pkgver/facelock-x86_64-linux-gnu"
-    "pam_facelock-$pkgver.so::$url/releases/download/v$pkgver/pam_facelock.so"
-    "facelock-polkit-agent-$pkgver-x86_64::$url/releases/download/v$pkgver/facelock-polkit-agent-x86_64-linux-gnu"
+    "$_pkgname-$_tag.tar.gz::$url/archive/v$_tag.tar.gz"
+    "facelock-$_tag-x86_64::$url/releases/download/v$_tag/facelock-x86_64-linux-gnu"
+    "pam_facelock-$_tag.so::$url/releases/download/v$_tag/pam_facelock.so"
+    "facelock-polkit-agent-$_tag-x86_64::$url/releases/download/v$_tag/facelock-polkit-agent-x86_64-linux-gnu"
 )
 sha256sums=('__SRC_SHA256__' '__FACELOCK_SHA256__' '__PAM_SHA256__' '__POLKIT_SHA256__')
 
 package() {
-    cd "$_pkgname-$pkgver"
+    cd "$_pkgname-$_tag"
 
     # Prebuilt binaries from the GitHub Release
-    install -Dm755 "$srcdir/facelock-$pkgver-x86_64" "$pkgdir/usr/bin/facelock"
-    install -Dm755 "$srcdir/facelock-polkit-agent-$pkgver-x86_64" "$pkgdir/usr/bin/facelock-polkit-agent"
-    install -Dm755 "$srcdir/pam_facelock-$pkgver.so" "$pkgdir/usr/lib/security/pam_facelock.so"
+    install -Dm755 "$srcdir/facelock-$_tag-x86_64" "$pkgdir/usr/bin/facelock"
+    install -Dm755 "$srcdir/facelock-polkit-agent-$_tag-x86_64" "$pkgdir/usr/bin/facelock-polkit-agent"
+    install -Dm755 "$srcdir/pam_facelock-$_tag.so" "$pkgdir/usr/lib/security/pam_facelock.so"
 
     # Ancillary assets from the source tarball
     install -Dm644 config/facelock.toml "$pkgdir/etc/facelock/config.toml"

--- a/dist/apt/conf/distributions
+++ b/dist/apt/conf/distributions
@@ -1,15 +1,31 @@
 Origin: tysmith
 Label: Ty Smith Packages
-Codename: main
+Codename: trixie
 Architectures: amd64
 Components: facelock
-Description: Facelock APT repository - TPM enabled (modern Debian/Ubuntu)
+Description: Facelock APT repository - Debian 13 trixie TPM
 SignWith: default
 
 Origin: tysmith
 Label: Ty Smith Packages
-Codename: legacy
+Codename: bookworm
 Architectures: amd64
 Components: facelock
-Description: Facelock APT repository - non-TPM (older Debian/Ubuntu)
+Description: Facelock APT repository - Debian 12 bookworm legacy
+SignWith: default
+
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: resolute
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - Ubuntu 26.04 resolute TPM
+SignWith: default
+
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: noble
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - Ubuntu 24.04 noble legacy
 SignWith: default

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -1,0 +1,191 @@
+{
+  "reviewed_on": "2026-08-18",
+  "image_lookup": {
+    "date": "2026-08-18",
+    "docker_hub_source": "Docker Hub registry manifest metadata",
+    "fedora_source": "Fedora registry Docker-Content-Digest"
+  },
+  "apt_suites": {
+    "trixie": {
+      "platform_id": "debian-13",
+      "platform": "Debian 13",
+      "architecture": "amd64",
+      "variant": "tpm",
+      "revision_suffix": "~deb13u1",
+      "image": "docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958",
+      "image_amd64_digest": "sha256:d8f17b92dc7ff10f9c1fdecab0ad21103d1d24aed823c3a0359e4f50adfab3eb"
+    },
+    "bookworm": {
+      "platform_id": "debian-12",
+      "platform": "Debian 12",
+      "architecture": "amd64",
+      "variant": "legacy",
+      "revision_suffix": "~deb12u1",
+      "image": "docker.io/library/debian:12@sha256:813017f3d62be4b5891a7acca6a01bdcd4b8513daa81b1ab99d3a50385b26931",
+      "image_amd64_digest": "sha256:88a7d30d49e1d13f0aac17b0e5fb9e291717e3a7c4a512fe56636db576383b8a"
+    },
+    "resolute": {
+      "platform_id": "ubuntu-26.04",
+      "platform": "Ubuntu 26.04",
+      "architecture": "amd64",
+      "variant": "tpm",
+      "revision_suffix": "~ubuntu26.04.1",
+      "image": "docker.io/library/ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6",
+      "image_amd64_digest": "sha256:889d056d5c6c0bfb55789ff3710681d68e50713cb562d2196dc07110599c7a6f"
+    },
+    "noble": {
+      "platform_id": "ubuntu-24.04",
+      "platform": "Ubuntu 24.04",
+      "architecture": "amd64",
+      "variant": "legacy",
+      "revision_suffix": "~ubuntu24.04.1",
+      "image": "docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb",
+      "image_amd64_digest": "sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316"
+    }
+  },
+  "fedora": {
+    "43_eol_gate": "2026-12-02",
+    "branched": "45",
+    "rawhide_development_release": "46",
+    "staging_copr_targets": [
+      "fedora-43-x86_64",
+      "fedora-44-x86_64",
+      "fedora-45-x86_64"
+    ]
+  },
+  "copr_channels": {
+    "production": {
+      "owner": "tyvsmith",
+      "project": "facelock",
+      "api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
+      "expected_enabled_chroots": [
+        "fedora-43-x86_64",
+        "fedora-44-x86_64",
+        "fedora-45-x86_64"
+      ],
+      "prerelease_publication": false
+    },
+    "staging": {
+      "owner": "tyvsmith",
+      "project": "facelock-testing",
+      "provisioning_issue": 236,
+      "managed_by_this_change": false
+    }
+  },
+  "arch": {
+    "snapshot": "2026-08-18",
+    "repository": "https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch"
+  },
+  "publication": {
+    "prerelease": {
+      "github_release_prerelease": true,
+      "stable_apt": false,
+      "aur": false,
+      "production_copr": false
+    },
+    "stable": {
+      "github_release_prerelease": false,
+      "stable_apt": true,
+      "aur": true,
+      "production_copr_requires_stable_tagged_config": true
+    }
+  },
+  "platforms": [
+    {
+      "id": "debian-13",
+      "platform": "Debian 13 trixie",
+      "architecture": "amd64",
+      "variant": "TPM, staged APT/direct deb",
+      "runtime": "bundled ORT 1.20.1",
+      "lifecycle_depth": "full",
+      "image": "docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958",
+      "image_amd64_digest": "sha256:d8f17b92dc7ff10f9c1fdecab0ad21103d1d24aed823c3a0359e4f50adfab3eb"
+    },
+    {
+      "id": "debian-12",
+      "platform": "Debian 12 bookworm LTS",
+      "architecture": "amd64",
+      "variant": "legacy, staged APT/direct deb",
+      "runtime": "bundled ORT 1.20.1",
+      "lifecycle_depth": "full",
+      "image": "docker.io/library/debian:12@sha256:813017f3d62be4b5891a7acca6a01bdcd4b8513daa81b1ab99d3a50385b26931",
+      "image_amd64_digest": "sha256:88a7d30d49e1d13f0aac17b0e5fb9e291717e3a7c4a512fe56636db576383b8a"
+    },
+    {
+      "id": "ubuntu-26.04",
+      "platform": "Ubuntu 26.04 LTS",
+      "architecture": "amd64",
+      "variant": "TPM, staged APT/direct deb",
+      "runtime": "bundled ORT 1.20.1",
+      "lifecycle_depth": "full",
+      "image": "docker.io/library/ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6",
+      "image_amd64_digest": "sha256:889d056d5c6c0bfb55789ff3710681d68e50713cb562d2196dc07110599c7a6f"
+    },
+    {
+      "id": "ubuntu-24.04",
+      "platform": "Ubuntu 24.04 LTS",
+      "architecture": "amd64",
+      "variant": "legacy, staged APT/direct deb",
+      "runtime": "bundled ORT 1.20.1",
+      "lifecycle_depth": "full",
+      "image": "docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb",
+      "image_amd64_digest": "sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316"
+    },
+    {
+      "id": "fedora-43",
+      "platform": "Fedora 43",
+      "architecture": "x86_64",
+      "variant": "staging COPR",
+      "runtime": "system ORT",
+      "lifecycle_depth": "full",
+      "image": "registry.fedoraproject.org/fedora:43@sha256:0cdfbfa1b9a80483e9adc87f2b294feee71fd98d9c33f5f3758d10f95c980f16",
+      "eol_gate": "2026-12-02"
+    },
+    {
+      "id": "fedora-44-copr",
+      "platform": "Fedora 44",
+      "architecture": "x86_64",
+      "variant": "staging COPR",
+      "runtime": "system ORT",
+      "lifecycle_depth": "full",
+      "image": "registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb"
+    },
+    {
+      "id": "fedora-45",
+      "platform": "Fedora 45 branched",
+      "architecture": "x86_64",
+      "variant": "staging COPR",
+      "runtime": "system ORT",
+      "lifecycle_depth": "build/runtime smoke",
+      "image": "registry.fedoraproject.org/fedora:45@sha256:d7423b7358e350acd12f570d51855ea6e9c45c7fb2ae68f6cb034d237a2e41c4"
+    },
+    {
+      "id": "fedora-rawhide",
+      "platform": "Fedora Rawhide (Fedora 46 development)",
+      "architecture": "x86_64",
+      "variant": "development",
+      "runtime": "system ORT",
+      "lifecycle_depth": "build/runtime smoke",
+      "image": "registry.fedoraproject.org/fedora:rawhide@sha256:4ea2930fc462642d078e9ff77b1ad52b3e3ed1b0308bbc4f28a205af87487025"
+    },
+    {
+      "id": "fedora-44-direct",
+      "platform": "Fedora 44",
+      "architecture": "x86_64",
+      "variant": "direct RPM",
+      "runtime": "bundled ORT 1.20.1",
+      "lifecycle_depth": "full",
+      "image": "registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb"
+    },
+    {
+      "id": "arch-2026-08-18",
+      "platform": "Arch Linux Archive snapshot 2026-08-18",
+      "architecture": "x86_64",
+      "variant": "PKGBUILD and binary recipe",
+      "runtime": "system ORT",
+      "lifecycle_depth": "full",
+      "image": "docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b",
+      "image_amd64_digest": "sha256:aecf5b39bd3139a951090dfb3d940f9317e4c5fca038c65fb49ac03910f7133e"
+    }
+  ]
+}

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -51,6 +51,11 @@
       "fedora-43-x86_64",
       "fedora-44-x86_64",
       "fedora-45-x86_64"
+    ],
+    "packit_release_targets": [
+      "fedora-43-x86_64",
+      "fedora-44-x86_64",
+      "fedora-45-x86_64"
     ]
   },
   "copr_channels": {
@@ -58,10 +63,13 @@
       "owner": "tyvsmith",
       "project": "facelock",
       "api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
-      "expected_enabled_chroots": [
+      "required_supported_chroots": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",
         "fedora-45-x86_64"
+      ],
+      "optional_experimental_chroots": [
+        "fedora-rawhide-x86_64"
       ],
       "prerelease_publication": false
     },
@@ -97,6 +105,9 @@
       "architecture": "amd64",
       "variant": "TPM, staged APT/direct deb",
       "runtime": "bundled ORT 1.20.1",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958",
       "image_amd64_digest": "sha256:d8f17b92dc7ff10f9c1fdecab0ad21103d1d24aed823c3a0359e4f50adfab3eb"
@@ -107,6 +118,9 @@
       "architecture": "amd64",
       "variant": "legacy, staged APT/direct deb",
       "runtime": "bundled ORT 1.20.1",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "docker.io/library/debian:12@sha256:813017f3d62be4b5891a7acca6a01bdcd4b8513daa81b1ab99d3a50385b26931",
       "image_amd64_digest": "sha256:88a7d30d49e1d13f0aac17b0e5fb9e291717e3a7c4a512fe56636db576383b8a"
@@ -117,6 +131,9 @@
       "architecture": "amd64",
       "variant": "TPM, staged APT/direct deb",
       "runtime": "bundled ORT 1.20.1",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "docker.io/library/ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6",
       "image_amd64_digest": "sha256:889d056d5c6c0bfb55789ff3710681d68e50713cb562d2196dc07110599c7a6f"
@@ -127,6 +144,9 @@
       "architecture": "amd64",
       "variant": "legacy, staged APT/direct deb",
       "runtime": "bundled ORT 1.20.1",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb",
       "image_amd64_digest": "sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316"
@@ -137,6 +157,9 @@
       "architecture": "x86_64",
       "variant": "staging COPR",
       "runtime": "system ORT",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "registry.fedoraproject.org/fedora:43@sha256:0cdfbfa1b9a80483e9adc87f2b294feee71fd98d9c33f5f3758d10f95c980f16",
       "eol_gate": "2026-12-02"
@@ -147,6 +170,9 @@
       "architecture": "x86_64",
       "variant": "staging COPR",
       "runtime": "system ORT",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb"
     },
@@ -156,6 +182,9 @@
       "architecture": "x86_64",
       "variant": "staging COPR",
       "runtime": "system ORT",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "build/runtime smoke",
       "image": "registry.fedoraproject.org/fedora:45@sha256:d7423b7358e350acd12f570d51855ea6e9c45c7fb2ae68f6cb034d237a2e41c4"
     },
@@ -163,9 +192,25 @@
       "id": "fedora-rawhide",
       "platform": "Fedora Rawhide (Fedora 46 development)",
       "architecture": "x86_64",
-      "variant": "development",
+      "variant": "optional experimental production COPR chroot",
       "runtime": "system ORT",
-      "lifecycle_depth": "build/runtime smoke",
+      "support_tier": "experimental",
+      "release_target": false,
+      "optional": true,
+      "lifecycle_depth": "best-effort pinned Track D smoke only",
+      "smoke_track": "Track D",
+      "smoke_policy": "best-effort",
+      "alpha_blocking": false,
+      "prerelease_publication": false,
+      "evidence_eligibility": {
+        "lifecycle": false,
+        "artifact": false,
+        "upgrade": false,
+        "rollback": false,
+        "served_version": false,
+        "availability": false
+      },
+      "promotion_requires": "separately reviewed amendment and full Fedora gates",
       "image": "registry.fedoraproject.org/fedora:rawhide@sha256:4ea2930fc462642d078e9ff77b1ad52b3e3ed1b0308bbc4f28a205af87487025"
     },
     {
@@ -174,6 +219,9 @@
       "architecture": "x86_64",
       "variant": "direct RPM",
       "runtime": "bundled ORT 1.20.1",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb"
     },
@@ -183,6 +231,9 @@
       "architecture": "x86_64",
       "variant": "PKGBUILD and binary recipe",
       "runtime": "system ORT",
+      "support_tier": "supported",
+      "release_target": true,
+      "optional": false,
       "lifecycle_depth": "full",
       "image": "docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b",
       "image_amd64_digest": "sha256:aecf5b39bd3139a951090dfb3d940f9317e4c5fca038c65fb49ac03910f7133e"

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -19,6 +19,7 @@ follow it.
 - [Operating Modes](#operating-modes)
   - [facelock is-enrolled Exit Codes](#facelock-is-enrolled-exit-codes)
   - [facelock auth Exit Codes](#facelock-auth-exit-codes)
+- [Release Channels and APT Paths](#release-channels-and-apt-paths)
 - [Filesystem Paths](#filesystem-paths)
   - [Audit Log Entries](#audit-log-entries)
 - [Config Schema](#config-schema)
@@ -1278,6 +1279,38 @@ and never a correct one.
 | 0 | Face matched | PAM_SUCCESS |
 | 1 | No match / timeout / dark | PAM_AUTH_ERR |
 | 2 | Error / no enrolled faces | PAM_IGNORE |
+
+## Release Channels and APT Paths
+
+`dist/release-matrix.json` is the checked-in release-target authority. A strict
+prerelease tag has the form `vX.Y.Z-{alpha,beta,rc}.N`; it creates a GitHub
+prerelease and direct artifacts, but it must not publish to stable APT, stable AUR, or production COPR. Staging COPR infrastructure is owned by issue #236
+and is not provisioned or modified by the prerelease identity workflow.
+
+A stable `vX.Y.Z` tag may publish to stable APT and AUR only after validated
+release metadata classifies it as stable. Production COPR additionally
+requires a deliberately restored `trigger: release` job in the stable-tagged
+Packit configuration. Prerelease-capable configurations keep that job inert.
+Preflight and CI compare the public `tyvsmith/facelock` COPR API read-only with
+the exact production chroot authority and fail closed on missing or extra
+chroots; they never change the project.
+
+The public APT base is `https://tysmith.me/facelock/apt/`. Its stable suite
+paths and payload identities are:
+
+| Suite | Public Release path | Architecture | Variant |
+|-------|---------------------|--------------|---------|
+| `trixie` | `https://tysmith.me/facelock/apt/dists/trixie/Release` | amd64 | TPM |
+| `bookworm` | `https://tysmith.me/facelock/apt/dists/bookworm/Release` | amd64 | legacy |
+| `resolute` | `https://tysmith.me/facelock/apt/dists/resolute/Release` | amd64 | TPM |
+| `noble` | `https://tysmith.me/facelock/apt/dists/noble/Release` | amd64 | legacy |
+
+The former `main` and `legacy` suite names are retired; they are not aliases or
+redirects. Existing source entries must replace that suite component with the
+host operating-system codename while keeping the `facelock` component. Each
+stable publication consumes exactly one matching package for all four suites,
+and a prerelease or cross-suite version is rejected before signing or repository
+writes.
 
 ## Filesystem Paths
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1292,8 +1292,29 @@ release metadata classifies it as stable. Production COPR additionally
 requires a deliberately restored `trigger: release` job in the stable-tagged
 Packit configuration. Prerelease-capable configurations keep that job inert.
 Preflight and CI compare the public `tyvsmith/facelock` COPR API read-only with
-the exact production chroot authority and fail closed on missing or extra
-chroots; they never change the project.
+the production chroot authority; they never change the project. The required
+supported production COPR chroots are exactly Fedora 43, Fedora 44, and Fedora
+45. Rawhide is the only optional allowed experimental production chroot: its
+presence or absence is accepted, while any missing supported chroot or any
+other extra chroot fails closed.
+
+Every Packit `copr_build` target must be an explicit member of the checked-in
+allowlist: `fedora-43-x86_64`, `fedora-44-x86_64`, or
+`fedora-45-x86_64`. Mutable aliases such as `fedora-all`,
+`fedora-development`, and their architecture-suffixed forms are rejected, as
+is any other undeclared target. Rawhide is not a Packit staging or production
+release target; both `fedora-rawhide` and `fedora-rawhide-x86_64` fail
+validation. The prerelease rule is that no alpha may publish to Rawhide.
+Fedora 43 and Fedora 44 supply full lifecycle evidence; Fedora 45 supplies
+required build/runtime smoke. Rawhide cannot supply lifecycle, artifact,
+upgrade, rollback, served-version, or availability evidence; it is limited to
+best-effort pinned Track D smoke only. A Rawhide-only failure is not
+alpha-blocking. Promotion requires a separately reviewed amendment and full
+Fedora gates.
+
+Issue #236 owns pre-tag and post-publication proof that optional Rawhide serves
+no alpha or candidate build. This contract does not provision, publish to, or
+otherwise mutate COPR or Packit infrastructure.
 
 The public APT base is `https://tysmith.me/facelock/apt/`. Its stable suite
 paths and payload identities are:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -120,18 +120,37 @@ Stable packages are published under the matching codename at
 `dist/release-matrix.json` is the checked-in authority. The release workflow,
 APT configuration, Packit targets, and this table are checked against it.
 
-| Platform | Architecture | Variant/channel | Runtime | Lifecycle depth |
-|----------|--------------|-----------------|---------|-----------------|
-| Debian 13 trixie | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | full |
-| Debian 12 bookworm LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | full |
-| Ubuntu 26.04 LTS | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | full |
-| Ubuntu 24.04 LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | full |
-| Fedora 43 | x86_64 | staging COPR | system ORT | full through the 2026-12-02 EOL gate |
-| Fedora 44 | x86_64 | staging COPR | system ORT | full |
-| Fedora 45 branched | x86_64 | staging COPR | system ORT | build/runtime smoke |
-| Fedora Rawhide (Fedora 46 development) | x86_64 | development | system ORT | build/runtime smoke |
-| Fedora 44 | x86_64 | direct RPM | bundled ORT 1.20.1 | full |
-| Arch Linux Archive snapshot 2026-08-18 | x86_64 | PKGBUILD and binary recipe | system ORT | full |
+| Platform | Architecture | Variant/channel | Runtime | Support tier | Release target | Lifecycle depth |
+|----------|--------------|-----------------|---------|--------------|----------------|-----------------|
+| Debian 13 trixie | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | supported | yes | full |
+| Debian 12 bookworm LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | supported | yes | full |
+| Ubuntu 26.04 LTS | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | supported | yes | full |
+| Ubuntu 24.04 LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | supported | yes | full |
+| Fedora 43 | x86_64 | staging COPR | system ORT | supported | yes | full through the 2026-12-02 EOL gate |
+| Fedora 44 | x86_64 | staging COPR | system ORT | supported | yes | full |
+| Fedora 45 branched | x86_64 | staging COPR | system ORT | supported | yes | required build/runtime smoke |
+| Fedora Rawhide (Fedora 46 development) | x86_64 | optional experimental production COPR chroot | system ORT | experimental | no | best-effort pinned Track D smoke only |
+| Fedora 44 | x86_64 | direct RPM | bundled ORT 1.20.1 | supported | yes | full |
+| Arch Linux Archive snapshot 2026-08-18 | x86_64 | PKGBUILD and binary recipe | system ORT | supported | yes | full |
+
+Production COPR requires Fedora 43, Fedora 44, and Fedora 45. Rawhide is the
+only optional allowed experimental production chroot, so it may be present or
+absent; missing any required chroot or enabling any unknown extra fails closed.
+Every Packit `copr_build` target must be an explicit member of the checked-in
+allowlist: `fedora-43-x86_64`, `fedora-44-x86_64`, or
+`fedora-45-x86_64`. Mutable aliases such as `fedora-all`,
+`fedora-development`, and their architecture-suffixed forms are rejected, as
+is any other undeclared target. Rawhide is not a release target and is not a
+Packit staging or production release target. Both `fedora-rawhide` and
+`fedora-rawhide-x86_64` fail validation, and no alpha may publish to Rawhide.
+
+Fedora 43 and Fedora 44 carry the full lifecycle. Fedora 45 carries required
+build/runtime smoke. Rawhide remains best-effort pinned Track D smoke only; a
+Rawhide-only failure is not alpha-blocking, and Rawhide cannot supply lifecycle,
+artifact, upgrade, rollback, served-version, or availability evidence.
+Promotion requires a separately reviewed amendment and full Fedora gates.
+Issue #236 owns the pre-tag and post-publication proof that optional Rawhide
+serves no alpha or candidate build.
 
 Container identities are pinned by registry/index digest, with the linux/amd64
 manifest digest retained where the registry exposes both. They were resolved
@@ -194,8 +213,10 @@ just test-rpm-pkg
 `APT_GPG_PASSPHRASE` are configured in GitHub secrets (via `gh`). COPR needs no
 secret — it is driven by Packit. Preflight and CI also read the public
 production COPR API and require its enabled chroots to equal the checked-in
-43/44/45 authority. An extra or missing live chroot is a release-blocking drift;
-the checker never modifies the project. When the Packit CLI is available,
+authority: Fedora 43/44/45 are required and Rawhide is the only optional
+experimental chroot. Rawhide may be present or absent; a missing required
+chroot or any unknown extra is release-blocking drift. The checker never
+modifies the project. When the Packit CLI is available,
 preflight runs `packit config validate --offline`; `just test-copr` always runs
 that real schema gate inside its Fedora Packit container.
 
@@ -274,8 +295,9 @@ Before a stable release, the maintainer deliberately changes that trigger to
 production release job for a prerelease and rejects its absence for a stable.
 The deliberate stable restoration targets `fedora-43-x86_64`,
 `fedora-44-x86_64`, and the separate `fedora-45-x86_64` branched target.
-Rawhide is Fedora 46 development in this matrix and is not an alias for Fedora
-45.
+Rawhide is Fedora 46 development in this matrix, not an alias for Fedora 45,
+and not a staging or production Packit target. A configuration that targets
+Rawhide for release fails the matrix check.
 
 `.packit.yaml` deliberately uses JSON syntax, which is a valid YAML subset.
 Release guards therefore parse its jobs semantically with the Python standard
@@ -295,8 +317,9 @@ Fedora's ONNX Runtime.)
 1. Create a Fedora Account at https://accounts.fedoraproject.org
 2. Log in to COPR at https://copr.fedorainfracloud.org and ensure the
    `tyvsmith/facelock` project exists with the `fedora-43-x86_64`,
-   `fedora-44-x86_64`, and `fedora-45-x86_64` chroots enabled
-   (Settings → Chroots).
+   `fedora-44-x86_64`, and `fedora-45-x86_64` chroots enabled. The optional
+   `fedora-rawhide-x86_64` experimental chroot may be enabled or absent; no
+   other chroot is allowed (Settings → Chroots).
 3. Install the **Packit-as-a-Service** GitHub App on the repository:
    https://github.com/marketplace/packit-as-a-service
 4. In the COPR project → Settings → Permissions, grant the `packit` user

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,19 +20,61 @@ The project is pre-1.0. The public contract is:
 
 Rust crate APIs are internal and not part of the versioning contract.
 
+### Prerelease identity conversions
+
+Release input is strict SemVer: `X.Y.Z` or `X.Y.Z-{alpha,beta,rc}.N`. The same
+identity is converted explicitly for each package manager:
+
+| Surface | Alpha 1 | Stable |
+|---------|---------|--------|
+| Git tag | `v0.2.0-alpha.1` | `v0.2.0` |
+| Cargo | `0.2.0-alpha.1` | `0.2.0` |
+| Debian upstream | `0.2.0~alpha.1` | `0.2.0` |
+| RPM Version-Release | `0.2.0-0.1.alpha.1` | `0.2.0-1` |
+| Arch pkgver-pkgrel | `0.2.0alpha1-1` | `0.2.0-1` |
+| GitHub Release | prerelease | release |
+
+The first alpha Debian revisions are
+`0.2.0~alpha.1-1~deb13u1` (trixie),
+`0.2.0~alpha.1-1~deb12u1` (bookworm),
+`0.2.0~alpha.1-1~ubuntu26.04.1` (resolute), and
+`0.2.0~alpha.1-1~ubuntu24.04.1` (noble).
+
+Package rebuilds advance independently of the Cargo version. Debian and Arch
+increment their package revision for a rebuild of the same prerelease and reset
+it for the next semantic prerelease. RPM uses one monotonic prerelease counter
+across the whole series:
+
+```text
+Debian: 0.1.4-1 < 0.2.0~alpha.1-1 < 0.2.0~alpha.1-2 < 0.2.0~alpha.2-1 < 0.2.0~beta.1-1 < 0.2.0~rc.1-1 < 0.2.0-1
+RPM:    0.1.4-1 < 0.2.0-0.1.alpha.1 < 0.2.0-0.2.alpha.1 < 0.2.0-0.3.alpha.2 < 0.2.0-0.4.beta.1 < 0.2.0-0.5.rc.1 < 0.2.0-1
+Arch:   0.1.4-1 < 0.2.0alpha1-1 < 0.2.0alpha1-2 < 0.2.0alpha2-1 < 0.2.0beta1-1 < 0.2.0rc1-1 < 0.2.0-1
+```
+
+`scripts/release-versions.sh` is the executable conversion contract.
+Repeating the same prerelease is a package rebuild; repeating a stable version
+is rejected because Debian/Arch would otherwise advance while RPM remains at
+release 1. Semantic version regressions are rejected before any file is edited.
+`just test-release-matrix` verifies the exact order with native
+`dpkg --compare-versions`, `rpmdev-vercmp`, and `vercmp` in disposable,
+digest-pinned containers.
+
 ## How to Release
 
 ### Automated (recommended)
 
 ```bash
 just release 0.2.0
+# or
+just release 0.2.0-alpha.1
 ```
 
 This will:
-1. Bump version in `Cargo.toml`, `dist/PKGBUILD`, `dist/PKGBUILD-bin`, `dist/facelock.spec`, `dist/debian/changelog`
+1. Convert and bump Cargo, Arch tag/pkgver/pkgrel, RPM Version/Release, and Debian upstream/revision metadata
 2. Run `cargo check --workspace` to verify the version bump compiles
-3. Prompt you to update `CHANGELOG.md` (add entries under the new version heading)
-4. Print the `git commit` / `git tag` / `git push` commands for you to run
+3. Preserve package rebuild ordering, including the monotonic RPM prerelease counter
+4. Prompt you to update `CHANGELOG.md` (add entries under the new version heading)
+5. Print the `git commit` / `git tag` / `git push` commands for you to run
 
 Then push the tag to trigger the release workflow:
 
@@ -46,14 +88,16 @@ The `.github/workflows/release.yml` workflow:
 
 1. Builds release binaries and creates a GitHub Release
 2. Downloads ONNX Runtime for bundling in non-Arch packages
-3. Builds `.deb` package — **TPM** (Debian trixie container) and **legacy** (Ubuntu 24.04)
-4. Builds `.rpm` package in Fedora container (with TPM feature) and validates contents
+3. Builds four suite-specific `.deb` packages for trixie, bookworm, resolute, and noble
+4. Builds the direct `.rpm` package in the pinned Fedora 44 container and validates contents
 5. Validates Nix flake evaluation
-6. Publishes to AUR — `facelock` (source build), `facelock-bin` (prebuilt), and `facelock-git` (VCS) — if `AUR_SSH_KEY` secret is configured
-7. Publishes signed APT repository (if `APT_GPG_PRIVATE_KEY` and `APT_GPG_PASSPHRASE` are configured)
+6. Publishes stable releases to AUR — `facelock`, `facelock-bin`, and `facelock-git` — if `AUR_SSH_KEY` is configured
+7. Publishes stable releases to the signed, codenamed APT suites if the APT signing secrets are configured
 8. Triggers GitHub Pages rebuild to include updated APT repo
 
-Pre-release tags (containing `alpha`, `beta`, or `rc`) skip AUR and APT publishing.
+Validated prerelease tags set the GitHub Release `prerelease` output and upload
+direct artifacts, but skip stable APT and all AUR publication. The workflow
+guards use the validated release identity rather than substring matching.
 
 COPR (Fedora) is **not** built by `release.yml`. It is handled by [Packit](https://packit.dev),
 which reacts to the GitHub Release published in step 1. See the COPR section below.
@@ -62,10 +106,40 @@ which reacts to the GitHub Release published in step 1. See the COPR section bel
 
 | Channel | Build env | TPM | Version suffix | Use case |
 |---------|-----------|-----|----------------|----------|
-| `main` | Debian trixie container | Yes | `X.Y.Z-1` | Modern systems (trixie+, Ubuntu 25.04+) |
-| `legacy` | Ubuntu 24.04 runner | No | `X.Y.Z-1~legacy1` | Older systems (bookworm, Ubuntu 24.04) |
+| `trixie` | Debian 13 | Yes | `X.Y.Z-1~deb13u1` | Debian 13 |
+| `bookworm` | Debian 12 | No | `X.Y.Z-1~deb12u1` | Debian 12 LTS |
+| `resolute` | Ubuntu 26.04 | Yes | `X.Y.Z-1~ubuntu26.04.1` | Ubuntu 26.04 LTS |
+| `noble` | Ubuntu 24.04 | No | `X.Y.Z-1~ubuntu24.04.1` | Ubuntu 24.04 LTS |
 
-Both `.deb` packages are uploaded to the GitHub Release for direct download. For `apt install`, they are published to the signed APT repository at `https://tysmith.me/facelock/apt/`.
+All four `.deb` packages are uploaded to the GitHub Release for direct download.
+Stable packages are published under the matching codename at
+`https://tysmith.me/facelock/apt/`; ABI-distinct packages never share one suite.
+
+### Supported release matrix
+
+`dist/release-matrix.json` is the checked-in authority. The release workflow,
+APT configuration, Packit targets, and this table are checked against it.
+
+| Platform | Architecture | Variant/channel | Runtime | Lifecycle depth |
+|----------|--------------|-----------------|---------|-----------------|
+| Debian 13 trixie | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | full |
+| Debian 12 bookworm LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | full |
+| Ubuntu 26.04 LTS | amd64 | TPM, staged APT/direct deb | bundled ORT 1.20.1 | full |
+| Ubuntu 24.04 LTS | amd64 | legacy, staged APT/direct deb | bundled ORT 1.20.1 | full |
+| Fedora 43 | x86_64 | staging COPR | system ORT | full through the 2026-12-02 EOL gate |
+| Fedora 44 | x86_64 | staging COPR | system ORT | full |
+| Fedora 45 branched | x86_64 | staging COPR | system ORT | build/runtime smoke |
+| Fedora Rawhide (Fedora 46 development) | x86_64 | development | system ORT | build/runtime smoke |
+| Fedora 44 | x86_64 | direct RPM | bundled ORT 1.20.1 | full |
+| Arch Linux Archive snapshot 2026-08-18 | x86_64 | PKGBUILD and binary recipe | system ORT | full |
+
+Container identities are pinned by registry/index digest, with the linux/amd64
+manifest digest retained where the registry exposes both. They were resolved
+from Docker Hub registry metadata and Fedora registry `Docker-Content-Digest`
+on 2026-08-18. The Arch repository identity is pinned separately to
+`https://archive.archlinux.org/repos/2026/08/18/`; every matrix-associated CI
+and AUR `pacman` invocation installs that exact mirror before refreshing package
+metadata.
 
 ### Local distro validation
 
@@ -104,7 +178,8 @@ Run this before creating/pushing a release tag:
 
 ```bash
 just release-preflight              # stable release checks
-just release-preflight v0.2.0-rc1  # prerelease checks (AUR/COPR secrets optional)
+just release-preflight v0.2.0-rc.1 # prerelease checks; no stable secret access
+just test-release-matrix            # converters, matrix drift, native ordering
 just check
 just test-arch-pam
 just test-rpm
@@ -117,7 +192,12 @@ just test-rpm-pkg
 `just release-preflight` checks local tools, required packaging files (including
 `.packit.yaml`), and whether `AUR_SSH_KEY`, `APT_GPG_PRIVATE_KEY`, and
 `APT_GPG_PASSPHRASE` are configured in GitHub secrets (via `gh`). COPR needs no
-secret — it is driven by Packit.
+secret — it is driven by Packit. Preflight and CI also read the public
+production COPR API and require its enabled chroots to equal the checked-in
+43/44/45 authority. An extra or missing live chroot is a release-blocking drift;
+the checker never modifies the project. When the Packit CLI is available,
+preflight runs `packit config validate --offline`; `just test-copr` always runs
+that real schema gate inside its Fedora Packit container.
 
 ### Package repository setup (one-time)
 
@@ -182,14 +262,28 @@ After this, every non-prerelease tag push automatically updates the AUR package.
 
 #### COPR (Fedora/RHEL)
 
-Automated after setup, via [Packit](https://packit.dev) — the Fedora-ecosystem
-standard for upstream→COPR builds. There is **no webhook and no GitHub secret**.
+Packit reads `.packit.yaml` from the released tag. Packit's documented
+`upstream_tag_exclude` filtering applies to downstream synchronization jobs,
+not to `copr_build`, so it is not a prerelease safety boundary.
 
-The configuration lives in `.packit.yaml` at the repository root. It declares a
-single `copr_build` job with `trigger: release`: when `release.yml` publishes a
-GitHub Release, Packit generates an SRPM from `dist/facelock.spec` and builds it
-into the existing COPR project `tyvsmith/facelock` for `fedora-rawhide`,
-`fedora-42`, and `fedora-43` (x86_64).
+The prerelease-capable configuration keeps the production
+`tyvsmith/facelock` job at `trigger: ignore`. That makes an alpha-tagged config
+structurally incapable of selecting a release-triggered production project.
+Before a stable release, the maintainer deliberately changes that trigger to
+`release` in the stable-tagged config. `just release-preflight` rejects a
+production release job for a prerelease and rejects its absence for a stable.
+The deliberate stable restoration targets `fedora-43-x86_64`,
+`fedora-44-x86_64`, and the separate `fedora-45-x86_64` branched target.
+Rawhide is Fedora 46 development in this matrix and is not an alias for Fedora
+45.
+
+`.packit.yaml` deliberately uses JSON syntax, which is a valid YAML subset.
+Release guards therefore parse its jobs semantically with the Python standard
+library instead of comparing YAML spelling; general YAML outside that subset
+fails closed. The production project is `tyvsmith/facelock`. The planned
+prerelease staging project is `tyvsmith/facelock-testing`, but provisioning or
+changing it belongs to issue #236 and is not performed by this release-identity
+change.
 
 The COPR RPM is built **from source** and does **not** bundle ONNX Runtime — the
 spec's `Requires: onnxruntime` pulls Fedora's system `onnxruntime` package
@@ -200,8 +294,8 @@ Fedora's ONNX Runtime.)
 
 1. Create a Fedora Account at https://accounts.fedoraproject.org
 2. Log in to COPR at https://copr.fedorainfracloud.org and ensure the
-   `tyvsmith/facelock` project exists with the `fedora-rawhide-x86_64`,
-   `fedora-42-x86_64`, and `fedora-43-x86_64` chroots enabled
+   `tyvsmith/facelock` project exists with the `fedora-43-x86_64`,
+   `fedora-44-x86_64`, and `fedora-45-x86_64` chroots enabled
    (Settings → Chroots).
 3. Install the **Packit-as-a-Service** GitHub App on the repository:
    https://github.com/marketplace/packit-as-a-service
@@ -216,9 +310,10 @@ Fedora's ONNX Runtime.)
 Verify the COPR build locally before relying on it with `just test-copr`, which
 reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot.
 
-After setup, every non-prerelease GitHub Release triggers a COPR build
-automatically. To populate COPR without cutting a release (e.g. after first-time
-setup), run `packit build in-copr --owner tyvsmith --project facelock` locally.
+Only a stable-tagged config with the deliberately restored production release
+trigger can populate production COPR automatically. Prerelease staging project
+provisioning and served-repository validation are separate release-infrastructure
+work; do not point prerelease tags at production while it is unavailable.
 
 Note: a previously published release will **not** retroactively build — Packit
 reacts only to *new* Release events.
@@ -251,10 +346,20 @@ Automated after setup. The release workflow publishes a signed APT repository to
 
    Or use the web UI: https://github.com/tyvsmith/facelock/settings/secrets/actions
 
-The repository configuration lives in `dist/apt/conf/distributions`. Two suites are published:
+The repository configuration lives in `dist/apt/conf/distributions`. Four
+codenamed suites are published:
 
-- **`main`**: TPM-enabled build (Debian trixie+, Ubuntu 25.04+)
-- **`legacy`**: Non-TPM build (Ubuntu 24.04, Debian bookworm)
+- **`trixie`**: Debian 13 TPM build
+- **`bookworm`**: Debian 12 legacy build
+- **`resolute`**: Ubuntu 26.04 TPM build
+- **`noble`**: Ubuntu 24.04 legacy build
+
+The former ambiguous `main` and `legacy` suite names are retired. Existing
+clients must replace that suite component in their Facelock source entry with
+their operating-system codename before the first codenamed stable publication.
+Prerelease packages are never inserted into these stable suites.
+Stable publication requires exactly one suite-matching package for all four
+codenames before signing or repository writes begin.
 
 The APT repo is hosted at `https://tysmith.me/facelock/apt/` alongside the docs site. The public keyring is at `https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg`.
 
@@ -289,14 +394,20 @@ If CI is not configured or fails:
 ## Version Sources
 
 The canonical version is in the root `Cargo.toml` under `[workspace.package]`.
-All other files are synced by `just release`:
+The version fields synced by `just release` are:
 
 | File | Field |
 |------|-------|
 | `Cargo.toml` | `[workspace.package] version` |
-| `dist/PKGBUILD` | `pkgver` |
-| `dist/facelock.spec` | `Version` |
-| `dist/debian/changelog` | Version in first entry |
+| `dist/PKGBUILD`, `dist/PKGBUILD-bin` | upstream `_tag`, converted `pkgver`, package `pkgrel` |
+| `dist/PKGBUILD-git` | converted display `pkgver` |
+| `dist/facelock.spec` | converted `Version` and monotonic prerelease `Release` |
+| `dist/debian/changelog` | converted upstream and package revision in first entry |
+
+The independently maintained `dist/release-matrix.json` records supported
+targets, lifecycle depth, and immutable environment identities. Release
+preflight, CI, and release metadata checks validate that authority; `just
+release` does not rewrite it.
 
 ## ONNX Runtime Bundling
 

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -176,7 +176,7 @@ production-ready in the justfile install recipe.
 | Format | Location | Status |
 |--------|----------|--------|
 | Raw binaries | `release.yml` | Released. Triggered on `v*` tags. Uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, SHA256SUMS to GitHub Releases. |
-| `.deb` | `release.yml` (build-deb job) | Released. Built in CI, uploaded to GitHub Release. Signed APT repository at `tysmith.me/facelock/apt` (main/legacy variants). |
+| `.deb` | `release.yml` (build-deb job) | Released. Four suite-specific `.deb` artifacts for trixie, bookworm, resolute, and noble are built in CI and uploaded to GitHub Release. Stable releases publish the matching signed APT suites at `tysmith.me/facelock/apt`. |
 | `.rpm` | `release.yml` (build-rpm job) | Released. Built in CI for the GitHub Release asset. COPR builds from source via Packit (`tyvsmith/facelock`) per `releasing.md`. |
 | PKGBUILD (Arch) | `dist/PKGBUILD` | Released. Automated via tag CI; published to AUR (`facelock`, `facelock-git`). References `facelock.install` file. |
 | Nix flake | `dist/nix/flake.nix` | Exists with NixOS module (`module.nix`), derivation (`default.nix`), and dev shell. Not in nixpkgs. `doCheck = false` (needs camera). |
@@ -193,7 +193,7 @@ production-ready in the justfile install recipe.
 
 ### GitHub release workflow
 - Triggered by pushing a `v*` tag
-- Builds release binaries (with TPM support), .deb, and .rpm
+- Builds release binaries, four suite-specific `.deb` artifacts (trixie, bookworm, resolute, and noble), and the direct Fedora `.rpm` artifact
 - Uploads all artifacts to the GitHub Release with auto-generated release notes
 - Single architecture: x86_64 only
 

--- a/justfile
+++ b/justfile
@@ -26,6 +26,7 @@ test-all:
 # modes ARE a security contract in this project (0600 database, 0711 state
 # dir), and `non_octal_unix_permissions` is exactly the lint that catches a
 # `from_mode(600)` — which means 0o1130, not 0o600 — before it ships.
+
 # Keep in sync with .github/workflows/ci.yml.
 lint:
     cargo clippy --workspace --all-targets -- -D warnings
@@ -40,6 +41,7 @@ fmt:
 
 # Scan the dependency tree for RustSec advisories (mirrors the CI cargo-audit job).
 # Ignore policy lives in .cargo/audit.toml; deny policy is set here so CI matches.
+
 # Requires cargo-audit: cargo install cargo-audit --locked
 audit:
     cargo audit --deny unmaintained --deny unsound
@@ -51,6 +53,7 @@ audit:
 # polling + the async-executor/async-fs/async-lock trio) while allowing
 # signal-hook-registry, which the correct tokio backend legitimately pulls via
 # tokio's "process" feature. Keep in sync with .github/workflows/ci.yml
+
 # ("Build pam-facelock in isolation" + "Verify pam-facelock dependency surface").
 check-pam-standalone:
     #!/usr/bin/env bash
@@ -65,12 +68,13 @@ check-pam-standalone:
     echo "pam-facelock dependency guard passed"
 
 # Verify agent-facing docs still describe the tree they describe.
+
 # Pass a git ref to also run the coupling check against it.
 check-agent-docs base='':
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "{{base}}" ]; then
-        python3 test/check-agent-docs.py --base "{{base}}"
+    if [ -n "{{ base }}" ]; then
+        python3 test/check-agent-docs.py --base "{{ base }}"
     else
         python3 test/check-agent-docs.py
     fi
@@ -80,6 +84,7 @@ check: test lint fmt-check audit check-pam-standalone check-agent-docs
 
 # Build the PAM test container image (uses host-built release binaries).
 # Keep in sync with .github/workflows/ci.yml, which builds this same image
+
 # directly rather than going through this recipe.
 _build-test-container: build-release
     podman build -t facelock-pam-test -f test/Containerfile .
@@ -93,6 +98,7 @@ test-arch-pam: _build-test-container
 # and /var/log/facelock, including that any local user can traverse to its own
 # enrollment marker but list nothing and read no secret. This is the only test
 # that exercises the packaging wiring (install-files modes + the built-in
+
 # defaults) end to end — unit tests cannot.
 test-arch-layout: _build-test-container
     podman run --rm facelock-pam-test /run-layout-tests.sh
@@ -120,6 +126,7 @@ test-arch-layout: _build-test-container
 # lands, and lands via a temp name, so an interrupted copy cannot leave a
 # truncated model behind for the daemon to reject later.
 #
+
 # Populate models/*.onnx from an existing checkout or install tree
 link-models src="": (_link-models "explicit" src)
 
@@ -129,12 +136,13 @@ link-models src="": (_link-models "explicit" src)
 #   there is nothing to do, and never fail. A copy can be 435MB; that is worth
 #   opting into, not something `just test-arch-integration` should spend behind
 #   your back. When auto cannot finish the job it stays quiet and leaves the
-#   diagnosis to _require-models, which owns that message.
+
+# diagnosis to _require-models, which owns that message.
 _link-models mode="explicit" src="":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    if [ "{{mode}}" = "explicit" ]; then explicit=1; else explicit=0; fi
+    if [ "{{ mode }}" = "explicit" ]; then explicit=1; else explicit=0; fi
 
     manifest=models/manifest.toml
     if [ ! -f "$manifest" ]; then
@@ -173,8 +181,8 @@ _link-models mode="explicit" src="":
     fi
 
     candidates=()
-    if [ -n "{{src}}" ]; then
-        candidates+=("{{src}}")
+    if [ -n "{{ src }}" ]; then
+        candidates+=("{{ src }}")
     else
         # `git worktree list` prints the main worktree first. That is the
         # checkout a worktree can hardlink from for free.
@@ -333,6 +341,7 @@ _link-models mode="explicit" src="":
 # The _link-models dependency makes the common case not happen at all: a fresh
 # worktree hardlinks from the main checkout on the way in, so neither the
 # refusal nor the opt-out is reached. It only ever uses free mechanisms, so when
+
 # it declines, everything below still applies unchanged.
 _require-models allow_opt_out="0": (_link-models "auto")
     #!/usr/bin/env bash
@@ -342,7 +351,7 @@ _require-models allow_opt_out="0": (_link-models "auto")
         [ -f "$m" ] || missing+=("$m")
     done
     [ ${#missing[@]} -gt 0 ] || exit 0
-    if [ "{{allow_opt_out}}" = "1" ] && [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
+    if [ "{{ allow_opt_out }}" = "1" ] && [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
         echo "warning: missing ONNX models, continuing (FACELOCK_ALLOW_MISSING_MODELS=1):" >&2
         for m in "${missing[@]}"; do echo "           $m" >&2; done
         echo "         The daemon-start assertions will be reported as SKIPPED, not passed." >&2
@@ -356,7 +365,7 @@ _require-models allow_opt_out="0": (_link-models "auto")
     echo "       It names what it looked at, and how to get the models, if it finds" >&2
     echo "       no source. (models/*.onnx is gitignored, so nothing you link in can" >&2
     echo "       be committed by accident.)" >&2
-    if [ "{{allow_opt_out}}" = "1" ]; then
+    if [ "{{ allow_opt_out }}" = "1" ]; then
         echo "       To validate packaging only, with the daemon-start assertions counted" >&2
         echo "       as skipped: FACELOCK_ALLOW_MISSING_MODELS=1 just <recipe>" >&2
     fi
@@ -387,6 +396,7 @@ test-arch-integration: _require-models _build-test-container
     podman run --rm $devices "${env_args[@]}" facelock-pam-test /run-integration-tests.sh
 
 # FACELOCK_LIVE_TIMEOUT=300s just test-arch-oneshot      # relax the live steps
+
 # Automated oneshot (daemonless) integration tests (Arch, requires camera)
 test-arch-oneshot: _require-models _build-test-container
     #!/usr/bin/env bash
@@ -445,6 +455,7 @@ test-arch-release-shell: _build-test-container
     podman run --rm -it $devices facelock-pam-test /bin/bash
 
 # Build release and install to system
+
 # Run as: just install (builds as you, installs as root)
 install: build-release
     sudo env PATH="$PATH" just install-files
@@ -595,6 +606,7 @@ install-files:
     fi
 
 # Uninstall from system
+
 # Run as: just uninstall (elevates to root, preserving PATH)
 uninstall:
     sudo env PATH="$PATH" just uninstall-files
@@ -691,7 +703,6 @@ uninstall-files:
 # compiled in as the fallback. These recipes exist for translators and fail
 # with a clear message when the gettext tools are absent.
 # ---------------------------------------------------------------------------
-
 # Regenerate translation templates (po/*.pot) from source. The CLI catalog
 # extracts every `translate("...")` literal in the message seam
 # (crates/facelock-cli/src/message/ — the one place CLI user-facing English
@@ -701,6 +712,7 @@ uninstall-files:
 # because the seam keeps msgids as single-line plain literals (see the
 # "Adding a message" pattern in message/mod.rs). The domain modules are
 # globbed and sorted so a new one is picked up without editing this recipe
+
 # and the output stays byte-stable.
 pot:
     #!/usr/bin/env bash
@@ -763,6 +775,7 @@ pot:
 # `msgfmt --check` is what enforces the `{placeholder}` contract: paired with the
 # python-brace-format flags `just pot` writes, it rejects a translation that
 # typos, drops or invents a placeholder. Dropping --check would silently turn
+
 # that back off.
 mo:
     #!/usr/bin/env bash
@@ -788,17 +801,16 @@ mo:
     fi
 
 # Bump version and prepare a release commit + tag
+
 # Usage: just release 0.2.0
 release version:
     #!/usr/bin/env bash
     set -euo pipefail
-    VERSION="{{version}}"
+    VERSION="{{ version }}"
+    source scripts/release-versions.sh
 
     # Validate version format
-    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-        echo "Error: Version must be semver (e.g. 0.2.0), got '$VERSION'"
-        exit 1
-    fi
+    release_validate_cargo_version "$VERSION"
 
     # Check for clean working tree
     if [ -n "$(git status --porcelain)" ]; then
@@ -807,6 +819,14 @@ release version:
     fi
 
     OLD_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    release_validate_transition "$OLD_VERSION" "$VERSION"
+    ARCH_VERSION=$(release_arch_pkgver "$VERSION")
+    ARCH_RELEASE=$(release_next_arch_revision "$VERSION" dist/PKGBUILD)
+    DEBIAN_RELEASE=$(release_next_debian_revision "$VERSION" dist/debian/changelog)
+    DEBIAN_VERSION=$(release_debian_common_version "$VERSION" "$DEBIAN_RELEASE")
+    RPM_VERSION=$(release_rpm_version "$VERSION")
+    RPM_COUNTER=$(release_next_rpm_counter "$VERSION" dist/facelock.spec)
+    RPM_RELEASE=$(release_rpm_release "$VERSION" "$RPM_COUNTER")
     echo "Bumping version: $OLD_VERSION → $VERSION"
 
     # 1. Cargo.toml (workspace version)
@@ -815,13 +835,13 @@ release version:
 
     # 2. dist/PKGBUILD
     if [ -f dist/PKGBUILD ]; then
-        sed -i "s/^pkgver=.*/pkgver=$VERSION/" dist/PKGBUILD
+        sed -i "s/^_tag=.*/_tag=$VERSION/; s/^pkgver=.*/pkgver=$ARCH_VERSION/; s/^pkgrel=.*/pkgrel=$ARCH_RELEASE/" dist/PKGBUILD
         echo "  ✓ dist/PKGBUILD"
     fi
 
     # 2b. dist/PKGBUILD-bin (per-binary sha256sums are filled in by CI)
     if [ -f dist/PKGBUILD-bin ]; then
-        sed -i "s/^pkgver=.*/pkgver=$VERSION/" dist/PKGBUILD-bin
+        sed -i "s/^_tag=.*/_tag=$VERSION/; s/^pkgver=.*/pkgver=$ARCH_VERSION/; s/^pkgrel=.*/pkgrel=$ARCH_RELEASE/" dist/PKGBUILD-bin
         echo "  ✓ dist/PKGBUILD-bin"
     fi
 
@@ -830,20 +850,20 @@ release version:
     # without a git checkout, so AUR's web display falls back to this static
     # pkgver. Keep it in sync with the release so the AUR page doesn't drift.
     if [ -f dist/PKGBUILD-git ]; then
-        sed -i "s/^pkgver=.*/pkgver=$VERSION/" dist/PKGBUILD-git
+        sed -i "s/^pkgver=.*/pkgver=$ARCH_VERSION/" dist/PKGBUILD-git
         echo "  ✓ dist/PKGBUILD-git"
     fi
 
     # 3. dist/facelock.spec
     if [ -f dist/facelock.spec ]; then
-        sed -i "s/^Version:.*/Version:        $VERSION/" dist/facelock.spec
+        sed -i "s/^Version:.*/Version:        $RPM_VERSION/; s/^Release:.*/Release:        $RPM_RELEASE%{?dist}/" dist/facelock.spec
         echo "  ✓ dist/facelock.spec"
     fi
 
     # 4. dist/debian/changelog (prepend new entry)
     if [ -f dist/debian/changelog ]; then
         DATE=$(date -R)
-        sed -i "1i facelock ($VERSION-1) unstable; urgency=medium\n\n  * Release v$VERSION.\n\n -- Facelock Contributors <facelock@m.tysmith.me>  $DATE\n" dist/debian/changelog
+        sed -i "1i facelock ($DEBIAN_VERSION) unstable; urgency=medium\n\n  * Release v$VERSION.\n\n -- Facelock Contributors <facelock@m.tysmith.me>  $DATE\n" dist/debian/changelog
         echo "  ✓ dist/debian/changelog"
     fi
 
@@ -886,6 +906,8 @@ show-paths:
 # Detect host ONNX Runtime version for container builds.
 # Local binaries are built against the host ORT, so bundled ORT must match.
 # CI uses 1.20.1 (set in release.yml); local builds use whatever is installed.
+
+[private]
 _ort-version := `for ort in /usr/lib/libonnxruntime.so /usr/lib64/libonnxruntime.so; do if [ -e "$ort" ]; then readlink -f "$ort" | grep -oP '\d+\.\d+\.\d+$'; exit; fi; done; echo "1.20.1"`
 
 # Test RPM packaging in Fedora container
@@ -905,26 +927,28 @@ test-deb: build-release
 # Needs models/*.onnx: the validation starts the daemon under the hardened unit
 # and checks what it holds at runtime. FACELOCK_ALLOW_MISSING_MODELS=1 runs the
 # packaging half only, with the rest counted as skipped.
+
 # Package test — build real .deb, install via dpkg, validate under booted systemd
 test-deb-pkg: (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
     test/run-pkg-validate-systemd.sh facelock-deb-pkg
 
 # Package test — build real TPM .deb (trixie), install via dpkg, run automated validation
 test-deb-tpm-pkg: build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-tpm-pkg -f test/Containerfile.deb-tpm-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-deb-tpm-pkg -f test/Containerfile.deb-tpm-e2e .
     podman run --rm facelock-deb-tpm-pkg
 
 # Same model requirement (and same opt-out) as test-deb-pkg.
+
 # Package test — build real .rpm, install via dnf, validate under booted systemd
 test-rpm-pkg: (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
     test/run-pkg-validate-systemd.sh facelock-rpm-pkg
 
 # COPR-equivalent build — Packit SRPM + mock from-source rebuild on a Fedora chroot (slow, opt-in)
@@ -938,7 +962,7 @@ test-copr:
 test-deb-dev-shell: build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -958,7 +982,7 @@ test-deb-dev-shell: build-release
 test-rpm-dev-shell: build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -978,7 +1002,7 @@ test-rpm-dev-shell: build-release
 test-deb-release-shell: build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-deb-pkg -f test/Containerfile.deb-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -995,7 +1019,7 @@ test-deb-release-shell: build-release
 test-rpm-release-shell: build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{_ort-version}} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
+    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -1034,8 +1058,8 @@ test-apt-repo:
     # For local testing without GPG, strip SignWith lines
     sed -i '/^SignWith:/d' "${REPO_DIR}/conf/distributions"
 
-    # Find any .deb files (from just test-deb or CI artifacts)
-    DEB_FILES=$({ find . -maxdepth 1 -name 'facelock_*.deb'; find ./target -maxdepth 1 -name 'facelock_*.deb' 2>/dev/null; } | head -2)
+    # Find suite-versioned .deb files (from CI artifacts or local package tests).
+    DEB_FILES=$({ find . -maxdepth 1 -name 'facelock_*.deb'; find ./target -maxdepth 1 -name 'facelock_*.deb' 2>/dev/null; })
     if [ -z "$DEB_FILES" ]; then
         echo "No .deb files found. Building a test .deb is not required."
         echo "Validating reprepro config only..."
@@ -1046,23 +1070,31 @@ test-apt-repo:
         exit 0
     fi
 
-    # Add first .deb to main, second to legacy (or same to both)
-    FIRST_DEB=$(echo "$DEB_FILES" | head -1)
-    SECOND_DEB=$(echo "$DEB_FILES" | tail -1)
-
-    reprepro -b "${REPO_DIR}" includedeb main "$FIRST_DEB"
-    reprepro -b "${REPO_DIR}" includedeb legacy "$SECOND_DEB"
+    while IFS= read -r deb; do
+        version=$(dpkg-deb -f "$deb" Version)
+        case "$version" in
+            *~deb13u1) suite=trixie ;;
+            *~deb12u1) suite=bookworm ;;
+            *~ubuntu26.04.1) suite=resolute ;;
+            *~ubuntu24.04.1) suite=noble ;;
+            *) echo "SKIP: $deb has no supported suite suffix"; continue ;;
+        esac
+        reprepro -b "${REPO_DIR}" includedeb "$suite" "$deb"
+    done <<< "$DEB_FILES"
 
     echo ""
     echo "=== APT repo structure ==="
     find "${REPO_DIR}" -type f -not -path '*/db/*' -not -path '*/conf/*' | sort
 
     # Validate expected structure
-    for SUITE in main legacy; do
-        [ -f "${REPO_DIR}/dists/${SUITE}/Release" ] && echo "OK: dists/${SUITE}/Release"
-        [ -d "${REPO_DIR}/dists/${SUITE}/facelock/binary-amd64" ] && echo "OK: dists/${SUITE}/facelock/binary-amd64/"
+    for SUITE in trixie bookworm resolute noble; do
+        [ -f "${REPO_DIR}/dists/${SUITE}/Release" ] || { echo "MISSING: dists/${SUITE}/Release" >&2; exit 1; }
+        echo "OK: dists/${SUITE}/Release"
+        [ -d "${REPO_DIR}/dists/${SUITE}/facelock/binary-amd64" ] || { echo "MISSING: dists/${SUITE}/facelock/binary-amd64/" >&2; exit 1; }
+        echo "OK: dists/${SUITE}/facelock/binary-amd64/"
     done
-    [ -d "${REPO_DIR}/pool/facelock" ] && echo "OK: pool/facelock/"
+    [ -d "${REPO_DIR}/pool/facelock" ] || { echo "MISSING: pool/facelock/" >&2; exit 1; }
+    echo "OK: pool/facelock/"
 
     echo ""
     echo "APT repo generation: OK"
@@ -1070,17 +1102,20 @@ test-apt-repo:
 # Quick preflight before tagging a release
 # Usage:
 #   just release-preflight                 # assume stable release
-#   just release-preflight v0.2.0-rc1      # prerelease (secrets optional)
+
+# just release-preflight v0.2.0-rc.1     # prerelease (stable channels excluded)
 release-preflight tag='':
     #!/usr/bin/env bash
     set -euo pipefail
 
     failed=0
-    TAG="{{tag}}"
-    prerelease=0
-    if [ -n "$TAG" ] && echo "$TAG" | grep -Eq '(alpha|beta|rc)'; then
-        prerelease=1
+    source scripts/release-versions.sh
+    TAG="{{ tag }}"
+    if [ -z "$TAG" ]; then
+        TAG=$(release_tag_from_cargo "$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')")
     fi
+    VERSION=$(release_cargo_from_tag "$TAG")
+    if release_is_prerelease "$VERSION"; then prerelease=1; else prerelease=0; fi
 
     check_cmd() {
         local cmd="$1"
@@ -1102,12 +1137,18 @@ release-preflight tag='':
     echo "== Packaging file checks =="
     for f in \
         dist/PKGBUILD \
+        dist/PKGBUILD-bin \
         dist/PKGBUILD-git \
+        dist/release-matrix.json \
         dist/facelock.spec \
         dist/debian/control \
         dist/debian/rules \
         dist/apt/conf/distributions \
         .packit.yaml \
+        scripts/release-versions.sh \
+        test/release-version-contract.sh \
+        test/check-release-matrix.py \
+        test/check-live-release-channels.py \
         .github/workflows/release.yml; do
         if [ -f "$f" ]; then
             echo "OK: $f"
@@ -1117,16 +1158,31 @@ release-preflight tag='':
         fi
     done
 
+    if command -v packit >/dev/null 2>&1; then
+        packit config validate --offline -c .packit.yaml || failed=1
+    else
+        echo "SKIP: packit CLI not installed; test-copr runs the required schema gate"
+    fi
+
+    echo ""
+    echo "== Release identity and target contract =="
+    release_check_metadata "$TAG" || failed=1
+    bash test/release-version-contract.sh || failed=1
+    RELEASE_MATRIX_VERSION="$VERSION" python3 test/check-release-matrix.py || failed=1
+    python3 test/check-live-release-channels.py || failed=1
+
     echo ""
     echo "== GitHub release secret checks =="
     if [ "$prerelease" -eq 1 ]; then
-        echo "Mode: prerelease ($TAG) — AUR secrets are optional"
+        echo "Mode: prerelease ($TAG) — stable APT/AUR and production COPR are excluded"
     else
-        echo "Mode: stable release — AUR secrets are required"
+        echo "Mode: stable release — stable APT/AUR secrets and a production COPR release job are required"
     fi
     echo "Note: COPR builds are handled by Packit (.packit.yaml) — no secret required."
 
-    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    if [ "$prerelease" -eq 1 ]; then
+        echo "SKIP: prerelease preflight does not access stable publication secrets"
+    elif command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
         if gh secret list | grep -q '^AUR_SSH_KEY\b'; then
             echo "OK: AUR_SSH_KEY configured"
         else
@@ -1167,4 +1223,18 @@ release-preflight tag='':
     fi
 
     echo "Release preflight: OK"
-    echo "Next: run 'just check', 'just test-pam', 'just test-rpm', and 'just test-deb' before tagging."
+    echo "Next: run 'just check', 'just test-release-matrix', 'just test-arch-pam', 'just test-rpm', and 'just test-deb' before tagging."
+
+# Fast release contract tests that do not require distro package tools.
+test-release-contract:
+    bash test/release-version-contract.sh
+    python3 test/check-release-matrix.py
+
+# Native version comparison tools run only inside disposable, digest-pinned containers.
+test-release-native-ordering:
+    podman run --rm -v "$PWD:/repo:ro" -w /repo docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958 bash test/release-native-ordering.sh debian
+    podman run --rm -v "$PWD:/repo:ro" -w /repo registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb bash -lc 'dnf -qy install rpmdevtools && bash test/release-native-ordering.sh rpm'
+    podman run --rm -v "$PWD:/repo:ro" -w /repo docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b bash test/release-native-ordering.sh arch
+
+# Complete Track V version/matrix gate.
+test-release-matrix: test-release-contract test-release-native-ordering

--- a/scripts/release-versions.sh
+++ b/scripts/release-versions.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+# Shared release identity conversions. This file is sourced by release tooling.
+
+release_validate_cargo_version() {
+    local version="${1:-}"
+    if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$ ]]; then
+        echo "invalid Cargo release version '$version' (expected X.Y.Z or X.Y.Z-{alpha,beta,rc}.N)" >&2
+        return 1
+    fi
+}
+
+release_compare_unsigned() {
+    local left="${1:-}"
+    local right="${2:-}"
+    if [[ ! "$left" =~ ^[0-9]+$ || ! "$right" =~ ^[0-9]+$ ]]; then
+        echo "cannot compare non-negative integers '$left' and '$right'" >&2
+        return 1
+    fi
+    if [ "${#left}" -lt "${#right}" ]; then
+        printf '%s\n' -1
+    elif [ "${#left}" -gt "${#right}" ]; then
+        printf '%s\n' 1
+    elif [[ "$left" < "$right" ]]; then
+        printf '%s\n' -1
+    elif [[ "$left" > "$right" ]]; then
+        printf '%s\n' 1
+    else
+        printf '%s\n' 0
+    fi
+}
+
+release_compare_cargo_versions() {
+    local left="${1:-}"
+    local right="${2:-}"
+    local left_stage left_prerelease right_stage right_prerelease comparison index
+    local -a left_core right_core
+    release_validate_cargo_version "$left" || return 1
+    release_validate_cargo_version "$right" || return 1
+
+    [[ "$left" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.([0-9]+))?$ ]]
+    left_core=("${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
+    left_stage="${BASH_REMATCH[5]:-stable}"
+    left_prerelease="${BASH_REMATCH[6]:-0}"
+    [[ "$right" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.([0-9]+))?$ ]]
+    right_core=("${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
+    right_stage="${BASH_REMATCH[5]:-stable}"
+    right_prerelease="${BASH_REMATCH[6]:-0}"
+
+    for index in 0 1 2; do
+        comparison="$(release_compare_unsigned "${left_core[index]}" "${right_core[index]}")" || return 1
+        if [ "$comparison" != 0 ]; then
+            printf '%s\n' "$comparison"
+            return 0
+        fi
+    done
+
+    case "$left_stage" in alpha) left_stage=1 ;; beta) left_stage=2 ;; rc) left_stage=3 ;; stable) left_stage=4 ;; esac
+    case "$right_stage" in alpha) right_stage=1 ;; beta) right_stage=2 ;; rc) right_stage=3 ;; stable) right_stage=4 ;; esac
+    if [ "$left_stage" -lt "$right_stage" ]; then
+        printf '%s\n' -1
+    elif [ "$left_stage" -gt "$right_stage" ]; then
+        printf '%s\n' 1
+    elif [ "$left_stage" -eq 4 ]; then
+        printf '%s\n' 0
+    else
+        release_compare_unsigned "$left_prerelease" "$right_prerelease"
+    fi
+}
+
+release_validate_transition() {
+    local previous="${1:-}"
+    local next="${2:-}"
+    local comparison
+    comparison="$(release_compare_cargo_versions "$previous" "$next")" || return 1
+    if [ "$comparison" -gt 0 ]; then
+        echo "refusing release version regression from $previous to $next" >&2
+        return 1
+    elif [ "$comparison" -eq 0 ] && ! release_is_prerelease "$next"; then
+        echo "refusing repeated stable release version $next" >&2
+        return 1
+    fi
+}
+
+release_cargo_from_tag() {
+    local tag="${1:-}"
+    if [[ "$tag" != v* ]]; then
+        echo "invalid release tag '$tag' (expected leading v)" >&2
+        return 1
+    fi
+    local version="${tag#v}"
+    release_validate_cargo_version "$version" || return 1
+    printf '%s\n' "$version"
+}
+
+release_tag_from_cargo() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    printf 'v%s\n' "$version"
+}
+
+release_is_prerelease() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    [[ "$version" == *-* ]]
+}
+
+release_github_prerelease() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    if release_is_prerelease "$version"; then
+        printf 'true\n'
+    else
+        printf 'false\n'
+    fi
+}
+
+release_base_version() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    printf '%s\n' "${version%%-*}"
+}
+
+release_prerelease_suffix() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    if release_is_prerelease "$version"; then
+        printf '%s\n' "${version#*-}"
+    fi
+}
+
+release_debian_upstream() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    if release_is_prerelease "$version"; then
+        printf '%s~%s\n' "${version%%-*}" "${version#*-}"
+    else
+        printf '%s\n' "$version"
+    fi
+}
+
+release_validate_positive_revision() {
+    local revision="${1:-}"
+    if [[ ! "$revision" =~ ^[1-9][0-9]*$ ]]; then
+        echo "invalid package revision '$revision' (expected a positive integer)" >&2
+        return 1
+    fi
+}
+
+release_debian_common_version() {
+    local version="${1:-}"
+    local revision="${2:-}"
+    local upstream
+    release_validate_positive_revision "$revision" || return 1
+    upstream="$(release_debian_upstream "$version")" || return 1
+    printf '%s-%s\n' "$upstream" "$revision"
+}
+
+release_debian_suite_suffix() {
+    case "${1:-}" in
+        trixie) printf '~deb13u1\n' ;;
+        bookworm) printf '~deb12u1\n' ;;
+        resolute) printf '~ubuntu26.04.1\n' ;;
+        noble) printf '~ubuntu24.04.1\n' ;;
+        *)
+            echo "unsupported Debian/Ubuntu suite '${1:-}'" >&2
+            return 1
+            ;;
+    esac
+}
+
+release_debian_variant() {
+    case "${1:-}" in
+        trixie|resolute) printf 'tpm\n' ;;
+        bookworm|noble) printf 'legacy\n' ;;
+        *)
+            echo "unsupported Debian/Ubuntu suite '${1:-}'" >&2
+            return 1
+            ;;
+    esac
+}
+
+release_debian_version() {
+    local version="${1:-}"
+    local revision="${2:-}"
+    local suite="${3:-}"
+    local common suffix
+    common="$(release_debian_common_version "$version" "$revision")" || return 1
+    suffix="$(release_debian_suite_suffix "$suite")" || return 1
+    printf '%s%s\n' "$common" "$suffix"
+}
+
+release_debian_source_basename() {
+    local version="${1:-}"
+    local revision="${2:-}"
+    local suite="${3:-}"
+    local debian_version
+    debian_version="$(release_debian_version "$version" "$revision" "$suite")" || return 1
+    printf 'facelock_%s\n' "$debian_version"
+}
+
+release_debian_binary_basename() {
+    local version="${1:-}"
+    local revision="${2:-}"
+    local suite="${3:-}"
+    local architecture="${4:-}"
+    local source_basename
+    if [[ ! "$architecture" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+        echo "invalid Debian architecture '$architecture'" >&2
+        return 1
+    fi
+    source_basename="$(release_debian_source_basename "$version" "$revision" "$suite")" || return 1
+    printf '%s_%s\n' "$source_basename" "$architecture"
+}
+
+release_arch_pkgver() {
+    local version="${1:-}"
+    release_validate_cargo_version "$version" || return 1
+    if release_is_prerelease "$version"; then
+        local suffix="${version#*-}"
+        printf '%s%s\n' "${version%%-*}" "${suffix//./}"
+    else
+        printf '%s\n' "$version"
+    fi
+}
+
+release_arch_version() {
+    local version="${1:-}"
+    local revision="${2:-}"
+    local pkgver
+    release_validate_positive_revision "$revision" || return 1
+    pkgver="$(release_arch_pkgver "$version")" || return 1
+    printf '%s-%s\n' "$pkgver" "$revision"
+}
+
+release_rpm_version() {
+    release_base_version "${1:-}"
+}
+
+release_rpm_release() {
+    local version="${1:-}"
+    local counter="${2:-}"
+    release_validate_cargo_version "$version" || return 1
+    if release_is_prerelease "$version"; then
+        release_validate_positive_revision "$counter" || return 1
+        printf '0.%s.%s\n' "$counter" "${version#*-}"
+    else
+        printf '1\n'
+    fi
+}
+
+release_rpm_evr() {
+    local version="${1:-}"
+    local counter="${2:-}"
+    local rpm_version rpm_release
+    rpm_version="$(release_rpm_version "$version")" || return 1
+    rpm_release="$(release_rpm_release "$version" "$counter")" || return 1
+    printf '%s-%s\n' "$rpm_version" "$rpm_release"
+}
+
+release_next_arch_revision() {
+    local version="${1:-}"
+    local pkgbuild="${2:-}"
+    local new_pkgver old_pkgver old_pkgrel
+    new_pkgver="$(release_arch_pkgver "$version")" || return 1
+    old_pkgver="$(sed -n 's/^pkgver=//p' "$pkgbuild" | head -1)"
+    old_pkgrel="$(sed -n 's/^pkgrel=//p' "$pkgbuild" | head -1)"
+    if [ "$old_pkgver" = "$new_pkgver" ] && [[ "$old_pkgrel" =~ ^[1-9][0-9]*$ ]]; then
+        printf '%s\n' "$((old_pkgrel + 1))"
+    else
+        printf '1\n'
+    fi
+}
+
+release_next_debian_revision() {
+    local version="${1:-}"
+    local changelog="${2:-}"
+    local new_upstream current
+    new_upstream="$(release_debian_upstream "$version")" || return 1
+    current="$(sed -n 's/^facelock (\([^)]*\)).*/\1/p' "$changelog" | head -1)"
+    if [[ "$current" =~ ^(.+)-([1-9][0-9]*)(~.*)?$ ]] && [ "${BASH_REMATCH[1]}" = "$new_upstream" ]; then
+        printf '%s\n' "$((BASH_REMATCH[2] + 1))"
+    else
+        printf '1\n'
+    fi
+}
+
+release_current_debian_revision() {
+    local version="${1:-}"
+    local changelog="${2:-}"
+    local expected_upstream current
+    expected_upstream="$(release_debian_upstream "$version")" || return 1
+    current="$(sed -n 's/^facelock (\([^)]*\)).*/\1/p' "$changelog" | head -1)"
+    if [[ "$current" =~ ^(.+)-([1-9][0-9]*)(~.*)?$ ]] && [ "${BASH_REMATCH[1]}" = "$expected_upstream" ]; then
+        printf '%s\n' "${BASH_REMATCH[2]}"
+    else
+        echo "Debian changelog '$current' does not carry release $version" >&2
+        return 1
+    fi
+}
+
+release_next_rpm_counter() {
+    local version="${1:-}"
+    local spec="${2:-}"
+    local new_version old_version old_release
+    new_version="$(release_rpm_version "$version")" || return 1
+    old_version="$(sed -n 's/^Version:[[:space:]]*//p' "$spec" | head -1)"
+    old_release="$(sed -n 's/^Release:[[:space:]]*//p' "$spec" | head -1)"
+    if [ "$old_version" != "$new_version" ]; then
+        printf '1\n'
+    elif [[ "$old_release" =~ ^0\.([1-9][0-9]*)\.(alpha|beta|rc)\.([0-9]+)(%\{\?dist\})?$ ]]; then
+        local previous="$old_version-${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+        local previous_counter="${BASH_REMATCH[1]}"
+        release_validate_transition "$previous" "$version" || return 1
+        printf '%s\n' "$((previous_counter + 1))"
+    elif [[ "$old_release" =~ ^1(%\{\?dist\})?$ ]]; then
+        if release_is_prerelease "$version"; then
+            echo "refusing prerelease $version after stable RPM Version $old_version" >&2
+            return 1
+        fi
+        printf '1\n'
+    else
+        echo "cannot derive the next RPM prerelease counter from Release '$old_release'" >&2
+        return 1
+    fi
+}
+
+release_current_rpm_counter() {
+    local version="${1:-}"
+    local spec="${2:-}"
+    local expected_version old_version old_release
+    expected_version="$(release_rpm_version "$version")" || return 1
+    old_version="$(sed -n 's/^Version:[[:space:]]*//p' "$spec" | head -1)"
+    old_release="$(sed -n 's/^Release:[[:space:]]*//p' "$spec" | head -1)"
+    [ "$old_version" = "$expected_version" ] || { echo "RPM Version '$old_version' != '$expected_version'" >&2; return 1; }
+    if release_is_prerelease "$version"; then
+        if [[ "$old_release" =~ ^0\.([1-9][0-9]*)\.(alpha|beta|rc)\.([0-9]+)%\{\?dist\}$ ]] &&
+            [ "${BASH_REMATCH[2]}.${BASH_REMATCH[3]}" = "${version#*-}" ]; then
+            printf '%s\n' "${BASH_REMATCH[1]}"
+        else
+            echo "RPM Release '$old_release' does not carry prerelease $version" >&2
+            return 1
+        fi
+    elif [ "$old_release" = '1%{?dist}' ]; then
+        printf '1\n'
+    else
+        echo "RPM Release '$old_release' is not stable release 1" >&2
+        return 1
+    fi
+}
+
+release_packit_has_production_release_job() {
+    local config="${1:-.packit.yaml}"
+    python3 - "$config" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+try:
+    config = json.loads(Path(sys.argv[1]).read_text())
+    jobs = config["jobs"]
+    if not isinstance(jobs, list):
+        raise TypeError("jobs must be a list")
+except (OSError, KeyError, TypeError, json.JSONDecodeError) as error:
+    print(f"invalid JSON-subset Packit config: {error}", file=sys.stderr)
+    raise SystemExit(2)
+
+found = any(
+    isinstance(job, dict)
+    and job.get("job") == "copr_build"
+    and job.get("trigger") == "release"
+    and job.get("project") == "facelock"
+    for job in jobs
+)
+raise SystemExit(0 if found else 1)
+PY
+}
+
+release_validate_packit_channel() {
+    local version="${1:-}"
+    local config="${2:-.packit.yaml}"
+    local packit_status
+    release_validate_cargo_version "$version" || return 1
+    if release_packit_has_production_release_job "$config"; then
+        packit_status=0
+    else
+        packit_status=$?
+        if [ "$packit_status" -ne 1 ]; then
+            return "$packit_status"
+        fi
+    fi
+    if release_is_prerelease "$version"; then
+        if [ "$packit_status" -eq 0 ]; then
+            echo "prerelease $version cannot carry a release-triggered production COPR job" >&2
+            return 1
+        fi
+    elif [ "$packit_status" -ne 0 ]; then
+        echo "stable $version requires deliberate production COPR restoration in its stable-tagged config" >&2
+        return 1
+    fi
+}
+
+release_check_metadata() {
+    local tag="${1:-}"
+    local version cargo_version arch_pkgver debian_upstream rpm_version top_debian spec_release
+    version="$(release_cargo_from_tag "$tag")" || return 1
+    cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+    arch_pkgver="$(release_arch_pkgver "$version")" || return 1
+    debian_upstream="$(release_debian_upstream "$version")" || return 1
+    rpm_version="$(release_rpm_version "$version")" || return 1
+
+    [ "$cargo_version" = "$version" ] || { echo "Cargo.toml version '$cargo_version' != tag version '$version'" >&2; return 1; }
+    for pkgbuild in dist/PKGBUILD dist/PKGBUILD-bin; do
+        grep -Fqx "_tag=$version" "$pkgbuild" || { echo "$pkgbuild _tag does not match $version" >&2; return 1; }
+        grep -Fqx "pkgver=$arch_pkgver" "$pkgbuild" || { echo "$pkgbuild pkgver does not match $arch_pkgver" >&2; return 1; }
+        grep -Eq '^pkgrel=[1-9][0-9]*$' "$pkgbuild" || { echo "$pkgbuild has invalid pkgrel" >&2; return 1; }
+    done
+    grep -Fqx "pkgver=$arch_pkgver" dist/PKGBUILD-git || { echo "dist/PKGBUILD-git pkgver does not match $arch_pkgver" >&2; return 1; }
+    grep -Fqx "Version:        $rpm_version" dist/facelock.spec || { echo "RPM Version does not match $rpm_version" >&2; return 1; }
+    spec_release="$(sed -n 's/^Release:[[:space:]]*//p' dist/facelock.spec | head -1)"
+    if release_is_prerelease "$version"; then
+        if [[ ! "$spec_release" =~ ^0\.[1-9][0-9]*\.(alpha|beta|rc)\.([0-9]+)%\{\?dist\}$ ]] ||
+            [ "${BASH_REMATCH[1]:-}.${BASH_REMATCH[2]:-}" != "${version#*-}" ]; then
+            echo "RPM Release '$spec_release' does not match $version" >&2
+            return 1
+        fi
+    else
+        [ "$spec_release" = '1%{?dist}' ] || { echo "stable RPM Release must be 1%{?dist}" >&2; return 1; }
+    fi
+    top_debian="$(sed -n 's/^facelock (\([^)]*\)).*/\1/p' dist/debian/changelog | head -1)"
+    [[ "$top_debian" == "$debian_upstream-"* ]] || { echo "Debian changelog '$top_debian' does not match $version" >&2; return 1; }
+    release_validate_packit_channel "$version" .packit.yaml
+}
+
+release_write_github_outputs() {
+    local tag="${1:-}"
+    local output_file="${2:-}"
+    local version prerelease arch_pkgver debian_upstream debian_revision rpm_version rpm_counter
+    version="$(release_cargo_from_tag "$tag")" || return 1
+    prerelease="$(release_github_prerelease "$version")" || return 1
+    arch_pkgver="$(release_arch_pkgver "$version")" || return 1
+    debian_upstream="$(release_debian_upstream "$version")" || return 1
+    debian_revision="$(release_current_debian_revision "$version" dist/debian/changelog)" || return 1
+    rpm_version="$(release_rpm_version "$version")" || return 1
+    rpm_counter="$(release_current_rpm_counter "$version" dist/facelock.spec)" || return 1
+    {
+        printf 'cargo-version=%s\n' "$version"
+        printf 'prerelease=%s\n' "$prerelease"
+        printf 'arch-pkgver=%s\n' "$arch_pkgver"
+        printf 'debian-upstream=%s\n' "$debian_upstream"
+        printf 'debian-revision=%s\n' "$debian_revision"
+        printf 'rpm-version=%s\n' "$rpm_version"
+        printf 'rpm-counter=%s\n' "$rpm_counter"
+    } >> "$output_file"
+}

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -1,5 +1,7 @@
 # Single-stage test image — uses host-built release binaries (from `just build-release`)
-FROM archlinux:latest
+FROM docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
+
+RUN printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
 # Install dependencies
 # `sqlite` provides the sqlite3 CLI used by the device-coupling E2E assertions

--- a/test/Containerfile.copr
+++ b/test/Containerfile.copr
@@ -1,7 +1,7 @@
 # Container for `just test-copr` — a local COPR-equivalent build.
 # Bakes the Packit + mock toolchain; the build logic lives in test/copr-build.sh.
 # Must be run with --privileged (mock needs it) and the repo mounted at /repo:ro.
-FROM fedora:42
+FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
 RUN dnf install -y --setopt=install_weak_deps=False \
         packit mock rpm-build git tar \
     && dnf clean all

--- a/test/Containerfile.deb-e2e
+++ b/test/Containerfile.deb-e2e
@@ -1,6 +1,6 @@
 # E2E package test — builds a real .deb and installs via dpkg
 # Uses host-built release binaries (from `just build-release`); no Rust compilation in container.
-FROM ubuntu:24.04
+FROM docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,6 +41,7 @@ COPY systemd/ /build/systemd/
 COPY dbus/ /build/dbus/
 COPY dist/ /build/dist/
 COPY .github/workflows/scripts/build-deb.sh /build/.github/workflows/scripts/build-deb.sh
+COPY scripts/release-versions.sh /build/scripts/release-versions.sh
 
 # Copy test validation script and PAM test config
 COPY test/pkg-validate.sh /pkg-validate.sh
@@ -59,9 +60,9 @@ RUN mkdir -p /build/onnxruntime/lib && \
 
 # Build the .deb from the host-built binaries and install it
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0-test" "legacy" && \
-    (dpkg -i facelock_0.0.0-test-1~legacy1_amd64.deb || true) && \
+RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0" "noble" "1" && \
+    (dpkg -i facelock_0.0.0-1~ubuntu24.04.1_amd64.deb || true) && \
     apt-get update && apt-get install -f -y && \
-    rm -rf facelock_0.0.0-test-1~legacy1_amd64 facelock_0.0.0-test-1~legacy1_amd64.deb
+    rm -rf facelock_0.0.0-1~ubuntu24.04.1_amd64 facelock_0.0.0-1~ubuntu24.04.1_amd64.deb
 
 CMD ["/pkg-validate.sh"]

--- a/test/Containerfile.deb-tpm-e2e
+++ b/test/Containerfile.deb-tpm-e2e
@@ -1,7 +1,7 @@
 # E2E package test — builds a real TPM-enabled .deb and installs via dpkg
 # Uses host-built release binaries (from `just build-release`); no Rust compilation in container.
 # Mirrors the CI TPM .deb build which targets Debian trixie.
-FROM debian:trixie
+FROM docker.io/library/debian:13@sha256:34cd9e9fd437c0a095ec39cb2e73422c9f30821b0d0848ed74fd0d43bae4d958
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -49,6 +49,7 @@ COPY systemd/ /build/systemd/
 COPY dbus/ /build/dbus/
 COPY dist/ /build/dist/
 COPY .github/workflows/scripts/build-deb.sh /build/.github/workflows/scripts/build-deb.sh
+COPY scripts/release-versions.sh /build/scripts/release-versions.sh
 
 # Copy test validation scripts and PAM test config
 COPY test/pkg-validate.sh /pkg-validate.sh
@@ -66,10 +67,10 @@ RUN mkdir -p /build/onnxruntime/lib && \
 
 # Build the TPM .deb from host-built binaries and install it
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0-test" "tpm" && \
-    (dpkg -i facelock_0.0.0-test-1_amd64.deb || true) && \
+RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0" "trixie" "1" && \
+    (dpkg -i facelock_0.0.0-1~deb13u1_amd64.deb || true) && \
     apt-get update && apt-get install -f -y && \
-    rm -rf facelock_0.0.0-test-1_amd64 facelock_0.0.0-test-1_amd64.deb
+    rm -rf facelock_0.0.0-1~deb13u1_amd64 facelock_0.0.0-1~deb13u1_amd64.deb
 
 # Run the TPM PCR-binding regression first (needs the installed package + a
 # config file), then the package validation (which removes the package last).

--- a/test/Containerfile.fedora
+++ b/test/Containerfile.fedora
@@ -1,5 +1,5 @@
 # Single-stage test image — uses host-built release binaries (from `just build-release`)
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
 
 RUN dnf -y install pam dbus rpm-build libxkbcommon python3 systemd binutils glibc tpm2-tss && dnf clean all
 

--- a/test/Containerfile.rpm-e2e
+++ b/test/Containerfile.rpm-e2e
@@ -1,6 +1,6 @@
 # E2E package test — builds a real .rpm and installs via dnf
 # Uses host-built release binaries (from `just build-release`); no Rust compilation in container.
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
 
 # dbus-daemon (Fedora ships dbus-broker by default) is needed for the runtime
 # D-Bus tests in pkg-validate.sh, including the polkit agent boundary check.

--- a/test/Containerfile.ubuntu
+++ b/test/Containerfile.ubuntu
@@ -1,5 +1,5 @@
 # Single-stage test image — uses host-built release binaries (from `just build-release`)
-FROM ubuntu:24.04
+FROM docker.io/library/ubuntu:24.04@sha256:d78ab76437b1afc5f01e223d6bf0172763f404bb166441328845adbef44518cb
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -41,9 +41,28 @@ try:
     owner = production["owner"]
     project = production["project"]
     api_url = production["api_url"]
-    expected_chroots = set(production["expected_enabled_chroots"])
+    required_chroot_list = production["required_supported_chroots"]
+    optional_chroot_list = production["optional_experimental_chroots"]
 except (KeyError, TypeError) as error:
     fail(f"release matrix has no complete production COPR authority: {error}")
+
+if not isinstance(required_chroot_list, list) or not all(
+    isinstance(chroot, str) for chroot in required_chroot_list
+):
+    fail("release matrix production COPR required supported chroots are invalid")
+if not isinstance(optional_chroot_list, list) or not all(
+    isinstance(chroot, str) for chroot in optional_chroot_list
+):
+    fail("release matrix production COPR optional experimental chroots are invalid")
+required_chroots = set(required_chroot_list)
+optional_chroots = set(optional_chroot_list)
+if len(required_chroots) != len(required_chroot_list):
+    fail("release matrix production COPR required supported chroots contain duplicates")
+if len(optional_chroots) != len(optional_chroot_list):
+    fail("release matrix production COPR optional experimental chroots contain duplicates")
+if not required_chroots.isdisjoint(optional_chroots):
+    fail("release matrix production COPR required and optional chroots overlap")
+allowed_chroots = required_chroots | optional_chroots
 
 if args.response_file:
     response = load_json(args.response_file, "COPR response fixture")
@@ -57,23 +76,34 @@ else:
 
 if not isinstance(response, dict):
     fail("production COPR API response is not an object")
-if response.get("ownername") != owner or response.get("name") != project:
+expected_full_name = f"{owner}/{project}"
+if (
+    response.get("ownername") != owner
+    or response.get("name") != project
+    or response.get("full_name") != expected_full_name
+):
     fail(
         "production COPR identity drifted: "
-        f"expected {owner}/{project}, got {response.get('ownername')}/{response.get('name')}"
+        f"expected {expected_full_name}, "
+        f"got owner={response.get('ownername')!r}, name={response.get('name')!r}, "
+        f"full_name={response.get('full_name')!r}"
     )
 chroot_repos = response.get("chroot_repos")
 if not isinstance(chroot_repos, dict) or not all(isinstance(chroot, str) for chroot in chroot_repos):
     fail("production COPR API response has no valid chroot_repos object")
 
 live_chroots = set(chroot_repos)
-if live_chroots != expected_chroots:
-    missing = sorted(expected_chroots - live_chroots)
-    extra = sorted(live_chroots - expected_chroots)
+missing = sorted(required_chroots - live_chroots)
+extra = sorted(live_chroots - allowed_chroots)
+if missing or extra:
     fail(
         f"production COPR {owner}/{project} chroots drifted; "
-        f"expected={sorted(expected_chroots)}, live={sorted(live_chroots)}, "
+        f"required={sorted(required_chroots)}, optional={sorted(optional_chroots)}, "
+        f"live={sorted(live_chroots)}, "
         f"missing={missing}, extra={extra}"
     )
 
-print(f"live release channel contract: OK (production COPR {owner}/{project})")
+print(
+    f"live release channel contract: OK (production COPR {owner}/{project}; "
+    f"live={sorted(live_chroots)})"
+)

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Compare public release-channel state with the checked-in authority."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "dist" / "release-matrix.json"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json(path: Path, description: str) -> object:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read {description}: {error}")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--response-file",
+    type=Path,
+    help="read a COPR project response fixture instead of the public API",
+)
+args = parser.parse_args()
+
+matrix = load_json(MATRIX_PATH, "release matrix")
+try:
+    production = matrix["copr_channels"]["production"]
+    owner = production["owner"]
+    project = production["project"]
+    api_url = production["api_url"]
+    expected_chroots = set(production["expected_enabled_chroots"])
+except (KeyError, TypeError) as error:
+    fail(f"release matrix has no complete production COPR authority: {error}")
+
+if args.response_file:
+    response = load_json(args.response_file, "COPR response fixture")
+else:
+    request = urllib.request.Request(api_url, headers={"User-Agent": "facelock-release-matrix/1"})
+    try:
+        with urllib.request.urlopen(request, timeout=20) as remote:
+            response = json.load(remote)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        fail(f"cannot read the public production COPR API: {error}")
+
+if not isinstance(response, dict):
+    fail("production COPR API response is not an object")
+if response.get("ownername") != owner or response.get("name") != project:
+    fail(
+        "production COPR identity drifted: "
+        f"expected {owner}/{project}, got {response.get('ownername')}/{response.get('name')}"
+    )
+chroot_repos = response.get("chroot_repos")
+if not isinstance(chroot_repos, dict) or not all(isinstance(chroot, str) for chroot in chroot_repos):
+    fail("production COPR API response has no valid chroot_repos object")
+
+live_chroots = set(chroot_repos)
+if live_chroots != expected_chroots:
+    missing = sorted(expected_chroots - live_chroots)
+    extra = sorted(live_chroots - expected_chroots)
+    fail(
+        f"production COPR {owner}/{project} chroots drifted; "
+        f"expected={sorted(expected_chroots)}, live={sorted(live_chroots)}, "
+        f"missing={missing}, extra={extra}"
+    )
+
+print(f"live release channel contract: OK (production COPR {owner}/{project})")

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Fail closed when release target declarations drift from the alpha matrix."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "dist" / "release-matrix.json"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+try:
+    matrix = json.loads(MATRIX_PATH.read_text())
+except FileNotFoundError:
+    fail(f"missing checked-in release matrix: {MATRIX_PATH.relative_to(ROOT)}")
+except json.JSONDecodeError as error:
+    fail(f"invalid release matrix JSON: {error}")
+
+expected_rows = [
+    ("debian-13", "Debian 13 trixie", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
+    ("debian-12", "Debian 12 bookworm LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
+    ("ubuntu-26.04", "Ubuntu 26.04 LTS", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
+    ("ubuntu-24.04", "Ubuntu 24.04 LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
+    ("fedora-43", "Fedora 43", "x86_64", "staging COPR", "system ORT", "full"),
+    ("fedora-44-copr", "Fedora 44", "x86_64", "staging COPR", "system ORT", "full"),
+    ("fedora-45", "Fedora 45 branched", "x86_64", "staging COPR", "system ORT", "build/runtime smoke"),
+    ("fedora-rawhide", "Fedora Rawhide (Fedora 46 development)", "x86_64", "development", "system ORT", "build/runtime smoke"),
+    ("fedora-44-direct", "Fedora 44", "x86_64", "direct RPM", "bundled ORT 1.20.1", "full"),
+    ("arch-2026-08-18", "Arch Linux Archive snapshot 2026-08-18", "x86_64", "PKGBUILD and binary recipe", "system ORT", "full"),
+]
+actual_rows = [
+    (
+        row["id"],
+        row["platform"],
+        row["architecture"],
+        row["variant"],
+        row.get("runtime"),
+        row["lifecycle_depth"],
+    )
+    for row in matrix.get("platforms", [])
+]
+require(actual_rows == expected_rows, "platform/architecture/variant/runtime/lifecycle rows differ from issue #234")
+require(matrix.get("reviewed_on") == "2026-08-18", "matrix review date must be 2026-08-18")
+require(matrix.get("fedora", {}).get("43_eol_gate") == "2026-12-02", "Fedora 43 EOL gate drifted")
+today = date.fromisoformat(os.environ.get("RELEASE_MATRIX_TODAY", date.today().isoformat()))
+fedora_43_eol = date.fromisoformat(matrix["fedora"]["43_eol_gate"])
+require(today < fedora_43_eol, f"Fedora 43 reached its {fedora_43_eol.isoformat()} EOL gate; revise the matrix")
+require(matrix.get("fedora", {}).get("branched") == "45", "Fedora 45 must remain a separate branched target")
+require(matrix.get("fedora", {}).get("rawhide_development_release") == "46", "Rawhide must identify Fedora 46 development")
+copr_channels = matrix.get("copr_channels", {})
+production_copr = copr_channels.get("production", {})
+staging_copr = copr_channels.get("staging", {})
+expected_copr_targets = {"fedora-43-x86_64", "fedora-44-x86_64", "fedora-45-x86_64"}
+require(production_copr.get("owner") == "tyvsmith", "production COPR owner drifted")
+require(production_copr.get("project") == "facelock", "production COPR project drifted")
+require(
+    production_copr.get("api_url")
+    == "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
+    "production COPR public API drifted",
+)
+require(set(production_copr.get("expected_enabled_chroots", [])) == expected_copr_targets, "production COPR chroot authority drifted")
+require(production_copr.get("prerelease_publication") is False, "production COPR must exclude prereleases")
+require(staging_copr.get("project") == "facelock-testing", "staging COPR identity drifted")
+require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisioning must remain owned by issue #236")
+require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")
+require(set(matrix.get("fedora", {}).get("staging_copr_targets", [])) == expected_copr_targets, "staging COPR target authority drifted")
+require(matrix.get("arch", {}).get("snapshot") == "2026-08-18", "Arch snapshot drifted")
+arch_repository = matrix.get("arch", {}).get("repository")
+require(
+    arch_repository == "https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch",
+    "Arch archive repository drifted",
+)
+for row in matrix.get("platforms", []):
+    image = row.get("image")
+    if image is not None:
+        require(
+            re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image) is not None,
+            f"{row['id']} image is not digest-pinned: {image!r}",
+        )
+
+expected_suites = {"trixie", "bookworm", "resolute", "noble"}
+suite_map = matrix.get("apt_suites", {})
+require(set(suite_map) == expected_suites, "canonical APT suite set drifted")
+expected_suite_contracts = {
+    "trixie": {
+        "platform_id": "debian-13",
+        "platform": "Debian 13",
+        "architecture": "amd64",
+        "variant": "tpm",
+        "revision_suffix": "~deb13u1",
+    },
+    "bookworm": {
+        "platform_id": "debian-12",
+        "platform": "Debian 12",
+        "architecture": "amd64",
+        "variant": "legacy",
+        "revision_suffix": "~deb12u1",
+    },
+    "resolute": {
+        "platform_id": "ubuntu-26.04",
+        "platform": "Ubuntu 26.04",
+        "architecture": "amd64",
+        "variant": "tpm",
+        "revision_suffix": "~ubuntu26.04.1",
+    },
+    "noble": {
+        "platform_id": "ubuntu-24.04",
+        "platform": "Ubuntu 24.04",
+        "architecture": "amd64",
+        "variant": "legacy",
+        "revision_suffix": "~ubuntu24.04.1",
+    },
+}
+platforms_by_id = {row["id"]: row for row in matrix.get("platforms", [])}
+for suite, expected in expected_suite_contracts.items():
+    details = suite_map[suite]
+    for field, value in expected.items():
+        require(details.get(field) == value, f"APT suite {suite} {field} drifted: {details.get(field)!r}")
+    platform_row = platforms_by_id.get(expected["platform_id"])
+    require(platform_row is not None, f"APT suite {suite} references a missing platform row")
+    require(platform_row["architecture"] == expected["architecture"], f"APT suite {suite} architecture disagrees with its platform row")
+    require(platform_row["image"] == details.get("image"), f"APT suite {suite} image disagrees with its platform row")
+    require(
+        platform_row["variant"].lower().split(",", 1)[0] == expected["variant"],
+        f"APT suite {suite} variant disagrees with its platform row",
+    )
+
+apt_config = (ROOT / "dist/apt/conf/distributions").read_text()
+declared_suites = set(re.findall(r"^Codename:\s*(\S+)\s*$", apt_config, re.MULTILINE))
+require(declared_suites == expected_suites, f"APT config suites {sorted(declared_suites)} != {sorted(expected_suites)}")
+require("Codename: main" not in apt_config and "Codename: legacy" not in apt_config, "ambiguous APT suites remain")
+
+try:
+    packit = json.loads((ROOT / ".packit.yaml").read_text())
+    packit_jobs = packit["jobs"]
+    require(isinstance(packit_jobs, list), "Packit jobs must be a list")
+except (KeyError, TypeError, json.JSONDecodeError) as error:
+    fail(f"Packit config must remain valid JSON-subset YAML: {error}")
+production_jobs = [
+    job
+    for job in packit_jobs
+    if isinstance(job, dict) and job.get("job") == "copr_build" and job.get("project") == "facelock"
+]
+require(len(production_jobs) == 1, f"Packit must define exactly one production COPR job, found {len(production_jobs)}")
+production_job = production_jobs[0]
+require(
+    production_job.get("owner") == production_copr["owner"],
+    "Packit production COPR owner disagrees with the release matrix",
+)
+production_trigger = production_job.get("trigger")
+require(
+    production_trigger in {"ignore", "release"},
+    f"Packit production COPR trigger must be 'ignore' or 'release', got {production_trigger!r}",
+)
+release_version = os.environ.get("RELEASE_MATRIX_VERSION")
+if release_version is not None:
+    require(
+        re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?", release_version)
+        is not None,
+        f"invalid RELEASE_MATRIX_VERSION: {release_version!r}",
+    )
+if release_version is not None and "-" not in release_version:
+    require(
+        production_trigger == "release",
+        "stable release config must deliberately restore the production COPR release job",
+    )
+elif release_version is not None:
+    require(
+        production_trigger == "ignore",
+        "prerelease-tagged Packit config can select a release-triggered production COPR job",
+    )
+packit_target_list = production_job.get("targets")
+require(
+    isinstance(packit_target_list, list) and all(isinstance(target, str) for target in packit_target_list),
+    "Packit production COPR targets must be a list of strings",
+)
+packit_targets = set(packit_target_list)
+require(len(packit_target_list) == len(packit_targets), "Packit production COPR targets must be unique")
+require(packit_targets == expected_copr_targets, f"Packit targets drifted: {sorted(packit_targets)}")
+require("fedora-rawhide-x86_64" not in packit_targets, "Rawhide/F46 must not be conflated with Fedora 45 staging COPR")
+
+workflow = (ROOT / ".github/workflows/release.yml").read_text()
+for suite, details in suite_map.items():
+    expected_block = re.compile(
+        rf"(?m)^\s+- suite: {re.escape(suite)}\s*$\n"
+        rf"^\s+variant: {re.escape(details['variant'])}\s*$\n"
+        rf"^\s+architecture: {re.escape(details['architecture'])}\s*$\n"
+        rf"^\s+image: {re.escape(details['image'])}\s*$"
+    )
+    require(expected_block.search(workflow) is not None, f"release workflow suite/variant/architecture/image drifted for {suite}")
+publication_inputs = re.findall(
+    r'"(trixie|bookworm|resolute|noble)=\$\(ls debs/(trixie|bookworm|resolute|noble)/facelock_\*\.deb\)"',
+    workflow,
+)
+require(
+    len(publication_inputs) == 4 and set(publication_inputs) == {(suite, suite) for suite in expected_suites},
+    f"stable APT publication inputs drifted or duplicated: {publication_inputs}",
+)
+deb_builder = (ROOT / ".github/workflows/scripts/build-deb.sh").read_text()
+require(
+    'release_debian_binary_basename "$VERSION" "$REVISION" "$SUITE" amd64' in deb_builder,
+    "Debian artifact architecture no longer matches the amd64 release matrix",
+)
+apt_publisher = (ROOT / ".github/workflows/scripts/publish-apt.sh").read_text()
+require(
+    'source "$SCRIPT_DIR/../../../scripts/release-versions.sh"' in apt_publisher,
+    "APT publisher does not source the central release version contract",
+)
+require(
+    'EXPECTED_SUFFIX="$(release_debian_suite_suffix "$SUITE")"' in apt_publisher,
+    "APT publisher does not derive suite suffixes from the central release version contract",
+)
+for suffix in ("~deb13u1", "~deb12u1", "~ubuntu26.04.1", "~ubuntu24.04.1"):
+    require(suffix not in apt_publisher, f"APT publisher duplicates the central suite suffix {suffix}")
+direct_fedora_image = next(row["image"] for row in matrix["platforms"] if row["id"] == "fedora-44-direct")
+require(f"image: {direct_fedora_image}" in workflow, "direct RPM workflow must pin Fedora 44 by digest")
+require("prerelease: ${{ needs.metadata.outputs.prerelease }}" in workflow, "GitHub Release prerelease output is not wired")
+require(workflow.count("needs.metadata.outputs.prerelease == 'false'") >= 2, "stable APT/AUR guards are not derived from validated metadata")
+require("project: facelock" not in workflow, "workflow contains a selectable production COPR project")
+
+arch_image = next(row["image"] for row in matrix["platforms"] if row["id"] == "arch-2026-08-18")
+aur_publisher = (ROOT / ".github/workflows/scripts/publish-aur.sh").read_text()
+require(arch_image in aur_publisher, "AUR publication helper does not use the immutable Arch matrix image")
+
+
+def require_arch_mirror_before_each_pacman(relative_path: str) -> None:
+    content = (ROOT / relative_path).read_text()
+    pacman_commands = list(re.finditer(r"(?m)^\s*(?:RUN\s+)?pacman\s", content))
+    require(pacman_commands, f"expected an Arch package invocation in {relative_path}")
+    boundary = 0
+    for command in pacman_commands:
+        require(
+            arch_repository in content[boundary : command.start()].replace(r"\$", "$"),
+            f"{relative_path} does not configure the exact Arch snapshot before every pacman invocation",
+        )
+        boundary = command.end()
+
+
+for arch_consumer in (".github/workflows/ci.yml", ".github/workflows/scripts/publish-aur.sh", "test/Containerfile"):
+    require_arch_mirror_before_each_pacman(arch_consumer)
+ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+justfile = (ROOT / "justfile").read_text()
+live_channel_command = "python3 test/check-live-release-channels.py"
+require(live_channel_command in ci_workflow, "CI does not compare live release channels with the checked-in authority")
+require(live_channel_command in justfile, "release preflight does not compare live release channels with the checked-in authority")
+require("ARCH_SNAPSHOT" not in justfile, "unused ARCH_SNAPSHOT signaling remains")
+
+for pkgbuild_name in ("PKGBUILD", "PKGBUILD-bin"):
+    pkgbuild = (ROOT / "dist" / pkgbuild_name).read_text()
+    require(re.search(r"^_tag=", pkgbuild, re.MULTILINE) is not None, f"dist/{pkgbuild_name} has no upstream _tag")
+    require("v$_tag" in pkgbuild, f"dist/{pkgbuild_name} does not fetch the upstream _tag")
+
+docs = (ROOT / "docs/releasing.md").read_text()
+for phrase in (
+    "0.2.0~alpha.1-1~deb13u1",
+    "0.2.0-0.1.alpha.1",
+    "0.2.0alpha1-1",
+    "Fedora 43",
+    "2026-12-02",
+    "Fedora 45 branched",
+    "Fedora Rawhide (Fedora 46 development)",
+    "Arch Linux Archive snapshot 2026-08-18",
+    "stable-tagged config",
+):
+    require(phrase in docs, f"release documentation omits matrix/version phrase: {phrase}")
+
+contracts = (ROOT / "docs/contracts.md").read_text()
+for phrase in (
+    "## Release Channels and APT Paths",
+    "https://tysmith.me/facelock/apt/dists/trixie/Release",
+    "https://tysmith.me/facelock/apt/dists/bookworm/Release",
+    "https://tysmith.me/facelock/apt/dists/resolute/Release",
+    "https://tysmith.me/facelock/apt/dists/noble/Release",
+    "`main` and `legacy`",
+    "stable APT, stable AUR, or production COPR",
+    "issue #236",
+):
+    require(phrase in contracts, f"system contracts omit release-channel phrase: {phrase}")
+
+release_skill = (ROOT / ".claude/skills/release/SKILL.md").read_text()
+for phrase in (
+    "Tags are parsed strictly as `vX.Y.Z` or `vX.Y.Z-{alpha,beta,rc}.N`.",
+    "A bare invocation derives the version from `Cargo.toml` and classifies it with the same parser.",
+):
+    require(phrase in release_skill, f"release skill omits strict preflight classification: {phrase}")
+require("a tag matching" not in release_skill, "release skill still describes substring prerelease classification")
+require("Running it bare skips" not in release_skill, "release skill still claims bare preflight skips classification")
+
+copr_build_test = (ROOT / "test/copr-build.sh").read_text()
+packit_schema_command = "packit config validate --offline -c .packit.yaml"
+require(
+    packit_schema_command in copr_build_test,
+    "COPR-equivalent gate does not run Packit's real offline schema validator",
+)
+require(packit_schema_command in justfile, "release preflight does not run Packit's schema validator when available")
+
+install_docs = {
+    "README.md": (ROOT / "README.md").read_text(),
+    "book/src/quickstart.md": (ROOT / "book/src/quickstart.md").read_text(),
+    "website/index.html": (ROOT / "website/index.html").read_text(),
+}
+apt_platform_mappings = (
+    ("Debian 13", "trixie", "TPM"),
+    ("Debian 12", "bookworm", "legacy"),
+    ("Ubuntu 26.04", "resolute", "TPM"),
+    ("Ubuntu 24.04", "noble", "legacy"),
+)
+retired_apt_source = re.compile(
+    r"https://tysmith\.me/facelock/apt\s+(?:main|legacy)\s+facelock",
+    re.IGNORECASE,
+)
+for relative_path, content in install_docs.items():
+    require(retired_apt_source.search(content) is None, f"{relative_path} still configures a retired APT suite")
+    require("https://tysmith.me/facelock/apt" in content, f"{relative_path} omits the public APT base")
+    for platform, suite, variant in apt_platform_mappings:
+        mapping = re.compile(
+            rf"(?im)^.*{re.escape(platform)}.*{re.escape(suite)}.*{re.escape(variant)}.*$"
+        )
+        require(mapping.search(content) is not None, f"{relative_path} omits {platform}/{suite}/{variant} mapping")
+
+readme = install_docs["README.md"]
+require("four suite-specific `.deb` artifacts" in readme, "README release wording does not name the four Debian artifacts")
+roadmap = (ROOT / "docs/testing-roadmap.md").read_text()
+for phrase in (
+    "four suite-specific `.deb` artifacts",
+    "trixie, bookworm, resolute, and noble",
+):
+    require(phrase in roadmap, f"testing roadmap omits release artifact inventory: {phrase}")
+require(retired_apt_source.search(roadmap) is None, "testing roadmap still names retired APT suites")
+
+print("release matrix contract: OK")

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -33,16 +33,26 @@ except json.JSONDecodeError as error:
     fail(f"invalid release matrix JSON: {error}")
 
 expected_rows = [
-    ("debian-13", "Debian 13 trixie", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
-    ("debian-12", "Debian 12 bookworm LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
-    ("ubuntu-26.04", "Ubuntu 26.04 LTS", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
-    ("ubuntu-24.04", "Ubuntu 24.04 LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "full"),
-    ("fedora-43", "Fedora 43", "x86_64", "staging COPR", "system ORT", "full"),
-    ("fedora-44-copr", "Fedora 44", "x86_64", "staging COPR", "system ORT", "full"),
-    ("fedora-45", "Fedora 45 branched", "x86_64", "staging COPR", "system ORT", "build/runtime smoke"),
-    ("fedora-rawhide", "Fedora Rawhide (Fedora 46 development)", "x86_64", "development", "system ORT", "build/runtime smoke"),
-    ("fedora-44-direct", "Fedora 44", "x86_64", "direct RPM", "bundled ORT 1.20.1", "full"),
-    ("arch-2026-08-18", "Arch Linux Archive snapshot 2026-08-18", "x86_64", "PKGBUILD and binary recipe", "system ORT", "full"),
+    ("debian-13", "Debian 13 trixie", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "supported", True, False, "full"),
+    ("debian-12", "Debian 12 bookworm LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "supported", True, False, "full"),
+    ("ubuntu-26.04", "Ubuntu 26.04 LTS", "amd64", "TPM, staged APT/direct deb", "bundled ORT 1.20.1", "supported", True, False, "full"),
+    ("ubuntu-24.04", "Ubuntu 24.04 LTS", "amd64", "legacy, staged APT/direct deb", "bundled ORT 1.20.1", "supported", True, False, "full"),
+    ("fedora-43", "Fedora 43", "x86_64", "staging COPR", "system ORT", "supported", True, False, "full"),
+    ("fedora-44-copr", "Fedora 44", "x86_64", "staging COPR", "system ORT", "supported", True, False, "full"),
+    ("fedora-45", "Fedora 45 branched", "x86_64", "staging COPR", "system ORT", "supported", True, False, "build/runtime smoke"),
+    (
+        "fedora-rawhide",
+        "Fedora Rawhide (Fedora 46 development)",
+        "x86_64",
+        "optional experimental production COPR chroot",
+        "system ORT",
+        "experimental",
+        False,
+        True,
+        "best-effort pinned Track D smoke only",
+    ),
+    ("fedora-44-direct", "Fedora 44", "x86_64", "direct RPM", "bundled ORT 1.20.1", "supported", True, False, "full"),
+    ("arch-2026-08-18", "Arch Linux Archive snapshot 2026-08-18", "x86_64", "PKGBUILD and binary recipe", "system ORT", "supported", True, False, "full"),
 ]
 actual_rows = [
     (
@@ -51,11 +61,17 @@ actual_rows = [
         row["architecture"],
         row["variant"],
         row.get("runtime"),
+        row.get("support_tier"),
+        row.get("release_target"),
+        row.get("optional"),
         row["lifecycle_depth"],
     )
     for row in matrix.get("platforms", [])
 ]
-require(actual_rows == expected_rows, "platform/architecture/variant/runtime/lifecycle rows differ from issue #234")
+require(
+    actual_rows == expected_rows,
+    "platform/architecture/variant/runtime/support-tier/release-target/optional/lifecycle rows differ from issue #234",
+)
 require(matrix.get("reviewed_on") == "2026-08-18", "matrix review date must be 2026-08-18")
 require(matrix.get("fedora", {}).get("43_eol_gate") == "2026-12-02", "Fedora 43 EOL gate drifted")
 today = date.fromisoformat(os.environ.get("RELEASE_MATRIX_TODAY", date.today().isoformat()))
@@ -67,6 +83,20 @@ copr_channels = matrix.get("copr_channels", {})
 production_copr = copr_channels.get("production", {})
 staging_copr = copr_channels.get("staging", {})
 expected_copr_targets = {"fedora-43-x86_64", "fedora-44-x86_64", "fedora-45-x86_64"}
+expected_experimental_chroots = {"fedora-rawhide-x86_64"}
+
+
+def require_string_set(value: object, expected: set[str], description: str) -> set[str]:
+    require(
+        isinstance(value, list) and all(isinstance(item, str) for item in value),
+        f"{description} must be a list of strings",
+    )
+    actual = set(value)
+    require(len(value) == len(actual), f"{description} must not contain duplicates")
+    require(actual == expected, f"{description} drifted: {sorted(actual)}")
+    return actual
+
+
 require(production_copr.get("owner") == "tyvsmith", "production COPR owner drifted")
 require(production_copr.get("project") == "facelock", "production COPR project drifted")
 require(
@@ -74,12 +104,38 @@ require(
     == "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
     "production COPR public API drifted",
 )
-require(set(production_copr.get("expected_enabled_chroots", [])) == expected_copr_targets, "production COPR chroot authority drifted")
+required_supported_chroots = require_string_set(
+    production_copr.get("required_supported_chroots"),
+    expected_copr_targets,
+    "production COPR required supported chroots",
+)
+optional_experimental_chroots = require_string_set(
+    production_copr.get("optional_experimental_chroots"),
+    expected_experimental_chroots,
+    "production COPR optional experimental chroots",
+)
+require(
+    required_supported_chroots.isdisjoint(optional_experimental_chroots),
+    "production COPR required supported and optional experimental chroots must be disjoint",
+)
+require(
+    "expected_enabled_chroots" not in production_copr,
+    "production COPR authority must separate required supported and optional experimental chroots",
+)
 require(production_copr.get("prerelease_publication") is False, "production COPR must exclude prereleases")
 require(staging_copr.get("project") == "facelock-testing", "staging COPR identity drifted")
 require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisioning must remain owned by issue #236")
 require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")
-require(set(matrix.get("fedora", {}).get("staging_copr_targets", [])) == expected_copr_targets, "staging COPR target authority drifted")
+staging_copr_targets = require_string_set(
+    matrix.get("fedora", {}).get("staging_copr_targets"),
+    expected_copr_targets,
+    "staging COPR target authority",
+)
+packit_release_targets = require_string_set(
+    matrix.get("fedora", {}).get("packit_release_targets"),
+    expected_copr_targets,
+    "Packit release target authority",
+)
 require(matrix.get("arch", {}).get("snapshot") == "2026-08-18", "Arch snapshot drifted")
 arch_repository = matrix.get("arch", {}).get("repository")
 require(
@@ -128,6 +184,27 @@ expected_suite_contracts = {
     },
 }
 platforms_by_id = {row["id"]: row for row in matrix.get("platforms", [])}
+rawhide = platforms_by_id.get("fedora-rawhide", {})
+require(rawhide.get("smoke_track") == "Track D", "Rawhide must remain on pinned Track D smoke")
+require(rawhide.get("smoke_policy") == "best-effort", "Rawhide smoke must remain best-effort")
+require(rawhide.get("alpha_blocking") is False, "a Rawhide-only failure cannot block an alpha")
+require(rawhide.get("prerelease_publication") is False, "no prerelease may publish to Rawhide")
+require(
+    rawhide.get("evidence_eligibility")
+    == {
+        "lifecycle": False,
+        "artifact": False,
+        "upgrade": False,
+        "rollback": False,
+        "served_version": False,
+        "availability": False,
+    },
+    "Rawhide cannot supply release evidence",
+)
+require(
+    rawhide.get("promotion_requires") == "separately reviewed amendment and full Fedora gates",
+    "Rawhide promotion contract drifted",
+)
 for suite, expected in expected_suite_contracts.items():
     details = suite_map[suite]
     for field, value in expected.items():
@@ -152,6 +229,29 @@ try:
     require(isinstance(packit_jobs, list), "Packit jobs must be a list")
 except (KeyError, TypeError, json.JSONDecodeError) as error:
     fail(f"Packit config must remain valid JSON-subset YAML: {error}")
+for job_index, job in enumerate(packit_jobs):
+    if not isinstance(job, dict) or job.get("job") != "copr_build":
+        continue
+    target_list = job.get("targets")
+    target_description = f"Packit copr_build job {job_index} targets"
+    require(
+        isinstance(target_list, list)
+        and bool(target_list)
+        and all(isinstance(target, str) and bool(target) for target in target_list),
+        f"{target_description} must be a non-empty list of non-empty strings",
+    )
+    targets = set(target_list)
+    require(len(target_list) == len(targets), f"{target_description} must be unique")
+    undeclared_targets = targets - packit_release_targets
+    require(
+        not undeclared_targets,
+        f"{target_description} contain undeclared targets outside the explicit allowlist: {sorted(undeclared_targets)}",
+    )
+    if job.get("project") == staging_copr["project"]:
+        require(
+            targets == staging_copr_targets,
+            f"Packit staging COPR targets drifted: {sorted(targets)}",
+        )
 production_jobs = [
     job
     for job in packit_jobs
@@ -192,8 +292,7 @@ require(
 )
 packit_targets = set(packit_target_list)
 require(len(packit_target_list) == len(packit_targets), "Packit production COPR targets must be unique")
-require(packit_targets == expected_copr_targets, f"Packit targets drifted: {sorted(packit_targets)}")
-require("fedora-rawhide-x86_64" not in packit_targets, "Rawhide/F46 must not be conflated with Fedora 45 staging COPR")
+require(packit_targets == packit_release_targets, f"Packit targets drifted: {sorted(packit_targets)}")
 
 workflow = (ROOT / ".github/workflows/release.yml").read_text()
 for suite, details in suite_map.items():
@@ -267,6 +366,7 @@ for pkgbuild_name in ("PKGBUILD", "PKGBUILD-bin"):
     require("v$_tag" in pkgbuild, f"dist/{pkgbuild_name} does not fetch the upstream _tag")
 
 docs = (ROOT / "docs/releasing.md").read_text()
+normalized_docs = re.sub(r"\s+", " ", docs)
 for phrase in (
     "0.2.0~alpha.1-1~deb13u1",
     "0.2.0-0.1.alpha.1",
@@ -275,12 +375,20 @@ for phrase in (
     "2026-12-02",
     "Fedora 45 branched",
     "Fedora Rawhide (Fedora 46 development)",
+    "optional experimental production COPR chroot",
+    "best-effort pinned Track D smoke only",
+    "not a release target",
+    "Every Packit `copr_build` target must be an explicit member of the checked-in allowlist",
+    "Mutable aliases such as `fedora-all`, `fedora-development`, and their architecture-suffixed forms are rejected",
+    "cannot supply lifecycle, artifact, upgrade, rollback, served-version, or availability evidence",
+    "separately reviewed amendment and full Fedora gates",
     "Arch Linux Archive snapshot 2026-08-18",
     "stable-tagged config",
 ):
-    require(phrase in docs, f"release documentation omits matrix/version phrase: {phrase}")
+    require(phrase in normalized_docs, f"release documentation omits matrix/version phrase: {phrase}")
 
 contracts = (ROOT / "docs/contracts.md").read_text()
+normalized_contracts = re.sub(r"\s+", " ", contracts)
 for phrase in (
     "## Release Channels and APT Paths",
     "https://tysmith.me/facelock/apt/dists/trixie/Release",
@@ -289,9 +397,17 @@ for phrase in (
     "https://tysmith.me/facelock/apt/dists/noble/Release",
     "`main` and `legacy`",
     "stable APT, stable AUR, or production COPR",
+    "required supported production COPR chroots are exactly Fedora 43, Fedora 44, and Fedora 45",
+    "Rawhide is the only optional allowed experimental production chroot",
+    "Every Packit `copr_build` target must be an explicit member of the checked-in allowlist",
+    "Mutable aliases such as `fedora-all`, `fedora-development`, and their architecture-suffixed forms are rejected",
+    "Rawhide is not a Packit staging or production release target",
+    "no alpha may publish to Rawhide",
+    "Rawhide cannot supply lifecycle, artifact, upgrade, rollback, served-version, or availability evidence",
+    "separately reviewed amendment and full Fedora gates",
     "issue #236",
 ):
-    require(phrase in contracts, f"system contracts omit release-channel phrase: {phrase}")
+    require(phrase in normalized_contracts, f"system contracts omit release-channel phrase: {phrase}")
 
 release_skill = (ROOT / ".claude/skills/release/SKILL.md").read_text()
 for phrase in (

--- a/test/copr-build.sh
+++ b/test/copr-build.sh
@@ -12,7 +12,7 @@
 # `packit srpm` rewrites the spec file in place.
 set -uo pipefail
 
-CHROOT="${COPR_CHROOT:-fedora-42-x86_64}"
+CHROOT="${COPR_CHROOT:-fedora-44-x86_64}"
 RESULT=0
 section() { echo; echo "==== $* ===="; }
 
@@ -23,10 +23,19 @@ cd /work || { echo "FAIL: no workdir"; exit 1; }
 git config --global --add safe.directory /work
 echo "Branch: $(git branch --show-current 2>/dev/null)  HEAD: $(git rev-parse --short HEAD 2>/dev/null)"
 
+section "Packit configuration schema"
+packit config validate --offline -c .packit.yaml || { echo "FAIL: invalid Packit configuration"; exit 1; }
+
 section "packit srpm"
 packit srpm 2>&1 | tee /tmp/srpm.log
 SRPM=$(grep -oE '/[^ ]+\.src\.rpm' /tmp/srpm.log | tail -1)
-[ -z "$SRPM" ] && SRPM=$(ls /work/*.src.rpm 2>/dev/null | head -1)
+if [ -z "$SRPM" ]; then
+  for candidate in /work/*.src.rpm; do
+    [ -f "$candidate" ] || continue
+    SRPM="$candidate"
+    break
+  done
+fi
 if [ -z "$SRPM" ] || [ ! -f "$SRPM" ]; then echo "FAIL: packit srpm produced no SRPM"; exit 1; fi
 cp "$SRPM" /tmp/ ; SRPM="/tmp/$(basename "$SRPM")"
 echo "SRPM: $SRPM"
@@ -43,7 +52,13 @@ else
 fi
 
 section "Built RPM checks"
-BIN_RPM=$(ls /tmp/mock/facelock-*.x86_64.rpm 2>/dev/null | grep -v debug | head -1)
+BIN_RPM=""
+for candidate in /tmp/mock/facelock-*.x86_64.rpm; do
+  [ -f "$candidate" ] || continue
+  case "$candidate" in *debug*) continue ;; esac
+  BIN_RPM="$candidate"
+  break
+done
 if [ -z "$BIN_RPM" ]; then echo "FAIL: no binary RPM produced"; exit 1; fi
 echo "RPM: $BIN_RPM"
 if rpm -qp --requires "$BIN_RPM" | grep -qi 'onnxruntime'; then

--- a/test/release-native-ordering.sh
+++ b/test/release-native-ordering.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/release-versions.sh
+source "$repo_root/scripts/release-versions.sh"
+
+kind="${1:?Usage: release-native-ordering.sh <debian|rpm|arch>}"
+
+case "$kind" in
+    debian)
+        versions=(
+            0.1.4-1
+            "$(release_debian_common_version 0.2.0-alpha.1 1)"
+            "$(release_debian_common_version 0.2.0-alpha.1 2)"
+            "$(release_debian_common_version 0.2.0-alpha.2 1)"
+            "$(release_debian_common_version 0.2.0-beta.1 1)"
+            "$(release_debian_common_version 0.2.0-rc.1 1)"
+            "$(release_debian_common_version 0.2.0 1)"
+        )
+        compare() { dpkg --compare-versions "$1" lt "$2"; }
+        ;;
+    rpm)
+        versions=(
+            0.1.4-1
+            "$(release_rpm_evr 0.2.0-alpha.1 1)"
+            "$(release_rpm_evr 0.2.0-alpha.1 2)"
+            "$(release_rpm_evr 0.2.0-alpha.2 3)"
+            "$(release_rpm_evr 0.2.0-beta.1 4)"
+            "$(release_rpm_evr 0.2.0-rc.1 5)"
+            "$(release_rpm_evr 0.2.0 1)"
+        )
+        compare() { rpmdev-vercmp "$1" "$2" | grep -Fq ' < '; }
+        ;;
+    arch)
+        versions=(
+            0.1.4-1
+            "$(release_arch_version 0.2.0-alpha.1 1)"
+            "$(release_arch_version 0.2.0-alpha.1 2)"
+            "$(release_arch_version 0.2.0-alpha.2 1)"
+            "$(release_arch_version 0.2.0-beta.1 1)"
+            "$(release_arch_version 0.2.0-rc.1 1)"
+            "$(release_arch_version 0.2.0 1)"
+        )
+        compare() { [ "$(vercmp "$1" "$2")" -lt 0 ]; }
+        ;;
+    *)
+        echo "unknown native ordering kind: $kind" >&2
+        exit 2
+        ;;
+esac
+
+for ((index = 0; index + 1 < ${#versions[@]}; index++)); do
+    left="${versions[index]}"
+    right="${versions[index + 1]}"
+    if ! compare "$left" "$right"; then
+        echo "native $kind ordering failed: $left !< $right" >&2
+        exit 1
+    fi
+done
+
+echo "native $kind ordering: OK (${versions[*]})"

--- a/test/release-native-ordering.sh
+++ b/test/release-native-ordering.sh
@@ -30,7 +30,16 @@ case "$kind" in
             "$(release_rpm_evr 0.2.0-rc.1 5)"
             "$(release_rpm_evr 0.2.0 1)"
         )
-        compare() { rpmdev-vercmp "$1" "$2" | grep -Fq ' < '; }
+        compare() {
+            local status
+            if rpmdev-vercmp "$1" "$2" >/dev/null; then
+                status=0
+            else
+                status=$?
+            fi
+            # rpmdev-vercmp status 12 means EVR2 is newer than EVR1.
+            [ "$status" -eq 12 ]
+        }
         ;;
     arch)
         versions=(

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../scripts/release-versions.sh
+source "$repo_root/scripts/release-versions.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    rm -f "$packit_fixture"
+    rm -f "${packit_complex_fixture:-}" "${packit_commented_fixture:-}"
+    rm -f "${github_output_fixture:-}"
+    if [ -n "${tmp_root:-}" ] && [ -d "$tmp_root" ]; then
+        rm -rf "$tmp_root"
+    fi
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local context="$3"
+    if [ "$actual" != "$expected" ]; then
+        fail "$context: expected '$expected', got '$actual'"
+    fi
+}
+
+assert_rejected() {
+    local kind="$1"
+    shift
+    if "$kind" "$@" >/dev/null 2>&1; then
+        fail "$kind accepted malformed inputs: $*"
+    fi
+}
+
+assert_file_line() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fqx "$expected" "$file"; then
+        fail "$file does not contain exact line: $expected"
+    fi
+}
+
+assert_eq "0.2.0-alpha.1" "$(release_cargo_from_tag v0.2.0-alpha.1)" "tag to Cargo"
+assert_eq "v0.2.0-alpha.1" "$(release_tag_from_cargo 0.2.0-alpha.1)" "Cargo to tag"
+assert_eq "true" "$(release_github_prerelease 0.2.0-alpha.1)" "GitHub alpha classification"
+assert_eq "false" "$(release_github_prerelease 0.2.0)" "GitHub stable classification"
+assert_eq "0.2.0~alpha.1" "$(release_debian_upstream 0.2.0-alpha.1)" "Debian upstream"
+assert_eq "0.2.0alpha1" "$(release_arch_pkgver 0.2.0-alpha.1)" "Arch pkgver"
+assert_eq "0.2.0" "$(release_rpm_version 0.2.0-alpha.1)" "RPM Version"
+assert_eq "0.1.alpha.1" "$(release_rpm_release 0.2.0-alpha.1 1)" "RPM prerelease Release"
+assert_eq "1" "$(release_rpm_release 0.2.0 99)" "RPM stable Release"
+
+release_validate_transition 0.1.4 0.2.0-alpha.1
+release_validate_transition 0.2.0-alpha.1 0.2.0-alpha.1
+release_validate_transition 0.2.0-alpha.1 0.2.0-alpha.2
+release_validate_transition 0.2.0-alpha.2 0.2.0-beta.1
+release_validate_transition 0.2.0-beta.1 0.2.0-rc.1
+release_validate_transition 0.2.0-rc.1 0.2.0
+assert_rejected release_validate_transition 0.2.0-alpha.2 0.2.0-alpha.1
+assert_rejected release_validate_transition 0.2.0-beta.1 0.2.0-alpha.3
+assert_rejected release_validate_transition 0.2.0-rc.1 0.2.0-beta.2
+assert_rejected release_validate_transition 0.2.0 0.2.0-rc.2
+assert_rejected release_validate_transition 0.2.0 0.2.0
+
+assert_eq "0.2.0~alpha.1-1~deb13u1" "$(release_debian_version 0.2.0-alpha.1 1 trixie)" "Debian 13 revision"
+assert_eq "0.2.0~alpha.1-1~deb12u1" "$(release_debian_version 0.2.0-alpha.1 1 bookworm)" "Debian 12 revision"
+assert_eq "0.2.0~alpha.1-1~ubuntu26.04.1" "$(release_debian_version 0.2.0-alpha.1 1 resolute)" "Ubuntu 26.04 revision"
+assert_eq "0.2.0~alpha.1-1~ubuntu24.04.1" "$(release_debian_version 0.2.0-alpha.1 1 noble)" "Ubuntu 24.04 revision"
+assert_eq "~deb13u1" "$(release_debian_suite_suffix trixie)" "Debian 13 suite suffix"
+assert_eq "~deb12u1" "$(release_debian_suite_suffix bookworm)" "Debian 12 suite suffix"
+assert_eq "~ubuntu26.04.1" "$(release_debian_suite_suffix resolute)" "Ubuntu 26.04 suite suffix"
+assert_eq "~ubuntu24.04.1" "$(release_debian_suite_suffix noble)" "Ubuntu 24.04 suite suffix"
+assert_eq "facelock_0.2.0~alpha.1-1~deb13u1_amd64" "$(release_debian_binary_basename 0.2.0-alpha.1 1 trixie amd64)" "Debian binary basename"
+assert_eq "facelock_0.2.0~alpha.1-1~deb13u1" "$(release_debian_source_basename 0.2.0-alpha.1 1 trixie)" "Debian source basename"
+
+assert_rejected release_validate_cargo_version 0.2.0-alpha1
+assert_rejected release_validate_cargo_version 0.2.0-preview.1
+assert_rejected release_validate_cargo_version 0.2
+assert_rejected release_cargo_from_tag 0.2.0-alpha.1
+assert_rejected release_cargo_from_tag v0.2.0-alpha.1-extra
+assert_rejected release_github_prerelease invalid
+assert_rejected release_debian_common_version invalid 1
+assert_rejected release_debian_version 0.2.0 1 sid
+assert_rejected release_debian_source_basename invalid 1 trixie
+assert_rejected release_debian_binary_basename 0.2.0 1 sid amd64
+assert_rejected release_arch_version invalid 1
+assert_rejected release_rpm_evr invalid 1
+
+github_output_fixture="$(mktemp)"
+assert_rejected release_write_github_outputs v9.9.9-alpha.1 "$github_output_fixture"
+if [ -s "$github_output_fixture" ]; then
+    fail "release_write_github_outputs left partial output after rejecting inconsistent metadata"
+fi
+
+packit_fixture="$(mktemp)"
+trap cleanup EXIT
+cat > "$packit_fixture" <<'JSON'
+{
+  "jobs": [
+    {
+      "job": "copr_build",
+      "trigger": "ignore",
+      "owner": "tysmith",
+      "project": "facelock",
+      "targets": ["fedora-44-x86_64"]
+    }
+  ]
+}
+JSON
+release_validate_packit_channel 0.2.0-alpha.1 "$packit_fixture"
+if release_validate_packit_channel 0.2.0 "$packit_fixture" >/dev/null 2>&1; then
+    fail "stable preflight accepted a config without deliberate production COPR restoration"
+fi
+sed -i 's/"trigger": "ignore"/"trigger": "release"/' "$packit_fixture"
+if release_validate_packit_channel 0.2.0-alpha.1 "$packit_fixture" >/dev/null 2>&1; then
+    fail "prerelease preflight accepted a release-triggered production COPR job"
+fi
+release_validate_packit_channel 0.2.0 "$packit_fixture"
+
+packit_complex_fixture="$(mktemp)"
+cat > "$packit_complex_fixture" <<'JSON'
+{
+  "jobs": [
+    {
+      "targets": ["fedora-44-x86_64"],
+      "project": "facelock-testing",
+      "trigger": "pull_request",
+      "job": "copr_build",
+      "owner": "tyvsmith"
+    },
+    {
+      "project": "facelock",
+      "targets": ["fedora-43-x86_64", "fedora-44-x86_64", "fedora-45-x86_64"],
+      "owner": "tyvsmith",
+      "trigger": "release",
+      "job": "copr_build"
+    }
+  ]
+}
+JSON
+if release_validate_packit_channel 0.2.0-alpha.1 "$packit_complex_fixture" >/dev/null 2>&1; then
+    fail "prerelease preflight accepted a reordered production job after another Packit job"
+fi
+release_validate_packit_channel 0.2.0 "$packit_complex_fixture"
+
+packit_commented_fixture="$(mktemp)"
+cat > "$packit_commented_fixture" <<'YAML'
+specfile_path: dist/facelock.spec
+upstream_package_name: facelock
+downstream_package_name: facelock
+upstream_tag_template: "v{version}"
+jobs:
+  # General YAML is valid to Packit but outside the guard's JSON-subset contract.
+  - targets:
+      - fedora-43-x86_64
+      - fedora-44-x86_64
+      - fedora-45-x86_64
+    owner: "tyvsmith"
+    project: "facelock"
+    trigger: "release"
+    job: "copr_build"
+YAML
+if release_validate_packit_channel 0.2.0-alpha.1 "$packit_commented_fixture" >/dev/null 2>&1; then
+    fail "prerelease preflight accepted a commented config outside the JSON-subset Packit contract"
+fi
+
+debian_versions=(
+    0.1.4-1
+    "$(release_debian_common_version 0.2.0-alpha.1 1)"
+    "$(release_debian_common_version 0.2.0-alpha.1 2)"
+    "$(release_debian_common_version 0.2.0-alpha.2 1)"
+    "$(release_debian_common_version 0.2.0-beta.1 1)"
+    "$(release_debian_common_version 0.2.0-rc.1 1)"
+    "$(release_debian_common_version 0.2.0 1)"
+)
+rpm_versions=(
+    0.1.4-1
+    "$(release_rpm_evr 0.2.0-alpha.1 1)"
+    "$(release_rpm_evr 0.2.0-alpha.1 2)"
+    "$(release_rpm_evr 0.2.0-alpha.2 3)"
+    "$(release_rpm_evr 0.2.0-beta.1 4)"
+    "$(release_rpm_evr 0.2.0-rc.1 5)"
+    "$(release_rpm_evr 0.2.0 1)"
+)
+arch_versions=(
+    0.1.4-1
+    "$(release_arch_version 0.2.0-alpha.1 1)"
+    "$(release_arch_version 0.2.0-alpha.1 2)"
+    "$(release_arch_version 0.2.0-alpha.2 1)"
+    "$(release_arch_version 0.2.0-beta.1 1)"
+    "$(release_arch_version 0.2.0-rc.1 1)"
+    "$(release_arch_version 0.2.0 1)"
+)
+
+assert_eq "0.1.4-1 0.2.0~alpha.1-1 0.2.0~alpha.1-2 0.2.0~alpha.2-1 0.2.0~beta.1-1 0.2.0~rc.1-1 0.2.0-1" "${debian_versions[*]}" "exact Debian order identities"
+assert_eq "0.1.4-1 0.2.0-0.1.alpha.1 0.2.0-0.2.alpha.1 0.2.0-0.3.alpha.2 0.2.0-0.4.beta.1 0.2.0-0.5.rc.1 0.2.0-1" "${rpm_versions[*]}" "exact RPM order identities"
+assert_eq "0.1.4-1 0.2.0alpha1-1 0.2.0alpha1-2 0.2.0alpha2-1 0.2.0beta1-1 0.2.0rc1-1 0.2.0-1" "${arch_versions[*]}" "exact Arch order identities"
+
+tmp_root="$(mktemp -d)"
+export XDG_RUNTIME_DIR="$tmp_root/runtime"
+release_repo="$tmp_root/release-repo"
+matrix_root="$tmp_root/matrix-root"
+mkdir -p "$release_repo/dist/debian" "$release_repo/scripts" "$tmp_root/bin" "$XDG_RUNTIME_DIR"
+mkdir -p "$matrix_root/.claude/skills/release" "$matrix_root/.github/workflows/scripts" "$matrix_root/book/src" "$matrix_root/dist/apt/conf" "$matrix_root/docs" "$matrix_root/test" "$matrix_root/website"
+cp "$repo_root/.claude/skills/release/SKILL.md" "$matrix_root/.claude/skills/release/"
+cp "$repo_root/.packit.yaml" "$matrix_root/"
+cp "$repo_root/justfile" "$matrix_root/"
+cp "$repo_root/.github/workflows/ci.yml" "$matrix_root/.github/workflows/"
+cp "$repo_root/.github/workflows/release.yml" "$matrix_root/.github/workflows/"
+cp "$repo_root/.github/workflows/scripts/build-deb.sh" "$matrix_root/.github/workflows/scripts/"
+cp "$repo_root/.github/workflows/scripts/publish-apt.sh" "$matrix_root/.github/workflows/scripts/"
+cp "$repo_root/.github/workflows/scripts/publish-aur.sh" "$matrix_root/.github/workflows/scripts/"
+cp "$repo_root/dist/PKGBUILD" "$repo_root/dist/PKGBUILD-bin" "$repo_root/dist/release-matrix.json" "$matrix_root/dist/"
+cp "$repo_root/dist/apt/conf/distributions" "$matrix_root/dist/apt/conf/"
+cp "$repo_root/docs/releasing.md" "$repo_root/docs/contracts.md" "$matrix_root/docs/"
+cp "$repo_root/docs/testing-roadmap.md" "$matrix_root/docs/"
+cp "$repo_root/README.md" "$matrix_root/"
+cp "$repo_root/book/src/quickstart.md" "$matrix_root/book/src/"
+cp "$repo_root/website/index.html" "$matrix_root/website/"
+cp "$repo_root/test/check-release-matrix.py" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile" "$matrix_root/test/"
+cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
+
+apt_publisher_root="$tmp_root/apt-publisher-root"
+mkdir -p "$apt_publisher_root/.github/workflows/scripts" "$apt_publisher_root/scripts" "$apt_publisher_root/debs"
+cp "$repo_root/.github/workflows/scripts/publish-apt.sh" "$apt_publisher_root/.github/workflows/scripts/"
+cp "$repo_root/scripts/release-versions.sh" "$apt_publisher_root/scripts/"
+sed -i "s/noble) printf '~ubuntu24.04.1/noble) printf '~ubuntu24.04.99/" "$apt_publisher_root/scripts/release-versions.sh"
+for suite in trixie bookworm resolute noble; do
+    : > "$apt_publisher_root/debs/$suite.deb"
+done
+cat > "$tmp_root/bin/dpkg-deb" <<'SH'
+#!/usr/bin/env bash
+case "$2" in
+    */trixie.deb) printf '%s\n' '0.2.0-1~deb13u1' ;;
+    */bookworm.deb) printf '%s\n' '0.2.0-1~deb12u1' ;;
+    */resolute.deb) printf '%s\n' '0.2.0-1~ubuntu26.04.1' ;;
+    */noble.deb) printf '%s\n' '0.2.0-1~ubuntu24.04.1' ;;
+    *) exit 1 ;;
+esac
+SH
+chmod +x "$tmp_root/bin/dpkg-deb"
+if apt_guard_output=$(
+    env -u APT_GPG_PRIVATE_KEY -u APT_GPG_PASSPHRASE PATH="$tmp_root/bin:$PATH" \
+        bash "$apt_publisher_root/.github/workflows/scripts/publish-apt.sh" \
+        "$apt_publisher_root/repo" \
+        "trixie=$apt_publisher_root/debs/trixie.deb" \
+        "bookworm=$apt_publisher_root/debs/bookworm.deb" \
+        "resolute=$apt_publisher_root/debs/resolute.deb" \
+        "noble=$apt_publisher_root/debs/noble.deb" 2>&1
+); then
+    fail "APT publisher accepted noble suffix drift in the central release contract"
+fi
+case "$apt_guard_output" in
+    *"does not match stable APT suite noble (~ubuntu24.04.99)"*) ;;
+    *) fail "APT publisher did not consume the mutated central noble suffix: $apt_guard_output" ;;
+esac
+
+sed -i 's/"trigger": "ignore"/"trigger": "release"/' "$matrix_root/.packit.yaml"
+env -u RELEASE_MATRIX_VERSION python3 "$matrix_root/test/check-release-matrix.py"
+if RELEASE_MATRIX_VERSION=0.2.0-alpha.1 python3 "$matrix_root/test/check-release-matrix.py" >/dev/null 2>&1; then
+    fail "release matrix checker accepted a production COPR release job for a prerelease identity"
+fi
+RELEASE_MATRIX_VERSION=0.2.0 python3 "$matrix_root/test/check-release-matrix.py"
+
+matrix_mutation_index=0
+assert_matrix_mutation_rejected() {
+    local context="$1"
+    local relative_file="$2"
+    local expression="$3"
+    local mutation_root="$tmp_root/matrix-mutation-$matrix_mutation_index"
+    matrix_mutation_index=$((matrix_mutation_index + 1))
+    cp -R "$matrix_root" "$mutation_root"
+    sed -i "$expression" "$mutation_root/$relative_file"
+    if cmp -s "$matrix_root/$relative_file" "$mutation_root/$relative_file"; then
+        fail "matrix mutation fixture did not change $relative_file: $context"
+    fi
+    if RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" >/dev/null 2>&1; then
+        fail "release matrix checker accepted drift: $context"
+    fi
+}
+
+assert_matrix_mutation_rejected \
+    "trixie workflow variant tpm to legacy" \
+    ".github/workflows/release.yml" \
+    '0,/variant: tpm/s//variant: legacy/'
+assert_matrix_mutation_rejected \
+    "trixie revision suffix" \
+    "dist/release-matrix.json" \
+    '0,/"revision_suffix": "~deb13u1"/s//"revision_suffix": "~deb99u1"/'
+assert_matrix_mutation_rejected \
+    "trixie suite architecture" \
+    "dist/release-matrix.json" \
+    '0,/"architecture": "amd64"/s//"architecture": "arm64"/'
+assert_matrix_mutation_rejected \
+    "trixie duplicated platform mapping" \
+    "dist/release-matrix.json" \
+    '0,/"platform": "Debian 13"/s//"platform": "Debian 12"/'
+assert_matrix_mutation_rejected \
+    "stable publication suite input noble to duplicate trixie" \
+    ".github/workflows/release.yml" \
+    "s/\"noble=\$(ls debs\\/noble/\"trixie=\$(ls debs\\/noble/"
+
+live_copr_exact="$tmp_root/live-copr-exact.json"
+live_copr_drift="$tmp_root/live-copr-drift.json"
+live_copr_wrong_project="$tmp_root/live-copr-wrong-project.json"
+cat > "$live_copr_exact" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+cat > "$live_copr_drift" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/",
+    "fedora-rawhide-x86_64": "https://example.invalid/rawhide/"
+  }
+}
+JSON
+cat > "$live_copr_wrong_project" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_exact"
+if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_drift" >/dev/null 2>&1; then
+    fail "live COPR checker accepted an extra production chroot"
+fi
+if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_wrong_project" >/dev/null 2>&1; then
+    fail "live COPR checker accepted the wrong project identity"
+fi
+
+prerelease_deb="$tmp_root/facelock-prerelease.deb"
+: > "$prerelease_deb"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "0.2.0-1~deb13u1"\n' > "$tmp_root/bin/dpkg-deb"
+chmod +x "$tmp_root/bin/dpkg-deb"
+if apt_guard_output=$(
+    PATH="$tmp_root/bin:$PATH" \
+        bash "$repo_root/.github/workflows/scripts/publish-apt.sh" \
+        "$tmp_root/apt-repo" "trixie=$prerelease_deb" 2>&1
+); then
+    fail "stable APT publisher accepted an incomplete suite set"
+fi
+case "$apt_guard_output" in
+    *"requires exactly one package for each stable suite"*) ;;
+    *) fail "stable APT publisher did not reject the incomplete suite set before signing setup: $apt_guard_output" ;;
+esac
+
+if apt_guard_output=$(
+    PATH="$tmp_root/bin:$PATH" \
+        bash "$repo_root/.github/workflows/scripts/publish-apt.sh" \
+        "$tmp_root/apt-repo" \
+        "trixie=$prerelease_deb" "trixie=$prerelease_deb" \
+        "resolute=$prerelease_deb" "noble=$prerelease_deb" 2>&1
+); then
+    fail "stable APT publisher accepted a duplicate suite"
+fi
+case "$apt_guard_output" in
+    *"duplicate stable APT suite 'trixie'"*) ;;
+    *) fail "stable APT publisher did not reject the duplicate suite before signing setup: $apt_guard_output" ;;
+esac
+
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "0.2.0~alpha.1-1~deb13u1"\n' > "$tmp_root/bin/dpkg-deb"
+if apt_guard_output=$(
+    PATH="$tmp_root/bin:$PATH" \
+        bash "$repo_root/.github/workflows/scripts/publish-apt.sh" \
+        "$tmp_root/apt-repo" \
+        "trixie=$prerelease_deb" "bookworm=$prerelease_deb" \
+        "resolute=$prerelease_deb" "noble=$prerelease_deb" 2>&1
+); then
+    fail "stable APT publisher accepted a prerelease package"
+fi
+case "$apt_guard_output" in
+    *"refusing prerelease"*) ;;
+    *) fail "stable APT publisher did not reject the prerelease before signing setup: $apt_guard_output" ;;
+esac
+
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "0.2.0-1~ubuntu24.04.1"\n' > "$tmp_root/bin/dpkg-deb"
+if apt_guard_output=$(
+    PATH="$tmp_root/bin:$PATH" \
+        bash "$repo_root/.github/workflows/scripts/publish-apt.sh" \
+        "$tmp_root/apt-repo" \
+        "trixie=$prerelease_deb" "bookworm=$prerelease_deb" \
+        "resolute=$prerelease_deb" "noble=$prerelease_deb" 2>&1
+); then
+    fail "stable APT publisher accepted a package built for a different suite"
+fi
+case "$apt_guard_output" in
+    *"does not match stable APT suite"*) ;;
+    *) fail "stable APT publisher did not reject the suite/version mismatch before signing setup: $apt_guard_output" ;;
+esac
+
+assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0-alpha.1 unused
+
+apt_recipe_root="$tmp_root/apt-recipe-root"
+mkdir -p "$apt_recipe_root/dist/apt/conf" "$apt_recipe_root/target"
+cp "$repo_root/justfile" "$apt_recipe_root/"
+cp "$repo_root/dist/apt/conf/distributions" "$apt_recipe_root/dist/apt/conf/"
+: > "$apt_recipe_root/facelock_0.2.0-1~deb13u1_amd64.deb"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "0.2.0-1~deb13u1"\n' > "$tmp_root/bin/dpkg-deb"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp_root/bin/reprepro"
+chmod +x "$tmp_root/bin/dpkg-deb" "$tmp_root/bin/reprepro"
+if (
+    cd "$apt_recipe_root"
+    PATH="$tmp_root/bin:$PATH" just test-apt-repo >/dev/null 2>&1
+); then
+    fail "test-apt-repo accepted missing Release, binary, and pool paths"
+fi
+
+cp "$repo_root/justfile" "$repo_root/Cargo.toml" "$repo_root/Cargo.lock" "$release_repo/"
+cp "$repo_root/dist/PKGBUILD" "$repo_root/dist/PKGBUILD-bin" "$repo_root/dist/PKGBUILD-git" "$repo_root/dist/facelock.spec" "$release_repo/dist/"
+cp "$repo_root/dist/debian/changelog" "$release_repo/dist/debian/"
+cp "$repo_root/scripts/release-versions.sh" "$release_repo/scripts/"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$tmp_root/bin/cargo"
+chmod +x "$tmp_root/bin/cargo"
+
+git -C "$release_repo" init -q
+git -C "$release_repo" config user.name release-test
+git -C "$release_repo" config user.email release-test@example.invalid
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm baseline
+
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-alpha.1 >/dev/null
+)
+assert_file_line "$release_repo/Cargo.toml" 'version = "0.2.0-alpha.1"'
+assert_file_line "$release_repo/dist/PKGBUILD" '_tag=0.2.0-alpha.1'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgver=0.2.0alpha1'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+assert_file_line "$release_repo/dist/PKGBUILD-bin" '_tag=0.2.0-alpha.1'
+assert_file_line "$release_repo/dist/PKGBUILD-bin" 'pkgver=0.2.0alpha1'
+assert_file_line "$release_repo/dist/facelock.spec" 'Version:        0.2.0'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        0.1.alpha.1%{?dist}'
+grep -Fq 'facelock (0.2.0~alpha.1-1) unstable;' "$release_repo/dist/debian/changelog" || fail "first alpha Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm alpha-1-build-1
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-alpha.1 >/dev/null
+)
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=2'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        0.2.alpha.1%{?dist}'
+grep -Fq 'facelock (0.2.0~alpha.1-2) unstable;' "$release_repo/dist/debian/changelog" || fail "rebuilt alpha Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm alpha-1-build-2
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-alpha.2 >/dev/null
+)
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        0.3.alpha.2%{?dist}'
+grep -Fq 'facelock (0.2.0~alpha.2-1) unstable;' "$release_repo/dist/debian/changelog" || fail "successive alpha Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm alpha-2-build-1
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-beta.1 >/dev/null
+)
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgver=0.2.0beta1'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        0.4.beta.1%{?dist}'
+grep -Fq 'facelock (0.2.0~beta.1-1) unstable;' "$release_repo/dist/debian/changelog" || fail "beta Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm beta-1-build-1
+if (
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-alpha.3 >/dev/null 2>&1
+); then
+    fail "just release accepted an alpha after the same base reached beta"
+fi
+git -C "$release_repo" diff --quiet || fail "rejected beta-to-alpha transition changed release metadata"
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-rc.1 >/dev/null
+)
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgver=0.2.0rc1'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        0.5.rc.1%{?dist}'
+grep -Fq 'facelock (0.2.0~rc.1-1) unstable;' "$release_repo/dist/debian/changelog" || fail "release candidate Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm rc-1-build-1
+(
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0 >/dev/null
+)
+assert_file_line "$release_repo/dist/PKGBUILD" '_tag=0.2.0'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgver=0.2.0'
+assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+assert_file_line "$release_repo/dist/facelock.spec" 'Version:        0.2.0'
+assert_file_line "$release_repo/dist/facelock.spec" 'Release:        1%{?dist}'
+grep -Fq 'facelock (0.2.0-1) unstable;' "$release_repo/dist/debian/changelog" || fail "stable Debian revision missing"
+
+git -C "$release_repo" add .
+git -C "$release_repo" -c commit.gpgsign=false commit -qm stable
+if (
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0 >/dev/null 2>&1
+); then
+    fail "just release accepted a repeated stable version"
+fi
+git -C "$release_repo" diff --quiet || fail "rejected repeated stable release changed release metadata"
+if (
+    cd "$release_repo"
+    PATH="$tmp_root/bin:$PATH" just release 0.2.0-alpha.3 >/dev/null 2>&1
+); then
+    fail "just release accepted a prerelease after the same RPM Version reached stable"
+fi
+git -C "$release_repo" diff --quiet || fail "rejected stable-to-prerelease transition changed release metadata"
+
+echo "release version contract: OK"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -284,6 +284,73 @@ assert_matrix_mutation_rejected() {
     fi
 }
 
+append_packit_job() {
+    local config_path="$1"
+    local job_json="$2"
+    python3 - "$config_path" "$job_json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+config = json.loads(path.read_text())
+config["jobs"].append(json.loads(sys.argv[2]))
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+}
+
+packit_extra_job_index=0
+assert_extra_packit_job_rejected() {
+    local context="$1"
+    local job_json="$2"
+    local mutation_root="$tmp_root/packit-extra-job-$packit_extra_job_index"
+    local checker_output
+    packit_extra_job_index=$((packit_extra_job_index + 1))
+    cp -R "$matrix_root" "$mutation_root"
+    append_packit_job "$mutation_root/.packit.yaml" "$job_json"
+    if checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" 2>&1); then
+        printf '%s\n' "$checker_output"
+        fail "release matrix checker accepted an extra Packit job: $context"
+    fi
+    echo "release matrix Packit case: $context rejected"
+}
+
+valid_packit_staging_root="$tmp_root/packit-valid-staging"
+cp -R "$matrix_root" "$valid_packit_staging_root"
+append_packit_job \
+    "$valid_packit_staging_root/.packit.yaml" \
+    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+RELEASE_MATRIX_VERSION=0.2.0 python3 "$valid_packit_staging_root/test/check-release-matrix.py" >/dev/null
+echo "release matrix Packit case: exact facelock-testing staging targets accepted"
+
+assert_extra_packit_job_rejected \
+    "canonical Rawhide target outside production and staging" \
+    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide"]}'
+assert_extra_packit_job_rejected \
+    "fedora-all mutable alias" \
+    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-all"]}'
+assert_extra_packit_job_rejected \
+    "fedora-development mutable alias" \
+    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development"]}'
+assert_extra_packit_job_rejected \
+    "architecture-suffixed mutable alias" \
+    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
+assert_extra_packit_job_rejected \
+    "facelock-testing Rawhide target" \
+    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}'
+assert_extra_packit_job_rejected \
+    "Rawhide target outside production and staging" \
+    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
+assert_extra_packit_job_rejected \
+    "facelock-testing incomplete staging targets" \
+    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}'
+assert_extra_packit_job_rejected \
+    "duplicate targets outside production and staging" \
+    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-43-x86_64"]}'
+assert_extra_packit_job_rejected \
+    "invalid targets outside production and staging" \
+    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":"fedora-43-x86_64"}'
+
 assert_matrix_mutation_rejected \
     "trixie workflow variant tpm to legacy" \
     ".github/workflows/release.yml" \
@@ -304,11 +371,37 @@ assert_matrix_mutation_rejected \
     "stable publication suite input noble to duplicate trixie" \
     ".github/workflows/release.yml" \
     "s/\"noble=\$(ls debs\\/noble/\"trixie=\$(ls debs\\/noble/"
+assert_matrix_mutation_rejected \
+    "production required supported chroot missing" \
+    "dist/release-matrix.json" \
+    '/"required_supported_chroots"/,/]/s/        "fedora-43-x86_64",//'
+assert_matrix_mutation_rejected \
+    "production optional experimental chroot overlaps a supported chroot" \
+    "dist/release-matrix.json" \
+    '/"optional_experimental_chroots"/,/]/s/"fedora-rawhide-x86_64"/"fedora-45-x86_64"/'
+assert_matrix_mutation_rejected \
+    "Rawhide support tier promoted to supported" \
+    "dist/release-matrix.json" \
+    '/"id": "fedora-rawhide"/,/"lifecycle_depth"/s/"support_tier": "experimental"/"support_tier": "supported"/'
+assert_matrix_mutation_rejected \
+    "Rawhide marked as a release target" \
+    "dist/release-matrix.json" \
+    '/"id": "fedora-rawhide"/,/"lifecycle_depth"/s/"release_target": false/"release_target": true/'
+assert_matrix_mutation_rejected \
+    "Rawhide served-version evidence enabled" \
+    "dist/release-matrix.json" \
+    's/"served_version": false/"served_version": true/'
+assert_matrix_mutation_rejected \
+    "Packit release target Fedora 45 to Rawhide" \
+    ".packit.yaml" \
+    's/"fedora-45-x86_64"/"fedora-rawhide-x86_64"/'
 
-live_copr_exact="$tmp_root/live-copr-exact.json"
-live_copr_drift="$tmp_root/live-copr-drift.json"
+live_copr_supported_only="$tmp_root/live-copr-supported-only.json"
+live_copr_supported_with_rawhide="$tmp_root/live-copr-supported-with-rawhide.json"
+live_copr_missing_supported="$tmp_root/live-copr-missing-supported.json"
+live_copr_unknown_extra="$tmp_root/live-copr-unknown-extra.json"
 live_copr_wrong_project="$tmp_root/live-copr-wrong-project.json"
-cat > "$live_copr_exact" <<'JSON'
+cat > "$live_copr_supported_only" <<'JSON'
 {
   "ownername": "tyvsmith",
   "name": "facelock",
@@ -320,7 +413,7 @@ cat > "$live_copr_exact" <<'JSON'
   }
 }
 JSON
-cat > "$live_copr_drift" <<'JSON'
+cat > "$live_copr_supported_with_rawhide" <<'JSON'
 {
   "ownername": "tyvsmith",
   "name": "facelock",
@@ -330,6 +423,32 @@ cat > "$live_copr_drift" <<'JSON'
     "fedora-44-x86_64": "https://example.invalid/44/",
     "fedora-45-x86_64": "https://example.invalid/45/",
     "fedora-rawhide-x86_64": "https://example.invalid/rawhide/"
+  }
+}
+JSON
+cat > "$live_copr_missing_supported" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-rawhide-x86_64": "https://example.invalid/rawhide/"
+  }
+}
+JSON
+cat > "$live_copr_unknown_extra" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/",
+    "fedora-rawhide-x86_64": "https://example.invalid/rawhide/",
+    "fedora-46-x86_64": "https://example.invalid/46/"
   }
 }
 JSON
@@ -345,13 +464,23 @@ cat > "$live_copr_wrong_project" <<'JSON'
   }
 }
 JSON
-python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_exact"
-if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_drift" >/dev/null 2>&1; then
-    fail "live COPR checker accepted an extra production chroot"
+python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_supported_only"
+echo "release channel case: supported-only accepted"
+python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_supported_with_rawhide"
+echo "release channel case: supported-plus-optional-Rawhide accepted"
+if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_missing_supported" >/dev/null 2>&1; then
+    fail "live COPR checker accepted a missing supported production chroot"
 fi
+echo "release channel case: missing-supported rejected"
+if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_unknown_extra" >/dev/null 2>&1; then
+    fail "live COPR checker accepted an unknown extra production chroot"
+fi
+echo "release channel case: unknown-extra rejected"
 if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$live_copr_wrong_project" >/dev/null 2>&1; then
     fail "live COPR checker accepted the wrong project identity"
 fi
+echo "release channel case: wrong-project rejected"
+echo "release channel case: Rawhide-in-Packit-targets rejected"
 
 prerelease_deb="$tmp_root/facelock-prerelease.deb"
 : > "$prerelease_deb"

--- a/website/index.html
+++ b/website/index.html
@@ -367,14 +367,19 @@
               <span class="terminal-title">terminal</span>
             </div>
             <div class="terminal-body">
-              <div><span class="comment"># Add signing key (Debian trixie+, Ubuntu 25.04+)</span></div>
+              <div><span class="comment"># Debian 13 — trixie — TPM</span></div>
+              <div><span class="comment"># Debian 12 — bookworm — legacy</span></div>
+              <div><span class="comment"># Ubuntu 26.04 — resolute — TPM</span></div>
+              <div><span class="comment"># Ubuntu 24.04 — noble — legacy</span></div>
+              <div><span class="comment"># Add signing key</span></div>
               <div><span class="prompt">$</span> <span class="command">sudo install -d -m 0755 /etc/apt/keyrings</span></div>
               <div><span class="prompt">$</span> <span class="command">curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \</span></div>
               <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="command">| sudo tee /etc/apt/keyrings/tysmith-archive-keyring.gpg &gt;/dev/null</span></div>
               <div>&nbsp;</div>
-              <div><span class="comment"># Add repository</span></div>
+              <div><span class="comment"># Set the exact suite above; trixie is the Debian 13 example</span></div>
+              <div><span class="prompt">$</span> <span class="command">APT_SUITE=trixie</span></div>
               <div><span class="prompt">$</span> <span class="command">echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] \</span></div>
-              <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="command">https://tysmith.me/facelock/apt main facelock" \</span></div>
+              <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="command">https://tysmith.me/facelock/apt ${APT_SUITE} facelock" \</span></div>
               <div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="command">| sudo tee /etc/apt/sources.list.d/facelock.list</span></div>
               <div>&nbsp;</div>
               <div><span class="comment"># Install + run setup wizard</span></div>


### PR DESCRIPTION
## Why

Prerelease identities and supported release targets were implicit, which could misorder native packages or leak alpha artifacts into stable channels. This makes release identity, platform coverage, consumer mappings, and stable-channel exclusions executable and fail-closed.

## Changes

- convert strict SemVer identities for Cargo, Debian, RPM, Arch, and GitHub releases
- preserve native prerelease rebuild ordering and reject invalid release transitions
- pin the distro matrix, container identities, and Arch repository snapshot
- enforce codenamed APT suites and exclude prereleases from stable APT, AUR, and production COPR
- require Fedora 43, 44, and 45 as supported production COPR chroots
- allow Rawhide as the only optional experimental production chroot
- exclude Rawhide from Packit release targets and release evidence
- reject mutable Packit aliases and undeclared `copr_build` targets
- validate Packit semantics, workflow consumers, documentation paths, and public COPR drift
- centralize Debian suite variants and suffixes across builders and publication
- update release, path, lifecycle-depth, and channel contracts
- resolve #234

## Validation

- run `just test-release-contract`
- run `python3 test/check-live-release-channels.py`
- run `bash test/release-native-ordering.sh arch`
- run `cargo build --workspace`
- run `cargo test --workspace`
- run `cargo clippy --workspace --all-targets -- -D warnings`
- run `cargo fmt --all -- --check`
- run `shellcheck -S warning`
- run `git diff --check`

## Limitations

- defer fresh Debian and RPM native comparator runs because the approved container runtime is unavailable
- retain lifecycle-test debt owned by #229 and #230