### PR TITLE
fix(pam): remove owned service edits transactionally

### DIFF
--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -227,10 +227,16 @@ modified.")]
 Removal is never gated by the sensitive-service list and never prompts — it can \
 only take away a way to authenticate. Facelock-owned backups and legacy \
 .facelock-backup files are cleaned by default; --keep-backup preserves them. \
+--all ignores configured PAM directories, scans the compiled system roots, \
+preflights and journals the complete recognized set, and rolls every earlier \
+file back if a later replacement or final active-reference scan fails. \
 --yes/--no-confirm is accepted for symmetry with `add`.")]
     Remove {
         #[command(flatten)]
         service: PamServiceArg,
+        /// Remove every recognized Facelock-owned PAM edit under the system PAM roots
+        #[arg(long, conflicts_with = "service")]
+        all: bool,
         #[command(flatten)]
         confirm: ConfirmArg,
         /// Treat a missing service file as success instead of an error
@@ -296,6 +302,7 @@ impl From<PamCli> for PamRequest {
             },
             PamCli::Remove {
                 service,
+                all,
                 confirm,
                 if_present,
                 keep_backup,
@@ -304,7 +311,7 @@ impl From<PamCli> for PamRequest {
             } => PamRequest {
                 action: PamAction::Remove,
                 services: service.service,
-                all: false,
+                all,
                 // Symmetry with `add`; `remove` has nothing to suppress today.
                 no_confirm: confirm.yes || json.json,
                 allow_sensitive: false,

--- a/crates/facelock-cli/src/commands/capabilities.rs
+++ b/crates/facelock-cli/src/commands/capabilities.rs
@@ -67,6 +67,7 @@ pub const CAPABILITIES: &[&str] = &[
     "pam-if-present",
     "pam-json",
     "pam-multi-service",
+    "pam-remove-all",
     "pam-status",
     "pam-status-all",
     "quiet",

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -125,7 +125,7 @@ use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
 
 use dialoguer::Confirm;
@@ -579,6 +579,12 @@ fn secure_state_directory(directory: &fs::File, expected_owner: (u32, u32)) -> s
     directory.sync_all()
 }
 
+fn create_state_directory(root: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(PAM_BACKUPS_DIR_MODE);
+    builder.create(root)
+}
+
 /// One complete mutation of PAM configuration and its rollback state.
 /// Holding the state-directory flock in this guard prevents recovery or a
 /// competing writer from observing a prepared pair between publication and
@@ -756,7 +762,7 @@ impl BackupStore {
                     format!("{} is not a directory", root.display()),
                 ));
             }
-            Err(error) if error.kind() == ErrorKind::NotFound => fs::create_dir(root)?,
+            Err(error) if error.kind() == ErrorKind::NotFound => create_state_directory(root)?,
             Err(error) => return Err(error),
         }
 
@@ -8345,6 +8351,20 @@ mod tests {
             fs::metadata(&backup_dir).unwrap().permissions().mode() & 0o7777,
             0o700
         );
+    }
+
+    #[test]
+    fn new_state_directory_is_never_group_or_world_accessible() {
+        let root = tempfile::tempdir().unwrap();
+        let backup_dir = root.path().join("pam-backups");
+
+        create_state_directory(&backup_dir).unwrap();
+
+        let mode = fs::symlink_metadata(&backup_dir)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o077, 0);
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -120,11 +120,11 @@
 //! something this should be guessing at, so it is written down rather than
 //! attempted.
 
-use std::ffi::{CString, OsStr};
+use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
-use std::os::unix::ffi::OsStrExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
 
@@ -142,6 +142,21 @@ use crate::state_layout::{PAM_BACKUPS_DIR, PAM_BACKUPS_DIR_MODE};
 /// a parameter so tests drive the whole writer against a tempdir,
 /// unprivileged.
 pub const PAM_DIR: &str = "/etc/pam.d";
+
+/// Compiled PAM roots used for machine-wide discovery and package cleanup.
+///
+/// Unlike the explicit named writer's configurable search path, this list is
+/// deliberately independent of `config.toml`: uninstall must find Facelock
+/// references even when configuration cannot be loaded.
+pub const PAM_SYSTEM_DIRS: &[&str] = &[PAM_DIR, "/usr/lib/pam.d"];
+
+/// Fixed roots scanned by config-independent package cleanup.
+///
+/// Fedora's `/etc/pam.d/{system,password,...}-auth` entries are generated
+/// symlinks into `/etc/authselect`. Cleanup never follows those links; it
+/// scans the generated directory independently so an active reference there
+/// is still an unmanaged blocker while an unrelated stock link is harmless.
+const PAM_CLEANUP_DIRS: &[&str] = &[PAM_DIR, "/usr/lib/pam.d", "/etc/authselect"];
 
 /// The line this command adds and removes. Matching is by module name rather
 /// than by these bytes — see [`is_facelock_pam_line`].
@@ -224,6 +239,11 @@ const MAX_RECORD_BYTES: usize = 16 * 1024;
 
 /// PAM rollback bytes are deliberately generous but finite.
 const MAX_BACKUP_BYTES: usize = 1024 * 1024;
