### PR TITLE
test(pam): freeze line placement contract

### DIFF
--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -9223,6 +9223,30 @@ mod tests {
         "#%PAM-1.0\nauth      sufficient pam_facelock.so\nauth\t\tinclude\t\tsystem-auth";
 
     #[test]
+    fn pam_line_placement_contract_is_frozen() {
+        const CANONICAL_LINE: &[u8; 36] = b"auth      sufficient pam_facelock.so";
+        const OMARCHY_SKELETON: &[u8] = b"#%PAM-1.0\n\
+auth       required                    pam_deny.so\n\
+account    include                     system-local-login\n";
+        const OMARCHY_CONFIGURED: &[u8] = b"#%PAM-1.0\n\
+auth      sufficient pam_facelock.so\n\
+auth       required                    pam_deny.so\n\
+account    include                     system-local-login\n";
+        const HEADERLESS_NO_AUTH: &[u8] = b"account required pam_unix.so\n";
+        const HEADERLESS_CONFIGURED: &[u8] = b"auth      sufficient pam_facelock.so\n\
+account required pam_unix.so\n";
+
+        assert_eq!(PAM_LINE.as_bytes(), CANONICAL_LINE);
+        assert_eq!(PAM_LINE.len(), 36);
+        assert!(!PAM_LINE.contains('\n'));
+        assert_eq!(with_line_inserted(OMARCHY_SKELETON), OMARCHY_CONFIGURED);
+        assert_eq!(
+            with_line_inserted(HEADERLESS_NO_AUTH),
+            HEADERLESS_CONFIGURED
+        );
+    }
+
+    #[test]
     fn backup_prepare_and_commit_are_versioned_root_only_provenance() {
         let root = tempfile::tempdir().unwrap();
         let backup_dir = root.path().join("pam-backups");

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -125,7 +125,7 @@ use std::fs;
 use std::io::{IsTerminal, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
 
 use dialoguer::Confirm;
@@ -610,6 +610,12 @@ fn secure_state_directory(directory: &fs::File, expected_owner: (u32, u32)) -> s
     directory.sync_all()
 }
 
+fn create_state_directory(root: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(PAM_BACKUPS_DIR_MODE);
+    builder.create(root)
+}
+
 /// One complete mutation of PAM configuration and its rollback state.
 /// Holding the state-directory flock in this guard prevents recovery or a
 /// competing writer from observing a prepared pair between publication and
@@ -806,7 +812,7 @@ impl BackupStore {
                     format!("{} is not a directory", root.display()),
                 ));
             }
-            Err(error) if error.kind() == ErrorKind::NotFound => fs::create_dir(root)?,
+            Err(error) if error.kind() == ErrorKind::NotFound => create_state_directory(root)?,
             Err(error) => return Err(error),
         }
 
@@ -9306,6 +9312,20 @@ account required pam_unix.so\n";
             fs::metadata(&backup_dir).unwrap().permissions().mode() & 0o7777,
             0o700
         );
+    }
+
+    #[test]
+    fn new_state_directory_is_never_group_or_world_accessible() {
+        let root = tempfile::tempdir().unwrap();
+        let backup_dir = root.path().join("pam-backups");
+
+        create_state_directory(&backup_dir).unwrap();
+
+        let mode = fs::symlink_metadata(&backup_dir)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o077, 0);
     }
 
     #[test]

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1017,8 +1017,7 @@ currently invokes tolerant `pam-auth-update --remove facelock` before shared
 cleanup; byte-exact profile lifecycle and rollback are #224 scope. Fedora
 authselect profile selection, regeneration and rollback are #226 scope;
 `remove --all` only scans `/etc/authselect` as a detection-only root and never
-edits generated state. This does not implement #166's final emitted-byte
-freeze.
+edits generated state.
 
 **`--json`** emits exactly one document on stdout and no human text; `--quiet`
 suppresses even that, leaving the exit code as the whole answer, as it does for
@@ -1150,15 +1149,70 @@ as "not configured".
 process, one root check and one closing hint. Duplicates collapse. No
 `--service` means `sudo`, which is what bare `setup --pam` has always meant.
 
