### PR TITLE
docs(packaging): freeze removal ownership semantics

### DIFF
--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -144,11 +144,20 @@ Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, o
 just uninstall
 ```
 
-Config and data are preserved in `/etc/facelock` and `/var/lib/facelock`. To remove everything:
+### Package lifecycle and retained data
 
-```bash
-sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock
-```
+Ordinary package removal and `just uninstall` preserve the face database,
+encryption keys, downloaded models, enrollment markers, audit logs, snapshots,
+and setup state. Debian also retains its conffile until `purge`; RPM follows
+`%config(noreplace)` and may retain an administrator-modified config as
+`config.toml.rpmsave`.
+
+Facelock does not currently expose a safe "remove everything" command. Do not
+replace package lifecycle handling with a broad recursive deletion: configured
+state paths can live outside the default directories, and links, mounts, or
+wrong-owner remnants require inspection rather than traversal. The authoritative
+fixed-root, retained-data, and erasure-limit contract is in
+`docs/contracts.md`, "Package Lifecycle Ownership".
 
 ## Configuration
 

--- a/dist/debian/postrm
+++ b/dist/debian/postrm
@@ -10,8 +10,9 @@ facelock uninstalled. User data preserved at:
   /var/lib/facelock/  (face database, ONNX models)
   /var/log/facelock/  (audit logs and snapshots)
 
-To remove all face data, config, models, and logs:
-  sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock
+Retained state cleanup is intentionally not automated.
+Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings.
+Filesystem deletion does not securely erase SSDs, snapshots, or backups.
 
 EOF
         ;;

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -139,6 +139,7 @@ post_remove() {
     echo "==>   /var/lib/facelock/  (face database, ONNX models)"
     echo "==>   /var/log/facelock/  (audit logs and snapshots)"
     echo "==>"
-    echo "==> To remove all face data, config, models, and logs:"
-    echo "==>   sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+    echo "==> Retained state cleanup is intentionally not automated."
+    echo "==> Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
+    echo "==> Filesystem deletion does not securely erase SSDs, snapshots, or backups."
 }

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -169,8 +169,9 @@ if [ $1 -eq 0 ]; then
     echo "  /var/lib/facelock/  (face database, ONNX models)"
     echo "  /var/log/facelock/  (audit logs and snapshots)"
     echo ""
-    echo "To remove all face data, config, models, and logs:"
-    echo "  rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+    echo "Retained state cleanup is intentionally not automated."
+    echo "Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
+    echo "Filesystem deletion does not securely erase SSDs, snapshots, or backups."
 fi
 
 %files

--- a/dist/omarchy/omarchy-remove-security-face
+++ b/dist/omarchy/omarchy-remove-security-face
@@ -26,8 +26,14 @@ done
 
 echo
 echo "PAM lines removed. Face data, models, and the facelock package remain installed."
-echo "To purge everything:"
-echo "  sudo pacman -Rns facelock        # or your distro's package manager"
-echo "  sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+echo "To remove package-owned static files:"
+echo "  sudo pacman -Rs facelock         # or your distro's package manager"
+echo "Retained state remains under these fixed roots:"
+echo "  /etc/facelock/"
+echo "  /var/lib/facelock/"
+echo "  /var/log/facelock/"
+echo "Retained state cleanup is intentionally not automated."
+echo "Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
+echo "Filesystem deletion does not securely erase SSDs, snapshots, or backups."
 echo
 echo -e "\e[32mFacial authentication removed.\e[0m"

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -20,6 +20,7 @@ follow it.
   - [facelock is-enrolled Exit Codes](#facelock-is-enrolled-exit-codes)
   - [facelock auth Exit Codes](#facelock-auth-exit-codes)
 - [Release Channels and APT Paths](#release-channels-and-apt-paths)
+- [Package Lifecycle Ownership](#package-lifecycle-ownership)
 - [Filesystem Paths](#filesystem-paths)
   - [Audit Log Entries](#audit-log-entries)
 - [Config Schema](#config-schema)
@@ -1354,6 +1355,104 @@ host operating-system codename while keeping the `facelock` component. Each
 stable publication consumes exactly one matching package for all four suites,
 and a prerelease or cross-suite version is rejected before signing or repository
 writes.
+
+## Package Lifecycle Ownership
+
+This is the Wave 0 ownership freeze for issue #232. It defines what later
+package lifecycle work is allowed to remove; it does not claim that the current
+Debian purge script already implements the bounded purge described below.
+**Ordinary removal is not data deletion.** Removing the package must leave a
+machine reinstallable without losing its biometric or operational state.
+
+The ownership classes are deliberately separate:
+
+| Class | Examples | Ordinary removal |
+|-------|----------|------------------|
+| Package-owned static integration | binaries and shared libraries, systemd/OpenRC/runit/s6 units, D-Bus policy and activation, tmpfiles configuration, shipped quirks, PAM/authselect profiles, Omarchy helpers, translations, bundled runtime libraries | Remove through the package manager. These files can be recreated byte-for-byte by reinstalling the package |
+| Administrator configuration | `/etc/facelock/config.toml` and the package manager's saved replacement for an administrator-modified copy | Apply the native package-family rules below. Do not treat administrator configuration as biometric state or as disposable static integration |
+| Biometric and operational state | the database and its WAL/SHM sidecars, encryption keys and sealed keys, downloaded models, enrollment markers, setup state, audit logs, and snapshots under the compiled roots | Preserve all of it. A reinstall reuses it; ordinary removal never interprets absence of the package as consent to discard it |
+| PAM integration and provenance | a `pam_facelock.so` rule, a Facelock-created local override and its provenance header, and `<service>.facelock-backup` rollback files | Attempt safe cleanup inside the fixed PAM root. Delete provenance only after the corresponding PAM cleanup is proven complete |
+| Externally configured state | any database, model directory, key, sealed key, audit log, or snapshot path configured outside the compiled Facelock roots | Never package-owned. Leave it untouched and report it as an external remnant |
+
+PAM provenance and rollback files are not biometric state. They exist to
+explain or reverse an authentication-stack edit, so retaining all of them
+forever makes an otherwise successful uninstall look incomplete. Conversely,
+deleting them before the PAM edit is known to be gone destroys the evidence and
+rollback path for a service that still references a removed module.
+
+**Preserve PAM provenance when cleanup is incomplete; remove it only after
+successful cleanup.** Successful cleanup means the service file was safely
+resolved inside `/etc/pam.d`, its Facelock rule was removed (or was already
+absent), and any candidate override or backup was proven to be Facelock-created
+and no longer needed. A Facelock-created override may be deleted to reveal its
+vendor file only when it has no administrator changes. Never restore a backup
+over a newer service file merely because the backup exists. An unreadable,
+unwritable, wrong-owner, non-regular, changed, linked, or mount-separated
+service file makes cleanup incomplete: preserve its override, provenance
+header, and `.facelock-backup`, and report the exact remnant. Cleanup of one
+service does not authorize deleting provenance for a different service.
+
+### Native configuration lifecycles
+
+The package families reach the same ownership result through different native
+mechanisms:
+
+| Family and operation | Administrator-configuration contract |
+|----------------------|--------------------------------------|
+| Debian `remove` | `/etc/facelock/config.toml` is a Debian conffile and remains at its installed path. Biometric and operational state also remains |
+| Debian `purge` | `dpkg` removes the conffile, and the post-removal purge may then remove only safe remnants inside the compiled roots. Unsafe and external remnants are retained and reported |
+| RPM erase | `/etc/facelock/config.toml` is RPM `%config(noreplace)`. RPM removes an unmodified copy and retains an administrator-modified copy according to RPM semantics, commonly as `config.toml.rpmsave`. A `.rpmsave` is retained state, not evidence of a failed erase and not something a Facelock script deletes |
+| Arch package removal | the `backup` entry follows pacman's native saved-configuration behavior (including `.pacsave` when applicable). Facelock lifecycle code does not bypass it |
+| `just uninstall` | no package manager owns the config, so the source-install uninstall preserves `/etc/facelock` with the biometric and operational state |
+
+Debian `postrm purge` is self-contained. It never invokes the already-removed
+`facelock` binary. By the time `postrm` runs, package payloads cannot be treated
+as available cleanup tools. The future bounded purge must make its decisions
+from fixed constants and the remaining filesystem state, using only utilities
+that the maintainer script can rely on after removal; it cannot delegate safety
+checks or deletion to the CLI it is purging.
+
+RPM and Arch have no Debian-style second `purge` phase. Their ordinary erase
+therefore removes static integration and safely cleaned PAM provenance, while
+preserving biometric state and whatever administrator-configuration artifact
+their package manager retained.
+
+### Fixed-root purge boundary
+
+The only purge roots are the compiled Facelock roots:
+`/etc/facelock`, `/var/lib/facelock`, and `/var/log/facelock`. `/etc/pam.d` is
+a separate, fixed root for the narrow PAM cleanup above; it is never a recursive
+purge root. A configured path that remains within a compiled Facelock root is
+eligible for a later Debian purge only under the same safety checks as every
+other descendant.
+
+Configured paths outside those roots are external remnants. This includes
+external values of `daemon.model_dir`, `storage.db_path`, `encryption.key_path`,
+`encryption.sealed_key_path`, `audit.path`, and `snapshots.dir`. Removal and
+purge must leave them untouched, report that they were refused as external, and
+must not claim that all Facelock data is gone. A path becoming external through
+configuration does not expand package ownership.
+
+Any later purge implementation operates from fixed path constants and examines
+each entry without trusting path traversal. It must never follow a symbolic link
+or act through a hard-linked object, never cross a mount point, and never recurse through a
+non-directory or an object whose ownership cannot be proven safe. A root or
+descendant that fails those checks remains in place and is reported. A safe
+root may still be cleaned around an unsafe child, but the final report must name
+every remnant rather than describe the root as removed.
+
+Safety refusals and external remnants must not strand package-manager state.
+In particular, Debian purge reports and preserves an unsafe object but lets the
+maintainer-script lifecycle finish, so a link, mount, or wrong-owner file cannot
+leave the package permanently half-purged. This is not a broad recursive-delete
+contract: later code must enumerate the bounded roots and reject anything it
+cannot prove is inside them.
+
+Finally, filesystem removal does not promise secure erasure. Unlinking files
+does not guarantee that data is absent from SSD flash translation layers,
+snapshots, backups, journal history, or remapped blocks. Lifecycle messages may
+say which names were removed and which remnants remain; they must not describe
+purge as forensic destruction of biometric data.
 
 ## Filesystem Paths
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,11 +90,20 @@ Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, o
 just uninstall
 ```
 