+
+/// Whole-machine cleanup journals are path-free and bounded before parsing.
+const REMOVE_ALL_VERSION: u32 = 1;
+const MAX_REMOVE_ALL_TARGETS: usize = 1024;
+const MAX_REMOVE_ALL_JOURNAL_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -331,6 +351,14 @@ enum CleanupCrashPoint {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoveAllRollbackPoint {
+    ReverseExchange,
+    TempUnlink,
+    BindingUnlink,
+    IntentUnlink,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PamReplaceCrashPoint {
     Intent,
     ReplacementTemp,
@@ -382,6 +410,51 @@ struct PreparedBackup {
     provenance: ProvenanceRecord,
     backup_identity: Option<FileIdentity>,
     record_identity: Option<FileIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoveAllJournalTarget {
+    service: String,
+    backup: String,
+    original: FileIdentity,
+    installed_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoveAllJournal {
+    version: u32,
+    operation: String,
+    keep_backup: bool,
+    targets: Vec<RemoveAllJournalTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoveAllCommittedTarget {
+    service: String,
+    backup: String,
+    installed: FileIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoveAllCommit {
+    version: u32,
+    operation: String,
+    journal_sha256: String,
+    keep_backup: bool,
+    targets: Vec<RemoveAllCommittedTarget>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoveAllPoint {
+    Locked,
+    Journaled,
+    BeforeMutation(usize),
+    AfterMutation(usize),
+    CommitMarked,
 }
 
 #[derive(Debug, Clone)]
@@ -574,7 +647,6 @@ impl BackupTransaction<'_> {
             .replace_pam_with_intent_unlocked_hook(prepared, path, expected, content, |_| Ok(()))
     }
 
-    #[cfg(test)]
     fn replace_pam_with_intent_hook(
         &self,
         prepared: &PreparedBackup,
@@ -1506,6 +1578,37 @@ impl BackupStore {
         }
     }
 
+    fn open_existing_read_only(root: &Path) -> std::io::Result<Option<Self>> {
+        match fs::symlink_metadata(root) {
+            Ok(meta) if meta.file_type().is_dir() => {
+                let expected_owner = expected_state_owner(root);
+                let directory = open_directory_nofollow(root)?;
+                let metadata = directory.metadata()?;
+                if !state_directory_attributes_match(
+                    metadata.mode(),
+                    metadata.uid(),
+                    metadata.gid(),
+                    expected_owner,
+                ) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "PAM backup state directory owner or mode is not trusted",
+                    ));
+                }
+                Ok(Some(Self {
+                    root: root.to_path_buf(),
+                    expected_owner,
+                }))
+            }
+            Ok(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{} is not a directory", root.display()),
+            )),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
     fn lock_exclusive(&self) -> std::io::Result<fs::File> {
         let directory = open_directory_nofollow(&self.root)?;
         // SAFETY: `directory` is a live descriptor. Closing the returned file
@@ -1519,6 +1622,7 @@ impl BackupStore {
 
     fn transaction<'a>(&'a self, dirs: &PamDirs) -> std::io::Result<BackupTransaction<'a>> {
         let lock = self.lock_exclusive()?;
+        recover_remove_all_locked(self, dirs)?;
         self.recover_unlocked(dirs)?;
         Ok(BackupTransaction {
             store: self,
@@ -2897,7 +3001,8 @@ fn sync_directory(path: &Path) -> std::io::Result<()> {
     fs::File::open(path)?.sync_all()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FileIdentity {
     device: u64,
     inode: u64,
@@ -2926,6 +3031,61 @@ fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
     Ok(unsafe { fs::File::from_raw_fd(fd) })
 }
 
+/// Enumerate names through an already-open directory descriptor.
+///
+/// `std::fs::read_dir` resolves a pathname again. Cleanup instead needs the
+/// directory whose identity was accepted by `open_directory_nofollow`, even
+/// if that pathname is renamed while discovery is running.
+fn directory_entry_names(directory: &fs::File) -> std::io::Result<Vec<OsString>> {
+    struct DirectoryStream(*mut libc::DIR);
+    impl Drop for DirectoryStream {
+        fn drop(&mut self) {
+            // SAFETY: `fdopendir` returned this unique stream and `Drop` runs
+            // once. `closedir` also closes the duplicated descriptor.
+            unsafe { libc::closedir(self.0) };
+        }
+    }
+
+    // SAFETY: `directory` remains live. The duplicate is transferred to
+    // `fdopendir`, so enumeration cannot change or close the caller's fd.
+    let duplicated = unsafe { libc::fcntl(directory.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `duplicated` is a new directory descriptor owned by this call.
+    let stream = unsafe { libc::fdopendir(duplicated) };
+    if stream.is_null() {
+        let error = std::io::Error::last_os_error();
+        // SAFETY: ownership was not transferred when `fdopendir` failed.
+        unsafe { libc::close(duplicated) };
+        return Err(error);
+    }
+    let stream = DirectoryStream(stream);
+    let mut names = Vec::new();
+    loop {
+        // SAFETY: Linux exposes thread-local errno here. Clearing it lets a
+        // null `readdir` distinguish end-of-stream from an actual error.
+        unsafe { *libc::__errno_location() = 0 };
+        // SAFETY: `stream` remains open and is used by this thread only.
+        let entry = unsafe { libc::readdir(stream.0) };
+        if entry.is_null() {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(0) {
+                break;
+            }
+            return Err(error);
+        }
+        // SAFETY: `readdir` returns one live dirent whose d_name is
+        // NUL-terminated until the next call. Copy it before continuing.
+        let bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+        if bytes == b"." || bytes == b".." {
+            continue;
+        }
+        names.push(OsString::from_vec(bytes.to_vec()));
+    }
+    Ok(names)
+}
+
 fn entry_exists_at(directory: &fs::File, name: &str) -> std::io::Result<bool> {
     let name = CString::new(name.as_bytes()).map_err(|_| {
         std::io::Error::new(std::io::ErrorKind::InvalidInput, "state name contains NUL")
@@ -2951,6 +3111,67 @@ fn entry_exists_at(directory: &fs::File, name: &str) -> std::io::Result<bool> {
     } else {
         Err(error)
     }
+}
+
+fn metadata_at_nofollow(directory: &fs::File, name: &OsStr) -> std::io::Result<libc::stat> {
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "file name contains NUL")
+    })?;
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: the live directory descriptor and C basename identify one
+    // directory entry; NOFOLLOW observes the entry itself and the output
+    // points to writable storage for one stat value.
+    if unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            metadata.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful fstatat initialized the complete stat value.
+    Ok(unsafe { metadata.assume_init() })
+}
+
+fn read_link_at(directory: &fs::File, name: &OsStr) -> std::io::Result<PathBuf> {
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "file name contains NUL")
+    })?;
+    let mut target = vec![0_u8; libc::PATH_MAX as usize + 1];
+    // SAFETY: `name` and the output buffer remain live for the call. readlinkat
+    // reads the link bytes themselves and never traverses the final component.
+    let length = unsafe {
+        libc::readlinkat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            target.as_mut_ptr().cast(),
+            target.len(),
+        )
+    };
+    if length < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let length = length as usize;
+    if length == target.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "PAM symlink target is too long",
+        ));
+    }
+    target.truncate(length);
+    Ok(PathBuf::from(OsString::from_vec(target)))
+}
+
+fn symlink_is_covered_by_later_root(
+    directory: &fs::File,
+    service: &str,
+    later_roots: &[PathBuf],
+) -> std::io::Result<bool> {
+    let target = read_link_at(directory, OsStr::new(service))?;
+    Ok(target.is_absolute() && later_roots.iter().any(|root| target == root.join(service)))
 }
 
 fn open_regular_at(directory: &fs::File, name: &OsStr) -> std::io::Result<fs::File> {
@@ -3782,6 +4003,14 @@ impl PamDirs {
             .map_or_else(Self::default, Self::from_config)
     }
 
+    /// Fixed, compiled roots for config-independent machine-wide cleanup.
+    fn system_cleanup() -> Self {
+        PamDirs {
+            dirs: PAM_CLEANUP_DIRS.iter().map(PathBuf::from).collect(),
+            backup_dir: PathBuf::from(PAM_BACKUPS_DIR),
+        }
+    }
+
     /// The search path a config that has *already been parsed* names.
     ///
     /// `facelock status` holds a [`crate::resolved::ConfigLoad`] before it
@@ -3838,11 +4067,7 @@ pub(crate) fn only(dir: impl AsRef<Path>) -> PamDirs {
 impl Default for PamDirs {
     fn default() -> Self {
         PamDirs {
-            dirs: facelock_core::config::PamConfig::default()
-                .config_dirs
-                .into_iter()
-                .map(PathBuf::from)
-                .collect(),
+            dirs: PAM_SYSTEM_DIRS.iter().map(PathBuf::from).collect(),
             backup_dir: PathBuf::from(PAM_BACKUPS_DIR),
         }
     }
@@ -3915,8 +4140,9 @@ pub struct PamRequest {
     /// Requested services, in the order given. Empty means
     /// [`DEFAULT_PAM_SERVICE`].
     pub services: Vec<String>,
-    /// `status` only: report every service on the search path that carries the
-    /// facelock line instead of the named ones.
+    /// Enumerating forms: report (`status`) or clean (`remove`) every service
+    /// on the applicable search path that carries the facelock line instead
+    /// of acting on named services.
     ///
     /// A flag rather than a new meaning for a bare `pam status`, because that
     /// invocation's exit code is 0/1/2 *about `sudo`* today and an integrator
@@ -6271,6 +6497,10 @@ pub fn run(request: PamRequest) -> anyhow::Result<i32> {
         require_module_installed()?;
     }
 
+    if request.action == PamAction::Remove && request.all {
+        return remove_all_in(&PamDirs::system_cleanup(), &request);
+    }
+
     write_in(&PamDirs::system(), &request)
 }
 
@@ -6483,6 +6713,1191 @@ fn write_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Result<i32> {
     } else {
         WRITE_OK
     })
+}
+
+/// Whether every live reference in `content` has the exact physical spelling
+/// emitted by Facelock before versioned state existed.
+///
+/// The broad parser remains correct for named `pam remove`: an operator who
+/// names a service explicitly asked to remove its module rule. Machine-wide
+/// cleanup has no such authorization, so spacing, controls and options are
+/// ownership evidence rather than cosmetic differences.
+fn has_only_exact_legacy_facelock_rules(content: &[u8]) -> bool {
+    let mut found = false;
+    for rule in PamDocument::new(content).logical_rules() {
+        if !is_facelock_rule(rule.bytes) {
+            continue;
+        }
+        found = true;
+        let mut next = rule.start;
+        let mut saw_exact = false;
+        while next < rule.end {
+            let Some(line) = PhysicalLine::at(content, next) else {
+                return false;
+            };
+            if line
+                .semantic()
+                .windows(b"pam_facelock.so".len())
+                .any(|window| window == b"pam_facelock.so")
+            {
+                if line.content() != PAM_LINE.as_bytes() {
+                    return false;
+                }
+                saw_exact = true;
+            }
+            next = line.end;
+        }
+        if !saw_exact {
+            return false;
+        }
+    }
+    found
+}
+
+fn strict_record_names_for_service(root: &Path, service: &str) -> std::io::Result<Vec<String>> {
+    let mut names = Vec::new();
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(names),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Some(backup) = name.strip_suffix(".json") else {
+            continue;
+        };
+        if backup_service(backup) == Some(service) {
+            names.push(name);
+        }
+    }
+    Ok(names)
+}
+
+fn remove_all_reference_is_owned(
+    store: Option<&BackupStore>,
+    service: &str,
+    content: &[u8],
+) -> anyhow::Result<bool> {
+    let Some(store) = store else {
+        return Ok(has_only_exact_legacy_facelock_rules(content));
+    };
+    let strict_names = strict_record_names_for_service(&store.root, service)?;
+    let records = store.validated_records(service)?;
+    if strict_names.len() != records.len() {
+        anyhow::bail!("corrupt PAM provenance for service {service}");
+    }
+    if records.is_empty() {
+        return Ok(has_only_exact_legacy_facelock_rules(content));
+    }
+    let current = sha256_hex(content);
+    if records.iter().any(|record| {
+        record.provenance.state == ProvenanceState::Committed
+            && record.provenance.installed_sha256 == current
+    }) {
+        return Ok(true);
+    }
+    anyhow::bail!("PAM service {service} no longer matches its Facelock provenance")
+}
+
+fn remove_all_name_is_candidate(
+    store: Option<&BackupStore>,
+    service: &str,
+) -> std::io::Result<bool> {
+    if is_service_name(service) {
+        return Ok(true);
+    }
+    if confined(service).is_err() {
+        return Ok(false);
+    }
+    let Some(store) = store else {
+        return Ok(false);
+    };
+    Ok(!strict_record_names_for_service(&store.root, service)?.is_empty())
+}
+
+fn remove_all_services_with_store(
+    dirs: &PamDirs,
+    open_store: impl FnOnce(&Path) -> std::io::Result<Option<BackupStore>>,
+) -> anyhow::Result<Vec<String>> {
+    let store = open_store(dirs.backup_dir())?;
+    let mut services = Vec::new();
+    let mut blockers = Vec::new();
+
+    for (root_index, base) in dirs.iter().enumerate() {
+        let directory = match open_directory_nofollow(base) {
+            Ok(directory) => directory,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                blockers.push(format!("{} could not be scanned: {error}", base.display()));
+                continue;
+            }
+        };
+        let entries = match directory_entry_names(&directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                blockers.push(format!("{} could not be scanned: {error}", base.display()));
+                continue;
+            }
+        };
+        for entry_name in entries {
+            let Some(service) = entry_name.to_str().map(str::to_owned) else {
+                blockers.push(format!(
+                    "{} contains a PAM entry with a non-UTF-8 name",
+                    base.display()
+                ));
+                continue;
+            };
+            if !remove_all_name_is_candidate(store.as_ref(), &service)? {
+                continue;
+            }
+            let entry_metadata = match metadata_at_nofollow(&directory, OsStr::new(&service)) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    blockers.push(format!(
+                        "{} is unmanaged: {error}",
+                        base.join(&service).display()
+                    ));
+                    continue;
+                }
+            };
+            let file_type = entry_metadata.st_mode & libc::S_IFMT;
+            if file_type == libc::S_IFDIR {
+                continue;
+            }
+            if file_type == libc::S_IFLNK {
+                if symlink_is_covered_by_later_root(
+                    &directory,
+                    &service,
+                    &dirs.dirs[root_index + 1..],
+                )
+                .unwrap_or(false)
+                {
+                    continue;
+                }
+                blockers.push(format!(
+                    "{} is unmanaged: PAM service is a symlink",
+                    base.join(&service).display()
+                ));
+                continue;
+            }
+            if file_type != libc::S_IFREG {
+                blockers.push(format!(
+                    "{} is unmanaged: PAM service is not a regular file",
+                    base.join(&service).display()
+                ));
+                continue;
+            }
+            let file = match open_regular_at(&directory, OsStr::new(&service)) {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error)
+                    if error.raw_os_error() == Some(libc::ELOOP)
+                        && symlink_is_covered_by_later_root(
+                            &directory,
+                            &service,
+                            &dirs.dirs[root_index + 1..],
+                        )
+                        .unwrap_or(false) =>
+                {
+                    continue;
+                }
+                Err(error) => {
+                    blockers.push(format!(
+                        "{} is unmanaged: {error}",
+                        base.join(&service).display()
+                    ));
+                    continue;
+                }
+            };
+            let content = match read_open_bounded(&file, MAX_BACKUP_BYTES) {
+                Ok(content) => content,
+                Err(error) => {
+                    blockers.push(format!(
+                        "{} is unmanaged: {error}",
+                        base.join(&service).display()
+                    ));
+                    continue;
+                }
+            };
+            if !PamDocument::new(&content).has_facelock_rule() {
+                continue;
+            }
+            if root_index != 0 {
+                blockers.push(format!(
+                    "{} is an unmanaged reference outside the writable PAM root",
+                    base.join(&service).display()
+                ));
+                continue;
+            }
+            match remove_all_reference_is_owned(store.as_ref(), &service, &content) {
+                Ok(true) => services.push(service),
+                Ok(false) => blockers.push(format!(
+                    "{} is an administrator-managed PAM reference",
+                    base.join(&service).display()
+                )),
+                Err(error) => blockers.push(error.to_string()),
+            }
+        }
+    }
+
+    if !blockers.is_empty() {
+        anyhow::bail!(blockers.join("; "));
+    }
+    services.sort();
+    services.dedup();
+    Ok(services)
+}
+
+fn remove_all_services(dirs: &PamDirs) -> anyhow::Result<Vec<String>> {
+    remove_all_services_with_store(dirs, BackupStore::open_existing)
+}
+
+fn remove_all_services_read_only(dirs: &PamDirs) -> anyhow::Result<Vec<String>> {
+    remove_all_services_with_store(dirs, BackupStore::open_existing_read_only)
+}
+
+fn valid_remove_all_operation(operation: &str) -> bool {
+    let Some((seconds, nanoseconds)) = operation.split_once('-') else {
+        return false;
+    };
+    !seconds.is_empty()
+        && seconds.bytes().all(|byte| byte.is_ascii_digit())
+        && seconds.parse::<u64>().is_ok()
+        && nanoseconds.len() == 9
+        && nanoseconds.bytes().all(|byte| byte.is_ascii_digit())
+        && nanoseconds
+            .parse::<u32>()
+            .is_ok_and(|value| value < 1_000_000_000)
+}
+
+fn remove_all_journal_name(operation: &str) -> String {
+    format!(".facelock-remove-all-{operation}.json")
+}
+
+fn remove_all_commit_name(operation: &str) -> String {
+    format!(".facelock-remove-all-commit-{operation}.json")
+}
+
+fn valid_remove_all_target(target: &RemoveAllJournalTarget) -> bool {
+    confined(&target.service).is_ok()
+        && valid_backup_name(&target.service, &target.backup)
+        && target.original.links == 1
+        && target.original.mode & libc::S_IFMT == libc::S_IFREG
+        && valid_sha256(&target.original.sha256)
+        && valid_sha256(&target.installed_sha256)
+}
+
+fn valid_remove_all_journal(journal: &RemoveAllJournal) -> bool {
+    journal.version == REMOVE_ALL_VERSION
+        && valid_remove_all_operation(&journal.operation)
+        && !journal.targets.is_empty()
+        && journal.targets.len() <= MAX_REMOVE_ALL_TARGETS
+        && journal.targets.iter().all(valid_remove_all_target)
+        && {
+            let mut services = journal
+                .targets
+                .iter()
+                .map(|target| target.service.as_str())
+                .collect::<Vec<_>>();
+            let original_len = services.len();
+            services.sort_unstable();
+            services.dedup();
+            services.len() == original_len
+        }
+}
+
+fn valid_remove_all_commit(commit: &RemoveAllCommit) -> bool {
+    commit.version == REMOVE_ALL_VERSION
+        && valid_remove_all_operation(&commit.operation)
+        && valid_sha256(&commit.journal_sha256)
+        && !commit.targets.is_empty()
+        && commit.targets.len() <= MAX_REMOVE_ALL_TARGETS
+        && commit.targets.iter().all(|target| {
+            confined(&target.service).is_ok()
+                && valid_backup_name(&target.service, &target.backup)
+                && target.installed.links == 1
+                && target.installed.mode & libc::S_IFMT == libc::S_IFREG
+                && valid_sha256(&target.installed.sha256)
+        })
+        && {
+            let mut services = commit
+                .targets
+                .iter()
+                .map(|target| target.service.as_str())
+                .collect::<Vec<_>>();
+            let original_len = services.len();
+            services.sort_unstable();
+            services.dedup();
+            services.len() == original_len
+        }
+}
+
+fn remove_all_binding_identity(binding: &PublicationBinding) -> FileIdentity {
+    FileIdentity {
+        device: binding.device,
+        inode: binding.inode,
+        links: binding.links,
+        sha256: binding.sha256.clone(),
+        mode: binding.mode,
+        uid: binding.uid,
+        gid: binding.gid,
+    }
+}
+
+fn create_remove_all_journal(
+    store: &BackupStore,
+    keep_backup: bool,
+    targets: Vec<RemoveAllJournalTarget>,
+) -> std::io::Result<(RemoveAllJournal, String, Vec<u8>, FileIdentity)> {
+    use std::io::{Error, ErrorKind};
+
+    let mut since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+    for _ in 0..MAX_TIMESTAMP_COLLISION_PROBES {
+        let operation = format!(
+            "{}-{:09}",
+            since_epoch.as_secs(),
+            since_epoch.subsec_nanos()
+        );
+        let name = remove_all_journal_name(&operation);
+        let commit_name = remove_all_commit_name(&operation);
+        if fs::symlink_metadata(store.root.join(&name)).is_ok()
+            || fs::symlink_metadata(store.root.join(&commit_name)).is_ok()
+        {
+            since_epoch = since_epoch
+                .checked_add(std::time::Duration::from_nanos(1))
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "remove-all clock overflow"))?;
+            continue;
+        }
+        let journal = RemoveAllJournal {
+            version: REMOVE_ALL_VERSION,
+            operation,
+            keep_backup,
+            targets: targets.clone(),
+        };
+        let encoded = serde_json::to_vec_pretty(&journal)
+            .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+        if encoded.len() > MAX_REMOVE_ALL_JOURNAL_BYTES {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "remove-all journal exceeds its size limit",
+            ));
+        }
+        match atomic_state_create(&store.root, &name, &encoded) {
+            Ok(identity) => return Ok((journal, name, encoded, identity)),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                since_epoch = since_epoch
+                    .checked_add(std::time::Duration::from_nanos(1))
+                    .ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "remove-all clock overflow")
+                    })?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(Error::new(
+        ErrorKind::AlreadyExists,
+        "remove-all journal collision probe limit exhausted",
+    ))
+}
+
+fn unlink_remove_all_state(
+    store: &BackupStore,
+    name: &str,
+    identity: &FileIdentity,
+) -> std::io::Result<()> {
+    let directory = open_directory_nofollow(&store.root)?;
+    unlink_at_if_identity_matches(&directory, name, identity, MAX_REMOVE_ALL_JOURNAL_BYTES)?;
+    directory.sync_all()
+}
+
+fn exact_batch_publication(
+    store: &BackupStore,
+    target: &RemoveAllJournalTarget,
+) -> std::io::Result<Option<(ValidIntent, ValidPublication)>> {
+    let intents = store.validated_intents()?;
+    let publications = store.validated_publications()?;
+    let intent_name = intent_name(IntentRole::PamReplace, &target.backup);
+    let publication_name = publication_name(PublicationRole::PamReplace, &target.backup);
+    let state_directory = open_directory_nofollow(&store.root)?;
+    let intent = intents.into_iter().find(|intent| {
+        intent.name == intent_name
+            && intent.intent.service == target.service
+            && intent.intent.original_sha256 == target.original.sha256
+            && intent.intent.installed_sha256 == target.installed_sha256
+    });
+    let publication = publications.into_iter().find(|publication| {
+        publication.name == publication_name
+            && publication.binding.service == target.service
+            && publication.binding.sha256 == target.installed_sha256
+    });
+    match (intent, publication) {
+        (Some(intent), Some(publication))
+            if BackupStore::publication_matches_intent(&publication.binding, &intent) =>
+        {
+            Ok(Some((intent, publication)))
+        }
+        (None, None)
+            if !entry_exists_at(&state_directory, &intent_name)?
+                && !entry_exists_at(&state_directory, &publication_name)? =>
+        {
+            Ok(None)
+        }
+        _ => Err(std::io::Error::other(
+            "remove-all publication evidence is incomplete or invalid",
+        )),
+    }
+}
+
+fn prepared_for_remove_all_target(
+    store: &BackupStore,
+    target: &RemoveAllJournalTarget,
+) -> std::io::Result<PreparedBackup> {
+    store
+        .validated_records(&target.service)?
+        .into_iter()
+        .find(|prepared| {
+            prepared.backup == target.backup
+                && prepared.provenance.state == ProvenanceState::Prepared
+                && prepared.provenance.original_sha256 == target.original.sha256
+                && prepared.provenance.installed_sha256 == target.installed_sha256
+        })
+        .ok_or_else(|| std::io::Error::other("remove-all rollback pair is missing or invalid"))
+}
+
+fn recover_unstarted_remove_all_publication(
+    store: &BackupStore,
+    dirs: &PamDirs,
+    target: &RemoveAllJournalTarget,
+    current: &FileIdentity,
+) -> std::io::Result<bool> {
+    let intent_name = intent_name(IntentRole::PamReplace, &target.backup);
+    let publication_name = publication_name(PublicationRole::PamReplace, &target.backup);
+    let state_directory = open_directory_nofollow(&store.root)?;
+    if entry_exists_at(&state_directory, &publication_name)? {
+        return Ok(false);
+    }
+    let Some(intent) = store.validated_intents()?.into_iter().find(|intent| {
+        intent.name == intent_name
+            && intent.intent.role == IntentRole::PamReplace
+            && intent.intent.service == target.service
+            && intent.intent.backup == target.backup
+            && intent.intent.original_sha256 == target.original.sha256
+            && intent.intent.installed_sha256 == target.installed_sha256
+            && exact_original_intent_identity(&intent.intent, &target.original)
+    }) else {
+        return Ok(false);
+    };
+    let prepared = prepared_for_remove_all_target(store, target)?;
+    let record_hash = prepared
+        .record_identity
+        .as_ref()
+        .map(|identity| identity.sha256.as_str())
+        .ok_or_else(|| std::io::Error::other("remove-all record identity is missing"))?;
+    if intent.intent.sequence != prepared.provenance.sequence
+        || intent.intent.record_sha256.as_deref() != Some(record_hash)
+    {
+        return Ok(false);
+    }
+    if !identity_matches(&target.original, current) {
+        return Ok(false);
+    }
+    let pam_directory = open_directory_nofollow(dirs.overrides())?;
+    if entry_exists_at(&pam_directory, &pam_replace_name(&target.backup))? {
+        return Ok(false);
+    }
+    unlink_state_if_identity_matches(&store.root, &intent.name, &intent.identity)?;
+    Ok(true)
+}
+
+fn remove_all_pair_state_is_absent(
+    directory: &fs::File,
+    target: &RemoveAllJournalTarget,
+) -> std::io::Result<bool> {
+    let names = [
+        target.backup.clone(),
+        format!("{}.json", target.backup),
+        quarantine_name("backup", &target.backup),
+        format!("{}.json", quarantine_name("record", &target.backup)),
+        intent_name(IntentRole::Cleanup, &target.backup),
+    ];
+    for name in names {
+        if entry_exists_at(directory, &name)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn cleanup_remove_all_pair(
+    store: &BackupStore,
+    directory: &fs::File,
+    target: &RemoveAllJournalTarget,
+) -> std::io::Result<()> {
+    let cleanup_name = intent_name(IntentRole::Cleanup, &target.backup);
+    let cleanup_intent = store.validated_intents()?.into_iter().find(|intent| {
+        intent.name == cleanup_name
+            && intent.intent.role == IntentRole::Cleanup
+            && intent.intent.service == target.service
+            && intent.intent.backup == target.backup
+            && intent.intent.original_sha256 == target.original.sha256
+            && intent.intent.installed_sha256 == target.installed_sha256
+    });
+    if let Some(intent) = cleanup_intent {
+        store.recover_cleanup_intent(directory, &intent)?;
+        if remove_all_pair_state_is_absent(directory, target)? {
+            return Ok(());
+        }
+        return Err(std::io::Error::other(
+            "remove-all rollback pair cleanup remains incomplete or ambiguous",
+        ));
+    }
+    if entry_exists_at(directory, &cleanup_name)? {
+        return Err(std::io::Error::other(
+            "remove-all rollback pair has invalid cleanup evidence",
+        ));
+    }
+    let backup_quarantine = quarantine_name("backup", &target.backup);
+    let record_quarantine = format!("{}.json", quarantine_name("record", &target.backup));
+    if entry_exists_at(directory, &backup_quarantine)?
+        || entry_exists_at(directory, &record_quarantine)?
+    {
+        return Err(std::io::Error::other(
+            "remove-all rollback pair has conflicting quarantine state",
+        ));
+    }
+    match prepared_for_remove_all_target(store, target) {
+        Ok(prepared) => store.cleanup_one_at(directory, &prepared, |_| Ok(())),
+        Err(_) if remove_all_pair_state_is_absent(directory, target)? => Ok(()),
+        Err(_) => Err(std::io::Error::other(
+            "remove-all rollback pair is partial, substituted, or conflicting",
+        )),
+    }
+}
+
+fn cleanup_remove_all_pairs(
+    store: &BackupStore,
+    journal: &RemoveAllJournal,
+) -> std::io::Result<()> {
+    let directory = open_directory_nofollow(&store.root)?;
+    for target in &journal.targets {
+        cleanup_remove_all_pair(store, &directory, target)?;
+    }
+    directory.sync_all()
+}
+
+fn finish_rolled_back_remove_all_publication(
+    store: &BackupStore,
+    dirs: &PamDirs,
+    target: &RemoveAllJournalTarget,
+    publication: &ValidPublication,
+    temp_name: &str,
+    after_boundary: &mut impl FnMut(RemoveAllRollbackPoint) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let directory = open_directory_nofollow(dirs.overrides())?;
+    let current = open_identity_at(&directory, &target.service, MAX_BACKUP_BYTES)?
+        .ok_or_else(|| std::io::Error::other("rolled-back PAM service is missing"))?;
+    if !identity_matches(&target.original, &current) {
+        return Err(std::io::Error::other(
+            "rolled-back PAM service no longer matches its original identity",
+        ));
+    }
+
+    if let Some(temp) = open_identity_at(&directory, temp_name, MAX_BACKUP_BYTES)? {
+        if !binding_identity_matches(&publication.binding, &temp) {
+            return Err(std::io::Error::other(
+                "rolled-back PAM replacement temp is ambiguous",
+            ));
+        }
+        unlink_at_if_identity_matches(&directory, temp_name, &temp, MAX_BACKUP_BYTES)?;
+        directory.sync_all()?;
+        after_boundary(RemoveAllRollbackPoint::TempUnlink)?;
+    }
+
+    unlink_state_if_identity_matches(&store.root, &publication.name, &publication.identity)?;
+    after_boundary(RemoveAllRollbackPoint::BindingUnlink)?;
+
+    let current = open_identity_at(&directory, &target.service, MAX_BACKUP_BYTES)?
+        .ok_or_else(|| std::io::Error::other("rolled-back PAM service is missing"))?;
+    if !recover_unstarted_remove_all_publication(store, dirs, target, &current)? {
+        return Err(std::io::Error::other(
+            "rolled-back PAM intent is not exact unstarted evidence",
+        ));
+    }
+    after_boundary(RemoveAllRollbackPoint::IntentUnlink)
+}
+
+fn rollback_remove_all(
+    store: &BackupStore,
+    dirs: &PamDirs,
+    journal: &RemoveAllJournal,
+    journal_name: &str,
+    journal_identity: &FileIdentity,
+) -> std::io::Result<()> {
+    rollback_remove_all_with_hook(store, dirs, journal, journal_name, journal_identity, |_| {
+        Ok(())
+    })
+}
+
+fn rollback_remove_all_with_hook(
+    store: &BackupStore,
+    dirs: &PamDirs,
+    journal: &RemoveAllJournal,
+    journal_name: &str,
+    journal_identity: &FileIdentity,
+    mut after_boundary: impl FnMut(RemoveAllRollbackPoint) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let mut ambiguous = Vec::new();
+    for target in journal.targets.iter().rev() {
+        let canonical = dirs.overrides().join(&target.service);
+        let current = match read_regular_nofollow(&canonical) {
+            Ok((_, identity)) => identity,
+            Err(error) => {
+                ambiguous.push(format!("{}: {error}", target.service));
+                continue;
+            }
+        };
+        match recover_unstarted_remove_all_publication(store, dirs, target, &current) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(error) => {
+                ambiguous.push(format!("{}: {error}", target.service));
+                continue;
+            }
+        }
+        match exact_batch_publication(store, target) {
+            Ok(Some((_intent, publication))) => {
+                let installed = remove_all_binding_identity(&publication.binding);
+                let directory = match open_directory_nofollow(dirs.overrides()) {
+                    Ok(directory) => directory,
+                    Err(error) => {
+                        ambiguous.push(format!("{}: {error}", target.service));
+                        continue;
+                    }
+                };
+                let temp_name = pam_replace_name(&target.backup);
+                let temp = match open_identity_at(&directory, &temp_name, MAX_BACKUP_BYTES) {
+                    Ok(identity) => identity,
+                    Err(error) => {
+                        ambiguous.push(format!("{}: {error}", target.service));
+                        continue;
+                    }
+                };
+                if identity_matches(&installed, &current)
+                    && temp
+                        .as_ref()
+                        .is_some_and(|temp| identity_matches(&target.original, temp))
+                {
+                    if let Err(error) = rename_exchange_at(&directory, &temp_name, &target.service)
+                    {
+                        ambiguous.push(format!("{} rollback failed: {error}", target.service));
+                        continue;
+                    }
+                    after_boundary(RemoveAllRollbackPoint::ReverseExchange)?;
+                } else if !identity_matches(&target.original, &current)
+                    || temp
+                        .as_ref()
+                        .is_some_and(|temp| !identity_matches(&installed, temp))
+                {
+                    ambiguous.push(format!("{} changed before rollback", target.service));
+                    continue;
+                }
+                finish_rolled_back_remove_all_publication(
+                    store,
+                    dirs,
+                    target,
+                    &publication,
+                    &temp_name,
+                    &mut after_boundary,
+                )?;
+            }
+            Ok(None) if identity_matches(&target.original, &current) => {}
+            Ok(None) => ambiguous.push(format!("{} changed after preflight", target.service)),
+            Err(error) => ambiguous.push(format!("{}: {error}", target.service)),
+        }
+    }
+
+    if !ambiguous.is_empty() {
+        return Err(std::io::Error::other(format!(
+            "remove-all rollback retained evidence: {}",
+            ambiguous.join("; ")
+        )));
+    }
+    cleanup_remove_all_pairs(store, journal)?;
+    unlink_remove_all_state(store, journal_name, journal_identity)
+}
+
+fn committed_remove_all_targets(
+    store: &BackupStore,
+    journal: &RemoveAllJournal,
+) -> std::io::Result<Vec<RemoveAllCommittedTarget>> {
+    journal
+        .targets
+        .iter()
+        .map(|target| {
+            let (_, publication) = exact_batch_publication(store, target)?.ok_or_else(|| {
+                std::io::Error::other("remove-all publication binding disappeared before commit")
+            })?;
+            let installed = remove_all_binding_identity(&publication.binding);
+            Ok(RemoveAllCommittedTarget {
+                service: target.service.clone(),
+                backup: target.backup.clone(),
+                installed,
+            })
+        })
+        .collect()
+}
+
+fn finish_committed_remove_all(
+    store: &BackupStore,
+    dirs: &PamDirs,
+    journal: Option<(&RemoveAllJournal, &str, &FileIdentity)>,
+    commit: &RemoveAllCommit,
+    commit_name: &str,
+    commit_identity: &FileIdentity,
+) -> std::io::Result<()> {
+    for target in &commit.targets {
+        let path = dirs.overrides().join(&target.service);
+        let (_, current) = read_regular_nofollow(&path)?;
+        if !identity_matches(&target.installed, &current) {
+            return Err(std::io::Error::other(format!(
+                "{} changed before remove-all cleanup",
+                target.service
+            )));
+        }
+    }
+    store.recover_publications(dirs)?;
+    store.recover_intents(dirs)?;
+
+    let state_directory = open_directory_nofollow(&store.root)?;
+    for target in &commit.targets {
+        let exact_intent = intent_name(IntentRole::PamReplace, &target.backup);
+        let exact_binding = publication_name(PublicationRole::PamReplace, &target.backup);
+        if entry_exists_at(&state_directory, &exact_intent)?
+            || entry_exists_at(&state_directory, &exact_binding)?
+        {
+            return Err(std::io::Error::other(
+                "remove-all publication evidence could not be finalized",
+            ));
+        }
+    }
+
+    for target in &commit.targets {
+        if commit.keep_backup {
+            let prepared = store
+                .validated_records(&target.service)?
+                .into_iter()
+                .find(|record| record.backup == target.backup)
+                .ok_or_else(|| {
+                    std::io::Error::other("remove-all rollback pair disappeared before commit")
+                })?;
+            if prepared.provenance.state == ProvenanceState::Prepared {
+                store.commit_unlocked(&prepared, |_| Ok(()))?;
+            }
+        } else {
+            for prepared in store.validated_records(&target.service)? {
+                store.cleanup_one_at(&state_directory, &prepared, |_| Ok(()))?;
+            }
+            remove_legacy_backup(dirs, &target.service)?;
+        }
+    }
+    state_directory.sync_all()?;
+
+    if let Some((_, name, identity)) = journal {
+        unlink_remove_all_state(store, name, identity)?;
+    }
+    unlink_remove_all_state(store, commit_name, commit_identity)
+}
+
+#[derive(Debug)]
+struct LoadedRemoveAll<T> {
+    name: String,
+    value: T,
+    encoded: Vec<u8>,
+    identity: FileIdentity,
+}
+
+type LoadedRemoveAllState = (
+    Option<LoadedRemoveAll<RemoveAllJournal>>,
+    Option<LoadedRemoveAll<RemoveAllCommit>>,
+);
+
+fn load_remove_all_state(store: &BackupStore) -> std::io::Result<LoadedRemoveAllState> {
+    let directory = open_directory_nofollow(&store.root)?;
+    let mut journal = None;
+    let mut commit = None;
+    for entry in fs::read_dir(&store.root)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let commit_operation = name
+            .strip_prefix(".facelock-remove-all-commit-")
+            .and_then(|rest| rest.strip_suffix(".json"))
+            .filter(|operation| valid_remove_all_operation(operation));
+        let journal_operation = name
+            .strip_prefix(".facelock-remove-all-")
+            .and_then(|rest| rest.strip_suffix(".json"))
+            .filter(|operation| valid_remove_all_operation(operation));
+        let (operation, is_commit) = if let Some(operation) = commit_operation {
+            (operation, true)
+        } else if let Some(operation) = journal_operation {
+            (operation, false)
+        } else {
+            continue;
+        };
+        let file = open_regular_at(&directory, OsStr::new(&name)).map_err(|error| {
+            std::io::Error::other(format!("reserved remove-all state is invalid: {error}"))
+        })?;
+        let metadata = file.metadata()?;
+        let encoded = read_open_bounded(&file, MAX_REMOVE_ALL_JOURNAL_BYTES)?;
+        let identity = identity_for_bytes(&metadata, &encoded);
+        if !state_identity_matches(store.expected_owner, &identity, &identity.sha256) {
+            return Err(std::io::Error::other(
+                "reserved remove-all state owner or mode is invalid",
+            ));
+        }
+        if is_commit {
+            let value: RemoveAllCommit = serde_json::from_slice(&encoded).map_err(|error| {
+                std::io::Error::other(format!("remove-all commit is corrupt: {error}"))
+            })?;
+            if operation != value.operation || !valid_remove_all_commit(&value) {
+                return Err(std::io::Error::other("remove-all commit is invalid"));
+            }
+            if commit
+                .replace(LoadedRemoveAll {
+                    name,
+                    value,
+                    encoded,
+                    identity,
+                })
+                .is_some()
+            {
+                return Err(std::io::Error::other(
+                    "multiple remove-all commits require manual review",
+                ));
+            }
+            continue;
+        }
+        let value: RemoveAllJournal = serde_json::from_slice(&encoded).map_err(|error| {
+            std::io::Error::other(format!("remove-all journal is corrupt: {error}"))
+        })?;
+        if operation != value.operation || !valid_remove_all_journal(&value) {
+            return Err(std::io::Error::other("remove-all journal is invalid"));
+        }
+        if journal
+            .replace(LoadedRemoveAll {
+                name,
+                value,
+                encoded,
+                identity,
+            })
+            .is_some()
+        {
+            return Err(std::io::Error::other(
+                "multiple remove-all journals require manual review",
+            ));
+        }
+    }
+    if let (Some(journal), Some(commit)) = (&journal, &commit) {
+        let corresponding = commit.value.operation == journal.value.operation
+            && commit.value.keep_backup == journal.value.keep_backup
+            && commit.value.journal_sha256 == sha256_hex(&journal.encoded)
+            && commit.value.targets.len() == journal.value.targets.len()
+            && commit.value.targets.iter().zip(&journal.value.targets).all(
+                |(committed, planned)| {
+                    committed.service == planned.service
+                        && committed.backup == planned.backup
+                        && committed.installed.sha256 == planned.installed_sha256
+                },
+            );
+        if !corresponding {
+            return Err(std::io::Error::other(
+                "remove-all journal and commit do not describe one transaction",
+            ));
+        }
+    }
+    Ok((journal, commit))
+}
+
+#[cfg(test)]
+fn recover_remove_all_in(dirs: &PamDirs) -> std::io::Result<()> {
+    let Some(store) = BackupStore::open_existing(dirs.backup_dir())? else {
+        return Ok(());
+    };
+    let _lock = store.lock_exclusive()?;
+    recover_remove_all_locked(&store, dirs)
+}
+
+fn recover_remove_all_locked(store: &BackupStore, dirs: &PamDirs) -> std::io::Result<()> {
+    let (journal, commit) = load_remove_all_state(store)?;
+    if let Some(commit) = commit {
+        return finish_committed_remove_all(
+            store,
+            dirs,
+            journal
+                .as_ref()
+                .map(|journal| (&journal.value, journal.name.as_str(), &journal.identity)),
+            &commit.value,
+            &commit.name,
+            &commit.identity,
+        );
+    }
+    if let Some(journal) = journal {
+        rollback_remove_all(
+            store,
+            dirs,
+            &journal.value,
+            &journal.name,
+            &journal.identity,
+        )?;
+    }
+    Ok(())
+}
+
+fn remove_all_in_with_report_hook(
+    dirs: &PamDirs,
+    request: &PamRequest,
+    hook: impl FnMut(RemoveAllPoint) -> std::io::Result<()>,
+    mut report_hook: impl FnMut(&[ServiceReport]),
+) -> anyhow::Result<i32> {
+    use std::cell::RefCell;
+    use std::io::{Error, ErrorKind};
+
+    debug_assert_eq!(request.action, PamAction::Remove);
+    debug_assert!(request.all);
+    if request.dry_run {
+        let services = remove_all_services_read_only(dirs)?;
+        if services.is_empty() {
+            report_hook(&[]);
+            return Ok(WRITE_OK);
+        }
+        if services.len() > MAX_REMOVE_ALL_TARGETS {
+            anyhow::bail!("remove-all target limit exceeded");
+        }
+        let mut named = request.clone();
+        named.all = false;
+        named.services = services;
+        return write_in(dirs, &named);
+    }
+
+    // Avoid creating state for a clear no-op or a rejected first preflight.
+    // Once state exists, the second scan below is authoritative and happens
+    // while the same transaction lock is held through final cleanup.
+    let store = match BackupStore::open_existing(dirs.backup_dir())? {
+        Some(store) => store,
+        None => {
+            let services = remove_all_services(dirs)?;
+            if services.is_empty() {
+                report_hook(&[]);
+                return Ok(WRITE_OK);
+            }
+            BackupStore::open(dirs.backup_dir())?
+        }
+    };
+    let transaction = store.transaction(dirs)?;
+    let hook = RefCell::new(hook);
+    hook.borrow_mut()(RemoveAllPoint::Locked)?;
+    let services = remove_all_services(dirs)?;
+    if services.is_empty() {
+        report_hook(&[]);
+        return Ok(WRITE_OK);
+    }
+    if services.len() > MAX_REMOVE_ALL_TARGETS {
+        anyhow::bail!("remove-all target limit exceeded");
+    }
+    let mut named = request.clone();
+    named.all = false;
+    named.services = services;
+    let write = WriteRequest {
+        action: WriteAction::Remove,
+        request: &named,
+        remedy: "--allow-sensitive",
+    };
+    let targets = plan_writes(dirs, &write)?;
+    let mut planned = Vec::with_capacity(targets.len());
+    for target in targets {
+        let Plan::Rewrite { content } = &target.plan else {
+            anyhow::bail!(
+                "remove-all target {} no longer needs a rewrite",
+                target.service
+            );
+        };
+        let expected = target.identity.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "remove-all target {} has no captured identity",
+                target.service
+            )
+        })?;
+        let installed = with_line_removed(content);
+        let prepared = transaction.plan(&target.service, content, &installed)?;
+        transaction.persist(&prepared, content)?;
+        planned.push((target, installed, prepared, expected));
+    }
+    let journal_targets = planned
+        .iter()
+        .map(
+            |(target, installed, prepared, expected)| RemoveAllJournalTarget {
+                service: target.service.clone(),
+                backup: prepared.backup.clone(),
+                original: expected.clone(),
+                installed_sha256: sha256_hex(installed),
+            },
+        )
+        .collect();
+    let (journal, journal_name, journal_encoded, journal_identity) =
+        create_remove_all_journal(&store, request.keep_backup, journal_targets)?;
+    if let Err(error) = hook.borrow_mut()(RemoveAllPoint::Journaled) {
+        return Err(error.into());
+    }
+
+    const HELD: &str = "remove-all publication retained for batch commit";
+    for (index, (target, installed, prepared, expected)) in planned.iter().enumerate() {
+        if let Err(error) = hook.borrow_mut()(RemoveAllPoint::BeforeMutation(index)) {
+            if error.kind() == ErrorKind::Interrupted {
+                return Err(error.into());
+            }
+            let rollback =
+                rollback_remove_all(&store, dirs, &journal, &journal_name, &journal_identity);
+            return Err(anyhow::anyhow!(match rollback {
+                Ok(()) => error.to_string(),
+                Err(rollback) => format!("{error}; {rollback}"),
+            }));
+        }
+        let user_error = RefCell::new(None);
+        let result = transaction.replace_pam_with_intent_hook(
+            prepared,
+            &target.path,
+            expected,
+            installed,
+            |point| {
+                if point != PamReplaceCrashPoint::Exchange {
+                    return Ok(());
+                }
+                match hook.borrow_mut()(RemoveAllPoint::AfterMutation(index)) {
+                    Ok(()) => Err(Error::new(ErrorKind::Interrupted, HELD)),
+                    Err(error) => {
+                        let kind = error.kind();
+                        *user_error.borrow_mut() = Some(error);
+                        Err(Error::new(kind, "remove-all hook stopped publication"))
+                    }
+                }
+            },
+        );
+        if let Some(error) = user_error.into_inner() {
+            if error.kind() == ErrorKind::Interrupted {
+                return Err(error.into());
+            }
+            let rollback =
+                rollback_remove_all(&store, dirs, &journal, &journal_name, &journal_identity);
+            return Err(anyhow::anyhow!(match rollback {
+                Ok(()) => error.to_string(),
+                Err(rollback) => format!("{error}; {rollback}"),
+            }));
+        }
+        match result {
+            Err(error) if error.kind() == ErrorKind::Interrupted && error.to_string() == HELD => {}
+            Err(error) if is_ambiguous_publication(&error) => return Err(error.into()),
+            Err(error) => {
+                let rollback =
+                    rollback_remove_all(&store, dirs, &journal, &journal_name, &journal_identity);
+                return Err(anyhow::anyhow!(match rollback {
+                    Ok(()) => error.to_string(),
+                    Err(rollback) => format!("{error}; {rollback}"),
+                }));
+            }
+            Ok(()) => {
+                return Err(anyhow::anyhow!(
+                    "remove-all publication finalized without retained recovery evidence"
+                ));
+            }
+        }
+    }
+
+    if let Err(error) = remove_all_services(dirs).and_then(|remaining| {
+        if remaining.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!("remove-all final scan still found active references")
+        }
+    }) {
+        let rollback =
+            rollback_remove_all(&store, dirs, &journal, &journal_name, &journal_identity);
+        return Err(anyhow::anyhow!(match rollback {
+            Ok(()) => error.to_string(),
+            Err(rollback) => format!("{error}; {rollback}"),
+        }));
+    }
+
+    let committed_targets = committed_remove_all_targets(&store, &journal)?;
+    let commit = RemoveAllCommit {
+        version: REMOVE_ALL_VERSION,
+        operation: journal.operation.clone(),
+        journal_sha256: sha256_hex(&journal_encoded),
+        keep_backup: journal.keep_backup,
+        targets: committed_targets,
+    };
+    let commit_encoded = serde_json::to_vec_pretty(&commit)
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+    if commit_encoded.len() > MAX_REMOVE_ALL_JOURNAL_BYTES {
+        anyhow::bail!("remove-all commit exceeds its size limit");
+    }
+    let commit_name = remove_all_commit_name(&journal.operation);
+    let commit_identity = match atomic_state_create(&store.root, &commit_name, &commit_encoded) {
+        Ok(identity) => identity,
+        Err(error) if is_ambiguous_publication(&error) => return Err(error.into()),
+        Err(error) => {
+            let rollback =
+                rollback_remove_all(&store, dirs, &journal, &journal_name, &journal_identity);
+            return Err(anyhow::anyhow!(match rollback {
+                Ok(()) => error.to_string(),
+                Err(rollback) => format!("{error}; {rollback}"),
+            }));
+        }
+    };
+    hook.borrow_mut()(RemoveAllPoint::CommitMarked)?;
+    finish_committed_remove_all(
+        &store,
+        dirs,
+        Some((&journal, &journal_name, &journal_identity)),
+        &commit,
+        &commit_name,
+        &commit_identity,
+    )?;
+    let reports = planned
+        .iter()
+        .map(|(target, _, _, _)| ServiceReport {
+            service: target.service.clone(),
+            path: Some(target.reported_path()),
+            backup: request
+                .keep_backup
+                .then(|| reported_backup(dirs, target))
+                .flatten(),
+            shadows: target.shadows_string(),
+            outcome: Outcome::Removed,
+        })
+        .collect::<Vec<_>>();
+    report_hook(&reports);
+    Ok(WRITE_OK)
+}
+
+fn remove_all_in_with_hook(
+    dirs: &PamDirs,
+    request: &PamRequest,
+    hook: impl FnMut(RemoveAllPoint) -> std::io::Result<()>,
+) -> anyhow::Result<i32> {
+    remove_all_in_with_report_hook(dirs, request, hook, |reports| {
+        emit_json(request, request.dry_run, reports, &[]);
+    })
+}
+
+fn remove_all_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Result<i32> {
+    remove_all_in_with_hook(dirs, request, |_| Ok(()))
 }
 
 /// `pam status` against `base`.