+**PAM line placement.** The direct CLI writer emits exactly this 36-byte
+literal; the literal itself has no trailing newline:
+
+```pam
+auth      sufficient pam_facelock.so
+```
+
+The control is frozen to `sufficient`: a successful face can satisfy the
+stack, while a non-match or unavailable face path continues under the
+service-owned rules that follow. Ordinary login and privilege stacks commonly
+reach their password modules there. Omarchy's face-only context instead
+continues to `pam_deny.so`; its password attempt uses a separate PAM context.
+There is intentionally no `--control` option. A caller cannot silently
+substitute `required`, an extended control, or another stack policy for the
+line whose behavior downstream consumers and Facelock cleanup rely on.
+
+The line is inserted immediately before the first *logical* rule whose first
+ASCII-whitespace-delimited type token is `auth`, matched
+ASCII-case-insensitively and with Linux-PAM's optional leading `-`;
+`authtok_type=` is not an auth type. If no auth rule exists and the first
+physical line is exactly `#%PAM-1.0`, the line follows that header. Without
+that exact leading header it starts at byte 0. This header-aware fallback is
+the post-#192 contract; it supersedes #166's original top-of-file wording.
+
+Omarchy owns this exact backend-neutral `omarchy-lock-face` skeleton:
+
+```pam
+#%PAM-1.0
+auth       required                    pam_deny.so
+account    include                     system-local-login
+```
+
+The direct writer produces this exact stack, leaving Omarchy's face-only lane
+to reach its plain denial when Facelock does not succeed:
+
+```pam
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth       required                    pam_deny.so
+account    include                     system-local-login
+```
+
+Add idempotency and named `pam status` recognition are deliberately broader
+than the emitted bytes. Any uncommented logical rule whose semantic bytes
+contain the exact, case-sensitive byte sequence `pam_facelock.so` is an active
+reference: `add` does not emit a duplicate, and `status` reports it present.
+This is substring recognition, not a PAM module-token-boundary promise.
+`pam remove --all` is stricter: a broad active reference is not automatically
+Facelock-owned. Without validated provenance or the exact vendor-copy shape,
+only the exact canonical physical line in a conventional service is eligible
+for cleanup; custom control, spacing, or options block the whole-machine run
+for administrator review rather than being rewritten.
+
+This emitted-byte contract applies only to direct CLI service-file writes.
+The Debian `pam-auth-update` profile intentionally emits
+`[success=end default=ignore] pam_facelock.so`, and the Fedora authselect
+profiles use authselect's generated layout. Both remain visible to the same
+broad `add`/`status` active-reference recognition, but neither is required to
+match the canonical direct-writer bytes.
+
 **Service-file edits are byte-preserving.** A backslash followed only by spaces
 or tabs before LF or CRLF continues the same logical PAM rule, so insertion
 never splits that rule. A `#` ends the semantic rule even after a continuation;
-comment and blank physical lines remain untouched. The line goes above the
-first logical rule whose first ASCII-whitespace-delimited type token is `auth`,
-matched ASCII-case-insensitively and with Linux-PAM's optional leading `-`;
-`authtok_type=` is not an auth type. When there is no auth rule, the line goes
-directly after a leading `#%PAM-1.0` header, or at the top when that header is
-absent.
+comment and blank physical lines remain untouched.
 
 Removal drops the whole genuine logical Facelock rule. For recovery from older
 facelock output that inserted the canonical physical line between an


### PR DESCRIPTION
## Why

Direct PAM consumers depend on exact emitted bytes and placement, but those details were spread across implementation tests rather than one explicit contract. Freezing them prevents a formatting or ordering change from silently altering fallback behavior.

## Changes

- pin the canonical PAM line and header-aware placement in one contract test
- freeze the downstream Omarchy stack ordering around `pam_deny.so`
- document direct-writer, distro-native, and ownership distinctions

## Validation

- `just check`
- `just test-arch-pam`
- `just test-arch-layout`