### PR TITLE
fix(setup): require explicit sensitive authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Explicit authorization for sensitive `setup --pam` writes** (#207):
+  `--yes` and its `--no-confirm` alias now suppress only the ordinary per-file
+  confirmation. Adding Facelock to a shared or login PAM stack requires the
+  independent `--allow-sensitive` flag, matching `facelock pam add`; the flag
+  requires `--pam`, conflicts with `--remove`, and is advertised by capability
+  `setup-allow-sensitive`.
 - **`facelock pam status --all`** (#203): enumerate every service in the
   resolved pam.d directories that names `pam_facelock.so`, through the same row
   builder, `action` words and JSON document as `pam status --service`, so the
@@ -54,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closing summary or handed to the hyprlock integration.
 - **`facelock pam add | remove | status`** (#180): one command owns every write
   to `/etc/pam.d`, and `setup --pam` is now an alias onto it that keeps parsing
-  and keeps its behaviour. `--service` is repeatable on all three verbs, so
+  for existing wrappers. `--service` is repeatable on all three verbs, so
   several services are configured in one process under one root check.
   Validation is two-phase: a typo'd or gated service name writes nothing at all.
   `add` takes `--allow-sensitive` to unlock the shared auth stacks and

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -43,7 +43,7 @@ facelock setup --pam --service polkit-1 # install to a specific service
 facelock setup --pam --remove           # remove the PAM line
 facelock setup --pam --service hyprlock --if-present  # a missing service file is success
 facelock setup --pam --remove --if-present  # ...on removal too
-facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
+facelock setup --pam --service sshd -y --allow-sensitive  # suppress the prompt and authorize the sensitive write
 facelock setup --no-pam                 # wizard, but never touch /etc/pam.d
 facelock setup --camera /dev/video2     # answer step 1 from the command line
 ```
@@ -72,9 +72,9 @@ Actions are the steps that change the system: PAM, systemd, enrollment. `--no-pa
 |------|---------|
 | *(none)* | Full interactive wizard. If stdin is not a terminal, this falls back to the non-interactive flow. |
 | `--non-interactive` | No prompts. Choices resolve to config-or-default. Runs the base setup only: directories, model download and verification, encryption, path permissions. No PAM, no systemd, no enrollment unless asked for explicitly. |
-| `-y`, `--yes` (alias `--no-confirm`) | Suppress confirmation prompts, and unlock the sensitive-service gate. |
+| `-y`, `--yes` (alias `--no-confirm`) | Suppress ordinary confirmation prompts. Does not authorize a sensitive PAM edit. |
 
-`--non-interactive` suppresses the per-file "Proceed?" confirmation before a PAM edit on its own, since it promises no prompts. It deliberately does **not** unlock the sensitive-service gate: the shared auth stacks `common-auth`, `password-auth`, `password-auth-ac`, `system-auth`, `system-auth-ac` and `system-login`, plus `login` and `sshd`, still require an explicit `--yes`, so `facelock setup --non-interactive --pam --service sshd` refuses until you add it. Locking yourself out of a machine should take two decisions, not one.
+`--yes` and `--non-interactive` suppress the per-file "Proceed?" confirmation; neither unlocks the sensitive-service gate. The shared auth stacks `common-auth`, `password-auth`, `password-auth-ac`, `system-auth`, `system-auth-ac` and `system-login`, plus `login` and `sshd`, require `--allow-sensitive`. Thus even `facelock setup --pam --service sshd --yes` refuses. Locking yourself out of a machine should take two independent decisions: whether to skip the prompt, and whether to authorize the sensitive write.
 
 ### Choice flags
 
@@ -115,7 +115,7 @@ Each pair is a clap override pair: **a later flag wins over an earlier one.** `-
 Two details worth knowing:
 
 - `--pam` inside the wizard configures **exactly one service** — `--service`, defaulting to `sudo`. It does not apply the multi-select's pre-checked candidates. `--pam` means the same thing everywhere, whether or not the base setup is also running.
-- `--pam` is an alias onto [`facelock pam add`](#facelock-pam) / `facelock pam remove`, which is the primary spelling and the one that takes several services in one process. Every `setup --pam` invocation keeps parsing and keeps its behaviour, including that `-y` is what unlocks a sensitive service here where `--allow-sensitive` does it on `facelock pam add`.
+- `--pam` is an alias onto [`facelock pam add`](#facelock-pam) / `facelock pam remove`, which is the primary spelling and the one that takes several services in one process. Existing `setup --pam` invocations keep parsing; sensitive additions now use the same explicit `--allow-sensitive` authorization as `facelock pam add`, while `-y` only suppresses the prompt.
 - `--enroll` answers the "would you like to enroll a face now?" confirmation as well as forcing the step, so it runs unattended. Combined with `--non-interactive` it enrolls without any prompt at all.
 
 ### Action modifiers
@@ -125,6 +125,7 @@ Two details worth knowing:
 | `--service <name>` | `--pam` | Target PAM service. Default `sudo`. |
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
 | `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
+| `--allow-sensitive` | `--pam` add | Explicitly authorize adding Facelock to `common-auth`, `login`, `password-auth`, `password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac`, or `system-login`. Does not suppress the confirmation prompt and conflicts with `--remove`. |
 | `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
 
 These `requires` relationships are enforced by the parser. `facelock setup --remove` is a clear error naming the missing `--pam`, not a silently ignored flag.
@@ -141,13 +142,16 @@ When the base setup does run alongside an action, the actions run inside it, at 
 
 ### Compatibility matrix
 
-Single-flag behavior is unchanged. Only combinations that previously *dropped* a flag behave differently, and they change from silently wrong to doing what was asked.
+Most legacy behavior is unchanged. Combinations that previously *dropped* a
+flag now do what was asked, while the security-sensitive `setup --pam --yes`
+case now refuses a shared or login stack until `--allow-sensitive` is present.
 
 | Invocation | Before | After |
 |------------|--------|-------|
 | `setup` | full wizard | unchanged |
 | `setup --non-interactive` | base only, no PAM/systemd/enroll | unchanged |
 | `setup --pam --service sudo` | PAM only | unchanged |
+| `setup --pam --service system-auth -y` | authorized the sensitive write | refuses until `--allow-sensitive` is added; `-y` only suppresses the prompt |
 | `setup --systemd` | systemd only | unchanged |
 | `setup --systemd --pam` | **silently dropped `--pam`** — ran systemd only | runs **both** |
 | `setup --non-interactive --pam` | **silently dropped `--non-interactive`** — ran PAM only | base setup **+** PAM |

--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -27,9 +27,8 @@ pub struct UserArg {
     pub user: Option<String>,
 }
 
-/// Confirmation bypass for the commands whose only prompt is "are you sure?" —
-/// `remove` and `clear`. `setup` deliberately declares its own `yes` instead,
-/// because there the flag also unlocks a gate; see [`SetupCli`].
+/// Confirmation bypass for commands whose prompt is an ordinary confirmation.
+/// It never grants a separate authorization such as `--allow-sensitive`.
 ///
 /// `--no-confirm` shipped on `setup` only; it is carried as a hidden alias on
 /// every site so a wrapper written against either spelling keeps working.
@@ -62,7 +61,7 @@ pub struct DryRunArg {
 
 /// `facelock setup`'s command line.
 ///
-/// Its only job is to become a [`SetupArgs`]. Naming the 16 fields once means
+/// Its only job is to become a [`SetupArgs`]. Naming the 17 fields once means
 /// `main` and the tests reach the resolver through the same conversion; when
 /// they were two hand-written destructures, a field added to one could be
 /// silently missing from the other.
@@ -71,16 +70,8 @@ pub struct SetupCli {
     /// Run in non-interactive mode (skip wizard)
     #[arg(long)]
     pub non_interactive: bool,
-    // Not a shared `ConfirmArg`: on `setup` the flag means more than it does
-    // elsewhere. It skips the per-file "Proceed?" prompt *and* unlocks the
-    // gate that otherwise refuses to write into a sensitive PAM service
-    // (`SENSITIVE_SERVICES` in commands/pam.rs). Rendering that as plain
-    // prompt suppression would understate what the user is authorizing.
-    // Spelling still cannot drift: `cli_flag_conformance` pins `-y` and the
-    // `no-confirm` alias on every arg named `yes`, wherever it is declared.
-    /// Skip confirmation prompts, and unlock the sensitive-service gate (also: --no-confirm)
-    #[arg(short = 'y', long, alias = "no-confirm")]
-    pub yes: bool,
+    #[command(flatten)]
+    pub confirm: ConfirmArg,
 
     // -- Action pairs. A later flag wins over an earlier one, so a wrapper
     //    script can append an override to a command it did not construct.
@@ -116,6 +107,9 @@ pub struct SetupCli {
     /// Used with --pam: treat an absent service file as success
     #[arg(long = "if-present", requires = "pam")]
     pub if_present: bool,
+    /// Used with --pam: permit sensitive PAM services
+    #[arg(long = "allow-sensitive", requires = "pam", conflicts_with = "remove")]
+    pub allow_sensitive: bool,
 
     // -- Choice flags. Supplying a value answers the question, and so skips
     //    the matching wizard step.
@@ -137,7 +131,7 @@ impl From<SetupCli> for SetupArgs {
     fn from(cli: SetupCli) -> Self {
         let SetupCli {
             non_interactive,
-            yes,
+            confirm,
             pam,
             no_pam,
             systemd,
@@ -148,6 +142,7 @@ impl From<SetupCli> for SetupArgs {
             service,
             remove,
             if_present,
+            allow_sensitive,
             camera,
             models,
             execution_provider,
@@ -155,7 +150,7 @@ impl From<SetupCli> for SetupArgs {
         } = cli;
         SetupArgs {
             non_interactive,
-            yes,
+            yes: confirm.yes,
             pam,
             no_pam,
             systemd,
@@ -166,6 +161,7 @@ impl From<SetupCli> for SetupArgs {
             service,
             remove,
             if_present,
+            allow_sensitive,
             camera,
             models,
             execution_provider,

--- a/crates/facelock-cli/src/commands/capabilities.rs
+++ b/crates/facelock-cli/src/commands/capabilities.rs
@@ -71,6 +71,7 @@ pub const CAPABILITIES: &[&str] = &[
     "pam-status",
     "pam-status-all",
     "quiet",
+    "setup-allow-sensitive",
     "setup-if-present",
     "setup-no-pam",
     "setup-systemd",
@@ -149,6 +150,7 @@ mod tests {
         "pam-status",
         "pam-status-all",
         "quiet",
+        "setup-allow-sensitive",
         "setup-if-present",
         "setup-no-pam",
         "setup-systemd",
@@ -169,6 +171,15 @@ mod tests {
                  names are added, never removed"
             );
         }
+    }
+
+    #[test]
+    fn setup_sensitive_authorization_is_probeable() {
+        assert!(
+            CAPABILITIES.contains(&"setup-allow-sensitive"),
+            "wrappers need to distinguish prompt-only setup --yes from builds \
+             where that flag also authorized sensitive PAM writes"
+        );
     }
 
     /// Strict `<` proves sorted and deduplicated in one pass — the contract

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -22,9 +22,9 @@
 //!    *and* unlocked [`SENSITIVE_SERVICES`], so there was no way to say
 //!    "unattended, and still refuse `system-auth`". [`PamRequest::no_confirm`]
 //!    and [`PamRequest::allow_sensitive`] are now separate, and
-//!    **`--no-confirm` never implies `--allow-sensitive`**. `setup --yes`
-//!    keeps its combined meaning and is the one documented exception; the
-//!    alias maps it onto both.
+//!    **`--no-confirm` never implies `--allow-sensitive`**. The `setup --pam`
+//!    alias exposes the same separation: `--yes` suppresses its prompt and
+//!    `--allow-sensitive` authorizes a gated write.
 //! 4. **A no-op was indistinguishable from an action.** The old writer
 //!    returned `Ok(())` for *installed*, *already present* and *declined*
 //!    alike, which is why integrations pre-grepped `/etc/pam.d/<service>` for
@@ -187,7 +187,7 @@ pub const PAM_MODULE_PATHS: &[&str] = &[
 ];
 
 /// Services whose stacks can lock the machine, or the network, out. Adding
-/// face auth here needs `--allow-sensitive` (`--yes` on the `setup` alias);
+/// face auth here needs `--allow-sensitive` on every CLI surface;
 /// **removing** it needs no gate on sensitivity, because removal can only take
 /// away a way to authenticate — the confinement rules still apply to it, and
 /// to `status`, like any other verb.
@@ -4388,9 +4388,8 @@ struct WriteRequest<'a> {
     action: WriteAction,
     request: &'a PamRequest,
     /// The flag that unlocks [`SENSITIVE_SERVICES`] **on this surface**:
-    /// `--allow-sensitive` on the verb, `--yes` on the `setup --pam` alias,
-    /// which keeps its combined meaning. The refusal has to name the flag the
-    /// caller can actually reach.
+    /// `--allow-sensitive` on both the verb and the `setup --pam` alias. The
+    /// refusal has to name the flag the caller can actually reach.
     remedy: &'a str,
 }
 
@@ -9091,9 +9090,8 @@ fn status_code(outcome: &Outcome, if_present: bool) -> i32 {
 /// builds a request, names every field, and the writer reads the same value in
 /// both phases.
 ///
-/// The `remedy` is `--yes` on all three: `setup --yes` keeps its combined
-/// meaning — it is the documented exception to the flag split — so the refusal
-/// has to name the flag this surface actually honours.
+/// The `remedy` is `--allow-sensitive` on every setup alias. `setup --yes`
+/// suppresses the ordinary confirmation only, matching `pam add --yes`.
 ///
 /// Root is re-checked in the two that `run_with_plan` reaches directly for a
 /// standalone `--pam`, which does not take the base setup's root pre-check.
@@ -9108,7 +9106,7 @@ pub(crate) fn install_for_setup(request: &PamRequest) -> anyhow::Result<()> {
     let write = WriteRequest {
         action: WriteAction::Add,
         request,
-        remedy: "--yes",
+        remedy: "--allow-sensitive",
     };
     let sink = Sink::human();
     let dirs = PamDirs::system();
@@ -9128,7 +9126,7 @@ pub(crate) fn remove_for_setup(request: &PamRequest) -> anyhow::Result<()> {
     let write = WriteRequest {
         action: WriteAction::Remove,
         request,
-        remedy: "--yes",
+        remedy: "--allow-sensitive",
     };
     let sink = Sink::human();
     let dirs = PamDirs::system();
@@ -9156,7 +9154,7 @@ pub(crate) fn install_one_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Re
     let write = WriteRequest {
         action: WriteAction::Add,
         request,
-        remedy: "--yes",
+        remedy: "--allow-sensitive",
     };
     let sink = Sink::human();
     let reports = apply_all(dirs, &plan_writes(dirs, &write)?, &write, &sink);
@@ -12900,6 +12898,32 @@ mod tests {
 
         assert_eq!(write_in(&only(dir.path()), &request).unwrap(), WRITE_OK);
         assert_eq!(read(&dir, "sshd"), SUDO_AFTER);
+    }
+
+    /// The setup alias uses `--yes` only for prompt suppression. A sensitive
+    /// write stays refused until the alias's explicit authorization is set,
+    /// and the refusal names that authorization rather than the prompt flag.
+    #[test]
+    fn setup_alias_requires_explicit_sensitive_authorization() {
+        let dir = seeded(&[("system-auth", SUDO_BEFORE)]);
+        let before = snapshot(dir.path());
+        let prompt_only = PamRequest {
+            no_confirm: true,
+            ..add(&["system-auth"])
+        };
+
+        let error = install_one_in(&only(dir.path()), &prompt_only)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("--allow-sensitive"), "got: {error}");
+        assert_eq!(before, snapshot(dir.path()));
+
+        let authorized = PamRequest {
+            allow_sensitive: true,
+            ..prompt_only
+        };
+        assert!(install_one_in(&only(dir.path()), &authorized).unwrap());
+        assert_eq!(read(&dir, "system-auth"), SUDO_AFTER);
     }
 
     /// Removal is the safe direction, so it is not gated at all: a user who

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -125,7 +125,7 @@ use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
 
 use dialoguer::Confirm;
@@ -610,6 +610,12 @@ fn secure_state_directory(directory: &fs::File, expected_owner: (u32, u32)) -> s
     directory.sync_all()
 }
 
+fn create_state_directory(root: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(PAM_BACKUPS_DIR_MODE);
+    builder.create(root)
+}
+
 /// One complete mutation of PAM configuration and its rollback state.
 /// Holding the state-directory flock in this guard prevents recovery or a
 /// competing writer from observing a prepared pair between publication and
@@ -806,7 +812,7 @@ impl BackupStore {
                     format!("{} is not a directory", root.display()),
                 ));
             }
-            Err(error) if error.kind() == ErrorKind::NotFound => fs::create_dir(root)?,
+            Err(error) if error.kind() == ErrorKind::NotFound => create_state_directory(root)?,
             Err(error) => return Err(error),
         }
 
@@ -9282,6 +9288,20 @@ mod tests {
             fs::metadata(&backup_dir).unwrap().permissions().mode() & 0o7777,
             0o700
         );
+    }
+
+    #[test]
+    fn new_state_directory_is_never_group_or_world_accessible() {
+        let root = tempfile::tempdir().unwrap();
+        let backup_dir = root.path().join("pam-backups");
+
+        create_state_directory(&backup_dir).unwrap();
+
+        let mode = fs::symlink_metadata(&backup_dir)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o077, 0);
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -144,6 +144,7 @@ pub struct SetupArgs {
     pub service: Option<String>,
     pub remove: bool,
     pub if_present: bool,
+    pub allow_sensitive: bool,
     pub camera: Option<String>,
     pub models: Option<ModelPreset>,
     pub execution_provider: Option<ExecutionProviderChoice>,
@@ -165,6 +166,7 @@ pub struct SetupPlan {
     pub execution_provider: Option<ExecutionProviderChoice>,
     pub encryption: Option<EncryptionChoice>,
     pub yes: bool,
+    pub allow_sensitive: bool,
 }
 
 impl Default for SetupPlan {
@@ -180,6 +182,7 @@ impl Default for SetupPlan {
             execution_provider: None,
             encryption: None,
             yes: false,
+            allow_sensitive: false,
         }
     }
 }
@@ -269,6 +272,7 @@ pub fn resolve_setup_plan(args: SetupArgs) -> SetupPlan {
         execution_provider: args.execution_provider,
         encryption: args.encryption,
         yes: args.yes,
+        allow_sensitive: args.allow_sensitive,
     }
 }
 
@@ -348,14 +352,14 @@ struct PamKnobs {
 /// because it *is* the security property: `--non-interactive` promises no
 /// prompts, so it suppresses the per-file "Proceed?" confirmation, and it
 /// deliberately does **not** bypass the sensitive-service gate. `setup --yes`
-/// is the one flag that still means both halves — "skip the prompt" *and*
-/// "unlock the sensitive services" — and so maps onto both. On `facelock pam
-/// add` the two are separate flags and neither implies the other.
+/// also suppresses prompts only. `--allow-sensitive` is the separate,
+/// explicit authorization to unlock the sensitive services, matching
+/// `facelock pam add`; neither flag implies the other.
 fn setup_pam_knobs(plan: &SetupPlan) -> PamKnobs {
     let no_prompt = plan.base == Some(BaseMode::NonInteractive);
     PamKnobs {
         no_confirm: plan.yes || no_prompt,
-        allow_sensitive: plan.yes,
+        allow_sensitive: plan.allow_sensitive,
     }
 }
 
@@ -2233,9 +2237,9 @@ fn pam_step_in(
                 service: service.clone(),
             });
             // Step 9 runs only under a wizard base, never
-            // `--non-interactive`, so `setup_pam_knobs` reduces to `plan.yes`
-            // on both knobs here. Splitting them would make `--pam --service X
-            // --yes` start prompting where it never did.
+            // `--non-interactive`, so its prompt knob reduces to `plan.yes`.
+            // Sensitive authorization stays an independent decision carried
+            // by `plan.allow_sensitive`.
             //
             // The returned bool, not the absence of an `Err`, decides whether
             // this service is named in the closing summary and whether the
@@ -4067,21 +4071,19 @@ mod tests {
         }
     }
 
-    /// The wizard's multi-select hands every selected service to the writer
-    /// with the sensitive gate already unlocked (`install_one_in(base,
-    /// &service, true, true)`), because the multi-select *is* the consent and
-    /// no candidate is gated. That argument is only true while the two lists
-    /// are disjoint, and they are two lists in two modules — so the emptiness
-    /// of the intersection is the thing to check, not the list above, which a
-    /// name added to `SENSITIVE_SERVICES` would not appear in.
+    /// The ordinary wizard multi-select does not grant sensitive-service
+    /// authorization. Its candidates therefore have to stay disjoint from
+    /// `SENSITIVE_SERVICES`, or a default wizard selection could unexpectedly
+    /// require a separate authorization. The lists live in different modules,
+    /// so pin their intersection directly rather than relying on the exclusions
+    /// above, which would not notice a new sensitive-service entry.
     #[test]
     fn no_candidate_is_a_sensitive_service() {
         for candidate in PAM_CANDIDATES {
             assert!(
                 !super::super::pam::SENSITIVE_SERVICES.contains(&candidate.service),
-                "`{}` is offered by the wizard, which unlocks the sensitive \
-                 gate for every service it offers — remove it from one list or \
-                 the other",
+                "`{}` is offered by the wizard without implicit sensitive \
+                 authorization — remove it from one list or the other",
                 candidate.service
             );
         }
@@ -4730,16 +4732,17 @@ mod action_tests {
         assert_eq!(before["polkit-1"], after["polkit-1"]);
     }
 
-    /// The `setup --yes` mapping is the security property the flag split has
-    /// to preserve, and it is the one part of it that lives on this side of
-    /// the seam. `commands::pam` pins that the engine honours the knobs;
-    /// this pins that `setup` sets them right.
+    /// `setup --yes` and `--non-interactive` answer prompts only. Neither is
+    /// authorization to edit a shared or login PAM stack.
+    /// `commands::pam` pins that the engine honours the knobs; this pins that
+    /// `setup` keeps prompt suppression separate from sensitive authorization.
     #[test]
-    fn setup_maps_yes_to_both_knobs_and_non_interactive_to_only_one() {
-        let with = |base, yes| {
+    fn setup_maps_prompt_and_sensitive_authorization_independently() {
+        let with = |base, yes, allow_sensitive| {
             setup_pam_knobs(&SetupPlan {
                 base,
                 yes,
+                allow_sensitive,
                 ..SetupPlan::default()
             })
         };
@@ -4750,18 +4753,23 @@ mod action_tests {
         };
 
         // Standalone `--pam`: ask, and refuse the sensitive services.
-        assert_eq!(with(None, false), knobs(false, false));
+        assert_eq!(with(None, false, false), knobs(false, false));
         // `--non-interactive --pam`: no prompts, and *still* refuse them.
         assert_eq!(
-            with(Some(BaseMode::NonInteractive), false),
+            with(Some(BaseMode::NonInteractive), false, false),
             knobs(true, false)
         );
-        // `--pam --yes`: the documented combined meaning — both halves.
-        assert_eq!(with(None, true), knobs(true, true));
+        // `--pam --yes`: suppress the ordinary confirmation, but do not
+        // authorize a sensitive PAM mutation.
+        assert_eq!(with(None, true, false), knobs(true, false));
         assert_eq!(
-            with(Some(BaseMode::NonInteractive), true),
-            knobs(true, true)
+            with(Some(BaseMode::NonInteractive), true, false),
+            knobs(true, false)
         );
+        // `--allow-sensitive` authorizes the gated write and does not answer
+        // the ordinary confirmation by itself.
+        assert_eq!(with(None, false, true), knobs(false, true));
+        assert_eq!(with(None, true, true), knobs(true, true));
     }
 
     // -- `--no-systemd` -----------------------------------------------------

--- a/crates/facelock-cli/src/conformance/capabilities.rs
+++ b/crates/facelock-cli/src/conformance/capabilities.rs
@@ -122,6 +122,7 @@ fn capability_names_are_all_implemented() {
                     "`--quiet` must be global — every command honours it"
                 );
             }
+            "setup-allow-sensitive" => assert_long(setup, "allow_sensitive", "allow-sensitive"),
             "setup-if-present" => assert_long(setup, "if_present", "if-present"),
             "setup-no-pam" => assert_long(setup, "no_pam", "no-pam"),
             "setup-systemd" => assert_long(setup, "systemd", "systemd"),

--- a/crates/facelock-cli/src/conformance/docs.rs
+++ b/crates/facelock-cli/src/conformance/docs.rs
@@ -442,9 +442,7 @@ fn docs_cli_examples_never_install_into_a_gated_service() {
                 }
                 Commands::Setup(setup) => {
                     let plan = resolve_setup_plan(SetupArgs::from(setup));
-                    // `setup --yes` is the documented exception: it maps onto
-                    // --allow-sensitive as well as --no-confirm.
-                    if plan.yes {
+                    if plan.allow_sensitive {
                         continue;
                     }
                     let PamPref::Install {
@@ -457,7 +455,7 @@ fn docs_cli_examples_never_install_into_a_gated_service() {
                     if let Some(service) = gated(std::slice::from_ref(service)) {
                         panic!(
                             "`{rendered}` in {doc_path} installs into the gated service \
-                             `{service}` without -y, so it fails as written"
+                             `{service}` without --allow-sensitive, so it fails as written"
                         );
                     }
                 }

--- a/crates/facelock-cli/src/conformance/flags.rs
+++ b/crates/facelock-cli/src/conformance/flags.rs
@@ -60,6 +60,7 @@ fn matrix_row_bare_setup_is_the_full_wizard() {
     assert_eq!(p.execution_provider, None);
     assert_eq!(p.encryption, None);
     assert!(!p.yes);
+    assert!(!p.allow_sensitive);
 }
 
 #[test]
@@ -1004,7 +1005,7 @@ fn pam_service_is_repeatable_and_ordered() {
 
 /// **`--no-confirm` must never imply `--allow-sensitive`.** They are
 /// separate authorizations: "do not ask me" and "yes, edit system-auth".
-/// `setup --yes` keeps the combined meaning and is the sole exception.
+/// The primary PAM verb and the setup alias both enforce that separation.
 #[test]
 fn no_confirm_and_allow_sensitive_are_independent() {
     for skip_prompts in [
@@ -1027,8 +1028,52 @@ fn no_confirm_and_allow_sensitive_are_independent() {
         "--allow-sensitive accepts a risk; it does not skip the question"
     );
 
-    // `setup --yes` is the documented exception, unchanged.
-    assert!(plan(&["--pam", "--yes"]).yes);
+    // The setup alias must keep the same separation.
+    let setup = plan(&["--pam", "--yes"]);
+    assert!(setup.yes);
+    assert!(!setup.allow_sensitive);
+}
+
+/// `setup --pam` exposes the same explicit sensitive authorization as the
+/// primary `pam add` surface, and the modifier is meaningless without PAM.
+#[test]
+fn setup_accepts_explicit_sensitive_authorization_only_with_pam() {
+    let authorized = [
+        "facelock",
+        "setup",
+        "--pam",
+        "--service",
+        "system-auth",
+        "--yes",
+        "--allow-sensitive",
+    ];
+    assert!(
+        Cli::try_parse_from(authorized).is_ok(),
+        "`{}` must parse",
+        authorized.join(" ")
+    );
+    assert!(
+        Cli::try_parse_from(["facelock", "setup", "--allow-sensitive"]).is_err(),
+        "--allow-sensitive without --pam must be rejected"
+    );
+    assert!(
+        Cli::try_parse_from([
+            "facelock",
+            "setup",
+            "--pam",
+            "--remove",
+            "--allow-sensitive",
+        ])
+        .is_err(),
+        "removal is never sensitive-gated, so it must not accept a meaningless authorization"
+    );
+
+    let resolved = plan(&["--pam", "--allow-sensitive"]);
+    assert!(resolved.allow_sensitive);
+    assert!(
+        !resolved.yes,
+        "sensitive authorization must not suppress the prompt"
+    );
 }
 
 /// `--allow-sensitive` is an `add`-only flag: removal can only take away a

--- a/crates/facelock-cli/src/message/pam.rs
+++ b/crates/facelock-cli/src/message/pam.rs
@@ -186,10 +186,9 @@ pub enum PamMessage {
         path: String,
         links: String,
     },
-    /// `remedy` is the flag that unlocks this surface: `--allow-sensitive` on
-    /// `pam add`, `--yes` on the `setup --pam` alias, which keeps its
-    /// combined meaning. Carrying it as data is what lets one message be
-    /// truthful on both.
+    /// `remedy` is the explicit flag that unlocks the sensitive gate on the
+    /// current surface. It is `--allow-sensitive` for both `pam add` and the
+    /// `setup --pam` alias.
     PamSensitiveRefused {
         service: String,
         remedy: String,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,7 @@ facelock setup --pam --service polkit-1 # install to a specific service
 facelock setup --pam --remove           # remove the PAM line
 facelock setup --pam --service hyprlock --if-present  # a missing service file is success
 facelock setup --pam --remove --if-present  # ...on removal too
-facelock setup --pam --service sshd -y  # a sensitive service: -y is what unlocks it
+facelock setup --pam --service sshd -y --allow-sensitive  # suppress the prompt and authorize the sensitive write
 facelock setup --no-pam                 # wizard, but never touch /etc/pam.d
 facelock setup --camera /dev/video2     # answer step 1 from the command line
 ```
@@ -103,12 +103,15 @@ since omitting a flag already gives the default.
 |------|---------|
 | *(none)* | Full interactive wizard. Falls back to the non-interactive flow when stdin is not a terminal. |
 | `--non-interactive` | No prompts. Choices resolve to config-or-default. Runs the base setup only: directories, model download and verification, encryption, path permissions. No PAM, no systemd, no enrollment unless asked for explicitly. |
-| `-y`, `--yes` (alias `--no-confirm`) | Suppress confirmation prompts, and unlock the sensitive-service gate. |
+| `-y`, `--yes` (alias `--no-confirm`) | Suppress ordinary confirmation prompts. Does not authorize a sensitive PAM edit. |
 
-`--non-interactive` suppresses the per-file "Proceed?" confirmation on its own,
-since it promises no prompts. It does **not** unlock the sensitive-service
-gate, so `facelock setup --non-interactive --pam --service sshd` refuses until
-`-y` is added. Locking yourself out of a machine takes two decisions.
+`--yes` and `--non-interactive` suppress the per-file "Proceed?" confirmation;
+neither unlocks the sensitive-service gate. The shared auth stacks
+`common-auth`, `password-auth`, `password-auth-ac`, `system-auth`,
+`system-auth-ac` and `system-login`, plus `login` and `sshd`, require
+`--allow-sensitive`. Thus even `facelock setup --pam --service sshd --yes`
+refuses. Locking yourself out of a machine takes two independent decisions:
+whether to skip the prompt, and whether to authorize the sensitive write.
 
 ### Choice flags
 
@@ -166,6 +169,7 @@ forcing the step, so it runs unattended.
 | `--service <NAME>` | `--pam` | Target PAM service. Default `sudo`. |
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
 | `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
+| `--allow-sensitive` | `--pam` add | Explicitly authorize adding Facelock to `common-auth`, `login`, `password-auth`, `password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac`, or `system-login`. Does not suppress the confirmation prompt and conflicts with `--remove`. |
 | `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
 
 The parser enforces these, so `facelock setup --remove` is an error naming the
@@ -183,13 +187,15 @@ then PAM.
 
 `--pam` is an alias onto [`facelock pam add | remove`](#facelock-pam), which is
 the primary spelling and the one that takes several services in one process.
-Every `setup --pam` invocation keeps parsing and keeps its behaviour.
+Existing `setup --pam` invocations keep parsing. Sensitive additions now use
+the same explicit `--allow-sensitive` authorization as `facelock pam add`,
+while `-y` only suppresses the prompt.
 
 Eight services are gated: the shared auth stacks `common-auth`,
 `password-auth`, `password-auth-ac`, `system-auth`, `system-auth-ac` and
 `system-login`, plus `login` and `sshd`.
-`facelock setup --pam --service login` refuses until `-y` is added, and on
-`facelock pam add` the same gate is `--allow-sensitive`.
+`facelock setup --pam --service login` refuses until `--allow-sensitive` is
+added, even when `-y` is present.
 
 Every `setup` run reconciles the per-user enrollment markers behind
 [`facelock is-enrolled`](#facelock-is-enrolled) against the database, which is

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -54,6 +54,7 @@ follow it.
 | `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, daemon, enrollment, PAM — the daemon before enrollment, so enrollment and the recognition test run on the transport later authentications use); removes a leftover `facelock` group from an older install, best-effort (ADR 010) |
 | `facelock setup --systemd` | Install/enable systemd units |
 | `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
+| `facelock setup --pam --allow-sensitive` | Explicitly authorize an add to a sensitive PAM service. Does not suppress confirmation and conflicts with `--remove` |
 | `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |
 | `facelock pam remove` | Remove it. Root. Cleans validated Facelock-owned rollback state by default; `--keep-backup` preserves it |
 | `facelock pam remove --all` | Config-independent, whole-machine removal of recognized Facelock-owned direct PAM edits beneath compiled roots. Root. Conflicts with `--service` |
@@ -277,11 +278,12 @@ plan resolution above stays on `setup` — `--pam`, `--no-pam`, `--service`,
 the execution moved. The alias is exact, including the two things that make it
 not a plain forward:
 
-- **`setup --yes` keeps its combined meaning** and is the one documented
-  exception to the flag split below. It maps onto *both* of the writer's knobs:
-  `--no-confirm` (skip the per-file question) **and** `--allow-sensitive`
-  (accept the sensitive services listed below). `--non-interactive` maps onto
-  `--no-confirm` alone, as it always has.
+- **`setup --yes` maps onto `--no-confirm` only.** It suppresses the ordinary
+  per-file question and does not authorize a sensitive PAM mutation.
+  `--non-interactive` has the same prompt-only effect, as it always has.
+  `setup --pam --allow-sensitive` maps onto the writer's separate
+  authorization and does not suppress the question. The flag conflicts with
+  `--remove`, whose safe direction is never sensitive-gated.
 - **The root refusal is a hard error, not a `sudo` re-exec.** Standalone
   `--pam` never offered the interactive escalation (`needs_root_precheck`), and
   `facelock pam add|remove` does not either.
@@ -436,7 +438,8 @@ crash-recoverable transaction and rollback pair, described below. Named
 `pam add` and `pam remove` do not use a whole-set journal; the compiled-root
 `pam remove --all` transaction is specified separately below.
 
-**`--no-confirm` never implies `--allow-sensitive`.** They are separate
+**`--no-confirm` never implies `--allow-sensitive`, including through
+`setup --pam`.** They are separate
 authorizations: "do not ask me" and "yes, edit the shared auth stack". The
 gated services are `common-auth`, `login`, `password-auth`,
 `password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac` and
@@ -450,9 +453,10 @@ spelling made the gate depend on the operator's distribution. `login` and
 `sshd` are the two that are not: each locks one specific door — the TTY, the
 network — rather than every one at once. `--yes` and
 `--no-confirm` are the same flag (the shared `ConfirmArg` spelling, so "skip
-prompts" reads the same on `pam add` as on `remove` and `clear`) and neither
-unlocks the gate. `setup --yes` keeps the combined meaning and is the sole
-exception. `remove` is never gated **on sensitivity** — removal can only take
+prompts" reads the same on `setup`, `pam add`, `remove` and `clear`) and neither
+unlocks the gate. Both `pam add` and its `setup --pam` alias expose the same
+explicit `--allow-sensitive` authorization. `remove` is never gated **on
+sensitivity** — removal can only take
 away a way to authenticate — and never prompts, which is what
 `setup --pam --remove` has always done; the confinement rules below apply to
 every verb, `remove` and `status` included. `--yes`/`--no-confirm` is accepted there for symmetry and has
@@ -1013,8 +1017,8 @@ currently invokes tolerant `pam-auth-update --remove facelock` before shared
 cleanup; byte-exact profile lifecycle and rollback are #224 scope. Fedora
 authselect profile selection, regeneration and rollback are #226 scope;
 `remove --all` only scans `/etc/authselect` as a detection-only root and never
-edits generated state. This does not implement #207 sensitive-authorization
-changes or #166's final emitted-byte freeze.
+edits generated state. This does not implement #166's final emitted-byte
+freeze.
 
 **`--json`** emits exactly one document on stdout and no human text; `--quiet`
 suppresses even that, leaving the exit code as the whole answer, as it does for
@@ -1502,6 +1506,7 @@ that is not on this list is not being denied, only not yet promised.
 | `pam-status` | `pam status` exists — the unprivileged `/etc/pam.d` read (DEC-6 below) |
 | `pam-status-all` | `pam status --all` exists, and conflicts with `--service` — the enumerating form, which answers "what is configured on this machine?" rather than "is this name configured?" |
 | `quiet` | the global `--quiet` |
+| `setup-allow-sensitive` | `setup --pam` accepts `--allow-sensitive` as the explicit sensitive-service authorization; `--yes` remains prompt suppression only |
 | `setup-if-present` | `setup --pam --if-present`, on add and on `--remove` alike |
 | `setup-no-pam` | `setup --no-pam` |
 | `setup-systemd` | `setup --systemd` |

--- a/docs/security.md
+++ b/docs/security.md
@@ -922,8 +922,7 @@ Fedora authselect profile selection, regeneration, and rollback remain #226
 scope. This command treats `/etc/authselect` as detection-only and never edits
 generated profile state.
 
-This does not implement #207 sensitive-authorization changes or #166's final
-emitted-byte freeze.
+This does not implement #166's final emitted-byte freeze.
 
 #### A0. Config File Trust (Required)
 

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -63,12 +63,15 @@ permissions. No PAM, no systemd, and no enrollment unless explicitly
 requested.
 .TP
 .B \-y\fR, \fB\-\-yes
-Skip confirmation prompts, and unlock the gate that otherwise refuses to modify
-a sensitive PAM service file (\fBcommon\-auth\fR, \fBlogin\fR,
+Skip ordinary confirmation prompts. This does not authorize a sensitive PAM
+edit. Also accepted as \fB\-\-no\-confirm\fR.
+.TP
+.B \-\-allow\-sensitive
+Explicitly authorize adding Facelock to \fBcommon\-auth\fR, \fBlogin\fR,
 \fBpassword\-auth\fR, \fBpassword\-auth\-ac\fR, \fBsshd\fR,
-\fBsystem\-auth\fR, \fBsystem\-auth\-ac\fR, \fBsystem\-login\fR).
-\fB\-\-non\-interactive\fR suppresses the per-file confirmation on its own but
-does \fInot\fR unlock that gate. Also accepted as \fB\-\-no\-confirm\fR.
+\fBsystem\-auth\fR, \fBsystem\-auth\-ac\fR, or \fBsystem\-login\fR. This does
+not suppress the confirmation prompt, requires \fB\-\-pam\fR, and conflicts
+with \fB\-\-remove\fR.
 .TP
 .B \-\-pam
 Install or manage PAM module configuration. On its own, configures one service
@@ -146,10 +149,10 @@ later flag on the command line wins.
 and
 .BR "facelock pam remove" ,
 which is the primary spelling and the one that takes several services in one
-process. Every \fBsetup \-\-pam\fR invocation keeps parsing and keeps its
-behaviour, including the rule that \fB\-y\fR is what unlocks a sensitive
-service here where \fB\-\-allow\-sensitive\fR does it on
+process. Existing \fBsetup \-\-pam\fR invocations keep parsing; sensitive
+additions use the same explicit \fB\-\-allow\-sensitive\fR authorization as
 .BR "facelock pam add" .
+\fB\-y\fR only suppresses the confirmation prompt.
 .TP
 .B is\-enrolled
 Report whether a user has a usable face enrollment. The exit status is the

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 11:23-0700\n"
+"POT-Creation-Date: 2026-08-20 11:34-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -392,29 +392,29 @@ msgstr ""
 msgid "Face auth failed: {reason}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:285
+#: crates/facelock-cli/src/message/pam.rs:284
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:291
+#: crates/facelock-cli/src/message/pam.rs:290
 msgid ""
 "  PAM module not found. Tried: {paths}\n"
 "  Install it first, then run: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:296
+#: crates/facelock-cli/src/message/pam.rs:295
 #, python-brace-format
 msgid "  Configuring PAM for {service}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:300
+#: crates/facelock-cli/src/message/pam.rs:299
 #, python-brace-format
 msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:305
+#: crates/facelock-cli/src/message/pam.rs:304
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -425,42 +425,42 @@ msgid ""
 "  be asked to confirm each file individually.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:310
+#: crates/facelock-cli/src/message/pam.rs:309
 msgid "Select services to enable face authentication for"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:313
+#: crates/facelock-cli/src/message/pam.rs:312
 #, python-brace-format
 msgid "  Failed to configure {service}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:316
+#: crates/facelock-cli/src/message/pam.rs:315
 msgid "  No PAM services selected."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:318
+#: crates/facelock-cli/src/message/pam.rs:317
 #, python-brace-format
 msgid "PAM service file not found: {paths}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:322
+#: crates/facelock-cli/src/message/pam.rs:321
 #, python-brace-format
 msgid "PAM line already present in {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:325
+#: crates/facelock-cli/src/message/pam.rs:324
 msgid "inserted before the first 'auth' line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:327
+#: crates/facelock-cli/src/message/pam.rs:326
 msgid "no 'auth' line found — inserted after the PAM header"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:330
+#: crates/facelock-cli/src/message/pam.rs:329
 msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:339
+#: crates/facelock-cli/src/message/pam.rs:338
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -470,21 +470,21 @@ msgid ""
 "(To configure manually instead, add the line above to each service yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:348
+#: crates/facelock-cli/src/message/pam.rs:347
 msgid "Proceed?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:350
+#: crates/facelock-cli/src/message/pam.rs:349
 #, python-brace-format
 msgid "Skipped {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:353
+#: crates/facelock-cli/src/message/pam.rs:352
 #, python-brace-format
 msgid "Backed up {path} -> {backup}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:362
+#: crates/facelock-cli/src/message/pam.rs:361
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
@@ -493,28 +493,28 @@ msgid ""
 "  # or: sudo facelock pam remove --service {service}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:371
+#: crates/facelock-cli/src/message/pam.rs:370
 #, python-brace-format
 msgid "Removed facelock PAM line from {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:375
+#: crates/facelock-cli/src/message/pam.rs:374
 #, python-brace-format
 msgid "No facelock PAM line found in {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:379
+#: crates/facelock-cli/src/message/pam.rs:378
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:383
+#: crates/facelock-cli/src/message/pam.rs:382
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:393
+#: crates/facelock-cli/src/message/pam.rs:392
 msgid ""
 "\n"
 "About to create {path} from the vendor file {vendor}:\n"
@@ -524,7 +524,7 @@ msgid ""
 "(To configure manually instead, copy that file and add the line above yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:408
+#: crates/facelock-cli/src/message/pam.rs:407
 msgid ""
 "Created {path} from {vendor} with the facelock PAM line.\n"
 "This local override shadows the vendor file and will not track vendor updates.\n"
@@ -534,57 +534,57 @@ msgid ""
 "An unchanged Facelock-created override is deleted; a modified override is kept after its facelock line is removed."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:418
+#: crates/facelock-cli/src/message/pam.rs:417
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Deleted unchanged local override; {vendor} is authoritative again."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:424
+#: crates/facelock-cli/src/message/pam.rs:423
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because administrator or vendor drift no longer matches {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:430
+#: crates/facelock-cli/src/message/pam.rs:429
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:436
+#: crates/facelock-cli/src/message/pam.rs:435
 msgid ""
 "No facelock PAM line found in {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:442
+#: crates/facelock-cli/src/message/pam.rs:441
 #, python-brace-format
 msgid "Would remove the facelock PAM line from {path}, delete the unchanged local override, and make {vendor} authoritative again."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:448
+#: crates/facelock-cli/src/message/pam.rs:447
 #, python-brace-format
 msgid "PAM service file exists only at {path}, which is package-owned and never modified by facelock. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:453
+#: crates/facelock-cli/src/message/pam.rs:452
 #, python-brace-format
 msgid "{path}: vendor file only, no facelock PAM line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:457
+#: crates/facelock-cli/src/message/pam.rs:456
 #, python-brace-format
 msgid "Would create {path} from {vendor} with the facelock PAM line ({hint})."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:466
+#: crates/facelock-cli/src/message/pam.rs:465
 msgid ""
 "Cannot create the local override {path}: {dir} is not writable ({error}).\n"
 "The vendor copy of this service is package-owned, so facelock will not edit it in place."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:476
+#: crates/facelock-cli/src/message/pam.rs:475
 msgid ""
 "\n"
 "==> facelock PAM line for manual extension to other services:\n"
@@ -592,101 +592,101 @@ msgid ""
 "==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:482
+#: crates/facelock-cli/src/message/pam.rs:481
 #, python-brace-format
 msgid "Invalid PAM service name '{service}': a service is one file name under /etc/pam.d, so it may not be empty, contain '/', or be '.' or '..'."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:488
+#: crates/facelock-cli/src/message/pam.rs:487
 msgid ""
 "Refusing to touch {path}: it is a symlink to {target}. PAM service links are never followed beneath {dir}.\n"
 "Edit the real service file directly, or the tool that generates it — authselect regenerates system-auth and password-auth from /etc/authselect."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:498
+#: crates/facelock-cli/src/message/pam.rs:497
 msgid ""
 "Refusing to touch {path}: it is one of {links} names for the same file, so an edit here would change a file outside /etc/pam.d that facelock cannot name.\n"
 "Break the link first: sudo cp -p {path} {path}.new && sudo mv {path}.new {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:504
+#: crates/facelock-cli/src/message/pam.rs:503
 msgid ""
 "Refusing to modify '{service}': this is a sensitive PAM service.\n"
 "Re-run with {remedy} to accept the risk of locking yourself out."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:510
+#: crates/facelock-cli/src/message/pam.rs:509
 msgid ""
 "PAM module not found. Tried: {paths}\n"
 "Install it first: cargo build --release -p pam-facelock && sudo cp target/release/libpam_facelock.so {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:515
+#: crates/facelock-cli/src/message/pam.rs:514
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to add."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:519
+#: crates/facelock-cli/src/message/pam.rs:518
 #, python-brace-format
 msgid "Would add the facelock PAM line to {path} ({hint})."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:523
+#: crates/facelock-cli/src/message/pam.rs:522
 #, python-brace-format
 msgid "Would remove the facelock PAM line from {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:527
+#: crates/facelock-cli/src/message/pam.rs:526
 #, python-brace-format
 msgid "No change needed for {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:531
+#: crates/facelock-cli/src/message/pam.rs:530
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:535
+#: crates/facelock-cli/src/message/pam.rs:534
 #, python-brace-format
 msgid "{path}: facelock PAM line present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:539
+#: crates/facelock-cli/src/message/pam.rs:538
 #, python-brace-format
 msgid "{path}: no facelock PAM line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:543
+#: crates/facelock-cli/src/message/pam.rs:542
 #, python-brace-format
 msgid "{paths}: service file absent"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:547
+#: crates/facelock-cli/src/message/pam.rs:546
 #, python-brace-format
 msgid "{path}: unreadable ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:551
+#: crates/facelock-cli/src/message/pam.rs:550
 #, python-brace-format
 msgid "{path}: facelock PAM line present (local override of {vendor})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:555
+#: crates/facelock-cli/src/message/pam.rs:554
 #, python-brace-format
 msgid "{dir}: directory not checked ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:559
+#: crates/facelock-cli/src/message/pam.rs:558
 #, python-brace-format
 msgid "No service file under {dirs} carries the facelock PAM line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:564
+#: crates/facelock-cli/src/message/pam.rs:563
 #, python-brace-format
 msgid "No service file under {dirs} carries the facelock PAM line, but {unchecked} could not be checked, so this is not an answer about the whole machine."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:569
+#: crates/facelock-cli/src/message/pam.rs:568
 #, python-brace-format
 msgid "No directory on the search path could be read: {dirs}."
 msgstr ""

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -190,16 +190,19 @@ if [ -n "$PAM_SENSITIVE" ]; then
     run_test "pam add refuses sensitive service $PAM_SENSITIVE under --no-confirm" \
         "facelock pam add --service $PAM_SENSITIVE --no-confirm > /tmp/pam-sensitive.out 2>&1; test \$? -ne 0 && grep -q 'sensitive PAM service' /tmp/pam-sensitive.out && sha256sum -c --status /tmp/pam-sensitive.sha" \
         0
-    # The alias has its own refusal, naming its own flag: `setup --yes` is the
-    # documented exception that means both "do not ask" and "unlock the gate",
-    # so the message has to say --yes and not --allow-sensitive. Without this
-    # row the alias could lose the gate entirely and only the verb would notice.
-    run_test "setup --pam refuses sensitive service $PAM_SENSITIVE without --yes" \
-        "facelock setup --pam --service $PAM_SENSITIVE > /tmp/pam-sensitive-alias.out 2>&1; test \$? -ne 0 && grep -q 'sensitive PAM service' /tmp/pam-sensitive-alias.out && grep -q -- '--yes' /tmp/pam-sensitive-alias.out && sha256sum -c --status /tmp/pam-sensitive.sha" \
+    # The alias must preserve the verb's two independent decisions: --yes
+    # suppresses the ordinary prompt, but only --allow-sensitive authorizes
+    # this write. The hash proves the refusal happened before mutation.
+    run_test "setup --pam --yes refuses sensitive service $PAM_SENSITIVE without --allow-sensitive" \
+        "facelock setup --pam --service $PAM_SENSITIVE --yes > /tmp/pam-sensitive-alias.out 2>&1; test \$? -ne 0 && grep -q 'sensitive PAM service' /tmp/pam-sensitive-alias.out && grep -q -- '--allow-sensitive' /tmp/pam-sensitive-alias.out && sha256sum -c --status /tmp/pam-sensitive.sha" \
+        0
+    run_test "setup --pam explicit authorization configures sensitive service $PAM_SENSITIVE" \
+        "facelock setup --pam --service $PAM_SENSITIVE --yes --allow-sensitive >/tmp/pam-sensitive-authorized.out 2>&1; test \$? -eq 0 && grep -qxF '$PAM_LINE_TEXT' /etc/pam.d/$PAM_SENSITIVE && facelock setup --pam --service $PAM_SENSITIVE --remove --yes >/tmp/pam-sensitive-remove.out 2>&1 && sha256sum -c --status /tmp/pam-sensitive.sha" \
         0
     cp -p /tmp/pam-sensitive.orig "/etc/pam.d/$PAM_SENSITIVE"
     rm -f "/etc/pam.d/$PAM_SENSITIVE.facelock-backup" /tmp/pam-sensitive.orig \
-          /tmp/pam-sensitive-alias.out
+          /tmp/pam-sensitive-alias.out /tmp/pam-sensitive-authorized.out \
+          /tmp/pam-sensitive-remove.out
 else
     echo "SKIP: no sensitive service file in the image to test the gate"
 fi


### PR DESCRIPTION
## Why

`setup --pam --yes` currently turns prompt suppression into authorization to edit sensitive PAM stacks. Unattended integrations should require a separate explicit security decision.

## Changes

- separate setup prompt suppression from sensitive-service authorization
- require `--allow-sensitive` for sensitive `setup --pam` additions
- document and probe the new setup capability

## Validation

- `just check`
- `just test-arch-pam`
- `just test-arch-layout`