### PR TITLE
fix(camera): require verified y16 texture scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -716,20 +716,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/proc/<pid>/task/*/status` on the running daemon and asserts `CAP_CHOWN` is
   clear on every thread.
 
-- **Y16 8-bit scaling is pinned at camera open**: the bit-depth shift is derived
-  once and reused for the whole session. Deriving it per frame was contrast
-  normalization upstream of the IR texture check — it moved the scale
-  `security.ir_texture_min_stddev` is calibrated against in response to scene
-  illumination, and a single saturated pixel blacked out whole frames. The shift
-  comes from the new quirk key `y16_bit_depth` when a device declares one
-  (hardware truth, no frame inspected); otherwise it is calibrated from the peak
-  of a short burst of frames rather than a single frame, so a dark pre-AGC frame
-  at open no longer pins an 8-bit scale that clips the rest of the session.
-  "The session" is the lifetime of one open camera: the daemon's warm camera
-  hold keeps the scale it pinned, and a reopen recalibrates — no scale is
-  carried across a reopen onto a device that did not produce it. On IR hardware
-  the burst is emitter-LED-on time inside `Camera::open` (bounded by one
-  second); declaring `y16_bit_depth` skips it.
+- **Y16 authentication now requires verified scale provenance** (#161): a
+  selected and negotiated Y16 stream is eligible for the absolute IR texture
+  check only when its matched quirk declares a valid `y16_bit_depth` in
+  `8..=16`. Missing or invalid depth rejects authentication recoverably before
+  any authentication capture, including when `security.require_ir = false`, so
+  password fallback remains available without skipping texture enforcement or
+  downgrading to RGB. The selected normalized FourCC establishes the expected
+  state before open, and the post-`S_FMT` FourCC is checked again so negotiation
+  drift to unverified Y16 rejects the same way. GREY remains native 8-bit.
+  Scene-derived Y16 calibration is lazy and limited to non-authentication
+  capture; it never establishes authentication evidence or verified provenance.
 
 ## [0.1.4] - 2026-05-31
 

--- a/config/quirks.d/00-defaults.toml
+++ b/config/quirks.d/00-defaults.toml
@@ -22,14 +22,18 @@
 #   format_preference       - preferred pixel format (e.g. "GREY", "Y16 ", "YUYV");
 #                             counts as IR evidence only when IR-typical and
 #                             actually advertised by the capture node
-#   y16_bit_depth           - effective bit depth of this sensor's Y16 samples
-#                             (8..=16, e.g. 10 for a 10-bit sensor). Pins the
-#                             Y16 -> 8-bit scale from hardware truth instead of
-#                             calibrating it from frames at camera open.
+#   y16_bit_depth           - verified effective bit depth of this sensor's Y16
+#                             samples (8..=16, e.g. 10 for a 10-bit sensor).
+#                             Required for Y16 authentication. Add only from
+#                             hardware documentation or validation; scene
+#                             calibration is not authentication evidence.
 #   rotation                - image rotation in degrees (0, 90, 180, 270)
 #   notes                   - human-readable explanation
 
 # --- Intel RealSense ---
+# No y16_bit_depth is shipped for these entries because facelock has no Y16
+# hardware validation record. Their Y16 streams classify as IR but auth rejects
+# recoverably until an evidence-backed local or shipped quirk supplies depth.
 
 [[quirk]]
 vendor_id = "8086"

--- a/crates/facelock-camera/src/caps.rs
+++ b/crates/facelock-camera/src/caps.rs
@@ -11,7 +11,7 @@ use facelock_core::config::DeviceConfig;
 use facelock_core::error::Result;
 use facelock_core::types::CameraCaps;
 
-use crate::capture::Camera;
+use crate::capture::{Camera, ir_texture_scale_for_format, select_format_for_quirk};
 use crate::device::{self, DeviceInfo};
 use crate::quirks::{Quirk, QuirksDb, device_fingerprint};
 
@@ -56,10 +56,20 @@ impl ResolvedCamera {
     /// `ResolvedCamera` has.
     pub fn interrogate(info: DeviceInfo, quirks: &QuirksDb) -> Self {
         let quirk = quirks.find_match(&info).cloned();
+        let available: Vec<String> = info
+            .formats
+            .iter()
+            .map(|format| format.fourcc.trim().to_string())
+            .collect();
+        let selected_format = select_format_for_quirk(quirk.as_ref(), &available)
+            .and_then(|index| available.get(index))
+            .map(String::as_str)
+            .unwrap_or("");
         let caps = CameraCaps {
             is_ir: device::is_ir_camera_resolved(&info, Some(quirks)),
             fingerprint: device_fingerprint(&info.path),
             applied_quirks: quirk.as_ref().map(quirk_id).into_iter().collect(),
+            ir_texture_scale: ir_texture_scale_for_format(selected_format, quirk.as_ref()),
         };
         Self { info, quirk, caps }
     }
@@ -92,7 +102,7 @@ pub fn quirk_id(quirk: &Quirk) -> String {
 mod tests {
     use super::*;
     use crate::ir_emitter::EmitterXuInfo;
-    use facelock_core::types::{DeviceFingerprint, FormatInfo};
+    use facelock_core::types::{DeviceFingerprint, FormatInfo, IrTextureScale};
 
     fn device_with(name: &str, fourccs: &[&str]) -> DeviceInfo {
         DeviceInfo {
@@ -125,6 +135,69 @@ mod tests {
             rotation: None,
             notes: None,
         }
+    }
+
+    fn y16_quirks(bit_depth: Option<u8>) -> QuirksDb {
+        let mut db = QuirksDb::default();
+        let mut q = quirk("(?i)test y16 camera");
+        q.format_preference = Some("Y16".into());
+        q.y16_bit_depth = bit_depth;
+        db.push_quirk_for_test(q);
+        db
+    }
+
+    #[test]
+    fn y16_without_a_declared_bit_depth_has_unverified_texture_scale() {
+        let resolved = ResolvedCamera::interrogate(
+            device_with("Test Y16 Camera", &["Y16"]),
+            &y16_quirks(None),
+        );
+
+        assert_eq!(
+            resolved.caps.ir_texture_scale,
+            IrTextureScale::UnverifiedY16
+        );
+    }
+
+    #[test]
+    fn y16_with_an_invalid_declared_bit_depth_has_unverified_texture_scale() {
+        for bit_depth in [0, 7, 17, u8::MAX] {
+            let resolved = ResolvedCamera::interrogate(
+                device_with("Test Y16 Camera", &["Y16"]),
+                &y16_quirks(Some(bit_depth)),
+            );
+
+            assert_eq!(
+                resolved.caps.ir_texture_scale,
+                IrTextureScale::UnverifiedY16,
+                "invalid bit depth {bit_depth} must not become trusted scale provenance"
+            );
+        }
+    }
+
+    #[test]
+    fn y16_with_a_valid_declared_bit_depth_has_verified_texture_scale() {
+        for bit_depth in [10, 12, 16] {
+            let resolved = ResolvedCamera::interrogate(
+                device_with("Test Y16 Camera", &["Y16"]),
+                &y16_quirks(Some(bit_depth)),
+            );
+
+            assert_eq!(
+                resolved.caps.ir_texture_scale,
+                IrTextureScale::VerifiedY16 { bit_depth },
+            );
+        }
+    }
+
+    #[test]
+    fn grey_selection_never_requires_y16_scale_provenance() {
+        let resolved = ResolvedCamera::interrogate(
+            device_with("Test Y16 Camera", &["GREY", "Y16"]),
+            &QuirksDb::default(),
+        );
+
+        assert_eq!(resolved.caps.ir_texture_scale, IrTextureScale::NotY16);
     }
 
     #[test]

--- a/crates/facelock-camera/src/capture.rs
+++ b/crates/facelock-camera/src/capture.rs
@@ -1,7 +1,7 @@
 use facelock_core::config::DeviceConfig;
 use facelock_core::error::{FacelockError, Result};
 use facelock_core::traits::CameraSource;
-use facelock_core::types::Frame;
+use facelock_core::types::{Frame, IrTextureScale};
 use image::ImageReader;
 use std::io::Cursor;
 use std::time::{Duration, Instant};
@@ -25,23 +25,21 @@ const CAPTURE_TIMEOUT: Duration = Duration::from_secs(2);
 /// keeps that discard correct if the buffer depth ever changes.
 pub const MMAP_BUFFERS: u32 = 4;
 
-/// Minimum frames sampled at open to calibrate the Y16 -> 8-bit scale when no
-/// quirk supplies a sensor bit depth. Calibrating from a single frame races the
-/// camera's own AGC/AE warmup: a dark first frame pins an 8-bit scale that
-/// clips every warmed-up 10/12-bit frame to flat white, which the IR texture
-/// check then rejects. A short burst gives exposure time to move.
+/// Minimum frames sampled on the first non-auth capture to calibrate Y16 ->
+/// 8-bit conversion when no quirk supplies a sensor bit depth. Calibrating
+/// from a single frame races the camera's own AGC/AE warmup: a dark first
+/// frame pins an 8-bit scale that clips every warmed-up 10/12-bit frame to
+/// flat white. A short burst gives exposure time to move.
 ///
-/// This burst is paid on a COLD open only, and only on a Y16 device: the
-/// daemon's warm hold (ADR 008 §4) reuses the `Camera` and therefore its
-/// already-pinned scale. It is nonetheless emitter-LED-on time on IR
-/// hardware, which is exactly what ADR 008 set out to shorten — a device that
-/// declares `y16_bit_depth` in its quirk skips the burst entirely and is the
-/// preferred configuration on any camera where the reopen cost matters.
+/// Authentication rejects unverified Y16 before reaching this burst. Other
+/// callers pay it only once per open camera: the daemon's warm hold (ADR 008
+/// §4) reuses the `Camera` and therefore its already-pinned conversion scale.
 const Y16_CALIBRATION_FRAMES: usize = 8;
 
 /// Wall-clock ceiling on that burst. Frames are already flowing when it runs,
 /// so it normally costs a fraction of a second; the budget keeps a stalling
-/// camera from stretching `Camera::open` by `CAPTURE_TIMEOUT` eight times over.
+/// camera from stretching the first non-auth capture by `CAPTURE_TIMEOUT`
+/// eight times over.
 ///
 /// This bounds when the burst STOPS starting new captures, not when it
 /// returns: the check sits at the top of the loop, so a dequeue begun just
@@ -96,17 +94,49 @@ fn quirk_format_preference(quirk: Option<&Quirk>) -> Option<&str> {
 
 /// The Y16 shift implied by a quirk's declared sensor bit depth, if any.
 /// A depth the 16-bit container cannot hold is a quirks-file typo rather than
-/// hardware truth: warn and let frame calibration decide instead.
+/// hardware truth. Non-auth capture can still calibrate its conversion from
+/// frames, but authentication treats that scale as unverified.
 fn quirk_y16_shift(quirk: Option<&Quirk>) -> Option<u8> {
     let bit_depth = quirk.and_then(|q| q.y16_bit_depth)?;
     let shift = preprocess::y16_shift_from_bit_depth(bit_depth);
     if shift.is_none() {
         tracing::warn!(
             bit_depth,
-            "quirk y16_bit_depth is outside 8..=16 — ignoring, calibrating from frames"
+            "quirk y16_bit_depth is outside 8..=16 — ignoring for authentication; \
+             non-auth capture will calibrate conversion from frames"
         );
     }
     shift
+}
+
+/// Scale provenance for the format a camera will actually feed into the IR
+/// texture check. The raw quirk value is trusted only when it describes the
+/// Y16 container (8..=16); scene calibration never upgrades this state.
+pub(crate) fn ir_texture_scale_for_format(format: &str, quirk: Option<&Quirk>) -> IrTextureScale {
+    if format != "Y16" {
+        return IrTextureScale::NotY16;
+    }
+
+    match quirk.and_then(|q| q.y16_bit_depth) {
+        Some(bit_depth) if preprocess::y16_shift_from_bit_depth(bit_depth).is_some() => {
+            IrTextureScale::VerifiedY16 { bit_depth }
+        }
+        _ => IrTextureScale::UnverifiedY16,
+    }
+}
+
+/// Select the format a camera is expected to negotiate, using the same quirk
+/// and global priority as [`Camera::open_resolved`].
+pub(crate) fn select_format_for_quirk(
+    quirk: Option<&Quirk>,
+    available: &[String],
+) -> Option<usize> {
+    let mut preferred: Vec<&str> = Vec::with_capacity(DECODABLE_FORMATS.len() + 1);
+    if let Some(fmt_pref) = quirk_format_preference(quirk) {
+        preferred.push(fmt_pref);
+    }
+    preferred.extend_from_slice(DECODABLE_FORMATS);
+    select_format(&preferred, available)
 }
 
 /// How many frames the calibration burst aims for on this device. A quirk's
@@ -120,22 +150,23 @@ fn y16_calibration_frames(quirk: Option<&Quirk>) -> usize {
         .max(Y16_CALIBRATION_FRAMES as u32) as usize
 }
 
-/// Pin the session Y16 scale by sampling a burst of frames and taking the
-/// brightest sample any of them produced.
+/// Pin a non-auth session's Y16 conversion scale by sampling a burst of frames
+/// and taking the brightest sample any of them produced.
 ///
 /// More frames raise the peak toward the sensor's full scale, which is the
 /// point of the burst. They do NOT bound it from above: `y16_peak` is an
 /// unbounded max over every pixel, so one stuck pixel or one specular IR
 /// glint sets it alone. On a 10-bit sensor a pixel latched at 4095 pins
 /// shift 4 where 2 was right, and every later frame is scaled down 4x —
-/// enough to drop a real face under `ir_texture_min_stddev` for the whole
-/// session. `Y16Calibration::Saturated` only catches the `u16::MAX`
+/// enough to darken a non-auth preview/enrollment for the whole session.
+/// `Y16Calibration::Saturated` only catches the `u16::MAX`
 /// endpoint, so that case warns nothing. A quirk's `y16_bit_depth` is the
-/// only way to take the scale out of the scene's hands entirely.
+/// only way to take the scale out of the scene's hands entirely, and the only
+/// scale authentication accepts.
 ///
-/// A capture error ends the open. It is tempting to tolerate a few and keep
-/// sampling, but no `next()` error is transient here: `v4l`'s capture stream
-/// advances `arena_index` only on a successful dequeue and re-queues that
+/// A capture error ends the first capture. It is tempting to tolerate a few
+/// and keep sampling, but no `next()` error is transient here: `v4l`'s
+/// capture stream advances `arena_index` only on a successful dequeue and re-queues that
 /// same index on the following call, so one failed dequeue leaves the buffer
 /// queued in the kernel and every later call re-queues it and gets EINVAL.
 /// Tolerating errors would therefore trade a hard failure carrying the real
@@ -241,7 +272,10 @@ pub struct Camera<'a> {
     emitter_xu_info: Option<EmitterXuInfo>,
     /// Capabilities computed at construction — see `crate::caps` (gap D8).
     caps: CameraCaps,
-    /// Y16 -> 8-bit shift, derived once at open. Never recomputed per frame:
+    /// Y16 -> 8-bit shift. A verified quirk pins it at open; an unverified Y16
+    /// leaves it absent until the first non-auth capture calibrates it. Auth
+    /// rejects the unverified capability before capture. Once present it is
+    /// never recomputed per frame:
     /// a per-frame scale is contrast normalization upstream of the IR texture
     /// check (see `docs/security.md` §1.C).
     ///
@@ -249,7 +283,10 @@ pub struct Camera<'a> {
     /// daemon's warm camera hold (ADR 008 §4): a hold reuses this same struct,
     /// so the scale it pinned stays pinned; a reopen constructs a new `Camera`
     /// and recalibrates. Nothing carries a scale across a reopen.
-    y16_shift: u8,
+    y16_shift: Option<u8>,
+    /// Number of frames used if a non-auth caller first captures from an
+    /// unverified Y16 stream.
+    y16_calibration_frames: usize,
 }
 
 impl<'a> Camera<'a> {
@@ -271,7 +308,8 @@ impl<'a> Camera<'a> {
     /// - `format_preference` is prepended to the format priority list.
     /// - `warmup_frames` replaces `config.warmup_frames`.
     /// - `rotation` replaces `config.rotation`.
-    /// - `y16_bit_depth` pins the Y16 scale, skipping frame calibration.
+    /// - `y16_bit_depth` pins verified Y16 scale, skipping non-auth frame
+    ///   calibration.
     pub(crate) fn open_resolved(
         config: &DeviceConfig,
         quirk: Option<&Quirk>,
@@ -309,15 +347,8 @@ impl<'a> Camera<'a> {
             .enum_formats()
             .map_err(|e| FacelockError::Camera(format!("failed to enum formats: {e}")))?;
 
-        let mut preferred: Vec<&str> = Vec::with_capacity(DECODABLE_FORMATS.len() + 1);
-        if let Some(fmt_pref) = quirk_format_preference(quirk) {
-            tracing::debug!(format = fmt_pref, "quirk: prepending format preference");
-            preferred.push(fmt_pref);
-        }
-        preferred.extend_from_slice(DECODABLE_FORMATS);
-
         let available: Vec<String> = formats.iter().map(|f| normalize_fourcc(f.fourcc)).collect();
-        let selected_fourcc = select_format(&preferred, &available)
+        let selected_fourcc = select_format_for_quirk(quirk, &available)
             .map(|idx| formats[idx].fourcc)
             .ok_or_else(|| {
                 FacelockError::Camera(format!(
@@ -347,6 +378,11 @@ impl<'a> Camera<'a> {
         let width = fmt.width;
         let height = fmt.height;
         let format_str = normalize_fourcc(fmt.fourcc);
+        let mut caps = caps;
+        // A V4L2 driver may negotiate a different FourCC than requested. The
+        // open camera's auth boundary must describe what frames actually use,
+        // not what interrogation predicted before `VIDIOC_S_FMT`.
+        caps.ir_texture_scale = ir_texture_scale_for_format(&format_str, quirk);
         tracing::info!(
             device = %device_path,
             format = %format_str,
@@ -396,47 +432,21 @@ impl<'a> Camera<'a> {
             false
         };
 
-        // Pin the Y16 -> 8-bit scale for the whole session. A quirk-declared
-        // sensor bit depth is authoritative; otherwise calibrate from a burst
-        // of frames. Must run after the IR emitter is enabled, otherwise the
-        // scale is derived from unlit frames and every lit frame clips to white.
+        // Pin verified Y16 scale at open. An unverified stream stays
+        // uncalibrated until a non-auth caller asks for a frame: auth can then
+        // reject negotiated-format drift without capturing calibration data.
         let y16_shift = if format_str == "Y16" {
             match quirk_y16_shift(quirk) {
                 Some(shift) => {
                     tracing::info!(device = %device_path, shift, "Y16 session scale from quirk bit depth");
-                    shift
+                    Some(shift)
                 }
-                None => {
-                    // Not `?`: the emitter is already lit and `Camera` does not
-                    // exist yet, so an early return here would skip the `Drop`
-                    // that is the only thing which turns it back off. Every
-                    // other failure path above runs before the emitter is
-                    // enabled; this one is the exception, so it cleans up.
-                    match calibrate_y16_shift(
-                        &mut stream,
-                        &device_path,
-                        y16_calibration_frames(quirk),
-                    ) {
-                        Ok(shift) => shift,
-                        Err(e) => {
-                            if ir_emitter_active
-                                && let Some(ref xu_info) = emitter_xu_info
-                                && let Err(off) =
-                                    ir_emitter::disable_emitter_with_info(&device_path, xu_info)
-                            {
-                                tracing::warn!(
-                                    "failed to disable IR emitter on {device_path} after \
-                                             Y16 calibration failed: {off}"
-                                );
-                            }
-                            return Err(e);
-                        }
-                    }
-                }
+                None => None,
             }
         } else {
-            0
+            Some(0)
         };
+        let y16_calibration_frames = y16_calibration_frames(quirk);
 
         // Apply quirk overrides for rotation (warmup_frames is handled by the caller
         // since Camera::open doesn't consume warmup frames itself).
@@ -463,6 +473,7 @@ impl<'a> Camera<'a> {
             emitter_xu_info,
             caps,
             y16_shift,
+            y16_calibration_frames,
         })
     }
 
@@ -508,6 +519,17 @@ impl<'a> Camera<'a> {
 
     /// Internal: capture and convert to RGB, applying downscale and rotation.
     fn capture_rgb(&mut self) -> Result<(Vec<u8>, u32, u32)> {
+        if self.format == "Y16" && self.y16_shift.is_none() {
+            // Authentication checks `caps.ir_texture_scale` before any
+            // capture. This lazy path exists for enrollment/preview/bench
+            // conversion only and never upgrades the capability to verified.
+            self.y16_shift = Some(calibrate_y16_shift(
+                &mut self.stream,
+                &self.device_path,
+                self.y16_calibration_frames,
+            )?);
+        }
+
         // stream.next() uses the v4l built-in poll with CAPTURE_TIMEOUT.
         // If the camera stops producing frames, this returns TimedOut error
         // instead of blocking forever.
@@ -529,7 +551,10 @@ impl<'a> Camera<'a> {
             }
             "Y16" => {
                 // 16-bit grayscale -> 8-bit at the session-fixed scale, replicated 3x
-                let gray = preprocess::y16_to_gray(buf, self.y16_shift);
+                let shift = self.y16_shift.ok_or_else(|| {
+                    FacelockError::Camera("Y16 conversion scale was not initialized".into())
+                })?;
+                let gray = preprocess::y16_to_gray(buf, shift);
                 let mut rgb = Vec::with_capacity(gray.len() * 3);
                 for &p in &gray {
                     rgb.push(p);
@@ -769,8 +794,8 @@ mod tests {
 
     #[test]
     fn quirk_y16_shift_absent_falls_back_to_calibration() {
-        // No quirk, and a quirk without the field, both leave the burst
-        // calibration in charge.
+        // No quirk, and a quirk without the field, both leave non-auth burst
+        // calibration in charge without verifying authentication scale.
         assert_eq!(quirk_y16_shift(None), None);
         assert_eq!(quirk_y16_shift(Some(&quirk_with_format("Y16"))), None);
     }
@@ -796,6 +821,30 @@ mod tests {
         assert_eq!(quirk_y16_shift(Some(&quirk)), None);
         quirk.y16_bit_depth = Some(4);
         assert_eq!(quirk_y16_shift(Some(&quirk)), None);
+    }
+
+    #[test]
+    fn actual_negotiated_format_controls_y16_texture_scale_provenance() {
+        use facelock_core::types::IrTextureScale;
+
+        let mut quirk = quirk_with_format("Y16");
+        quirk.y16_bit_depth = Some(12);
+        assert_eq!(
+            ir_texture_scale_for_format("GREY", Some(&quirk)),
+            IrTextureScale::NotY16,
+            "a driver that negotiates GREY must not inherit Y16 requirements"
+        );
+        assert_eq!(
+            ir_texture_scale_for_format("Y16", Some(&quirk)),
+            IrTextureScale::VerifiedY16 { bit_depth: 12 }
+        );
+
+        quirk.y16_bit_depth = Some(17);
+        assert_eq!(
+            ir_texture_scale_for_format("Y16", Some(&quirk)),
+            IrTextureScale::UnverifiedY16,
+            "an invalid raw quirk value is provenance, not verification"
+        );
     }
 
     #[test]

--- a/crates/facelock-camera/src/preprocess.rs
+++ b/crates/facelock-camera/src/preprocess.rs
@@ -103,19 +103,19 @@ pub fn y16_shift_from_peak(peak: u16) -> u8 {
     (16 - peak.leading_zeros()).saturating_sub(8) as u8
 }
 
-/// Right-shift that maps a Y16 sensor's effective bit depth onto 8 bits,
-/// derived from the brightest sample in `data`.
+/// Right-shift that maps a Y16 container onto 8 bits, derived from the
+/// brightest sample in `data` for non-auth conversion.
 ///
 /// The shift MUST be derived once per camera session and reused for every
 /// frame. Recomputing it per frame is contrast normalization upstream of
-/// [`check_ir_texture`], whose `min_stddev` cutoff is calibrated against a
-/// fixed scale (see `docs/security.md` §1.C).
+/// [`check_ir_texture`], whose `min_stddev` cutoff requires verified hardware
+/// scale provenance instead (see `docs/security.md` §1.C).
 ///
 /// Test-only, deliberately: a one-shot whole-buffer helper is the shape a
 /// per-frame call takes, and shipping it as API invites exactly the recompute
-/// the paragraph above forbids. The capture path pins the scale from a burst
-/// instead (`calibrate_y16_shift`); this remains so the tests can pin the
-/// peak-to-shift mapping in one call.
+/// the paragraph above forbids. Non-auth capture pins its conversion scale
+/// from a burst instead (`calibrate_y16_shift`); this remains so the tests can
+/// pin the peak-to-shift mapping in one call.
 #[cfg(test)]
 fn y16_shift(data: &[u8]) -> u8 {
     y16_shift_from_peak(y16_peak(data))
@@ -124,8 +124,8 @@ fn y16_shift(data: &[u8]) -> u8 {
 /// Right-shift for a sensor bit depth supplied by the hardware quirks DB.
 ///
 /// `None` for a depth that cannot describe a Y16 sample (below 8 bits, or above
-/// the 16-bit container); the caller warns and falls back to frame calibration
-/// rather than trusting a typo in a quirks file.
+/// the 16-bit container); the caller never trusts a typo as authentication
+/// provenance. Non-auth conversion may still fall back to frame calibration.
 pub fn y16_shift_from_bit_depth(bit_depth: u8) -> Option<u8> {
     (8..=16).contains(&bit_depth).then(|| bit_depth - 8)
 }

--- a/crates/facelock-camera/src/quirks.rs
+++ b/crates/facelock-camera/src/quirks.rs
@@ -35,10 +35,10 @@ pub struct Quirk {
     /// Preferred pixel format
     #[serde(default)]
     pub format_preference: Option<String>,
-    /// Effective bit depth of this sensor's Y16 samples (8..=16). Authoritative
-    /// when present: the session Y16 -> 8-bit shift becomes `bit_depth - 8` and
-    /// no calibration frames are captured, so the scale cannot depend on what
-    /// the lens happened to see at open.
+    /// Verified effective bit depth of this sensor's Y16 samples (8..=16).
+    /// When present and valid, the session Y16 -> 8-bit shift becomes
+    /// `bit_depth - 8`; absent or invalid values cannot authorize Y16 texture
+    /// enforcement, even if non-auth conversion calibrates from frames.
     #[serde(default)]
     pub y16_bit_depth: Option<u8>,
     /// Image rotation in degrees
@@ -478,8 +478,8 @@ notes = "Test camera"
         assert_eq!(file.quirk[0].vendor_id.as_deref(), Some("8086"));
         assert_eq!(file.quirk[0].force_ir, Some(true));
         assert_eq!(file.quirk[0].warmup_frames, Some(10));
-        // Omitted keys stay None: an entry written before y16_bit_depth existed
-        // keeps calibrating the Y16 scale from frames.
+        // Omitted keys stay None: non-auth conversion may calibrate from
+        // frames, but Y16 authentication remains unverified.
         assert_eq!(file.quirk[0].y16_bit_depth, None);
     }
 
@@ -883,6 +883,29 @@ notes = "Full test quirk"
             if let Some(pref) = q.format_preference.as_deref() {
                 assert_eq!(pref, pref.trim(), "loader left padding on {pref:?}");
             }
+        }
+    }
+
+    /// The repository has no Y16 hardware validation record yet. Keep the
+    /// shipped RealSense entries explicitly unverified instead of inventing a
+    /// sensor depth from their 16-bit V4L2 container.
+    #[test]
+    fn shipped_y16_quirks_do_not_claim_an_unverified_bit_depth() {
+        let Some(quirks) = shipped_default_quirks() else {
+            return;
+        };
+        let y16: Vec<_> = quirks
+            .iter()
+            .filter(|q| q.format_preference.as_deref() == Some("Y16"))
+            .collect();
+
+        assert_eq!(y16.len(), 3, "expected the three shipped RealSense entries");
+        for q in y16 {
+            assert_eq!(
+                q.y16_bit_depth, None,
+                "shipped quirk {:?} claims Y16 depth without validation evidence",
+                q.notes
+            );
         }
     }
 

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -221,13 +221,17 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
         }
     };
 
-    // Discard warmup frames for AGC/AE stabilization.
-    for _ in 0..warmup {
-        if cancel.is_cancelled() {
-            info!(user = %user, "cancelled");
-            return 2;
+    // Negotiation may drift from the preflight FourCC. Do not let warmup
+    // capture precede the auth loop's stable unverified-Y16 rejection.
+    if camera.capabilities().ir_texture_scale != facelock_core::types::IrTextureScale::UnverifiedY16
+    {
+        for _ in 0..warmup {
+            if cancel.is_cancelled() {
+                info!(user = %user, "cancelled");
+                return 2;
+            }
+            let _ = camera.capture();
         }
-        let _ = camera.capture();
     }
 
     // Load embeddings through the decryption-aware path so the oneshot binary
@@ -308,19 +312,20 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
             info!(user = %user, duration_ms, "cancelled");
             2
         }
-        AuthOutcome::Error {
-            kind: ErrorKind::AllFramesDark,
-            ..
-        } => {
-            // `authenticate_with_embeddings` already audited this one, so
+        AuthOutcome::Error { kind, .. }
+            if matches!(
+                kind,
+                ErrorKind::AllFramesDark | ErrorKind::Y16BitDepthRequired
+            ) =>
+        {
+            // `authenticate_with_embeddings` already audited both classes, so
             // unlike the arm below there is nothing to write here.
-            info!(user = %user, "all frames dark");
-            oneshot_exit_code(ErrorKind::AllFramesDark)
+            info!(user = %user, error_kind = ?kind, "camera authentication rejected");
+            oneshot_exit_code(kind)
         }
         AuthOutcome::Error { kind, message } => {
-            // Errors from authenticate() other than all-frames-dark are
-            // storage errors which happen before the auth loop — audit those
-            // here, under the class's own label.
+            // Errors not audited by the camera auth loop are written here,
+            // under the class's own label.
             audit::write_audit_entry(
                 &config.audit,
                 &AuditEntry {
@@ -536,6 +541,7 @@ fn oneshot_exit_code(kind: ErrorKind) -> i32 {
         | ErrorKind::RateLimited
         | ErrorKind::RateLimitCheckFailed
         | ErrorKind::IrRequired
+        | ErrorKind::Y16BitDepthRequired
         | ErrorKind::Internal => 2,
     }
 }
@@ -683,6 +689,12 @@ mod tests {
             (
                 ErrorKind::IrRequired,
                 "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).",
+                "error",
+                2,
+            ),
+            (
+                ErrorKind::Y16BitDepthRequired,
+                "Y16 IR texture scale is unverified; authentication requires a verified y16_bit_depth (8..=16) quirk",
                 "error",
                 2,
             ),

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -71,10 +71,28 @@ pub(crate) fn resolve_camera_device(config: &Config) -> anyhow::Result<ResolvedC
     Ok(ResolvedCamera::interrogate(device_info, &quirks))
 }
 
-/// Open an already-resolved camera and discard warmup frames.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CameraPurpose {
+    Authentication,
+    Capture,
+}
+
+fn warmup_capture_count(
+    purpose: CameraPurpose,
+    ir_texture_scale: facelock_core::types::IrTextureScale,
+    requested: u32,
+) -> u32 {
+    match (purpose, ir_texture_scale) {
+        (CameraPurpose::Authentication, facelock_core::types::IrTextureScale::UnverifiedY16) => 0,
+        _ => requested,
+    }
+}
+
+/// Open an already-resolved camera and apply its purpose-specific warmup.
 fn open_resolved_camera(
     config: &Config,
     resolved: ResolvedCamera,
+    purpose: CameraPurpose,
 ) -> anyhow::Result<Camera<'static>> {
     // Discard warmup frames for AGC/AE stabilization.
     // Quirk override takes precedence over config value.
@@ -86,9 +104,10 @@ fn open_resolved_camera(
     let mut camera = resolved
         .open(&config.device)
         .context("failed to open camera")?;
-    if warmup > 0 {
-        debug!(warmup, "discarding warmup frames");
-        for _ in 0..warmup {
+    let captures = warmup_capture_count(purpose, camera.capabilities().ir_texture_scale, warmup);
+    if captures > 0 {
+        debug!(warmup = captures, "discarding warmup frames");
+        for _ in 0..captures {
             let _ = camera.capture();
         }
     }
@@ -98,7 +117,11 @@ fn open_resolved_camera(
 
 /// Open camera with quirks support and warmup frame discarding.
 pub fn open_camera(config: &Config) -> anyhow::Result<Camera<'static>> {
-    open_resolved_camera(config, resolve_camera_device(config)?)
+    open_resolved_camera(
+        config,
+        resolve_camera_device(config)?,
+        CameraPurpose::Capture,
+    )
 }
 
 pub fn load_engine(config: &Config) -> anyhow::Result<FaceEngine> {
@@ -157,7 +180,7 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
         };
     }
 
-    let mut camera = open_resolved_camera(config, resolved)?;
+    let mut camera = open_resolved_camera(config, resolved, CameraPurpose::Authentication)?;
     let mut engine = load_engine(config)?;
 
     // Load embeddings with encryption support, matching the daemon handler path.
@@ -422,6 +445,36 @@ warmup_frames = 9
         // own warmup_frames.
         assert!(resolved.quirk.is_none());
         assert!(resolved.caps.applied_quirks.is_empty());
+    }
+
+    /// Post-open unverified Y16 is fatal only to authentication. Authentication
+    /// must reach its provenance rejection without capturing, while preview,
+    /// enrollment, and bench retain the requested AGC/AE warmup that also
+    /// drives lazy non-auth Y16 calibration.
+    #[test]
+    fn direct_open_warmup_policy_is_request_purpose_aware() {
+        let requested = 7;
+        let scale = facelock_core::types::IrTextureScale::UnverifiedY16;
+
+        assert_eq!(
+            warmup_capture_count(CameraPurpose::Authentication, scale, requested),
+            0,
+            "authentication must reject post-open Y16 provenance before capture"
+        );
+        assert_eq!(
+            warmup_capture_count(CameraPurpose::Capture, scale, requested),
+            requested,
+            "non-auth direct capture must preserve configured warmup"
+        );
+        assert_eq!(
+            warmup_capture_count(
+                CameraPurpose::Authentication,
+                facelock_core::types::IrTextureScale::NotY16,
+                requested,
+            ),
+            requested,
+            "GREY and color authentication must preserve configured warmup"
+        );
     }
 
     // --- N8: encrypted-store loading in the direct path ---

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -155,6 +155,22 @@ pub struct FormatInfo {
     pub sizes: Vec<(u32, u32)>,
 }
 
+/// Provenance for the pixel scale consumed by the IR texture check.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IrTextureScale {
+    /// The selected/negotiated format is not Y16. GREY is already 8-bit and
+    /// needs no Y16 scale provenance.
+    #[default]
+    NotY16,
+    /// The selected/negotiated format is Y16 and a valid hardware quirk pins
+    /// its effective bit depth. The raw depth is retained as provenance.
+    VerifiedY16 { bit_depth: u8 },
+    /// The selected/negotiated format is Y16, but the matched quirk has no
+    /// valid `y16_bit_depth`. A scene-derived conversion shift must never be
+    /// treated as verification for the absolute IR texture threshold.
+    UnverifiedY16,
+}
+
 /// Capabilities of a camera device, computed once at construction from device
 /// interrogation (format enumeration, quirks match, sysfs identity) and
 /// carried by the camera itself — so nothing downstream has to thread
@@ -173,6 +189,10 @@ pub struct CameraCaps {
     /// Human-readable identifiers of the quirks applied to this device, for
     /// diagnostics ("why did this camera behave oddly").
     pub applied_quirks: Vec<String>,
+    /// Provenance for the pixel scale consumed by the IR texture check.
+    /// Derived from the selected format during interrogation and recomputed
+    /// from the actual negotiated FourCC when the stream opens.
+    pub ir_texture_scale: IrTextureScale,
 }
 
 impl CameraCaps {

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -58,6 +58,9 @@ pub enum ErrorKind {
     /// `security.require_ir` and the resolved device is not IR.
     /// **Frozen wire string.**
     IrRequired,
+    /// The selected/negotiated camera format is Y16, but no valid
+    /// `y16_bit_depth` quirk verifies the absolute texture scale.
+    Y16BitDepthRequired,
     /// Every captured frame was below the darkness threshold — the camera
     /// produced no usable image, which is not a non-match.
     AllFramesDark,
@@ -77,6 +80,7 @@ impl ErrorKind {
         ErrorKind::RateLimited,
         ErrorKind::RateLimitCheckFailed,
         ErrorKind::IrRequired,
+        ErrorKind::Y16BitDepthRequired,
         ErrorKind::AllFramesDark,
         ErrorKind::Internal,
     ];
@@ -97,6 +101,7 @@ impl ErrorKind {
             ErrorKind::RateLimited => "rate limited".to_string(),
             ErrorKind::RateLimitCheckFailed => format!("rate limit check failed: {detail}"),
             ErrorKind::IrRequired => "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED).".to_string(),
+            ErrorKind::Y16BitDepthRequired => "Y16 IR texture scale is unverified; authentication requires a verified y16_bit_depth (8..=16) quirk".to_string(),
             ErrorKind::AllFramesDark => "all frames dark".to_string(),
             ErrorKind::Internal => detail.to_string(),
         }
@@ -116,6 +121,7 @@ impl ErrorKind {
             | ErrorKind::Storage
             | ErrorKind::RateLimitCheckFailed
             | ErrorKind::IrRequired
+            | ErrorKind::Y16BitDepthRequired
             | ErrorKind::AllFramesDark
             | ErrorKind::Internal => "error",
         }
@@ -331,6 +337,11 @@ pub fn pre_check_with_context(
         }
     }
 
+    if caps.ir_texture_scale == facelock_core::types::IrTextureScale::UnverifiedY16 {
+        warn!(user, "Y16 IR texture scale is unverified");
+        return Some(AuthOutcome::error(ErrorKind::Y16BitDepthRequired));
+    }
+
     if config.security.require_ir && !caps.is_ir {
         warn!(user, "IR camera required but device is not IR");
         return Some(AuthOutcome::error(ErrorKind::IrRequired));
@@ -515,8 +526,43 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
 ) -> AuthOutcome {
     let stored = Wiped(stored);
     let device_is_ir = camera.capabilities().is_ir;
+    let ir_texture_scale = camera.capabilities().ir_texture_scale;
     let live_fingerprint = camera.capabilities().fingerprint.clone();
     let start = Instant::now();
+
+    // Opening a camera may block long enough for its caller to leave. An
+    // abandoned attempt takes precedence over every property learned from
+    // that open, including an unverified negotiated Y16 format, and neither
+    // outcome may consume a frame.
+    if cancel.is_cancelled() {
+        return cancelled(config, user, source, start, 0);
+    }
+
+    // Defense in depth behind the pre-open gate: V4L2 may negotiate a
+    // different FourCC than interrogation predicted, and direct callers must
+    // not be able to enter the compare loop with scene-calibrated Y16 data.
+    // This applies independently of `require_ir`; disabling IR enforcement is
+    // not a way to make an unverified absolute texture scale trustworthy.
+    if ir_texture_scale == facelock_core::types::IrTextureScale::UnverifiedY16 {
+        let kind = ErrorKind::Y16BitDepthRequired;
+        let message = kind.render("");
+        audit::write_audit_entry(
+            &config.audit,
+            &AuditEntry {
+                timestamp: audit::now_iso8601(),
+                user: user.to_string(),
+                result: kind.audit_result().to_string(),
+                source: Some(source),
+                similarity: None,
+                frame_count: Some(0),
+                duration_ms: Some(start.elapsed().as_millis() as u64),
+                device: config.device.path.clone(),
+                model_label: None,
+                error: Some(message.clone()),
+            },
+        );
+        return AuthOutcome::Error { kind, message };
+    }
     let save_snapshots = config.snapshots.mode != facelock_core::config::SnapshotMode::Off;
     let label_for =
         |id: u32| -> Option<String> { models.iter().find(|m| m.id == id).map(|m| m.label.clone()) };
@@ -978,6 +1024,8 @@ fn is_lid_closed() -> bool {
 mod tests {
     use super::*;
 
+    const Y16_SCALE_REJECTION: &str = "Y16 IR texture scale is unverified; authentication requires a verified y16_bit_depth (8..=16) quirk";
+
     /// The two strings PAM substring-matches to choose `PAM_AUTH_ERR` over
     /// `PAM_IGNORE` are frozen protocol (docs/contracts.md). They now come out
     /// of [`ErrorKind::render`]; this pins that they come out byte-identical.
@@ -988,6 +1036,10 @@ mod tests {
         assert_eq!(
             ErrorKind::IrRequired.render(""),
             "IR camera required for authentication. Set security.require_ir = false to override (NOT RECOMMENDED)."
+        );
+        assert_eq!(
+            ErrorKind::Y16BitDepthRequired.render(""),
+            Y16_SCALE_REJECTION
         );
     }
 
@@ -1201,6 +1253,56 @@ enabled = false
         );
         assert!(matches!(outcome, AuthOutcome::Cancelled));
         assert_eq!(camera.captures, 0);
+    }
+
+    #[test]
+    fn unverified_y16_cannot_capture_or_reach_auth_success() {
+        let token = CancelToken::new();
+        let mut camera = CancellingCamera {
+            captures: 0,
+            cancel_at: u32::MAX,
+            token: token.clone(),
+            caps: CameraCaps {
+                is_ir: false,
+                ir_texture_scale: facelock_core::types::IrTextureScale::UnverifiedY16,
+                ..Default::default()
+            },
+        };
+        let embedding = facelock_test_support::fixtures::known_embedding(0);
+        let mut stored = [(1, embedding)];
+        let models = [facelock_core::types::FaceModelInfo {
+            id: 1,
+            user: "alice".into(),
+            label: "front".into(),
+            created_at: 0,
+            embedder_model: "test".into(),
+            device_id: None,
+        }];
+        let outcome = authenticate_with_embeddings(
+            &mut camera,
+            &mut SeeingEngine,
+            &mut stored,
+            &models,
+            &cancellable_config(),
+            "alice",
+            AuditSource::Daemon,
+            &token,
+        );
+
+        assert!(
+            matches!(
+                outcome,
+                AuthOutcome::Error {
+                    kind: ErrorKind::Y16BitDepthRequired,
+                    ref message,
+                } if message == Y16_SCALE_REJECTION
+            ),
+            "unverified Y16 must be a stable recoverable rejection, got {outcome:?}"
+        );
+        assert_eq!(
+            camera.captures, 0,
+            "the auth loop must reject before capture"
+        );
     }
 
     /// An engine that finds a face on every frame and matches nothing (the
@@ -1428,6 +1530,69 @@ enabled = false
             )
             .unwrap();
         store
+    }
+
+    #[test]
+    fn pre_check_rejects_unverified_y16_regardless_of_require_ir() {
+        let mut config = test_pre_check_config();
+        config.security.abort_if_ssh = false;
+        config.security.abort_if_lid_closed = false;
+        let store = store_with_enrolled_user("alice");
+        let rate_limiter = RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        );
+        let caps = CameraCaps {
+            is_ir: false,
+            ir_texture_scale: facelock_core::types::IrTextureScale::UnverifiedY16,
+            ..Default::default()
+        };
+
+        for require_ir in [false, true] {
+            config.security.require_ir = require_ir;
+            let response = pre_check(&config, &store, "alice", &rate_limiter, &caps);
+            assert!(
+                matches!(
+                    response,
+                    Some(AuthOutcome::Error {
+                        kind: ErrorKind::Y16BitDepthRequired,
+                        ref message,
+                    }) if message == Y16_SCALE_REJECTION
+                ),
+                "require_ir={require_ir} must return the stable Y16 scale rejection: {response:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pre_check_allows_grey_and_verified_y16_texture_scales() {
+        let mut config = test_pre_check_config();
+        config.security.abort_if_ssh = false;
+        config.security.abort_if_lid_closed = false;
+        config.security.require_ir = false;
+        let store = store_with_enrolled_user("alice");
+        let rate_limiter = RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        );
+
+        let allowed = [
+            facelock_core::types::IrTextureScale::NotY16,
+            facelock_core::types::IrTextureScale::VerifiedY16 { bit_depth: 10 },
+            facelock_core::types::IrTextureScale::VerifiedY16 { bit_depth: 12 },
+            facelock_core::types::IrTextureScale::VerifiedY16 { bit_depth: 16 },
+        ];
+        for ir_texture_scale in allowed {
+            let caps = CameraCaps {
+                is_ir: true,
+                ir_texture_scale,
+                ..Default::default()
+            };
+            assert!(
+                pre_check(&config, &store, "alice", &rate_limiter, &caps).is_none(),
+                "{ir_texture_scale:?} must remain usable"
+            );
+        }
     }
 
     #[test]

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -320,6 +320,22 @@ fn discard_frames<C: CameraSource>(
     Ok(())
 }
 
+fn has_unverified_y16_scale(camera: &impl CameraSource) -> bool {
+    camera.capabilities().ir_texture_scale == facelock_core::types::IrTextureScale::UnverifiedY16
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AcquisitionPurpose {
+    Capture,
+    Authentication,
+}
+
+impl AcquisitionPurpose {
+    fn may_discard_from(self, camera: &impl CameraSource) -> bool {
+        self != Self::Authentication || !has_unverified_y16_scale(camera)
+    }
+}
+
 /// The camera and everything that decides when it closes.
 ///
 /// One owner for the open stream and the warm-hold deadline, so the invariant
@@ -367,6 +383,26 @@ impl<C: CameraSource> CameraLease<C> {
         config: &Config,
         cancel: &CancelToken,
     ) -> Result<&'a mut C, String> {
+        self.acquire_for(config, cancel, AcquisitionPurpose::Capture)
+    }
+
+    /// Authentication's acquisition path. Unlike preview and enrollment, an
+    /// authentication must capture nothing when the opened stream reveals
+    /// unverified Y16 provenance: the auth loop will reject it immediately.
+    fn acquire_for_authentication<'a>(
+        &'a mut self,
+        config: &Config,
+        cancel: &CancelToken,
+    ) -> Result<&'a mut C, String> {
+        self.acquire_for(config, cancel, AcquisitionPurpose::Authentication)
+    }
+
+    fn acquire_for<'a>(
+        &'a mut self,
+        config: &Config,
+        cancel: &CancelToken,
+        purpose: AcquisitionPurpose,
+    ) -> Result<&'a mut C, String> {
         self.deadline = None;
         if cancel.is_cancelled() {
             self.close("cancelled before the camera was needed");
@@ -379,6 +415,7 @@ impl<C: CameraSource> CameraLease<C> {
             // those would let a fresh attempt match on the tail of the last
             // one. AE is already settled, so no warmup discard is needed.
             let stale = match self.camera.as_mut() {
+                Some(camera) if !purpose.may_discard_from(camera) => Ok(()),
                 Some(camera) => discard_frames(camera, MMAP_BUFFERS - 1, "stale", cancel),
                 None => Ok(()),
             };
@@ -412,7 +449,9 @@ impl<C: CameraSource> CameraLease<C> {
                 .unwrap_or(config.device.warmup_frames);
             // A cold warmup discard is advisory (AGC/AE settling); a failure
             // here is left for the scan loop to surface, as it always was.
-            if let Err(e) = discard_frames(&mut camera, warmup, "warmup", cancel) {
+            if purpose.may_discard_from(&camera)
+                && let Err(e) = discard_frames(&mut camera, warmup, "warmup", cancel)
+            {
                 debug!("warmup discard failed: {e}");
                 // A cancellation during warmup aborts the acquire outright:
                 // the request is over before it started (ADR 008 §8).
@@ -965,7 +1004,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         };
 
         let attempt_started = Instant::now();
-        let camera = match self.lease.acquire(&self.config, cancel) {
+        let camera = match self.lease.acquire_for_authentication(&self.config, cancel) {
             Ok(camera) => camera,
             Err(message) => {
                 // The callee below is what normally wipes `stored` (D11);
@@ -1402,6 +1441,58 @@ mod tests {
             after_warm,
             Some((warmup + MMAP_BUFFERS - 1) as usize),
             "warm reuse must discard exactly MMAP_BUFFERS - 1 frames and no warmup"
+        );
+    }
+
+    /// Scene-derived Y16 calibration is permitted for preview, but it never
+    /// upgrades the stream's authentication provenance. That must not make
+    /// preview inherit authentication's zero-frame post-open rejection path:
+    /// a warm preview still has to dequeue the previous request's V4L2 ring
+    /// before it returns a fresh frame.
+    #[test]
+    fn warm_unverified_y16_preview_reuse_discards_stale_buffers() {
+        let config = lease_config(3);
+        let caps = facelock_core::types::CameraCaps {
+            ir_texture_scale: facelock_core::types::IrTextureScale::UnverifiedY16,
+            ..Default::default()
+        };
+        let mut lease = CameraLease::new(
+            Some(Box::new(move |_| {
+                Ok(MockCamera::bright(64, 64, MOCK_FRAMES).with_caps(caps.clone()))
+            })),
+            None,
+        );
+
+        let first = lease
+            .acquire(&config, &live())
+            .expect("the first preview opens the camera");
+        first
+            .capture_rgb_only()
+            .expect("the first preview captures a frame");
+        assert_eq!(
+            first.capabilities().ir_texture_scale,
+            facelock_core::types::IrTextureScale::UnverifiedY16,
+            "non-auth capture must not upgrade Y16 authentication provenance"
+        );
+        lease.touch_preview(&config);
+        let before_reuse = lease
+            .camera
+            .as_ref()
+            .expect("preview holds camera")
+            .captures();
+
+        lease
+            .acquire(&config, &live())
+            .expect("the next preview reuses the warm camera");
+        let after_reuse = lease
+            .camera
+            .as_ref()
+            .expect("camera remains open")
+            .captures();
+        assert_eq!(
+            after_reuse - before_reuse,
+            (MMAP_BUFFERS - 1) as usize,
+            "unverified Y16 preview must discard every stale MMAP buffer"
         );
     }
 

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use facelock_core::config::Config;
-use facelock_core::types::MatchResult;
+use facelock_core::types::{CameraCaps, IrTextureScale, MatchResult};
 use facelock_daemon::audit::AuditSource;
 use facelock_daemon::auth::AuthOutcome;
 use facelock_daemon::cancel::CancelToken;
@@ -1104,6 +1104,93 @@ fn a_cancellation_before_the_camera_opens_is_still_audited() {
     );
 
     // And it is an abstention, not a failed attempt: nothing is charged.
+    let inspect = FaceStore::create(&db_path).unwrap();
+    assert!(
+        inspect.check_rate_limit("testuser", 1, 60).unwrap(),
+        "a cancellation must leave the rate-limit budget untouched"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    cleanup_db(&db_path);
+}
+
+/// A cancellation may land while a slow camera factory is opening the stream.
+/// Once open returns, cancellation still precedes every post-open rejection:
+/// negotiated unverified Y16 cannot replace an abandoned attempt with a Y16
+/// policy error, and neither path may capture a frame.
+#[test]
+fn cancellation_during_open_precedes_unverified_y16_and_is_audited() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let db_path = temp_db_path("cancel-during-open-audit");
+    cleanup_db(&db_path);
+    let dir = std::env::temp_dir().join(format!(
+        "facelock-cancel-during-open-audit-{}-{unique}",
+        std::process::id()
+    ));
+    let log_path = dir.join("audit.jsonl");
+
+    let db_path_str = db_path.to_string_lossy().into_owned();
+    let mut config = Config::parse(&fixtures::test_config_toml(&db_path_str)).unwrap();
+    config.recognition.timeout_secs = 1;
+    config.audit.enabled = true;
+    config.audit.path = log_path.display().to_string();
+
+    {
+        let store = FaceStore::create(&db_path).unwrap();
+        store
+            .add_model("testuser", "front", &fixtures::known_embedding(0), "")
+            .unwrap();
+    }
+
+    let cancel = CancelToken::new();
+    let factory_cancel = cancel.clone();
+    let factory: MockCameraFactory = Box::new(move |_cfg| {
+        factory_cancel.cancel();
+        Ok(MockCamera::bright(64, 64, 60).with_caps(CameraCaps {
+            ir_texture_scale: IrTextureScale::UnverifiedY16,
+            ..Default::default()
+        }))
+    });
+
+    let mut handler = Handler::new(
+        config.clone(),
+        MockFaceEngine::one_face(unit_at_angle(0.0)),
+        FaceStore::create(&db_path).unwrap(),
+        RateLimiter::new(
+            config.security.rate_limit.max_attempts,
+            config.security.rate_limit.window_secs,
+        ),
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+
+    let resp = handler.handle_authenticate("testuser".into(), AuthIntent::Authenticate, &cancel);
+    match resp {
+        DaemonResponse::Error { ref message } => assert_eq!(
+            message, "cancelled",
+            "cancellation after open must precede the post-open Y16 rejection"
+        ),
+        other => panic!("expected a cancellation, got {other:?}"),
+    }
+
+    let written = std::fs::read_to_string(&log_path).expect("audit log must exist");
+    let entries: Vec<serde_json::Value> = written
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("audit entry must be valid JSON"))
+        .collect();
+    assert_eq!(entries.len(), 1, "one attempt, one entry: {entries:?}");
+    assert_eq!(entries[0]["result"], "cancelled");
+    assert_eq!(entries[0]["frame_count"], 0);
+    assert!(entries[0]["error"].is_null());
+
     let inspect = FaceStore::create(&db_path).unwrap();
     assert!(
         inspect.check_rate_limit("testuser", 1, 60).unwrap(),

--- a/crates/facelock-daemon/tests/server_authz.rs
+++ b/crates/facelock-daemon/tests/server_authz.rs
@@ -24,7 +24,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use facelock_core::config::Config;
 use facelock_core::notify::{Notifier, NullNotifier};
-use facelock_core::types::CameraCaps;
+use facelock_core::types::{CameraCaps, IrTextureScale};
 use facelock_daemon::cancel::CancelToken;
 use facelock_daemon::handler::Handler;
 use facelock_daemon::rate_limit::RateLimiter;
@@ -488,6 +488,117 @@ async fn require_ir_flows_in_band_with_the_exact_protocol_string() {
         result.label.contains("IR camera required"),
         "PAM string-matches \"IR camera required\", got: {}",
         result.label
+    );
+}
+
+#[tokio::test]
+async fn unverified_y16_flows_in_band_without_opening_the_camera() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let emb = fixtures::known_embedding(1);
+    let store = FaceStore::open_memory().unwrap();
+    store
+        .add_model("alice", "front", &emb, "test-embedder")
+        .unwrap();
+    let config = test_config(5, 1);
+    assert!(
+        !config.security.require_ir,
+        "this test pins the no-bypass rule"
+    );
+    let rate_limiter = RateLimiter::new(5, 60);
+    let opened = Arc::new(AtomicBool::new(false));
+    let opened_in_factory = Arc::clone(&opened);
+    let factory: MockCameraFactory = Box::new(move |_| {
+        opened_in_factory.store(true, Ordering::SeqCst);
+        Ok(MockCamera::bright(64, 64, 1))
+    });
+    let caps = CameraCaps {
+        is_ir: true,
+        ir_texture_scale: IrTextureScale::UnverifiedY16,
+        ..Default::default()
+    };
+    let svc = service(
+        Handler::new(
+            config,
+            MockFaceEngine::one_face(emb),
+            store,
+            rate_limiter,
+            caps,
+            Some(factory),
+            None,
+        )
+        .unwrap(),
+    );
+
+    let result = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
+    assert!(!result.matched);
+    assert_eq!(result.model_id, -2, "recoverable error sentinel");
+    assert_eq!(
+        result.label,
+        "Y16 IR texture scale is unverified; authentication requires a verified y16_bit_depth (8..=16) quirk"
+    );
+    assert!(
+        !opened.load(Ordering::SeqCst),
+        "preflight knew the scale was unverified, so it must not open the camera"
+    );
+}
+
+#[tokio::test]
+async fn negotiated_y16_drift_rejects_before_warmup_or_auth_capture() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let emb = fixtures::known_embedding(1);
+    let store = FaceStore::open_memory().unwrap();
+    store
+        .add_model("alice", "front", &emb, "test-embedder")
+        .unwrap();
+    let mut config = test_config(5, 1);
+    config.device.warmup_frames = 3;
+    let rate_limiter = RateLimiter::new(5, 60);
+    let opened = Arc::new(AtomicBool::new(false));
+    let opened_in_factory = Arc::clone(&opened);
+    let factory: MockCameraFactory = Box::new(move |_| {
+        opened_in_factory.store(true, Ordering::SeqCst);
+        Ok(MockCamera::with_frames(Vec::new()).with_caps(CameraCaps {
+            is_ir: true,
+            ir_texture_scale: IrTextureScale::UnverifiedY16,
+            ..Default::default()
+        }))
+    });
+    // Interrogation predicted GREY. Only opening reveals that the driver
+    // negotiated Y16, so this path must open but must never capture a frame.
+    let predicted_caps = CameraCaps {
+        is_ir: true,
+        ir_texture_scale: IrTextureScale::NotY16,
+        ..Default::default()
+    };
+    let svc = service(
+        Handler::new(
+            config,
+            MockFaceEngine::one_face(emb),
+            store,
+            rate_limiter,
+            predicted_caps,
+            Some(factory),
+            None,
+        )
+        .unwrap(),
+    );
+
+    let result = svc
+        .authenticate_as(alice(), "alice", CancelToken::new())
+        .await
+        .unwrap();
+
+    assert!(opened.load(Ordering::SeqCst));
+    assert!(!result.matched);
+    assert_eq!(result.model_id, -2, "recoverable error sentinel");
+    assert_eq!(
+        result.label,
+        "Y16 IR texture scale is unverified; authentication requires a verified y16_bit_depth (8..=16) quirk"
     );
 }
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,10 +40,15 @@ LTS (Resolute). Other Debian and Ubuntu releases are unsupported.
 
 IR cameras provide anti-spoofing protection. Facelock auto-detects IR cameras from the pixel formats they report — a node that enumerates *only* IR-typical mono formats (GREY, Y8, Y10, Y12, Y16) with no color format (YUYV/MJPG) mixed in — or from a hardware quirk that matches the device. The device name is never used to classify a camera as IR.
 
-Known working:
-- Logitech BRIO (IR mode)
-- Intel RealSense (IR stream)
-- Most laptops with Windows Hello IR cameras
+Hardware-validated in the current alpha test record:
+
+- Logitech BRIO 046d:085e IR node, native GREY (#162: 33/33 integration and
+  27/27 oneshot scenarios)
+
+Intel RealSense and other Windows Hello IR devices are recognized by the
+classification/quirks paths, but their Y16 authentication support is
+conditional on a verified sensor depth as described below. There is no Y16
+hardware validation record yet.
 
 ### RGB Cameras (development only)
 
@@ -57,7 +62,7 @@ RGB cameras work with `security.require_ir = false` but provide no anti-spoofing
 | YUYV | Full | Raw format, converted to RGB |
 | NV12 | Full | Semi-planar 4:2:0; common on Intel IPU processed cameras |
 | GREY | Full | IR cameras, replicated to RGB |
-| Y16 | Full | 16-bit IR grayscale, bit-depth-aware conversion to 8-bit |
+| Y16 | Conditional for authentication | 16-bit IR grayscale; auth requires a valid, hardware-verified `y16_bit_depth` quirk (8..=16) |
 | Y8, Y10, Y12 | Not supported | IR-typical classification evidence, but not decodable; excluded from the setup wizard and automatic selection with a path/format warning |
 | Raw Bayer (SGRBG10, ...) | Not supported | Raw sensor nodes are skipped by auto-detection |
 | Other | Not supported | Device is rejected at open with an error listing its formats |
@@ -72,6 +77,21 @@ enabled and every detected IR node is excluded this way, the setup wizard
 stops with all excluded IR paths and formats instead of offering an RGB node.
 When `require_ir` is disabled, a decodable RGB node remains a valid explicit
 wizard choice.
+
+Y16 has a separate scale-provenance gate because the absolute IR texture
+threshold is meaningful only at a known 8-bit conversion scale. Facelock
+derives expected provenance from the selected normalized FourCC before open
+and checks the actual negotiated FourCC again after open. Actual Y16 with a
+missing or invalid `y16_bit_depth` is rejected recoverably before auth capture,
+even when `security.require_ir = false`; this setting cannot bypass the scale
+gate. GREY remains an ordinary verified 8-bit path. Scene-based calibration is
+available only for non-auth Y16 conversion and never becomes authentication
+evidence.
+
+The shipped Intel RealSense Y16 quirks intentionally omit `y16_bit_depth`:
+their format selection and IR classification remain useful, but authentication
+rejects them until hardware evidence supports an 8..=16 value. Do not infer
+sensor depth from the 16-bit V4L2 container alone.
 
 ### Intel IPU6/IPU7 MIPI cameras (v4l2-relayd)
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2751,16 +2751,29 @@ A quirk's `format_preference` is compared whitespace-trimmed and is **dropped
 with a warning** if it names a format facelock cannot decode, rather than
 winning negotiation and then failing every capture.
 
-On a Y16 device, open also pins the session's 16-bit-to-8-bit shift, which is
-never recomputed per frame (`docs/security.md` §1.C). A quirk's `y16_bit_depth`
-(8..=16) is authoritative and skips frame inspection; otherwise the shift comes
-from the brightest sample in a burst of frames captured at open (at least the
-device's `warmup_frames`; the burst stops starting captures after one second,
-so a dequeue already in flight can carry it to roughly one second plus one
-`CAPTURE_TIMEOUT`). The pinned shift belongs to
-the open camera: a warm hold (see "Camera hold" above) keeps it, and a reopen
-recalibrates. A Y16 device that produces no frame at all within the calibration
-budget fails `Camera::open` rather than opening with a guessed scale.
+On a selected or negotiated Y16 stream, authentication requires verified scale
+provenance. A valid matched quirk `y16_bit_depth` in 8..=16 produces
+`VerifiedY16 { bit_depth }` and pins the session shift to `bit_depth - 8`; a
+missing or invalid value produces `UnverifiedY16`. Scene-derived calibration may
+pin conversion for non-auth preview, enrollment, or benchmarking, but it never
+upgrades provenance and is never accepted by the absolute IR texture check.
+
+Interrogation derives the expected state from the normalized FourCC selected by
+the same quirk preference and negotiation priority used at open. Authentication
+rejects known `UnverifiedY16` before opening the camera. After `VIDIOC_S_FMT`, the
+opened camera recomputes state from the actual normalized negotiated FourCC;
+negotiation drift to unverified Y16 skips warmup/calibration capture and receives
+the same rejection before comparison. An actual GREY stream is `NotY16` and
+preserves the existing 8-bit behavior, even if that device also advertised Y16.
+
+The rejection class is `ErrorKind::Y16BitDepthRequired` with the stable rendered
+message `Y16 IR texture scale is unverified; authentication requires a verified
+y16_bit_depth (8..=16) quirk`. It uses the daemon’s in-band `-2` error sentinel
+and oneshot exit 2, both mapping to `PAM_IGNORE` so password fallback remains
+available without an auth success. This gate applies regardless of
+`security.require_ir`; disabling IR enforcement cannot bypass unknown Y16 scale.
+It never reclassifies or downgrades Y16 to RGB and never skips texture
+enforcement.
 
 Open also **rejects a padded stride**: for GREY/NV12 (`bytesperline == width`)
 and Y16/YUYV (`bytesperline == 2 * width`), a device reporting anything else
@@ -2946,6 +2959,11 @@ crate to share the type (its dependency ceiling is libc/toml/serde/zbus):
 | `IR camera required` | `IrRequired` | `PAM_IGNORE` |
 | `cancelled` (matched **exactly**) | `AuthOutcome::Cancelled` | `PAM_IGNORE` |
 
+`Y16BitDepthRequired` is a stable recoverable class even though PAM does not
+substring-match it: the daemon’s `-2` encoding maps it to `PAM_IGNORE`, and
+oneshot exit 2 maps it to the same code. Its full rendered message is pinned by
+`ErrorKind::classify` and tests.
+
 Changing any of these strings is a protocol break.
 
 `cancelled` is not an `ErrorKind`. A rejection class is a statement about this
@@ -2984,7 +3002,7 @@ the module falls through (oneshot fallback / password), never `PAM_SUCCESS`.
 | No match, face seen (model_id -4) | `PAM_AUTH_ERR` (7) |
 | No match, no face seen (model_id -1) | `PAM_IGNORE` (25) |
 | Rate limited (daemon, model_id -2) | `PAM_AUTH_ERR` (7) — no oneshot fallback |
-| IR required / internal daemon error (model_id -2) | `PAM_IGNORE` (25) — no oneshot fallback |
+| IR required / unverified Y16 texture scale / internal daemon error (model_id -2) | `PAM_IGNORE` (25) — no oneshot fallback |
 | Suppressed (model_id -3) | `PAM_AUTHINFO_UNAVAIL` (9) |
 | Daemon unavailable / untrusted (non-root) peer | oneshot fallback, else `PAM_IGNORE` (25) |
 | Config missing, unparseable, or untrusted (not root-owned / group- or world-writable, incl. parents) | `PAM_IGNORE` (25) |
@@ -3053,7 +3071,16 @@ an IR-typical format, only the format-bearing node(s) classify IR. A quirk's
 `format_preference` participates in that decision only when the preferred
 format is itself IR-typical and actually advertised; an RGB preference such as
 MJPG cannot exempt an RGB sibling from demotion (see
-`docs/security.md` §A). Frame variance is passive
+`docs/security.md` §A).
+
+Y16 texture enforcement is separately fail-closed on scale provenance: only a
+valid verified `y16_bit_depth` quirk permits authentication; absent/invalid
+depth rejects recoverably before auth capture, including when
+`security.require_ir = false`. GREY is already 8-bit and is unaffected. Facelock
+does not introduce a scene-derived or scale-invariant authentication metric in
+this alpha.
+
+Frame variance is passive
 anti-photo only (does not stop video replay); it is evaluated over a sliding window
 of the most recent `min_auth_frames` matched frames (see `docs/security.md` §B), with
 a 0.985 cutoff rejecting truly static input (≳0.999) with margin; the

--- a/docs/security.md
+++ b/docs/security.md
@@ -184,60 +184,45 @@ The auth loop previously fed a **CLAHE**-equalized frame into `check_ir_texture`
 i.e. CLAHE was masking exactly the spoof this check exists to catch. CLAHE now belongs
 only to the recognition/embedding path; texture measurement uses `frame.gray` directly.
 
-**Fixed Y16 scale**: 16-bit IR sensors are converted to 8-bit with a right-shift derived
-from the effective sensor bit depth. That shift is pinned once at camera open and reused
-for every frame of the session. Deriving it per frame is per-frame contrast normalization
-— the same class of mistake as feeding CLAHE output to this check — and it would move the
-scale `ir_texture_min_stddev` is calibrated against on every frame, including in response
-to attacker-controlled illumination. A quirk's `y16_bit_depth`
-(`/etc/facelock/quirks.d/`) is **authoritative** when present — the shift becomes
-`bit_depth - 8` and no frame is inspected; the fallback samples a burst of frames at open
-(at least the device's declared `warmup_frames`) and takes their peak, so the scale does
-not hinge on whatever a single pre-AGC frame happened to see.
+**Verified Y16 scale (conservative alpha rule)**: the absolute
+`ir_texture_min_stddev` threshold is meaningful only after Y16 samples are mapped onto a
+known 8-bit scale. Authentication therefore accepts an actual selected/negotiated Y16
+format only when its matched quirk declares a valid, hardware-verified `y16_bit_depth` in
+8..=16. The session shift is then `bit_depth - 8`, fixed before any auth frame is captured
+and never recomputed per frame. Missing or invalid depth has typed provenance
+`UnverifiedY16`; it never reaches the texture comparison.
 
-**A scene-derived scale is not purely a reliability risk. One of its two error directions
-is fail-open.** Both are worth stating plainly:
+Facelock derives this state twice. Interrogation applies the real format preference and
+normal negotiation priority to the enumerated normalized FourCCs, so a known unverified
+Y16 choice is rejected before opening the camera. After `VIDIOC_S_FMT`, the opened camera
+recomputes it from the actual normalized FourCC. If a driver negotiated Y16 after a
+different format was predicted, authentication skips warmup/calibration capture and
+returns the same rejection before the auth loop can succeed. An actual GREY stream is
+`NotY16` and keeps the existing 8-bit behavior, even when the same device also advertises
+Y16.
 
-- *Shift too high* (a stuck pixel or specular glint inflates the burst peak): frames go
-  dark, std_dev collapses, this check **rejects**. Fails closed.
-- *Shift too low* (the burst never saw anything bright): nothing clips while raw samples
-  stay under the truncated full scale, so it acts as a clean 2^k contrast stretch on
-  exactly the buffer this check measures — the Y16→8-bit output reaches `check_ir_texture`
-  unmodified, because the RGB replication is 3x and `rgb_to_gray`'s coefficients sum to
-  256. std_dev scales linearly with the stretch. On a 12-bit sensor whose burst peaks near
-  1000, the shift lands at 2 instead of 4 and every score is multiplied by 4: a flat
-  spoof at a true std_dev of 4, inside the "flat surfaces score < 5" band below, measures
-  16 and clears the 10.0 cutoff. **`ir_texture_min_stddev` is an absolute threshold on a
-  scale-dependent statistic, so at the wrong scale it stops discriminating at all.**
+The stable recoverable message is `Y16 IR texture scale is unverified; authentication
+requires a verified y16_bit_depth (8..=16) quirk`. The daemon returns its ordinary `-2`
+error sentinel; oneshot returns exit 2; PAM maps either path to `PAM_IGNORE`, preserving
+password fallback. The gate applies even when `security.require_ir = false`: disabling IR
+classification enforcement does not make an unknown pixel scale trustworthy. It neither
+reclassifies/downgrades the device to RGB nor silently skips the texture check.
 
-Exploiting it needs a Y16 device with no `y16_bit_depth`, influence over the scene across
-a cold open, and a spoof dim enough to stay unclipped; the peak is a max over every pixel
-with the emitter lit, so holding it under a quarter of full scale needs a uniformly dim
-field of view. This is analysis, not a demonstration: facelock has no Y16 hardware, and
-the <5 / >15 bands below were measured on an **8-bit GREY** node and have never been
-validated through the Y16 path.
+Scene calibration remains available for non-auth Y16 conversion such as preview,
+enrollment, and benchmarking. It runs lazily on their first capture and pins one shift for
+that camera session, but it never upgrades `UnverifiedY16` or authorizes authentication.
+This separation closes the previous fail-open direction: a dim calibration scene could
+pick a shift that inflated a flat spoof's measured standard deviation above the absolute
+threshold. A scale-invariant texture metric is intentionally not introduced in this
+alpha.
 
-Pin `y16_bit_depth` on any Y16 device you control — it removes the scene from the decision
-entirely. V4L2 cannot report a sensor's effective bit depth, so on an unlisted camera the
-shift is necessarily a guess; making this check scale-invariant is the generic fix and is
-tracked separately.
-
-"The session" is the lifetime of one open camera, and under the daemon's warm camera hold
-(ADR 008 §4) that can span several authentication attempts, not just one: a held stream
-keeps the scale it pinned. A **reopen** always recalibrates — the daemon's camera factory
-resolves and opens afresh on every cold open, so no scale is ever carried across a reopen
-onto a device that did not produce it. That is the same invariant `ResolvedCamera` holds
-for `is_ir` and the fingerprint.
-
-Cost note: on a Y16 device with no `y16_bit_depth` quirk, the calibration burst runs inside
-`Camera::open`, *before* the warmup discard and with the IR emitter already enabled — so it
-is emitter-LED-on time on every cold open. The burst stops starting captures after one
-second, but the check sits at the top of its loop, so a dequeue already in flight can carry
-it to about one second plus one `CAPTURE_TIMEOUT`. It is also paid *in addition to* the
-caller's own warmup discard, so a device declaring `warmup_frames = 10` spends 10 burst
-frames and then discards 10 more. Declaring `y16_bit_depth` skips the burst entirely and is
-the preferred configuration on IR hardware. The shipped RealSense entries in
-`config/quirks.d/00-defaults.toml` do **not** declare one yet.
+Hardware evidence is deliberately asymmetric. The Logitech BRIO 046d:085e IR node was
+manually exercised in native GREY for #162 (33/33 integration and 27/27 oneshot
+scenarios), so this rule preserves an observed path. Facelock has no Y16 hardware or
+fixture validation record; the texture bands below have never been validated through
+Y16. The shipped Intel RealSense Y16 quirks therefore do not declare a depth and reject
+authentication recoverably until an evidence-backed local or shipped quirk does. Do not
+infer effective sensor depth from the 16-bit V4L2 container.
 
 **Raw-frame calibration**: on the raw frame, flat surfaces (photos/screens in IR) score
 std_dev **< 5**, real IR skin scores **> 15**. The cutoff `security.ir_texture_min_stddev`


### PR DESCRIPTION
- reject unverified y16 texture scales before authentication because absolute IR texture checks require declared sensor provenance
- preserve GREY, verified Y16, non-auth calibration, and PAM password fallback
- document the contracts and signed hardware evidence gate for #161
- validate with just check and focused camera, daemon, and PAM suites