-Config and data are preserved in `/etc/facelock` and `/var/lib/facelock`. To remove everything:
+### Package lifecycle and retained data
 
-```bash
-sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock
-```
+Ordinary package removal and `just uninstall` preserve the face database,
+encryption keys, downloaded models, enrollment markers, audit logs, snapshots,
+and setup state. Debian also retains its conffile until `purge`; RPM follows
+`%config(noreplace)` and may retain an administrator-modified config as
+`config.toml.rpmsave`.
+
+Facelock does not currently expose a safe "remove everything" command. Do not
+replace package lifecycle handling with a broad recursive deletion: configured
+state paths can live outside the default directories, and links, mounts, or
+wrong-owner remnants require inspection rather than traversal. See
+[Package Lifecycle Ownership](contracts.md#package-lifecycle-ownership) for the
+fixed roots, retained-data rules, and the limits of filesystem deletion.
 
 ## Configuration
 

--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ check-pam-standalone:
     fi
     echo "pam-facelock dependency guard passed"
 
-# Verify agent-facing docs still describe the tree they describe.
+# Verify agent-facing docs and executable documentation contracts.
 
 # Pass a git ref to also run the coupling check against it.
 check-agent-docs base='':
@@ -78,6 +78,7 @@ check-agent-docs base='':
     else
         python3 test/check-agent-docs.py
     fi
+    bash test/lifecycle-ownership-contract.sh
 
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
 check: test lint fmt-check audit check-pam-standalone check-agent-docs
@@ -693,8 +694,9 @@ uninstall-files:
     echo "==>   /var/lib/facelock/  (face database, ONNX models ~100MB)"
     echo "==>   /var/log/facelock/  (audit logs and snapshots)"
     echo "==>"
-    echo "==> To remove all face data, config, models, and logs:"
-    echo "==>   sudo rm -rf /etc/facelock /var/lib/facelock /var/log/facelock"
+    echo "==> Retained state cleanup is intentionally not automated."
+    echo "==> Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
+    echo "==> Filesystem deletion does not securely erase SSDs, snapshots, or backups."
 
 # ---------------------------------------------------------------------------
 # Localization (optional tooling)

--- a/test/lifecycle-ownership-contract.sh
+++ b/test/lifecycle-ownership-contract.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+failures=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    failures=$((failures + 1))
+}
+
+# These token-aware detectors are exercised by mutation fixtures below before
+# they inspect shipped guidance.
+has_recursive_retained_rm() {
+    awk '
+        function clean(token) {
+            sub(/^[^[:alnum:]_./-]+/, "", token)
+            sub(/[^[:alnum:]_./-]+$/, "", token)
+            return token
+        }
+
+        {
+            rm_seen = 0
+            recursive = 0
+            retained_root = 0
+
+            for (i = 1; i <= NF; i++) {
+                token = clean($i)
+                if (!rm_seen) {
+                    if (token == "rm")
+                        rm_seen = 1
+                    continue
+                }
+
+                if (token == "--recursive" || token ~ /^-[^-]*[rR][^-]*$/)
+                    recursive = 1
+                if (token ~ /^\/etc\/facelock(\/|$)/ ||
+                    token ~ /^\/var\/lib\/facelock(\/|$)/ ||
+                    token ~ /^\/var\/log\/facelock(\/|$)/)
+                    retained_root = 1
+            }
+
+            if (rm_seen && recursive && retained_root) {
+                print FNR ":" $0
+                found = 1
+            }
+        }
+
+        END { exit(found ? 0 : 1) }
+    '
+}
+
+has_nosave_facelock_removal() {
+    awk '
+        function clean(token) {
+            sub(/^[^[:alnum:]_./-]+/, "", token)
+            sub(/[^[:alnum:]_./-]+$/, "", token)
+            return token
+        }
+
+        {
+            pacman_seen = 0
+            remove = 0
+            nosave = 0
+            facelock = 0
+
+            for (i = 1; i <= NF; i++) {
+                raw = $i
+                token = clean(raw)
+                if (!pacman_seen) {
+                    if (token == "pacman")
+                        pacman_seen = 1
+                    continue
+                }
+
+                if (token == "--remove" || token ~ /^-[^-]*R[^-]*$/)
+                    remove = 1
+                if (token == "--nosave" || token ~ /^-[^-]*n[^-]*$/)
+                    nosave = 1
+                if (token == "facelock")
+                    facelock = 1
+
+                if (raw ~ /;/ || raw ~ /^#/ || token == "&&" || token == "||")
+                    break
+            }
+
+            if (pacman_seen && remove && nosave && facelock) {
+                print FNR ":" $0
+                found = 1
+            }
+        }
+
+        END { exit(found ? 0 : 1) }
+    '
+}
+
+assert_unsafe_fixture_detected() {
+    local detector="$1"
+    local name="$2"
+    local fixture="$3"
+
+    if ! "$detector" <<<"$fixture" >/dev/null; then
+        fail "mutation fixture escaped $detector: $name"
+    fi
+}
+
+assert_safe_fixture_allowed() {
+    local detector="$1"
+    local name="$2"
+    local fixture="$3"
+
+    if "$detector" <<<"$fixture" >/dev/null; then
+        fail "safe fixture triggered $detector: $name"
+    fi
+}
+
+# Recursive-rm flag case and ordering must not change the answer.
+assert_unsafe_fixture_detected has_recursive_retained_rm "uppercase recursive flag" \
+    'sudo rm -R /etc/facelock'
+assert_unsafe_fixture_detected has_recursive_retained_rm "grouped recursive flag" \
+    'rm -fr /var/lib/facelock'
+assert_unsafe_fixture_detected has_recursive_retained_rm "separate reordered flags" \
+    'rm -f -r /var/log/facelock'
+assert_unsafe_fixture_detected has_recursive_retained_rm "uppercase grouped recursive flag" \
+    'rm -Rf /etc/facelock'
+assert_unsafe_fixture_detected has_recursive_retained_rm "long recursive flag" \
+    'rm --recursive /var/lib/facelock'
+assert_safe_fixture_allowed has_recursive_retained_rm "package-owned static cleanup" \
+    'rm -rf /usr/share/facelock'
+assert_safe_fixture_allowed has_recursive_retained_rm "temporary directory cleanup" \
+    "rm -rf \"\$TMPDIR\""
+
+# Pacman save destruction is unsafe only for a Facelock removal command.
+assert_unsafe_fixture_detected has_nosave_facelock_removal "grouped nosave" \
+    'sudo pacman -Rns facelock'
+assert_unsafe_fixture_detected has_nosave_facelock_removal "reordered grouped nosave" \
+    'sudo pacman -Rsn facelock'
+assert_unsafe_fixture_detected has_nosave_facelock_removal "long nosave" \
+    'sudo pacman --remove --nosave facelock'
+assert_safe_fixture_allowed has_nosave_facelock_removal "save-preserving removal" \
+    'sudo pacman -Rs facelock'
+assert_safe_fixture_allowed has_nosave_facelock_removal "different package" \
+    'sudo pacman -Rns unrelated-package'
+assert_safe_fixture_allowed has_nosave_facelock_removal "unrelated prose" \
+    'pacman documents --nosave; facelock retains state'
+
+require_text() {
+    local path="$1"
+    local text="$2"
+
+    if ! grep -Fq -- "$text" "$repo_root/$path"; then
+        fail "$path must contain: $text"
+    fi
+}
+
+reject_text() {
+    local path="$1"
+    local text="$2"
+
+    if grep -Fq -- "$text" "$repo_root/$path"; then
+        fail "$path must not contain: $text"
+    fi
+}
+
+require_lifecycle_text() {
+    local text="$1"
+
+    if ! grep -Fq -- "$text" <<<"$lifecycle_prose"; then
+        fail "Package Lifecycle Ownership section must contain: $text"
+    fi
+}
+
+require_lifecycle_row() {
+    local label="$1"
+    shift
+    local rows
+    local count
+
+    rows="$(grep -F -- "| $label |" <<<"$lifecycle_section" || true)"
+    count="$(grep -Fc -- "| $label |" <<<"$lifecycle_section" || true)"
+    if [ "$count" -ne 1 ]; then
+        fail "Package Lifecycle Ownership must contain exactly one '$label' row (found $count)"
+        return
+    fi
+
+    local text
+    for text in "$@"; do
+        if ! grep -Fq -- "$text" <<<"$rows"; then
+            fail "'$label' row must contain: $text"
+        fi
+    done
+}
+
+reject_state_purge_command() {
+    local path="$1"
+    local unsafe_lines
+
+    if unsafe_lines="$(has_recursive_retained_rm <"$repo_root/$path")"; then
+        printf '%s\n' "$unsafe_lines" >&2
+        fail "$path recommends recursive deletion of retained Facelock state"
+    fi
+}
+
+reject_nosave_facelock_removal() {
+    local path="$1"
+    local unsafe_lines
+
+    if unsafe_lines="$(has_nosave_facelock_removal <"$repo_root/$path")"; then
+        printf '%s\n' "$unsafe_lines" >&2
+        fail "$path recommends removing Facelock with Pacman's no-save option"
+    fi
+}
+
+contract="docs/contracts.md"
+lifecycle_section="$({
+    sed -n '/^## Package Lifecycle Ownership$/,/^## Filesystem Paths$/p' \
+        "$repo_root/$contract"
+} || true)"
+
+if [ -z "$lifecycle_section" ]; then
+    fail "$contract is missing the Package Lifecycle Ownership section"
+fi
+lifecycle_prose="$(tr '\n' ' ' <<<"$lifecycle_section")"
+
+# Freeze status and the ownership classes are scoped to the lifecycle section,
+# not satisfied by an unrelated mention elsewhere in this large contract file.
+require_lifecycle_text "This is the Wave 0 ownership freeze for issue #232."
+require_lifecycle_text "does not claim that the current"
+require_lifecycle_text "Debian purge script already implements the bounded purge"
+require_lifecycle_text "Ordinary removal is not data deletion."
+require_lifecycle_row "Package-owned static integration" \
+    "Remove through the package manager" \
+    "recreated byte-for-byte by reinstalling the package"
+require_lifecycle_row "Biometric and operational state" \
+    "database and its WAL/SHM sidecars" \
+    "encryption keys and sealed keys" \
+    "downloaded models" \
+    "enrollment markers" \
+    "audit logs" \
+    "Preserve all of it"
+require_lifecycle_row "PAM integration and provenance" \
+    "Delete provenance only after the corresponding PAM cleanup is proven complete"
+require_lifecycle_row "Externally configured state" \
+    "Never package-owned" \
+    "Leave it untouched and report it as an external remnant"
+
+# Bind each package operation to its own row so remove, purge, and erase cannot
+# borrow one another's promises.
+require_lifecycle_row "Debian \`remove\`" \
+    "Debian conffile" \
+    "remains at its installed path" \
+    "Biometric and operational state also remains"
+require_lifecycle_row "Debian \`purge\`" \
+    "removes the conffile" \
+    "only safe remnants inside the compiled roots" \
+    "Unsafe and external remnants are retained and reported"
+require_lifecycle_row "RPM erase" \
+    "RPM \`%config(noreplace)\`" \
+    "\`.rpmsave\` is retained state" \
+    "not something a Facelock script deletes"
+require_lifecycle_row "Arch package removal" \
+    "pacman's native saved-configuration behavior" \
+    "\`.pacsave\`"
+require_lifecycle_row "\`just uninstall\`" \
+    "preserves \`/etc/facelock\`" \
+    "biometric and operational state"
+
+require_lifecycle_text "PAM provenance and rollback files are not biometric state."
+require_lifecycle_text "Preserve PAM provenance when cleanup is incomplete"
+require_lifecycle_text "The only purge roots are the compiled Facelock roots"
+require_lifecycle_text "Configured paths outside those roots are external remnants"
+require_lifecycle_text "leave them untouched, report that they were refused as external"
+require_lifecycle_text "never follow a symbolic link"
+require_lifecycle_text "hard-linked object"
+require_lifecycle_text "never cross a mount point"
+require_lifecycle_text "must not strand package-manager state"
+require_lifecycle_text "does not promise secure erasure"
+require_lifecycle_text "Debian \`postrm purge\` is self-contained"
+require_lifecycle_text "never invokes the already-removed \`facelock\` binary"
+
+for guide in docs/quickstart.md book/src/quickstart.md; do
+    require_text "$guide" "Package lifecycle and retained data"
+done
+
+lifecycle_messages=(
+    justfile
+    dist/debian/postrm
+    dist/facelock.spec
+    dist/facelock.install
+    dist/omarchy/omarchy-remove-security-face
+)
+
+lifecycle_guidance=(
+    docs/quickstart.md
+    book/src/quickstart.md
+    "${lifecycle_messages[@]}"
+)
+
+for surface in "${lifecycle_guidance[@]}"; do
+    reject_state_purge_command "$surface"
+done
+
+for message in "${lifecycle_messages[@]}"; do
+    reject_text "$message" "To remove all face data"
+    require_text "$message" "Retained state cleanup is intentionally not automated."
+    require_text "$message" "Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
+    require_text "$message" "Filesystem deletion does not securely erase SSDs, snapshots, or backups."
+done
+
+reject_nosave_facelock_removal dist/omarchy/omarchy-remove-security-face
+require_text dist/omarchy/omarchy-remove-security-face \
+    "sudo pacman -Rs facelock"
+
+if [ "$failures" -ne 0 ]; then
+    echo "lifecycle ownership contract: $failures failure(s)" >&2
+    exit 1
+fi
+
+echo "lifecycle ownership contract: OK"


### PR DESCRIPTION
- freeze cross-distro ownership before lifecycle scripts are rewritten
- preserve biometric and administrator state while bounding future fixed-root cleanup
- reject unsafe retained-state removal guidance in required checks
- relate #232