@@ -6837,6 +8252,7 @@ fn add_left_the_line(outcome: &Outcome) -> bool {
 mod tests {
     use super::*;
 
+    use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -10002,6 +11418,36 @@ mod tests {
             .collect()
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    struct DirectorySnapshot {
+        device: u64,
+        inode: u64,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+        modified_seconds: i64,
+        modified_nanoseconds: i64,
+        changed_seconds: i64,
+        changed_nanoseconds: i64,
+        entries: BTreeMap<String, Vec<u8>>,
+    }
+
+    fn directory_snapshot(dir: &Path) -> DirectorySnapshot {
+        let metadata = fs::symlink_metadata(dir).unwrap();
+        DirectorySnapshot {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            mode: metadata.mode(),
+            uid: metadata.uid(),
+            gid: metadata.gid(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+            entries: snapshot(dir),
+        }
+    }
+
     fn add(services: &[&str]) -> PamRequest {
         PamRequest {
             action: PamAction::Add,
@@ -12048,6 +13494,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn remove_all_uses_compiled_system_roots_not_configured_search_dirs() {
+        let configured = PamDirs::new(vec![PathBuf::from("/srv/custom-pam")]);
+        let cleanup = PamDirs::system_cleanup();
+
+        assert_ne!(cleanup, configured);
+        assert_eq!(cleanup.overrides(), Path::new(PAM_DIR));
+        assert_eq!(
+            cleanup.iter().collect::<Vec<_>>(),
+            [
+                Path::new("/etc/pam.d"),
+                Path::new("/usr/lib/pam.d"),
+                Path::new("/etc/authselect")
+            ]
+        );
+        assert_eq!(cleanup.backup_dir(), Path::new(PAM_BACKUPS_DIR));
+    }
+
     // -----------------------------------------------------------------------
     // The module probe (P1b, #170)
     // -----------------------------------------------------------------------
@@ -12189,6 +13653,942 @@ mod tests {
                 ..PamRequest::default()
             },
         )
+    }
+
+    fn remove_all(dirs: &PamDirs) -> anyhow::Result<i32> {
+        remove_all_in(
+            dirs,
+            &PamRequest {
+                action: PamAction::Remove,
+                all: true,
+                no_confirm: true,
+                ..PamRequest::default()
+            },
+        )
+    }
+
+    #[test]
+    fn remove_all_cleans_provenance_owned_arbitrary_services() {
+        let dir = seeded(&[("custom-greeter", SUDO_BEFORE)]);
+        let dirs = only(dir.path());
+        assert_eq!(
+            write_in(&dirs, &add(&["custom-greeter"])).unwrap(),
+            WRITE_OK
+        );
+
+        assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+        assert_eq!(
+            fs::read(dir.path().join("custom-greeter")).unwrap(),
+            SUDO_BEFORE.as_bytes()
+        );
+        assert!(
+            BackupStore::open_existing(dirs.backup_dir())
+                .unwrap()
+                .unwrap()
+                .validated_records("custom-greeter")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn remove_all_finds_provenance_owned_writer_accepted_artifact_names() {
+        let dir = seeded(&[(".custom", SUDO_BEFORE), ("custom.pacsave", SUDO_BEFORE)]);
+        let dirs = only(dir.path());
+
+        assert_eq!(
+            write_in(&dirs, &add(&[".custom", "custom.pacsave"])).unwrap(),
+            WRITE_OK
+        );
+        assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+
+        assert_eq!(read(&dir, ".custom"), SUDO_BEFORE);
+        assert_eq!(read(&dir, "custom.pacsave"), SUDO_BEFORE);
+    }
+
+    #[test]
+    fn provenance_with_remove_all_prefix_survives_the_next_named_transaction() {
+        for service in [
+            ".facelock-remove-all-user",
+            ".facelock-remove-all-commit-user",
+        ] {
+            let dir = seeded(&[(service, SUDO_BEFORE)]);
+            let dirs = only(dir.path());
+
+            assert_eq!(write_in(&dirs, &add(&[service])).unwrap(), WRITE_OK);
+            assert_eq!(write_in(&dirs, &remove(&[service])).unwrap(), WRITE_OK);
+            assert_eq!(read(&dir, service), SUDO_BEFORE, "{service}");
+        }
+    }
+
+    #[test]
+    fn provenance_with_remove_all_prefix_round_trips_through_remove_all() {
+        for service in [
+            ".facelock-remove-all-user",
+            ".facelock-remove-all-commit-user",
+        ] {
+            let dir = seeded(&[(service, SUDO_BEFORE)]);
+            let dirs = only(dir.path());
+
+            assert_eq!(write_in(&dirs, &add(&[service])).unwrap(), WRITE_OK);
+            assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+            assert_eq!(read(&dir, service), SUDO_BEFORE, "{service}");
+        }
+    }
+
+    #[test]
+    fn remove_all_preserves_unowned_administrator_artifacts() {
+        let dir = seeded(&[
+            (".custom", SUDO_AFTER),
+            ("custom.pacsave", SUDO_AFTER),
+            ("custom.rpmsave", SUDO_AFTER),
+            ("custom~", SUDO_AFTER),
+        ]);
+        let dirs = only(dir.path());
+        let before = snapshot(dir.path());
+
+        assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+
+        assert_eq!(snapshot(dir.path()), before);
+    }
+
+    #[test]
+    fn remove_all_cleans_exact_legacy_emission_without_provenance() {
+        let dir = seeded(&[("pre-0.2-service", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+
+        assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+        assert_eq!(
+            fs::read(dir.path().join("pre-0.2-service")).unwrap(),
+            SUDO_BEFORE.as_bytes()
+        );
+    }
+
+    #[test]
+    fn remove_all_json_reports_the_committed_transaction() {
+        let dir = seeded(&[("pre-0.2-service", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            json: true,
+            ..PamRequest::default()
+        };
+        let document = RefCell::new(None);
+
+        assert_eq!(
+            remove_all_in_with_report_hook(
+                &dirs,
+                &request,
+                |_| Ok(()),
+                |reports| {
+                    *document.borrow_mut() =
+                        Some(report_json(PamAction::Remove, false, reports, &[]));
+                },
+            )
+            .unwrap(),
+            WRITE_OK
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(document.borrow().as_deref().unwrap()).unwrap();
+        assert_eq!(value["command"], "remove");
+        assert_eq!(value["dry_run"], false);
+        assert_eq!(value["services"][0]["service"], "pre-0.2-service");
+        assert_eq!(value["services"][0]["action"], "removed");
+        assert_eq!(value["services"][0]["backup"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn remove_all_keep_backup_preserves_versioned_and_legacy_rollback_state() {
+        let dir = seeded(&[("custom-greeter", SUDO_BEFORE)]);
+        let dirs = only(dir.path());
+        assert_eq!(
+            write_in(&dirs, &add(&["custom-greeter"])).unwrap(),
+            WRITE_OK
+        );
+        fs::write(
+            dir.path().join("custom-greeter.facelock-backup"),
+            SUDO_BEFORE,
+        )
+        .unwrap();
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            keep_backup: true,
+            ..PamRequest::default()
+        };
+
+        assert_eq!(remove_all_in(&dirs, &request).unwrap(), WRITE_OK);
+        assert_eq!(
+            fs::read(dir.path().join("custom-greeter")).unwrap(),
+            SUDO_BEFORE.as_bytes()
+        );
+        assert!(dir.path().join("custom-greeter.facelock-backup").exists());
+        assert!(
+            !BackupStore::open_existing(dirs.backup_dir())
+                .unwrap()
+                .unwrap()
+                .validated_records("custom-greeter")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn remove_all_rejects_corrupt_provenance_before_mutation() {
+        let dir = seeded(&[("custom-greeter", SUDO_BEFORE)]);
+        let dirs = only(dir.path());
+        assert_eq!(
+            write_in(&dirs, &add(&["custom-greeter"])).unwrap(),
+            WRITE_OK
+        );
+        let record = fs::read_dir(dirs.backup_dir())
+            .unwrap()
+            .map(Result::unwrap)
+            .find(|entry| entry.file_name().to_string_lossy().ends_with(".json"))
+            .unwrap()
+            .path();
+        fs::write(&record, b"{not provenance}").unwrap();
+        let before = snapshot(dir.path());
+
+        assert!(remove_all(&dirs).is_err());
+        assert_eq!(snapshot(dir.path()), before);
+    }
+
+    #[test]
+    fn remove_all_preserves_linked_entries_and_outside_sentinels() {
+        let root = tempfile::tempdir().unwrap();
+        let pam = root.path().join("pam.d");
+        fs::create_dir(&pam).unwrap();
+        let symlink_sentinel = root.path().join("symlink-sentinel");
+        let hardlink_sentinel = root.path().join("hardlink-sentinel");
+        fs::write(&symlink_sentinel, SUDO_AFTER).unwrap();
+        fs::write(&hardlink_sentinel, SUDO_AFTER).unwrap();
+        std::os::unix::fs::symlink(&symlink_sentinel, pam.join("linked-service")).unwrap();
+        fs::hard_link(&hardlink_sentinel, pam.join("hardlinked-service")).unwrap();
+        fs::write(pam.join("owned-service"), SUDO_AFTER).unwrap();
+        let dirs = only(&pam);
+
+        assert!(remove_all(&dirs).is_err());
+        assert_eq!(fs::read(&symlink_sentinel).unwrap(), SUDO_AFTER.as_bytes());
+        assert_eq!(fs::read(&hardlink_sentinel).unwrap(), SUDO_AFTER.as_bytes());
+        assert_eq!(
+            fs::read(pam.join("owned-service")).unwrap(),
+            SUDO_AFTER.as_bytes(),
+            "a link blocker must be found in preflight before the owned target changes"
+        );
+    }
+
+    #[test]
+    fn remove_all_skips_only_links_covered_by_a_separately_scanned_root() {
+        let root = tempfile::tempdir().unwrap();
+        let pam = root.path().join("pam.d");
+        let vendor = root.path().join("vendor-pam.d");
+        let authselect = root.path().join("authselect");
+        fs::create_dir(&pam).unwrap();
+        fs::create_dir(&vendor).unwrap();
+        fs::create_dir(&authselect).unwrap();
+        fs::create_dir(authselect.join("custom")).unwrap();
+        fs::write(
+            authselect.join("system-auth"),
+            b"# generated\nauth required pam_unix.so\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(authselect.join("system-auth"), pam.join("system-auth"))
+            .unwrap();
+        fs::write(pam.join("owned-service"), SUDO_AFTER).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![pam.clone(), vendor, authselect.clone()],
+            backup_dir: root.path().join("pam-backups"),
+        };
+
+        assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);
+        assert_eq!(
+            fs::read(pam.join("owned-service")).unwrap(),
+            SUDO_BEFORE.as_bytes()
+        );
+        assert!(
+            pam.join("system-auth")
+                .symlink_metadata()
+                .unwrap()
+                .is_symlink()
+        );
+
+        fs::write(pam.join("owned-service"), SUDO_AFTER).unwrap();
+        fs::write(authselect.join("system-auth"), SUDO_AFTER).unwrap();
+        let before = snapshot(&pam);
+        assert!(remove_all(&dirs).is_err());
+        assert_eq!(snapshot(&pam), before);
+    }
+
+    #[test]
+    fn remove_all_preserves_customized_and_vendor_root_references_as_blockers() {
+        let (_root, etc, vendor) = pair();
+        let customized =
+            b"#%PAM-1.0\nauth required pam_facelock.so debug\nauth include system-auth\n";
+        fs::write(etc.join("admin-service"), customized).unwrap();
+        fs::write(vendor.join("vendor-service"), SUDO_AFTER).unwrap();
+        let dirs = both(&etc, &vendor);
+        let before_etc = snapshot(&etc);
+        let before_vendor = snapshot(&vendor);
+
+        assert!(remove_all(&dirs).is_err());
+        assert_eq!(snapshot(&etc), before_etc);
+        assert_eq!(snapshot(&vendor), before_vendor);
+    }
+
+    #[test]
+    fn remove_all_journals_the_complete_set_before_first_pam_mutation() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+
+        let error = remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::Journaled {
+                let journals = fs::read_dir(dirs.backup_dir())?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry.file_name().to_str().is_some_and(|name| {
+                            name.starts_with(".facelock-remove-all-") && name.ends_with(".json")
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(journals.len(), 1);
+                let value: serde_json::Value =
+                    serde_json::from_slice(&fs::read(journals[0].path())?).unwrap();
+                let services = value["targets"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|target| target["service"].as_str().unwrap())
+                    .collect::<Vec<_>>();
+                assert_eq!(services, ["alpha", "beta"]);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "stop after durable journal",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("stop after durable journal"));
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_AFTER.as_bytes()
+        );
+        assert_eq!(
+            fs::read(dir.path().join("beta")).unwrap(),
+            POLKIT_AFTER.as_bytes()
+        );
+    }
+
+    #[test]
+    fn remove_all_holds_the_state_lock_across_preflight_and_commit() {
+        use std::cell::RefCell;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = seeded(&[("alpha", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        let (attempted_tx, attempted_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let worker = RefCell::new(None);
+
+        assert_eq!(
+            remove_all_in_with_hook(&dirs, &request, |point| {
+                if point == RemoveAllPoint::Locked {
+                    let competing_dirs = dirs.clone();
+                    let attempted_tx = attempted_tx.clone();
+                    let acquired_tx = acquired_tx.clone();
+                    *worker.borrow_mut() = Some(std::thread::spawn(move || {
+                        let store = BackupStore::open(competing_dirs.backup_dir()).unwrap();
+                        attempted_tx.send(()).unwrap();
+                        let transaction = store.transaction(&competing_dirs).unwrap();
+                        acquired_tx.send(()).unwrap();
+                        drop(transaction);
+                    }));
+                    attempted_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+                    assert!(
+                        acquired_rx
+                            .recv_timeout(Duration::from_millis(100))
+                            .is_err(),
+                        "a competing recovery acquired the lock during remove-all preflight"
+                    );
+                }
+                Ok(())
+            })
+            .unwrap(),
+            WRITE_OK
+        );
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.into_inner().unwrap().join().unwrap();
+    }
+
+    #[test]
+    fn remove_all_dry_run_does_not_recover_or_change_an_interrupted_batch() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::AfterMutation(0) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "leave an interrupted batch",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+        let pam_before = snapshot(dir.path());
+        let state_before = snapshot(dirs.backup_dir());
+        let dry_run = PamRequest {
+            dry_run: true,
+            ..request
+        };
+
+        let _ = remove_all_in(&dirs, &dry_run);
+
+        assert_eq!(snapshot(dir.path()), pam_before);
+        assert_eq!(snapshot(dirs.backup_dir()), state_before);
+    }
+
+    #[test]
+    fn remove_all_dry_run_does_not_repair_an_untrusted_state_directory() {
+        let dir = seeded(&[("alpha", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        BackupStore::open(dirs.backup_dir()).unwrap();
+        fs::write(
+            dirs.backup_dir().join("administrator-evidence"),
+            b"retain exact state bytes\n",
+        )
+        .unwrap();
+        fs::set_permissions(
+            dirs.backup_dir(),
+            fs::Permissions::from_mode(PAM_BACKUPS_DIR_MODE | 0o055),
+        )
+        .unwrap();
+        let before = directory_snapshot(dirs.backup_dir());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            dry_run: true,
+            ..PamRequest::default()
+        };
+
+        let error = remove_all_in(&dirs, &request).unwrap_err();
+
+        assert!(error.to_string().contains("owner or mode is not trusted"));
+        assert_eq!(directory_snapshot(dirs.backup_dir()), before);
+    }
+
+    #[test]
+    fn remove_all_rolls_back_earlier_files_when_a_later_recheck_fails() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let alpha_inode = fs::metadata(dir.path().join("alpha")).unwrap().ino();
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        let changed = b"# administrator changed beta after preflight\n";
+
+        assert!(
+            remove_all_in_with_hook(&dirs, &request, |point| {
+                if point == RemoveAllPoint::BeforeMutation(1) {
+                    fs::write(dir.path().join("beta"), changed)?;
+                }
+                Ok(())
+            })
+            .is_err()
+        );
+
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_AFTER.as_bytes(),
+            "the first successful removal must be restored"
+        );
+        assert_eq!(
+            fs::metadata(dir.path().join("alpha")).unwrap().ino(),
+            alpha_inode,
+            "rollback must exchange the exact displaced inode back"
+        );
+        assert_eq!(fs::read(dir.path().join("beta")).unwrap(), changed);
+    }
+
+    #[test]
+    fn remove_all_final_rescan_rolls_back_when_a_new_reference_appears() {
+        let dir = seeded(&[("alpha", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        let alpha_inode = fs::metadata(dir.path().join("alpha")).unwrap().ino();
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+
+        assert!(
+            remove_all_in_with_hook(&dirs, &request, |point| {
+                if point == RemoveAllPoint::AfterMutation(0) {
+                    fs::write(
+                        dir.path().join("late-admin-reference"),
+                        b"auth required pam_facelock.so debug\n",
+                    )?;
+                }
+                Ok(())
+            })
+            .is_err()
+        );
+
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_AFTER.as_bytes()
+        );
+        assert_eq!(
+            fs::metadata(dir.path().join("alpha")).unwrap().ino(),
+            alpha_inode,
+            "the preflight inode must be restored when the final scan fails"
+        );
+        assert_eq!(
+            fs::read(dir.path().join("late-admin-reference")).unwrap(),
+            b"auth required pam_facelock.so debug\n"
+        );
+    }
+
+    #[test]
+    fn remove_all_recovery_rolls_back_a_crash_after_an_earlier_file() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+
+        let error = remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::AfterMutation(0) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "crash after alpha",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("crash after alpha"));
+
+        recover_remove_all_in(&dirs).unwrap();
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_AFTER.as_bytes()
+        );
+        assert_eq!(
+            fs::read(dir.path().join("beta")).unwrap(),
+            POLKIT_AFTER.as_bytes()
+        );
+    }
+
+    #[test]
+    fn remove_all_recovery_resumes_every_binding_first_rollback_publication_boundary() {
+        for crash_at in [
+            RemoveAllRollbackPoint::ReverseExchange,
+            RemoveAllRollbackPoint::TempUnlink,
+            RemoveAllRollbackPoint::BindingUnlink,
+            RemoveAllRollbackPoint::IntentUnlink,
+        ] {
+            let dir = seeded(&[("alpha", SUDO_AFTER)]);
+            let dirs = only(dir.path());
+            let request = PamRequest {
+                action: PamAction::Remove,
+                all: true,
+                no_confirm: true,
+                ..PamRequest::default()
+            };
+            let error = remove_all_in_with_hook(&dirs, &request, |point| {
+                if point == RemoveAllPoint::AfterMutation(0) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "leave a published remove-all replacement",
+                    ));
+                }
+                Ok(())
+            })
+            .unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("leave a published remove-all replacement"),
+                "{crash_at:?}: {error}"
+            );
+
+            let store = BackupStore::open_existing(dirs.backup_dir())
+                .unwrap()
+                .unwrap();
+            let (journal, commit) = load_remove_all_state(&store).unwrap();
+            assert!(commit.is_none(), "{crash_at:?}");
+            let journal = journal.unwrap();
+            let rollback_error = rollback_remove_all_with_hook(
+                &store,
+                &dirs,
+                &journal.value,
+                &journal.name,
+                &journal.identity,
+                |point| {
+                    if point == crash_at {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Interrupted,
+                            "crash at rollback publication cleanup boundary",
+                        ));
+                    }
+                    Ok(())
+                },
+            )
+            .unwrap_err();
+            assert_eq!(
+                rollback_error.kind(),
+                std::io::ErrorKind::Interrupted,
+                "{crash_at:?}: {rollback_error}"
+            );
+            drop(store);
+
+            recover_remove_all_in(&dirs).unwrap_or_else(|error| panic!("{crash_at:?}: {error}"));
+
+            assert_eq!(
+                fs::read(dir.path().join("alpha")).unwrap(),
+                SUDO_AFTER.as_bytes(),
+                "{crash_at:?}"
+            );
+            assert_eq!(
+                fs::read_dir(dirs.backup_dir()).unwrap().count(),
+                0,
+                "{crash_at:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn remove_all_recovery_cleans_an_exact_intent_only_pam_replacement() {
+        let dir = seeded(&[("alpha", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        let store = BackupStore::open(dirs.backup_dir()).unwrap();
+        let transaction = store.transaction(&dirs).unwrap();
+        let path = dir.path().join("alpha");
+        let (original, expected) = read_regular_nofollow(&path).unwrap();
+        let installed = with_line_removed(&original);
+        let prepared = transaction.plan("alpha", &original, &installed).unwrap();
+        transaction.persist(&prepared, &original).unwrap();
+        create_remove_all_journal(
+            &store,
+            false,
+            vec![RemoveAllJournalTarget {
+                service: "alpha".to_owned(),
+                backup: prepared.backup.clone(),
+                original: expected.clone(),
+                installed_sha256: sha256_hex(&installed),
+            }],
+        )
+        .unwrap();
+
+        let error = transaction
+            .replace_pam_with_intent_hook(&prepared, &path, &expected, &installed, |point| {
+                if point == PamReplaceCrashPoint::Intent {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "crash after remove-all PAM intent",
+                    ));
+                }
+                Ok(())
+            })
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+        drop(transaction);
+
+        recover_remove_all_in(&dirs).unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), original);
+        assert_eq!(fs::read_dir(dirs.backup_dir()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn remove_all_recovery_resumes_every_rollback_pair_cleanup_boundary() {
+        for crash_at in [
+            CleanupCrashPoint::Intent,
+            CleanupCrashPoint::BackupQuarantine,
+            CleanupCrashPoint::RecordQuarantine,
+            CleanupCrashPoint::BackupUnlink,
+            CleanupCrashPoint::RecordUnlink,
+        ] {
+            let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+            let dirs = only(dir.path());
+            let store = BackupStore::open(dirs.backup_dir()).unwrap();
+            let transaction = store.transaction(&dirs).unwrap();
+            let path = dir.path().join("alpha");
+            let (original, expected) = read_regular_nofollow(&path).unwrap();
+            let installed = with_line_removed(&original);
+            let planned = transaction.plan("alpha", &original, &installed).unwrap();
+            transaction.persist(&planned, &original).unwrap();
+            let target = RemoveAllJournalTarget {
+                service: "alpha".to_owned(),
+                backup: planned.backup.clone(),
+                original: expected,
+                installed_sha256: sha256_hex(&installed),
+            };
+            let beta_path = dir.path().join("beta");
+            let (beta_original, beta_expected) = read_regular_nofollow(&beta_path).unwrap();
+            let beta_installed = with_line_removed(&beta_original);
+            let beta_planned = transaction
+                .plan("beta", &beta_original, &beta_installed)
+                .unwrap();
+            transaction.persist(&beta_planned, &beta_original).unwrap();
+            let beta_target = RemoveAllJournalTarget {
+                service: "beta".to_owned(),
+                backup: beta_planned.backup,
+                original: beta_expected,
+                installed_sha256: sha256_hex(&beta_installed),
+            };
+            create_remove_all_journal(&store, false, vec![target.clone(), beta_target]).unwrap();
+            let prepared = prepared_for_remove_all_target(&store, &target).unwrap();
+            let directory = open_directory_nofollow(dirs.backup_dir()).unwrap();
+
+            let error = store
+                .cleanup_one_at(&directory, &prepared, |point| {
+                    if point == crash_at {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Interrupted,
+                            "crash during remove-all pair cleanup",
+                        ));
+                    }
+                    Ok(())
+                })
+                .unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+            drop(transaction);
+
+            recover_remove_all_in(&dirs).unwrap();
+
+            assert_eq!(fs::read(&path).unwrap(), original, "{crash_at:?}");
+            assert_eq!(fs::read(&beta_path).unwrap(), beta_original, "{crash_at:?}");
+            assert_eq!(
+                fs::read_dir(dirs.backup_dir()).unwrap().count(),
+                0,
+                "{crash_at:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn remove_all_recovery_preserves_partial_substituted_and_conflicting_pairs() {
+        for state in ["partial", "substituted", "conflicting"] {
+            let dir = seeded(&[("alpha", SUDO_AFTER)]);
+            let dirs = only(dir.path());
+            let store = BackupStore::open(dirs.backup_dir()).unwrap();
+            let transaction = store.transaction(&dirs).unwrap();
+            let path = dir.path().join("alpha");
+            let (original, expected) = read_regular_nofollow(&path).unwrap();
+            let installed = with_line_removed(&original);
+            let planned = transaction.plan("alpha", &original, &installed).unwrap();
+            transaction.persist(&planned, &original).unwrap();
+            create_remove_all_journal(
+                &store,
+                false,
+                vec![RemoveAllJournalTarget {
+                    service: "alpha".to_owned(),
+                    backup: planned.backup.clone(),
+                    original: expected,
+                    installed_sha256: sha256_hex(&installed),
+                }],
+            )
+            .unwrap();
+            let backup = dirs.backup_dir().join(&planned.backup);
+            let record = dirs.backup_dir().join(format!("{}.json", planned.backup));
+            match state {
+                "partial" => fs::remove_file(&backup).unwrap(),
+                "substituted" => fs::write(&record, b"administrator state\n").unwrap(),
+                "conflicting" => fs::write(
+                    dirs.backup_dir()
+                        .join(quarantine_name("backup", &planned.backup)),
+                    &original,
+                )
+                .unwrap(),
+                _ => unreachable!(),
+            }
+            drop(transaction);
+            let before = snapshot(dirs.backup_dir());
+
+            assert!(recover_remove_all_in(&dirs).is_err(), "{state}");
+
+            assert_eq!(snapshot(dirs.backup_dir()), before, "{state}");
+            assert_eq!(fs::read(&path).unwrap(), original, "{state}");
+        }
+    }
+
+    #[test]
+    fn every_pam_transaction_recovers_remove_all_before_generic_state() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::AfterMutation(0) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "crash after alpha",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        let store = BackupStore::open_existing(dirs.backup_dir())
+            .unwrap()
+            .unwrap();
+        drop(store.transaction(&dirs).unwrap());
+
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_AFTER.as_bytes()
+        );
+        assert_eq!(
+            fs::read(dir.path().join("beta")).unwrap(),
+            POLKIT_AFTER.as_bytes()
+        );
+    }
+
+    #[test]
+    fn remove_all_recovery_completes_a_durable_commit_without_rolling_back() {
+        let dir = seeded(&[("alpha", SUDO_AFTER), ("beta", POLKIT_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::CommitMarked {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "crash after commit marker",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        recover_remove_all_in(&dirs).unwrap();
+        assert_eq!(
+            fs::read(dir.path().join("alpha")).unwrap(),
+            SUDO_BEFORE.as_bytes()
+        );
+        assert_eq!(
+            fs::read(dir.path().join("beta")).unwrap(),
+            POLKIT_BEFORE.as_bytes()
+        );
+        assert!(fs::read_dir(dirs.backup_dir()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".facelock-remove-all-")
+        }));
+    }
+
+    #[test]
+    fn remove_all_recovery_preserves_an_orphan_commit_with_duplicate_services() {
+        let dir = seeded(&[("alpha", SUDO_AFTER)]);
+        let dirs = only(dir.path());
+        let request = PamRequest {
+            action: PamAction::Remove,
+            all: true,
+            no_confirm: true,
+            ..PamRequest::default()
+        };
+        remove_all_in_with_hook(&dirs, &request, |point| {
+            if point == RemoveAllPoint::CommitMarked {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "leave a self-contained commit",
+                ));
+            }
+            Ok(())
+        })
+        .unwrap_err();
+
+        let store = BackupStore::open_existing(dirs.backup_dir())
+            .unwrap()
+            .unwrap();
+        let (journal, commit) = load_remove_all_state(&store).unwrap();
+        let journal = journal.unwrap();
+        let commit = commit.unwrap();
+        let mut duplicate = commit.value;
+        duplicate.targets.push(duplicate.targets[0].clone());
+        fs::write(
+            dirs.backup_dir().join(&commit.name),
+            serde_json::to_vec_pretty(&duplicate).unwrap(),
+        )
+        .unwrap();
+        fs::remove_file(dirs.backup_dir().join(&journal.name)).unwrap();
+        let pam_before = snapshot(dir.path());
+        let state_before = snapshot(dirs.backup_dir());
+
+        let error = recover_remove_all_in(&dirs).unwrap_err();
+
+        assert!(error.to_string().contains("remove-all commit is invalid"));
+        assert_eq!(snapshot(dir.path()), pam_before);
+        assert_eq!(snapshot(dirs.backup_dir()), state_before);
+    }
+
+    #[test]
+    fn remove_all_enumerates_the_open_root_descriptor_after_path_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let pam = root.path().join("pam.d");
+        let held = root.path().join("held-pam.d");
+        fs::create_dir(&pam).unwrap();
+        fs::write(pam.join("original-service"), SUDO_AFTER).unwrap();
+        let directory = open_directory_nofollow(&pam).unwrap();
+
+        fs::rename(&pam, &held).unwrap();
+        fs::create_dir(&pam).unwrap();
+        fs::write(pam.join("replacement-service"), SUDO_AFTER).unwrap();
+
+        let names = directory_entry_names(&directory).unwrap();
+        assert!(
+            names
+                .iter()
+                .any(|name| name == OsStr::new("original-service"))
+        );
+        assert!(
+            !names
+                .iter()
+                .any(|name| name == OsStr::new("replacement-service"))
+        );
     }
 
     /// The headline: every configured service is listed, from both

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -4087,83 +4087,199 @@ mod tests {
         }
     }
 
-    /// The uninstall paths of all four packagers each hardcode the set of
-    /// `/etc/pam.d/<service>` files to strip `pam_facelock.so` out of, because
-    /// they are shell run by a package manager and cannot read
-    /// `PAM_CANDIDATES`. That duplication has already rotted once: the lists
-    /// covered three services while setup offered eight, so five services kept
-    /// a stale facelock line after the package was removed. Nothing failed
-    /// loudly — the drift is only visible on an uninstall nobody runs in CI.
-    ///
-    /// This pins the direction that matters: every service the writer can put a
-    /// line into must be *covered* by every packager. That is two lists, not
-    /// one — `PAM_CANDIDATES`, which the wizard offers, and
-    /// `SENSITIVE_SERVICES`, which `--allow-sensitive` (or `setup --yes`)
-    /// unlocks. The second was the gap: adding a distribution's spelling of
-    /// the shared auth stack to the gate made it reachable, and nothing said
-    /// the uninstall had to learn about it.
-    ///
-    /// It is deliberately a superset check and not set equality — the
-    /// packaging lists also carry services that are not candidates yet, and
-    /// naming a service that no host has is inert because every loop is
-    /// guarded by `[ -f "$PAM_FILE" ]`. Equality would turn "packaging cleans
-    /// up more than setup writes" — always safe — into a failure, and would
-    /// break whenever a candidate lands in one branch and the packaging list
-    /// in another.
+    /// Every uninstall surface delegates discovery and mutation to the same
+    /// config-independent command. A fixed service list cannot cover the
+    /// arbitrary names accepted by `pam add --service`, and a shell `sed`
+    /// cannot enforce the writer's provenance, confinement or rollback rules.
     #[test]
-    fn packaging_uninstall_covers_every_pam_candidate() {
-        // Assembled so this test's own prose is not what it matches on.
-        let decl = format!("FACELOCK_PAM_SERVICES={}", '"');
+    fn every_installer_calls_the_shared_pam_cleanup() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
 
         for rel in [
             "dist/facelock.install",
             "dist/facelock.spec",
             "dist/debian/prerm",
+            "dist/omarchy/omarchy-remove-security-face",
             "justfile",
         ] {
             let path = root.join(rel);
             let source = fs::read_to_string(&path)
                 .unwrap_or_else(|e| panic!("{rel} must be readable from the workspace: {e}"));
 
-            let listed: Vec<&str> = source
-                .lines()
-                .find_map(|l| l.trim_start().strip_prefix(&decl)?.split_once('"'))
-                .map(|(value, _)| value.split_whitespace().collect())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "{rel} must declare its PAM service list on one line as \
-                         FACELOCK_PAM_SERVICES=\"svc svc ...\". It is the single \
-                         literal both uninstall loops (pam_facelock.so lines and \
-                         .facelock-backup files) read, and this test's only handle \
-                         on it."
-                    )
-                });
+            assert!(
+                source.contains("facelock pam remove --all"),
+                "{rel} must call the shared config-independent PAM cleanup"
+            );
+            assert!(!source.contains("FACELOCK_PAM_SERVICES="), "{rel}");
+            assert!(!source.contains("sed -i '/pam_facelock"), "{rel}");
+        }
+    }
 
-            for gated in super::super::pam::SENSITIVE_SERVICES {
-                assert!(
-                    listed.contains(gated),
-                    "{rel} does not clean up /etc/pam.d/{gated}, but it is in \
-                     SENSITIVE_SERVICES, so `facelock pam add --service {gated} \
-                     --allow-sensitive` writes a pam_facelock.so line into it. \
-                     Add {gated} to FACELOCK_PAM_SERVICES in {rel} (naming a \
-                     service the host lacks is inert — the loops skip missing \
-                     files). Currently listed there: {listed:?}"
-                );
-            }
+    #[test]
+    fn man_pages_contain_no_prohibited_control_bytes() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut pages = fs::read_dir(root.join("man"))
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "1"))
+            .collect::<Vec<_>>();
+        pages.sort();
+        assert!(
+            !pages.is_empty(),
+            "the man-page control-byte guard must cover a page"
+        );
 
-            for candidate in PAM_CANDIDATES {
-                assert!(
-                    listed.contains(&candidate.service),
-                    "{rel} does not clean up /etc/pam.d/{svc}, but `facelock setup` \
-                     offers to write a pam_facelock.so line into it. Uninstalling \
-                     would leave that line behind, pointing at a module that is no \
-                     longer on disk. Add {svc} to FACELOCK_PAM_SERVICES in {rel} \
-                     (naming a service the host lacks is inert — the loops skip \
-                     missing files). Currently listed there: {listed:?}",
-                    svc = candidate.service,
-                );
-            }
+        for path in pages {
+            let bytes = fs::read(&path).unwrap();
+            let prohibited = bytes
+                .iter()
+                .enumerate()
+                .filter_map(|(offset, byte)| {
+                    matches!(*byte, 0x00..=0x08 | 0x0b..=0x0c | 0x0e..=0x1f | 0x7f)
+                        .then_some((offset, *byte))
+                })
+                .collect::<Vec<_>>();
+
+            assert!(
+                prohibited.is_empty(),
+                "{} contains prohibited control bytes at offset/byte pairs: {prohibited:?}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn arch_packages_ship_an_aborting_pretransaction_cleanup_hook() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let hook = fs::read_to_string(root.join("dist/facelock-pam-remove.hook")).unwrap();
+        for required in [
+            "Operation = Remove",
+            "Type = Package",
+            "When = PreTransaction",
+            "Exec = /usr/bin/facelock pam remove --all",
+            "AbortOnFail",
+        ] {
+            assert!(hook.contains(required), "missing `{required}`");
+        }
+        assert!(
+            !hook.contains("Operation = Upgrade"),
+            "the cleanup hook must not remove configured PAM edits during upgrade"
+        );
+        let contracts = fs::read_to_string(root.join("docs/contracts.md")).unwrap();
+        assert!(contracts.contains("Remove-only"));
+        assert!(!contracts.contains("`Remove`/`Upgrade`"));
+        for pkgbuild in ["dist/PKGBUILD", "dist/PKGBUILD-git", "dist/PKGBUILD-bin"] {
+            let source = fs::read_to_string(root.join(pkgbuild)).unwrap();
+            assert!(source.contains("facelock-pam-remove.hook"), "{pkgbuild}");
+            assert!(source.contains("usr/share/libalpm/hooks"), "{pkgbuild}");
+        }
+    }
+
+    #[test]
+    fn package_validation_proves_removal_aborts_before_the_module_is_removed() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let validation = fs::read_to_string(root.join("test/pkg-validate.sh")).unwrap();
+
+        for required in [
+            "facelock-package-owned",
+            "facelock-package-blocker",
+            "dpkg removal aborts on an unmanaged PAM reference",
+            "#224-deferred profile mutation is visible after aborted dpkg removal",
+            "rpm removal aborts on an unmanaged PAM reference",
+            "PAM module remains after aborted package removal",
+            "recognized PAM edit remains after aborted package removal",
+        ] {
+            assert!(validation.contains(required), "missing `{required}`");
+        }
+    }
+
+    #[test]
+    fn package_validation_covers_frontend_abort_retention_and_success() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let validation = fs::read_to_string(root.join("test/pkg-validate.sh")).unwrap();
+
+        for required in [
+            "apt-get wrapper removal aborts on an unmanaged PAM reference",
+            "apt-get wrapper keeps the package installed after abort",
+            "apt-get wrapper keeps the PAM module after abort",
+            "apt-get wrapper preserves recognized PAM edit bytes after abort",
+            "apt wrapper removal aborts on an unmanaged PAM reference",
+            "apt wrapper keeps the package installed after abort",
+            "apt wrapper keeps the PAM module after abort",
+            "apt wrapper preserves recognized PAM edit bytes after abort",
+            "apt-get wrapper removal succeeds without a blocker",
+            "apt-get wrapper leaves the package not installed",
+            "apt-get wrapper removes the PAM module",
+            "apt wrapper removal succeeds without a blocker",
+            "apt wrapper leaves the package not installed",
+            "apt wrapper removes the PAM module",
+            "dnf wrapper removal aborts on an unmanaged PAM reference",
+            "dnf wrapper keeps the package installed after abort",
+            "dnf wrapper keeps the PAM module after abort",
+            "dnf wrapper preserves recognized PAM edit bytes after abort",
+            "dnf wrapper removal succeeds without a blocker",
+        ] {
+            assert!(validation.contains(required), "missing `{required}`");
+        }
+        assert!(validation.contains("db:Status-Status"));
+        let rpm = fs::read_to_string(root.join("test/Containerfile.rpm-e2e")).unwrap();
+        for rel in [
+            "test/Containerfile.deb-e2e",
+            "test/Containerfile.deb-tpm-e2e",
+        ] {
+            let deb = fs::read_to_string(root.join(rel)).unwrap();
+            assert!(deb.contains("/facelock-test-package.deb"), "{rel}");
+            assert!(
+                deb.contains("(dpkg -i /facelock-test-package.deb || true)"),
+                "{rel}"
+            );
+        }
+        assert!(rpm.contains("/facelock-test-package.rpm"));
+    }
+
+    #[test]
+    fn rpm_preun_propagates_shared_cleanup_failure() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let spec = fs::read_to_string(root.join("dist/facelock.spec")).unwrap();
+
+        assert!(
+            spec.contains("facelock pam remove --all || exit $?"),
+            "the RPM preun scriptlet must abort before a later best-effort command can mask cleanup failure"
+        );
+    }
+
+    #[test]
+    fn package_runner_never_mounts_checkout_models_at_the_mutable_runtime_path() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let runner = fs::read_to_string(root.join("test/run-pkg-validate-systemd.sh")).unwrap();
+
+        assert!(runner.contains("$PWD/models:/facelock-test-models:ro"));
+        assert!(runner.contains("cp /facelock-test-models/*.onnx /var/lib/facelock/models/"));
+        assert!(
+            !runner.contains("$PWD/models:/var/lib/facelock/models"),
+            "the removal test deletes its runtime model directory; the checkout must never be mounted there"
+        );
+    }
+
+    #[test]
+    fn arch_package_validation_runs_an_aborting_booted_transaction() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let justfile = fs::read_to_string(root.join("justfile")).unwrap();
+        let container = fs::read_to_string(root.join("test/Containerfile")).unwrap();
+        let runner = fs::read_to_string(root.join("test/run-arch-package-systemd.sh")).unwrap();
+        let validation = fs::read_to_string(root.join("test/arch-package-validate.sh")).unwrap();
+
+        assert!(justfile.contains("test/run-arch-package-systemd.sh facelock-pam-test"));
+        assert!(container.contains("test/build-arch-test-package.sh"));
+        assert!(runner.contains("--systemd=always"));
+        for required in [
+            "pacman removal aborts on an unmanaged PAM reference",
+            "facelock-package-owned",
+            "facelock-package-blocker",
+            "pacman -Q facelock",
+            "PAM module remains after aborted package removal",
+        ] {
+            assert!(validation.contains(required), "missing `{required}`");
         }
     }
 

--- a/crates/facelock-cli/src/conformance/capabilities.rs
+++ b/crates/facelock-cli/src/conformance/capabilities.rs
@@ -103,19 +103,17 @@ fn capability_names_are_all_implemented() {
             "pam-status" => {
                 sub(pam, "status");
             }
-            // The flag exists on `status` and nowhere else. That it *conflicts*
-            // with `--service` is not askable of an `Arg` — clap exposes no
-            // getter for conflicts — so it is proved by parsing, in
-            // `flags.rs`'s `all_is_a_status_only_flag_and_leaves_the_bare_form_alone`.
+            "pam-remove-all" => {
+                assert_long(sub(pam, "remove"), "all", "all");
+                assert!(
+                    !sub(pam, "add").get_arguments().any(|a| a.get_id() == "all"),
+                    "`pam add` must not offer machine-wide mutation"
+                );
+            }
+            // The status enumerator is backed independently from destructive
+            // cleanup so callers can branch on the exact operation they need.
             "pam-status-all" => {
                 assert_long(sub(pam, "status"), "all", "all");
-                for verb in ["add", "remove"] {
-                    assert!(
-                        !sub(pam, verb).get_arguments().any(|a| a.get_id() == "all"),
-                        "`pam {verb}` must not offer --all: a write verb has \
-                         nothing to enumerate"
-                    );
-                }
             }
             "quiet" => {
                 assert_long(&root, "quiet", "quiet");

--- a/crates/facelock-cli/src/conformance/flags.rs
+++ b/crates/facelock-cli/src/conformance/flags.rs
@@ -844,6 +844,7 @@ fn legacy_invocations_still_parse() {
         ],
         &["facelock", "pam", "add", "--service", "x", "--if-present"],
         &["facelock", "pam", "remove"],
+        &["facelock", "pam", "remove", "--all"],
         &[
             "facelock",
             "pam",
@@ -1066,8 +1067,8 @@ fn pam_remove_keep_backup_is_an_explicit_opt_out() {
     }
 }
 
-/// `--all` is `status`-only, takes no `--service`, and leaves the bare form
-/// alone.
+/// `--all` is an enumerating flag for status and removal, takes no
+/// `--service`, and leaves both bare forms alone.
 ///
 /// The last clause is the compatibility one: `pam status` with no flags has
 /// meant `sudo` since the verb shipped, and its exit code is 0/1/2 about that
@@ -1075,9 +1076,15 @@ fn pam_remove_keep_backup_is_an_explicit_opt_out() {
 /// without changing their command line, which is why `--all` is a flag rather
 /// than a new default (docs/contracts.md, "facelock pam Semantics").
 #[test]
-fn all_is_a_status_only_flag_and_leaves_the_bare_form_alone() {
+fn all_enumerates_status_or_removal_and_leaves_bare_forms_alone() {
     assert!(pam_request(&["status", "--all"]).all);
     assert!(pam_request(&["status", "--all", "--json"]).json);
+    let removal = pam_request(&["remove", "--all"]);
+    assert!(removal.all);
+    assert_eq!(
+        removal.action,
+        facelock_cli::commands::pam::PamAction::Remove
+    );
 
     let bare = pam_request(&["status"]);
     assert!(!bare.all, "bare `pam status` must still mean one service");
@@ -1085,6 +1092,9 @@ fn all_is_a_status_only_flag_and_leaves_the_bare_form_alone() {
         bare.services.is_empty(),
         "...resolved to sudo in the command"
     );
+    let bare_remove = pam_request(&["remove"]);
+    assert!(!bare_remove.all, "bare `pam remove` must still mean sudo");
+    assert!(bare_remove.services.is_empty());
 
     // `--if-present` composes: the pair is documented as answering
     // "everything configured, and absence is not an error".
@@ -1094,10 +1104,10 @@ fn all_is_a_status_only_flag_and_leaves_the_bare_form_alone() {
         // Enumerating and naming are two questions; a request that did both
         // would have to drop one silently.
         &["facelock", "pam", "status", "--all", "--service", "sudo"][..],
-        // A write verb has nothing to enumerate: `add --all` would have to
-        // mean "edit every service file on the machine".
+        &["facelock", "pam", "remove", "--all", "--service", "sudo"],
+        // Addition is deliberately named: `add --all` would edit every PAM
+        // service file on the machine rather than clean Facelock-owned work.
         &["facelock", "pam", "add", "--all"],
-        &["facelock", "pam", "remove", "--all"],
     ] {
         assert!(
             Cli::try_parse_from(argv).is_err(),

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -63,6 +63,7 @@ package() {
 
     # tmpfiles.d for runtime directories
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
+    install -Dm644 dist/facelock-pam-remove.hook "$pkgdir/usr/share/libalpm/hooks/facelock-pam-remove.hook"
 
     # Omarchy helper scripts (inert if walker/omarchy isn't installed)
     install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"

--- a/dist/PKGBUILD-bin
+++ b/dist/PKGBUILD-bin
@@ -40,6 +40,7 @@ package() {
     install -Dm644 dbus/org.facelock.Daemon.conf "$pkgdir/usr/share/dbus-1/system.d/org.facelock.Daemon.conf"
     install -Dm644 dbus/org.facelock.Daemon.service "$pkgdir/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
+    install -Dm644 dist/facelock-pam-remove.hook "$pkgdir/usr/share/libalpm/hooks/facelock-pam-remove.hook"
 
     install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"
     install -Dm755 dist/omarchy/omarchy-remove-security-face "$pkgdir/usr/bin/omarchy-remove-security-face"

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -65,6 +65,7 @@ package() {
 
     # tmpfiles.d for runtime directories
     install -Dm644 dist/facelock.tmpfiles "$pkgdir/usr/lib/tmpfiles.d/facelock.conf"
+    install -Dm644 dist/facelock-pam-remove.hook "$pkgdir/usr/share/libalpm/hooks/facelock-pam-remove.hook"
 
     # Omarchy helper scripts (inert if walker/omarchy isn't installed)
     install -Dm755 dist/omarchy/omarchy-setup-security-face "$pkgdir/usr/bin/omarchy-setup-security-face"

--- a/dist/debian/prerm
+++ b/dist/debian/prerm
@@ -14,38 +14,9 @@ case "$1" in
             pam-auth-update --remove facelock 2>/dev/null || true
         fi
 
-        # pam-auth-update only manages the shared common-auth stack, but
-        # `facelock setup --pam` edits /etc/pam.d/<service> directly and
-        # pam-auth-update knows nothing about those edits. Without the loop
-        # below every service configured through setup keeps its
-        # pam_facelock.so line after the package is gone.
-        #
-        # Every PAM service `facelock setup` can write to: the services offered
-        # by the setup multi-select (PAM_CANDIDATES in
-        # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates
-        # behind a confirmation (SENSITIVE_SERVICES). `--service` accepts an
-        # arbitrary name, so this list can never be exhaustive; it covers
-        # everything facelock itself offers or gates. Missing files are
-        # skipped, so naming a service this host does not have is inert. A
-        # drift test in setup.rs
-        # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
-        # candidate is added without being listed here.
-        FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd common-auth password-auth system-login system-auth-ac password-auth-ac"
-
-        # Remove PAM lines (regex match — tolerates whitespace/option variations)
-        for service in $FACELOCK_PAM_SERVICES; do
-            PAM_FILE="/etc/pam.d/$service"
-            if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
-                sed -i '/pam_facelock\.so/d' "$PAM_FILE"
-                echo "Removed face authentication from $PAM_FILE"
-            fi
-        done
-
-        # Remove PAM safety backups created by `facelock setup`
-        for service in $FACELOCK_PAM_SERVICES; do
-            backup="/etc/pam.d/$service.facelock-backup"
-            [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
-        done
+        # Scan the fixed PAM roots and atomically clean every Facelock-owned
+        # direct edit. A non-zero result aborts dpkg before the module leaves.
+        facelock pam remove --all
 
         # Kill facelock polkit agent if running (lets the DE's agent take over)
         pkill -f facelock-polkit-agent 2>/dev/null || true

--- a/dist/facelock-pam-remove.hook
+++ b/dist/facelock-pam-remove.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Remove
+Type = Package
+Target = facelock
+Target = facelock-git
+Target = facelock-bin
+
+[Action]
+Description = Removing Facelock-owned PAM references...
+When = PreTransaction
+Exec = /usr/bin/facelock pam remove --all
+AbortOnFail

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -102,36 +102,10 @@ pre_remove() {
     # Kill facelock polkit agent if running (lets the DE's agent take over)
     pkill -f facelock-polkit-agent 2>/dev/null || true
 
-    # Every PAM service `facelock setup` can write to: the services offered by
-    # the setup multi-select (PAM_CANDIDATES in
-    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind
-    # a confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary
-    # name, so this list can never be exhaustive; it covers everything facelock
-    # itself offers or gates. Missing files are skipped, so naming a service
-    # this host does not have is inert. A drift test in setup.rs
-    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
-    # candidate is added without being listed here.
-    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd common-auth password-auth system-login system-auth-ac password-auth-ac"
-
-    # Remove PAM lines (regex match — tolerates whitespace/option variations)
-    for service in $FACELOCK_PAM_SERVICES; do
-        PAM_FILE="/etc/pam.d/$service"
-        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
-            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
-            echo "==> Removed face authentication from $PAM_FILE"
-        fi
-    done
-
-    # Remove PAM safety backups created by `facelock setup`
-    for service in $FACELOCK_PAM_SERVICES; do
-        backup="/etc/pam.d/$service.facelock-backup"
-        [ -f "$backup" ] && rm -f "$backup" && echo "==> Removed $backup"
-    done
-    # The loop above exits non-zero when the last service has no backup — which
-    # is the common case — and that would be pre_remove's return value. Same
-    # guard as _facelock_secure_paths, so pacman does not report a failed
-    # scriptlet on an uninstall that did exactly what it should.
-    return 0
+    # The PreTransaction libalpm hook runs this before pacman starts removing
+    # files and aborts the transaction on failure. Keep the scriptlet call as
+    # an idempotent belt-and-suspenders path for package tools that skip hooks.
+    facelock pam remove --all || return $?
 }
 
 post_remove() {

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -134,28 +134,9 @@ echo "  2. sudo facelock enroll      (register your face)"
 # lockout. At `required` (a hand-edit facelock never makes) the same stale line
 # would lock the service out, which is why the cleanup still matters.
 if [ $1 -eq 0 ]; then
-    # Every PAM service `facelock setup` can write to: the services offered by
-    # the setup multi-select (PAM_CANDIDATES in
-    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind
-    # a confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary
-    # name, so this list can never be exhaustive; it covers everything facelock
-    # itself offers or gates. Missing files are skipped, so naming a service
-    # this host does not have is inert. A drift test in setup.rs
-    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new
-    # candidate is added without being listed here.
-    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd common-auth password-auth system-login system-auth-ac password-auth-ac"
-
-    for service in $FACELOCK_PAM_SERVICES; do
-        PAM_FILE="/etc/pam.d/$service"
-        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
-            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
-        fi
-    done
-    # Remove PAM safety backups created by `facelock setup`
-    for service in $FACELOCK_PAM_SERVICES; do
-        backup="/etc/pam.d/$service.facelock-backup"
-        [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
-    done
+    # Abort rpm removal while the module and cleanup binary are still present
+    # if any active reference cannot be classified and removed safely.
+    facelock pam remove --all || exit $?
     # Kill facelock polkit agent if running (lets the DE's agent take over)
     pkill -f facelock-polkit-agent 2>/dev/null || true
 fi

--- a/dist/omarchy/omarchy-remove-security-face
+++ b/dist/omarchy/omarchy-remove-security-face
@@ -17,12 +17,7 @@ if [[ -f $HOME/.config/hypr/hyprlock.conf ]]; then
   facelock hyprlock disable || true
 fi
 
-for service in sudo polkit-1 hyprlock; do
-  if [[ -f /etc/pam.d/$service ]] && grep -q 'pam_facelock\.so' "/etc/pam.d/$service"; then
-    echo "Removing pam_facelock.so from /etc/pam.d/$service..."
-    sudo facelock setup --pam --service "$service" --remove --yes
-  fi
-done
+sudo facelock pam remove --all
 
 echo
 echo "PAM lines removed. Face data, models, and the facelock package remain installed."

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -632,7 +632,10 @@ from; the package's own file is left byte for byte. That copy reports
 `overridden` rather than `installed`, and `pam status` reports a service with no
 local copy as `vendor-only` rather than as `missing`. Deleting the override
 restores the vendor file. Set `[pam] config_dirs` if your distribution's vendor
-directory is somewhere else.
+directory is somewhere else for explicit `add`, named `remove`, and test
+resolution. Machine-wide `pam remove --all` deliberately ignores that setting,
+scans the compiled system roots `/etc/pam.d` and `/usr/lib/pam.d`, and
+separately scans the fixed detection-only generated root `/etc/authselect`.
 
 ### facelock pam add
 
@@ -688,6 +691,7 @@ default `pam remove`, but they are not rewritten into versioned provenance.
 ```bash
 sudo facelock pam remove                                     # /etc/pam.d/sudo
 sudo facelock pam remove --service login                     # removal is never gated
+sudo facelock pam remove --all                               # every recognized owned edit
 sudo facelock pam remove --service hyprlock --if-present     # a missing file is success
 sudo facelock pam remove --service sudo --keep-backup        # retain rollback state
 sudo facelock pam remove --service sudo --dry-run --json
@@ -695,9 +699,66 @@ sudo facelock pam remove --service sudo --dry-run --json
 
 Takes the same flags as `add` except `--allow-sensitive`, which it does not
 offer: removal can only take away a way to authenticate, so there is nothing to
-gate. It never prompts either. By default it removes Facelock-owned provenance
+gate. It never prompts either. Named removal uses the configured lookup path.
+By default it removes Facelock-owned provenance
 and backups for the requested service, including the legacy adjacent
 `<service>.facelock-backup` name. `--keep-backup` opts out of that cleanup.
+
+`remove --all` is the package-safe, config-independent form. It opens the
+compiled `/etc/pam.d`, `/usr/lib/pam.d`, and detection-only `/etc/authselect`
+roots without following links, enumerates the opened directory descriptors,
+and uses directory-relative regular/single-link reads. A symlink is skipped
+only when its exact absolute target is the same service in a later compiled
+root that is scanned independently; every other linked entry is an unmanaged
+blocker. This lets Fedora's unrelated generated PAM links be checked at their
+fixed root without traversing the links. Directory contents are detection
+ground truth; provenance can authenticate an arbitrary service Facelock
+previously changed, but never supplies a target path. An exact pre-0.2
+`auth      sufficient pam_facelock.so` edit is recognized only under a
+conventional service basename. Dot-prefixed and package/administrator artifact
+names such as `.pacsave`, `.rpmsave` and `~` require strict provenance for that
+exact name; unowned artifacts are ignored and preserved. A customized control,
+options or spacing, corrupt provenance for a candidate, any other linked entry,
+or a reference in a read-only root is an unmanaged blocker. Nothing is changed
+when preflight finds one.
+
+With `--dry-run`, an existing PAM backup directory is inspected read-only and
+must already have its trusted owner and mode. The preview does not repair or
+sync that directory, acquire its write lock, or run recovery; it refuses the
+preview if the directory is not already trusted.
+
+Before the first PAM file changes, the command persists rollback state for the
+complete target set and one bounded, root-owned whole-set journal. Each
+replacement re-resolves and rechecks the planned identity. A later failure or
+the final compiled-root rescan finding any active reference exchanges every
+earlier original inode back in reverse order. Only after the rescan is clear is
+a self-contained commit marker published and cleanup finalized. Recovery rolls
+back a prepared journal and completes a durable commit marker. It recognizes
+an exact intent-only, pre-publication service as unstarted only while the
+canonical full identity still matches and both temp and binding are absent.
+After a reverse exchange, rollback removes the identity-checked replacement
+temp, then its publication binding, then delegates the remaining base intent
+to that exact intent-only recovery. Each boundary is restartable; ordinary
+forward publication keeps its existing cleanup order.
+Cleanup recovery resumes exact pair quarantine/unlink state; a fully absent
+pair is already clean, but partial or conflicting state blocks. `--keep-backup`
+preserves versioned and legacy rollback state for every target; the default
+cleans only validated Facelock-owned state.
+
+The command reads no Facelock config, database, model, camera, daemon, or ONNX
+Runtime state. Package uninstallers invoke it while the CLI and PAM module are
+still installed. Debian and RPM removal abort if cleanup cannot prove a clear
+final scan. Booted coverage runs direct `dpkg`/`rpm` and the `apt-get`, `apt`,
+and `dnf` frontends through abort retention and blocker-free success. Arch
+packages also ship a Remove-only libalpm `PreTransaction` hook with
+`AbortOnFail`, so pacman stops before removing either file.
+This all-or-nothing promise covers direct PAM edits owned by this command.
+Debian's separately managed `pam-auth-update` profile lifecycle and byte-exact
+profile rollback are tracked in #224; the current `prerm` removes that profile
+before calling the shared direct-edit cleanup.
+Fedora's authselect profile lifecycle is tracked separately in #226; this
+command only detects references in generated `/etc/authselect` state and never
+changes that state.
 
 ### facelock pam status
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -56,6 +56,7 @@ follow it.
 | `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
 | `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |
 | `facelock pam remove` | Remove it. Root. Cleans validated Facelock-owned rollback state by default; `--keep-backup` preserves it |
+| `facelock pam remove --all` | Config-independent, whole-machine removal of recognized Facelock-owned direct PAM edits beneath compiled roots. Root. Conflicts with `--service` |
 | `facelock pam status` | Report whether services carry the line. Reads only, **no root** — the probe to branch on instead of grepping `/etc/pam.d` |
 | `facelock setup` choice flags | `--camera <PATH\|auto>`, `--models <standard\|balanced\|high>`, `--execution-provider <cpu\|cuda\|rocm\|openvino\|auto>`, `--encryption <tpm\|keyfile\|none\|auto>`. Precedence: CLI flag > config file > built-in default |
 | `facelock setup` action opt-outs | `--no-pam`, `--no-systemd`, `--no-enroll` decline an action outright (and their `--pam`/`--systemd`/`--enroll` counterparts force it). Later flag wins |
@@ -309,7 +310,8 @@ subject to the auth/open fail-closed checks.
 
 ### facelock pam Semantics
 
-`facelock pam add | remove | status` owns every write to `/etc/pam.d`.
+`facelock pam add | remove | status` and the machine-wide
+`facelock pam remove --all` cleanup own every direct write to `/etc/pam.d`.
 `setup --pam` is an alias onto it (above), and the wizard's step 9 calls the
 same writer, so there is one implementation of the edit and one set of rules.
 
@@ -320,7 +322,9 @@ does not exist, so a writer that looked only in `/etc/pam.d` could not
 configure the service at all. The list is `[pam] config_dirs` (Config Schema
 below) for a distribution whose vendor directory is somewhere else; there is no
 way to ask Linux-PAM at run time which one it was compiled with, so the default
-is the pair above and configuration is never required. A hit that is *refused* —
+for named add, remove and status is the pair above and configuration is never
+required. Machine-wide `remove --all` uses its own fixed roots described below.
+A hit that is *refused* —
 a hard link or any symlink — is still a hit: the search does
 not fall through to the next directory, because that would let a vendor file
 silently take over from an `/etc` entry facelock declined to follow.
@@ -374,10 +378,11 @@ absolute name *replaces* the base — so this is the check, not the join.
 Anything else is accepted: `PAM_CANDIDATES` is the wizard's menu, **not** an
 allowlist, and a service that is not on it must keep working.
 
-**Every symlinked service entry is refused.** The writer `lstat`s the entry for
-diagnostics, but read, mutation and recovery all reopen the confined service
-basename relative to an already-open PAM root with `O_NOFOLLOW`; neither a
-resolved absolute target nor a target recorded in provenance is ever opened.
+**Every symlinked service entry is refused by named add, remove and status.**
+The writer `lstat`s the entry for diagnostics, but read, mutation and recovery
+all reopen the confined service basename relative to an already-open PAM root
+with `O_NOFOLLOW`; neither a resolved absolute target nor a target recorded in
+provenance is ever opened.
 This applies even when the link text appears to remain in the same directory.
 It also prevents Facelock from editing generated authselect state through
 `/etc/pam.d/system-auth` or `/etc/pam.d/password-auth`, and prevents a hand-made
@@ -421,8 +426,9 @@ actually happens: a typo'd or gated service name. It is **not** a transaction:
 a write-phase I/O error on service N leaves 1..N-1 written. Those are reported
 per service and the exit code is non-zero; the remaining services are still
 attempted. Each individual local mutation has its own serialized,
-crash-recoverable transaction and rollback pair, described below. This is not
-the multi-service rollback journal owned by #227.
+crash-recoverable transaction and rollback pair, described below. Named
+`pam add` and `pam remove` do not use a whole-set journal; the compiled-root
+`pam remove --all` transaction is specified separately below.
 
 **`--no-confirm` never implies `--allow-sensitive`.** They are separate
 authorizations: "do not ask me" and "yes, edit the shared auth stack". The
@@ -472,6 +478,8 @@ validation phase, before any prompt exists to skip, so an unattended
 | `pam status --all --if-present` | 0/1/2 | unchanged from `--all`: an enumerated name was found, so there is no absent case to forgive |
 | `pam add`, `pam remove` | 0 | every service reached its requested state — including `unchanged`, `overridden` (`add` created the `/etc/pam.d` copy), `vendor-only` (`remove` had nothing of its own to take out of a package-owned file), `absent` under `--if-present`, and `declined` |
 | `pam add`, `pam remove` | non-zero | a validation failure (nothing written) or a write failure |
+| `pam remove --all` | 0 | every recognized writable direct reference was removed, the final compiled-root scan was clear, and the whole-set transaction committed and cleaned; an empty scan is an idempotent success |
+| `pam remove --all` | non-zero | preflight, journal, identity, write, final-rescan or recovery failure; direct PAM mutations are rolled back where their exact identities prove that safe, otherwise transaction evidence is retained |
 
 `pam status` is on `grep`'s scale and `is-enrolled`'s: a boolean query whose
 exit code is the answer. Across several services the worst outcome wins. A
@@ -479,7 +487,8 @@ exit code is the answer. Across several services the worst outcome wins. A
 asked, and `--json` is how a script tells it from an install.
 
 **`--dry-run`** prints the resolved plan, writes nothing, and exits 0. It is
-honoured *after* the root check (see DEC-6 above).
+honoured *after* the root check (see DEC-6 above). On `remove --all` it performs
+no transaction recovery and creates no state.
 
 **A service that exists in no directory names them all.** The refusal `add`
 and `remove` raise, and the line `status` prints, both list every path tried:
@@ -754,7 +763,8 @@ record intent/exchange. Local remove and vendor-create planning, publication
 and recovery run under the same guard. A competing writer or recovery cannot
 discard an add's prepared pair between persistence and commit. Backup cleanup
 after a successful or no-op remove is a separate locked quarantine phase; this
-does not claim multi-service atomicity or the #227 package-cleanup journal.
+does not make named mutations multi-service atomic. The `pam remove --all`
+transaction below keeps its whole-set lock through batch cleanup.
 
 Recovery treats state as an untrusted hint and re-resolves only the recorded
 confined service under the current PAM write root. It recovers publication
@@ -794,10 +804,145 @@ identities before unlinking. Legacy cleanup is confined to the override root
 and rechecks the exact regular, single-link entry immediately before unlink.
 Malformed provenance, lookalike names, symlinks, hard links, changed entries
 and unrelated administrator files are retained. `--keep-backup` opts out of
-both versioned and legacy cleanup. This per-service behavior does not implement
-#227's compiled-root `remove --all`, package loop, broad lifecycle cleanup or
-multi-file rollback, #206 vendor-drift cleanup, #207 sensitive-authorization
-changes, or #166's final emitted-byte freeze.
+both versioned and legacy cleanup.
+
+**`pam remove --all` is the config-independent whole-machine cleanup.** It
+ignores `[pam].config_dirs` and opens the compiled roots `/etc/pam.d`
+(writable override), `/usr/lib/pam.d` (detection-only vendor state), and
+`/etc/authselect` (detection-only generated state). Missing or corrupt config,
+database, model, camera, daemon and ONNX Runtime state cannot redirect or block
+it. It enumerates already-open directory descriptors and re-resolves each
+confined basename with directory-relative, no-follow operations. A candidate
+must remain a regular, single-link file whose bounded bytes and complete
+identity can be rechecked. Directory contents are detection ground truth;
+provenance is untrusted ownership evidence, never a target path.
+
+No symlink is followed. A symlink is skipped only when its text is the exact
+absolute path of the same service basename beneath a later compiled root that
+this run scans independently. This accounts for stock links such as
+`/etc/pam.d/system-auth -> /etc/authselect/system-auth` without trusting the
+link's contents. Every other symlink, hard-linked, nonregular or unreadable PAM
+entry that contains or could hide a Facelock reference is an unmanaged blocker.
+A reference found in the independently scanned `/usr/lib/pam.d` or
+`/etc/authselect` root is likewise an unmanaged read-only or external-root
+blocker. Structural directories, including authselect profile directories, are
+not PAM service files and are skipped. Nothing outside the fixed roots is
+followed or deleted.
+
+A writable direct file with a conventional PAM service basename is recognized
+as Facelock-owned when every Facelock logical rule uses the exact pre-versioned
+physical bytes `auth      sufficient pam_facelock.so`. Dot-prefixed names and
+the administrator/package artifact suffixes `.facelock-backup`, `.pacnew`,
+`.pacsave`, `.pacorig`, `.rpmnew`, `.rpmsave`, `.rpmorig`, `.dpkg-old`,
+`.dpkg-new`, `.dpkg-dist`, and `~` are not conventional legacy candidates.
+They are considered only when a strict provenance basename exists for that
+exact confined service and the current complete-file hash equals
+`installed_sha256` in its validated committed pair. This lets `remove --all`
+find every arbitrary name accepted by the named writer without treating an
+unowned administrator artifact as an active PAM service. Customized controls,
+options or spacing, corrupt or ambiguous provenance for a candidate, invalid
+bytes, path escapes, link swaps, identity drift and concurrent edits block the
+whole run during preflight. Nothing is changed when preflight finds a blocker.
+An empty scan is an idempotent success.
+
+**The whole set is journaled before the first PAM mutation.** Version 1 state
+is strict JSON with unknown fields rejected, regular single-link fixed-state
+owner and mode `0600`, no-clobber publication, a 4 MiB encoded limit and at
+most 1,024 unique confined services. Its reserved names and exact fields are:
+
+- `.facelock-remove-all-<operation>.json` contains exactly `version`,
+  `operation`, `keep_backup`, and `targets`. Each target contains exactly
+  `service`, strict `backup`, `original`, and `installed_sha256`; `original`
+  contains exactly `device`, `inode`, `links`, `sha256`, `mode`, `uid`, and
+  `gid` and must describe a regular single-link file.
+- `.facelock-remove-all-commit-<operation>.json` contains exactly `version`,
+  `operation`, `journal_sha256`, `keep_backup`, and `targets`. Each target
+  contains exactly `service`, strict `backup`, and `installed`, where
+  `installed` uses the same complete-identity fields and validation.
+
+`operation` is `<seconds>-<exactly-nine-digit-nanoseconds>`: seconds parse as
+`u64`, nanoseconds are below one billion, and collision allocation is bounded.
+Only a prefix plus that valid operation grammar is reserved batch state; a
+prefix-shaped strict provenance basename with another suffix remains ordinary
+per-service provenance. Both state files and every hash are bounded and
+validated, and duplicate services invalidate either target list before
+recovery. A commit pairs with a journal only when operation, keep flag, ordered
+service/backup set, exact journal hash and planned/committed installed hashes
+agree. Multiple, malformed or conflicting reserved entries require manual
+review.
+
+`pam remove --all --dry-run` opens an existing backup directory for read-only
+inspection and requires its owner and mode to be trusted already. It performs
+no owner/mode repair, directory sync, recovery or write locking; an untrusted
+directory makes the preview fail closed with its metadata and entries intact.
+
+One fixed-state-directory flock spans recovery of any earlier journal, the
+authoritative root scan and complete preflight, bounded operation and rollback
+pair allocation, publication of every #171 backup/provenance pair, journal
+publication, every PAM exchange, the final fixed-root active-reference scan,
+commit publication and evidence cleanup. Every per-service rollback pair is
+durable before the journal, and the complete journal is durable before the
+first PAM mutation. Each service then uses the #171 intent, publication
+binding, exact created-identity and `RENAME_EXCHANGE` protocol while retaining
+the displaced original inode.
+
+A later failure or a non-empty or unanswerable final scan reverse-exchanges
+every earlier file in reverse order after complete identity checks. Recovery
+does the same for a prepared journal without a valid commit. The strict,
+self-contained commit authenticates the journal bytes and every installed
+complete identity; once it is durable, recovery finishes per-file publication
+cleanup and validated backup cleanup instead of rolling the PAM files back.
+Any mismatch or ambiguity preserves the journal and per-file intent, binding,
+temp or displaced evidence, including administrator bytes, for review. Files
+are always published as complete byte sequences and PAM password fallback is
+unchanged.
+
+Prepared-journal recovery also recognizes the one provably unstarted
+per-service publication shape: the canonical service still has the journal's
+full original identity, the exact valid `pam_replace` intent agrees with the
+prepared pair's sequence and record hash, and the exact replacement temp and
+publication binding are both absent. It identity-checks and removes only that
+intent before continuing rollback. Any mismatch or extra name remains
+ambiguous. After reverse exchange and identity-checked replacement-temp
+cleanup, rollback removes the exact publication binding before delegating the
+remaining base intent to that intent-only recovery. Every boundary is
+restartable; normal forward publication retains its existing intent-first
+cleanup order. Rollback-pair cleanup is restart-idempotent across cleanup intent,
+both quarantine moves and both unlinks. An exact matching cleanup intent is
+resumed; a target whose canonical pair, quarantine pair and exact cleanup
+intent are all absent is already clean. Partial, substituted or conflicting
+pair state is preserved and blocks journal cleanup.
+
+On success, default cleanup removes only validated Facelock-owned versioned
+pairs and exact validated legacy `<service>.facelock-backup` state for every
+committed target. `--keep-backup` instead commits and preserves the new pairs
+and opts out of legacy cleanup. `--json` uses the standard single remove
+document with one committed `removed` row per target (and a backup path only
+under `--keep-backup`); an idempotent no-op has an empty `services` array.
+`--quiet` suppresses that document.
+
+**Every shipped uninstall surface delegates to this cleanup before deleting
+the binary or PAM module.** This includes the Arch source and binary packages,
+Debian `prerm`, RPM `%preun`, the Omarchy remover and `just uninstall`. Booted
+package coverage exercises direct `dpkg`/`rpm` and their `apt-get`, `apt`, and
+`dnf` frontends for abort retention and blocker-free success. Arch
+also ships `/usr/share/libalpm/hooks/facelock-pam-remove.hook`, a package
+Remove-only `PreTransaction` hook for target `facelock`; `AbortOnFail`
+runs `/usr/bin/facelock pam remove --all` before pacman changes the package,
+and the package scriptlet retains an idempotent second call. Debian and RPM
+propagate cleanup failure so the package, binary and module remain. Source and
+Omarchy removal stop before their deletes. The module can be removed only
+after the cleanup's final compiled-root scan succeeds.
+
+The all-or-nothing guarantee covers direct PAM edits owned and scanned by this
+transaction and retention of the package/module when that cleanup fails. It
+does not cover every package-manager or profile side effect. Debian `prerm`
+currently invokes tolerant `pam-auth-update --remove facelock` before shared
+cleanup; byte-exact profile lifecycle and rollback are #224 scope. Fedora
+authselect profile selection, regeneration and rollback are #226 scope;
+`remove --all` only scans `/etc/authselect` as a detection-only root and never
+edits generated state. This does not implement #206 vendor-drift cleanup, #207
+sensitive-authorization changes, or #166's final emitted-byte freeze.
 
 **`--json`** emits exactly one document on stdout and no human text; `--quiet`
 suppresses even that, leaving the exit code as the whole answer, as it does for
@@ -1281,6 +1426,7 @@ that is not on this list is not being denied, only not yet promised.
 | `pam-if-present` | `pam add`/`pam remove`/`pam status` accept `--if-present` |
 | `pam-json` | `pam add`/`pam remove`/`pam status` accept `--json` |
 | `pam-multi-service` | `pam add`/`pam remove`/`pam status` take a repeatable `--service` — several services in one process, one root check |
+| `pam-remove-all` | `pam remove --all` exists, conflicts with `--service`, and uses compiled-root whole-set cleanup |
 | `pam-status` | `pam status` exists — the unprivileged `/etc/pam.d` read (DEC-6 below) |
 | `pam-status-all` | `pam status --all` exists, and conflicts with `--service` — the enumerating form, which answers "what is configured on this machine?" rather than "is this name configured?" |
 | `quiet` | the global `--quiet` |
@@ -1578,6 +1724,8 @@ writes.
 | `/var/lib/facelock/pam-backups/` | root:root | 700 | Fixed-root PAM rollback state; not affected by `[pam].config_dirs` or `storage.db_path` |
 | `/var/lib/facelock/pam-backups/<service>.<seconds>-<nanoseconds>` | root:root | 600 | Original PAM service bytes; nanoseconds are exactly nine digits |
 | `/var/lib/facelock/pam-backups/<service>.<seconds>-<nanoseconds>.json` | root:root | 600 | Strict versioned provenance for the adjacent rollback bytes |
+| `/var/lib/facelock/pam-backups/.facelock-remove-all-<operation>.json` | root:root | 600 | Strict prepared whole-set PAM removal journal |
+| `/var/lib/facelock/pam-backups/.facelock-remove-all-commit-<operation>.json` | root:root | 600 | Strict self-contained whole-set commit and recovery marker |
 | `/var/log/facelock/` | root:root | 700 | Log dir — per-user auth history and raw face snapshots are root-only |
 | `/var/log/facelock/audit.jsonl` | root:root | 600 | Structured audit log |
 | `/var/log/facelock/snapshots/` | root:root | 700 | Auth snapshots (raw face images) |
@@ -1710,8 +1858,11 @@ handled by the desktop's normal password agent) is unverified pending
 live-desktop testing and may require a design change. Behavior here is
 fail-closed: a non-eligible action is never face-authorized.
 
-`[pam].config_dirs` is where `facelock pam add | remove | status` looks for PAM
-service files, in search order — Linux-PAM's own precedence, earliest wins.
+`[pam].config_dirs` is where named `facelock pam add | remove | status` looks
+for PAM service files, in search order — Linux-PAM's own precedence, earliest
+wins. `facelock pam remove --all` always uses the compiled `/etc/pam.d`,
+`/usr/lib/pam.d`, and detection-only `/etc/authselect` roots and cannot be
+redirected by configuration.
 Default: `["/etc/pam.d", "/usr/lib/pam.d"]`. **The first entry is the override
 directory: every write lands there and every later entry is read-only**, so a
 service that resolves only in a later one is copied into the first before the

--- a/docs/security.md
+++ b/docs/security.md
@@ -814,6 +814,78 @@ replacement, and every publication-binding role keeps its intent, replacement
 temp, and visible binding. Recovery can therefore classify the complete set;
 checked cleanup remains limited to definite failures before the rename.
 
+Machine-wide `pam remove --all` adds one whole-set transaction over these
+per-service primitives. It ignores `[pam] config_dirs` and scans only the
+compiled `/etc/pam.d`, `/usr/lib/pam.d`, and detection-only `/etc/authselect`
+roots by enumerating already-open directory descriptors. Facelock does not
+follow generated links: it skips one only when the link's exact absolute target
+is the same service beneath a later compiled root that is scanned
+independently. Every other linked entry is a blocker, while a reference found
+in the independently scanned generated root is an unmanaged external-root
+reference. A conventional direct local reference is writable when every
+Facelock rule has the exact pre-versioned emitted bytes. A dot-prefixed or
+package/administrator artifact name is considered only when an exact strict
+provenance basename exists and its current hash matches committed provenance;
+unowned `.pacsave`, `.rpmsave`, `~` and similar artifacts are preserved and
+ignored. Customized rules, corrupt provenance for a candidate, linked or
+unreadable entries, and references in read-only roots are unmanaged blockers;
+preflight reports them without following or changing them. Directory contents
+remain detection ground truth, and provenance is never a target path or an
+instruction to mutate.
+
+The `--dry-run` path validates an existing PAM backup directory read-only. It
+requires the directory's trusted owner and mode without repairing or syncing
+them, acquiring the write lock, or running recovery; a trust failure preserves
+the directory metadata and entries and refuses the preview.
+
+For a clear preflight, Facelock prepares a validated backup/provenance pair for
+every target, then atomically publishes one strict, bounded `remove-all`
+journal before the first PAM exchange. The journal contains only confined
+services, strict backup basenames, full original identities and installed
+hashes. One state-directory flock spans journal recovery, the complete
+preflight, all exchanges, final active-reference rescan, commit publication and
+cleanup. A later identity failure or non-empty final rescan exchanges every
+earlier displaced original inode back in reverse order. Recovery does the same
+for a journal without its commit marker. A strict self-contained commit marker
+binds the journal hash and every published full identity; once durable,
+recovery completes validated publication/state cleanup instead of rolling the
+PAM files back. Ambiguity preserves the journal and per-file evidence.
+Only names whose extracted operation has the strict batch timestamp grammar
+enter this recovery path; prefix-shaped per-service provenance remains
+ordinary provenance. Duplicate services invalidate either journal or commit
+before any recovery cleanup.
+An intent-only PAM replacement is cleaned as unstarted only when the canonical
+file still has the journal's complete original identity, the intent agrees
+with the prepared pair, and both exact temp and binding names are absent.
+After reverse exchange and identity-checked replacement-temp cleanup, rollback
+removes the exact publication binding before delegating the base intent to
+that exact intent-only recovery. Each boundary is restartable; normal forward
+publication retains its existing intent-first cleanup order.
+Rollback-pair cleanup resumes an exact cleanup intent across both quarantine
+moves and unlinks; total absence is already clean, while partial, substituted
+or conflicting state is preserved.
+
+The uninstall call path reaches this command before removing the CLI or PAM
+module and does not parse config or touch the database, models, camera, daemon,
+or ONNX Runtime. Debian `prerm` and RPM `%preun` failures abort their package
+removals. Booted tests exercise direct `dpkg`/`rpm` plus `apt-get`, `apt` and
+`dnf` wrapper abort retention and blocker-free success. Arch packages install
+a Remove-only libalpm `PreTransaction` hook whose
+`AbortOnFail` action runs the same command, with the package scriptlet retaining
+an idempotent second call. Source and Omarchy uninstallers delegate to the same
+path. The module is removed only after the compiled-root final scan succeeds.
+The all-or-nothing guarantee covers the direct PAM edits owned and scanned by
+this transaction, plus retaining the package/module when it fails. Debian's
+separately managed `pam-auth-update` profile lifecycle and byte-exact rollback
+remain #224 scope; the current `prerm` removes that profile before invoking the
+shared direct-edit cleanup.
+Fedora authselect profile selection, regeneration, and rollback remain #226
+scope. This command treats `/etc/authselect` as detection-only and never edits
+generated profile state.
+
+This does not implement #206 vendor-drift cleanup, #207
+sensitive-authorization changes, or #166's final emitted-byte freeze.
+
 #### A0. Config File Trust (Required)
 
 The PAM module runs in a root context, so `/etc/facelock/config.toml` is an

--- a/justfile
+++ b/justfile
@@ -92,6 +92,7 @@ _build-test-container: build-release
 # Automated PAM smoke tests (Arch container)
 test-arch-pam: _build-test-container
     podman run --rm facelock-pam-test
+    test/run-arch-package-systemd.sh facelock-pam-test
 
 # Automated state-layout test (Arch container, camera-free).
 # Asserts the exact modes and ownership of everything under /var/lib/facelock
@@ -621,31 +622,9 @@ uninstall-files:
     systemctl stop facelock-daemon.service 2>/dev/null || true
     systemctl disable facelock-daemon.service 2>/dev/null || true
 
-    # Every PAM service `facelock setup` can write to: the services offered by
-    # the setup multi-select (PAM_CANDIDATES in
-    # crates/facelock-cli/src/commands/setup.rs) plus the ones it gates behind a
-    # confirmation (SENSITIVE_SERVICES). `--service` accepts an arbitrary name,
-    # so this list can never be exhaustive; it covers everything facelock itself
-    # offers or gates. Missing files are skipped, so naming a service this host
-    # does not have is inert. A drift test in setup.rs
-    # (`packaging_uninstall_covers_every_pam_candidate`) fails if a new candidate
-    # is added without being listed here.
-    FACELOCK_PAM_SERVICES="sudo polkit-1 hyprlock swaylock kscreenlocker_greet gdm-password sddm lightdm omarchy-lock-face system-auth login sshd common-auth password-auth system-login system-auth-ac password-auth-ac"
-
-    # Remove PAM lines (match on module name, not exact spacing)
-    for service in $FACELOCK_PAM_SERVICES; do
-        PAM_FILE="/etc/pam.d/$service"
-        if [ -f "$PAM_FILE" ] && grep -q 'pam_facelock\.so' "$PAM_FILE"; then
-            sed -i '/pam_facelock\.so/d' "$PAM_FILE"
-            echo "Removed face auth from $PAM_FILE"
-        fi
-    done
-
-    # Remove PAM safety backups created by `facelock setup`
-    for service in $FACELOCK_PAM_SERVICES; do
-        backup="/etc/pam.d/$service.facelock-backup"
-        [ -f "$backup" ] && rm -f "$backup" && echo "Removed $backup"
-    done
+    # The binary still exists here, so a failed final scan stops before either
+    # it or the PAM module is removed.
+    facelock pam remove --all
 
     # Kill facelock polkit agent if running (so the DE's agent can take over)
     pkill -f facelock-polkit-agent 2>/dev/null || true

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -1,4 +1,4 @@
-.TH FACELOCK 1 "2026-08-12" "facelock" "User Commands"
+.TH FACELOCK 1 "2026-08-20" "facelock" "User Commands"
 .SH NAME
 facelock \- Linux face authentication
 .SH SYNOPSIS
@@ -493,7 +493,38 @@ Remove the facelock line. Root. Same flags as \fBadd\fR except
 take away a way to authenticate, so there is nothing to gate. It never prompts,
 and it removes validated Facelock backup state plus the exact legacy adjacent
 \fI.facelock\-backup\fR name by default. \fB\-\-keep\-backup\fR preserves
-both forms of rollback state.
+both forms of rollback state. \fB\-\-all\fR conflicts with \fB\-\-service\fR
+and scans the compiled system roots
+.I /etc/pam.d
+and
+.I /usr/lib/pam.d
+plus the detection-only generated root
+.I /etc/authselect
+instead of configured PAM directories. It recognizes exact pre-versioned
+Facelock rules under conventional service names and current files authenticated
+by strict provenance. Dot-prefixed and package or administrator artifact names
+require provenance for that exact name; unowned artifacts are preserved.
+Customized rules, corrupt provenance, linked files and read-only-root references
+block the whole operation without a write. A link is skipped only when its exact
+target is the same service in a later compiled root that is scanned independently;
+the link itself is never followed.
+.IP
+With \fB--dry-run\fR, an existing PAM backup directory is inspected
+read-only and must already have its trusted owner and mode. The preview does
+not repair or sync it, acquire its write lock, or run recovery.
+.IP
+The complete target set is backed up and journaled before the first PAM file
+changes. Every replacement is identity-rechecked; a later failure or a final
+scan that still finds an active reference restores every earlier original in
+reverse order. A durable commit marker makes crash recovery finish validated
+cleanup rather than roll the files back. Intent-only pre-publication recovery
+requires the complete original identity and absent temp/binding; it is
+restartable after rollback removes the checked temp, binding, then intent.
+Pair cleanup resumes exact quarantine/unlink state and rejects partial
+conflicts. This path
+reads no Facelock config,
+database, model, daemon, camera or inference state and is the cleanup command
+used by package uninstallers while the binary and PAM module are still present.
 .TP
 .B status
 Report whether services carry the line. Reads only and needs

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -50,12 +50,22 @@ COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
 # Fake daemon harness for the PAM peer-UID container test (plan 05)
 COPY test/fake-facelock-daemon.py /fake-facelock-daemon.py
 
+# Install a minimal real libalpm package carrying the production hook and
+# scriptlet. The booted package test removes it only after the ordinary PAM
+# suite has used the installed binary and module.
+COPY test/arch-package/ /arch-package/
+COPY test/build-arch-test-package.sh /build/test/build-arch-test-package.sh
+RUN chmod +x /build/test/build-arch-test-package.sh && \
+    /build/test/build-arch-test-package.sh
+
 # Copy test scripts
 COPY test/run-container-tests.sh /run-tests.sh
 COPY test/run-integration-tests.sh /run-integration-tests.sh
 COPY test/run-oneshot-tests.sh /run-oneshot-tests.sh
 COPY test/run-layout-tests.sh /run-layout-tests.sh
-RUN chmod +x /run-tests.sh /run-integration-tests.sh /run-oneshot-tests.sh /run-layout-tests.sh
+COPY test/arch-package-validate.sh /arch-package-validate.sh
+RUN chmod +x /run-tests.sh /run-integration-tests.sh /run-oneshot-tests.sh \
+    /run-layout-tests.sh /arch-package-validate.sh
 
 # Clean up build dir to save image size
 RUN rm -rf /build

--- a/test/Containerfile.deb-e2e
+++ b/test/Containerfile.deb-e2e
@@ -61,7 +61,8 @@ RUN mkdir -p /build/onnxruntime/lib && \
 # Build the .deb from the host-built binaries and install it
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0" "noble" "1" && \
-    (dpkg -i facelock_0.0.0-1~ubuntu24.04.1_amd64.deb || true) && \
+    cp facelock_0.0.0-1~ubuntu24.04.1_amd64.deb /facelock-test-package.deb && \
+    (dpkg -i /facelock-test-package.deb || true) && \
     apt-get update && apt-get install -f -y && \
     rm -rf facelock_0.0.0-1~ubuntu24.04.1_amd64 facelock_0.0.0-1~ubuntu24.04.1_amd64.deb
 

--- a/test/Containerfile.deb-tpm-e2e
+++ b/test/Containerfile.deb-tpm-e2e
@@ -68,7 +68,8 @@ RUN mkdir -p /build/onnxruntime/lib && \
 # Build the TPM .deb from host-built binaries and install it
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN bash /build/.github/workflows/scripts/build-deb.sh "0.0.0" "trixie" "1" && \
-    (dpkg -i facelock_0.0.0-1~deb13u1_amd64.deb || true) && \
+    cp facelock_0.0.0-1~deb13u1_amd64.deb /facelock-test-package.deb && \
+    (dpkg -i /facelock-test-package.deb || true) && \
     apt-get update && apt-get install -f -y && \
     rm -rf facelock_0.0.0-1~deb13u1_amd64 facelock_0.0.0-1~deb13u1_amd64.deb
 

--- a/test/Containerfile.rpm-e2e
+++ b/test/Containerfile.rpm-e2e
@@ -48,6 +48,7 @@ RUN mkdir -p /build/onnxruntime/lib && \
 
 # Build the .rpm from pre-built binaries and install it
 RUN bash /build/test/build-rpm-prebuilt.sh "0.0.0" && \
+    cp ./*.rpm /facelock-test-package.rpm && \
     dnf install -y ./*.rpm && \
     rm -rf ~/rpmbuild ./*.rpm
 

--- a/test/arch-package-validate.sh
+++ b/test/arch-package-validate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+run_test() {
+    local name="$1"
+    local cmd="$2"
+    echo -n "TEST: $name ... "
+    if bash -c "$cmd" > /tmp/arch-package-output 2>&1; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL"
+        cat /tmp/arch-package-output
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+owned=/etc/pam.d/facelock-package-owned
+blocker=/etc/pam.d/facelock-package-blocker
+rm -f /etc/pam.d/facelock-test "$owned" "$blocker"
+cat > "$owned" <<'EOF'
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      include system-auth
+EOF
+cat > "$blocker" <<'EOF'
+#%PAM-1.0
+auth required pam_facelock.so debug
+auth include system-auth
+EOF
+chmod 644 "$owned" "$blocker"
+sha256sum "$owned" > /tmp/facelock-package-owned.sha
+sha256sum "$blocker" > /tmp/facelock-package-blocker.sha
+
+printf '[invalid\n' > /etc/facelock/config.toml
+install -Dm600 /dev/null /var/lib/facelock/facelock.db
+rm -rf /var/lib/facelock/models
+export ORT_DYLIB_PATH=/facelock-test-missing-onnxruntime.so
+
+run_test "pacman removal aborts on an unmanaged PAM reference" \
+    "! pacman -R --noconfirm facelock"
+run_test "pacman keeps the package installed after aborted removal" \
+    "pacman -Q facelock"
+run_test "PAM module remains after aborted package removal" \
+    "test -f /usr/lib/security/pam_facelock.so"
+run_test "recognized PAM edit remains after aborted package removal" \
+    "sha256sum -c --status /tmp/facelock-package-owned.sha"
+run_test "unmanaged PAM reference remains after aborted package removal" \
+    "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+
+rm -f "$blocker"
+run_test "pacman removal succeeds after the blocker is cleared" \
+    "pacman -R --noconfirm facelock"
+run_test "recognized arbitrary PAM edit is cleaned before module removal" \
+    "test -f $owned && ! grep -q pam_facelock.so $owned"
+run_test "pacman removed the cleanup binary and PAM module" \
+    "! test -e /usr/bin/facelock && ! test -e /usr/lib/security/pam_facelock.so"
+run_test "pacman no longer reports the package installed" \
+    "! pacman -Q facelock"
+
+rm -f "$owned" /tmp/facelock-package-owned.sha \
+    /tmp/facelock-package-blocker.sha /tmp/arch-package-output
+
+echo ""
+echo "=== Arch package results: $PASS passed, $FAIL failed ==="
+test "$FAIL" -eq 0

--- a/test/arch-package/PKGBUILD
+++ b/test/arch-package/PKGBUILD
@@ -1,0 +1,15 @@
+pkgname=facelock
+pkgver=0.0.0
+pkgrel=1
+pkgdesc='Facelock libalpm cleanup test fixture'
+arch=('x86_64')
+license=('MIT')
+install=facelock.install
+
+package() {
+    install -Dm755 /build/target/release/facelock "$pkgdir/usr/bin/facelock"
+    install -Dm755 /build/target/release/libpam_facelock.so \
+        "$pkgdir/usr/lib/security/pam_facelock.so"
+    install -Dm644 /build/dist/facelock-pam-remove.hook \
+        "$pkgdir/usr/share/libalpm/hooks/facelock-pam-remove.hook"
+}

--- a/test/build-arch-test-package.sh
+++ b/test/build-arch-test-package.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir=/tmp/facelock-arch-package
+install -d -m 0755 -o testuser -g testuser "$build_dir"
+install -m 0644 -o testuser -g testuser /arch-package/PKGBUILD "$build_dir/PKGBUILD"
+install -m 0644 -o testuser -g testuser /build/dist/facelock.install \
+    "$build_dir/facelock.install"
+
+runuser -u testuser -- bash -c \
+    'cd /tmp/facelock-arch-package && makepkg --nodeps --noconfirm'
+package=$(find "$build_dir" -maxdepth 1 -type f -name 'facelock-*.pkg.tar.zst' -print -quit)
+test -n "$package"
+pacman -U --noconfirm --overwrite '*' "$package"

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -303,24 +303,166 @@ fi
 echo ""
 echo "=== Package Removal Test ==="
 
+PACKAGE_OWNED_PAM=/etc/pam.d/facelock-package-owned
+PACKAGE_BLOCKER_PAM=/etc/pam.d/facelock-package-blocker
+# The PAM loading rows above own this synthetic service. Package cleanup must
+# see only the fixtures created for this block, so retire it before preflight.
+rm -f /etc/pam.d/facelock-test "$PACKAGE_OWNED_PAM" "$PACKAGE_BLOCKER_PAM"
+cat > "$PACKAGE_OWNED_PAM" <<'EOF'
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      include system-auth
+EOF
+cat > "$PACKAGE_BLOCKER_PAM" <<'EOF'
+#%PAM-1.0
+auth required pam_facelock.so debug
+auth include system-auth
+EOF
+chmod 644 "$PACKAGE_OWNED_PAM" "$PACKAGE_BLOCKER_PAM"
+sha256sum "$PACKAGE_OWNED_PAM" > /tmp/facelock-package-owned.sha
+sha256sum "$PACKAGE_BLOCKER_PAM" > /tmp/facelock-package-blocker.sha
+
+# Cleanup is intentionally independent of every runtime input. These invalid
+# or absent values are installed only after all daemon/auth checks above.
+printf '[invalid\n' > /etc/facelock/config.toml
+install -Dm600 /dev/null /var/lib/facelock/facelock.db
+rm -rf /var/lib/facelock/models
+export ORT_DYLIB_PATH=/facelock-test-missing-onnxruntime.so
+
 if command -v dpkg >/dev/null 2>&1 && dpkg -s facelock >/dev/null 2>&1; then
+    # #224 owns Debian profile lifecycle and rollback. Keep this case visible:
+    # today's prerm asks pam-auth-update to remove the active package profile
+    # before the #227 direct-edit transaction runs. A later direct blocker
+    # aborts dpkg and retains the package/module, but does not promise to roll
+    # that separately managed common-auth change back.
+    run_test "dpkg abort coverage starts with the pam-auth-update profile active" \
+        "grep -q pam_facelock.so /etc/pam.d/common-auth"
+    sha256sum /etc/pam.d/common-auth > /tmp/facelock-common-auth.before
+    run_test "dpkg removal aborts on an unmanaged PAM reference" \
+        "! dpkg -r facelock"
+    run_test "#224-deferred profile mutation is visible after aborted dpkg removal" \
+        "! sha256sum -c --status /tmp/facelock-common-auth.before && ! grep -q pam_facelock.so /etc/pam.d/common-auth"
+    run_test "dpkg keeps the package installed after aborted removal" \
+        "dpkg-query -W -f='\${binary:Package}\n' facelock | grep -qx facelock"
+    run_test "PAM module remains after aborted package removal" \
+        "[ -f /lib/security/pam_facelock.so ] || [ -f /usr/lib/security/pam_facelock.so ] || [ -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "recognized PAM edit remains after aborted package removal" \
+        "sha256sum -c --status /tmp/facelock-package-owned.sha"
+    run_test "unmanaged PAM reference remains after aborted package removal" \
+        "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+    run_test "apt-get wrapper removal aborts on an unmanaged PAM reference" \
+        "! apt-get remove -y facelock"
+    run_test "apt-get wrapper keeps the package installed after abort" \
+        "dpkg-query -W -f='\${binary:Package}\n' facelock | grep -qx facelock"
+    run_test "apt-get wrapper keeps the PAM module after abort" \
+        "[ -f /lib/security/pam_facelock.so ] || [ -f /usr/lib/security/pam_facelock.so ] || [ -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "apt-get wrapper preserves recognized PAM edit bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-owned.sha"
+    run_test "apt-get wrapper preserves blocker bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+    run_test "apt wrapper removal aborts on an unmanaged PAM reference" \
+        "! apt remove -y facelock"
+    run_test "apt wrapper keeps the package installed after abort" \
+        "dpkg-query -W -f='\${binary:Package}\n' facelock | grep -qx facelock"
+    run_test "apt wrapper keeps the PAM module after abort" \
+        "[ -f /lib/security/pam_facelock.so ] || [ -f /usr/lib/security/pam_facelock.so ] || [ -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "apt wrapper preserves recognized PAM edit bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-owned.sha"
+    run_test "apt wrapper preserves blocker bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+    rm -f "$PACKAGE_BLOCKER_PAM"
     run_test "Package removal via dpkg" "dpkg -r facelock"
+    run_test "recognized arbitrary PAM edit cleaned before dpkg removes the module" \
+        "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
     run_test "facelock binary removed after dpkg -r" "[ ! -f /usr/bin/facelock ]"
     run_test "PAM module removed after dpkg -r" \
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
     run_test "Config preserved after dpkg -r (conffile)" "[ -f /etc/facelock/config.toml ]"
+    run_test "facelock reinstalls before apt-get wrapper success" \
+        "apt-get install -y /facelock-test-package.deb"
+    cat > "$PACKAGE_OWNED_PAM" <<'EOF'
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      include system-auth
+EOF
+    chmod 644 "$PACKAGE_OWNED_PAM"
+    run_test "apt-get wrapper removal succeeds without a blocker" \
+        "apt-get remove -y facelock"
+    run_test "apt-get wrapper cleans the recognized direct PAM edit" \
+        "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
+    run_test "apt-get wrapper leaves the package not installed" \
+        "! dpkg-query -W -f='\${db:Status-Status}\n' facelock 2>/dev/null | grep -qx installed"
+    run_test "apt-get wrapper removes the PAM module" \
+        "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "facelock reinstalls before apt wrapper success" \
+        "apt-get install -y /facelock-test-package.deb"
+    cat > "$PACKAGE_OWNED_PAM" <<'EOF'
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      include system-auth
+EOF
+    chmod 644 "$PACKAGE_OWNED_PAM"
+    run_test "apt wrapper removal succeeds without a blocker" \
+        "apt remove -y facelock"
+    run_test "apt wrapper cleans the recognized direct PAM edit" \
+        "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
+    run_test "apt wrapper leaves the package not installed" \
+        "! dpkg-query -W -f='\${db:Status-Status}\n' facelock 2>/dev/null | grep -qx installed"
+    run_test "apt wrapper removes the PAM module" \
+        "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
 elif command -v rpm >/dev/null 2>&1 && rpm -q facelock >/dev/null 2>&1; then
     # Modify config so RPM treats it as user-edited and preserves it as .rpmsave
     echo "# modified by test" >> /etc/facelock/config.toml
+    run_test "rpm removal aborts on an unmanaged PAM reference" \
+        "! rpm -e facelock"
+    run_test "rpm keeps the package installed after aborted removal" \
+        "rpm -q facelock"
+    run_test "PAM module remains after aborted package removal" \
+        "[ -f /lib/security/pam_facelock.so ] || [ -f /usr/lib/security/pam_facelock.so ] || [ -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "recognized PAM edit remains after aborted package removal" \
+        "sha256sum -c --status /tmp/facelock-package-owned.sha"
+    run_test "unmanaged PAM reference remains after aborted package removal" \
+        "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+    run_test "dnf wrapper removal aborts on an unmanaged PAM reference" \
+        "! dnf remove -y facelock"
+    run_test "dnf wrapper keeps the package installed after abort" \
+        "rpm -q facelock"
+    run_test "dnf wrapper keeps the PAM module after abort" \
+        "[ -f /lib/security/pam_facelock.so ] || [ -f /usr/lib/security/pam_facelock.so ] || [ -f /usr/lib64/security/pam_facelock.so ]"
+    run_test "dnf wrapper preserves recognized PAM edit bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-owned.sha"
+    run_test "dnf wrapper preserves blocker bytes after abort" \
+        "sha256sum -c --status /tmp/facelock-package-blocker.sha"
+    rm -f "$PACKAGE_BLOCKER_PAM"
     run_test "Package removal via rpm" "rpm -e facelock"
+    run_test "recognized arbitrary PAM edit cleaned before rpm removes the module" \
+        "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
     run_test "facelock binary removed after rpm -e" "[ ! -f /usr/bin/facelock ]"
     run_test "PAM module removed after rpm -e" \
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
     run_test "Config preserved after rpm -e (config(noreplace))" "[ -f /etc/facelock/config.toml ] || [ -f /etc/facelock/config.toml.rpmsave ]"
+    run_test "facelock reinstalls before dnf wrapper success" \
+        "dnf install -y /facelock-test-package.rpm"
+    cat > "$PACKAGE_OWNED_PAM" <<'EOF'
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      include system-auth
+EOF
+    chmod 644 "$PACKAGE_OWNED_PAM"
+    run_test "dnf wrapper removal succeeds without a blocker" \
+        "dnf remove -y facelock"
+    run_test "dnf wrapper cleans the recognized direct PAM edit" \
+        "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
+    run_test "dnf wrapper removes the package and PAM module" \
+        "! rpm -q facelock && [ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
 else
     skip_test "package removal block (removal, binary/PAM module gone, config preserved)" \
         "facelock was not installed by dpkg or rpm here"
 fi
+
+rm -f "$PACKAGE_OWNED_PAM" "$PACKAGE_BLOCKER_PAM" \
+    /tmp/facelock-package-owned.sha /tmp/facelock-package-blocker.sha \
+    /tmp/facelock-common-auth.before
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="

--- a/test/run-arch-package-systemd.sh
+++ b/test/run-arch-package-systemd.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image=${1:?usage: run-arch-package-systemd.sh <image>}
+container=$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
+    "$image" /usr/lib/systemd/systemd)
+trap 'podman rm -f "$container" >/dev/null 2>&1 || true' EXIT
+
+booted=
+for _ in $(seq 1 120); do
+    state=$(podman exec "$container" systemctl is-system-running 2>/dev/null || true)
+    case "$state" in
+        running|degraded)
+            booted=1
+            break
+            ;;
+    esac
+    sleep 1
+done
+if [ -z "$booted" ]; then
+    podman exec "$container" systemctl --failed --no-pager 2>&1 || true
+    exit 1
+fi
+
+podman exec "$container" /arch-package-validate.sh

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -24,7 +24,10 @@ shopt -s nullglob
 onnx=(models/*.onnx)
 shopt -u nullglob
 if [ "${#onnx[@]}" -gt 0 ]; then
-    mounts=(-v "$PWD/models:/var/lib/facelock/models")
+    # Stage read-only rather than mounting over the runtime model directory.
+    # pkg-validate removes its disposable runtime copy before the uninstall
+    # assertions to prove package cleanup has no model dependency.
+    mounts=(-v "$PWD/models:/facelock-test-models:ro")
 elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
     echo "WARNING: no models/*.onnx in repo — the daemon-start assertions will be" >&2
     echo "         reported as skipped (FACELOCK_ALLOW_MISSING_MODELS=1)." >&2
@@ -64,6 +67,11 @@ if [ -z "$booted" ]; then
     echo "ERROR: systemd did not reach running/degraded state" >&2
     podman exec "$cid" systemctl --failed --no-pager 2>&1 || true
     exit 1
+fi
+
+if [ "${#onnx[@]}" -gt 0 ]; then
+    podman exec "$cid" /bin/sh -c \
+        'install -d /var/lib/facelock/models && cp /facelock-test-models/*.onnx /var/lib/facelock/models/'
 fi
 
 podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh


### PR DESCRIPTION
## Why

Package removal must not leave active PAM references behind or delete administrator-owned PAM configuration.

## Summary

- add config-independent `pam remove --all` with fixed-root provenance classification and durable whole-set rollback
- route Arch, Debian, RPM, Omarchy, and source uninstall paths through shared fail-closed cleanup
- document journal recovery, dry-run, JSON, and package lifecycle contracts
- close #227

## Validation

- `just check`
- `just test-arch-pam`
- `just test-arch-layout`
- `just test-deb-pkg`
- `just test-deb-tpm-pkg`
- `just test-rpm-pkg`
