### PR TITLE
fix(daemon): bind remote checks to caller process

### DIFF
--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -176,7 +176,9 @@
 # Default: false
 # disabled = false
 
-# Refuse face auth when connected via SSH (no camera available).
+# Refuse remote face auth. One-shot PAM checks its sanitized SSH
+# environment; non-root daemon Authenticate requires a live D-Bus ProcessFD
+# whose logind session is local. false skips that daemon lookup.
 # Default: true
 # abort_if_ssh = true
 

--- a/crates/facelock-cli/src/commands/capabilities.rs
+++ b/crates/facelock-cli/src/commands/capabilities.rs
@@ -58,6 +58,7 @@ use crate::message;
 pub const CAPABILITIES: &[&str] = &[
     "capabilities",
     "config-edit",
+    "daemon-processfd-session-gate",
     "daemon-restart",
     "devices-json",
     "is-enrolled",
@@ -138,6 +139,7 @@ mod tests {
     const CAPABILITIES_EVER_EMITTED: &[&str] = &[
         "capabilities",
         "config-edit",
+        "daemon-processfd-session-gate",
         "daemon-restart",
         "devices-json",
         "is-enrolled",

--- a/crates/facelock-cli/src/conformance/capabilities.rs
+++ b/crates/facelock-cli/src/conformance/capabilities.rs
@@ -42,6 +42,14 @@ fn capability_names_are_all_implemented() {
             "config-edit" => {
                 sub(sub(&root, "config"), "edit");
             }
+            "daemon-processfd-session-gate" => {
+                const {
+                    assert!(
+                        facelock_daemon::server::DBUS_PROCESSFD_SESSION_GATE,
+                        "the daemon must compile the ProcessFD-backed remote-session gate"
+                    );
+                }
+            }
             "daemon-restart" => {
                 sub(sub(&root, "daemon"), "restart");
             }

--- a/crates/facelock-daemon/Cargo.toml
+++ b/crates/facelock-daemon/Cargo.toml
@@ -24,8 +24,9 @@ bytemuck = { version = "1", features = ["derive"] }
 serde = { workspace = true }
 serde_json = "1"
 thiserror = { workspace = true }
-# The D-Bus server (src/server.rs) — async service, runtime, and the
-# signal/sleep watchers. libc backs the post-init capability drop.
+# The D-Bus server (src/server.rs) — async service/runtime and cancellable
+# ProcessFD/logind provenance queries. libc backs pidfd liveness and the
+# post-init capability drop.
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time"] }
 futures-util = "0.3"

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -212,15 +212,13 @@ impl AuthOutcome {
 
 /// Which of [`pre_check`]'s environment gates a caller may skip.
 ///
-/// The only intended consumer is `facelock test` (N11, issue #96): it is
-/// root-only, and an admin legitimately runs it over SSH or with the lid
-/// closed on a docked laptop while diagnosing recognition, which is exactly
-/// what `abort_if_ssh`/`abort_if_lid_closed` exist to stop an *attacker* from
-/// doing. Every other gate in `pre_check` (disabled, enrollment,
-/// rate-limiting, `require_ir`) still applies to `test` unchanged — this
-/// struct exists so that carve-out is explicit at every call site instead of
-/// a parallel copy of the gate logic (see #95, which this whole `pre_check`
-/// unification closes).
+/// D-Bus `Authenticate` skips only the daemon process's irrelevant SSH
+/// environment after its server boundary verifies the caller's ProcessFD and
+/// logind session. `facelock test` (N11, issue #96) skips SSH and lid checks
+/// because it is root-only diagnostic recognition. Every other gate in
+/// `pre_check` (disabled, enrollment, rate-limiting, `require_ir`) remains
+/// unchanged. Keeping these contexts explicit avoids a parallel copy of the
+/// gate logic (see #95).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PreCheckContext {
     pub skip_ssh_gate: bool,
@@ -228,10 +226,21 @@ pub struct PreCheckContext {
 }
 
 impl PreCheckContext {
-    /// The default, fully-enforced context every real authentication path
-    /// (daemon `Authenticate`, oneshot `facelock auth`) uses.
+    /// The default, fully-enforced environment context used by one-shot auth
+    /// and direct handler calls. D-Bus `Authenticate` selects
+    /// [`Self::daemon_authenticate`] after checking caller provenance.
     pub fn enforced() -> Self {
         Self::default()
+    }
+
+    /// Daemon `Authenticate` after the D-Bus caller's remote-session
+    /// provenance has been checked: ignore only the daemon's own SSH
+    /// environment and keep the lid gate enforced.
+    pub fn daemon_authenticate() -> Self {
+        Self {
+            skip_ssh_gate: true,
+            skip_lid_gate: false,
+        }
     }
 
     /// `facelock test`'s context (N11): skip the SSH/lid gates, keep
@@ -1435,6 +1444,13 @@ enabled = false
         let ctx = PreCheckContext::test();
         assert!(ctx.skip_ssh_gate);
         assert!(ctx.skip_lid_gate);
+    }
+
+    #[test]
+    fn daemon_authenticate_context_skips_only_daemon_environment_ssh() {
+        let ctx = PreCheckContext::daemon_authenticate();
+        assert!(ctx.skip_ssh_gate);
+        assert!(!ctx.skip_lid_gate);
     }
 
     #[test]

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -32,8 +32,9 @@ use crate::rate_limit::RateLimiter;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AuthIntent {
     /// A real authentication — every PAM stack (sudo, login, screen
-    /// lockers), the polkit agent, `facelock auth`. Fully enforced, and a
-    /// failed attempt charges the shared rate-limit budget.
+    /// lockers), the polkit agent, `facelock auth`. Fully enforced (the D-Bus
+    /// server owns caller-session provenance), and a failed attempt charges
+    /// the shared rate-limit budget.
     Authenticate,
     /// A diagnostic run of root-only `facelock test` (N11, issue #96).
     /// Skips only the SSH/lid physical-presence gates, and never charges the
@@ -948,6 +949,19 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         user: &str,
         intent: AuthIntent,
     ) -> Option<DaemonResponse> {
+        self.preflight_authenticate_with_context(user, intent, intent.pre_check_context())
+    }
+
+    /// Run preflight with a transport-selected environment context. The D-Bus
+    /// server uses this only after its caller ProcessFD/session check; direct
+    /// handler callers keep [`Self::preflight_authenticate`]'s enforced
+    /// real-authentication context.
+    pub(crate) fn preflight_authenticate_with_context(
+        &mut self,
+        user: &str,
+        intent: AuthIntent,
+        context: PreCheckContext,
+    ) -> Option<DaemonResponse> {
         auth::pre_check_audited_with_context(
             &self.config,
             &self.store,
@@ -955,7 +969,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             &self.rate_limiter,
             &self.device_caps,
             intent.audit_source(),
-            intent.pre_check_context(),
+            context,
         )
         .map(Into::into)
     }
@@ -1117,13 +1131,19 @@ mod tests {
         assert!(!AuthIntent::Test.charges_rate_limit());
     }
 
-    /// The SSH/lid physical-presence gates are skippable for the diagnostic
-    /// intent only (N11); every other gate applies to both.
+    /// The generic real-authentication intent remains fully enforced for
+    /// direct handler callers. The D-Bus server explicitly supplies its
+    /// caller-ProcessFD context at its preflight boundary. The diagnostic
+    /// intent skips both physical-presence gates (N11).
     #[test]
-    fn only_the_test_intent_skips_the_ssh_and_lid_gates() {
+    fn daemon_authenticate_skips_only_the_environment_ssh_gate() {
         let real = AuthIntent::Authenticate.pre_check_context();
         assert!(!real.skip_ssh_gate);
         assert!(!real.skip_lid_gate);
+
+        let daemon = PreCheckContext::daemon_authenticate();
+        assert!(daemon.skip_ssh_gate);
+        assert!(!daemon.skip_lid_gate);
 
         let test = AuthIntent::Test.pre_check_context();
         assert!(test.skip_ssh_gate);

--- a/crates/facelock-daemon/src/server.rs
+++ b/crates/facelock-daemon/src/server.rs
@@ -9,6 +9,9 @@
 //! plus an injected rebuild recipe ([`HandlerRebuild`]) for the live reload.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
@@ -25,7 +28,7 @@ use nix::unistd::{Uid, User};
 use tracing::{error, info, warn};
 use zbus::{fdo, interface, object_server::SignalEmitter};
 
-use crate::auth::ErrorKind;
+use crate::auth::{ErrorKind, PreCheckContext};
 use crate::cancel::CancelToken;
 use crate::handler::{AuthIntent, CAMERA_POLL_INTERVAL, DaemonRequest, DaemonResponse, Handler};
 
@@ -40,6 +43,179 @@ pub type HandlerRebuild<C, E> = Box<dyn Fn() -> Result<Handler<C, E>, String> + 
 
 /// [`HandlerRebuild`] with the production camera and engine.
 pub type ProductionRebuild = HandlerRebuild<Camera<'static>, FaceEngine>;
+
+/// Capability probe for integrations that require daemon-side remote-session
+/// enforcement from a D-Bus ProcessFD.
+pub const DBUS_PROCESSFD_SESSION_GATE: bool = true;
+
+/// Deliberately uniform authorization error for a remote caller and for an
+/// identity whose local-session provenance cannot be established. Detailed
+/// causes belong in the privileged daemon journal, not on the unprivileged
+/// wire.
+pub const PROCESS_PROVENANCE_DENIED_MESSAGE: &str =
+    "Authenticate requires a live local caller process";
+
+/// Whole-operation deadline for credentials, ProcessFD, and login1
+/// provenance. This stays below the PAM client's D-Bus method timeout so the
+/// daemon can return its uniform fail-closed denial itself.
+const PROCESS_PROVENANCE_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Cancellation is an atomic flag/epoch rather than an async notification;
+/// poll it cheaply while an async D-Bus provenance request is outstanding.
+const PROCESS_PROVENANCE_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+type SessionCheckFuture = Pin<Box<dyn Future<Output = Result<bool, String>> + Send>>;
+type SessionCheck = Box<dyn FnOnce() -> SessionCheckFuture + Send>;
+
+struct SessionProvenance {
+    check: SessionCheck,
+    timeout: Duration,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ProcessProvenanceError {
+    #[error("D-Bus credentials omitted ProcessFD")]
+    Missing,
+    #[error("invalid D-Bus ProcessFD: {0}")]
+    Invalid(String),
+    #[error("D-Bus ProcessFD no longer identifies a live process")]
+    Dead,
+    #[error("logind session lookup failed: {0}")]
+    SessionLookup(String),
+}
+
+fn pid_from_pidfd(process_fd: BorrowedFd<'_>) -> Result<u32, ProcessProvenanceError> {
+    let fdinfo = std::fs::read_to_string(format!("/proc/self/fdinfo/{}", process_fd.as_raw_fd()))
+        .map_err(|error| ProcessProvenanceError::Invalid(error.to_string()))?;
+    let value = fdinfo
+        .lines()
+        .find_map(|line| line.strip_prefix("Pid:"))
+        .map(str::trim)
+        .ok_or_else(|| {
+            ProcessProvenanceError::Invalid(
+                "descriptor is not a Linux process file descriptor".to_owned(),
+            )
+        })?;
+    if value == "-1" {
+        return Err(ProcessProvenanceError::Dead);
+    }
+
+    let pid = value
+        .parse::<u32>()
+        .map_err(|error| ProcessProvenanceError::Invalid(error.to_string()))?;
+    if pid == 0 {
+        return Err(ProcessProvenanceError::Invalid(
+            "pidfd reported PID 0".to_owned(),
+        ));
+    }
+    Ok(pid)
+}
+
+fn pidfd_is_live(process_fd: BorrowedFd<'_>) -> Result<bool, ProcessProvenanceError> {
+    let mut poll_fd = libc::pollfd {
+        fd: process_fd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: `poll_fd` points to one initialized pollfd for the duration of
+    // the non-blocking call, and the borrowed descriptor outlives the call.
+    let result = unsafe { libc::poll(&mut poll_fd, 1, 0) };
+    if result < 0 {
+        return Err(ProcessProvenanceError::Invalid(
+            std::io::Error::last_os_error().to_string(),
+        ));
+    }
+    if poll_fd.revents & libc::POLLNVAL != 0 {
+        return Err(ProcessProvenanceError::Invalid(
+            "descriptor was closed".to_owned(),
+        ));
+    }
+    Ok(result == 0)
+}
+
+async fn stable_process_session_is_remote<L, A, Fut>(
+    pid: u32,
+    mut process_is_live: A,
+    lookup_session: L,
+) -> Result<bool, ProcessProvenanceError>
+where
+    L: FnOnce(u32) -> Fut,
+    A: FnMut() -> Result<bool, ProcessProvenanceError>,
+    Fut: Future<Output = Result<bool, String>>,
+{
+    if !process_is_live()? {
+        return Err(ProcessProvenanceError::Dead);
+    }
+    let remote = lookup_session(pid)
+        .await
+        .map_err(ProcessProvenanceError::SessionLookup)?;
+    if !process_is_live()? {
+        return Err(ProcessProvenanceError::Dead);
+    }
+    Ok(remote)
+}
+
+async fn processfd_session_is_remote<L, Fut>(
+    credentials: &zbus::fdo::ConnectionCredentials,
+    lookup_session: L,
+) -> Result<bool, ProcessProvenanceError>
+where
+    L: FnOnce(u32) -> Fut,
+    Fut: Future<Output = Result<bool, String>>,
+{
+    let process_fd = credentials
+        .process_fd()
+        .ok_or(ProcessProvenanceError::Missing)?
+        .as_fd();
+    let pid = pid_from_pidfd(process_fd)?;
+    stable_process_session_is_remote(pid, || pidfd_is_live(process_fd), lookup_session).await
+}
+
+async fn logind_session_is_remote(connection: &zbus::Connection, pid: u32) -> Result<bool, String> {
+    let manager = zbus::Proxy::new(
+        connection,
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        "org.freedesktop.login1.Manager",
+    )
+    .await
+    .map_err(|error| format!("create logind manager proxy: {error}"))?;
+    let session_path: zbus::zvariant::OwnedObjectPath = manager
+        .call("GetSessionByPID", &(pid,))
+        .await
+        .map_err(|error| format!("logind GetSessionByPID({pid}) failed: {error}"))?;
+    let session = zbus::Proxy::new(
+        connection,
+        "org.freedesktop.login1",
+        session_path,
+        "org.freedesktop.login1.Session",
+    )
+    .await
+    .map_err(|error| format!("create logind session proxy: {error}"))?;
+    session
+        .get_property("Remote")
+        .await
+        .map_err(|error| format!("read logind session Remote property: {error}"))
+}
+
+async fn caller_session_is_remote(
+    connection: &zbus::Connection,
+    sender: Option<zbus::names::OwnedUniqueName>,
+) -> Result<bool, String> {
+    let sender = sender.ok_or_else(|| "D-Bus message omitted its sender".to_owned())?;
+    let dbus = zbus::fdo::DBusProxy::new(connection)
+        .await
+        .map_err(|error| format!("create D-Bus credentials proxy: {error}"))?;
+    let credentials = dbus
+        .get_connection_credentials(zbus::names::BusName::from(sender.inner().clone()))
+        .await
+        .map_err(|error| format!("GetConnectionCredentials({sender}) failed: {error}"))?;
+    processfd_session_is_remote(&credentials, |pid| {
+        logind_session_is_remote(connection, pid)
+    })
+    .await
+    .map_err(|error| error.to_string())
+}
 
 /// Failures bringing up or running the D-Bus server.
 #[derive(Debug, thiserror::Error)]
@@ -382,6 +558,39 @@ impl CurrentRequest {
         match self.0.slot.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+async fn wait_for_provenance_cancellation(
+    cancel: CancelToken,
+    current: CurrentRequest,
+    cancellation_checkpoint: u64,
+) {
+    loop {
+        if cancel.is_cancelled() || current.cancellation_epoch() != cancellation_checkpoint {
+            return;
+        }
+        tokio::time::sleep(PROCESS_PROVENANCE_CANCEL_POLL_INTERVAL).await;
+    }
+}
+
+async fn run_bounded_session_check(
+    session_check: SessionCheck,
+    cancel: CancelToken,
+    current: CurrentRequest,
+    cancellation_checkpoint: u64,
+    timeout: Duration,
+) -> Result<bool, String> {
+    tokio::select! {
+        biased;
+        _ = wait_for_provenance_cancellation(cancel, current, cancellation_checkpoint) => {
+            Err("caller session provenance cancelled".to_owned())
+        }
+        result = tokio::time::timeout(timeout, session_check()) => {
+            result.unwrap_or_else(|_| {
+                Err(format!("caller session provenance exceeded its {timeout:?} deadline"))
+            })
         }
     }
 }
@@ -964,12 +1173,59 @@ where
         user: &str,
         cancel: CancelToken,
     ) -> fdo::Result<AuthResult> {
+        self.authenticate_as_with_session_check(caller, user, cancel, || async {
+            Err("D-Bus caller process provenance was not supplied".to_string())
+        })
+        .await
+    }
+
+    /// `Authenticate` with a lazy ProcessFD-backed session check. The check
+    /// is invoked only for non-root callers when the installed configuration
+    /// enables `abort_if_ssh`; every other path drops it without lookup.
+    pub async fn authenticate_as_with_session_check<F, Fut>(
+        &self,
+        caller: CallerIdentity,
+        user: &str,
+        cancel: CancelToken,
+        session_check: F,
+    ) -> fdo::Result<AuthResult>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<bool, String>> + Send + 'static,
+    {
+        self.authenticate_as_with_session_check_timeout(
+            caller,
+            user,
+            cancel,
+            PROCESS_PROVENANCE_TIMEOUT,
+            session_check,
+        )
+        .await
+    }
+
+    async fn authenticate_as_with_session_check_timeout<F, Fut>(
+        &self,
+        caller: CallerIdentity,
+        user: &str,
+        cancel: CancelToken,
+        session_timeout: Duration,
+        session_check: F,
+    ) -> fdo::Result<AuthResult>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<bool, String>> + Send + 'static,
+    {
+        let session_provenance = SessionProvenance {
+            check: Box::new(move || Box::pin(session_check())),
+            timeout: session_timeout,
+        };
         self.run_authentication(
             caller,
             user,
             Method::Authenticate,
             AuthIntent::Authenticate,
             cancel,
+            session_provenance,
         )
         .await
     }
@@ -996,16 +1252,28 @@ where
             Method::TestAuthenticate,
             AuthIntent::Test,
             cancel,
+            SessionProvenance {
+                check: Box::new(|| {
+                    Box::pin(async {
+                        Err(
+                            "TestAuthenticate does not resolve caller session provenance"
+                                .to_string(),
+                        )
+                    })
+                }),
+                timeout: PROCESS_PROVENANCE_TIMEOUT,
+            },
         )
         .await
     }
 
     /// The body both authentication entry points share, so the diagnostic
     /// method cannot drift from the real one: same authorization table, same
-    /// capture slot, same handler call, same in-band error encoding, same
-    /// notification, same redaction. Only `method` (which authorization
-    /// applies) and `intent` (what the attempt costs and which gates run)
-    /// differ.
+    /// capture slot, same handler call, same recoverable-error encoding, same
+    /// notification, same redaction. `Authenticate` additionally owns the
+    /// non-root caller-provenance boundary above handler preflight. Only
+    /// `method` (which authorization applies) and `intent` (what the attempt
+    /// costs and which gates run) otherwise differ.
     async fn run_authentication(
         &self,
         caller: CallerIdentity,
@@ -1013,6 +1281,7 @@ where
         method: Method,
         intent: AuthIntent,
         cancel: CancelToken,
+        session_provenance: SessionProvenance,
     ) -> fdo::Result<AuthResult> {
         authorize_method(&caller, method, Some(user))?;
         if method == Method::Authenticate
@@ -1033,13 +1302,55 @@ where
         let cancellation_checkpoint = self.current.cancellation_epoch();
         self.last_activity.store(now_secs(), Ordering::Relaxed);
         self.maybe_reload_handler();
+        let caller_uid = caller.uid;
         let caller_is_root = caller.uid == 0;
+        let pre_check_context = if method == Method::Authenticate {
+            PreCheckContext::daemon_authenticate()
+        } else {
+            intent.pre_check_context()
+        };
         let handler = self.handler.clone();
         let capture_slot = Arc::clone(&self.capture_slot);
         let current = self.current.clone();
+        let operation = method.name();
+
+        // Snapshot only the installed SSH-gate policy under the handler
+        // mutex. Credentials and login1 are asynchronous D-Bus operations;
+        // awaiting either while retaining this guard would let a stalled
+        // system-bus peer pin all later handler operations and shutdown.
+        let provenance_required = if method == Method::Authenticate && !caller_is_root {
+            let handler = Arc::clone(&handler);
+            let capture_slot = Arc::clone(&capture_slot);
+            tokio::task::spawn_blocking(move || {
+                let handler = lock_handler_with_timeout_before_capture(
+                    &handler,
+                    Some((capture_slot.as_ref(), operation)),
+                )?;
+                Ok::<bool, fdo::Error>(handler.config.security.abort_if_ssh)
+            })
+            .await
+            .map_err(|error| fdo::Error::Failed(format!("task join error: {error}")))??
+        } else {
+            false
+        };
+
+        let provenance = if provenance_required {
+            Some(
+                run_bounded_session_check(
+                    session_provenance.check,
+                    cancel.clone(),
+                    current.clone(),
+                    cancellation_checkpoint,
+                    session_provenance.timeout,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
         let notifier_factory = self.notifier_factory.clone();
         let user = user.to_string();
-        let operation = method.name();
         let result = tokio::task::spawn_blocking(move || {
             // Keep this guard across both phases. A config reload cannot swap
             // in a new handler after the gates passed but before capture.
@@ -1047,7 +1358,50 @@ where
                 &handler,
                 Some((capture_slot.as_ref(), operation)),
             )?;
-            let response = if let Some(response) = handler.preflight_authenticate(&user, intent) {
+            if method == Method::Authenticate
+                && !caller_is_root
+                && handler.config.security.abort_if_ssh
+            {
+                match provenance {
+                    Some(Ok(false)) => {}
+                    Some(Ok(true)) => {
+                        warn!(
+                            caller_uid,
+                            user, "remote login session denied for Authenticate"
+                        );
+                        return Err(fdo::Error::AccessDenied(
+                            PROCESS_PROVENANCE_DENIED_MESSAGE.to_string(),
+                        ));
+                    }
+                    Some(Err(reason)) => {
+                        warn!(
+                            caller_uid,
+                            user, reason, "caller session provenance unavailable"
+                        );
+                        return Err(fdo::Error::AccessDenied(
+                            PROCESS_PROVENANCE_DENIED_MESSAGE.to_string(),
+                        ));
+                    }
+                    None => {
+                        // The installed policy changed from disabled to
+                        // enabled while this request was outside the lock.
+                        // Never perform provenance I/O under the guard and
+                        // never admit a request that was not checked under
+                        // the policy now governing capture.
+                        warn!(
+                            caller_uid,
+                            user,
+                            "caller session provenance unavailable after abort_if_ssh was enabled"
+                        );
+                        return Err(fdo::Error::AccessDenied(
+                            PROCESS_PROVENANCE_DENIED_MESSAGE.to_string(),
+                        ));
+                    }
+                }
+            }
+            let response = if let Some(response) =
+                handler.preflight_authenticate_with_context(&user, intent, pre_check_context)
+            {
                 response
             } else {
                 // Only a request whose camera-independent gates passed may
@@ -1408,6 +1762,8 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         user: &str,
     ) -> fdo::Result<AuthResult> {
         let caller = resolve_caller_identity(&hdr, connection).await?;
+        let sender = hdr.sender().map(|sender| sender.to_owned().into());
+        let session_connection = connection.clone();
         // One token for this call and nothing else. zbus dispatches each
         // method in its own task, so anything shared between calls is shared
         // between *concurrent* calls: a token owned by the service could be
@@ -1418,7 +1774,11 @@ impl FacelockService<Camera<'static>, FaceEngine> {
         // (ADR 008 §5).
         let cancel = CancelToken::new();
         let _watch = watch_caller_departure(connection, hdr.sender(), cancel.clone()).await;
-        let result = self.authenticate_as(caller, user, cancel).await;
+        let result = self
+            .authenticate_as_with_session_check(caller, user, cancel, move || async move {
+                caller_session_is_remote(&session_connection, sender).await
+            })
+            .await;
 
         // Emit auth_attempted signal (best-effort, don't fail auth if signal
         // fails). The payload deliberately carries no similarity score — the
@@ -2137,6 +2497,9 @@ async fn poll_shutdown(
 mod tests {
     use super::*;
 
+    use std::collections::VecDeque;
+    use std::os::fd::{FromRawFd, OwnedFd};
+
     use facelock_core::config::{Config, NotificationConfig, NotificationMode};
     use facelock_core::notify::{Notifier, NullNotifier};
     use facelock_core::types::{CameraCaps, MatchResult};
@@ -2148,6 +2511,103 @@ mod tests {
             uid,
             username: username.map(str::to_string),
         }
+    }
+
+    fn pidfd_for(pid: u32) -> OwnedFd {
+        // SAFETY: pidfd_open returns a new owned descriptor on success. The
+        // result is checked before ownership is constructed.
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32 };
+        assert!(
+            raw >= 0,
+            "pidfd_open failed: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: `raw` is a fresh descriptor returned by pidfd_open above.
+        unsafe { OwnedFd::from_raw_fd(raw) }
+    }
+
+    #[tokio::test]
+    async fn processfd_credentials_fail_closed_when_the_fd_is_missing_or_invalid() {
+        let missing = zbus::fdo::ConnectionCredentials::default();
+        assert!(matches!(
+            processfd_session_is_remote(&missing, |_| async { Ok(false) }).await,
+            Err(ProcessProvenanceError::Missing)
+        ));
+
+        let regular: OwnedFd = tempfile::tempfile().expect("regular file").into();
+        let invalid = zbus::fdo::ConnectionCredentials::default().set_process_fd(regular.into());
+        assert!(matches!(
+            processfd_session_is_remote(&invalid, |_| async { Ok(false) }).await,
+            Err(ProcessProvenanceError::Invalid(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_live_processfd_is_the_only_source_of_the_logind_pid() {
+        let credentials = zbus::fdo::ConnectionCredentials::default()
+            .set_process_id(u32::MAX)
+            .set_process_fd(pidfd_for(std::process::id()).into());
+
+        let remote = processfd_session_is_remote(&credentials, |pid| async move {
+            assert_eq!(pid, std::process::id());
+            Ok(false)
+        })
+        .await
+        .expect("live self pidfd");
+
+        assert!(!remote);
+    }
+
+    #[tokio::test]
+    async fn a_dead_processfd_fails_closed_before_logind_lookup() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn child");
+        let process_fd = pidfd_for(child.id());
+        child.kill().expect("kill child");
+        child.wait().expect("reap child");
+        let credentials =
+            zbus::fdo::ConnectionCredentials::default().set_process_fd(process_fd.into());
+
+        let result = processfd_session_is_remote(&credentials, |_| async {
+            panic!("a dead identity must not reach logind")
+        })
+        .await;
+        assert!(matches!(result, Err(ProcessProvenanceError::Dead)));
+    }
+
+    #[tokio::test]
+    async fn death_during_lookup_cannot_authorize_a_reused_numeric_pid() {
+        let mut liveness = VecDeque::from([true, false]);
+        let result = stable_process_session_is_remote(
+            4242,
+            || Ok(liveness.pop_front().expect("two liveness checks")),
+            |pid| async move {
+                assert_eq!(pid, 4242);
+                // Even if logind answered for a process that reused 4242,
+                // the dead pidfd below must make this answer unusable.
+                Ok(false)
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(ProcessProvenanceError::Dead)));
+        assert!(liveness.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stable_process_session_preserves_loginds_local_or_remote_answer() {
+        assert!(
+            !stable_process_session_is_remote(10, || Ok(true), |_| async { Ok(false) })
+                .await
+                .unwrap()
+        );
+        assert!(
+            stable_process_session_is_remote(11, || Ok(true), |_| async { Ok(true) })
+                .await
+                .unwrap()
+        );
     }
 
     fn mock_handler_with_timeout(timeout_secs: u32) -> Handler<MockCamera, MockFaceEngine> {
@@ -2200,6 +2660,149 @@ enabled = false
 
     fn mock_service() -> FacelockService<MockCamera, MockFaceEngine> {
         mock_service_with_reload(None, None)
+    }
+
+    fn mock_service_with_remote_gate() -> FacelockService<MockCamera, MockFaceEngine> {
+        let mut handler = mock_handler_with_timeout(1);
+        handler.config.security.abort_if_ssh = true;
+        FacelockService::new(
+            handler,
+            None,
+            None,
+            Arc::new(|_| Box::new(NullNotifier) as Box<dyn Notifier>),
+        )
+    }
+
+    async fn wait_until_set(flag: &AtomicBool) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !flag.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("session check should start");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stalled_provenance_is_bounded_without_holding_the_handler() {
+        let service = Arc::new(mock_service_with_remote_gate());
+        let started = Arc::new(AtomicBool::new(false));
+        let check_started = Arc::clone(&started);
+        let authenticating = Arc::clone(&service);
+
+        let auth = tokio::spawn(async move {
+            authenticating
+                .authenticate_as_with_session_check_timeout(
+                    caller(1000, Some("alice")),
+                    "alice",
+                    CancelToken::new(),
+                    Duration::from_millis(100),
+                    move || async move {
+                        check_started.store(true, Ordering::SeqCst);
+                        std::future::pending::<Result<bool, String>>().await
+                    },
+                )
+                .await
+        });
+
+        wait_until_set(&started).await;
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            service.list_models_as(caller(0, Some("root")), "alice"),
+        )
+        .await
+        .expect("stalled provenance must not retain the handler")
+        .expect("a later root operation remains authorized");
+
+        let denied = tokio::time::timeout(Duration::from_secs(1), auth)
+            .await
+            .expect("provenance deadline must bound the request")
+            .expect("authentication task must not panic");
+        assert!(matches!(
+            denied,
+            Err(fdo::Error::AccessDenied(message))
+                if message == PROCESS_PROVENANCE_DENIED_MESSAGE
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_cancels_a_stalled_provenance_check_without_waiting_for_its_deadline() {
+        let service = Arc::new(mock_service_with_remote_gate());
+        let started = Arc::new(AtomicBool::new(false));
+        let check_started = Arc::clone(&started);
+        let authenticating = Arc::clone(&service);
+
+        let auth = tokio::spawn(async move {
+            authenticating
+                .authenticate_as_with_session_check_timeout(
+                    caller(1000, Some("alice")),
+                    "alice",
+                    CancelToken::new(),
+                    Duration::from_secs(5),
+                    move || async move {
+                        check_started.store(true, Ordering::SeqCst);
+                        std::future::pending::<Result<bool, String>>().await
+                    },
+                )
+                .await
+        });
+
+        wait_until_set(&started).await;
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            service.shutdown_as(caller(0, Some("root"))),
+        )
+        .await
+        .expect("shutdown must not wait for stalled provenance")
+        .expect("root shutdown remains authorized");
+
+        let denied = tokio::time::timeout(Duration::from_millis(250), auth)
+            .await
+            .expect("shutdown must drop the stalled check before its deadline")
+            .expect("authentication task must not panic");
+        assert!(matches!(
+            denied,
+            Err(fdo::Error::AccessDenied(message))
+                if message == PROCESS_PROVENANCE_DENIED_MESSAGE
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn caller_cancellation_drops_a_stalled_provenance_check_before_its_deadline() {
+        let service = Arc::new(mock_service_with_remote_gate());
+        let started = Arc::new(AtomicBool::new(false));
+        let check_started = Arc::clone(&started);
+        let cancel = CancelToken::new();
+        let request_cancel = cancel.clone();
+        let authenticating = Arc::clone(&service);
+
+        let auth = tokio::spawn(async move {
+            authenticating
+                .authenticate_as_with_session_check_timeout(
+                    caller(1000, Some("alice")),
+                    "alice",
+                    request_cancel,
+                    Duration::from_secs(5),
+                    move || async move {
+                        check_started.store(true, Ordering::SeqCst);
+                        std::future::pending::<Result<bool, String>>().await
+                    },
+                )
+                .await
+        });
+
+        wait_until_set(&started).await;
+        cancel.cancel();
+
+        let denied = tokio::time::timeout(Duration::from_millis(250), auth)
+            .await
+            .expect("caller cancellation must drop the stalled check")
+            .expect("authentication task must not panic");
+        assert!(matches!(
+            denied,
+            Err(fdo::Error::AccessDenied(message))
+                if message == PROCESS_PROVENANCE_DENIED_MESSAGE
+        ));
     }
 
     #[tokio::test]

--- a/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
+++ b/crates/facelock-daemon/tests/test_authenticate_ssh_gate.rs
@@ -1,22 +1,14 @@
-//! The SSH physical-presence gate across the two authentication entry
-//! points, pinned through the real service (D6).
+//! The remote-session physical-presence gate across the real service (D6).
 //!
-//! `abort_if_ssh` exists to stop an *attacker* from authenticating a face
-//! session from a remote shell. It is not meant to stop an admin — already
-//! root, by construction, since `facelock test` requires it — from
-//! diagnosing recognition over SSH, which is why `PreCheckContext::test`
-//! exists (N11). Before `TestAuthenticate` there was nowhere on the daemon
-//! transport to apply that context: `test` arrived as an ordinary
-//! `Authenticate` call, indistinguishable from real auth, so the carve-out
-//! could only ever work in direct/oneshot mode. Now it applies on both.
-//!
-//! One test, alone in its own integration binary on purpose: it mutates
-//! `SSH_CONNECTION`, which is process-global state. Cargo gives each
-//! integration test file its own process, so owning this file means owning
-//! the environment — no lock to forget, and no sibling test that could
-//! observe the mutation.
+//! The daemon process environment is never caller provenance. For a
+//! non-root D-Bus `Authenticate` with `abort_if_ssh = true`, the server must
+//! consult the caller's live ProcessFD-backed logind session and deny every
+//! remote or unverifiable identity as a D-Bus authorization error. Disabling
+//! the setting skips the lookup altogether. Root skips only this provenance
+//! gate; it still runs ordinary authorization and real authentication.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use facelock_core::config::Config;
 use facelock_core::notify::{Notifier, NullNotifier};
@@ -35,9 +27,10 @@ use facelock_test_support::{MockCamera, MockFaceEngine};
 /// cannot be shared without exporting a test-only type from production code.
 type MockCameraFactory = Box<dyn Fn(&Config) -> Result<MockCamera, String> + Send + Sync>;
 
-#[tokio::test]
-async fn test_authenticate_skips_the_ssh_gate_that_authenticate_enforces() {
-    let config = Config::parse(
+const PROCESS_PROVENANCE_DENIED: &str = "Authenticate requires a live local caller process";
+
+fn service(abort_if_ssh: bool) -> FacelockService<MockCamera, MockFaceEngine> {
+    let config = Config::parse(&format!(
         r#"
 [recognition]
 threshold = 0.45
@@ -47,7 +40,7 @@ timeout_secs = 2
 require_ir = false
 require_frame_variance = false
 require_landmark_liveness = false
-abort_if_ssh = true
+abort_if_ssh = {abort_if_ssh}
 abort_if_lid_closed = false
 
 [encryption]
@@ -56,7 +49,7 @@ method = "none"
 [audit]
 enabled = false
 "#,
-    )
+    ))
     .unwrap();
 
     let emb = fixtures::known_embedding(1);
@@ -79,42 +72,140 @@ enabled = false
         None,
     )
     .unwrap();
-    let svc = FacelockService::new(
+    FacelockService::new(
         handler,
         None,
         None,
         Arc::new(|_user: &str| Box::new(NullNotifier) as Box<dyn Notifier>),
-    );
-    let root = CallerIdentity {
-        uid: 0,
-        username: Some("root".into()),
-    };
+    )
+}
 
-    let previous = std::env::var("SSH_CONNECTION").ok();
-    unsafe { std::env::set_var("SSH_CONNECTION", "1.2.3.4 5678 10.0.0.1 22") };
+fn caller(uid: u32, username: &str) -> CallerIdentity {
+    CallerIdentity {
+        uid,
+        username: Some(username.into()),
+    }
+}
 
-    // Real authentication: the gate fires, in-band, before the camera runs.
-    let real = svc
-        .authenticate_as(root.clone(), "alice", CancelToken::new())
-        .await
-        .unwrap();
-    assert!(!real.matched);
-    assert_eq!(real.model_id, -2, "recoverable error sentinel: {real:?}");
-    assert_eq!(real.label, "SSH session detected");
+#[track_caller]
+fn assert_process_provenance_denied(
+    result: zbus::fdo::Result<facelock_core::dbus_interface::AuthResult>,
+) {
+    match result {
+        Err(zbus::fdo::Error::AccessDenied(message)) => {
+            assert_eq!(message, PROCESS_PROVENANCE_DENIED);
+        }
+        other => panic!("expected out-of-band AccessDenied, got {other:?}"),
+    }
+}
 
-    // The diagnostic entry point runs the comparison anyway.
-    let diagnostic = svc
-        .test_authenticate_as(root, "alice", CancelToken::new())
+#[tokio::test]
+async fn non_root_authenticate_allows_local_and_denies_remote_session() {
+    let local = service(true)
+        .authenticate_as_with_session_check(
+            caller(1000, "alice"),
+            "alice",
+            CancelToken::new(),
+            || async { Ok(false) },
+        )
         .await
         .unwrap();
     assert!(
-        diagnostic.matched,
-        "TestAuthenticate must skip the SSH gate and reach the comparison \
-         loop, got: {diagnostic:?}"
+        local.matched,
+        "a verified local session reaches recognition"
     );
 
-    match previous {
-        Some(value) => unsafe { std::env::set_var("SSH_CONNECTION", value) },
-        None => unsafe { std::env::remove_var("SSH_CONNECTION") },
+    let remote = service(true)
+        .authenticate_as_with_session_check(
+            caller(1000, "alice"),
+            "alice",
+            CancelToken::new(),
+            || async { Ok(true) },
+        )
+        .await;
+    assert_process_provenance_denied(remote);
+}
+
+#[tokio::test]
+async fn missing_invalid_and_dead_processfd_fail_closed_out_of_band() {
+    for reason in [
+        "D-Bus credentials omitted ProcessFD",
+        "ProcessFD is not a pidfd",
+        "ProcessFD process exited",
+    ] {
+        let denied = service(true)
+            .authenticate_as_with_session_check(
+                caller(1000, "alice"),
+                "alice",
+                CancelToken::new(),
+                move || async move { Err(reason.to_string()) },
+            )
+            .await;
+        assert_process_provenance_denied(denied);
     }
+}
+
+#[tokio::test]
+async fn disabled_remote_gate_performs_no_process_or_session_lookup() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::clone(&calls);
+
+    let result = service(false)
+        .authenticate_as_with_session_check(
+            caller(1000, "alice"),
+            "alice",
+            CancelToken::new(),
+            move || async move {
+                checked.fetch_add(1, Ordering::SeqCst);
+                Err("lookup must not run".to_string())
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(result.matched);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn ordinary_authorization_denial_precedes_process_lookup() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::clone(&calls);
+
+    let result = service(true)
+        .authenticate_as_with_session_check(
+            caller(1000, "alice"),
+            "bob",
+            CancelToken::new(),
+            move || async move {
+                checked.fetch_add(1, Ordering::SeqCst);
+                Ok(false)
+            },
+        )
+        .await;
+
+    assert!(matches!(result, Err(zbus::fdo::Error::AccessDenied(_))));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn root_bypasses_only_remote_provenance() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let checked = Arc::clone(&calls);
+
+    let result = service(true)
+        .authenticate_as_with_session_check(
+            caller(0, "root"),
+            "alice",
+            CancelToken::new(),
+            move || async move {
+                checked.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(result.matched, "root still runs real Authenticate");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,7 +84,7 @@ Controls how the PAM module reaches the face engine.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `disabled` | bool | `false` | Disable face authentication entirely. PAM returns IGNORE, falling through to the next auth method. |
-| `abort_if_ssh` | bool | `true` | Refuse face auth when connected via SSH (no camera available). |
+| `abort_if_ssh` | bool | `true` | Refuse remote face auth. One-shot PAM uses its sanitized SSH environment; non-root daemon `Authenticate` requires a live D-Bus ProcessFD and a local logind session. `false` skips the daemon's ProcessFD/PID/logind/session lookup. Root bypasses only the daemon remote-session check. |
 | `abort_if_lid_closed` | bool | `true` | Refuse face auth when the laptop lid is closed (camera blocked). |
 | `require_ir` | bool | `true` | Require an IR camera for authentication. RGB cameras are trivially spoofed with a printed photo. Only set to `false` for development/testing. |
 | `require_frame_variance` | bool | `true` | Require multiple frames with different embeddings before accepting. Defends against static photo attacks. |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1672,6 +1672,7 @@ that is not on this list is not being denied, only not yet promised.
 |------|---------|
 | `capabilities` | this command exists, so a consumer's membership test is uniform across every name |
 | `config-edit` | `config edit` exists — the verb ADR 009 split out of the old `--edit` flag |
+| `daemon-processfd-session-gate` | daemon `Authenticate` supports the ProcessFD-backed logind remote-session gate documented under IPC Protocol |
 | `daemon-restart` | `daemon restart` exists — the verb ADR 009 moved under `daemon` from the top-level `restart` |
 | `devices-json` | `devices --json` |
 | `is-enrolled` | `is-enrolled` exists — the unprivileged enrollment probe whose exit code is the contract |
@@ -2833,7 +2834,9 @@ hill-climbing oracle by construction rather than by redacting fields):
 - `Authenticate`: root or the matching Unix user. The one user-scoped method
   — screen lockers run their PAM stack as the user, so this is architecture,
   not policy. It is **real authentication**: a failed attempt always
-  consumes rate-limit budget, whatever the caller's UID.
+  consumes rate-limit budget, whatever the caller's UID. When
+  `security.abort_if_ssh = true`, an authorized non-root caller must also
+  prove a live local process/session identity as described below.
 - `TestAuthenticate`: **root only.** Same arguments and same `AuthResult`
   reply as `Authenticate`, and the same gates except that it skips the
   SSH/lid physical-presence aborts and charges no rate-limit budget on
@@ -2866,6 +2869,39 @@ root-only and ingress-budget-free. This availability budget is distinct from
 `security.rate_limit`: the latter remains the persistent, per-target-user
 biometric-guess limiter and still charges root `Authenticate` failures under
 the rules in "facelock test Semantics".
+
+The remote-session gate is bound to the D-Bus caller rather than the daemon's
+environment. For an authorized non-root `Authenticate` with
+`security.abort_if_ssh = true`, the daemon asks
+`org.freedesktop.DBus.GetConnectionCredentials` for the message sender's
+unique bus name and requires the returned `ProcessFD`. It derives the PID from
+that pidfd's kernel metadata, checks that the pidfd is live both before and
+after `org.freedesktop.login1.Manager.GetSessionByPID`, and reads the selected
+session's `Remote` property. It never trusts the credentials' numeric
+`ProcessID`, never classifies the caller from a security label, and rejects a
+PID-reuse race because a dead original pidfd invalidates the intervening
+logind answer.
+
+A remote session, omitted or invalid ProcessFD, dead caller, unavailable or
+inconsistent logind answer, cancellation, or expiry of the four-second
+provenance deadline (covering credentials, ProcessFD validation, and logind)
+all fail closed as the same out-of-band
+`org.freedesktop.DBus.Error.AccessDenied` message: `Authenticate requires a
+live local caller process`. The privileged daemon journal keeps the detailed
+cause; the unprivileged wire does not distinguish remote from unverifiable
+provenance. Credentials and login1 are queried asynchronously without
+retaining the handler mutex. Caller departure, `ReleaseCamera`, suspend, and
+shutdown cancel a pending query, so a stalled system-bus reply cannot delay
+later handler operations or daemon shutdown. This check runs after method
+authorization, non-root ingress charging, the early busy check, and live
+config reload, but before handler preflight or capture admission. UID 0
+bypasses only this remote-session provenance check: ordinary authorization and
+the persistent
+biometric-guess limiter remain unchanged. `TestAuthenticate` remains its
+separate root-only diagnostic method. When `abort_if_ssh = false`, the daemon
+performs no ProcessFD, PID, logind, or session lookup at all. The one-shot
+transport continues to enforce SSH provenance from the PAM-sanitized
+`SSH_CONNECTION` / `SSH_TTY` environment instead of D-Bus.
 
 Ingress buckets are process-local, are discarded after enough idle monotonic
 time to refill the full burst, and are capped at 1024 UID entries with
@@ -2954,8 +2990,9 @@ Sentinel `model_id` values (only meaningful with `matched == false`):
 Recoverable errors travel **in-band** (model_id `-2`), not as D-Bus errors, so
 clients can distinguish "the daemon decided auth cannot proceed" from "the
 daemon is unavailable". D-Bus errors remain for authorization failures,
-daemon-busy, and transport problems. In particular, a rate-limited state is a
-daemon decision and must never make the PAM client retry via a root oneshot.
+daemon-busy, transport problems, and the non-root ProcessFD/session gate above.
+In particular, a rate-limited state is a daemon decision and must never make
+the PAM client retry via a root oneshot.
 
 `-4` exists because `similarity` cannot carry "was a face seen?": the score is
 redacted to `0.0` for every non-root caller, so a user-run locker (hyprlock)

--- a/docs/security.md
+++ b/docs/security.md
@@ -718,6 +718,31 @@ non-root admission fails closed as the same recoverable in-band rate-limit
 response until daemon restart; the daemon never resumes from possibly
 half-mutated ingress state.
 
+With `security.abort_if_ssh = true`, an admitted non-root `Authenticate` must
+also carry a live process identity from the bus daemon's
+`GetConnectionCredentials` `ProcessFD`. The daemon derives the PID only from
+that pidfd's `/proc/self/fdinfo` metadata, checks pidfd liveness on both sides
+of logind's `GetSessionByPID`, and accepts only a session whose `Remote`
+property is false. It does not use the racy numeric `ProcessID` credential and
+does not require a security label. Missing, malformed, dead, remote, and
+unverifiable identities and expiry of the four-second provenance deadline
+(covering credentials, ProcessFD validation, and logind) all produce the same
+AccessDenied message on the wire; the detailed reason is
+confined to the privileged daemon journal. Credentials and login1 are queried
+asynchronously without retaining the handler mutex. Caller departure,
+`ReleaseCamera`, suspend, and shutdown cancel a pending query, so a stalled
+system-bus reply cannot pin later handler operations or daemon shutdown. A
+caller that exits while logind is being queried cannot authorize a process
+that later reuses its numeric PID because the original pidfd is rechecked
+before the answer is used.
+
+UID 0 bypasses only that remote-session provenance check; it still uses the
+ordinary `Authenticate` authorization and the SQLite-backed biometric-guess
+limiter. When `abort_if_ssh = false`, no ProcessFD, PID, logind, or session
+lookup occurs. `TestAuthenticate` is separately root-only. The one-shot PAM
+fallback retains its environment check, using only the explicitly forwarded
+`SSH_CONNECTION` / `SSH_TTY` variables.
+
 An unenrolled UID is answered by the audited `pre_check` from SQLite
 (`has_models`) before the global capture slot is claimed. Saturated ingress and
 busy-camera rejections happen before that audit writer, which bounds audit-file
@@ -732,14 +757,12 @@ daemon (`StartServiceByName` is open to every context in `system.conf`) and can
 make bounded, cheap self-authentication requests. Distinct local accounts can
 combine their independent refill rates; the hard memory cap does not claim to
 be aggregate admission control. Face unlock continues to fail closed to the
-password. `abort_if_ssh` is enforced by the PAM client from its own environment;
-a direct bus caller is not subject to it, which was already true for group
-members. The first admitted request after a config-file mtime change may pay a
-handler rebuild, but that mtime is claimed before the attempt: a failed rebuild
-keeps the old handler and is not retried until the root-owned config file
-changes again. A completed rebuild is generation-checked before installation;
-if a newer mtime was claimed while it was building, the stale handler is
-discarded rather than reactivating older security configuration.
+password. The first admitted request after a config-file mtime change may pay
+a handler rebuild, but that mtime is claimed before the attempt: a failed
+rebuild keeps the old handler and is not retried until the root-owned config
+file changes again. A completed rebuild is generation-checked before
+installation; if a newer mtime was claimed while it was building, the stale
+handler is discarded rather than reactivating older security configuration.
 
 The scope table's catch-all arm is root-only, so a method added later is closed until it is deliberately opened up. Two entries are spelled out explicitly rather than left to that catch-all, because their root-only scope is load-bearing rather than incidental:
 - `PreviewDetectFrame` runs per-frame with neither `pre_check` nor the rate limiter. For any weaker caller it would be a continuous similarity feed at camera framerate; together with score redaction, denying non-root callers closes the hill-climbing oracle by construction (see A5 below).

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -133,6 +133,13 @@ echo ""
 # to a writable location since default may not be writable in containers
 sed -i 's|db_path.*|db_path = "/tmp/facelock-test.db"|' /etc/facelock/config.toml 2>/dev/null || true
 
+# This camera container starts a standalone dbus-daemon, not systemd-logind,
+# so it has no authoritative login sessions for the daemon's ProcessFD gate.
+# Disable only that gate here; unit/service tests cover its fail-closed and
+# local/remote behavior, while the rest of this script keeps exercising the
+# real daemon authentication/capture path.
+sed -i '/^\[security\]/a abort_if_ssh = false' /etc/facelock/config.toml
+
 # Start a real system bus so CLI commands use the D-Bus daemon path.
 mkdir -p /run/dbus
 dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true


### PR DESCRIPTION
## Why

Remote-session policy needs caller-bound process evidence so PID reuse cannot bypass SSH restrictions.

## Changes

- bind non-root remote checks to D-Bus ProcessFD credentials
- fail closed on invalid, remote, stalled, or cancelled provenance
- preserve root and disabled-policy bypasses plus ingress ordering

## Validation

- run just check
- exercise timeout, cancellation, PID-reuse, root, and configuration boundaries