### PR TITLE
fix(packaging): preserve system asset lifecycle

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -9,7 +9,7 @@ derives-from:
   - dist/facelock.tmpfiles
   - systemd/facelock-daemon.service
   - docs/adr/**
-reviewed: 2026-08-21
+reviewed: 2026-08-22
 ---
 
 # Security Rules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,19 +183,35 @@ jobs:
         run: |
           printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
           pacman -Syu --noconfirm \
+            fakeroot \
             git \
             just \
-            python
+            perl \
+            python \
+            ripgrep \
+            util-linux
 
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Normalize checkout trust metadata
+        run: |
+          checkout_owner="$(stat -c '%u:%g' -- "$GITHUB_WORKSPACE")"
+          chown -R -- "$checkout_owner" "$GITHUB_WORKSPACE"
+          chmod go-w -- "$GITHUB_WORKSPACE"
 
       - name: Trust the workspace checkout
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Verify agent docs still describe the tree
         run: just check-agent-docs "${{ github.event.pull_request.base.sha }}"
+
+      - name: Verify source-install daemon lifecycle
+        run: just test-source-install-daemon-lifecycle
+
+      - name: Verify Debian source contract
+        run: just test-deb-source-contract
 
       - name: Verify release target declarations
         run: python3 test/check-release-matrix.py
@@ -299,3 +315,6 @@ jobs:
           else
             echo "No Containerfile, skipping"
           fi
+
+      - name: Verify source-install lifecycle under systemd
+        run: test/run-source-install-daemon-lifecycle-systemd.sh facelock-pam-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,7 @@ jobs:
             curl \
             debhelper \
             dpkg-dev \
+            just \
             libpam0g-dev \
             libssl-dev \
             libtss2-dev \
@@ -229,7 +230,7 @@ jobs:
 
       - name: Validate Debian source contract
         run: |
-          bash test/deb-source-contract.sh
+          just test-deb-source-contract
           dpkg-checkbuilddeps
 
       - name: Build suite-specific .deb package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Source-install activation lifecycle** (#221): source installs now hold the
+  canonical `/run/facelock/lifecycle.lock`, establish a manager-proved systemd
+  activation barrier, preserve the daemon's active/inactive and enabled state,
+  and restore safely on normal exit or caught signals. Exact known historical
+  systemd/D-Bus copies are staged and rollback-capable through the protected
+  writes, with signal-safe child/parent handoff and preplan reconciliation,
+  published only while activation remains barred, and ambiguous or
+  administrator-modified state preserved. Privileged entrypoints use fixed
+  trusted paths; ordinary installs fail closed without systemd except for the
+  authenticated offline test-image path.
+- **System asset ownership migration** (#228): `facelock setup --systemd` no
+  longer creates or overwrites package/source-owned systemd and D-Bus files.
+  It validates their exact bytes and metadata, removes only reviewed exact
+  historical `/etc` copies through a failure-atomic no-replace quarantine,
+  preserves ambiguous administrator state, and verifies the intended unit and
+  activation files resolve before enabling the daemon. It treats D-Bus policy
+  as merged configuration and reports unrelated local fragments. Package
+  configuration no longer refreshes a marker-matched legacy policy, source
+  installs consume the same reviewed digest inventory, and source uninstall
+  leaves every historical `/etc` copy untouched without changing daemon-state
+  restoration policy.
+
 ### Added
 
 - **Explicit authorization for sensitive `setup --pam` writes** (#207):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -527,6 +527,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Debian PAM and daemon package lifecycle is opt-in and state-preserving**
+  (#224): direct `pam add`/`setup --pam` now refuses an already-selected exact
+  `pam-auth-update` profile before writing, using fixed-root no-follow evidence
+  and exact disable/password-validation guidance. Package removal preserves and
+  blocks on every selected or inconsistent shared profile because older
+  releases recorded no proof separating package auto-enable from administrator
+  choice; after explicit disable, it preflights then transactionally cleans
+  direct edits before generated service teardown. Ordinary removal stops the
+  daemon but preserves enabled state for reinstall; purge retires that state.
+  Fresh, reinstall and upgrade paths leave inactive daemons inactive and
+  preserve enabled/disabled state, while an already-active daemon is restarted
+  so it picks up the upgraded binary. Compat 13's generated package-scoped
+  tmpfiles activation is the sole install-time create. The inert packaged
+  profile remains `Default: no`, and fresh install still leaves `common-auth`
+  byte-for-byte unchanged.
 - **PAM service files are resolved through the vendor directories** (#201):
   `/etc/pam.d`, then `/usr/lib/pam.d`, first hit wins, configurable with
   `[pam] config_dirs`. On a current Arch install polkit ships its stack at

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The CLI works in all modes — it connects to the daemon if available, otherwise
 ## CLI Reference
 
 ```
-facelock setup          Download models, install systemd/PAM
+facelock setup          Download models, validate systemd, configure PAM
 facelock is-enrolled    Is this user enrolled? (exit 0/1/2)
 facelock enroll         Capture and store a face
 facelock test           Test recognition

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -580,6 +580,18 @@ Manage the facelock line in `/etc/pam.d` service files. This command owns every 
 
 A service name is looked up in `/etc/pam.d` first and `/usr/lib/pam.d` second — Linux-PAM's own order, first hit wins — because packages ship their configuration there: on current Arch `polkit` installs `/usr/lib/pam.d/polkit-1` and there is no `/etc/pam.d/polkit-1` at all. Only `/etc/pam.d` is ever written to. A service that exists only in a vendor directory is copied there first, with the facelock line already in it and a two-line header saying what it was forked from; the package's own file is left byte for byte. That copy reports `overridden` rather than `installed`, and `pam status` reports a service with no local copy as `vendor-only` rather than as `missing`. Deleting the override restores the vendor file. Set `[pam] config_dirs` if your distribution's vendor directory is somewhere else.
 
+On Debian and Ubuntu, a selected packaged `pam-auth-update` profile is already
+one Facelock authentication path. Direct `pam add` and `setup --pam` refuse
+before writing and give the exact disable and correct/wrong-password validation
+sequence, then tell you to retry the original Facelock command with all of its
+services and flags. Untrusted evidence or any saved-selection/live-graph
+disagreement also fails closed.
+
+`facelock pam shared-profile-status` is an internal, read-only Debian package
+maintainer probe. It exits 0 only for the exact active packaged
+`pam-auth-update` profile, 1 when the profile is cleanly unselected, and 2 for
+untrusted or inconsistent state; it never changes PAM or backup state.
+
 ### facelock pam add
 
 ```bash

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -36,7 +36,7 @@ The step starts the daemon, or restarts it if one is already running. The encryp
 ```bash
 facelock setup                          # interactive wizard
 facelock setup --non-interactive        # base setup, no prompts, no PAM/systemd/enroll
-facelock setup --systemd                # install systemd units
+facelock setup --systemd                # validate installed assets, reload and enable
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
 facelock setup --pam --service polkit-1 # install to a specific service
@@ -126,7 +126,7 @@ Two details worth knowing:
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
 | `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
 | `--allow-sensitive` | `--pam` add | Explicitly authorize adding Facelock to `common-auth`, `login`, `password-auth`, `password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac`, or `system-login`. Does not suppress the confirmation prompt and conflicts with `--remove`. |
-| `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
+| `--disable` | `--systemd` | Disable and stop the units without changing installed assets. |
 
 These `requires` relationships are enforced by the parser. `facelock setup --remove` is a clear error naming the missing `--pam`, not a silently ignored flag.
 

--- a/book/src/compatibility.md
+++ b/book/src/compatibility.md
@@ -12,10 +12,15 @@
 
 ## Tested Distributions
 
+Debian-family support starts at Debian 13+ and Ubuntu 26.04+; older Debian and
+Ubuntu releases are unsupported.
+
 | Distribution | Init System | Mode | Status |
 |-------------|-------------|------|--------|
 | Arch Linux | systemd | daemon + D-Bus activation | Primary target |
 | Arch Linux | systemd | oneshot | Tested |
+| Debian 13 (Trixie) | systemd | daemon + D-Bus activation | Booted package gate |
+| Ubuntu 26.04 LTS (Resolute) | systemd | daemon + D-Bus activation | Booted package gate |
 | Container (Arch) | none | daemon (manual) | CI-tested |
 | Container (Arch) | none | oneshot | CI-tested |
 
@@ -24,8 +29,6 @@
 | Distribution | Init System | Mode |
 |-------------|-------------|------|
 | Fedora 38+ | systemd | daemon + D-Bus activation |
-| Ubuntu 26.04+ | systemd | daemon + D-Bus activation |
-| Debian 13+ | systemd | daemon + D-Bus activation |
 | Any Linux | any / none | oneshot |
 | Void Linux | runit | oneshot or manual daemon |
 | Alpine Linux | OpenRC | oneshot or manual daemon |

--- a/book/src/compatibility.md
+++ b/book/src/compatibility.md
@@ -12,8 +12,8 @@
 
 ## Tested Distributions
 
-Debian-family support starts at Debian 13+ and Ubuntu 26.04+; older Debian and
-Ubuntu releases are unsupported.
+Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
+LTS (Resolute). Other Debian and Ubuntu releases are unsupported.
 
 | Distribution | Init System | Mode | Status |
 |-------------|-------------|------|--------|

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -29,7 +29,7 @@ The CLI works in all modes -- it connects to the daemon if available, otherwise 
 
 ```
 facelock (unified binary)
-├── facelock setup          Download models, install systemd/PAM
+├── facelock setup          Download models, validate systemd, configure PAM
 ├── facelock enroll         Capture and store a face
 ├── facelock test           Test recognition
 ├── facelock list           List enrolled models

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -150,11 +150,17 @@ and setup state. Debian also retains its conffile until `purge`; RPM follows
 `%config(noreplace)` and may retain an administrator-modified config as
 `config.toml.rpmsave`.
 
-Facelock does not currently expose a safe "remove everything" command. Do not
-replace package lifecycle handling with a broad recursive deletion: configured
-state paths can live outside the default directories, and links, mounts, or
-wrong-owner remnants require inspection rather than traversal. The authoritative
-fixed-root, retained-data, and erasure-limit contract is in
+Debian purge removes only provably safe entries inside the three compiled
+Facelock roots. Unsafe or externally configured remnants are retained and
+reported. The helper leaves the three compiled roots in place; dpkg may then
+remove an empty `/etc/facelock` conffile parent, while admitted files
+and empty descendant directories are removed.
+
+The Facelock CLI does not currently expose a safe "remove everything" command.
+Do not replace package lifecycle handling with a broad recursive deletion:
+configured state paths can live outside the default directories, and links,
+mounts, or wrong-owner remnants require inspection rather than traversal. The
+authoritative fixed-root, retained-data, and erasure-limit contract is in
 `docs/contracts.md`, "Package Lifecycle Ownership".
 
 ## Configuration

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -186,9 +186,14 @@ Every management command is root-only; the CLI offers to re-run itself under
 `sudo` on a terminal. Face unlock itself (hyprlock, swaylock, the polkit
 agent, `facelock is-enrolled`) needs no group and no re-login: the bus admits
 any local user's `Authenticate` for their own account (ADR 010). If a lock
-screen still reports `AccessDenied` right after an upgrade, the bus has not
-re-read the policy yet — `sudo facelock setup --systemd` rewrites it and asks
-for a reload, or reboot.
+screen still reports `AccessDenied` right after an upgrade, the bus may not
+have re-read the policy yet. `sudo facelock setup --systemd` validates the
+package-owned policy, transactionally retires only the byte-exact historical
+duplicate, and asks for a reload; it never rewrites a package file or an
+administrator-modified `/etc` copy. D-Bus merges all policy fragments, so setup
+reports other local fragments for review instead of calling them ineffective.
+Resolve a preserved-path or rollback error, review any reported local policy,
+or reboot.
 
 The `facelock` group is no longer used (ADR 010). `sudo facelock setup`, `just
 install-files` and the package scriptlets remove a leftover group; if it

--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -81,10 +81,10 @@ pub struct SetupCli {
     /// Do not touch PAM configuration at all (no prompt, no write)
     #[arg(long = "no-pam", overrides_with = "pam")]
     pub no_pam: bool,
-    /// Install and enable systemd units
+    /// Validate installed systemd/D-Bus assets, reload, and enable the daemon
     #[arg(long, overrides_with = "no_systemd")]
     pub systemd: bool,
-    /// Do not install or enable systemd units
+    /// Do not validate, reload, or enable systemd/D-Bus assets
     #[arg(long = "no-systemd", overrides_with = "systemd")]
     pub no_systemd: bool,
     /// Enroll a face during setup

--- a/crates/facelock-cli/src/args.rs
+++ b/crates/facelock-cli/src/args.rs
@@ -190,6 +190,9 @@ pub struct PamServiceArg {
 /// construct in a test.
 #[derive(Subcommand)]
 pub enum PamCli {
+    /// Inspect Debian's packaged shared profile for package lifecycle guards
+    #[command(hide = true)]
+    SharedProfileStatus,
     /// Add the facelock line to one or more /etc/pam.d service files
     #[command(after_help = "\
 --yes/--no-confirm only skips the per-file confirmation. Editing one of the \
@@ -274,6 +277,11 @@ read, so 'not configured' and 'not checked' are never the same answer.")]
 impl From<PamCli> for PamRequest {
     fn from(cli: PamCli) -> Self {
         match cli {
+            PamCli::SharedProfileStatus => PamRequest {
+                action: PamAction::Status,
+                shared_profile_status: true,
+                ..PamRequest::default()
+            },
             PamCli::Add {
                 service,
                 confirm,
@@ -283,6 +291,7 @@ impl From<PamCli> for PamRequest {
                 json,
             } => PamRequest {
                 action: PamAction::Add,
+                shared_profile_status: false,
                 services: service.service,
                 all: false,
                 // `--json` implies `--no-confirm` and never `--allow-sensitive`:
@@ -306,6 +315,7 @@ impl From<PamCli> for PamRequest {
                 json,
             } => PamRequest {
                 action: PamAction::Remove,
+                shared_profile_status: false,
                 services: service.service,
                 all,
                 // Symmetry with `add`; `remove` has nothing to suppress today.

--- a/crates/facelock-cli/src/commands/pam.rs
+++ b/crates/facelock-cli/src/commands/pam.rs
@@ -246,6 +246,21 @@ const REMOVE_ALL_LEGACY_VERSION: u32 = 1;
 const MAX_REMOVE_ALL_TARGETS: usize = 1024;
 const MAX_REMOVE_ALL_JOURNAL_BYTES: usize = 4 * 1024 * 1024;
 
+/// Debian's fixed `pam-auth-update` roots. A privileged direct PAM edit must
+/// not accept these paths from configuration or the environment.
+const PAM_AUTH_UPDATE_PROFILES_DIR: &str = "/usr/share/pam-configs";
+const PAM_AUTH_UPDATE_STATE_DIR: &str = "/var/lib/pam";
+const PAM_AUTH_UPDATE_PAM_DIR: &str = "/etc/pam.d";
+const PAM_AUTH_UPDATE_PROFILE: &[u8] = concat!(
+    "Name: Facelock face authentication\n",
+    "Default: no\n",
+    "Priority: 900\n",
+    "Auth-Type: Primary\n",
+    "Auth:\n",
+    "\t[success=end default=ignore]\tpam_facelock.so\n",
+)
+.as_bytes();
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum ProvenanceState {
@@ -3427,6 +3442,166 @@ fn read_regular_nofollow(path: &Path) -> std::io::Result<(Vec<u8>, FileIdentity)
     Ok((content, identity))
 }
 
+/// Open one `pam-auth-update` input through an already-validated directory.
+/// The detector is read-only, but it still treats ownership, writable modes,
+/// symlinks and hard links as trust failures: otherwise privileged detection
+/// could be made to read an arbitrary file or accept mutable evidence.
+fn read_pam_auth_update_file(
+    root: &Path,
+    name: &str,
+    expected_owner: (u32, u32),
+) -> std::io::Result<Option<Vec<u8>>> {
+    use std::io::{Error, ErrorKind};
+
+    let directory = match open_directory_nofollow(root) {
+        Ok(directory) => directory,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let directory_metadata = directory.metadata()?;
+    if (directory_metadata.uid(), directory_metadata.gid()) != expected_owner
+        || directory_metadata.mode() & 0o022 != 0
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            format!("{} has untrusted ownership or permissions", root.display()),
+        ));
+    }
+    let file = match open_regular_at(&directory, OsStr::new(name)) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if (metadata.uid(), metadata.gid()) != expected_owner || metadata.mode() & 0o022 != 0 {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            format!(
+                "{}/{} has untrusted ownership or permissions",
+                root.display(),
+                name
+            ),
+        ));
+    }
+    read_open_bounded(&file, MAX_RECORD_BYTES).map(Some)
+}
+
+fn pam_auth_update_state_selects_facelock(content: &[u8]) -> bool {
+    content
+        .split(|byte| *byte == b'\n')
+        .any(|line| line.strip_suffix(b"\r").unwrap_or(line) == b"Module: facelock")
+}
+
+/// Confirm the live Facelock module is inside the generated Primary block,
+/// rather than mistaking an administrator's direct rule elsewhere in
+/// `common-auth` for a selected shared profile.
+fn common_auth_has_managed_facelock(content: &[u8]) -> bool {
+    let mut primary = false;
+    for line in content.split(|byte| *byte == b'\n') {
+        let semantic = line.strip_suffix(b"\r").unwrap_or(line);
+        if semantic.starts_with(b"# here are the per-package modules")
+            && semantic
+                .windows(b"Primary".len())
+                .any(|part| part == b"Primary")
+        {
+            primary = true;
+            continue;
+        }
+        if primary && semantic.starts_with(b"# here's the fallback if no module succeeds") {
+            return false;
+        }
+        if primary && is_facelock_rule(semantic) {
+            return true;
+        }
+    }
+    false
+}
+
+fn active_pam_auth_update_profile(roots: &PamAuthUpdateRoots) -> std::io::Result<bool> {
+    use std::io::{Error, ErrorKind};
+
+    let owner = if roots.is_system() {
+        (0, 0)
+    } else {
+        (unsafe { libc::geteuid() }, unsafe { libc::getegid() })
+    };
+    let state = read_pam_auth_update_file(&roots.state, "auth", owner)?;
+    let selected = state
+        .as_deref()
+        .is_some_and(pam_auth_update_state_selects_facelock);
+    let common_auth = read_pam_auth_update_file(&roots.pam, "common-auth", owner)?;
+    let live = common_auth
+        .as_deref()
+        .is_some_and(common_auth_has_managed_facelock);
+    if !selected && live {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "live PAM graph contains an unselected Facelock profile",
+        ));
+    }
+    if !selected {
+        return Ok(false);
+    }
+    let Some(_) = common_auth else {
+        return Err(Error::new(
+            ErrorKind::NotFound,
+            "selected Facelock profile has no common-auth graph",
+        ));
+    };
+    if !live {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "selected Facelock profile does not match the live PAM graph",
+        ));
+    }
+    let Some(profile) = read_pam_auth_update_file(&roots.profiles, "facelock", owner)? else {
+        return Err(Error::new(
+            ErrorKind::NotFound,
+            "selected Facelock profile metadata is missing",
+        ));
+    };
+    if profile != PAM_AUTH_UPDATE_PROFILE {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "selected Facelock profile metadata does not match the packaged profile",
+        ));
+    }
+    Ok(true)
+}
+
+fn guard_direct_add(dirs: &PamDirs, action: WriteAction) -> anyhow::Result<()> {
+    if action != WriteAction::Add {
+        return Ok(());
+    }
+    let Some(roots) = &dirs.pam_auth_update else {
+        return Ok(());
+    };
+    let active = active_pam_auth_update_profile(roots).map_err(|error| {
+        anyhow::anyhow!("cannot safely inspect the pam-auth-update profile: {error}")
+    })?;
+    if active {
+        return Err(fail(PamMessage::PamAuthUpdateProfileActive));
+    }
+    Ok(())
+}
+
+/// Exit on `pam status`'s 0/1/2 scale: selected and live, unselected, or not
+/// safely knowable. The package script consumes only the code; the diagnostic
+/// for an unsafe graph remains visible on stderr.
+fn shared_profile_status(roots: &PamAuthUpdateRoots) -> i32 {
+    match active_pam_auth_update_profile(roots) {
+        Ok(true) => STATUS_PRESENT,
+        Ok(false) => STATUS_MISSING,
+        Err(error) => {
+            Terminal.error(&PamMessage::PamConfigureFailed {
+                service: "pam-auth-update profile".to_string(),
+                error: error.to_string(),
+            });
+            STATUS_ERROR
+        }
+    }
+}
+
 fn identity_matches(expected: &FileIdentity, actual: &FileIdentity) -> bool {
     (
         expected.device,
@@ -4114,6 +4289,31 @@ const HARD_LINKED: &str = "hard-linked service file";
 pub(crate) struct PamDirs {
     dirs: Vec<PathBuf>,
     backup_dir: PathBuf,
+    pam_auth_update: Option<PamAuthUpdateRoots>,
+}
+
+/// Inputs to the Debian shared-profile detector. Production constructs only
+/// [`PamAuthUpdateRoots::system`]; explicit roots let tests exercise the
+/// detector without reading or mutating the host PAM graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PamAuthUpdateRoots {
+    profiles: PathBuf,
+    state: PathBuf,
+    pam: PathBuf,
+}
+
+impl PamAuthUpdateRoots {
+    fn system() -> Self {
+        Self {
+            profiles: PathBuf::from(PAM_AUTH_UPDATE_PROFILES_DIR),
+            state: PathBuf::from(PAM_AUTH_UPDATE_STATE_DIR),
+            pam: PathBuf::from(PAM_AUTH_UPDATE_PAM_DIR),
+        }
+    }
+
+    fn is_system(&self) -> bool {
+        self == &Self::system()
+    }
 }
 
 impl PamDirs {
@@ -4173,6 +4373,7 @@ impl PamDirs {
         PamDirs {
             dirs,
             backup_dir: PathBuf::from(PAM_BACKUPS_DIR),
+            pam_auth_update: None,
         }
     }
 
@@ -4190,9 +4391,11 @@ impl PamDirs {
     /// a privileged process, so the environment cannot redirect where a root
     /// `pam add` writes.
     pub(crate) fn system() -> Self {
-        crate::resolved::ConfigLoad::read()
+        let mut dirs = crate::resolved::ConfigLoad::read()
             .config()
-            .map_or_else(Self::default, Self::from_config)
+            .map_or_else(Self::default, Self::from_config);
+        dirs.pam_auth_update = Some(PamAuthUpdateRoots::system());
+        dirs
     }
 
     /// Fixed, compiled roots for config-independent machine-wide cleanup.
@@ -4200,6 +4403,7 @@ impl PamDirs {
         PamDirs {
             dirs: PAM_CLEANUP_DIRS.iter().map(PathBuf::from).collect(),
             backup_dir: PathBuf::from(PAM_BACKUPS_DIR),
+            pam_auth_update: None,
         }
     }
 
@@ -4261,6 +4465,7 @@ impl Default for PamDirs {
         PamDirs {
             dirs: PAM_SYSTEM_DIRS.iter().map(PathBuf::from).collect(),
             backup_dir: PathBuf::from(PAM_BACKUPS_DIR),
+            pam_auth_update: None,
         }
     }
 }
@@ -4272,6 +4477,7 @@ impl From<&Path> for PamDirs {
         PamDirs {
             dirs: vec![dir.to_path_buf()],
             backup_dir: dir.join(".facelock-pam-backups"),
+            pam_auth_update: None,
         }
     }
 }
@@ -4329,6 +4535,10 @@ impl PamAction {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PamRequest {
     pub action: PamAction,
+    /// Fixed-root, read-only Debian package lifecycle probe. It is reachable
+    /// only through a hidden internal subcommand and never composes with a
+    /// named or enumerating service operation.
+    pub shared_profile_status: bool,
     /// Requested services, in the order given. Empty means
     /// [`DEFAULT_PAM_SERVICE`].
     pub services: Vec<String>,
@@ -7225,6 +7435,9 @@ fn emit_json(
 /// re-running a `/etc/pam.d` edit under `sudo` from a wrapper script is a
 /// surprise, not a convenience.
 pub fn run(request: PamRequest) -> anyhow::Result<i32> {
+    if request.shared_profile_status {
+        return Ok(shared_profile_status(&PamAuthUpdateRoots::system()));
+    }
     // `status` needs no root and returns before the check, as it always has.
     if request.action == PamAction::Status {
         return Ok(status_in(&PamDirs::system(), &request));
@@ -7460,6 +7673,7 @@ fn write_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Result<i32> {
     let sink = Sink::verb(request.json);
 
     // Phase one. An `Err` here has written nothing, by construction.
+    guard_direct_add(dirs, action)?;
     let targets = plan_writes(dirs, &write)?;
     let reports = apply_all(dirs, &targets, &write, &sink);
 
@@ -9144,6 +9358,7 @@ pub(crate) fn install_for_setup(request: &PamRequest) -> anyhow::Result<()> {
     };
     let sink = Sink::human();
     let dirs = PamDirs::system();
+    guard_direct_add(&dirs, WriteAction::Add)?;
     let reports = apply_all(&dirs, &plan_writes(&dirs, &write)?, &write, &sink);
     // Before the hint, which the alias has never printed after a failure —
     // unlike the verb, whose closing hint fires whatever the rows say.
@@ -9191,6 +9406,7 @@ pub(crate) fn install_one_in(dirs: &PamDirs, request: &PamRequest) -> anyhow::Re
         remedy: "--allow-sensitive",
     };
     let sink = Sink::human();
+    guard_direct_add(dirs, WriteAction::Add)?;
     let reports = apply_all(dirs, &plan_writes(dirs, &write)?, &write, &sink);
     first_failure(&reports)?;
     Ok(reports
@@ -9227,6 +9443,9 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    /// Independent contract value so a mutation of the production bound is observable.
+    const EXPECTED_MAX_RECORD_BYTES: usize = 16 * 1024;
 
     // -----------------------------------------------------------------------
     // Goldens captured from `main` (4c8cf28) before the extraction.
@@ -10036,7 +10255,7 @@ account required pam_unix.so\n";
     fn bounded_record_read_refuses_oversized_untrusted_json() {
         let root = tempfile::tempdir().unwrap();
         let path = root.path().join("record");
-        fs::write(&path, vec![b' '; MAX_RECORD_BYTES + 1]).unwrap();
+        fs::write(&path, vec![b' '; EXPECTED_MAX_RECORD_BYTES + 1]).unwrap();
         let file = fs::File::open(path).unwrap();
 
         let error = read_open_bounded(&file, MAX_RECORD_BYTES).unwrap_err();
@@ -12482,32 +12701,83 @@ account required pam_unix.so\n";
     }
 
     #[derive(Debug, PartialEq, Eq)]
-    struct DirectorySnapshot {
+    struct MetadataSnapshot {
         device: u64,
         inode: u64,
+        links: u64,
         mode: u32,
         uid: u32,
         gid: u32,
+        size: u64,
         modified_seconds: i64,
         modified_nanoseconds: i64,
         changed_seconds: i64,
         changed_nanoseconds: i64,
-        entries: BTreeMap<String, Vec<u8>>,
     }
 
-    fn directory_snapshot(dir: &Path) -> DirectorySnapshot {
-        let metadata = fs::symlink_metadata(dir).unwrap();
-        DirectorySnapshot {
+    fn metadata_snapshot(path: &Path) -> MetadataSnapshot {
+        let metadata = fs::symlink_metadata(path).unwrap();
+        MetadataSnapshot {
             device: metadata.dev(),
             inode: metadata.ino(),
+            links: metadata.nlink(),
             mode: metadata.mode(),
             uid: metadata.uid(),
             gid: metadata.gid(),
+            size: metadata.len(),
             modified_seconds: metadata.mtime(),
             modified_nanoseconds: metadata.mtime_nsec(),
             changed_seconds: metadata.ctime(),
             changed_nanoseconds: metadata.ctime_nsec(),
-            entries: snapshot(dir),
+        }
+    }
+
+    #[derive(PartialEq, Eq)]
+    struct FileSnapshot {
+        metadata: MetadataSnapshot,
+        bytes: Vec<u8>,
+    }
+
+    impl std::fmt::Debug for FileSnapshot {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("FileSnapshot")
+                .field("metadata", &self.metadata)
+                .field("sha256", &sha256_hex(&self.bytes))
+                .finish()
+        }
+    }
+
+    fn file_snapshot(path: &Path) -> FileSnapshot {
+        FileSnapshot {
+            metadata: metadata_snapshot(path),
+            bytes: fs::read(path).unwrap_or_default(),
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct DirectorySnapshot {
+        metadata: MetadataSnapshot,
+        entries: BTreeMap<String, FileSnapshot>,
+    }
+
+    fn directory_snapshot(dir: &Path) -> DirectorySnapshot {
+        let entries = fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                (!entry.file_type().unwrap().is_dir()).then_some(entry)
+            })
+            .map(|entry| {
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    file_snapshot(&entry.path()),
+                )
+            })
+            .collect();
+        DirectorySnapshot {
+            metadata: metadata_snapshot(dir),
+            entries,
         }
     }
 
@@ -12539,6 +12809,232 @@ account required pam_unix.so\n";
             .unwrap();
         let path = store.latest_committed(service).unwrap().unwrap();
         fs::read(path).unwrap()
+    }
+
+    const FACELOCK_PAM_AUTH_UPDATE_PROFILE: &str = concat!(
+        "Name: Facelock face authentication\n",
+        "Default: no\n",
+        "Priority: 900\n",
+        "Auth-Type: Primary\n",
+        "Auth:\n",
+        "\t[success=end default=ignore]\tpam_facelock.so\n",
+    );
+
+    #[test]
+    fn shared_profile_detector_pins_the_exact_packaged_profile_bytes() {
+        assert_eq!(
+            PAM_AUTH_UPDATE_PROFILE,
+            include_bytes!("../../../../debian/pam-auth-update")
+        );
+    }
+
+    fn pam_auth_update_fixture(active: bool) -> (tempfile::TempDir, PamAuthUpdateRoots) {
+        let root = tempfile::tempdir().unwrap();
+        let profiles = root.path().join("usr/share/pam-configs");
+        let state = root.path().join("var/lib/pam");
+        let pam = root.path().join("etc/pam.d");
+        fs::create_dir_all(&profiles).unwrap();
+        fs::create_dir_all(&state).unwrap();
+        fs::create_dir_all(&pam).unwrap();
+        fs::write(profiles.join("facelock"), FACELOCK_PAM_AUTH_UPDATE_PROFILE).unwrap();
+        fs::write(
+            state.join("auth"),
+            if active {
+                "Module: facelock\n[success=end default=ignore]\tpam_facelock.so\n"
+            } else {
+                "Module: unix\n[success=end default=ignore]\tpam_unix.so\n"
+            },
+        )
+        .unwrap();
+        fs::write(
+            pam.join("common-auth"),
+            if active {
+                concat!(
+                    "# here are the per-package modules (the \"Primary\" block)\n",
+                    "auth\t[success=1 default=ignore]\tpam_facelock.so\n",
+                    "auth\t[success=1 default=ignore]\tpam_unix.so nullok\n",
+                    "# here's the fallback if no module succeeds\n",
+                )
+            } else {
+                concat!(
+                    "# here are the per-package modules (the \"Primary\" block)\n",
+                    "auth\t[success=1 default=ignore]\tpam_unix.so nullok\n",
+                    "# here's the fallback if no module succeeds\n",
+                )
+            },
+        )
+        .unwrap();
+        let roots = PamAuthUpdateRoots {
+            profiles,
+            state,
+            pam,
+        };
+        (root, roots)
+    }
+
+    #[test]
+    fn direct_add_refuses_an_exact_active_pam_auth_update_profile_without_writing() {
+        let (_root, roots) = pam_auth_update_fixture(true);
+        fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![roots.pam.clone()],
+            backup_dir: roots.pam.join(".facelock-pam-backups"),
+            pam_auth_update: Some(roots),
+        };
+        let before = directory_snapshot(dirs.overrides());
+
+        let error = write_in(&dirs, &add(&["sudo"])).unwrap_err().to_string();
+
+        assert_eq!(
+            error,
+            "Facelock's pam-auth-update profile is active; direct PAM edits would configure Facelock twice. To migrate, run `sudo pam-auth-update --disable facelock`, verify that a real correct password succeeds and a wrong password fails, then retry the original Facelock command with all of its services and flags."
+        );
+        assert_eq!(directory_snapshot(dirs.overrides()), before);
+        assert!(!dirs.backup_dir().exists());
+    }
+
+    #[test]
+    fn direct_add_refuses_symlinked_pam_auth_update_state_without_following_it() {
+        let (_root, roots) = pam_auth_update_fixture(true);
+        fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+        let outside = roots.state.join("administrator-auth");
+        fs::write(&outside, b"do not read or change me\n").unwrap();
+        fs::remove_file(roots.state.join("auth")).unwrap();
+        std::os::unix::fs::symlink(&outside, roots.state.join("auth")).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![roots.pam.clone()],
+            backup_dir: roots.pam.join(".facelock-pam-backups"),
+            pam_auth_update: Some(roots),
+        };
+        let before = directory_snapshot(dirs.overrides());
+
+        let error = write_in(&dirs, &add(&["sudo"])).unwrap_err().to_string();
+
+        assert!(error.contains("cannot safely inspect the pam-auth-update profile"));
+        assert_eq!(fs::read(outside).unwrap(), b"do not read or change me\n");
+        assert_eq!(directory_snapshot(dirs.overrides()), before);
+        assert!(!dirs.backup_dir().exists());
+    }
+
+    #[test]
+    fn oversized_shared_profile_inputs_fail_closed_without_pam_or_backup_mutation() {
+        #[derive(Clone, Copy, Debug)]
+        enum Input {
+            Profile,
+            State,
+            CommonAuth,
+        }
+
+        for input in [Input::Profile, Input::State, Input::CommonAuth] {
+            let (_root, roots) = pam_auth_update_fixture(true);
+            fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+            let input_path = match input {
+                Input::Profile => roots.profiles.join("facelock"),
+                Input::State => roots.state.join("auth"),
+                Input::CommonAuth => roots.pam.join("common-auth"),
+            };
+            let mut oversized = fs::read(&input_path).unwrap();
+            oversized.resize(EXPECTED_MAX_RECORD_BYTES + 1, b'\n');
+            fs::write(&input_path, &oversized).unwrap();
+            for path in [
+                roots.profiles.join("facelock"),
+                roots.state.join("auth"),
+                roots.pam.join("common-auth"),
+                roots.pam.join("sudo"),
+            ] {
+                fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap();
+            }
+            let profiles_before = directory_snapshot(&roots.profiles);
+            let state_before = directory_snapshot(&roots.state);
+            let pam_before = directory_snapshot(&roots.pam);
+            let dirs = PamDirs {
+                dirs: vec![roots.pam.clone()],
+                backup_dir: roots.pam.join(".facelock-pam-backups"),
+                pam_auth_update: Some(roots.clone()),
+            };
+
+            assert_eq!(shared_profile_status(&roots), STATUS_ERROR, "{input:?}");
+            let error = write_in(&dirs, &add(&["sudo"])).unwrap_err().to_string();
+
+            assert!(
+                error.contains("state file exceeds size limit"),
+                "{input:?}: {error}"
+            );
+            assert_eq!(
+                directory_snapshot(&roots.profiles),
+                profiles_before,
+                "{input:?}"
+            );
+            assert_eq!(directory_snapshot(&roots.state), state_before, "{input:?}");
+            assert_eq!(directory_snapshot(&roots.pam), pam_before, "{input:?}");
+            assert!(!dirs.backup_dir().exists(), "{input:?}");
+        }
+    }
+
+    #[test]
+    fn unselected_pam_auth_update_profile_does_not_block_direct_add() {
+        let (_root, roots) = pam_auth_update_fixture(false);
+        fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![roots.pam.clone()],
+            backup_dir: roots.pam.join(".facelock-pam-backups"),
+            pam_auth_update: Some(roots),
+        };
+
+        assert_eq!(write_in(&dirs, &add(&["sudo"])).unwrap(), WRITE_OK);
+        assert_eq!(
+            fs::read_to_string(dirs.overrides().join("sudo")).unwrap(),
+            SUDO_AFTER
+        );
+    }
+
+    #[test]
+    fn selected_profile_with_an_inconsistent_live_graph_refuses_direct_add() {
+        let (_root, roots) = pam_auth_update_fixture(true);
+        fs::write(
+            roots.pam.join("common-auth"),
+            "auth\t[success=1 default=ignore]\tpam_unix.so nullok\n",
+        )
+        .unwrap();
+        fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![roots.pam.clone()],
+            backup_dir: roots.pam.join(".facelock-pam-backups"),
+            pam_auth_update: Some(roots),
+        };
+        let before = directory_snapshot(dirs.overrides());
+
+        let error = write_in(&dirs, &add(&["sudo"])).unwrap_err().to_string();
+
+        assert!(error.contains("selected Facelock profile does not match the live PAM graph"));
+        assert_eq!(directory_snapshot(dirs.overrides()), before);
+    }
+
+    #[test]
+    fn live_profile_with_an_unselected_state_refuses_direct_add() {
+        let (_root, roots) = pam_auth_update_fixture(false);
+        fs::write(
+            roots.pam.join("common-auth"),
+            concat!(
+                "# here are the per-package modules (the \"Primary\" block)\n",
+                "auth\t[success=1 default=ignore]\tpam_facelock.so\n",
+                "auth\t[success=1 default=ignore]\tpam_unix.so nullok\n",
+                "# here's the fallback if no module succeeds\n",
+            ),
+        )
+        .unwrap();
+        fs::write(roots.pam.join("sudo"), SUDO_BEFORE).unwrap();
+        let dirs = PamDirs {
+            dirs: vec![roots.pam.clone()],
+            backup_dir: roots.pam.join(".facelock-pam-backups"),
+            pam_auth_update: Some(roots),
+        };
+        let before = directory_snapshot(dirs.overrides());
+
+        let error = write_in(&dirs, &add(&["sudo"])).unwrap_err().to_string();
+
+        assert!(error.contains("live PAM graph contains an unselected Facelock profile"));
+        assert_eq!(directory_snapshot(dirs.overrides()), before);
     }
 
     // -- byte identity with `main` ------------------------------------------
@@ -13983,6 +14479,7 @@ account required pam_unix.so\n";
         PamDirs {
             dirs: vec![etc.to_path_buf(), vendor.to_path_buf()],
             backup_dir: etc.join(".facelock-pam-backups"),
+            pam_auth_update: None,
         }
     }
 
@@ -14395,6 +14892,7 @@ account required pam_unix.so\n";
         let dirs = PamDirs {
             dirs: vec![etc.clone(), vendor.clone()],
             backup_dir: state.clone(),
+            pam_auth_update: None,
         };
         fs::write(vendor.join("polkit-1"), POLKIT_BEFORE).unwrap();
         assert_eq!(write_in(&dirs, &add(&["polkit-1"])).unwrap(), WRITE_OK);
@@ -14906,6 +15404,7 @@ account required pam_unix.so\n";
         let dirs = PamDirs {
             dirs: vec![etc.clone(), vendor.clone(), detection_only.clone()],
             backup_dir: root.path().join("state"),
+            pam_auth_update: None,
         };
         assert_eq!(write_in(&dirs, &add(&["polkit-1"])).unwrap(), WRITE_OK);
         let request = PamRequest {
@@ -14942,6 +15441,7 @@ account required pam_unix.so\n";
         let dirs = PamDirs {
             dirs: vec![etc.clone(), higher.clone(), lower.clone()],
             backup_dir: root.path().join("state"),
+            pam_auth_update: None,
         };
         assert_eq!(write_in(&dirs, &add(&["polkit-1"])).unwrap(), WRITE_OK);
         let request = remove(&["polkit-1"]);
@@ -14977,6 +15477,7 @@ account required pam_unix.so\n";
         let dirs = PamDirs {
             dirs: vec![etc.clone(), higher.clone(), lower.clone()],
             backup_dir: root.path().join("state"),
+            pam_auth_update: None,
         };
         assert_eq!(write_in(&dirs, &add(&["polkit-1"])).unwrap(), WRITE_OK);
         let request = PamRequest {
@@ -16479,6 +16980,7 @@ account required pam_unix.so\n";
         let dirs = PamDirs {
             dirs: vec![pam.clone(), vendor, authselect.clone()],
             backup_dir: root.path().join("pam-backups"),
+            pam_auth_update: None,
         };
 
         assert_eq!(remove_all(&dirs).unwrap(), WRITE_OK);

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1,6 +1,10 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::CString;
 use std::fs;
-use std::io::{IsTerminal, Write};
-use std::path::Path;
+use std::io::{self, IsTerminal, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, bail};
@@ -32,13 +36,20 @@ use super::pam::only;
 use super::pam::{PAM_LINE, PAM_MODULE_PATHS, PamAction, PamDirs, PamRequest};
 
 /// Embedded systemd unit file.
-const SERVICE_UNIT: &str = include_str!("../../../../systemd/facelock-daemon.service");
+const SERVICE_UNIT_BYTES: &[u8] = include_bytes!("../../../../systemd/facelock-daemon.service");
 
 /// Embedded D-Bus activation service file.
-const DBUS_SERVICE: &str = include_str!("../../../../dbus/org.facelock.Daemon.service");
+const DBUS_SERVICE_BYTES: &[u8] = include_bytes!("../../../../dbus/org.facelock.Daemon.service");
 
 /// Embedded D-Bus policy configuration.
+#[cfg(test)]
 const DBUS_POLICY: &str = include_str!("../../../../dbus/org.facelock.Daemon.conf");
+const DBUS_POLICY_BYTES: &[u8] = include_bytes!("../../../../dbus/org.facelock.Daemon.conf");
+
+/// Reviewed hashes of every exact historical system asset eligible for
+/// automatic legacy-copy migration.  The source installer reads the same file.
+const LEGACY_SYSTEM_ASSET_HASHES: &str =
+    include_str!("../../../../dist/legacy-system-assets.sha256");
 
 /// Embedded model manifest (same source as facelock-face).
 const MANIFEST_TOML: &str = include_str!("../../../../models/manifest.toml");
@@ -2386,7 +2397,7 @@ fn wizard_hyprlock_handoff(theme: &ColorfulTheme) {
         return;
     }
 
-    let status = Command::new("runuser")
+    let status = privileged_command("runuser")
         .args(["-u", &sudo_user, "--", "facelock", "hyprlock", "enable"])
         .status();
 
@@ -3007,19 +3018,820 @@ fn verify_after_download(path: &Path, expected_sha256: &str, name: &str) -> anyh
 }
 
 // ---------------------------------------------------------------------------
-// systemd unit installation
+// systemd and D-Bus asset validation
 // ---------------------------------------------------------------------------
 
-const SYSTEMD_UNIT_DIR: &str = "/usr/lib/systemd/system";
 const SERVICE_FILENAME: &str = "facelock-daemon.service";
-const DBUS_SYSTEM_SERVICES_DIR: &str = "/usr/share/dbus-1/system-services";
-const DBUS_SYSTEM_CONF_DIR: &str = "/usr/share/dbus-1/system.d";
-const DBUS_SERVICE_FILENAME: &str = "org.facelock.Daemon.service";
-const DBUS_POLICY_FILENAME: &str = "org.facelock.Daemon.conf";
-const LEGACY_SYSTEMD_UNIT_PATH: &str = "/etc/systemd/system/facelock-daemon.service";
-const LEGACY_DBUS_SYSTEM_SERVICE_PATH: &str =
-    "/etc/dbus-1/system-services/org.facelock.Daemon.service";
-const LEGACY_DBUS_SYSTEM_CONF_PATH: &str = "/etc/dbus-1/system.d/org.facelock.Daemon.conf";
+
+#[derive(Debug, Clone, Copy)]
+struct SystemAsset {
+    id: &'static str,
+    canonical_path: &'static str,
+    legacy_path: &'static str,
+    quarantine_path: &'static str,
+    current: &'static [u8],
+}
+
+const SYSTEM_ASSETS: &[SystemAsset] = &[
+    SystemAsset {
+        id: "systemd-unit",
+        canonical_path: "/usr/lib/systemd/system/facelock-daemon.service",
+        legacy_path: "/etc/systemd/system/facelock-daemon.service",
+        quarantine_path: "/etc/systemd/system/.facelock-migrate-systemd-unit",
+        current: SERVICE_UNIT_BYTES,
+    },
+    SystemAsset {
+        id: "dbus-policy",
+        canonical_path: "/usr/share/dbus-1/system.d/org.facelock.Daemon.conf",
+        legacy_path: "/etc/dbus-1/system.d/org.facelock.Daemon.conf",
+        quarantine_path: "/etc/dbus-1/system.d/.facelock-migrate-dbus-policy",
+        current: DBUS_POLICY_BYTES,
+    },
+    SystemAsset {
+        id: "dbus-activation",
+        canonical_path: "/usr/share/dbus-1/system-services/org.facelock.Daemon.service",
+        legacy_path: "/etc/dbus-1/system-services/org.facelock.Daemon.service",
+        quarantine_path: "/etc/dbus-1/system-services/.facelock-migrate-dbus-activation",
+        current: DBUS_SERVICE_BYTES,
+    },
+];
+
+#[derive(Debug, Clone, Copy)]
+struct SystemAssetLayout<'a> {
+    root: &'a Path,
+    expected_uid: u32,
+    expected_gid: u32,
+}
+
+impl<'a> SystemAssetLayout<'a> {
+    fn new(root: &'a Path, expected_uid: u32, expected_gid: u32) -> Self {
+        Self {
+            root,
+            expected_uid,
+            expected_gid,
+        }
+    }
+
+    fn production() -> Self {
+        Self::new(Path::new("/"), 0, 0)
+    }
+
+    fn path(self, absolute: &str) -> PathBuf {
+        self.root.join(absolute.trim_start_matches('/'))
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn parse_legacy_system_asset_hashes(
+    manifest: &str,
+) -> anyhow::Result<BTreeMap<&str, BTreeSet<&str>>> {
+    let mut parsed: BTreeMap<&str, BTreeSet<&str>> = SYSTEM_ASSETS
+        .iter()
+        .map(|asset| (asset.id, BTreeSet::new()))
+        .collect();
+
+    for (line_number, line) in manifest.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut fields = line.split_ascii_whitespace();
+        let Some(id) = fields.next() else {
+            continue;
+        };
+        let Some(hash) = fields.next() else {
+            bail!(
+                "invalid legacy system-asset allowlist record at line {}",
+                line_number + 1
+            );
+        };
+        if fields.next().is_some() || hash.len() != 64 {
+            bail!(
+                "invalid legacy system-asset allowlist record at line {}",
+                line_number + 1
+            );
+        }
+        if !hash
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            bail!(
+                "invalid legacy system-asset allowlist digest at line {}",
+                line_number + 1
+            );
+        }
+        let Some(hashes) = parsed.get_mut(id) else {
+            bail!(
+                "unknown legacy system-asset allowlist id at line {}",
+                line_number + 1
+            );
+        };
+        if !hashes.insert(hash) {
+            bail!(
+                "duplicate legacy system-asset allowlist record at line {}",
+                line_number + 1
+            );
+        }
+    }
+    Ok(parsed)
+}
+
+fn legacy_hash_is_known(asset_id: &str, digest: &str) -> anyhow::Result<bool> {
+    let parsed = parse_legacy_system_asset_hashes(LEGACY_SYSTEM_ASSET_HASHES)?;
+    let Some(hashes) = parsed.get(asset_id) else {
+        bail!("unknown system asset id {asset_id}");
+    };
+    if hashes.contains(digest) {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn validate_system_asset_parents(
+    layout: &SystemAssetLayout<'_>,
+    absolute: &str,
+) -> anyhow::Result<()> {
+    let root_metadata = fs::symlink_metadata(layout.root).with_context(|| {
+        format!(
+            "failed to inspect system-asset layout root {}",
+            layout.root.display()
+        )
+    })?;
+    if !root_metadata.file_type().is_dir()
+        || root_metadata.uid() != layout.expected_uid
+        || root_metadata.gid() != layout.expected_gid
+        || root_metadata.mode() & 0o022 != 0
+    {
+        bail!(
+            "system-asset layout root is linked, non-directory, wrongly owned, or writable by group/other: {}",
+            layout.root.display()
+        );
+    }
+    let relative = absolute
+        .strip_prefix('/')
+        .context("system asset path is not absolute")?;
+    let mut current = layout.root.to_path_buf();
+    let mut components = relative.split('/').peekable();
+
+    while let Some(component) = components.next() {
+        if components.peek().is_none() {
+            break;
+        }
+        if component.is_empty() || component == "." || component == ".." {
+            bail!("system asset path has an unsafe component: {absolute}");
+        }
+        current.push(component);
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to inspect system asset parent {}",
+                        current.display()
+                    )
+                });
+            }
+        };
+        if !metadata.file_type().is_dir()
+            || metadata.uid() != layout.expected_uid
+            || metadata.gid() != layout.expected_gid
+            || metadata.mode() & 0o022 != 0
+        {
+            bail!(
+                "system asset parent is linked, non-directory, wrongly owned, or writable by group/other and was preserved: {}",
+                current.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_canonical_asset(
+    layout: &SystemAssetLayout<'_>,
+    asset: &SystemAsset,
+) -> anyhow::Result<()> {
+    validate_system_asset_parents(layout, asset.canonical_path)?;
+    let path = layout.path(asset.canonical_path);
+    let metadata = fs::symlink_metadata(&path)
+        .with_context(|| format!("package-owned system asset is missing: {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!(
+            "package-owned system asset is not a regular non-symlink file: {}",
+            path.display()
+        );
+    }
+    if metadata.nlink() != 1 {
+        bail!(
+            "package-owned system asset has {} links instead of one: {}",
+            metadata.nlink(),
+            path.display()
+        );
+    }
+    if metadata.uid() != layout.expected_uid || metadata.gid() != layout.expected_gid {
+        bail!(
+            "package-owned system asset has owner {}:{} instead of {}:{}: {}",
+            metadata.uid(),
+            metadata.gid(),
+            layout.expected_uid,
+            layout.expected_gid,
+            path.display()
+        );
+    }
+    let mode = metadata.mode() & 0o7777;
+    if mode != 0o644 {
+        bail!(
+            "package-owned system asset has mode {mode:04o} instead of 0644: {}",
+            path.display()
+        );
+    }
+    let bytes = fs::read(&path).with_context(|| {
+        format!(
+            "failed to read package-owned system asset {}",
+            path.display()
+        )
+    })?;
+    if bytes != asset.current {
+        bail!(
+            "package-owned system asset bytes do not match this Facelock build: {}",
+            path.display()
+        );
+    }
+    let current_digest = sha256_hex(asset.current);
+    if !legacy_hash_is_known(asset.id, &current_digest)? {
+        bail!(
+            "current {} bytes are missing from the reviewed legacy allowlist",
+            asset.canonical_path
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyAssetState {
+    Absent,
+    ExactKnown,
+}
+
+fn inspect_known_legacy_path(
+    layout: &SystemAssetLayout<'_>,
+    asset: &SystemAsset,
+    absolute: &str,
+    description: &str,
+) -> anyhow::Result<LegacyAssetState> {
+    validate_system_asset_parents(layout, absolute)?;
+    let path = layout.path(absolute);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(LegacyAssetState::Absent);
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect {description} {}", path.display()));
+        }
+    };
+
+    let preserved = |reason: &str| {
+        anyhow::anyhow!(
+            "{description} {} is {reason}; it was preserved. Move it aside or restore an exact Facelock copy, then retry",
+            path.display()
+        )
+    };
+    if !metadata.file_type().is_file() {
+        return Err(preserved("linked or non-regular"));
+    }
+    if metadata.nlink() != 1 {
+        return Err(preserved("multiply linked"));
+    }
+    if metadata.uid() != layout.expected_uid || metadata.gid() != layout.expected_gid {
+        return Err(preserved("not owned by the trusted system owner"));
+    }
+    if metadata.mode() & 0o7777 != 0o644 {
+        return Err(preserved("not mode 0644"));
+    }
+    let bytes = fs::read(&path).with_context(|| {
+        format!(
+            "failed to read {description} {}; it was preserved",
+            path.display()
+        )
+    })?;
+    if !legacy_hash_is_known(asset.id, &sha256_hex(&bytes))? {
+        return Err(preserved("modified or unknown"));
+    }
+    Ok(LegacyAssetState::ExactKnown)
+}
+
+fn inspect_legacy_asset(
+    layout: &SystemAssetLayout<'_>,
+    asset: &SystemAsset,
+) -> anyhow::Result<LegacyAssetState> {
+    inspect_known_legacy_path(layout, asset, asset.legacy_path, "legacy system asset")
+}
+
+fn system_asset_quarantine_path(layout: &SystemAssetLayout<'_>, asset: &SystemAsset) -> PathBuf {
+    layout.path(asset.quarantine_path)
+}
+
+fn rename_noreplace(source: &Path, target: &Path) -> io::Result<()> {
+    let source = CString::new(source.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "source path contains an interior NUL",
+        )
+    })?;
+    let target = CString::new(target.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "target path contains an interior NUL",
+        )
+    })?;
+
+    // Linux is Facelock's platform contract. Fail closed when renameat2 is not
+    // available; a replacing rename is never an acceptable fallback.
+    // SAFETY: both pointers come from live, NUL-terminated `CString` values;
+    // `renameat2` reads them only for this call, and both directory fds are the
+    // documented `AT_FDCWD` sentinel.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn quarantine_is_absent(layout: &SystemAssetLayout<'_>, asset: &SystemAsset) -> anyhow::Result<()> {
+    let absolute = asset.quarantine_path;
+    validate_system_asset_parents(layout, absolute)?;
+    let path = layout.path(absolute);
+    match fs::symlink_metadata(&path) {
+        Ok(_) => bail!(
+            "fixed migration quarantine collides with an existing path and was preserved: {}",
+            path.display()
+        ),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to inspect migration quarantine {}", path.display())),
+    }
+}
+
+fn rollback_system_asset_quarantines<F>(
+    layout: &SystemAssetLayout<'_>,
+    staged: &[&SystemAsset],
+    rename: &mut F,
+) -> Vec<String>
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    let mut failures = Vec::new();
+    for asset in staged.iter().rev() {
+        let quarantine_absolute = asset.quarantine_path;
+        let quarantine = layout.path(quarantine_absolute);
+        let legacy = layout.path(asset.legacy_path);
+        match inspect_known_legacy_path(layout, asset, quarantine_absolute, "migration quarantine")
+        {
+            Ok(LegacyAssetState::ExactKnown) => {}
+            Ok(LegacyAssetState::Absent) => {
+                failures.push(format!(
+                    "rollback quarantine disappeared and could not restore {}",
+                    legacy.display()
+                ));
+                continue;
+            }
+            Err(error) => {
+                failures.push(error.to_string());
+                continue;
+            }
+        }
+        match fs::symlink_metadata(&legacy) {
+            Ok(_) => {
+                failures.push(format!(
+                    "rollback collision preserved both names for administrator review: {} and {}",
+                    legacy.display(),
+                    quarantine.display()
+                ));
+                continue;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                failures.push(format!(
+                    "failed to inspect rollback destination {}: {error}",
+                    legacy.display()
+                ));
+                continue;
+            }
+        }
+        if let Err(error) = rename(&quarantine, &legacy) {
+            failures.push(format!(
+                "failed to roll back {} without replacement: {error}",
+                legacy.display()
+            ));
+            continue;
+        }
+        match inspect_legacy_asset(layout, asset) {
+            Ok(LegacyAssetState::ExactKnown) => {}
+            Ok(LegacyAssetState::Absent) => failures.push(format!(
+                "rollback reported success but did not restore {}",
+                legacy.display()
+            )),
+            Err(error) => failures.push(error.to_string()),
+        }
+    }
+    failures
+}
+
+fn migration_failure_with_rollback<F>(
+    layout: &SystemAssetLayout<'_>,
+    staged: &[&SystemAsset],
+    rename: &mut F,
+    failure: anyhow::Error,
+) -> anyhow::Error
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    let rollback_failures = rollback_system_asset_quarantines(layout, staged, rename);
+    if rollback_failures.is_empty() {
+        anyhow::anyhow!("{failure}; every earlier migration candidate was rolled back")
+    } else {
+        anyhow::anyhow!(
+            "{failure}; migration rollback was incomplete:\n  - {}",
+            rollback_failures.join("\n  - ")
+        )
+    }
+}
+
+/// Validate immutable package/source-owned assets, then remove only exact
+/// reviewed legacy copies.  The complete canonical and legacy set is
+/// preflighted before the first removal, so an ambiguous entry preserves all
+/// legacy paths for administrator inspection.
+fn validate_and_migrate_system_assets(
+    layout: &SystemAssetLayout<'_>,
+) -> anyhow::Result<Vec<PathBuf>> {
+    validate_and_migrate_system_assets_with(layout, &mut rename_noreplace)
+}
+
+fn validate_and_migrate_system_assets_with<F>(
+    layout: &SystemAssetLayout<'_>,
+    rename: &mut F,
+) -> anyhow::Result<Vec<PathBuf>>
+where
+    F: FnMut(&Path, &Path) -> io::Result<()>,
+{
+    let mut recovery_completed = false;
+    let candidates = loop {
+        let mut failures = Vec::new();
+        let mut candidates = Vec::new();
+        let mut interrupted = Vec::new();
+
+        for asset in SYSTEM_ASSETS {
+            if let Err(error) = validate_canonical_asset(layout, asset) {
+                failures.push(error.to_string());
+            }
+        }
+        for asset in SYSTEM_ASSETS {
+            let legacy = inspect_legacy_asset(layout, asset);
+            let quarantine = inspect_known_legacy_path(
+                layout,
+                asset,
+                asset.quarantine_path,
+                "migration quarantine",
+            );
+            match (legacy, quarantine) {
+                (Ok(LegacyAssetState::Absent), Ok(LegacyAssetState::Absent)) => {}
+                (Ok(LegacyAssetState::ExactKnown), Ok(LegacyAssetState::Absent)) => {
+                    candidates.push(asset);
+                }
+                (Ok(LegacyAssetState::Absent), Ok(LegacyAssetState::ExactKnown)) => {
+                    interrupted.push(asset);
+                }
+                (Ok(LegacyAssetState::ExactKnown), Ok(LegacyAssetState::ExactKnown)) => {
+                    failures.push(format!(
+                        "both the legacy asset and its fixed migration quarantine exist and were preserved as ambiguous: {} and {}",
+                        layout.path(asset.legacy_path).display(),
+                        layout.path(asset.quarantine_path).display()
+                    ));
+                }
+                (Err(legacy_error), Err(quarantine_error)) => {
+                    failures.push(legacy_error.to_string());
+                    failures.push(quarantine_error.to_string());
+                }
+                (Err(error), Ok(_)) | (Ok(_), Err(error)) => {
+                    failures.push(error.to_string());
+                }
+            }
+        }
+
+        if !failures.is_empty() {
+            if recovery_completed {
+                bail!(
+                    "system asset validation failed after interrupted-staging names were restored; no fixed quarantine was deleted. Resolve the preserved paths and retry:\n  - {}",
+                    failures.join("\n  - ")
+                );
+            } else {
+                bail!(
+                    "system asset validation failed; no legacy files were changed. Reinstall Facelock with the package manager or `sudo just install-files`, resolve preserved /etc overrides, and retry:\n  - {}",
+                    failures.join("\n  - ")
+                );
+            }
+        }
+        if interrupted.is_empty() {
+            break candidates;
+        }
+        if recovery_completed {
+            bail!(
+                "fixed migration state changed immediately after interrupted-staging recovery; the exact known names were preserved for administrator review"
+            );
+        }
+
+        // A killed setup can leave a prefix of exact candidates at their
+        // fixed quarantine names. The complete three-pair set is authenticated
+        // above before any recovery move. Restore in rollback order with the
+        // same no-replace primitive, then restart the complete preflight.
+        for asset in interrupted.iter().rev() {
+            let legacy = layout.path(asset.legacy_path);
+            let quarantine = layout.path(asset.quarantine_path);
+            match inspect_legacy_asset(layout, asset)? {
+                LegacyAssetState::Absent => {}
+                LegacyAssetState::ExactKnown => {
+                    bail!(
+                        "interrupted-staging recovery found a new public collision and preserved both names: {} and {}",
+                        legacy.display(),
+                        quarantine.display()
+                    );
+                }
+            }
+            match inspect_known_legacy_path(
+                layout,
+                asset,
+                asset.quarantine_path,
+                "migration quarantine",
+            )? {
+                LegacyAssetState::ExactKnown => {}
+                LegacyAssetState::Absent => {
+                    bail!(
+                        "interrupted-staging recovery quarantine disappeared and was preserved: {}",
+                        quarantine.display()
+                    );
+                }
+            }
+            rename(&quarantine, &legacy).with_context(|| {
+                format!(
+                    "failed to restore interrupted migration quarantine without replacement; both names were preserved when present: {} to {}",
+                    quarantine.display(),
+                    legacy.display()
+                )
+            })?;
+            match inspect_legacy_asset(layout, asset)? {
+                LegacyAssetState::ExactKnown => {}
+                LegacyAssetState::Absent => {
+                    bail!(
+                        "interrupted-staging recovery reported success but did not restore {}",
+                        legacy.display()
+                    );
+                }
+            }
+            quarantine_is_absent(layout, asset)?;
+        }
+        recovery_completed = true;
+    };
+
+    let mut staged = Vec::new();
+    for asset in candidates {
+        let legacy = layout.path(asset.legacy_path);
+        let quarantine = system_asset_quarantine_path(layout, asset);
+        let state = match inspect_legacy_asset(layout, asset) {
+            Ok(state) => state,
+            Err(error) => {
+                return Err(migration_failure_with_rollback(
+                    layout, &staged, rename, error,
+                ));
+            }
+        };
+        match state {
+            LegacyAssetState::Absent => {
+                let failure = anyhow::anyhow!(
+                    "legacy asset disappeared after preflight: {}",
+                    legacy.display()
+                );
+                return Err(migration_failure_with_rollback(
+                    layout, &staged, rename, failure,
+                ));
+            }
+            LegacyAssetState::ExactKnown => {
+                if let Err(error) = quarantine_is_absent(layout, asset) {
+                    return Err(migration_failure_with_rollback(
+                        layout, &staged, rename, error,
+                    ));
+                }
+                if let Err(error) = rename(&legacy, &quarantine) {
+                    let failure = anyhow::anyhow!(
+                        "failed to quarantine exact known legacy system asset {} without replacement: {error}",
+                        legacy.display()
+                    );
+                    return Err(migration_failure_with_rollback(
+                        layout, &staged, rename, failure,
+                    ));
+                }
+                staged.push(asset);
+                let quarantine_absolute = asset.quarantine_path;
+                match inspect_known_legacy_path(
+                    layout,
+                    asset,
+                    quarantine_absolute,
+                    "migration quarantine",
+                ) {
+                    Ok(LegacyAssetState::ExactKnown) => {}
+                    Ok(LegacyAssetState::Absent) => {
+                        let failure = anyhow::anyhow!(
+                            "migration quarantine disappeared after staging: {}",
+                            quarantine.display()
+                        );
+                        return Err(migration_failure_with_rollback(
+                            layout, &staged, rename, failure,
+                        ));
+                    }
+                    Err(error) => {
+                        return Err(migration_failure_with_rollback(
+                            layout, &staged, rename, error,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // All public legacy names are absent, but rollback is still possible. The
+    // fixed quarantines are not published by deletion until every canonical
+    // path and staged identity has passed a final complete preflight.
+    for asset in SYSTEM_ASSETS {
+        if let Err(error) = validate_canonical_asset(layout, asset) {
+            return Err(migration_failure_with_rollback(
+                layout, &staged, rename, error,
+            ));
+        }
+    }
+    for asset in &staged {
+        let absolute = asset.quarantine_path;
+        match inspect_known_legacy_path(layout, asset, absolute, "migration quarantine") {
+            Ok(LegacyAssetState::ExactKnown) => {}
+            Ok(LegacyAssetState::Absent) => {
+                let failure = anyhow::anyhow!(
+                    "migration quarantine disappeared before publication: {}",
+                    layout.path(absolute).display()
+                );
+                return Err(migration_failure_with_rollback(
+                    layout, &staged, rename, failure,
+                ));
+            }
+            Err(error) => {
+                return Err(migration_failure_with_rollback(
+                    layout, &staged, rename, error,
+                ));
+            }
+        }
+    }
+
+    let mut migrated = Vec::new();
+    for asset in &staged {
+        let quarantine = system_asset_quarantine_path(layout, asset);
+        fs::remove_file(&quarantine).with_context(|| {
+            format!(
+                "legacy names were retired, but failed to remove fixed migration quarantine {}",
+                quarantine.display()
+            )
+        })?;
+        migrated.push(layout.path(asset.legacy_path));
+    }
+
+    // The transaction cannot isolate a second root process. Never report a
+    // completed migration without rechecking canonical bytes and the trusted
+    // root-equivalent identity after quarantine publication.
+    for asset in SYSTEM_ASSETS {
+        validate_canonical_asset(layout, asset)?;
+    }
+    Ok(migrated)
+}
+
+fn validate_systemd_unit_resolution(snapshot: &str, expected: &Path) -> anyhow::Result<()> {
+    let mut fragment_path = None;
+    let mut drop_in_paths = None;
+    for line in snapshot.lines() {
+        if let Some(value) = line.strip_prefix("FragmentPath=") {
+            if fragment_path.replace(value).is_some() {
+                bail!("systemd returned FragmentPath more than once");
+            }
+        } else if let Some(value) = line.strip_prefix("DropInPaths=") {
+            if drop_in_paths.replace(value).is_some() {
+                bail!("systemd returned DropInPaths more than once");
+            }
+        } else {
+            bail!("systemd returned an unexpected unit-resolution field");
+        }
+    }
+
+    let fragment_path = fragment_path.context("systemd did not return FragmentPath")?;
+    let drop_in_paths = drop_in_paths.context("systemd did not return DropInPaths")?;
+    if Path::new(fragment_path) != expected {
+        bail!(
+            "systemd resolves facelock-daemon.service to {fragment_path}, not the package/source-owned {}",
+            expected.display()
+        );
+    }
+    if !drop_in_paths.is_empty() {
+        bail!("systemd applies non-package drop-ins to facelock-daemon.service: {drop_in_paths}");
+    }
+    Ok(())
+}
+
+fn validate_dbus_asset_resolution(layout: &SystemAssetLayout<'_>) -> anyhow::Result<Vec<PathBuf>> {
+    for asset in &SYSTEM_ASSETS[1..] {
+        validate_canonical_asset(layout, asset)?;
+    }
+
+    // Activation definitions are winner-selected by exact bus-name filename.
+    // Policy is not: every policy fragment is merged. The exact historical
+    // duplicate must be retired, while unrelated local policy is preserved and
+    // reported below rather than described as ineffective.
+    for shadow in [
+        "/etc/dbus-1/system-services/org.facelock.Daemon.service",
+        "/run/dbus-1/system-services/org.facelock.Daemon.service",
+        "/usr/local/share/dbus-1/system-services/org.facelock.Daemon.service",
+        "/etc/dbus-1/system.d/org.facelock.Daemon.conf",
+    ] {
+        let path = layout.path(shadow);
+        match fs::symlink_metadata(&path) {
+            Ok(_) => bail!(
+                "D-Bus activation is shadowed or the exact historical policy duplicate remains at {}; it was preserved",
+                path.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to inspect D-Bus shadow path {}", path.display())
+                });
+            }
+        }
+    }
+
+    let mut local_policy = Vec::new();
+    for absolute in ["/etc/dbus-1/system.conf", "/etc/dbus-1/system-local.conf"] {
+        let path = layout.path(absolute);
+        match fs::symlink_metadata(&path) {
+            Ok(_) => local_policy.push(path),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to inspect local D-Bus policy {}", path.display())
+                });
+            }
+        }
+    }
+
+    let fragment_dir = layout.path("/etc/dbus-1/system.d");
+    match fs::read_dir(&fragment_dir) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry.with_context(|| {
+                    format!(
+                        "failed to enumerate local D-Bus policy directory {}",
+                        fragment_dir.display()
+                    )
+                })?;
+                let path = entry.path();
+                if path
+                    .extension()
+                    .is_some_and(|extension| extension == "conf")
+                {
+                    local_policy.push(path);
+                }
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to enumerate local D-Bus policy directory {}",
+                    fragment_dir.display()
+                )
+            });
+        }
+    }
+    local_policy.sort();
+    local_policy.dedup();
+    Ok(local_policy)
+}
 
 fn check_systemd() -> anyhow::Result<()> {
     if !Path::new("/run/systemd/system").exists() {
@@ -3036,8 +3848,20 @@ fn check_root() -> anyhow::Result<()> {
     Ok(())
 }
 
+const PRIVILEGED_PATH: &str = "/usr/sbin:/usr/bin:/sbin:/bin";
+
+fn privileged_command(program: &str) -> Command {
+    let mut command = Command::new(program);
+    command.env("PATH", PRIVILEGED_PATH);
+    command
+}
+
 fn run_cmd(program: &str, args: &[&str]) -> anyhow::Result<()> {
-    let output = Command::new(program)
+    run_cmd_output(program, args).map(|_| ())
+}
+
+fn run_cmd_output(program: &str, args: &[&str]) -> anyhow::Result<String> {
+    let output = privileged_command(program)
         .args(args)
         .output()
         .with_context(|| format!("failed to execute {program}"))?;
@@ -3045,26 +3869,7 @@ fn run_cmd(program: &str, args: &[&str]) -> anyhow::Result<()> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("{program} {} failed: {stderr}", args.join(" "));
     }
-    Ok(())
-}
-
-fn refresh_legacy_copy_if_present(path: &Path, contents: &str, marker: &str) -> anyhow::Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let existing = fs::read_to_string(path)
-        .with_context(|| format!("failed to read existing legacy file {}", path.display()))?;
-    if !existing.contains(marker) {
-        return Ok(());
-    }
-
-    write_file(path, contents.as_bytes(), 0o644)
-        .with_context(|| format!("failed to refresh {}", path.display()))?;
-    Terminal.info(&SystemMessage::RefreshedLegacyFile {
-        path: path.display().to_string(),
-    });
-    Ok(())
+    String::from_utf8(output.stdout).with_context(|| format!("{program} returned non-UTF-8 output"))
 }
 
 pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
@@ -3076,64 +3881,41 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         run_cmd("systemctl", &["disable", "--now", "facelock-daemon"])?;
         Terminal.info(&SystemMessage::SystemdUnitsDisabled);
     } else {
-        Terminal.info(&SystemMessage::InstallingSystemdUnits);
-
-        // Install systemd service unit
-        let unit_dir = Path::new(SYSTEMD_UNIT_DIR);
-        fs::create_dir_all(unit_dir)
-            .with_context(|| format!("failed to create {SYSTEMD_UNIT_DIR}"))?;
-
-        let service_path = unit_dir.join(SERVICE_FILENAME);
-        write_file(&service_path, SERVICE_UNIT.as_bytes(), 0o644)
-            .with_context(|| format!("failed to write {}", service_path.display()))?;
-        Terminal.info(&SystemMessage::WroteFile {
-            path: service_path.display().to_string(),
-        });
-        refresh_legacy_copy_if_present(
-            Path::new(LEGACY_SYSTEMD_UNIT_PATH),
-            SERVICE_UNIT,
-            "ExecStart=/usr/bin/facelock daemon",
-        )?;
-
-        // Install D-Bus policy file
-        let conf_dir = Path::new(DBUS_SYSTEM_CONF_DIR);
-        fs::create_dir_all(conf_dir)
-            .with_context(|| format!("failed to create {DBUS_SYSTEM_CONF_DIR}"))?;
-
-        let policy_path = conf_dir.join(DBUS_POLICY_FILENAME);
-        write_file(&policy_path, DBUS_POLICY.as_bytes(), 0o644)
-            .with_context(|| format!("failed to write {}", policy_path.display()))?;
-        Terminal.info(&SystemMessage::WroteFile {
-            path: policy_path.display().to_string(),
-        });
-        refresh_legacy_copy_if_present(
-            Path::new(LEGACY_DBUS_SYSTEM_CONF_PATH),
-            DBUS_POLICY,
-            "org.facelock.Daemon",
-        )?;
-
-        // Install D-Bus activation service
-        let svc_dir = Path::new(DBUS_SYSTEM_SERVICES_DIR);
-        fs::create_dir_all(svc_dir)
-            .with_context(|| format!("failed to create {DBUS_SYSTEM_SERVICES_DIR}"))?;
-
-        let dbus_svc_path = svc_dir.join(DBUS_SERVICE_FILENAME);
-        write_file(&dbus_svc_path, DBUS_SERVICE.as_bytes(), 0o644)
-            .with_context(|| format!("failed to write {}", dbus_svc_path.display()))?;
-        Terminal.info(&SystemMessage::WroteFile {
-            path: dbus_svc_path.display().to_string(),
-        });
-        refresh_legacy_copy_if_present(
-            Path::new(LEGACY_DBUS_SYSTEM_SERVICE_PATH),
-            DBUS_SERVICE,
-            "org.facelock.Daemon",
-        )?;
+        Terminal.info(&SystemMessage::ValidatingSystemAssets);
+        let migrated = validate_and_migrate_system_assets(&SystemAssetLayout::production())?;
+        for path in migrated {
+            Terminal.info(&SystemMessage::RemovedLegacySystemAsset {
+                path: path.display().to_string(),
+            });
+        }
 
         run_cmd("systemctl", &["daemon-reload"])?;
         Terminal.info(&SystemMessage::SystemctlDaemonReloadDone);
 
+        let layout = SystemAssetLayout::production();
+        let resolution = run_cmd_output(
+            "systemctl",
+            &[
+                "show",
+                SERVICE_FILENAME,
+                "--property=FragmentPath",
+                "--property=DropInPaths",
+                "--no-pager",
+            ],
+        )?;
+        validate_systemd_unit_resolution(
+            &resolution,
+            &layout.path(SYSTEM_ASSETS[0].canonical_path),
+        )?;
+        for path in validate_dbus_asset_resolution(&layout)? {
+            Terminal.notice(&SystemMessage::PreservedLocalDbusPolicy {
+                path: path.display().to_string(),
+            });
+        }
+        Terminal.info(&SystemMessage::SystemAssetsValidated);
+
         // The bus half of the same reload. Until the bus re-reads the policy
-        // written above, nothing may own `org.facelock.Daemon` — the system
+        // validated above, nothing may own `org.facelock.Daemon` — the system
         // bus denies `own` by default and root is not exempt. Bus
         // implementations differ on whether they pick the directory up over
         // inotify, so ask; where it was unnecessary this is a no-op, and a
@@ -3153,6 +3935,677 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod system_asset_tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+    use std::path::{Path, PathBuf};
+
+    const STALE_KNOWN_UNIT: &str = r#"[Unit]
+Description=Facelock Face Authentication Daemon
+After=local-fs.target
+
+[Service]
+Type=dbus
+BusName=org.facelock.Daemon
+ExecStart=/usr/bin/facelock daemon
+StandardOutput=journal
+StandardError=journal
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=1024
+
+# Phase 1: Filesystem isolation
+ProtectSystem=strict
+# ProtectHome=yes also hides /run/user/, breaking desktop notifications
+# (daemon sends notify-send via runuser to /run/user/<uid>/bus).
+# Use InaccessiblePaths instead to protect /home and /root without
+# affecting /run/user/.
+InaccessiblePaths=/home /root
+ReadWritePaths=/var/lib/facelock /var/log/facelock
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+# Phase 2: Kernel hardening
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+# Phase 2.5: Device access
+# DevicePolicy=closed/auto both use cgroup device ACLs which hide /dev/video*
+# from stat(), breaking camera auto-detection. Omitted — the daemon only needs
+# /dev/video* and /dev/tpmrm0, both protected by standard Unix permissions.
+# ProtectSystem=strict already prevents writing to /dev/.
+
+# Deferred: MemoryDenyWriteExecute=yes breaks ONNX Runtime JIT.
+# Phase 3 (seccomp, capabilities, network) deferred to future work.
+
+[Install]
+WantedBy=multi-user.target
+"#;
+
+    fn rooted(root: &Path, absolute: &str) -> PathBuf {
+        root.join(absolute.trim_start_matches('/'))
+    }
+
+    fn identity() -> (u32, u32) {
+        // SAFETY: these process-identity queries have no preconditions.
+        unsafe { (libc::geteuid(), libc::getegid()) }
+    }
+
+    fn seed_canonical_assets(root: &Path) {
+        for asset in SYSTEM_ASSETS {
+            let path = rooted(root, asset.canonical_path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, asset.current).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+    }
+
+    fn snapshot_canonical_assets(root: &Path) -> BTreeMap<&'static str, (Vec<u8>, u32, u32, u32)> {
+        SYSTEM_ASSETS
+            .iter()
+            .map(|asset| {
+                let path = rooted(root, asset.canonical_path);
+                let metadata = fs::symlink_metadata(&path).unwrap();
+                (
+                    asset.canonical_path,
+                    (
+                        fs::read(path).unwrap(),
+                        metadata.uid(),
+                        metadata.gid(),
+                        metadata.mode() & 0o7777,
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn layout(root: &Path) -> SystemAssetLayout<'_> {
+        let (uid, gid) = identity();
+        SystemAssetLayout::new(root, uid, gid)
+    }
+
+    fn seed_current_legacy_assets(root: &Path) {
+        for asset in SYSTEM_ASSETS {
+            let legacy = rooted(root, asset.legacy_path);
+            fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            fs::write(legacy, asset.current).unwrap();
+        }
+    }
+
+    #[test]
+    fn legacy_allowlist_parser_rejects_malformed_duplicate_and_unknown_records() {
+        let parsed = parse_legacy_system_asset_hashes(LEGACY_SYSTEM_ASSET_HASHES).unwrap();
+        assert_eq!(parsed["systemd-unit"].len(), 9);
+        assert_eq!(parsed["dbus-policy"].len(), 4);
+        assert_eq!(parsed["dbus-activation"].len(), 1);
+        let lines: Vec<&str> = LEGACY_SYSTEM_ASSET_HASHES.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            let id = line.split_ascii_whitespace().next().unwrap_or_default();
+            let expected_path = match id {
+                "systemd-unit" => Some("systemd/facelock-daemon.service"),
+                "dbus-policy" => Some("dbus/org.facelock.Daemon.conf"),
+                "dbus-activation" => Some("dbus/org.facelock.Daemon.service"),
+                _ => None,
+            };
+            let Some(expected_path) = expected_path else {
+                continue;
+            };
+            let provenance = lines
+                .get(index.wrapping_sub(1))
+                .and_then(|line| line.trim().strip_prefix("# source "))
+                .unwrap_or_else(|| panic!("record line {} lacks provenance", index + 1));
+            let (commit, path) = provenance
+                .split_once(':')
+                .unwrap_or_else(|| panic!("invalid provenance at line {index}"));
+            assert_eq!(commit.len(), 40, "provenance line {index}");
+            assert!(commit.bytes().all(|byte| byte.is_ascii_hexdigit()));
+            assert_eq!(path, expected_path, "provenance line {index}");
+        }
+        assert_eq!(
+            sha256_hex(STALE_KNOWN_UNIT.as_bytes()),
+            "d66167d09f8ff8303e583566970dfb4202e8c781082702191ecf2dbf336971ce"
+        );
+
+        let valid =
+            "systemd-unit a5ea88523bd5dd952a620da43f5552c656d69544301db6f5eda892458ea2ea12\n";
+        for (label, manifest) in [
+            ("missing digest", "systemd-unit\n".to_string()),
+            ("short digest", "systemd-unit cafe\n".to_string()),
+            (
+                "non-hex digest",
+                format!("systemd-unit {}g\n", "a".repeat(63)),
+            ),
+            ("duplicate", format!("{valid}{valid}")),
+            (
+                "unknown id",
+                valid.replacen("systemd-unit", "unknown-asset", 1),
+            ),
+            (
+                "extra field",
+                valid.trim_end().to_string() + " unexpected\n",
+            ),
+        ] {
+            let error = parse_legacy_system_asset_hashes(&manifest)
+                .expect_err(label)
+                .to_string();
+            assert!(error.contains("line"), "{label}: {error}");
+        }
+    }
+
+    #[test]
+    fn systemd_resolution_requires_the_canonical_fragment_and_no_dropins() {
+        let canonical = "/usr/lib/systemd/system/facelock-daemon.service";
+        validate_systemd_unit_resolution(
+            "FragmentPath=/usr/lib/systemd/system/facelock-daemon.service\nDropInPaths=\n",
+            Path::new(canonical),
+        )
+        .unwrap();
+
+        for (label, snapshot) in [
+            (
+                "legacy fragment",
+                "FragmentPath=/etc/systemd/system/facelock-daemon.service\nDropInPaths=\n",
+            ),
+            (
+                "drop-in",
+                "FragmentPath=/usr/lib/systemd/system/facelock-daemon.service\nDropInPaths=/etc/systemd/system/facelock-daemon.service.d/admin.conf\n",
+            ),
+            (
+                "duplicate field",
+                "FragmentPath=/usr/lib/systemd/system/facelock-daemon.service\nFragmentPath=/usr/lib/systemd/system/facelock-daemon.service\nDropInPaths=\n",
+            ),
+            (
+                "missing field",
+                "FragmentPath=/usr/lib/systemd/system/facelock-daemon.service\n",
+            ),
+        ] {
+            let error = validate_systemd_unit_resolution(snapshot, Path::new(canonical))
+                .expect_err(label)
+                .to_string();
+            assert!(error.contains("systemd"), "{label}: {error}");
+        }
+    }
+
+    #[test]
+    fn dbus_policy_is_merged_while_activation_rejects_higher_priority_definitions() {
+        for shadow in [
+            "/run/dbus-1/system-services/org.facelock.Daemon.service",
+            "/usr/local/share/dbus-1/system-services/org.facelock.Daemon.service",
+            "/etc/dbus-1/system.d/org.facelock.Daemon.conf",
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            seed_canonical_assets(temp.path());
+            let shadow = rooted(temp.path(), shadow);
+            fs::create_dir_all(shadow.parent().unwrap()).unwrap();
+            let bytes = if shadow.extension().is_some_and(|value| value == "conf") {
+                DBUS_POLICY_BYTES
+            } else {
+                DBUS_SERVICE_BYTES
+            };
+            fs::write(&shadow, bytes).unwrap();
+
+            let error = validate_dbus_asset_resolution(&layout(temp.path()))
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(shadow.to_str().unwrap()), "{error}");
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        let local_fragment = rooted(temp.path(), "/etc/dbus-1/system.d/90-facelock-admin.conf");
+        let system_local = rooted(temp.path(), "/etc/dbus-1/system-local.conf");
+        fs::create_dir_all(local_fragment.parent().unwrap()).unwrap();
+        fs::write(&local_fragment, b"<busconfig/>\n").unwrap();
+        fs::write(&system_local, b"<busconfig/>\n").unwrap();
+
+        let reported = validate_dbus_asset_resolution(&layout(temp.path())).unwrap();
+        assert_eq!(reported, vec![system_local, local_fragment]);
+        for path in &reported {
+            assert_eq!(fs::read(path).unwrap(), b"<busconfig/>\n");
+        }
+    }
+
+    #[test]
+    fn exact_current_and_stale_known_legacy_copies_are_removed_without_touching_canonical_assets() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        let before = snapshot_canonical_assets(temp.path());
+
+        let current_policy = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+        fs::create_dir_all(current_policy.parent().unwrap()).unwrap();
+        fs::write(&current_policy, SYSTEM_ASSETS[1].current).unwrap();
+
+        let current_activation = rooted(temp.path(), SYSTEM_ASSETS[2].legacy_path);
+        fs::create_dir_all(current_activation.parent().unwrap()).unwrap();
+        fs::write(&current_activation, SYSTEM_ASSETS[2].current).unwrap();
+
+        let stale_unit = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        fs::create_dir_all(stale_unit.parent().unwrap()).unwrap();
+        fs::write(&stale_unit, STALE_KNOWN_UNIT.as_bytes()).unwrap();
+
+        let migrated = validate_and_migrate_system_assets(&layout(temp.path())).unwrap();
+
+        assert_eq!(migrated.len(), 3);
+        assert!(!stale_unit.exists());
+        assert!(!current_policy.exists());
+        assert!(!current_activation.exists());
+        assert_eq!(snapshot_canonical_assets(temp.path()), before);
+
+        assert!(
+            validate_and_migrate_system_assets(&layout(temp.path()))
+                .unwrap()
+                .is_empty(),
+            "a repeated setup is idempotent"
+        );
+        assert_eq!(snapshot_canonical_assets(temp.path()), before);
+    }
+
+    #[test]
+    fn ambiguous_legacy_copy_prevents_every_removal_and_is_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+
+        let exact = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        fs::create_dir_all(exact.parent().unwrap()).unwrap();
+        fs::write(&exact, SYSTEM_ASSETS[0].current).unwrap();
+
+        let modified = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+        fs::create_dir_all(modified.parent().unwrap()).unwrap();
+        fs::write(&modified, b"administrator policy\n").unwrap();
+
+        let error = validate_and_migrate_system_assets(&layout(temp.path()))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains(modified.to_str().unwrap()), "{error}");
+        assert!(error.contains("preserved"), "{error}");
+        assert_eq!(fs::read(exact).unwrap(), SYSTEM_ASSETS[0].current);
+        assert_eq!(fs::read(modified).unwrap(), b"administrator policy\n");
+    }
+
+    #[test]
+    fn symlinked_and_hardlinked_legacy_copies_are_preserved_and_rejected() {
+        for linked in ["symlink", "hardlink"] {
+            let temp = tempfile::tempdir().unwrap();
+            seed_canonical_assets(temp.path());
+            let legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+            fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            let outside = temp.path().join("outside-unit");
+            fs::write(&outside, SYSTEM_ASSETS[0].current).unwrap();
+            if linked == "symlink" {
+                symlink(&outside, &legacy).unwrap();
+            } else {
+                fs::hard_link(&outside, &legacy).unwrap();
+            }
+
+            let error = validate_and_migrate_system_assets(&layout(temp.path()))
+                .unwrap_err()
+                .to_string();
+
+            assert!(error.contains(legacy.to_str().unwrap()), "{error}");
+            assert!(fs::symlink_metadata(&legacy).is_ok());
+            assert_eq!(fs::read(&outside).unwrap(), SYSTEM_ASSETS[0].current);
+        }
+    }
+
+    #[test]
+    fn a_symlinked_legacy_parent_is_preserved_without_touching_its_target() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        let legacy = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+        let outside_dir = temp.path().join("outside-policy-dir");
+        let outside = outside_dir.join("org.facelock.Daemon.conf");
+        fs::create_dir_all(&outside_dir).unwrap();
+        fs::write(&outside, SYSTEM_ASSETS[1].current).unwrap();
+        fs::create_dir_all(legacy.parent().unwrap().parent().unwrap()).unwrap();
+        symlink(&outside_dir, legacy.parent().unwrap()).unwrap();
+
+        let error = validate_and_migrate_system_assets(&layout(temp.path()))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains(legacy.parent().unwrap().to_str().unwrap()));
+        assert_eq!(fs::read(outside).unwrap(), SYSTEM_ASSETS[1].current);
+    }
+
+    #[test]
+    fn invalid_canonical_asset_fails_before_an_exact_legacy_copy_is_removed() {
+        for failure in ["content", "mode"] {
+            let temp = tempfile::tempdir().unwrap();
+            seed_canonical_assets(temp.path());
+            let canonical = rooted(temp.path(), SYSTEM_ASSETS[0].canonical_path);
+            if failure == "content" {
+                fs::write(&canonical, b"stale package unit\n").unwrap();
+            } else {
+                fs::set_permissions(&canonical, fs::Permissions::from_mode(0o600)).unwrap();
+            }
+            let legacy = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+            fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            fs::write(&legacy, SYSTEM_ASSETS[1].current).unwrap();
+
+            let error = validate_and_migrate_system_assets(&layout(temp.path()))
+                .unwrap_err()
+                .to_string();
+
+            assert!(error.contains(canonical.to_str().unwrap()), "{error}");
+            assert!(legacy.exists(), "canonical preflight must precede removal");
+        }
+    }
+
+    #[test]
+    fn a_late_quarantine_failure_rolls_back_every_earlier_candidate() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let mut calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            calls += 1;
+            if calls == 2 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected second-stage failure",
+                ));
+            }
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("injected second-stage failure"), "{error}");
+        for asset in SYSTEM_ASSETS {
+            assert!(rooted(temp.path(), asset.legacy_path).is_file());
+            assert!(!system_asset_quarantine_path(&layout, asset).exists());
+        }
+    }
+
+    #[test]
+    fn a_late_revalidation_failure_also_rolls_back_earlier_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let later = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+        let mut calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_noreplace(source, target)?;
+            calls += 1;
+            if calls == 1 {
+                fs::write(&later, b"administrator changed policy\n").unwrap();
+            }
+            Ok(())
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("modified or unknown"), "{error}");
+        let first = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        assert!(first.is_file(), "the first candidate was not rolled back");
+        assert!(!system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]).exists());
+        assert_eq!(fs::read(later).unwrap(), b"administrator changed policy\n");
+    }
+
+    #[test]
+    fn quarantine_collision_is_a_whole_set_preflight_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let collision = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[1]);
+        fs::write(&collision, b"administrator collision sentinel\n").unwrap();
+        let mut rename_calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_calls += 1;
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(collision.to_str().unwrap()), "{error}");
+        assert_eq!(rename_calls, 0, "preflight must precede every mutation");
+        assert_eq!(
+            fs::read(collision).unwrap(),
+            b"administrator collision sentinel\n"
+        );
+        for asset in SYSTEM_ASSETS {
+            assert!(rooted(temp.path(), asset.legacy_path).is_file());
+        }
+    }
+
+    #[test]
+    fn exact_interrupted_staging_is_restored_before_migration_restarts() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        for asset in &SYSTEM_ASSETS[..2] {
+            rename_noreplace(
+                &rooted(temp.path(), asset.legacy_path),
+                &system_asset_quarantine_path(&layout, asset),
+            )
+            .unwrap();
+        }
+
+        let migrated = validate_and_migrate_system_assets(&layout).unwrap();
+
+        assert_eq!(migrated.len(), SYSTEM_ASSETS.len());
+        for asset in SYSTEM_ASSETS {
+            assert!(!rooted(temp.path(), asset.legacy_path).exists());
+            assert!(!system_asset_quarantine_path(&layout, asset).exists());
+        }
+    }
+
+    #[test]
+    fn interrupted_staging_recovery_preflights_every_peer_before_restoring() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let interrupted_legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        let interrupted_quarantine = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]);
+        rename_noreplace(&interrupted_legacy, &interrupted_quarantine).unwrap();
+        let ambiguous_peer = rooted(temp.path(), SYSTEM_ASSETS[1].legacy_path);
+        fs::write(&ambiguous_peer, b"administrator policy\n").unwrap();
+        let mut rename_calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_calls += 1;
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(ambiguous_peer.to_str().unwrap()), "{error}");
+        assert_eq!(rename_calls, 0, "recovery began before whole-set preflight");
+        assert!(!interrupted_legacy.exists());
+        assert_eq!(
+            fs::read(interrupted_quarantine).unwrap(),
+            SYSTEM_ASSETS[0].current
+        );
+        assert_eq!(fs::read(ambiguous_peer).unwrap(), b"administrator policy\n");
+    }
+
+    #[test]
+    fn dual_public_and_quarantine_names_are_preserved_as_ambiguous() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        let quarantine = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]);
+        fs::write(&quarantine, SYSTEM_ASSETS[0].current).unwrap();
+        let mut rename_calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_calls += 1;
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(quarantine.to_str().unwrap()), "{error}");
+        assert_eq!(rename_calls, 0);
+        assert_eq!(fs::read(legacy).unwrap(), SYSTEM_ASSETS[0].current);
+        assert_eq!(fs::read(quarantine).unwrap(), SYSTEM_ASSETS[0].current);
+    }
+
+    #[test]
+    fn absent_public_with_unknown_quarantine_is_not_recovered() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        let quarantine = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]);
+        rename_noreplace(&legacy, &quarantine).unwrap();
+        fs::write(&quarantine, b"unknown quarantine\n").unwrap();
+        let mut rename_calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_calls += 1;
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(quarantine.to_str().unwrap()), "{error}");
+        assert!(error.contains("modified or unknown"), "{error}");
+        assert_eq!(rename_calls, 0);
+        assert!(!legacy.exists());
+        assert_eq!(fs::read(quarantine).unwrap(), b"unknown quarantine\n");
+    }
+
+    #[test]
+    fn interrupted_staging_recovery_never_replaces_a_new_public_collision() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        let quarantine = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]);
+        rename_noreplace(&legacy, &quarantine).unwrap();
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            if source == quarantine && target == legacy {
+                fs::write(&legacy, b"administrator replacement\n").unwrap();
+            }
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("without replacement"), "{error}");
+        assert_eq!(fs::read(legacy).unwrap(), b"administrator replacement\n");
+        assert_eq!(fs::read(quarantine).unwrap(), SYSTEM_ASSETS[0].current);
+    }
+
+    #[test]
+    fn rollback_collision_preserves_both_names_and_reports_incomplete_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let first_legacy = rooted(temp.path(), SYSTEM_ASSETS[0].legacy_path);
+        let first_quarantine = system_asset_quarantine_path(&layout, &SYSTEM_ASSETS[0]);
+        let mut calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            calls += 1;
+            if calls == 2 {
+                fs::write(&first_legacy, b"administrator replacement\n").unwrap();
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "injected second-stage failure",
+                ));
+            }
+            rename_noreplace(source, target)
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("rollback was incomplete"), "{error}");
+        assert!(error.contains(first_legacy.to_str().unwrap()), "{error}");
+        assert_eq!(
+            fs::read(first_legacy).unwrap(),
+            b"administrator replacement\n"
+        );
+        assert_eq!(
+            fs::read(first_quarantine).unwrap(),
+            SYSTEM_ASSETS[0].current
+        );
+    }
+
+    #[test]
+    fn canonical_change_before_publication_rolls_back_every_quarantine() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        let layout = layout(temp.path());
+        let canonical = rooted(temp.path(), SYSTEM_ASSETS[0].canonical_path);
+        let mut calls = 0;
+
+        let error = validate_and_migrate_system_assets_with(&layout, &mut |source, target| {
+            rename_noreplace(source, target)?;
+            calls += 1;
+            if calls == SYSTEM_ASSETS.len() {
+                fs::write(&canonical, b"privileged concurrent replacement\n").unwrap();
+            }
+            Ok(())
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(canonical.to_str().unwrap()), "{error}");
+        for asset in SYSTEM_ASSETS {
+            assert!(rooted(temp.path(), asset.legacy_path).is_file());
+            assert!(!system_asset_quarantine_path(&layout, asset).exists());
+        }
+    }
+
+    #[test]
+    fn an_untrusted_layout_root_fails_before_every_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        seed_canonical_assets(temp.path());
+        seed_current_legacy_assets(temp.path());
+        fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o777)).unwrap();
+        let layout = layout(temp.path());
+
+        let error = validate_and_migrate_system_assets(&layout)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("layout root"), "{error}");
+        for asset in SYSTEM_ASSETS {
+            assert!(rooted(temp.path(), asset.legacy_path).is_file());
+        }
+    }
+
+    #[test]
+    fn kernel_quarantine_rename_never_replaces_a_collision() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("source");
+        let target = temp.path().join("target");
+        fs::write(&source, b"source bytes\n").unwrap();
+        fs::write(&target, b"collision bytes\n").unwrap();
+
+        let error = rename_noreplace(&source, &target).unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(libc::EEXIST));
+        assert_eq!(fs::read(source).unwrap(), b"source bytes\n");
+        assert_eq!(fs::read(target).unwrap(), b"collision bytes\n");
+    }
 }
 
 /// How long a base flow waits for a freshly installed daemon to answer.
@@ -3303,7 +4756,7 @@ fn daemon_unit_is_active() -> bool {
 /// as "cannot prove a restart happened" on the restart branch and ignores
 /// entirely on the start branch.
 fn daemon_main_pid() -> Option<u32> {
-    let out = Command::new("systemctl")
+    let out = privileged_command("systemctl")
         .args(["show", "-p", "MainPID", "--value", SERVICE_FILENAME])
         .output()
         .ok()?;
@@ -3981,6 +5434,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn privileged_commands_use_a_fixed_trusted_path() {
+        let command = privileged_command("systemctl");
+        let path = command
+            .get_envs()
+            .find(|(key, _)| *key == "PATH")
+            .and_then(|(_, value)| value);
+
+        assert_eq!(path, Some(std::ffi::OsStr::new(PRIVILEGED_PATH)));
+    }
+
+    #[test]
     fn parse_manifest() {
         let manifest: ModelManifest = toml::from_str(MANIFEST_TOML).unwrap();
         assert_eq!(manifest.models.len(), 4);
@@ -4225,8 +5689,14 @@ mod tests {
         assert!(validation.contains("db:Status-Status"));
         let rpm = fs::read_to_string(root.join("test/Containerfile.rpm-e2e")).unwrap();
         let deb = fs::read_to_string(root.join("test/Containerfile.deb-runtime")).unwrap();
-        assert!(deb.contains("/facelock-test-package.deb"));
-        assert!(deb.contains("apt-get install -y /facelock-test-package.deb"));
+        let deb_lifecycle = fs::read_to_string(root.join("test/deb-package-lifecycle.sh")).unwrap();
+        assert!(deb.contains("COPY test/deb-package-lifecycle.sh /deb-package-lifecycle.sh"));
+        assert!(!deb.contains("COPY facelock-test-package.deb"));
+        assert!(!deb.contains("apt-get install -y /facelock-test-package.deb"));
+        assert!(
+            deb_lifecycle
+                .contains("apt_transaction install -y --no-install-recommends \"$PACKAGE\"")
+        );
         assert!(rpm.contains("/facelock-test-package.rpm"));
     }
 

--- a/crates/facelock-cli/src/conformance/flags.rs
+++ b/crates/facelock-cli/src/conformance/flags.rs
@@ -1112,6 +1112,35 @@ fn pam_remove_keep_backup_is_an_explicit_opt_out() {
     }
 }
 
+/// Package removal gets one fixed-root, read-only probe instead of parsing
+/// pam-auth-update state in a maintainer script. It is deliberately a hidden
+/// internal surface and carries no file-selection or mutation flags.
+#[test]
+fn pam_shared_profile_status_is_a_read_only_internal_probe() {
+    let request = pam_request(&["shared-profile-status"]);
+    assert!(request.shared_profile_status);
+    assert_eq!(
+        request.action,
+        facelock_cli::commands::pam::PamAction::Status
+    );
+    assert!(request.services.is_empty());
+    assert!(!request.all);
+
+    for argv in [
+        &["facelock", "pam", "shared-profile-status", "--all"][..],
+        &[
+            "facelock",
+            "pam",
+            "shared-profile-status",
+            "--service",
+            "sudo",
+        ],
+        &["facelock", "pam", "shared-profile-status", "--dry-run"],
+    ] {
+        assert!(Cli::try_parse_from(argv).is_err(), "must reject {argv:?}");
+    }
+}
+
 /// `--all` is an enumerating flag for status and removal, takes no
 /// `--service`, and leaves both bare forms alone.
 ///

--- a/crates/facelock-cli/src/message/pam.rs
+++ b/crates/facelock-cli/src/message/pam.rs
@@ -205,6 +205,10 @@ pub enum PamMessage {
         paths: String,
         path: String,
     },
+    /// Debian's shared profile is already selected and live. A direct rule
+    /// would create two Facelock auth paths, so the refusal gives the exact
+    /// opt-in migration command and verification sequence.
+    PamAuthUpdateProfileActive,
     PamServiceAbsentSkipped {
         path: String,
     },
@@ -520,6 +524,9 @@ impl Message for PamMessage {
                 ),
                 &[("paths", paths.clone()), ("path", path.clone())],
             ),
+            PamAuthUpdateProfileActive => translate(
+                "Facelock's pam-auth-update profile is active; direct PAM edits would configure Facelock twice. To migrate, run `sudo pam-auth-update --disable facelock`, verify that a real correct password succeeds and a wrong password fails, then retry the original Facelock command with all of its services and flags.",
+            ),
             PamServiceAbsentSkipped { path } => fill(
                 translate("PAM service file absent: {path}. Nothing to add."),
                 &[("path", path.clone())],
@@ -590,7 +597,7 @@ impl Message for PamMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for PamMessage {
-    const VARIANT_COUNT: usize = 54;
+    const VARIANT_COUNT: usize = 55;
 
     fn samples() -> Vec<Self> {
         use PamMessage::*;
@@ -709,6 +716,7 @@ impl super::Samples for PamMessage {
                 paths: s("/lib/security/pam_facelock.so, /usr/lib64/security/pam_facelock.so"),
                 path: s("/lib/security/pam_facelock.so"),
             },
+            PamAuthUpdateProfileActive,
             PamServiceAbsentSkipped { path: s("/p") },
             PamPlanAdd {
                 path: s("/p"),

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -25,12 +25,13 @@ pub enum SystemMessage {
     // -- the legacy facelock system group (ADR 010) --
     RetiredFacelockGroup,
 
-    // -- installing and removing the unit files --
+    // -- validating installed assets and controlling the unit --
     DisablingSystemdUnits,
     SystemdUnitsDisabled,
-    InstallingSystemdUnits,
-    WroteFile { path: String },
-    RefreshedLegacyFile { path: String },
+    ValidatingSystemAssets,
+    RemovedLegacySystemAsset { path: String },
+    PreservedLocalDbusPolicy { path: String },
+    SystemAssetsValidated,
     SystemctlDaemonReloadDone,
     SystemctlEnableDone { unit: String },
     DbusActivationEnabled,
@@ -66,14 +67,20 @@ impl Message for SystemMessage {
             }
             DisablingSystemdUnits => translate("Disabling facelock-daemon systemd units..."),
             SystemdUnitsDisabled => translate("facelock-daemon service disabled and stopped."),
-            InstallingSystemdUnits => {
-                translate("Installing facelock-daemon systemd and D-Bus units...")
+            ValidatingSystemAssets => {
+                translate("Validating installed facelock-daemon systemd and D-Bus assets...")
             }
-            WroteFile { path } => fill(translate("  Wrote {path}"), &[("path", path.clone())]),
-            RefreshedLegacyFile { path } => fill(
-                translate("  Refreshed legacy {path}"),
+            RemovedLegacySystemAsset { path } => fill(
+                translate("  Removed exact known legacy {path}"),
                 &[("path", path.clone())],
             ),
+            PreservedLocalDbusPolicy { path } => fill(
+                translate(
+                    "  Preserved merged local D-Bus policy {path}; review it if Facelock bus authorization is unexpected.",
+                ),
+                &[("path", path.clone())],
+            ),
+            SystemAssetsValidated => translate("  Installed systemd and D-Bus assets validated."),
             SystemctlDaemonReloadDone => translate("  systemctl daemon-reload done."),
             SystemctlEnableDone { unit } => fill(
                 translate("  systemctl enable {unit} done."),
@@ -94,7 +101,7 @@ impl Message for SystemMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    const VARIANT_COUNT: usize = 17;
+    const VARIANT_COUNT: usize = 18;
 
     fn samples() -> Vec<Self> {
         use SystemMessage::*;
@@ -110,9 +117,10 @@ impl super::Samples for SystemMessage {
             RetiredFacelockGroup,
             DisablingSystemdUnits,
             SystemdUnitsDisabled,
-            InstallingSystemdUnits,
-            WroteFile { path: s("/p") },
-            RefreshedLegacyFile { path: s("/p") },
+            ValidatingSystemAssets,
+            RemovedLegacySystemAsset { path: s("/p") },
+            PreservedLocalDbusPolicy { path: s("/p") },
+            SystemAssetsValidated,
             SystemctlDaemonReloadDone,
             SystemctlEnableDone {
                 unit: s("u.service"),
@@ -142,22 +150,26 @@ mod tests {
             "facelock-daemon service disabled and stopped."
         );
         assert_eq!(
-            InstallingSystemdUnits.localized(),
-            "Installing facelock-daemon systemd and D-Bus units..."
+            ValidatingSystemAssets.localized(),
+            "Validating installed facelock-daemon systemd and D-Bus assets..."
         );
         assert_eq!(
-            WroteFile {
+            RemovedLegacySystemAsset {
                 path: "/etc/systemd/system/facelock-daemon.service".into()
             }
             .localized(),
-            "  Wrote /etc/systemd/system/facelock-daemon.service"
+            "  Removed exact known legacy /etc/systemd/system/facelock-daemon.service"
         );
         assert_eq!(
-            RefreshedLegacyFile {
-                path: "/usr/lib/systemd/system/facelock-daemon.service".into()
+            PreservedLocalDbusPolicy {
+                path: "/etc/dbus-1/system.d/90-facelock-admin.conf".into()
             }
             .localized(),
-            "  Refreshed legacy /usr/lib/systemd/system/facelock-daemon.service"
+            "  Preserved merged local D-Bus policy /etc/dbus-1/system.d/90-facelock-admin.conf; review it if Facelock bus authorization is unexpected."
+        );
+        assert_eq!(
+            SystemAssetsValidated.localized(),
+            "  Installed systemd and D-Bus assets validated."
         );
         assert_eq!(
             SystemctlDaemonReloadDone.localized(),

--- a/debian/postinst
+++ b/debian/postinst
@@ -49,13 +49,6 @@ case "$1" in
             systemctl daemon-reload 2>/dev/null || true
         fi
 
-        # A legacy copy in /etc/dbus-1/system.d is read after /usr/share and would
-        # re-deny Authenticate (last matching rule wins); refresh it if present.
-        if [ -f /etc/dbus-1/system.d/org.facelock.Daemon.conf ] && \
-           grep -q 'org.facelock.Daemon' /etc/dbus-1/system.d/org.facelock.Daemon.conf; then
-            install -Dm644 /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
-                /etc/dbus-1/system.d/org.facelock.Daemon.conf 2>/dev/null || true
-        fi
         # Bus policy may have changed (ADR 010); ask the bus to re-read it.
         dbus-send --system --type=method_call --dest=org.freedesktop.DBus \
             /org/freedesktop/DBus org.freedesktop.DBus.ReloadConfig 2>/dev/null || true

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,11 +3,10 @@ set -e
 
 case "$1" in
     configure)
-        systemd-tmpfiles --create 2>/dev/null || true
-
         # Modes for the current layout, mirroring dist/facelock.tmpfiles for
-        # hosts where tmpfiles did not run. Nothing here moves, creates, or
-        # deletes data; every line is idempotent.
+        # existing paths before compat 13's package-scoped dh_installtmpfiles
+        # generated maintainer-script block runs. Nothing here moves or deletes
+        # data; every line is idempotent.
         # State dir: traversable by everyone, listable by root only (ADR 010).
         chown root:root /var/lib/facelock 2>/dev/null || true
         chmod 711 /var/lib/facelock 2>/dev/null || true
@@ -60,6 +59,14 @@ case "$1" in
         # Bus policy may have changed (ADR 010); ask the bus to re-read it.
         dbus-send --system --type=method_call --dest=org.freedesktop.DBus \
             /org/freedesktop/DBus org.freedesktop.DBus.ReloadConfig 2>/dev/null || true
+
+        # Pick up the upgraded binary only when a daemon was already running.
+        # This includes D-Bus-activated instances while leaving fresh,
+        # disabled and inactive installs untouched.
+        if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+        fi
 
         # Register/update the packaged opt-in profile without selecting it.
         if [ -x /usr/sbin/pam-auth-update ]; then

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,23 +1,1352 @@
 #!/bin/sh
 set -e
 
+run_lifecycle_helper() {
+    facelock_helper_mode="$1"
+    facelock_prefix=""
+    facelock_trusted_uid=0
+    facelock_trusted_gid=0
+    facelock_mountinfo=/proc/self/mountinfo
+    facelock_max_depth=64
+    facelock_max_nodes=10000
+    facelock_renameat2_syscall=316
+    facelock_test_pause_root=""
+    facelock_test_pause_dir=""
+    facelock_test_pause_point=""
+    facelock_test_pause_logical=""
+
+    # Tests exercise the real maintainer script below disposable roots. The
+    # override is deliberately unavailable to a root caller, so a package
+    # transaction can never redirect its privileged cleanup through the
+    # environment.
+    if [ -n "${FACELOCK_PURGE_TEST_ROOT:-}" ]; then
+        facelock_effective_uid="$({
+            while read -r facelock_label _ facelock_seen_uid _; do
+                if [ "$facelock_label" = "Uid:" ]; then
+                    printf '%s\n' "$facelock_seen_uid"
+                    break
+                fi
+            done </proc/self/status
+        } 2>/dev/null)"
+        case "$facelock_effective_uid" in
+            ''|*[!0-9]*)
+                echo "facelock purge: cannot verify the maintainer-script uid" >&2
+                return 1
+                ;;
+        esac
+        if [ "$facelock_effective_uid" -eq 0 ]; then
+            echo "facelock purge: refusing a test root in a privileged maintainer script" >&2
+            return 1
+        fi
+        case "$FACELOCK_PURGE_TEST_ROOT" in
+            /*) facelock_prefix="$FACELOCK_PURGE_TEST_ROOT" ;;
+            *)
+                echo "facelock purge: test root must be absolute" >&2
+                return 1
+                ;;
+        esac
+        case "${FACELOCK_PURGE_TEST_UID:-}" in
+            ''|*[!0-9]*)
+                echo "facelock purge: invalid test uid" >&2
+                return 1
+                ;;
+            *) facelock_trusted_uid="$FACELOCK_PURGE_TEST_UID" ;;
+        esac
+        case "${FACELOCK_PURGE_TEST_GID:-}" in
+            ''|*[!0-9]*)
+                echo "facelock purge: invalid test gid" >&2
+                return 1
+                ;;
+            *) facelock_trusted_gid="$FACELOCK_PURGE_TEST_GID" ;;
+        esac
+        if [ -n "${FACELOCK_PURGE_TEST_MOUNTINFO:-}" ]; then
+            facelock_mountinfo="$FACELOCK_PURGE_TEST_MOUNTINFO"
+        fi
+        case "${FACELOCK_PURGE_TEST_MAX_DEPTH:-}" in
+            '') ;;
+            *[!0-9]*)
+                echo "facelock purge: invalid test depth limit" >&2
+                return 1
+                ;;
+            *) facelock_max_depth="$FACELOCK_PURGE_TEST_MAX_DEPTH" ;;
+        esac
+        case "${FACELOCK_PURGE_TEST_MAX_NODES:-}" in
+            '') ;;
+            0|*[!0-9]*)
+                echo "facelock purge: invalid test node limit" >&2
+                return 1
+                ;;
+            *) facelock_max_nodes="$FACELOCK_PURGE_TEST_MAX_NODES" ;;
+        esac
+        case "${FACELOCK_PURGE_TEST_RENAMEAT2_SYSCALL:-}" in
+            '') ;;
+            0|*[!0-9]*)
+                echo "facelock purge: invalid test renameat2 syscall" >&2
+                return 1
+                ;;
+            *) facelock_renameat2_syscall="$FACELOCK_PURGE_TEST_RENAMEAT2_SYSCALL" ;;
+        esac
+        if [ -n "${FACELOCK_PURGE_TEST_PAUSE_ROOT:-}" ]; then
+            case "${FACELOCK_PURGE_TEST_PAUSE_ROOT:-}" in
+                /etc/facelock|/var/lib/facelock|/var/log/facelock)
+                    facelock_test_pause_root="$FACELOCK_PURGE_TEST_PAUSE_ROOT"
+                    ;;
+                *)
+                    echo "facelock purge: invalid test pause root" >&2
+                    return 1
+                    ;;
+            esac
+            if [ -z "${FACELOCK_PURGE_TEST_PAUSE_DIR:-}" ]; then
+                echo "facelock purge: test pause root requires a control directory" >&2
+                return 1
+            fi
+        fi
+        if [ -n "${FACELOCK_PURGE_TEST_PAUSE_DIR:-}" ]; then
+            case "${FACELOCK_PURGE_TEST_PAUSE_DIR:-}" in
+                "$facelock_prefix"/*)
+                    facelock_test_pause_dir="$FACELOCK_PURGE_TEST_PAUSE_DIR"
+                    ;;
+                *)
+                    echo "facelock purge: invalid test pause directory" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        if [ -n "${FACELOCK_PURGE_TEST_PAUSE_POINT:-}${FACELOCK_PURGE_TEST_PAUSE_LOGICAL:-}" ]; then
+            case "${FACELOCK_PURGE_TEST_PAUSE_POINT:-}" in
+                before-config-open|before-regular-open|before-regular-quarantine|before-regular-quarantine-move|after-regular-quarantine|before-regular-restore-move|before-regular-delete|before-directory-quarantine|before-directory-quarantine-move|after-directory-quarantine|before-directory-restore-move|before-directory-delete)
+                    facelock_test_pause_point="$FACELOCK_PURGE_TEST_PAUSE_POINT"
+                    ;;
+                *)
+                    echo "facelock purge: invalid test pause point" >&2
+                    return 1
+                    ;;
+            esac
+            case "${FACELOCK_PURGE_TEST_PAUSE_LOGICAL:-}" in
+                /etc/facelock|/etc/facelock/*|/var/lib/facelock|/var/lib/facelock/*|/var/log/facelock|/var/log/facelock/*)
+                    case "$FACELOCK_PURGE_TEST_PAUSE_LOGICAL" in
+                        */../*|*/..|*/./*|*/.)
+                            echo "facelock purge: invalid test pause path" >&2
+                            return 1
+                            ;;
+                    esac
+                    facelock_test_pause_logical="$FACELOCK_PURGE_TEST_PAUSE_LOGICAL"
+                    ;;
+                *)
+                    echo "facelock purge: invalid test pause path" >&2
+                    return 1
+                    ;;
+            esac
+            if [ -z "$facelock_test_pause_dir" ]; then
+                echo "facelock purge: test pause point requires a control directory" >&2
+                return 1
+            fi
+        fi
+    fi
+
+    if [ ! -x /usr/bin/perl ]; then
+        echo "facelock purge: /usr/bin/perl is unavailable; retained state was not inspected" >&2
+        return 1
+    fi
+
+    /usr/bin/perl - \
+        "$facelock_helper_mode" \
+        "$facelock_prefix" \
+        "$facelock_trusted_uid" \
+        "$facelock_trusted_gid" \
+        "$facelock_mountinfo" \
+        "$facelock_max_depth" \
+        "$facelock_max_nodes" \
+        "$facelock_renameat2_syscall" \
+        "$facelock_test_pause_root" \
+        "$facelock_test_pause_dir" \
+        "$facelock_test_pause_point" \
+        "$facelock_test_pause_logical" <<'PERL'
+use strict;
+use warnings;
+use Config;
+use Errno qw(EEXIST ENOENT ENOSYS ENOTEMPTY);
+use Fcntl qw(:DEFAULT :mode O_DIRECTORY O_NOFOLLOW O_NONBLOCK);
+
+my (
+    $operation,
+    $prefix,
+    $trusted_uid,
+    $trusted_gid,
+    $mountinfo_path,
+    $max_depth,
+    $max_nodes,
+    $renameat2_syscall,
+    $test_pause_root,
+    $test_pause_dir,
+    $test_pause_point,
+    $test_pause_logical,
+) = @ARGV;
+my @logical_roots = (
+    '/etc/facelock',
+    '/var/lib/facelock',
+    '/var/log/facelock',
+);
+my %reported;
+my %protected;
+my %mountpoints;
+my %mount_ids;
+my $test_pause_done = 0;
+
+sub actual_path {
+    my ($logical) = @_;
+    return $prefix . $logical;
+}
+
+sub report_text {
+    my ($text) = @_;
+    $text =~ s/([\x00-\x1f\x7f-\x9f])/sprintf('\\x%02x', ord($1))/ge;
+    return $text;
+}
+
+sub report_remnant {
+    my ($logical, $reason) = @_;
+    $protected{$logical} = 1;
+    my $key = "remnant\0$logical";
+    return if $reported{$key}++;
+    print STDERR 'facelock purge: remnant retained: ', report_text($logical),
+        ' (', report_text($reason), ")\n";
+}
+
+sub report_external {
+    my ($field, $path) = @_;
+    my $key = "external\0$field\0$path";
+    return if $reported{$key}++;
+    print STDERR 'facelock purge: external remnant retained: ',
+        report_text($field), '=', report_text($path), "\n";
+}
+
+sub report_external_hardlink {
+    my ($logical, $reason) = @_;
+    my $key = "external-hardlink\0$logical";
+    return if $reported{$key}++;
+    print STDERR 'facelock purge: external hard-link remnant retained: ',
+        report_text($logical), ' (', report_text($reason), ")\n";
+}
+
+sub decode_mount_path {
+    my ($path) = @_;
+    $path =~ s/\\([0-7]{3})/chr(oct($1))/ge;
+    return $path;
+}
+
+sub load_mountpoints {
+    my $mountinfo;
+    if (!open($mountinfo, '<', $mountinfo_path)) {
+        print STDERR 'facelock purge: cannot read mount topology from ',
+            report_text($mountinfo_path), ": $!\n";
+        return 0;
+    }
+    while (my $line = <$mountinfo>) {
+        chomp $line;
+        my @fields = split(/ /, $line);
+        next if @fields < 6;
+        $mount_ids{$fields[0]} = 1 if $fields[0] =~ /\A[0-9]+\z/;
+        $mountpoints{decode_mount_path($fields[4])} = 1;
+    }
+    if (!close($mountinfo)) {
+        print STDERR 'facelock purge: cannot finish reading mount topology from ',
+            report_text($mountinfo_path), ": $!\n";
+        return 0;
+    }
+    return 1;
+}
+
+sub trusted_directory {
+    my (@st) = @_;
+    return S_ISDIR($st[2])
+        && $st[4] == $trusted_uid
+        && $st[5] == $trusted_gid
+        && ($st[2] & 0022) == 0;
+}
+
+sub direct_enrollment_marker {
+    my ($logical) = @_;
+    return $logical =~ m{\A/var/lib/facelock/enrolled/[^/]+\z};
+}
+
+sub trusted_regular {
+    my ($logical, @st) = @_;
+    return 0 if !S_ISREG($st[2]) || $st[3] != 1;
+    if (direct_enrollment_marker($logical)) {
+        return ($st[2] & 0077) == 0;
+    }
+    return $st[4] == $trusted_uid
+        && $st[5] == $trusted_gid
+        && ($st[2] & 0022) == 0;
+}
+
+sub same_identity {
+    my ($left, $right) = @_;
+    return $left->[0] == $right->[0]
+        && $left->[1] == $right->[1]
+        && $left->[2] == $right->[2]
+        && $left->[3] == $right->[3]
+        && $left->[4] == $right->[4]
+        && $left->[5] == $right->[5];
+}
+
+sub same_directory_identity {
+    my ($left, $right) = @_;
+    return $left->[0] == $right->[0]
+        && $left->[1] == $right->[1]
+        && $left->[2] == $right->[2]
+        && $left->[4] == $right->[4]
+        && $left->[5] == $right->[5];
+}
+
+sub normalize_absolute {
+    my ($path) = @_;
+    return undef if $path !~ m{\A/};
+    my @parts;
+    for my $part (split(m{/+}, $path)) {
+        next if $part eq '' || $part eq '.';
+        if ($part eq '..') {
+            pop @parts if @parts;
+            next;
+        }
+        push @parts, $part;
+    }
+    return '/' . join('/', @parts);
+}
+
+sub is_compiled_path {
+    my ($path) = @_;
+    my $normalized = normalize_absolute($path);
+    return 0 if !defined($normalized);
+    for my $root (@logical_roots) {
+        return 1 if $normalized eq $root;
+        return 1 if index($normalized, $root . '/') == 0;
+    }
+    return 0;
+}
+
+sub decode_basic_string {
+    my ($raw) = @_;
+    my $decoded = '';
+    while (length($raw)) {
+        my $char = substr($raw, 0, 1, '');
+        if ($char ne '\\') {
+            $decoded .= $char;
+            next;
+        }
+        return undef if !length($raw);
+        my $escape = substr($raw, 0, 1, '');
+        my %simple = (
+            'b' => "\x08", 't' => "\x09", 'n' => "\x0a",
+            'f' => "\x0c", 'r' => "\x0d", '"' => '"', '\\' => '\\',
+        );
+        if (exists($simple{$escape})) {
+            $decoded .= $simple{$escape};
+            next;
+        }
+        if ($escape eq 'u' || $escape eq 'U') {
+            my $digits = $escape eq 'u' ? 4 : 8;
+            return undef if length($raw) < $digits;
+            my $hex = substr($raw, 0, $digits, '');
+            return undef if $hex !~ /\A[0-9A-Fa-f]+\z/;
+            my $value = hex($hex);
+            return undef if $value > 0x10ffff || ($value >= 0xd800 && $value <= 0xdfff);
+            $decoded .= chr($value);
+            next;
+        }
+        return undef;
+    }
+    return $decoded;
+}
+
+sub parse_string_value {
+    my ($value) = @_;
+    $value =~ s/\A\s+//;
+    $value =~ s/\s+\z//;
+    if ($value =~ /\A'([^']*)'\s*(?:#.*)?\z/) {
+        return $1;
+    }
+    if ($value =~ /\A"((?:[^"\\]|\\.)*)"\s*(?:#.*)?\z/) {
+        return decode_basic_string($1);
+    }
+    return undef;
+}
+
+sub parse_key_path {
+    my ($raw) = @_;
+    my @parts;
+    $raw =~ s/\A\s+//;
+    $raw =~ s/\s+\z//;
+    while (length($raw)) {
+        my $part;
+        if ($raw =~ s/\A"((?:[^"\\]|\\.)*)"//) {
+            $part = decode_basic_string($1);
+            return () if !defined($part);
+        } elsif ($raw =~ s/\A'([^']*)'//) {
+            $part = $1;
+        } elsif ($raw =~ s/\A([A-Za-z0-9_-]+)//) {
+            $part = $1;
+        } else {
+            return ();
+        }
+        push @parts, $part;
+        $raw =~ s/\A\s+//;
+        return @parts if !length($raw);
+        return () if $raw !~ s/\A\.//;
+        $raw =~ s/\A\s+//;
+        return () if !length($raw);
+    }
+    return @parts;
+}
+
+sub report_unclassifiable_configuration {
+    my ($reason) = @_;
+    my $key = 'configuration-unclassifiable';
+    return if $reported{$key}++;
+    print STDERR 'facelock purge: configuration could not be fully classified: ',
+        report_text($reason), "\n";
+}
+
+sub multiline_delimiter {
+    my ($raw_value) = @_;
+    $raw_value =~ s/\A\s+//;
+    return "'''" if index($raw_value, "'''") == 0
+        && index(substr($raw_value, 3), "'''") < 0;
+    return '"""' if index($raw_value, '"""') == 0
+        && index(substr($raw_value, 3), '"""') < 0;
+    return undef;
+}
+
+sub descriptor_path {
+    my ($handle, $name) = @_;
+    my $fd = fileno($handle);
+    die 'descriptor unexpectedly closed' if !defined($fd);
+    my $path = "/proc/self/fd/$fd";
+    return $path if !defined($name);
+    die 'invalid directory entry name' if $name eq '.' || $name eq '..'
+        || $name =~ m{/} || index($name, "\0") >= 0;
+    return "$path/$name";
+}
+
+sub descriptor_mount_id {
+    my ($handle) = @_;
+    my $fd = fileno($handle);
+    return undef if !defined($fd);
+    my $fdinfo;
+    return undef if !open($fdinfo, '<', "/proc/self/fdinfo/$fd");
+    my $mount_id;
+    while (my $line = <$fdinfo>) {
+        if ($line =~ /\Amnt_id:\s*([0-9]+)\s*\z/) {
+            $mount_id = $1;
+            last;
+        }
+    }
+    return undef if !close($fdinfo);
+    return $mount_id;
+}
+
+sub mount_identity_is_current {
+    my ($mount_id) = @_;
+    return 0 if !defined($mount_id);
+    # Synthetic mountinfo fixtures name exact fake mountpoints but cannot alter
+    # the kernel mount ID of their disposable directories.
+    return 1 if length($prefix);
+    return $mount_ids{$mount_id};
+}
+
+sub open_fixed_root {
+    my ($logical) = @_;
+    my $base_path = length($prefix) ? $prefix : '/';
+    my @base_before = lstat($base_path);
+    if (!@base_before || S_ISLNK($base_before[2]) || !trusted_directory(@base_before)) {
+        report_remnant($logical, 'fixed traversal anchor is not a trusted directory');
+        return undef;
+    }
+    my $base;
+    if (!sysopen($base, $base_path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)) {
+        report_remnant($logical, "cannot open fixed traversal anchor: $!");
+        return undef;
+    }
+    my @base_opened = stat($base);
+    if (!@base_opened || !same_directory_identity(\@base_before, \@base_opened)) {
+        close($base);
+        report_remnant($logical, 'fixed traversal anchor changed while it was opened');
+        return undef;
+    }
+    my $base_mount_id = descriptor_mount_id($base);
+    if (!mount_identity_is_current($base_mount_id)) {
+        close($base);
+        report_remnant($logical, 'cannot prove fixed traversal anchor mount identity');
+        return undef;
+    }
+
+    my @held = ($base);
+    my @chain;
+    my $parent = $base;
+    my $parent_mount_id = $base_mount_id;
+    my $component_logical = '';
+    my @parts = grep { length($_) } split(m{/+}, $logical);
+    for my $index (0 .. $#parts) {
+        my $name = $parts[$index];
+        $component_logical .= "/$name";
+        my $anchored = descriptor_path($parent, $name);
+        my @before = lstat($anchored);
+        return undef if !@before && $! == ENOENT;
+        if (!@before) {
+            report_remnant($component_logical, "cannot inspect fixed path component: $!");
+            return undef;
+        }
+        if (S_ISLNK($before[2])) {
+            report_remnant($component_logical, 'fixed path component is a symbolic link');
+            return undef;
+        }
+        if (!trusted_directory(@before)) {
+            report_remnant($component_logical, 'fixed path component is not a trusted directory');
+            return undef;
+        }
+        my $child;
+        if (!sysopen($child, $anchored, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)) {
+            report_remnant($component_logical, "cannot open fixed path component: $!");
+            return undef;
+        }
+        my @opened = stat($child);
+        if (!@opened || !same_directory_identity(\@before, \@opened)) {
+            close($child);
+            report_remnant($component_logical, 'fixed path component changed while it was opened');
+            return undef;
+        }
+        my $mount_id = descriptor_mount_id($child);
+        if (!mount_identity_is_current($mount_id)) {
+            close($child);
+            report_remnant($component_logical, 'cannot prove fixed path component mount identity');
+            return undef;
+        }
+        if ($index == $#parts
+            && ($mount_id != $parent_mount_id || $mountpoints{actual_path($logical)})) {
+            close($child);
+            report_remnant($logical, 'root is a mount point');
+            return undef;
+        }
+        push @held, $child;
+        push @chain, {
+            parent => $parent,
+            handle => $child,
+            name => $name,
+            logical => $component_logical,
+            before => [@opened],
+            mount_id => $mount_id,
+        };
+        $parent = $child;
+        $parent_mount_id = $mount_id;
+    }
+
+    return {
+        held => \@held,
+        base_path => $base_path,
+        base_handle => $base,
+        base_before => [@base_opened],
+        base_mount_id => $base_mount_id,
+        chain => \@chain,
+        parent => $held[-2],
+        root => $held[-1],
+        name => $parts[-1],
+        before => [stat($held[-1])],
+        mount_id => $parent_mount_id,
+        dev => (stat($held[-1]))[0],
+        logical => $logical,
+    };
+}
+
+sub fixed_root_is_current {
+    my ($root, $logical) = @_;
+    my @base_public = lstat($root->{base_path});
+    my @base_opened = stat($root->{base_handle});
+    my $base_mount_id = descriptor_mount_id($root->{base_handle});
+    if (!@base_public || !@base_opened
+        || !same_directory_identity($root->{base_before}, \@base_public)
+        || !same_directory_identity($root->{base_before}, \@base_opened)
+        || !mount_identity_is_current($base_mount_id)
+        || $base_mount_id != $root->{base_mount_id}) {
+        report_remnant($logical, 'fixed traversal anchor changed before deletion');
+        return 0;
+    }
+
+    for my $entry (@{$root->{chain}}) {
+        my $anchored = descriptor_path($entry->{parent}, $entry->{name});
+        my @public = lstat($anchored);
+        my @opened = stat($entry->{handle});
+        if (!@public || !@opened
+            || !same_directory_identity($entry->{before}, \@public)
+            || !same_directory_identity($entry->{before}, \@opened)) {
+            report_remnant($logical, 'fixed path chain changed before deletion');
+            return 0;
+        }
+        my $current;
+        if (!sysopen($current, $anchored, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)) {
+            report_remnant($logical, 'fixed path chain cannot be reopened before deletion');
+            return 0;
+        }
+        my @current = stat($current);
+        my $mount_id = descriptor_mount_id($current);
+        my $valid = @current
+            && same_directory_identity($entry->{before}, \@current)
+            && mount_identity_is_current($mount_id)
+            && $mount_id == $entry->{mount_id};
+        close($current);
+        if (!$valid) {
+            report_remnant($logical, 'fixed path chain mount changed before deletion');
+            return 0;
+        }
+    }
+    return 1;
+}
+
+sub maybe_pause_after_root_open {
+    my ($logical) = @_;
+    return if $test_pause_done || !length($test_pause_dir) || $logical ne $test_pause_root;
+    $test_pause_done = 1;
+    my $ready;
+    sysopen($ready, "$test_pause_dir/ready", O_WRONLY | O_CREAT | O_EXCL, 0600)
+        or die "cannot create test pause marker: $!";
+    close($ready) or die "cannot close test pause marker: $!";
+    for (1 .. 1000) {
+        return if -e "$test_pause_dir/resume";
+        select(undef, undef, undef, 0.01);
+    }
+    die 'timed out waiting for test traversal resume';
+}
+
+sub maybe_pause_at_test_point {
+    my ($point, $logical) = @_;
+    return if $test_pause_done || !length($test_pause_dir)
+        || $point ne $test_pause_point || $logical ne $test_pause_logical;
+    $test_pause_done = 1;
+    my $ready;
+    sysopen($ready, "$test_pause_dir/ready", O_WRONLY | O_CREAT | O_EXCL, 0600)
+        or die "cannot create test pause marker: $!";
+    close($ready) or die "cannot close test pause marker: $!";
+    for (1 .. 1000) {
+        return if -e "$test_pause_dir/resume";
+        select(undef, undef, undef, 0.01);
+    }
+    die 'timed out waiting for test traversal resume';
+}
+
+sub opened_entry_is_on_root_mount {
+    my ($handle, $root, $logical) = @_;
+    my $mount_id = descriptor_mount_id($handle);
+    my @opened = stat($handle);
+    if (!@opened
+        || $opened[0] != $root->{dev}
+        || !mount_identity_is_current($mount_id)
+        || $mount_id != $root->{mount_id}
+        || $mountpoints{actual_path($logical)}) {
+        report_remnant($logical, 'mount boundary');
+        return 0;
+    }
+    return 1;
+}
+
+sub inspect_external_configuration {
+    my $root_logical = '/etc/facelock';
+    my $root = open_fixed_root($root_logical);
+    return if !defined($root);
+
+    my $logical = '/etc/facelock/config.toml';
+    my $anchored = descriptor_path($root->{root}, 'config.toml');
+    my @before = lstat($anchored);
+    return if !@before && $! == ENOENT;
+    if (!@before) {
+        report_remnant($logical, "cannot inspect configuration: $!");
+        return;
+    }
+    if (!trusted_regular($logical, @before) || $before[7] > 1024 * 1024) {
+        report_remnant($logical, 'configuration is not a trusted single-link regular file');
+        return;
+    }
+    my $config;
+    maybe_pause_at_test_point('before-config-open', $logical);
+    if (!sysopen($config, $anchored, O_RDONLY | O_NOFOLLOW | O_NONBLOCK)) {
+        report_remnant($logical, "cannot open configuration: $!");
+        return;
+    }
+    my @opened = stat($config);
+    if (!@opened || !same_identity(\@before, \@opened)) {
+        close($config);
+        report_remnant($logical, 'configuration changed while it was inspected');
+        return;
+    }
+    if (!opened_entry_is_on_root_mount($config, $root, $logical)) {
+        close($config);
+        return;
+    }
+
+    my %wanted = (
+        daemon => { model_dir => 1 },
+        storage => { db_path => 1 },
+        encryption => { key_path => 1, sealed_key_path => 1 },
+        audit => { path => 1 },
+        snapshots => { dir => 1 },
+    );
+    my $section = '';
+    my $multiline;
+    while (my $line = <$config>) {
+        $line =~ s/\r?\n\z//;
+        if (defined($multiline)) {
+            $multiline = undef if index($line, $multiline) >= 0;
+            next;
+        }
+        next if $line =~ /\A\s*(?:#|\z)/;
+        if ($line =~ /\A\s*\[(.*)\]\s*(?:#.*)?\z/) {
+            my @table_path = parse_key_path($1);
+            if (@table_path != 1) {
+                $section = undef;
+                report_unclassifiable_configuration('unsupported table syntax');
+                next;
+            }
+            $section = $table_path[0];
+            next;
+        }
+        if ($line !~ /\A\s*(.*?)\s*=\s*(.*)\z/) {
+            report_unclassifiable_configuration('unsupported statement syntax');
+            next;
+        }
+        my ($raw_key, $raw_value) = ($1, $2);
+        my @key_path = parse_key_path($raw_key);
+        if (!@key_path || @key_path > 2) {
+            report_unclassifiable_configuration('unsupported key syntax');
+            next;
+        }
+        my ($field_section, $key);
+        if (@key_path == 2) {
+            # TOML dotted keys are relative to the active table. Only a
+            # document-root pair can name one of the six supported fields.
+            next if !defined($section) || length($section);
+            ($field_section, $key) = @key_path;
+        } else {
+            next if !defined($section);
+            ($field_section, $key) = ($section, $key_path[0]);
+        }
+        my $delimiter = multiline_delimiter($raw_value);
+        if (defined($delimiter)) {
+            report_unclassifiable_configuration('multiline string value');
+            $multiline = $delimiter;
+            next;
+        }
+        if (@key_path == 1 && defined($section) && !length($section)
+            && exists($wanted{$key})) {
+            report_unclassifiable_configuration("inline $key configuration");
+            next;
+        }
+        next if !exists($wanted{$field_section}) || !$wanted{$field_section}{$key};
+        my $path = parse_string_value($raw_value);
+        if (!defined($path)) {
+            report_unclassifiable_configuration("unsupported $field_section.$key value");
+            next;
+        }
+        report_external("$field_section.$key", $path) if !is_compiled_path($path);
+    }
+    report_unclassifiable_configuration('unterminated multiline string') if defined($multiline);
+    if (!close($config)) {
+        report_remnant($logical, "cannot finish reading configuration: $!");
+    }
+}
+
+sub close_traversal_streams {
+    my ($stack) = @_;
+    for my $frame (reverse(@$stack)) {
+        closedir($frame->{stream}) if defined($frame->{stream});
+        $frame->{stream} = undef;
+    }
+}
+
+sub restore_quarantined_directory {
+    my ($parent, $source_name, $quarantine_name, $logical, $identity) = @_;
+    my $source_path = descriptor_path($parent, $source_name);
+    my $quarantine_path = descriptor_path($parent, $quarantine_name);
+    my $quarantine_logical = $logical;
+    $quarantine_logical =~ s{[^/]+\z}{$quarantine_name};
+
+    maybe_pause_at_test_point('before-directory-restore-move', $logical);
+    if (!rename_noreplace($parent, $quarantine_name, $source_name)) {
+        if ($! == EEXIST) {
+            report_remnant($logical, 'replacement appeared while the verified directory was quarantined');
+            report_remnant($quarantine_logical, 'quarantined directory retained for recovery');
+        } else {
+            report_remnant($quarantine_logical, "cannot restore quarantined directory atomically: $!");
+        }
+        return 0;
+    }
+    my @restored = lstat($source_path);
+    if (!@restored || !same_directory_identity($identity, \@restored)) {
+        report_remnant($logical, 'restored directory identity is ambiguous');
+        return 0;
+    }
+    report_remnant($logical, 'directory changed during quarantine and was restored');
+    return 1;
+}
+
+sub traversal_chain_is_current;
+
+sub finish_directory_frame {
+    my ($frame, $root) = @_;
+    if (!closedir($frame->{stream})) {
+        $frame->{stream} = undef;
+        report_remnant($frame->{logical}, "cannot finish reading directory: $!");
+        return 0;
+    }
+    $frame->{stream} = undef;
+    # Keep the three compiled roots themselves as inert empty anchors. Their
+    # parents are outside the purge boundary, so removing a root cannot use the
+    # same in-root quarantine transaction as descendant directories.
+    return fixed_root_is_current($root, $root->{logical}) if $frame->{depth} == 0;
+    # A refused child makes this directory a retained remnant. Do not move the
+    # administrator-visible path merely to discover that the quarantine is
+    # nonempty when rmdir is attempted.
+    return 0 if !$frame->{children_removed};
+
+    my @opened = stat($frame->{handle});
+    my @current = lstat(descriptor_path($frame->{parent}, $frame->{name}));
+    if (!@opened || !@current
+        || !same_directory_identity($frame->{before}, \@opened)
+        || !same_directory_identity($frame->{before}, \@current)) {
+        report_remnant($frame->{logical}, 'directory changed before removal');
+        return 0;
+    }
+    my @parent_chain = @{$frame->{path_chain}};
+    pop @parent_chain;
+    if (!fixed_root_is_current($root, $root->{logical})
+        || !traversal_chain_is_current(\@parent_chain, $frame->{logical})) {
+        return 0;
+    }
+    maybe_pause_at_test_point('before-directory-quarantine', $frame->{logical});
+    my $quarantine_name = quarantine_entry(
+        $frame->{parent}, $frame->{name}, $frame->{logical}, $frame->{before},
+        'before-directory-quarantine-move');
+    return 0 if !defined($quarantine_name);
+    my $source_path = descriptor_path($frame->{parent}, $frame->{name});
+    my $quarantine_path = descriptor_path($frame->{parent}, $quarantine_name);
+    my $quarantine_logical = $frame->{logical};
+    $quarantine_logical =~ s{[^/]+\z}{$quarantine_name};
+    maybe_pause_at_test_point('after-directory-quarantine', $frame->{logical});
+    my @quarantined = lstat($quarantine_path);
+    my $quarantined_handle;
+    my $quarantined_valid = @quarantined
+        && same_directory_identity($frame->{before}, \@quarantined)
+        && sysopen($quarantined_handle, $quarantine_path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if ($quarantined_valid) {
+        my @opened_quarantine = stat($quarantined_handle);
+        $quarantined_valid = @opened_quarantine
+            && same_directory_identity($frame->{before}, \@opened_quarantine)
+            && opened_entry_is_on_root_mount(
+                $quarantined_handle, $root, $quarantine_logical);
+    }
+    # The disposable-root fixture can force the recovery branch so it can
+    # exercise a public-name collision at the exact atomic restore boundary.
+    if (length($prefix)
+        && $test_pause_point eq 'before-directory-restore-move'
+        && $test_pause_logical eq $frame->{logical}) {
+        $quarantined_valid = 0;
+    }
+    if (!$quarantined_valid) {
+        close($quarantined_handle) if defined($quarantined_handle);
+        my @identity = @quarantined ? @quarantined : @{$frame->{before}};
+        restore_quarantined_directory(
+            $frame->{parent}, $frame->{name}, $quarantine_name,
+            $frame->{logical}, \@identity);
+        return 0;
+    }
+    if (!fixed_root_is_current($root, $root->{logical})
+        || !traversal_chain_is_current(\@parent_chain, $frame->{logical})) {
+        close($quarantined_handle);
+        restore_quarantined_directory(
+            $frame->{parent}, $frame->{name}, $quarantine_name,
+            $frame->{logical}, \@quarantined);
+        return 0;
+    }
+    my @final = lstat($quarantine_path);
+    if (!@final || !same_directory_identity($frame->{before}, \@final)) {
+        close($quarantined_handle);
+        restore_quarantined_directory(
+            $frame->{parent}, $frame->{name}, $quarantine_name,
+            $frame->{logical}, @final ? \@final : \@quarantined);
+        return 0;
+    }
+    maybe_pause_at_test_point('before-directory-delete', $frame->{logical});
+    if (!rmdir($quarantine_path)) {
+        my $removal_error = "$!";
+        my @retained = lstat($quarantine_path);
+        if (@retained
+            && same_directory_identity($frame->{before}, \@retained)) {
+            restore_quarantined_directory(
+                $frame->{parent}, $frame->{name}, $quarantine_name,
+                $frame->{logical}, \@retained);
+        } else {
+            report_remnant(
+                $quarantine_logical, "directory removal failed: $removal_error");
+        }
+        close($quarantined_handle);
+        return 0;
+    }
+    close($quarantined_handle);
+    return 1;
+}
+
+sub traversal_chain_is_current {
+    my ($chain, $logical) = @_;
+    for my $entry (@$chain) {
+        my $anchored = descriptor_path($entry->{parent}, $entry->{name});
+        my @current = lstat($anchored);
+        my @opened = stat($entry->{handle});
+        my $mount_id = descriptor_mount_id($entry->{handle});
+        if (!@current || !@opened
+            || !same_directory_identity($entry->{before}, \@current)
+            || !same_directory_identity($entry->{before}, \@opened)
+            || !mount_identity_is_current($mount_id)
+            || $mount_id != $entry->{mount_id}) {
+            report_remnant($logical, 'opened descendant path changed before deletion');
+            return 0;
+        }
+    }
+    return 1;
+}
+
+sub traversal_frame_is_current {
+    my ($frame, $logical) = @_;
+    return traversal_chain_is_current($frame->{path_chain}, $logical);
+}
+
+sub rename_noreplace {
+    my ($parent, $source_name, $destination_name) = @_;
+    # Facelock's supported Debian-family packages are Architecture: amd64.
+    # x86-64 assigns renameat2 syscall number 316; RENAME_NOREPLACE is 1.
+    # Fail closed rather than falling back to a check followed by plain rename.
+    if ($Config{archname} !~ /\Ax86_64-/) {
+        $! = ENOSYS;
+        return 0;
+    }
+    my $parent_fd = fileno($parent);
+    my $mutable_source = "$source_name";
+    my $mutable_destination = "$destination_name";
+    return syscall($renameat2_syscall, $parent_fd, $mutable_source,
+        $parent_fd, $mutable_destination, 1) == 0;
+}
+
+sub quarantine_entry {
+    my ($parent, $source_name, $logical, $before, $pause_point) = @_;
+    for my $attempt (0 .. 31) {
+        my $name = sprintf('.facelock-purge-%x-%x-%02x',
+            $before->[0], $before->[1], $attempt);
+        next if $name eq $source_name;
+        maybe_pause_at_test_point($pause_point, $logical);
+        return $name if rename_noreplace($parent, $source_name, $name);
+        if ($! == EEXIST) {
+            my $collision_logical = $logical;
+            $collision_logical =~ s{[^/]+\z}{$name};
+            report_remnant($collision_logical, 'quarantine name collision');
+            next;
+        }
+        report_remnant($logical, "cannot quarantine entry atomically: $!");
+        return undef;
+    }
+    report_remnant($logical, 'no collision-free quarantine name is available');
+    return undef;
+}
+
+sub restore_quarantined_entry {
+    my ($parent, $source_name, $quarantine_name, $logical, $identity) = @_;
+    my $source_path = descriptor_path($parent, $source_name);
+    my $quarantine_path = descriptor_path($parent, $quarantine_name);
+    my $quarantine_logical = $logical;
+    $quarantine_logical =~ s{[^/]+\z}{$quarantine_name};
+
+    maybe_pause_at_test_point('before-regular-restore-move', $logical);
+    if (!rename_noreplace($parent, $quarantine_name, $source_name)) {
+        if ($! == EEXIST) {
+            report_remnant($logical, 'replacement appeared while the verified entry was quarantined');
+            report_remnant($quarantine_logical, 'quarantined entry retained for recovery');
+        } else {
+            report_remnant($quarantine_logical, "cannot restore quarantined entry atomically: $!");
+        }
+        return 0;
+    }
+    my @restored = lstat($source_path);
+    if (!@restored || !same_identity($identity, \@restored)) {
+        report_remnant($logical, 'restored entry identity is ambiguous');
+        return 0;
+    }
+    report_remnant($logical, 'entry changed during quarantine and was restored');
+    return 1;
+}
+
+sub purge_regular_entry {
+    my ($frame, $name, $logical, $before, $root) = @_;
+    my $parent = $frame->{handle};
+    if ($before->[3] != 1) {
+        report_remnant($logical, 'hard-linked regular file');
+        return 0;
+    }
+    if (!trusted_regular($logical, @$before)) {
+        report_remnant($logical, 'wrong owner or unsafe mode');
+        return 0;
+    }
+    my $anchored = descriptor_path($parent, $name);
+    my $opened;
+    maybe_pause_at_test_point('before-regular-open', $logical);
+    if (!sysopen($opened, $anchored, O_RDONLY | O_NOFOLLOW | O_NONBLOCK)) {
+        report_remnant($logical, "cannot open regular file: $!");
+        return 0;
+    }
+    my @opened = stat($opened);
+    if (!@opened || !same_identity($before, \@opened)) {
+        close($opened);
+        report_remnant($logical, 'regular file changed while it was opened');
+        return 0;
+    }
+    if (!opened_entry_is_on_root_mount($opened, $root, $logical)) {
+        close($opened);
+        return 0;
+    }
+    my @current = lstat($anchored);
+    if (!@current || !same_identity($before, \@current)) {
+        close($opened);
+        report_remnant($logical, 'changed before unlink');
+        return 0;
+    }
+    if (!fixed_root_is_current($root, $root->{logical})
+        || !traversal_frame_is_current($frame, $logical)) {
+        close($opened);
+        return 0;
+    }
+    maybe_pause_at_test_point('before-regular-quarantine', $logical);
+    my $quarantine_name = quarantine_entry(
+        $parent, $name, $logical, $before, 'before-regular-quarantine-move');
+    if (!defined($quarantine_name)) {
+        close($opened);
+        return 0;
+    }
+    my $quarantine_path = descriptor_path($parent, $quarantine_name);
+    my $quarantine_logical = $frame->{logical} . '/' . $quarantine_name;
+    maybe_pause_at_test_point('after-regular-quarantine', $logical);
+    my @quarantined = lstat($quarantine_path);
+    my $quarantined_handle;
+    my $quarantined_valid = @quarantined
+        && same_identity($before, \@quarantined)
+        && sysopen($quarantined_handle, $quarantine_path,
+            O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+    if ($quarantined_valid) {
+        my @opened_quarantine = stat($quarantined_handle);
+        $quarantined_valid = @opened_quarantine
+            && same_identity($before, \@opened_quarantine)
+            && opened_entry_is_on_root_mount($quarantined_handle, $root, $quarantine_logical);
+    }
+    # See the directory branch above: production never forces recovery.
+    if (length($prefix)
+        && $test_pause_point eq 'before-regular-restore-move'
+        && $test_pause_logical eq $logical) {
+        $quarantined_valid = 0;
+    }
+    if (!$quarantined_valid) {
+        close($quarantined_handle) if defined($quarantined_handle);
+        my @identity = @quarantined ? @quarantined : @$before;
+        restore_quarantined_entry(
+            $parent, $name, $quarantine_name, $logical, \@identity);
+        close($opened);
+        return 0;
+    }
+    if (!fixed_root_is_current($root, $root->{logical})
+        || !traversal_frame_is_current($frame, $logical)) {
+        close($quarantined_handle);
+        restore_quarantined_entry(
+            $parent, $name, $quarantine_name, $logical, \@quarantined);
+        close($opened);
+        return 0;
+    }
+    my @final = lstat($quarantine_path);
+    if (!@final || !same_identity($before, \@final)) {
+        close($quarantined_handle);
+        restore_quarantined_entry(
+            $parent, $name, $quarantine_name, $logical,
+            @final ? \@final : \@quarantined);
+        close($opened);
+        return 0;
+    }
+    maybe_pause_at_test_point('before-regular-delete', $logical);
+    if (!unlink($quarantine_path)) {
+        my $unlink_error = "$!";
+        my @retained = lstat($quarantine_path);
+        if (@retained && same_identity($before, \@retained)) {
+            restore_quarantined_entry(
+                $parent, $name, $quarantine_name, $logical, \@retained);
+        } else {
+            report_remnant($quarantine_logical, "unlink failed: $unlink_error");
+        }
+        close($quarantined_handle);
+        close($opened);
+        return 0;
+    }
+    my @after_unlink = stat($quarantined_handle);
+    if (!@after_unlink || $after_unlink[3] != 0) {
+        report_external_hardlink(
+            $logical, 'inode remains linked after quarantine unlink');
+    }
+    close($quarantined_handle);
+    close($opened);
+    return 1;
+}
+
+sub purge_open_root {
+    my ($root, $logical) = @_;
+    maybe_pause_after_root_open($logical);
+    return 0 if !fixed_root_is_current($root, $logical);
+    my $stream;
+    if (!opendir($stream, descriptor_path($root->{root}))) {
+        report_remnant($logical, "cannot enumerate opened root: $!");
+        return 0;
+    }
+    my @stack = ({
+        handle => $root->{root},
+        stream => $stream,
+        parent => $root->{parent},
+        name => $root->{name},
+        logical => $logical,
+        before => $root->{before},
+        depth => 0,
+        children_removed => 1,
+        path_chain => [],
+    });
+    my $nodes_seen = 0;
+
+    while (@stack) {
+        my $frame = $stack[-1];
+        $! = 0;
+        my $name = readdir($frame->{stream});
+        if (!defined($name)) {
+            if ($!) {
+                report_remnant($frame->{logical}, "cannot continue reading directory: $!");
+                close_traversal_streams(\@stack);
+                return 0;
+            }
+            my $removed = finish_directory_frame($frame, $root);
+            pop @stack;
+            if (@stack && !$removed) {
+                $stack[-1]->{children_removed} = 0;
+            }
+            next;
+        }
+        next if $name eq '.' || $name eq '..';
+        my $child_logical = $frame->{logical} . '/' . $name;
+        if ($protected{$child_logical}) {
+            $frame->{children_removed} = 0;
+            next;
+        }
+        $nodes_seen++;
+        if ($nodes_seen > $max_nodes) {
+            # The unvisited entries are deliberately not enumerated once the
+            # ceiling is reached. Name the retained subtree that contains all
+            # of them rather than implying only this first unseen child
+            # remains.
+            report_remnant($logical, "node limit exceeded ($max_nodes)");
+            close_traversal_streams(\@stack);
+            return 0;
+        }
+
+        my $anchored = descriptor_path($frame->{handle}, $name);
+        my @before = lstat($anchored);
+        next if !@before && $! == ENOENT;
+        if (!@before) {
+            report_remnant($child_logical, "cannot inspect: $!");
+            $frame->{children_removed} = 0;
+            next;
+        }
+        # PAM rollback state is opaque to this self-contained postrm. Only an
+        # exact trusted empty directory is eligible for removal; every other
+        # object at the fixed path is unresolved cleanup evidence regardless
+        # of whether the generic traversal could otherwise delete its type.
+        if ($child_logical eq '/var/lib/facelock/pam-backups'
+            && !S_ISDIR($before[2])) {
+            report_remnant(
+                $child_logical,
+                'PAM rollback state path is not a trusted empty directory');
+            $frame->{children_removed} = 0;
+            next;
+        }
+        if (S_ISLNK($before[2])) {
+            report_remnant($child_logical, 'symbolic link');
+            $frame->{children_removed} = 0;
+            next;
+        }
+        if (S_ISREG($before[2])) {
+            $frame->{children_removed} = 0
+                if !purge_regular_entry(
+                    $frame, $name, $child_logical, \@before, $root);
+            next;
+        }
+        if (!S_ISDIR($before[2])) {
+            report_remnant($child_logical, 'non-regular object');
+            $frame->{children_removed} = 0;
+            next;
+        }
+        if (!trusted_directory(@before)) {
+            report_remnant($child_logical, 'wrong owner or unsafe directory mode');
+            $frame->{children_removed} = 0;
+            next;
+        }
+        my $child_depth = $frame->{depth} + 1;
+        if ($child_depth > $max_depth) {
+            report_remnant($child_logical, "depth limit exceeded ($max_depth)");
+            $frame->{children_removed} = 0;
+            next;
+        }
+        my $child;
+        if (!sysopen($child, $anchored, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)) {
+            report_remnant($child_logical, "cannot open directory: $!");
+            $frame->{children_removed} = 0;
+            next;
+        }
+        my @opened = stat($child);
+        if (!@opened || !same_directory_identity(\@before, \@opened)) {
+            close($child);
+            report_remnant($child_logical, 'directory changed while it was opened');
+            $frame->{children_removed} = 0;
+            next;
+        }
+        if (!opened_entry_is_on_root_mount($child, $root, $child_logical)) {
+            close($child);
+            $frame->{children_removed} = 0;
+            next;
+        }
+        my $child_stream;
+        if (!opendir($child_stream, descriptor_path($child))) {
+            close($child);
+            report_remnant($child_logical, "cannot enumerate directory: $!");
+            $frame->{children_removed} = 0;
+            next;
+        }
+        if ($child_logical eq '/var/lib/facelock/pam-backups') {
+            my $has_rollback_state = 0;
+            my $scan_failed = 0;
+            while (1) {
+                $! = 0;
+                my $rollback_name = readdir($child_stream);
+                if (!defined($rollback_name)) {
+                    $scan_failed = 1 if $!;
+                    last;
+                }
+                next if $rollback_name eq '.' || $rollback_name eq '..';
+                $has_rollback_state = 1;
+                last;
+            }
+            if ($scan_failed) {
+                report_remnant(
+                    $child_logical, "cannot inspect PAM rollback state: $!");
+                closedir($child_stream);
+                close($child);
+                $frame->{children_removed} = 0;
+                next;
+            }
+            if ($has_rollback_state) {
+                report_remnant(
+                    $child_logical,
+                    'PAM rollback state remains after removal cleanup');
+                closedir($child_stream);
+                close($child);
+                $frame->{children_removed} = 0;
+                next;
+            }
+            rewinddir($child_stream);
+        }
+        push @stack, {
+            handle => $child,
+            stream => $child_stream,
+            parent => $frame->{handle},
+            name => $name,
+            logical => $child_logical,
+            before => \@before,
+            depth => $child_depth,
+            children_removed => 1,
+            path_chain => [
+                @{$frame->{path_chain}},
+                {
+                    parent => $frame->{handle},
+                    handle => $child,
+                    name => $name,
+                    before => [@opened],
+                    mount_id => descriptor_mount_id($child),
+                },
+            ],
+        };
+    }
+    return 1;
+}
+
+sub purge_roots {
+    if (!load_mountpoints()) {
+        report_remnant($_, 'mount topology is unavailable') for @logical_roots;
+        return;
+    }
+    inspect_external_configuration();
+    for my $logical (@logical_roots) {
+        next if $protected{$logical};
+        my $root = open_fixed_root($logical);
+        next if !defined($root);
+        purge_open_root($root, $logical);
+    }
+}
+
+my $ok = eval {
+    if ($operation eq 'report') {
+        if (load_mountpoints()) {
+            inspect_external_configuration();
+        }
+    } elsif ($operation eq 'purge') {
+        purge_roots();
+    } else {
+        die "unknown lifecycle helper operation: $operation";
+    }
+    1;
+};
+if (!$ok) {
+    my $error = $@ || 'unknown helper error';
+    chomp $error;
+    print STDERR 'facelock purge: helper stopped after preserving every uncertain remnant: ',
+        report_text($error), "\n";
+}
+
+# A refusal must not keep dpkg in a permanently half-purged state.
+exit 0;
+PERL
+}
+
 case "$1" in
     remove)
+        if ! run_lifecycle_helper report; then
+            echo "facelock purge: external paths could not be classified; no retained state was removed" >&2
+        fi
         cat <<EOF
 
-facelock uninstalled. User data preserved at:
+Facelock's package payload was removed. Ordinary removal preserves user data at:
   /etc/facelock/      (config.toml, encryption.key.sealed, setup markers)
   /var/lib/facelock/  (face database, ONNX models)
   /var/log/facelock/  (audit logs and snapshots)
 
-Retained state cleanup is intentionally not automated.
+If package purge was requested, a later maintainer-script phase attempts the bounded cleanup described below.
+Ordinary removal does not automate retained-state cleanup.
 Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings.
 Filesystem deletion does not securely erase SSDs, snapshots, or backups.
 
 EOF
         ;;
 
-    purge|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    purge)
+        if ! run_lifecycle_helper purge; then
+            echo "facelock purge: bounded cleanup was unavailable; retained state remains" >&2
+        fi
+        ;;
+
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
         ;;
 
     *)

--- a/debian/prerm
+++ b/debian/prerm
@@ -3,16 +3,30 @@ set -e
 
 case "$1" in
     remove|purge)
-        # Stop and disable systemd units
-        if [ -d /run/systemd/system ]; then
-            systemctl stop facelock-daemon 2>/dev/null || true
-            systemctl disable facelock-daemon 2>/dev/null || true
-        fi
+        # Never guess why a legacy/shared profile is selected. No released
+        # package left durable proof that it auto-enabled the profile, so an
+        # active or inconsistent selection belongs to the administrator and
+        # package removal must not silently rewrite common-auth.
+        profile_status=0
+        facelock pam shared-profile-status >/dev/null || profile_status=$?
+        case "$profile_status" in
+            0)
+                echo "facelock: refusing package removal because the pam-auth-update profile is active." >&2
+                echo "To migrate safely, run 'sudo pam-auth-update --disable facelock', verify a real correct password succeeds and a wrong password fails, then retry package removal." >&2
+                exit 1
+                ;;
+            1)
+                ;;
+            *)
+                echo "facelock: refusing package removal because the pam-auth-update profile state could not be verified safely." >&2
+                exit 1
+                ;;
+        esac
 
-        # Remove the common-auth profile installed from debian/pam-auth-update.
-        if [ -x /usr/sbin/pam-auth-update ]; then
-            pam-auth-update --remove facelock 2>/dev/null || true
-        fi
+        # Complete the read-only preflight before any package lifecycle state
+        # changes. The real remove-all journals and rolls back the whole fixed
+        # root set on a later write or interruption failure.
+        facelock pam remove --all --dry-run
 
         # Scan the fixed PAM roots and atomically clean every Facelock-owned
         # direct edit. A non-zero result aborts dpkg before the module leaves.

--- a/debian/rules
+++ b/debian/rules
@@ -61,6 +61,16 @@ override_dh_auto_test:
 
 override_dh_installsystemd:
 	dh_installsystemd --no-enable --no-start
+	# Trixie's debhelper 13.24 suppresses its remove-only prerm stop when
+	# --no-start is set; Resolute's 13.31 emits it. Reuse debhelper's exact
+	# autoscript only when absent, so fresh installs remain inert and both
+	# suites produce one package-scoped stop in the generated maintscript.
+	grep -Fqs "deb-systemd-invoke stop 'facelock-daemon.service'" \
+		debian/facelock.prerm.debhelper \
+		debian/.debhelper/generated/facelock/prerm.* || \
+		sed "s/#UNITFILES#/'facelock-daemon.service'/" \
+			/usr/share/debhelper/autoscripts/prerm-systemd-restart \
+			>> debian/facelock.prerm.debhelper
 
 # Preserve the reviewed upstream ORT bytes and their matching checksum file.
 override_dh_strip:

--- a/dist/facelock.install
+++ b/dist/facelock.install
@@ -40,16 +40,9 @@ _facelock_retire_group() {
     return 0
 }
 
-# The bus policy may have changed (ADR 010). Refresh any legacy copy, then ask
-# the bus to re-read. Best-effort throughout.
-_facelock_refresh_bus_policy() {
-    # A legacy copy in /etc/dbus-1/system.d is read after /usr/share and would
-    # re-deny Authenticate (last matching rule wins); refresh it if present.
-    if [ -f /etc/dbus-1/system.d/org.facelock.Daemon.conf ] && \
-       grep -q 'org.facelock.Daemon' /etc/dbus-1/system.d/org.facelock.Daemon.conf; then
-        install -Dm644 /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
-            /etc/dbus-1/system.d/org.facelock.Daemon.conf 2>/dev/null || true
-    fi
+# The bus policy may have changed (ADR 010). Ask the bus to re-read the
+# package-owned policy without overwriting any legacy /etc copy.
+_facelock_reload_bus_policy() {
     # Both dbus-daemon and dbus-broker watch the policy directory, but a
     # running lock screen may call Authenticate before they notice — ask
     # explicitly.
@@ -62,7 +55,7 @@ post_install() {
     systemd-tmpfiles --create
     _facelock_secure_paths
     _facelock_retire_group
-    _facelock_refresh_bus_policy
+    _facelock_reload_bus_policy
 
     # Reload systemd for D-Bus activation
     systemctl daemon-reload 2>/dev/null || true
@@ -76,7 +69,7 @@ post_upgrade() {
     systemd-tmpfiles --create
     _facelock_secure_paths
     _facelock_retire_group
-    _facelock_refresh_bus_policy
+    _facelock_reload_bus_policy
 
     # Pick up unit changes before the restart below, not after. Without this,
     # `systemctl restart` re-runs the *cached* unit and every change the new

--- a/dist/facelock.spec
+++ b/dist/facelock.spec
@@ -138,13 +138,6 @@ FACELOCK_ORT_SMOKE_MODEL=%{_builddir}/ort-smoke-model.onnx \
 if getent group facelock >/dev/null 2>&1; then
     groupdel facelock 2>/dev/null || true
 fi
-# A legacy copy in /etc/dbus-1/system.d is read after /usr/share and would
-# re-deny Authenticate (last matching rule wins); refresh it if present.
-if [ -f /etc/dbus-1/system.d/org.facelock.Daemon.conf ] && \
-   grep -q 'org.facelock.Daemon' /etc/dbus-1/system.d/org.facelock.Daemon.conf; then
-    install -Dm644 %{_datadir}/dbus-1/system.d/org.facelock.Daemon.conf \
-        /etc/dbus-1/system.d/org.facelock.Daemon.conf 2>/dev/null || true
-fi
 # Bus policy may have changed (ADR 010); ask the bus to re-read it.
 dbus-send --system --type=method_call --dest=org.freedesktop.DBus \
     /org/freedesktop/DBus org.freedesktop.DBus.ReloadConfig 2>/dev/null || true

--- a/dist/legacy-system-assets.sha256
+++ b/dist/legacy-system-assets.sha256
@@ -1,0 +1,37 @@
+# Exact Facelock system assets that repository setup/install code has shipped.
+#
+# Format: <asset-id> <sha256>.  setup.rs embeds this file and the source-install
+# migration reads it directly.  Add a digest only after reviewing the exact
+# historical bytes; marker, substring, and filename matches are intentionally
+# insufficient authority to delete an administrator-owned /etc override.
+
+# source 096931a45a5354970230ae4676ff06ecfe3671a7:systemd/facelock-daemon.service
+systemd-unit a5ea88523bd5dd952a620da43f5552c656d69544301db6f5eda892458ea2ea12
+# source 1470beb178a7bb983633a17905b95456b1b7e01f:systemd/facelock-daemon.service
+systemd-unit 92bd0768e83dff6975a3cd694a38c6cc16b4f2b3c17db433d20821cff6458e58
+# source dab45cdebe66919469f2d5cf81dc101ad617a561:systemd/facelock-daemon.service
+systemd-unit da291c66f41eebb33bd283b3ba832644a9ec2461275f1dda9cac46bf85c15c3f
+# source debc603cde6d870b69a3272623d4e9f0187cb4d7:systemd/facelock-daemon.service
+systemd-unit afb4fa589d2c26f06c7d6d11a67056198e8ff9eb1f9427ff35f48b9dd146e69a
+# source e006edc2d694a10e0b23d3f55bd78d02b9b5defc:systemd/facelock-daemon.service
+systemd-unit 5ae6a063fcefe9654078b8fc413291efea22980a82cea08a489c1c26405ec295
+# source c64b10f3b85683c12c7c12c5849f311402e6ce61:systemd/facelock-daemon.service
+systemd-unit 7544af14679278e404d54858fc84ba7616f20c6f1266e4e2d45eef8cd0c2c4b6
+# source 610c201a8cf21afe488eb6faaf14b77effa4a606:systemd/facelock-daemon.service
+systemd-unit dffe34d055857fd69150ced81f0d7fccad87060ae2318ee9f3ddcafcf48cf5a1
+# source 1d684ca528820c4da429f67862943330ccf13194:systemd/facelock-daemon.service
+systemd-unit 39438bae0d97852faeb95964006b8efc3ed658648e4a7ab9a4fdb33a175a5bfe
+# source 04ec3efe2decf6f7c2dd7a20d20d6f5d4aa5e190:systemd/facelock-daemon.service
+systemd-unit d66167d09f8ff8303e583566970dfb4202e8c781082702191ecf2dbf336971ce
+
+# source a0102318ff8a19aef8cad529e1b937ce69520186:dbus/org.facelock.Daemon.conf
+dbus-policy 39b42dabbadb3e22de4d0edc7614dfb91bc901819b9871423f45d8c3aae2f223
+# source f293b3e0a31fe5eb4ed7503ec4b5fcc74d31912d:dbus/org.facelock.Daemon.conf
+dbus-policy 6c44d14b1d7ba3e02021b101712ce0050a42347dbb1556ac63492916bd24c0a7
+# source 39ecc15b7718b181c85d6f490f5ea4f97d68ec39:dbus/org.facelock.Daemon.conf
+dbus-policy 31f6792628375aeb69d631de75e997574b480ca0610f4169c3db23865be34e5f
+# source 04ec3efe2decf6f7c2dd7a20d20d6f5d4aa5e190:dbus/org.facelock.Daemon.conf
+dbus-policy f046a97378b006122b71069fa831b983e293e3fdfec2d44edbdfa67ec0211e7c
+
+# source 04ec3efe2decf6f7c2dd7a20d20d6f5d4aa5e190:dbus/org.facelock.Daemon.service
+dbus-activation ed5ab678c401a4fe61c06fda3f31246a61fd4ce30b7add75bee671977260b9ee

--- a/docs/adr/009-cli-verb-noun-shape.md
+++ b/docs/adr/009-cli-verb-noun-shape.md
@@ -148,11 +148,15 @@ The two Omarchy rows record package-owned prototypes that existed when this ADR
 was accepted. Issue #173 later retired them; the rows are historical evidence,
 not current callers or shipped integration points.
 
+The `ExecStart=...` marker row is historical for the same reason. Issue #228
+replaced marker-based refresh with an exact historical-byte allowlist and made
+setup validate, rather than write, package-owned assets.
+
 | Invocation | Caller |
 |---|---|
 | `facelock auth --user X --config Y` | `pam_facelock.so`, pinned by `legacy_invocations_still_parse` |
 | `facelock daemon` | `systemd/facelock-daemon.service`, `dist/nix/module.nix`, `dist/s6/facelock-daemon/run`, `dist/runit/run`, and a `justfile` check that greps the unit for that exact string |
-| `ExecStart=/usr/bin/facelock daemon`, as a hard-coded literal | `commands::setup::run_systemd` passes it to `refresh_legacy_copy_if_present` as the marker deciding whether the unit at `/etc/systemd/system/facelock-daemon.service` is facelock's and should be refreshed. A rename makes the marker stop matching **silently**: the legacy unit is left stale and nothing fails to compile |
+| `ExecStart=/usr/bin/facelock daemon`, as a then-hard-coded literal | `commands::setup::run_systemd` passed it to the retired marker-based legacy refresh. Issue #228 removed that coupling; the row records why substring authority was unsafe |
 | `facelock setup --non-interactive`, `facelock devices`, `facelock enroll`, `facelock hyprlock enable`, `facelock test` | then-shipped Omarchy setup prototype (retired by #173) |
 | `facelock hyprlock disable`, `facelock setup --pam --service X --remove --yes` | then-shipped Omarchy removal prototype (retired by #173) |
 | `facelock is-enrolled`, `facelock pam status`, `facelock capabilities` | lock screens and wrapper scripts, per `docs/contracts.md` §CLI Subcommands |
@@ -235,8 +239,7 @@ enum, so rebasing under them costs more than waiting.
 - `crates/facelock-cli/src/main.rs`: `Cli`, `Commands`, `SHORT_REGISTRY`,
   `JSON_COMMANDS`, `cli_flag_conformance`, `legacy_invocations_still_parse`,
   `capability_names_are_all_implemented`
-- `crates/facelock-cli/src/commands/setup.rs`: `run_systemd`,
-  `refresh_legacy_copy_if_present`
+- `crates/facelock-cli/src/commands/setup.rs`: `run_systemd`
 - `docs/contracts.md` §CLI Subcommands, §CLI Flag Spelling, §CLI Privilege
   Model (DEC-6); `docs/releasing.md` pre-1.0 versioning contract
 - [ADR 004](004-tpm-encryption.md): software AES with optional TPM key sealing

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,7 @@ that once.
 ```bash
 facelock setup                          # interactive wizard
 facelock setup --non-interactive        # base setup, no prompts, no PAM/systemd/enroll
-facelock setup --systemd                # install systemd units
+facelock setup --systemd                # validate installed assets, reload and enable
 facelock setup --systemd --disable      # disable systemd units
 facelock setup --pam                    # install to /etc/pam.d/sudo
 facelock setup --pam --service polkit-1 # install to a specific service
@@ -170,7 +170,7 @@ forcing the step, so it runs unattended.
 | `--remove` | `--pam` | Remove the facelock PAM line instead of adding it. |
 | `--if-present` | `--pam` | Treat an absent service file as success rather than an error, on the add side as well as `--remove`. Read, parse and write failures stay fatal. Without it, a service that is not there is a hard error. |
 | `--allow-sensitive` | `--pam` add | Explicitly authorize adding Facelock to `common-auth`, `login`, `password-auth`, `password-auth-ac`, `sshd`, `system-auth`, `system-auth-ac`, or `system-login`. Does not suppress the confirmation prompt and conflicts with `--remove`. |
-| `--disable` | `--systemd` | Disable and stop the units instead of installing them. |
+| `--disable` | `--systemd` | Disable and stop the units without changing installed assets. |
 
 The parser enforces these, so `facelock setup --remove` is an error naming the
 missing `--pam` rather than a silently ignored flag.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -684,6 +684,21 @@ answered — no TTY on stdin, no TTY on stderr (where the prompt is drawn, so
 `2>install.log` counts), or `--json` — and the gate is decided before any
 prompt exists, so an unattended `pam add --service system-auth` still refuses.
 
+On Debian and Ubuntu, a selected packaged `pam-auth-update` profile is already
+one Facelock auth path. Before planning any direct add (including
+`setup --pam`), Facelock verifies the exact fixed-root profile, saved selection
+and live Primary block without following links. It refuses a duplicate with:
+`sudo pam-auth-update --disable facelock`, verify a real correct password
+succeeds and a wrong password fails, then retry the original Facelock command
+with all of its services and flags.
+Any disagreement between the saved selection and live graph, or untrusted
+state, also refuses without writing PAM or backup state.
+
+`facelock pam shared-profile-status` is an internal, read-only Debian package
+maintainer probe. It exits 0 only for that exact active profile, 1 when the
+profile is cleanly unselected, and 2 for untrusted or inconsistent state; it
+never changes PAM or backup state.
+
 Any symlinked service file is refused rather than written through: on an
 authselect system `system-auth` and `password-auth` link into generated state,
 and even an in-directory link would make a recorded service name resolve to a
@@ -801,9 +816,18 @@ packages also ship a Remove-only libalpm `PreTransaction` hook with
 `AbortOnFail`, so pacman stops before removing either file.
 This all-or-nothing promise covers direct PAM edits owned by this command.
 The packaged Debian `pam-auth-update` profile is opt-in (`Default: no`), so
-fresh installation leaves `common-auth` unchanged. Its separately managed
-profile lifecycle and byte-exact rollback are tracked in #224; the current
-`prerm` removes that profile before calling the shared direct-edit cleanup.
+fresh installation leaves `common-auth` unchanged. Package removal never
+silently disables a selected profile: it probes first and aborts with the
+package, module, PAM graph, direct edits and daemon state retained. Run
+`sudo pam-auth-update --disable facelock`, prove a real correct password
+succeeds and a wrong password fails, then retry removal. No older package
+persisted evidence distinguishing auto-enable from a later administrator
+choice, so every existing selection is preserved; automatic legacy migration
+is intentionally deferred. With the profile unselected, removal performs a
+read-only direct-cleanup preflight and the journaled cleanup before generated
+service lifecycle handling. Ordinary removal stops the daemon but preserves
+its enabled state for reinstall; only purge retires that state. The inert
+profile metadata leaves with the package without a generated-graph transition.
 Fedora #226 retired the packaged authselect profile and added a read-only
 upgrade guard. This command only detects references in generated
 `/etc/authselect` state and never changes that state.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -12,10 +12,15 @@
 
 ## Tested Distributions
 
+Debian-family support starts at Debian 13+ and Ubuntu 26.04+; older Debian and
+Ubuntu releases are unsupported.
+
 | Distribution | Init System | Mode | Status |
 |-------------|-------------|------|--------|
 | Arch Linux | systemd | daemon + D-Bus activation | Primary target |
 | Arch Linux | systemd | oneshot | Tested |
+| Debian 13 (Trixie) | systemd | daemon + D-Bus activation | Booted package gate |
+| Ubuntu 26.04 LTS (Resolute) | systemd | daemon + D-Bus activation | Booted package gate |
 | Container (Arch) | none | daemon (manual) | CI-tested |
 | Container (Arch) | none | oneshot | CI-tested |
 
@@ -24,8 +29,6 @@
 | Distribution | Init System | Mode |
 |-------------|-------------|------|
 | Fedora 38+ | systemd | daemon + D-Bus activation |
-| Ubuntu 26.04+ | systemd | daemon + D-Bus activation |
-| Debian 13+ | systemd | daemon + D-Bus activation |
 | Any Linux | any / none | oneshot |
 | Void Linux | runit | oneshot or manual daemon |
 | Alpine Linux | OpenRC | oneshot or manual daemon |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -12,8 +12,8 @@
 
 ## Tested Distributions
 
-Debian-family support starts at Debian 13+ and Ubuntu 26.04+; older Debian and
-Ubuntu releases are unsupported.
+Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
+LTS (Resolute). Other Debian and Ubuntu releases are unsupported.
 
 | Distribution | Init System | Mode | Status |
 |-------------|-------------|------|--------|

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -376,8 +376,20 @@ nothing.
 **Managed shared stacks are not leaf services.** Debian and Ubuntu compose
 their shared stacks with `pam-auth-update`; Fedora and RHEL use `authselect`.
 Facelock does not write through either manager's generated shared files.
-Explicit named leaf services remain supported on every package family: the
-writer resolves and edits only that requested service under the fixed PAM
+Before any direct `pam add` or `setup --pam` plan, Debian's detector reads only
+the compiled `/usr/share/pam-configs/facelock`, `/var/lib/pam/auth`, and
+`/etc/pam.d/common-auth` locations. It requires root-owned, non-writable,
+regular single-link files opened beneath no-follow directory descriptors, the
+exact packaged profile bytes, an exact `Module: facelock` selection, and a live
+Facelock rule inside pam-auth-update's Primary block. An active profile refuses
+the direct edit before backup state is created and says exactly how to run
+`sudo pam-auth-update --disable facelock`, verify password authentication, and
+retry the original Facelock command with all services and flags intact.
+Selected-but-inconsistent or untrusted state fails closed rather than being
+treated as inactive. A live managed rule whose saved selection is absent fails
+closed as well. The roots are not configurable and the environment cannot
+redirect them. Explicit named leaf services remain supported on every package
+family: the writer resolves and edits only that requested service under the PAM
 roots, while the sensitive-service gate and no-follow checks refuse generated
 `system-auth` and `password-auth` links.
 
@@ -1014,14 +1026,35 @@ Omarchy removal stop before their deletes. The module can be removed only
 after the cleanup's final compiled-root scan succeeds.
 
 The all-or-nothing guarantee covers direct PAM edits owned and scanned by this
-transaction and retention of the package/module when that cleanup fails. It
-does not cover every package-manager or profile side effect. Debian `prerm`
-currently invokes tolerant `pam-auth-update --remove facelock` before shared
-cleanup; byte-exact profile lifecycle and rollback are #224 scope. Fedora is
-separate: #226 owns only RPM payload retirement and the read-only upgrade guard.
+transaction and retention of the package/module when that cleanup fails.
+Debian removal adds a read-only boundary before it: the exact shared-profile
+probe runs first, followed by `pam remove --all --dry-run`, then the journaled
+real cleanup, and only then the generated ordinary-removal service stop.
+Ordinary removal preserves the unit's enabled state for reinstall; the
+generated purge path alone retires that state. A selected Facelock
+`pam-auth-update` profile blocks removal without changing `common-auth`, its
+selection state, direct edits, the service, the binary, or the PAM module. The
+diagnostic tells the administrator to run
+`sudo pam-auth-update --disable facelock`, verify that a real correct password
+succeeds and a wrong password fails, and retry removal. Unsafe or inconsistent
+shared-profile state also blocks.
+
+This release deliberately supports no automatic legacy/shared-profile
+migration or deselection. Older packages persisted no durable fact that can
+distinguish a package-auto-enabled profile from a later administrator choice;
+therefore every selected state is administrator-owned and preserved. This is
+the intentionally deferred legacy ambiguity: a future automatic transition
+requires exact package provenance recorded before the choice, a byte-and-
+metadata snapshot of the managed PAM graph, mutation while the old profile and
+binary still exist, `pam-auth-update`, reapplication of only provenance-owned
+direct edits, and real correct/wrong-password validation, with provable restore
+or retained evidence on failure. An unselected profile needs no graph
+transition: its `Default: no` metadata leaves with the package payload after
+the fixed-root direct cleanup succeeds. Fedora is separate:
+#226 owns only RPM payload retirement and the read-only upgrade guard.
 Shared-stack migration, regeneration, editing and rollback are explicitly rejected.
-Automatic profile selection is also rejected. `remove --all` only scans
-`/etc/authselect` as a detection-only root and never edits generated state.
+`remove --all` scans `/etc/authselect` as a detection-only root and never edits
+generated state.
 
 **`--json`** emits exactly one document on stdout and no human text; `--quiet`
 suppresses even that, leaving the exit code as the whole answer, as it does for
@@ -1895,8 +1928,28 @@ dependencies, with Cargo locked and offline. The clean rebuild must produce the
 same package identity, resolved dependencies, installed path set, and installed
 file hashes as the release build. Fresh installation leaves
 `facelock-daemon.service` disabled and inactive; D-Bus activation remains
-available after explicit setup. Package validation requires the installed TPM
-command surface and the suite-native `libtss2` dependency closure.
+available after explicit setup. Reinstall and upgrade restart the daemon only
+when it was already active, including an active D-Bus-activated instance; they
+preserve both enabled and disabled state and leave every inactive instance
+inactive. The post-install convergence still removes the retired `facelock`
+group, fixes ADR 010 ownership, refreshes a recognized legacy D-Bus policy
+copy, asks the bus to reload policy, and registers the opt-in PAM profile
+without selecting it. Package validation requires the installed TPM command
+surface and the suite-native `libtss2` dependency closure.
+
+Compat 13's generated `dh_installtmpfiles` post-install snippet is the sole
+install-time tmpfiles activation and invokes `systemd-tmpfiles` for
+`facelock.conf` only. The source `postinst` never runs a global tmpfiles create,
+so another package's configuration cannot be activated by a Facelock
+transaction.
+
+Trixie's debhelper 13.24 omits its remove-only service stop when
+`dh_installsystemd --no-start` is used, while Resolute's debhelper 13.31 emits
+it. The package build therefore appends debhelper's canonical
+`prerm-systemd-restart` template for the exact Facelock unit only when that stop
+is absent. This compatibility path is idempotent: both suites produce exactly
+one stop after successful PAM cleanup, neither starts or enables the daemon on
+installation, and only the generated purge path retires enabled state.
 
 ## ONNX Runtime Trust and Fedora RPM Modes
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -54,7 +54,7 @@ follow it.
 | Command | Purpose |
 |---------|---------|
 | `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, daemon, enrollment, PAM — the daemon before enrollment, so enrollment and the recognition test run on the transport later authentications use); removes a leftover `facelock` group from an older install, best-effort (ADR 010) |
-| `facelock setup --systemd` | Install/enable systemd units |
+| `facelock setup --systemd` | Validate installed systemd/D-Bus assets, retire exact known legacy copies, reload, verify resolution, and enable the daemon unit |
 | `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
 | `facelock setup --pam --allow-sensitive` | Explicitly authorize an add to a sensitive PAM service. Does not suppress confirmation and conflicts with `--remove` |
 | `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |
@@ -272,6 +272,90 @@ path took in the vendor directories, `--service polkit-1` finds
 `/usr/lib/pam.d/polkit-1` on a stock Arch box without it. Reserve
 `--if-present` for services a machine may genuinely not have. The default stays
 a hard error, which is what catches `--service polkti-1`.
+
+### facelock setup System Asset Ownership
+
+`facelock setup --systemd` is not an installer for immutable service assets.
+The Debian/RPM/Arch packages and `just install-files` own these canonical
+files:
+
+- `/usr/lib/systemd/system/facelock-daemon.service`
+- `/usr/share/dbus-1/system.d/org.facelock.Daemon.conf`
+- `/usr/share/dbus-1/system-services/org.facelock.Daemon.service`
+
+Setup requires each path to be a single-link `0644 root:root` regular file
+whose bytes match the running build. It never creates, overwrites, changes the
+mode or changes the owner of one. After `daemon-reload`, setup requires
+systemd's `FragmentPath` to name the canonical unit and refuses drop-ins. D-Bus
+activation is also winner-selected: setup refuses exact-name definitions in
+the higher-priority `/etc`, `/run`, and `/usr/local` service directories. D-Bus
+policy is different: every policy fragment is merged. Setup proves the
+canonical policy bytes are present and the exact historical `/etc` duplicate
+is retired; it preserves and reports every other local policy fragment and
+never claims those administrator rules are ineffective.
+
+The only static-file mutation setup may perform is retiring these historical
+legacy copies:
+
+- `/etc/systemd/system/facelock-daemon.service`
+- `/etc/dbus-1/system.d/org.facelock.Daemon.conf`
+- `/etc/dbus-1/system-services/org.facelock.Daemon.service`
+
+The complete canonical, legacy, and fixed quarantine set is preflighted before
+the first mutation.
+A legacy path is removable only when it is a single-link `0644 root:root`
+regular file whose SHA-256 is in `dist/legacy-system-assets.sha256`, the
+reviewed inventory of exact historical Facelock bytes. Missing paths are
+healthy and repeated migration is a no-op. Modified, unknown, symlinked,
+hardlinked, non-regular, wrongly owned or wrongly moded paths are preserved and
+make the action fail with the exact path and recovery direction; an ambiguous
+peer or quarantine collision prevents removal of every otherwise exact peer in
+that run. The sole recoverable pre-existing quarantine state is an absent
+public legacy name paired with its exact known, trusted fixed quarantine.
+Before restoring any such pair, setup preflights the complete canonical and
+three-pair set. It restores every recoverable pair in reverse order with
+no-replace semantics, revalidates the result, then restarts the complete
+migration preflight. A dual-name pair, changed quarantine, ambiguous peer, or
+recovery collision is preserved and reported without overwrite.
+
+Migration first moves every candidate with no-replace semantics to its fixed,
+same-parent `.facelock-migrate-*` quarantine. A later staging or revalidation
+failure rolls earlier candidates back in reverse order before any quarantine
+is deleted. Rollback never overwrites a replacement: a collision preserves
+both fixed names and reports incomplete recovery. Only after every legacy name
+is absent and the complete canonical and quarantine set has been revalidated
+does deletion of the quarantines publish the migration. Cleanup failure after
+that boundary can leave a reported fixed quarantine, but cannot leave a mix of
+active historical names; the next run authenticates, restores, and remigrates
+that exact pair through the same bounded protocol. Rust uses Linux
+`renameat2(RENAME_NOREPLACE)` without a replacing-rename fallback; the source
+helper uses same-parent GNU `mv -Tn` and verifies both names so a no-clobber
+skip is an error.
+
+Production pins the trusted identity to UID/GID `0:0` and requires the layout
+root, every existing parent, and every asset to have the documented trusted
+ownership and modes. The source helper's explicit alternate-layout test mode
+treats that real, non-linked layout directory's owner as the root-equivalent
+identity and also rejects a group/world-writable root. That identity can change
+the fixture just as root can change the production filesystem; it is not an
+isolation boundary.
+
+`setup --systemd --disable` stops and disables the unit without writing any
+service asset. A concurrent privileged writer can always replace root-owned
+names between filesystem operations; setup detects stable-path changes by
+revalidating immediately before removal, but does not claim isolation from a
+second root process. Administrators must not edit these paths concurrently.
+`just uninstall` removes only canonical `/usr` assets. It never inspects or
+removes any of the three historical `/etc` names, even when one is an exact
+known regular copy; linked and parent-linked forms are preserved as well. It
+preflights the complete canonical set before deletion: every existing parent
+component must be a non-linked directory owned by the trusted root-equivalent
+identity and not writable by group/other, while each existing direct target
+must be a single-link `0644` regular file with that identity. A linked,
+multiply linked, wrongly owned, wrongly moded or non-regular canonical target,
+or any untrusted canonical parent, preserves every canonical peer and fails the
+uninstall-files action. This path-based shell preflight does not claim
+isolation from another process with the same root-equivalent authority.
 
 **`--pam` is an alias onto `facelock pam add` / `facelock pam remove`.** The
 plan resolution above stays on `setup` — `--pam`, `--no-pam`, `--service`,
@@ -1932,10 +2016,12 @@ available after explicit setup. Reinstall and upgrade restart the daemon only
 when it was already active, including an active D-Bus-activated instance; they
 preserve both enabled and disabled state and leave every inactive instance
 inactive. The post-install convergence still removes the retired `facelock`
-group, fixes ADR 010 ownership, refreshes a recognized legacy D-Bus policy
-copy, asks the bus to reload policy, and registers the opt-in PAM profile
-without selecting it. Package validation requires the installed TPM command
-surface and the suite-native `libtss2` dependency closure.
+group, fixes ADR 010 ownership, leaves every legacy `/etc` systemd/D-Bus copy
+untouched, asks the bus to reload policy, and registers the opt-in PAM profile
+without selecting it. Exact known legacy-copy migration belongs to
+`facelock setup --systemd`; package configuration never overwrites an
+administrator-owned shadow. Package validation requires the installed TPM
+command surface and the suite-native `libtss2` dependency closure.
 
 Compat 13's generated `dh_installtmpfiles` post-install snippet is the sole
 install-time tmpfiles activation and invokes `systemd-tmpfiles` for
@@ -2112,11 +2198,12 @@ global tmpfiles command.
 
 ## Package Lifecycle Ownership
 
-This is the Wave 0 ownership freeze for issue #232. It defines what later
-package lifecycle work is allowed to remove; it does not claim that the current
-Debian purge script already implements the bounded purge described below.
-**Ordinary removal is not data deletion.** Removing the package must leave a
-machine reinstallable without losing its biometric or operational state.
+This is the Wave 0 ownership freeze for issue #232. It defines what package
+lifecycle work is allowed to remove, and the Debian post-removal script
+implements the bounded purge described below. **Ordinary removal is not data
+deletion.** Ordinary `remove` remains preservation-only: removing the package
+must leave a machine reinstallable without losing its biometric or operational
+state.
 
 The ownership classes are deliberately separate:
 
@@ -2125,7 +2212,7 @@ The ownership classes are deliberately separate:
 | Package-owned static integration | binaries and shared libraries, systemd/OpenRC/runit/s6 units, D-Bus policy and activation, tmpfiles configuration, shipped quirks, PAM/authselect profiles, translations, bundled runtime libraries | Remove through the package manager. These files can be recreated byte-for-byte by reinstalling the package |
 | Administrator configuration | `/etc/facelock/config.toml` and the package manager's saved replacement for an administrator-modified copy | Apply the native package-family rules below. Do not treat administrator configuration as biometric state or as disposable static integration |
 | Biometric and operational state | the database and its WAL/SHM sidecars, encryption keys and sealed keys, downloaded models, enrollment markers, setup state, audit logs, and snapshots under the compiled roots | Preserve all of it. A reinstall reuses it; ordinary removal never interprets absence of the package as consent to discard it |
-| PAM integration and provenance | a `pam_facelock.so` rule, a Facelock-created local override and its provenance header, and `<service>.facelock-backup` rollback files | Attempt safe cleanup inside the fixed PAM root. Delete provenance only after the corresponding PAM cleanup is proven complete |
+| PAM integration and provenance | a `pam_facelock.so` rule, a Facelock-created local override and its provenance header, legacy `<service>.facelock-backup` files, and rollback state under `/var/lib/facelock/pam-backups` | Attempt safe cleanup while the binary is still present. Delete provenance only after the corresponding PAM cleanup is proven complete |
 | Externally configured state | any database, model directory, key, sealed key, audit log, or snapshot path configured outside the compiled Facelock roots | Never package-owned. Leave it untouched and report it as an external remnant |
 
 PAM provenance and rollback files are not biometric state. They exist to
@@ -2145,6 +2232,10 @@ unwritable, wrong-owner, non-regular, changed, linked, or mount-separated
 service file makes cleanup incomplete: preserve its override, provenance
 header, and `.facelock-backup`, and report the exact remnant. Cleanup of one
 service does not authorize deleting provenance for a different service.
+The final Debian `postrm` never interprets rollback schemas. If
+`/var/lib/facelock/pam-backups` is nonempty after the earlier binary-backed
+cleanup, it retains and reports the entire opaque subtree; only a trusted empty
+directory is eligible for ordinary fixed-root removal.
 
 ### Native configuration lifecycles
 
@@ -2159,12 +2250,118 @@ mechanisms:
 | Arch package removal | the `backup` entry follows pacman's native saved-configuration behavior (including `.pacsave` when applicable). Facelock lifecycle code does not bypass it |
 | `just uninstall` | no package manager owns the config, so the source-install uninstall preserves `/etc/facelock` with the biometric and operational state |
 
+### Source-install daemon lifecycle
+
+The privileged `install` and `uninstall` entrypoints invoke absolute
+`/usr/bin/sudo`, `/usr/bin/env`, and `/usr/bin/just` paths with
+`PATH=/usr/bin:/bin`. The `install-files` and `uninstall-files` recipes use the
+exact `#!/usr/bin/bash -p` interpreter, set that fixed path before their first
+operation, and reject caller-supplied Bash startup hooks through the structural
+gate. Directly executed production helpers also use `/usr/bin/bash -p` and pin
+their production path. The root-owned checkout and another actor with root or
+equivalent filesystem authority remain trusted inputs.
+
+`just install-files` serializes its protected interval with
+`/run/facelock/lifecycle.lock`. It safely creates or validates
+`/run/facelock` as `root:root` mode `0755` (the fixture-root identity in
+offline tests), then captures the never-unlinked lock as a `root:root` mode
+`0600`, zero-byte, single-link regular file without following the public path.
+The lock stays held through manager/D-Bus restoration, migration publication,
+signal cleanup, and descriptor release. This is the canonical cross-entrypoint
+lifecycle lock path; other lifecycle entrypoints join it in their owning work.
+
+Before its first replacement write, the installer records exactly one service
+load, active, unit-file, fragment, effective command, and drop-in state. It
+admits only loaded active/inactive service state or a genuine first install.
+Probe failures, transitional/failed states, inconsistent manager/disk state,
+untrusted effective assets, a concurrent lifecycle holder, and malformed or
+duplicate properties abort before mutation. Persistent and runtime ordinary
+unit paths are snapshotted independently. An admitted path is absent, an exact
+administrator `/dev/null` or empty-file mask, or a bounded trusted regular
+override retained by descriptor, metadata, and digest. Systemd precedence is
+preserved; linked, multiply linked, writable, or changing state fails closed.
+
+Every admitted online state receives an owned activation barrier at
+`/run/systemd/system.control/facelock-daemon.service`. The no-clobber-created,
+descriptor-held `root:root` mode `0600` empty regular file is manager-proved as
+the effective mask before the daemon is stopped and before any install write.
+The helper also proves the active system bus, its standard service-directory
+topology, selected Facelock activation definition, policy-only includes, bus
+owner state, and systemd delegation. Custom or unreadable activation topology,
+direct D-Bus execution, or a higher-priority control conflict aborts. The
+source installer never changes enablement and restores only the active/inactive
+state captured at entry.
+
+The source recipe writes service assets only to the canonical `/usr` paths. It
+plans all three historical `/etc` public/quarantine pairs before the protected
+writes, including exact known copies, interrupted exact quarantines,
+administrator files, and systemd masks. After the canonical writes, it moves
+only reviewed exact historical copies to fixed same-parent quarantines with
+no-replace semantics. Trusted modified administrator files and masks remain at
+their exact recorded identities; a selected administrator D-Bus activation
+definition must still delegate to systemd. Unknown, linked, wrongly owned,
+wrongly moded, changing, or ambiguous state fails closed.
+
+Staging is not publication. Quarantines remain rollback-capable while later
+source writes and permission fixes run. A recipe failure or `HUP`, `INT`, or
+`TERM` restores every newly staged public name in reverse order before manager
+and D-Bus restoration; a pair that was already an interrupted quarantine is
+restored to that same pre-run state. The lifecycle treats the staging child
+and its exact parent-side identity record as one signal-critical operation.
+The child also traps exit and caught signals to reverse its locally known
+prefix; parent cleanup independently reconciles unchanged or staged names
+against the complete preplan even when the record was interrupted. Any mixed
+pair that cannot be restored without replacement remains preserved and keeps
+activation barred. Normal completion reloads and proves the
+canonical winners while the activation barrier is still effective, then
+revalidates and deletes the exact quarantines. Only after that commit and
+another topology proof may cleanup quarantine/remove the barrier and restart
+an initially active daemon. A pre-publication commit failure rolls back,
+reloads, and proves the original winners while still barred. A collision,
+partial publication, incomplete rollback, or unprovable manager/D-Bus state
+retains the safest provable barrier and suppresses restart.
+
+Barrier cleanup itself uses held descriptors, fixed same-parent quarantine
+names, no-replace recovery, bounded retries, and repeated disk/manager/D-Bus
+proof. An inactive or first-install daemon remains inactive. The initiating
+failure or signal remains the process result, and signal cleanup is
+non-reentrant until restoration and lock/descriptor release finish.
+
+Ordinary source install fails closed without systemd. The sole exception is
+the checked-in `test/Containerfile` offline image step, selected by its exact
+mode and marker. It authenticates the copied lifecycle/migration helpers and
+digest manifest, takes the same canonical lock inside the image, and proves no
+manager, bus, activation asset, installed Facelock indicator, or unreadable
+process identity exists before allowing writes. Distro maintainer scripts own
+their separate native lifecycle. The mocked/static gate is
+`just test-source-install-daemon-lifecycle`; the mount-free PID-1 gate is
+`just test-source-install-daemon-lifecycle-systemd`.
+
 Debian `postrm purge` is self-contained. It never invokes the already-removed
 `facelock` binary. By the time `postrm` runs, package payloads cannot be treated
-as available cleanup tools. The future bounded purge must make its decisions
-from fixed constants and the remaining filesystem state, using only utilities
-that the maintainer script can rely on after removal; it cannot delegate safety
-checks or deletion to the CLI it is purging.
+as available cleanup tools. The bounded purge makes its decisions from fixed
+constants and the remaining filesystem state and uses the Essential
+`perl-base` interpreter available throughout the package lifecycle; it cannot
+delegate safety checks or deletion to the CLI it is purging.
+The supported Debian-family artifacts are explicitly `Architecture: amd64`.
+For quarantine and recovery, the helper therefore invokes x86-64
+`renameat2(RENAME_NOREPLACE)` directly through Perl's `syscall`; an unsupported
+architecture, kernel, or filesystem fails closed and retains the entry. It
+never falls back to an absence check followed by a replacing rename.
+
+The post-removal script classifies the six supported configured path fields
+while the conffile is still available during `remove`, and repeats that report
+at `purge` when a configuration file remains. Its bounded TOML classifier
+recognizes canonical section assignments plus dotted and quoted key or table
+components with their TOML table scope intact. If a valid representation is
+outside that bounded grammar, including a multiline string, the script emits a
+controlled warning that the configuration could not be fully classified. An
+external value is reported but never opened, removed, or used as a traversal
+root. A configuration object that cannot be safely inspected and is reported
+as retained is protected from the later generic walk. The report therefore
+survives dpkg's normal ordering, in which it can remove the conffile before the
+final `postrm purge` call, without turning configuration into deletion
+authority.
 
 RPM and Arch have no Debian-style second `purge` phase. Their ordinary erase
 therefore removes static integration and safely cleaned PAM provenance, while
@@ -2221,9 +2418,11 @@ generated files unchanged. Neither test mutates the host PAM stack.
 The only purge roots are the compiled Facelock roots:
 `/etc/facelock`, `/var/lib/facelock`, and `/var/log/facelock`. `/etc/pam.d` is
 a separate, fixed root for the narrow PAM cleanup above; it is never a recursive
-purge root. A configured path that remains within a compiled Facelock root is
-eligible for a later Debian purge only under the same safety checks as every
-other descendant.
+purge root. The nonempty `/var/lib/facelock/pam-backups` subtree is an opaque
+exception inside the state root because any remaining entry is unresolved PAM
+cleanup evidence. A configured path that remains within a compiled Facelock
+root is eligible for a later Debian purge only under the same safety checks as
+every other descendant.
 
 Configured paths outside those roots are external remnants. This includes
 external values of `daemon.model_dir`, `storage.db_path`, `encryption.key_path`,
@@ -2232,20 +2431,74 @@ purge must leave them untouched, report that they were refused as external, and
 must not claim that all Facelock data is gone. A path becoming external through
 configuration does not expand package ownership.
 
-Any later purge implementation operates from fixed path constants and examines
-each entry without trusting path traversal. It must never follow a symbolic link
-or act through a hard-linked object, never cross a mount point, and never recurse through a
-non-directory or an object whose ownership cannot be proven safe. A root or
-descendant that fails those checks remains in place and is reported. A safe
-root may still be cleaned around an unsafe child, but the final report must name
-every remnant rather than describe the root as removed.
+The purge operates from fixed path constants and examines each entry without
+trusting path traversal. A root and every traversed directory must be a
+root-owned, non-group/world-writable directory on the root's device. Deletable
+leaves are single-link regular files with the same ownership and write-mode
+constraint. The only ownership exception is an owner-only regular file that is
+one of the direct children of `/var/lib/facelock/enrolled`; those enrollment
+markers are deliberately owned by the enrolled user. Other wrong-owner,
+non-regular, or multiply-linked objects remain in place.
+
+The helper pins every component from the fixed prefix through each purge root
+with `O_DIRECTORY|O_NOFOLLOW` descriptors, opens regular candidates with
+`O_NONBLOCK|O_NOFOLLOW`, and operates through `/proc/self/fd/<fd>` rather than
+reopening public pathnames. It revalidates the complete fixed chain and every
+opened descendant immediately before and after a removal quarantine. Mount IDs
+from `/proc/self/fdinfo` are combined with `/proc/self/mountinfo` to detect bind
+mounts even when their device number is unchanged; every descendant's `st_dev`
+must also equal the opened root's device.
+
+A safe regular file or empty descendant directory is first moved within its
+trusted, non-writable parent by a descriptor-anchored, atomic no-replace
+quarantine operation. A colliding quarantine name is preserved and reported;
+the helper may try a later bounded candidate but never replaces the collision.
+The helper reopens the admitted quarantine name and proves the original device,
+inode, type, link count, ownership, mode, mount, and fixed-chain identity before
+unlink or `rmdir`. Recovery uses the same atomic no-replace operation, so a
+replacement at the public name preserves both public and quarantine remnants.
+A failed unlink or directory removal restores the proven quarantine identity
+with no-replace recovery when possible instead of stranding it under a hidden
+name. After regular-file unlink, the still-open inode must reach link count
+zero; otherwise an external hard-link remnant is reported without claiming the
+data was fully removed.
+A directory with any refused child is never moved. The helper never removes
+the three compiled root directories because their parents are outside the
+recursive purge boundary; safely admitted contents and empty descendant
+directories are removed, while a root may still contain reported refused or
+opaque remnants. After the helper returns, dpkg may remove an empty
+`/etc/facelock` directory as part of native conffile purge. The helper must
+never cross a mount point.
+It must never follow a symbolic link, act through a hard-linked object, or
+recurse through an object whose ownership cannot be proven safe.
+
+The trusted-parent mode is also the purge concurrency boundary. Linux has no
+inode-conditional `unlinkat` or `rmdirat`: after the quarantine identity's final
+proof, deletion assumes no concurrent process with root or equivalent mutation
+authority is changing names in that root-owned, non-group/world-writable
+parent. The package transaction stops the service and owns this interval;
+ordinary unprivileged users cannot enter it. A separate same-authority process
+that deliberately mutates those parents is outside the package-purge contract,
+because no maintainer script can both delete a pathname and preserve an object
+that such a process substitutes at the deletion syscall itself.
+
+Traversal is iterative and bounded independently for each compiled root: at
+most 64 descendant-directory levels and 10,000 inspected entries. A directory
+beyond the depth limit remains as a reported subtree while safe siblings may
+still be cleaned. Reaching the node limit stops further cleanup of that root
+and reports the whole root subtree as retained rather than implying that only
+the first unseen entry is unsafe. A root or descendant that fails any other
+check remains in place and is reported. A safe root may still be cleaned around
+an unsafe child, but the final report must name every remnant rather than
+describe the root as removed. `/etc/pam.d` is not among these recursive roots,
+so purge cannot erase an incomplete PAM edit or its rollback provenance.
 
 Safety refusals and external remnants must not strand package-manager state.
-In particular, Debian purge reports and preserves an unsafe object but lets the
-maintainer-script lifecycle finish, so a link, mount, or wrong-owner file cannot
-leave the package permanently half-purged. This is not a broad recursive-delete
-contract: later code must enumerate the bounded roots and reject anything it
-cannot prove is inside them.
+In particular, Debian purge reports and preserves an unsafe object but returns
+success after reporting safety refusals, so a link, mount, wrong-owner object,
+or partial unlink failure cannot leave the package permanently half-purged.
+This is not a broad recursive-delete contract: the script enumerates the
+bounded roots and rejects anything it cannot prove is inside them.
 
 Finally, filesystem removal does not promise secure erasure. Unlinking files
 does not guarantee that data is absent from SSD flash translation layers,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,10 +98,16 @@ and setup state. Debian also retains its conffile until `purge`; RPM follows
 `%config(noreplace)` and may retain an administrator-modified config as
 `config.toml.rpmsave`.
 
-Facelock does not currently expose a safe "remove everything" command. Do not
-replace package lifecycle handling with a broad recursive deletion: configured
-state paths can live outside the default directories, and links, mounts, or
-wrong-owner remnants require inspection rather than traversal. See
+Debian purge removes only provably safe entries inside the three compiled
+Facelock roots. Unsafe or externally configured remnants are retained and
+reported. The helper leaves the three compiled roots in place; dpkg may then
+remove an empty `/etc/facelock` conffile parent, while admitted files
+and empty descendant directories are removed.
+
+The Facelock CLI does not currently expose a safe "remove everything" command.
+Do not replace package lifecycle handling with a broad recursive deletion:
+configured state paths can live outside the default directories, and links,
+mounts, or wrong-owner remnants require inspection rather than traversal. See
 [Package Lifecycle Ownership](contracts.md#package-lifecycle-ownership) for the
 fixed roots, retained-data rules, and the limits of filesystem deletion.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -584,6 +584,80 @@ to that keyfile's `0600` (root-only) protection. `pcr_binding` remains **default
 enabling it is a deliberate operator choice that commits to the reseal workflow. See
 `docs/configuration.md` for the `[encryption]` and `[tpm]` sections.
 
+#### D. Debian purge traversal (Implemented)
+
+Package purge is a privileged deletion boundary, separate from ordinary
+removal and from the explicit CLI data-purge workflow. The Debian `postrm`
+enumerates only `/etc/facelock`, `/var/lib/facelock`, and
+`/var/log/facelock`; it never grants deletion authority to configured paths.
+Before dpkg removes the conffile, the `remove` phase reports any configured
+model, database, key, sealed-key, audit, or snapshot path outside those roots.
+The bounded classifier accepts canonical section assignments and dotted or
+quoted key and table components while retaining their active TOML table scope.
+It reports a controlled classification warning for valid representations
+outside that grammar, including multiline strings. An unsafe configuration
+object reported as retained is protected from the later generic walk. The
+`purge` phase repeats the report when the conffile still exists but never opens
+an external value.
+
+PAM rollback state has a separate owner. If
+`/var/lib/facelock/pam-backups` remains nonempty after the binary-backed PAM
+cleanup, `postrm` treats the directory as an opaque subtree and retains it
+whole. It does not reinterpret provenance or delete safe-looking children; an
+empty trusted directory may be removed normally.
+
+Every traversed root and directory must be a root-owned,
+non-group/world-writable directory chain on one device. Every removable leaf
+must be a single-link regular file with compatible ownership and modes. The
+one narrow exception is a direct user-owned enrollment marker beneath
+`/var/lib/facelock/enrolled`, whose owner-only mode and protected parent make
+its provenance distinguishable from a wrong-owner file elsewhere. Symlinks,
+other hard links, special files, unsafe ownership or modes, and inspection or
+unlink failures are retained and named.
+
+The helper opens every fixed-prefix and root component with
+`O_DIRECTORY|O_NOFOLLOW`, keeps those descriptors pinned, and opens regular
+candidates with `O_NONBLOCK|O_NOFOLLOW`. Mount IDs from `/proc/self/fdinfo` are
+checked against `/proc/self/mountinfo`, which detects same-device bind mounts
+that an `st_dev` comparison alone misses; each descendant's device is also
+compared directly with the opened root. The fixed chain and opened descendant
+chain are rechecked immediately before and after quarantine.
+
+Safe regular files and empty descendant directories are moved within their
+trusted parent with descriptor-anchored x86-64
+`renameat2(RENAME_NOREPLACE)`, reopened at the admitted quarantine name, and
+proved to retain the inspected identity before unlink or `rmdir`. Quarantine
+collisions are preserved and reported, and recovery uses the same no-replace
+primitive so a public replacement cannot be overwritten. The supported Debian
+artifacts are `Architecture: amd64`; an unavailable syscall fails closed rather
+than degrading to check-then-rename. Failed unlink or `rmdir` attempts restore
+the proven object when possible. A still-open regular inode whose link count is
+nonzero after quarantine unlink is reported as an external hard-link remnant.
+Directories containing any refused child are never moved. The helper never
+removes the three compiled root directories, so no helper deletion operation
+is authorized in their out-of-bound parents. After the helper returns, native
+conffile purge may remove an empty `/etc/facelock` directory owned by dpkg;
+the state and log roots remain helper-owned anchors and may contain reported
+opaque or refused remnants.
+
+Root ownership and the prohibition on group/world-writable traversal parents
+form the concurrency boundary as well as the provenance boundary. Linux has no
+identity-conditional unlink or directory removal operation. After the final
+quarantine proof, package purge therefore assumes no concurrent root-equivalent
+writer substitutes that trusted name at the deletion syscall. The service is
+stopped for the package transaction and unprivileged users cannot mutate those
+parents; a deliberately concurrent same-authority writer is outside this
+maintainer-script contract.
+
+Traversal is iterative and bounded per compiled root to 64 descendant
+directory levels and 10,000 inspected entries. A directory beyond the depth
+limit is retained and reported while safe siblings remain eligible. Reaching
+the node limit stops that root and reports the whole root subtree. The helper
+otherwise cleans safe siblings around a refused child and returns success after
+reporting remnants so an unsafe filesystem object cannot strand dpkg. This is
+safe unlinking, not secure erasure: storage firmware, snapshots, backups,
+journals, and remapped blocks remain outside its guarantee.
+
 ### 4. D-Bus IPC Security
 
 **Attack**: Unauthorized user sends D-Bus messages to the daemon to trigger auth, enroll faces, or extract data.
@@ -594,9 +668,13 @@ enabling it is a deliberate operator choice that commits to the reseal workflow.
 
 Access to the daemon is governed by the D-Bus system bus policy in
 `dbus/org.facelock.Daemon.conf`, installed to `/usr/share/dbus-1/system.d/`
-and enforced by the bus itself (dbus-daemon or dbus-broker). Setup and package
-install may also refresh a legacy `/etc/dbus-1/system.d/` copy when present,
-but `/usr/share/...` is the canonical install path. Two grants (ADR 010):
+and enforced by the bus itself (dbus-daemon or dbus-broker). Package
+transactions never overwrite a legacy `/etc/dbus-1/system.d/` copy. Setup
+removes one only when it is an exact reviewed historical Facelock file;
+modified or linked copies are preserved and reported. D-Bus merges policy
+fragments rather than selecting one winner, so setup also reports unrelated
+local policy files without modifying them or claiming the package policy
+overrides them. Two grants (ADR 010):
 
 - **root**: may own the name, send anything on the interface, and receive the
   daemon's signals.
@@ -1156,7 +1234,10 @@ That walk only happens if the daemon actually starts, which needs `models/*.onnx
 checkout (they are gitignored). The Debian suite package gates and `just test-rpm-pkg` refuse to run without
 them, and `pkg-validate.sh` fails rather than skipping — set
 `FACELOCK_ALLOW_MISSING_MODELS=1` to accept a partial run, which then reports the missing
-assertions in its `N skipped` count instead of passing silently.
+model-dependent assertions in its `N skipped` count instead of passing silently.
+Any other skipped assertion fails package validation. The opt-out also names the active-service Debian
+upgrade cases it cannot run; inactive versioned upgrades and the clean-base dependency proof
+remain mandatory.
 
 #### B. systemd Hardening (Implemented)
 
@@ -1252,6 +1333,66 @@ with systemd as PID 1 (`test/run-pkg-validate-systemd.sh`) and assert via `syste
 that the installed unit carries the Phase 3 directives, that the daemon starts and answers on
 D-Bus inside the sandbox, and that an `AF_INET` socket cannot be created under the same
 directive set (outbound TCP blocked).
+
+#### C. Source-install activation barrier (Required)
+
+Replacing a source-installed binary or activation file while D-Bus/systemd can
+launch the daemon creates a time-of-check/time-of-use window. The privileged
+entrypoint uses absolute program paths and a fixed trusted `PATH`; the recipe
+uses privileged Bash mode, rejects startup-hook variables, and holds the
+canonical `/run/facelock/lifecycle.lock` for its complete protected interval.
+The helper safely creates or validates the `root:root` mode `0755` parent and
+captures the never-unlinked lock as a `root:root` mode `0600`, zero-byte,
+single-link regular file through a no-follow descriptor proof.
+
+The installer snapshots service state plus persistent/runtime administrator
+unit identities, then creates and opens an exact temporary systemd control-tier
+mask. It proves the barrier manager-effective before stop and requires the unit
+inactive, the bus name unowned, and every ordinary snapshot unchanged before
+the first write. The system bus executable, unit, configuration, supported
+policy includes, service directories, and selected Facelock definition require
+trusted parents and bounded non-writable identities. Only standard system
+service-directory topology and D-Bus activation delegated to
+`facelock-daemon.service` are admitted; direct activation and custom/unreadable
+topology fail closed.
+
+Canonical assets are written only under `/usr`. Before any install write, the
+lifecycle records exact identities for all three historical `/etc`
+public/quarantine pairs. After canonical writes it stages only digest-allowlisted
+historical copies to fixed same-parent quarantines without replacement.
+Trusted modified administrator files and systemd masks remain unchanged and
+are revalidated throughout. The quarantines remain available for reverse-order
+rollback across all later writes and signal/failure cleanup. Parent signal
+deferral spans both the staging child and the exact identity record. The child
+traps exit and caught signals to reverse its local prefix, while parent cleanup
+independently reconciles every preplanned pair if staging ended before that
+record. Recovery uses only exact unchanged/staged identities and no-replace
+moves; a collision preserves both names and the activation barrier.
+
+On normal completion, systemd and D-Bus reload and prove the canonical winners
+while activation remains barred. Only then may exact staged quarantines be
+deleted; barrier removal and an initially active daemon's restart follow a
+second complete proof. A pre-publication failure restores the original public
+or interrupted-quarantine state before manager/D-Bus restoration. A commit
+failure rolls back and reloads/proves the original winners while still barred.
+Incomplete rollback, a collision, changing identity, partial publication, or
+an unprovable reload retains the safest barrier and suppresses restart.
+
+Barrier quarantine/removal uses held descriptors, no-clobber recovery, bounded
+retries, and repeated disk, manager, D-Bus definition/configuration, and owner
+checks. Linux provides no inode-conditional `unlink`/`rmdir`; the final syscall
+therefore excludes an actor with root-equivalent write/search authority over
+the trusted parent. Such an actor could already replace the barrier directly.
+The protocol covers pre-existing hostile objects and unprivileged races and
+never claims isolation from a second hostile root process.
+
+Without systemd the source install aborts before mutation. Only the exact
+checked-in offline container-build marker may select the offline path, which
+authenticates its copied helpers/manifest, takes the same canonical lock, and
+proves the absence of manager, bus, activation, installed-Facelock, and running
+Facelock surfaces. Static/mocked and booted PID-1 regressions are respectively
+`just test-source-install-daemon-lifecycle` and
+`just test-source-install-daemon-lifecycle-systemd`.
 
 ### 7. Polkit / sudo Face Auth (Implemented)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -992,9 +992,29 @@ path. The module is removed only after the compiled-root final scan succeeds.
 The all-or-nothing guarantee covers the direct PAM edits owned and scanned by
 this transaction, plus retaining the package/module when it fails. Debian's
 packaged `pam-auth-update` profile is opt-in (`Default: no`), so fresh install
-does not alter `common-auth`. Its separately managed lifecycle and byte-exact
-rollback remain #224 scope; the current `prerm` removes that profile before
-invoking the shared direct-edit cleanup.
+does not alter `common-auth`. Direct `pam add` and `setup --pam` inspect only
+the fixed profile, selection-state and live `common-auth` paths with bounded,
+owner/mode/link-checked, no-follow reads. An exact selected and live profile
+refuses a duplicate direct edit; any saved-selection/live-graph disagreement,
+linked evidence, or modified evidence fails closed. Neither case writes PAM or
+backup state.
+
+Debian removal performs that fixed-root profile probe and a read-only
+`remove --all --dry-run` preflight before the journaled direct cleanup, and it
+reaches generated service lifecycle handling only after cleanup commits.
+Ordinary removal stops the daemon but preserves enabled state for reinstall;
+the generated purge path alone retires that state. A selected or unsafe shared
+profile aborts removal with the package, binary, module, PAM graph, direct edits
+and service state retained. The administrator is told to disable
+the profile through `pam-auth-update`, prove a real correct password succeeds
+and a wrong password fails, then retry. No released predecessor recorded exact
+package-auto-enable provenance, so Facelock never guesses that an existing
+selection is package-owned and never silently disables it. Automatic legacy
+profile migration is intentionally deferred until such provenance can support
+an exact graph snapshot, managed regeneration, provenance-owned direct-edit
+reapplication, real authentication validation, and provable restoration or
+retained evidence. An unselected `Default: no` profile causes no managed-graph
+transition when its package metadata is removed.
 The RPM retirement guard reads only `/etc/authselect/authselect.conf` before
 payload replacement. It requires fixed root ownership, mode, link count and a
 16 KiB bound, compares the first line's raw bytes before shell interpretation,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -206,9 +206,14 @@ Every management command is root-only; the CLI offers to re-run itself under
 `sudo` on a terminal. Face unlock itself (hyprlock, swaylock, the polkit
 agent, `facelock is-enrolled`) needs no group and no re-login: the bus admits
 any local user's `Authenticate` for their own account (ADR 010). If a lock
-screen still reports `AccessDenied` right after an upgrade, the bus has not
-re-read the policy yet — `sudo facelock setup --systemd` rewrites it and asks
-for a reload, or reboot.
+screen still reports `AccessDenied` right after an upgrade, the bus may not
+have re-read the policy yet. `sudo facelock setup --systemd` validates the
+package-owned policy, transactionally retires only the byte-exact historical
+duplicate, and asks for a reload; it never rewrites a package file or an
+administrator-modified `/etc` copy. D-Bus merges all policy fragments, so setup
+reports other local fragments for review instead of calling them ineffective.
+Resolve a preserved-path or rollback error, review any reported local policy,
+or reboot.
 
 The `facelock` group is no longer used (ADR 010). `sudo facelock setup`, `just
 install-files` and the package scriptlets remove a leftover group; if it

--- a/justfile
+++ b/justfile
@@ -79,10 +79,27 @@ check-agent-docs base='':
         python3 test/check-agent-docs.py
     fi
     bash test/lifecycle-ownership-contract.sh
+    bash test/debian-postrm-purge.sh
     bash test/rpm-authselect-contract.sh
 
+# Exercise Debian remove/purge policy below disposable fixed roots only.
+test-debian-postrm-purge:
+    bash test/debian-postrm-purge.sh
+
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
-check: test lint fmt-check audit check-pam-standalone check-agent-docs test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test
+check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets
+
+# Preserve the daemon's pre-install runtime state across source file replacement.
+test-source-install-daemon-lifecycle:
+    bash test/source-install-daemon-lifecycle.sh
+
+# Exercise the source-install barrier against a real systemd and system bus.
+test-source-install-daemon-lifecycle-systemd: _build-test-container
+    test/run-source-install-daemon-lifecycle-systemd.sh facelock-pam-test
+
+# Validate immutable system assets and migrate only exact historical /etc copies.
+test-legacy-system-assets:
+    bash test/legacy-system-assets.sh
 
 # Prove the deterministic, exact Cargo source component used by Debian builds.
 test-cargo-vendor-contract:
@@ -91,6 +108,7 @@ test-cargo-vendor-contract:
 # Static Debian source/metadata/release-consumer contract.
 test-deb-source-contract:
     bash test/deb-source-contract.sh
+    python3 test/deb-source-contract-test.py
 
 # Validate every binary package named by one exact generated manifest.
 test-deb-package-contract manifest:
@@ -477,17 +495,24 @@ test-arch-release-shell: _build-test-container
 
 # Run as: just install (builds as you, installs as root)
 install: build-release
-    sudo env PATH="$PATH" just install-files
+    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just install-files
 
 # Install pre-built binaries to system (requires root, no build)
 install-files:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash -p
     set -euo pipefail
+    PATH=/usr/bin:/bin
+    export PATH
 
     # Verify binaries exist
     for f in target/release/facelock target/release/libpam_facelock.so; do
         [ -f "$f" ] || { echo "Error: $f not found. Run 'just build-release' first."; exit 1; }
     done
+
+    # Keep a live daemon available across source upgrades without changing
+    # enablement or activating one that was inactive or only D-Bus-activatable.
+    source scripts/source-install-daemon-lifecycle.sh
+    facelock_source_install_begin
 
     # Binaries
     install -Dm755 target/release/facelock /usr/bin/facelock
@@ -510,25 +535,14 @@ install-files:
 
     # systemd unit
     install -Dm644 systemd/facelock-daemon.service /usr/lib/systemd/system/facelock-daemon.service
-    if [ -f /etc/systemd/system/facelock-daemon.service ] && \
-       grep -q 'ExecStart=/usr/bin/facelock daemon' /etc/systemd/system/facelock-daemon.service; then
-        install -Dm644 systemd/facelock-daemon.service /etc/systemd/system/facelock-daemon.service
-    fi
 
     # D-Bus policy and activation
     install -Dm644 dbus/org.facelock.Daemon.conf /usr/share/dbus-1/system.d/org.facelock.Daemon.conf
     install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service
-    if [ -f /etc/dbus-1/system.d/org.facelock.Daemon.conf ] && \
-       grep -q 'org.facelock.Daemon' /etc/dbus-1/system.d/org.facelock.Daemon.conf; then
-        install -Dm644 dbus/org.facelock.Daemon.conf /etc/dbus-1/system.d/org.facelock.Daemon.conf
-    fi
-    if [ -f /etc/dbus-1/system-services/org.facelock.Daemon.service ] && \
-       grep -q 'org.facelock.Daemon' /etc/dbus-1/system-services/org.facelock.Daemon.service; then
-        install -Dm644 dbus/org.facelock.Daemon.service /etc/dbus-1/system-services/org.facelock.Daemon.service
-    fi
-    # The bus may not have noticed the policy change yet; ask (best-effort).
-    dbus-send --system --type=method_call --dest=org.freedesktop.DBus \
-        /org/freedesktop/DBus org.freedesktop.DBus.ReloadConfig 2>/dev/null || true
+    # Retire only byte-exact historical Facelock copies while the source-install
+    # activation barrier is effective. The lifecycle records the fixed mutation
+    # identities before the first install write and proves the final state.
+    facelock_source_install_stage_and_record_legacy_migration /
 
     # Polkit agent binary (optional, do NOT install autostart — agent is not production-ready
     # and will steal polkit auth from the DE's agent, causing all privilege prompts to hang)
@@ -546,15 +560,6 @@ install-files:
     install -dm700 -o root -g root /var/lib/facelock/pam-backups
     install -dm700 -o root -g root /var/log/facelock
     install -dm700 -o root -g root /var/log/facelock/snapshots
-
-    # Enable D-Bus activation (if systemd present)
-    if [ -d /run/systemd/system ]; then
-        systemctl stop facelock-daemon.service 2>/dev/null || true
-        systemctl daemon-reload
-        systemctl reset-failed facelock-daemon.service 2>/dev/null || true
-        systemctl enable facelock-daemon.service 2>/dev/null || true
-        echo "D-Bus activation enabled."
-    fi
 
     # Fix permissions on existing data
     [ -d /etc/facelock ] && chown root:root /etc/facelock && chmod 755 /etc/facelock || true
@@ -579,6 +584,13 @@ install-files:
     # remove a group an older install created. Best-effort.
     if getent group facelock >/dev/null 2>&1; then
         groupdel facelock 2>/dev/null || true
+    fi
+
+    # Reload the replaced activation assets and restore only the runtime state
+    # captured before the protected write interval.
+    facelock_source_install_complete
+    if [ -d /run/systemd/system ]; then
+        echo "D-Bus activation enabled."
     fi
 
     echo ""
@@ -628,14 +640,16 @@ install-files:
 
 # Uninstall from system
 
-# Run as: just uninstall (elevates to root, preserving PATH)
+# Run as: just uninstall (elevates to root with a trusted command path)
 uninstall:
-    sudo env PATH="$PATH" just uninstall-files
+    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just uninstall-files
 
 # Uninstall files from system (requires root, called by uninstall)
 uninstall-files:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash -p
     set -euo pipefail
+    PATH=/usr/bin:/bin
+    export PATH
     # Stop and disable daemon
     systemctl stop facelock-daemon.service 2>/dev/null || true
     systemctl disable facelock-daemon.service 2>/dev/null || true
@@ -649,24 +663,9 @@ uninstall-files:
 
     # Remove binaries and units
     rm -f /usr/bin/facelock /lib/security/pam_facelock.so
-    # Decide whether the /etc/systemd/system/ override matches the installed unit
-    # (we want to clean up our own override, but never clobber an admin customization).
-    # We must compare BEFORE removing /usr/lib/systemd/system/facelock-daemon.service.
-    SYSTEM_OVERRIDE="/etc/systemd/system/facelock-daemon.service"
-    INSTALLED_UNIT="/usr/lib/systemd/system/facelock-daemon.service"
-    REMOVE_OVERRIDE=false
-    if [ -f "$SYSTEM_OVERRIDE" ] && [ -f "$INSTALLED_UNIT" ] && cmp -s "$INSTALLED_UNIT" "$SYSTEM_OVERRIDE"; then
-        REMOVE_OVERRIDE=true
-    fi
-    rm -f "$INSTALLED_UNIT"
-    if [ "$REMOVE_OVERRIDE" = true ]; then
-        rm -f "$SYSTEM_OVERRIDE"
-        echo "Removed $SYSTEM_OVERRIDE (matched installed unit)"
-    elif [ -f "$SYSTEM_OVERRIDE" ]; then
-        echo "Kept $SYSTEM_OVERRIDE (admin-modified or installed unit not present for comparison)"
-    fi
-    rm -f /usr/share/dbus-1/system.d/org.facelock.Daemon.conf
-    rm -f /usr/share/dbus-1/system-services/org.facelock.Daemon.service
+    # Remove only canonical /usr system assets. Historical /etc copies are
+    # administrator state and the reviewed migration is their sole owner.
+    scripts/uninstall-system-assets.sh /
     rm -f /usr/bin/facelock-polkit-agent
     rm -f /etc/xdg/autostart/org.facelock.AuthAgent.desktop
 
@@ -934,17 +933,27 @@ test-deb: test-deb-trixie-pkg test-deb-resolute-pkg
 test-deb-trixie-pkg: (_require-models "1")
     #!/usr/bin/env bash
     set -euo pipefail
-    test/build-deb-package-image.sh trixie facelock-deb-trixie-pkg
-    podman run --rm facelock-deb-trixie-pkg /tpm-pcr-e2e.sh
-    test/run-pkg-validate-systemd.sh facelock-deb-trixie-pkg
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-trixie.XXXXXX")"
+    trap 'rm -rf -- "$artifact_dir"' EXIT
+    package="$artifact_dir/facelock.deb"
+    test/build-deb-package-image.sh trixie facelock-deb-trixie-pkg "$package"
+    podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
+        facelock-deb-trixie-pkg \
+        /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
+    test/run-pkg-validate-systemd.sh facelock-deb-trixie-pkg "$package"
 
 # Ubuntu 26.04 Resolute package — exact source build, TPM/PCR, and booted lifecycle.
 test-deb-resolute-pkg: (_require-models "1")
     #!/usr/bin/env bash
     set -euo pipefail
-    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg
-    podman run --rm facelock-deb-resolute-pkg /tpm-pcr-e2e.sh
-    test/run-pkg-validate-systemd.sh facelock-deb-resolute-pkg
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-resolute.XXXXXX")"
+    trap 'rm -rf -- "$artifact_dir"' EXIT
+    package="$artifact_dir/facelock.deb"
+    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg "$package"
+    podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
+        facelock-deb-resolute-pkg \
+        /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
+    test/run-pkg-validate-systemd.sh facelock-deb-resolute-pkg "$package"
 
 # Same model requirement (and same opt-out) as the two Debian suite package gates.
 
@@ -966,7 +975,10 @@ test-copr:
 test-deb-dev-shell:
     #!/usr/bin/env bash
     set -euo pipefail
-    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-dev-shell.XXXXXX")"
+    trap 'rm -rf -- "$artifact_dir"' EXIT
+    package="$artifact_dir/facelock.deb"
+    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg "$package"
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -975,12 +987,12 @@ test-deb-dev-shell:
     for f in /var/lib/facelock/models/*.onnx /var/lib/facelock/models/*.toml; do
         [ -f "$f" ] && mounts="$mounts -v $f:/tmp/host-models/$(basename $f):ro"
     done
-    mounts="$mounts -v $(pwd)/test/container-config.toml:/tmp/container-config.toml:ro"
+    mounts="$mounts -v $(pwd)/test/container-config.toml:/tmp/container-config.toml:ro -v $package:/facelock-test-package.deb:ro,Z"
     echo "Starting dev shell (Ubuntu 26.04, .deb installed, host models). Try:"
     echo "  facelock enroll --user root --label myface"
     echo "  facelock test --user root"
     podman run --rm -it $devices $mounts facelock-deb-resolute-pkg \
-        bash -c "cp /tmp/container-config.toml /etc/facelock/config.toml; cp /tmp/host-models/* /var/lib/facelock/models/ 2>/dev/null; exec bash"
+        bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; cp /tmp/host-models/* /var/lib/facelock/models/ 2>/dev/null; exec bash"
 
 # Dev shell — interactive .rpm container with host models for fast iteration (requires camera)
 test-rpm-dev-shell: build-release
@@ -1006,18 +1018,21 @@ test-rpm-dev-shell: build-release
 test-deb-release-shell:
     #!/usr/bin/env bash
     set -euo pipefail
-    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-release-shell.XXXXXX")"
+    trap 'rm -rf -- "$artifact_dir"' EXIT
+    package="$artifact_dir/facelock.deb"
+    test/build-deb-package-image.sh resolute facelock-deb-resolute-pkg "$package"
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
     done
-    mounts="-v $(pwd)/test/container-config.toml:/tmp/container-config.toml:ro"
+    mounts="-v $(pwd)/test/container-config.toml:/tmp/container-config.toml:ro -v $package:/facelock-test-package.deb:ro,Z"
     echo "Starting release shell (Ubuntu 26.04, .deb installed, clean room). Try:"
     echo "  facelock setup"
     echo "  facelock enroll --user root --label myface"
     echo "  facelock test --user root"
     podman run --rm -it $devices $mounts facelock-deb-resolute-pkg \
-        bash -c "cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
+        bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
 
 # Release shell — clean-room .rpm container, real user experience (requires camera)
 test-rpm-release-shell: build-release

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -83,7 +83,17 @@ Decline PAM configuration entirely. No file under
 is read, backed up or written.
 .TP
 .B \-\-systemd
-Install and enable systemd units for the facelock daemon.
+Validate the installed package/source-owned systemd and D-Bus assets, remove
+only exact known legacy copies under
+.IR /etc ,
+using a no-replace quarantine transaction, reload and verify unit and activation
+resolution, then enable the facelock daemon unit. Modified or linked legacy
+copies are preserved and make the action fail. D-Bus policy fragments are
+merged, so unrelated local policy is preserved and reported rather than called
+ineffective. Immutable assets
+under
+.I /usr
+are never written by setup.
 .TP
 .B \-\-no\-systemd
 Decline systemd configuration. No unit files are written and

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -1,4 +1,4 @@
-.TH FACELOCK 1 "2026-08-20" "facelock" "User Commands"
+.TH FACELOCK 1 "2026-08-21" "facelock" "User Commands"
 .SH NAME
 facelock \- Linux face authentication
 .SH SYNOPSIS
@@ -498,6 +498,17 @@ A file with more than one hard link is refused \(em a link count says another
 name for it exists and not where. Before an in-place edit, a 0600 root:root
 backup and its versioned provenance record are written under
 .IR /var/lib/facelock/pam-backups/ .
+.IP
+On Debian and Ubuntu, a selected packaged \fBpam-auth-update\fR profile is
+already one Facelock authentication path. Before planning a direct add,
+Facelock verifies the fixed profile, saved selection and live Primary block
+with bounded no-follow reads. It refuses a duplicate and instructs the
+administrator to run
+.BR "sudo pam-auth-update --disable facelock" ,
+verify that a real correct password succeeds and a wrong password fails, then
+retry the original Facelock command with all of its services and flags. Any
+saved-selection/live-graph disagreement or untrusted state also refuses without
+a PAM or backup write.
 .TP
 .B remove
 Remove the facelock line. Root. Same flags as \fBadd\fR except
@@ -538,6 +549,17 @@ conflicts. This path
 reads no Facelock config,
 database, model, daemon, camera or inference state and is the cleanup command
 used by package uninstallers while the binary and PAM module are still present.
+.IP
+The Debian package never silently disables a selected shared profile. Removal
+probes it before the direct-edit dry run and aborts with package, module, PAM
+and daemon state retained when it is selected or unsafe. Disable it explicitly
+with \fBpam-auth-update\fR, verify correct and wrong password behavior, then
+retry package removal. Older packages recorded no proof distinguishing an
+automatic selection from an administrator choice, so automatic legacy
+migration is intentionally unsupported. An unselected opt-in profile leaves
+with the package only after direct cleanup commits; generated service handling
+follows that cleanup. Ordinary removal stops the daemon while preserving enabled
+state for reinstall, and purge retires that state.
 .IP
 An unchanged Facelock-created vendor override is also a cleanup target, including
 the exact restart state where its module rule is already absent. Version 2 batch

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-21 17:41-0700\n"
+"POT-Creation-Date: 2026-08-22 14:07-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1317,82 +1317,86 @@ msgstr ""
 msgid "{path} ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:43
+#: crates/facelock-cli/src/message/system.rs:44
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:45
+#: crates/facelock-cli/src/message/system.rs:46
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:48
+#: crates/facelock-cli/src/message/system.rs:49
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:51
+#: crates/facelock-cli/src/message/system.rs:52
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:53
+#: crates/facelock-cli/src/message/system.rs:54
 msgid "  Answered on the command line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:55
+#: crates/facelock-cli/src/message/system.rs:56
 msgid ""
 "  facelock-daemon was already running; restarted so enrollment uses\n"
 "  the new configuration."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:57
+#: crates/facelock-cli/src/message/system.rs:58
 msgid "  facelock-daemon is running."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:60
+#: crates/facelock-cli/src/message/system.rs:61
 msgid ""
 "  facelock-daemon did not answer within {seconds}s.\n"
 "  Continuing with direct camera access; check: systemctl status facelock-daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:65
+#: crates/facelock-cli/src/message/system.rs:66
 msgid "  Removed the legacy 'facelock' group; face unlock no longer uses it."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:67
+#: crates/facelock-cli/src/message/system.rs:68
 msgid "Disabling facelock-daemon systemd units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:68
+#: crates/facelock-cli/src/message/system.rs:69
 msgid "facelock-daemon service disabled and stopped."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:70
-msgid "Installing facelock-daemon systemd and D-Bus units..."
-msgstr ""
-
-#: crates/facelock-cli/src/message/system.rs:72
-#, python-brace-format
-msgid "  Wrote {path}"
+#: crates/facelock-cli/src/message/system.rs:71
+msgid "Validating installed facelock-daemon systemd and D-Bus assets..."
 msgstr ""
 
 #: crates/facelock-cli/src/message/system.rs:74
 #, python-brace-format
-msgid "  Refreshed legacy {path}"
-msgstr ""
-
-#: crates/facelock-cli/src/message/system.rs:77
-msgid "  systemctl daemon-reload done."
+msgid "  Removed exact known legacy {path}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/system.rs:79
 #, python-brace-format
-msgid "  systemctl enable {unit} done."
+msgid "  Preserved merged local D-Bus policy {path}; review it if Facelock bus authorization is unexpected."
 msgstr ""
 
 #: crates/facelock-cli/src/message/system.rs:83
+msgid "  Installed systemd and D-Bus assets validated."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:84
+msgid "  systemctl daemon-reload done."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:86
+#, python-brace-format
+msgid "  systemctl enable {unit} done."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:90
 msgid ""
 "\n"
 "facelock-daemon D-Bus activation is now enabled."

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-21 17:08-0700\n"
+"POT-Creation-Date: 2026-08-21 17:41-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -392,29 +392,29 @@ msgstr ""
 msgid "Face auth failed: {reason}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:288
+#: crates/facelock-cli/src/message/pam.rs:292
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:294
+#: crates/facelock-cli/src/message/pam.rs:298
 msgid ""
 "  PAM module not found. Tried: {paths}\n"
 "  Install it first, then run: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:299
+#: crates/facelock-cli/src/message/pam.rs:303
 #, python-brace-format
 msgid "  Configuring PAM for {service}..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:303
+#: crates/facelock-cli/src/message/pam.rs:307
 #, python-brace-format
 msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:308
+#: crates/facelock-cli/src/message/pam.rs:312
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -425,47 +425,47 @@ msgid ""
 "  be asked to confirm each file individually.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:313
+#: crates/facelock-cli/src/message/pam.rs:317
 msgid "Select services to enable face authentication for"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:316
+#: crates/facelock-cli/src/message/pam.rs:320
 #, python-brace-format
 msgid "  Failed to configure {service}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:321
+#: crates/facelock-cli/src/message/pam.rs:325
 #, python-brace-format
 msgid "  PAM service {service} reached the requested state, but rollback-state cleanup failed: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:325
+#: crates/facelock-cli/src/message/pam.rs:329
 msgid "  No PAM services selected."
-msgstr ""
-
-#: crates/facelock-cli/src/message/pam.rs:327
-#, python-brace-format
-msgid "PAM service file not found: {paths}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:331
 #, python-brace-format
+msgid "PAM service file not found: {paths}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:335
+#, python-brace-format
 msgid "PAM line already present in {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:334
+#: crates/facelock-cli/src/message/pam.rs:338
 msgid "inserted before the first 'auth' line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:336
+#: crates/facelock-cli/src/message/pam.rs:340
 msgid "no 'auth' line found — inserted after the PAM header"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:339
+#: crates/facelock-cli/src/message/pam.rs:343
 msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:348
+#: crates/facelock-cli/src/message/pam.rs:352
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -475,21 +475,21 @@ msgid ""
 "(To configure manually instead, add the line above to each service yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:357
+#: crates/facelock-cli/src/message/pam.rs:361
 msgid "Proceed?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:359
+#: crates/facelock-cli/src/message/pam.rs:363
 #, python-brace-format
 msgid "Skipped {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:362
+#: crates/facelock-cli/src/message/pam.rs:366
 #, python-brace-format
 msgid "Backed up {path} -> {backup}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:371
+#: crates/facelock-cli/src/message/pam.rs:375
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
@@ -498,28 +498,28 @@ msgid ""
 "  # or: sudo facelock pam remove --service {service}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:380
+#: crates/facelock-cli/src/message/pam.rs:384
 #, python-brace-format
 msgid "Removed facelock PAM line from {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:384
+#: crates/facelock-cli/src/message/pam.rs:388
 #, python-brace-format
 msgid "No facelock PAM line found in {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:388
+#: crates/facelock-cli/src/message/pam.rs:392
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:392
+#: crates/facelock-cli/src/message/pam.rs:396
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:402
+#: crates/facelock-cli/src/message/pam.rs:406
 msgid ""
 "\n"
 "About to create {path} from the vendor file {vendor}:\n"
@@ -529,7 +529,7 @@ msgid ""
 "(To configure manually instead, copy that file and add the line above yourself.)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:417
+#: crates/facelock-cli/src/message/pam.rs:421
 msgid ""
 "Created {path} from {vendor} with the facelock PAM line.\n"
 "This local override shadows the vendor file and will not track vendor updates.\n"
@@ -539,57 +539,57 @@ msgid ""
 "An unchanged Facelock-created override is deleted; a modified override is kept after its facelock line is removed."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:427
+#: crates/facelock-cli/src/message/pam.rs:431
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Deleted unchanged local override; {vendor} is authoritative again."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:433
+#: crates/facelock-cli/src/message/pam.rs:437
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because administrator or vendor drift no longer matches {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:439
+#: crates/facelock-cli/src/message/pam.rs:443
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:445
+#: crates/facelock-cli/src/message/pam.rs:449
 msgid ""
 "No facelock PAM line found in {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:451
+#: crates/facelock-cli/src/message/pam.rs:455
 #, python-brace-format
 msgid "Would remove the facelock PAM line from {path}, delete the unchanged local override, and make {vendor} authoritative again."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:457
+#: crates/facelock-cli/src/message/pam.rs:461
 #, python-brace-format
 msgid "PAM service file exists only at {path}, which is package-owned and never modified by facelock. Nothing to remove."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:462
+#: crates/facelock-cli/src/message/pam.rs:466
 #, python-brace-format
 msgid "{path}: vendor file only, no facelock PAM line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:466
+#: crates/facelock-cli/src/message/pam.rs:470
 #, python-brace-format
 msgid "Would create {path} from {vendor} with the facelock PAM line ({hint})."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:475
+#: crates/facelock-cli/src/message/pam.rs:479
 msgid ""
 "Cannot create the local override {path}: {dir} is not writable ({error}).\n"
 "The vendor copy of this service is package-owned, so facelock will not edit it in place."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:485
+#: crates/facelock-cli/src/message/pam.rs:489
 msgid ""
 "\n"
 "==> facelock PAM line for manual extension to other services:\n"
@@ -597,101 +597,105 @@ msgid ""
 "==> Add the above line above the first 'auth' line in any /etc/pam.d/<service> file."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:491
+#: crates/facelock-cli/src/message/pam.rs:495
 #, python-brace-format
 msgid "Invalid PAM service name '{service}': a service is one file name under /etc/pam.d, so it may not be empty, contain '/', or be '.' or '..'."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:497
+#: crates/facelock-cli/src/message/pam.rs:501
 msgid ""
 "Refusing to touch {path}: it is a symlink to {target}. PAM service links are never followed beneath {dir}.\n"
 "Edit the real service file directly, or the tool that generates it — authselect regenerates system-auth and password-auth from /etc/authselect."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:507
+#: crates/facelock-cli/src/message/pam.rs:511
 msgid ""
 "Refusing to touch {path}: it is one of {links} names for the same file, so an edit here would change a file outside /etc/pam.d that facelock cannot name.\n"
 "Break the link first: sudo cp -p {path} {path}.new && sudo mv {path}.new {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:513
+#: crates/facelock-cli/src/message/pam.rs:517
 msgid ""
 "Refusing to modify '{service}': this is a sensitive PAM service.\n"
 "Re-run with {remedy} to accept the risk of locking yourself out."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:519
+#: crates/facelock-cli/src/message/pam.rs:523
 msgid ""
 "PAM module not found. Tried: {paths}\n"
 "Install it first: cargo build --release -p pam-facelock && sudo cp target/release/libpam_facelock.so {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:524
+#: crates/facelock-cli/src/message/pam.rs:528
+msgid "Facelock's pam-auth-update profile is active; direct PAM edits would configure Facelock twice. To migrate, run `sudo pam-auth-update --disable facelock`, verify that a real correct password succeeds and a wrong password fails, then retry the original Facelock command with all of its services and flags."
+msgstr ""
+
+#: crates/facelock-cli/src/message/pam.rs:531
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to add."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:528
+#: crates/facelock-cli/src/message/pam.rs:535
 #, python-brace-format
 msgid "Would add the facelock PAM line to {path} ({hint})."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:532
+#: crates/facelock-cli/src/message/pam.rs:539
 #, python-brace-format
 msgid "Would remove the facelock PAM line from {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:536
+#: crates/facelock-cli/src/message/pam.rs:543
 #, python-brace-format
 msgid "No change needed for {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:540
+#: crates/facelock-cli/src/message/pam.rs:547
 #, python-brace-format
 msgid "PAM service file absent: {path}. Nothing to do."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:544
+#: crates/facelock-cli/src/message/pam.rs:551
 #, python-brace-format
 msgid "{path}: facelock PAM line present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:548
+#: crates/facelock-cli/src/message/pam.rs:555
 #, python-brace-format
 msgid "{path}: no facelock PAM line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:552
+#: crates/facelock-cli/src/message/pam.rs:559
 #, python-brace-format
 msgid "{paths}: service file absent"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:556
+#: crates/facelock-cli/src/message/pam.rs:563
 #, python-brace-format
 msgid "{path}: unreadable ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:560
+#: crates/facelock-cli/src/message/pam.rs:567
 #, python-brace-format
 msgid "{path}: facelock PAM line present (local override of {vendor})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:564
+#: crates/facelock-cli/src/message/pam.rs:571
 #, python-brace-format
 msgid "{dir}: directory not checked ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:568
+#: crates/facelock-cli/src/message/pam.rs:575
 #, python-brace-format
 msgid "No service file under {dirs} carries the facelock PAM line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:573
+#: crates/facelock-cli/src/message/pam.rs:580
 #, python-brace-format
 msgid "No service file under {dirs} carries the facelock PAM line, but {unchecked} could not be checked, so this is not an answer about the whole machine."
 msgstr ""
 
-#: crates/facelock-cli/src/message/pam.rs:578
+#: crates/facelock-cli/src/message/pam.rs:585
 #, python-brace-format
 msgid "No directory on the search path could be read: {dirs}."
 msgstr ""

--- a/scripts/migrate-legacy-system-assets.sh
+++ b/scripts/migrate-legacy-system-assets.sh
@@ -1,0 +1,587 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+export LC_ALL=C
+
+# Protected source installation preserves trusted administrator variants after
+# the lifecycle has proved their manager/D-Bus semantics. Standalone setup
+# migration keeps the stricter all-or-nothing ambiguity refusal.
+protected_source=false
+if [ "${1:-}" = --source-protected ]; then
+    protected_source=true
+    shift
+fi
+stage_only=false
+if [ "${1:-}" = --stage ]; then
+    [ "$protected_source" = true ] || {
+        echo "Error: --stage is reserved for the protected source-install lifecycle." >&2
+        exit 1
+    }
+    stage_only=true
+    shift
+fi
+
+# Production source installation is privileged. Never resolve migration tools
+# through the invoking user's command path. Alternate-layout tests retain their
+# injected PATH so failure and collision branches remain directly testable.
+if [ "${1:-/}" = / ]; then
+    PATH=/usr/bin:/bin
+    export PATH
+fi
+
+# Remove only exact, reviewed Facelock copies from the three historical /etc
+# paths.  Static /usr writes remain the responsibility of distro packaging and
+# `just install-files`; this helper only validates those writes and retires
+# historical copies that would override or duplicate them.
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+manifest="$repository_root/dist/legacy-system-assets.sha256"
+layout_root="${1:-/}"
+
+case "$layout_root" in
+    /*) ;;
+    *)
+        echo "Error: system-asset layout root must be absolute; no legacy files were changed." >&2
+        exit 1
+        ;;
+esac
+[ -d "$layout_root" ] && [ ! -L "$layout_root" ] || {
+    echo "Error: system-asset layout root is not a real directory; no legacy files were changed." >&2
+    exit 1
+}
+layout_root="$(cd -- "$layout_root" && pwd -P)"
+layout_prefix="${layout_root%/}"
+
+[ -f "$manifest" ] && [ ! -L "$manifest" ] || {
+    echo "Error: reviewed system-asset digest allowlist is missing or linked; no legacy files were changed." >&2
+    exit 1
+}
+
+if [ "$layout_root" = / ]; then
+    # Production is always the real system root. Tests may inject an isolated
+    # layout whose owner is the root-equivalent identity for that fixture.
+    expected_uid=0
+    expected_gid=0
+else
+    IFS=: read -r expected_uid expected_gid < <(stat -c '%u:%g' -- "$layout_root") || {
+        echo "Error: could not establish the system-asset layout owner; no legacy files were changed." >&2
+        exit 1
+    }
+fi
+
+assets=(
+    'systemd-unit|systemd/facelock-daemon.service|usr/lib/systemd/system/facelock-daemon.service|etc/systemd/system/facelock-daemon.service'
+    'dbus-policy|dbus/org.facelock.Daemon.conf|usr/share/dbus-1/system.d/org.facelock.Daemon.conf|etc/dbus-1/system.d/org.facelock.Daemon.conf'
+    'dbus-activation|dbus/org.facelock.Daemon.service|usr/share/dbus-1/system-services/org.facelock.Daemon.service|etc/dbus-1/system-services/org.facelock.Daemon.service'
+)
+
+allowlist_contains() {
+    local wanted_id="$1"
+    local wanted_hash="$2"
+
+    awk -v wanted_id="$wanted_id" -v wanted_hash="$wanted_hash" '
+        /^[[:space:]]*(#|$)/ { next }
+        {
+            if (NF != 2 || length($2) != 64 || $2 !~ /^[0-9a-f]+$/) exit 2
+            if ($1 != "systemd-unit" && $1 != "dbus-policy" &&
+                $1 != "dbus-activation") exit 2
+            key=$1 ":" $2
+            if (seen[key]++) exit 2
+            if ($1 == wanted_id && $2 == wanted_hash) found=1
+        }
+        END { if (!found) exit 1 }
+    ' "$manifest"
+}
+
+layout_root_is_trusted() {
+    local uid gid mode kind
+
+    IFS=: read -r uid gid mode kind < <(
+        stat -c '%u:%g:%a:%F' -- "$layout_root"
+    ) || return 1
+    [ "$uid" = "$expected_uid" ] &&
+        [ "$gid" = "$expected_gid" ] &&
+        [ "$kind" = directory ] &&
+        [ "$((8#$mode & 8#022))" -eq 0 ]
+}
+
+parents_are_trusted() {
+    local path="$1"
+    local relative parent_relative component current uid gid mode kind
+    local -a parent_components
+
+    case "$layout_prefix" in
+        '') relative="${path#/}" ;;
+        *)
+            case "$path" in
+                "$layout_prefix"/*) relative="${path#"$layout_prefix"/}" ;;
+                *) return 1 ;;
+            esac
+            ;;
+    esac
+    parent_relative="${relative%/*}"
+    current="$layout_root"
+    IFS='/' read -r -a parent_components <<<"$parent_relative"
+    for component in "${parent_components[@]}"; do
+        [ -n "$component" ] && [ "$component" != . ] && [ "$component" != .. ] ||
+            return 1
+        current="${current%/}/$component"
+        if [ ! -e "$current" ] && [ ! -L "$current" ]; then
+            return 0
+        fi
+        [ ! -L "$current" ] && [ -d "$current" ] || return 1
+        IFS=: read -r uid gid mode kind < <(
+            stat -c '%u:%g:%a:%F' -- "$current"
+        ) || return 1
+        [ "$uid" = "$expected_uid" ] &&
+            [ "$gid" = "$expected_gid" ] &&
+            [ "$kind" = directory ] &&
+            [ "$((8#$mode & 8#022))" -eq 0 ] || return 1
+    done
+}
+
+metadata_is_trusted_regular() {
+    local path="$1"
+    local uid gid mode links kind
+
+    parents_are_trusted "$path" || return 1
+    [ ! -L "$path" ] && [ -f "$path" ] || return 1
+    IFS=: read -r uid gid mode links kind < <(
+        stat -c '%u:%g:%a:%h:%F' -- "$path"
+    ) || return 1
+    [ "$uid" = "$expected_uid" ] &&
+        [ "$gid" = "$expected_gid" ] &&
+        [ "$mode" = 644 ] &&
+        [ "$links" -eq 1 ] &&
+        [ "$kind" = 'regular file' ]
+}
+
+metadata_is_administrator_mask() {
+    local path="$1"
+    local uid gid mode links size kind target
+
+    parents_are_trusted "$path" || return 1
+    IFS=: read -r uid gid mode links size kind < <(
+        stat -c '%u:%g:%a:%h:%s:%F' -- "$path"
+    ) || return 1
+    [ "$uid" = "$expected_uid" ] && [ "$gid" = "$expected_gid" ] &&
+        [ "$links" -eq 1 ] || return 1
+    if [ -L "$path" ]; then
+        [ "$kind" = 'symbolic link' ] || return 1
+        IFS= read -r -d '' target < <(readlink -z -- "$path") || return 1
+        [ "$target" = /dev/null ]
+        return
+    fi
+    [ -f "$path" ] && [ "$kind" = 'regular empty file' ] &&
+        [ "$size" -eq 0 ] && [ "$((8#$mode & 8#022))" -eq 0 ]
+}
+
+canonical_assets_are_valid() {
+    local record id source_relative canonical_relative legacy_relative
+    local source_path canonical_path current_hash
+
+    layout_root_is_trusted || return 1
+    for record in "${assets[@]}"; do
+        IFS='|' read -r id source_relative canonical_relative legacy_relative <<<"$record"
+        source_path="$repository_root/$source_relative"
+        canonical_path="$layout_prefix/$canonical_relative"
+        metadata_is_trusted_regular "$canonical_path" || return 1
+        cmp -s -- "$source_path" "$canonical_path" || return 1
+        current_hash="$(sha256sum -- "$source_path" | awk '{print $1}')"
+        allowlist_contains "$id" "$current_hash" || return 1
+    done
+}
+
+move_noreplace() {
+    local source="$1"
+    local destination="$2"
+
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+        return 1
+    fi
+    # GNU mv uses the kernel's no-replace operation where available. -T keeps
+    # the destination an exact name; -n forbids replacement. The state check
+    # catches both a concurrent collision and implementations that report a
+    # no-clobber skip as success.
+    mv -Tn -- "$source" "$destination" || return 1
+    [ ! -e "$source" ] && [ ! -L "$source" ] &&
+        { [ -e "$destination" ] || [ -L "$destination" ]; }
+}
+
+staged=()
+initial_interrupted=()
+stage_transaction_armed=false
+stage_transaction_complete=false
+
+rollback_staged() {
+    local index record id legacy_path quarantine_path expected_hash current_hash
+    local rollback_failed=0
+
+    for ((index=${#staged[@]} - 1; index >= 0; index--)); do
+        record="${staged[$index]}"
+        IFS='|' read -r id legacy_path quarantine_path expected_hash <<<"$record"
+        if [ -e "$legacy_path" ] || [ -L "$legacy_path" ]; then
+            if [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ] ||
+                ! metadata_is_trusted_regular "$legacy_path"; then
+                echo "Error: rollback collision preserved both names for administrator review: $legacy_path and $quarantine_path" >&2
+                rollback_failed=1
+                continue
+            fi
+            current_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+            if [ "$current_hash" != "$expected_hash" ] ||
+                ! allowlist_contains "$id" "$current_hash"; then
+                echo "Error: rollback preserved changed public bytes for administrator review: $legacy_path" >&2
+                rollback_failed=1
+            fi
+            continue
+        fi
+        if ! metadata_is_trusted_regular "$quarantine_path"; then
+            echo "Error: rollback preserved an untrusted quarantine for administrator review: $quarantine_path" >&2
+            rollback_failed=1
+            continue
+        fi
+        current_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+        if [ "$current_hash" != "$expected_hash" ] ||
+            ! allowlist_contains "$id" "$current_hash"; then
+            echo "Error: rollback preserved a changed quarantine for administrator review: $quarantine_path" >&2
+            rollback_failed=1
+            continue
+        fi
+        if ! move_noreplace "$quarantine_path" "$legacy_path" ||
+            ! metadata_is_trusted_regular "$legacy_path"; then
+            echo "Error: rollback collision preserved both names for administrator review: $legacy_path and $quarantine_path" >&2
+            rollback_failed=1
+            continue
+        fi
+        current_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+        if [ "$current_hash" != "$expected_hash" ] ||
+            [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; then
+            echo "Error: rollback could not prove the restored public identity: $legacy_path" >&2
+            rollback_failed=1
+        fi
+    done
+    return "$rollback_failed"
+}
+
+rollback_initial_interrupted() {
+    local index record id legacy_path quarantine_path expected_hash current_hash
+    local rollback_failed=0
+
+    for ((index=${#initial_interrupted[@]} - 1; index >= 0; index--)); do
+        record="${initial_interrupted[$index]}"
+        IFS='|' read -r id legacy_path quarantine_path expected_hash <<<"$record"
+        if [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; then
+            if [ -e "$legacy_path" ] || [ -L "$legacy_path" ] ||
+                ! metadata_is_trusted_regular "$quarantine_path"; then
+                echo "Error: rollback preserved an ambiguous interrupted pair: $legacy_path and $quarantine_path" >&2
+                rollback_failed=1
+                continue
+            fi
+            current_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+            if [ "$current_hash" != "$expected_hash" ] ||
+                ! allowlist_contains "$id" "$current_hash"; then
+                echo "Error: rollback preserved a changed interrupted quarantine: $quarantine_path" >&2
+                rollback_failed=1
+            fi
+            continue
+        fi
+        if ! metadata_is_trusted_regular "$legacy_path"; then
+            echo "Error: rollback could not find the interrupted identity at either fixed name: $legacy_path and $quarantine_path" >&2
+            rollback_failed=1
+            continue
+        fi
+        current_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+        if [ "$current_hash" != "$expected_hash" ] ||
+            ! allowlist_contains "$id" "$current_hash" ||
+            ! move_noreplace "$legacy_path" "$quarantine_path" ||
+            ! metadata_is_trusted_regular "$quarantine_path"; then
+            echo "Error: rollback could not restore the interrupted quarantine: $quarantine_path" >&2
+            rollback_failed=1
+            continue
+        fi
+        current_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+        if [ "$current_hash" != "$expected_hash" ] ||
+            [ -e "$legacy_path" ] || [ -L "$legacy_path" ]; then
+            echo "Error: rollback could not prove the interrupted quarantine identity: $quarantine_path" >&2
+            rollback_failed=1
+        fi
+    done
+    return "$rollback_failed"
+}
+
+rollback_stage_transaction() {
+    local rollback_failed=0
+
+    rollback_staged || rollback_failed=1
+    rollback_initial_interrupted || rollback_failed=1
+    return "$rollback_failed"
+}
+
+handle_stage_exit() {
+    local status="$?"
+
+    trap - EXIT HUP INT TERM
+    if [ "$stage_transaction_complete" != true ] &&
+        ! rollback_stage_transaction; then
+        echo "Error: signal/exit rollback was incomplete; inspect the reported fixed paths before retrying." >&2
+        status=1
+    fi
+    exit "$status"
+}
+
+handle_stage_signal() {
+    local signal="$1"
+    local status=1
+
+    case "$signal" in
+        HUP) status=129 ;;
+        INT) status=130 ;;
+        TERM) status=143 ;;
+    esac
+    exit "$status"
+}
+
+arm_stage_transaction() {
+    [ "$stage_only" = true ] || return 0
+    [ "$stage_transaction_armed" = false ] || return 0
+    trap 'handle_stage_exit' EXIT
+    trap 'handle_stage_signal HUP' HUP
+    trap 'handle_stage_signal INT' INT
+    trap 'handle_stage_signal TERM' TERM
+    stage_transaction_armed=true
+}
+
+abort_staging() {
+    local reason="$1"
+
+    echo "Error: $reason" >&2
+    if { [ "$stage_only" = true ] && ! rollback_stage_transaction; } ||
+        { [ "$stage_only" = false ] && ! rollback_staged; }; then
+        echo "Error: migration rollback was incomplete; inspect the reported fixed paths before retrying." >&2
+    else
+        stage_transaction_complete=true
+    fi
+    exit 1
+}
+
+recovery_completed=0
+initial_inventory_recorded=false
+while :; do
+    failures=()
+    candidates=()
+    interrupted=()
+
+    if ! layout_root_is_trusted; then
+        failures+=("system-asset layout root is wrongly owned or writable by group/other: $layout_root")
+    fi
+
+    # Validate every immutable asset before authorizing any /etc mutation.
+    for record in "${assets[@]}"; do
+        IFS='|' read -r id source_relative canonical_relative legacy_relative <<<"$record"
+        source_path="$repository_root/$source_relative"
+        canonical_path="$layout_prefix/$canonical_relative"
+        if ! metadata_is_trusted_regular "$canonical_path"; then
+            failures+=("package/source-owned asset is missing, linked, multiply linked, wrongly owned, or not mode 0644: $canonical_path")
+            continue
+        fi
+        if ! cmp -s -- "$source_path" "$canonical_path"; then
+            failures+=("package/source-owned asset bytes do not match this checkout: $canonical_path")
+            continue
+        fi
+        current_hash="$(sha256sum -- "$source_path" | awk '{print $1}')"
+        if ! allowlist_contains "$id" "$current_hash"; then
+            failures+=("current $source_relative bytes are absent from the reviewed allowlist")
+        fi
+    done
+
+    # Inventory all three exact public/quarantine pairs before any recovery or
+    # migration move. Only absent-public plus an exact known quarantine is a
+    # recoverable interrupted transaction. Every dual or untrusted state is
+    # preserved as ambiguous.
+    for record in "${assets[@]}"; do
+        IFS='|' read -r id source_relative canonical_relative legacy_relative <<<"$record"
+        legacy_path="$layout_prefix/$legacy_relative"
+        quarantine_path="${legacy_path%/*}/.facelock-migrate-$id"
+        legacy_state=absent
+        quarantine_state=absent
+        if ! parents_are_trusted "$legacy_path"; then
+            failures+=("legacy asset parent is linked, untrusted, or writable and was preserved: ${legacy_path%/*}")
+            continue
+        fi
+        if [ -e "$legacy_path" ] || [ -L "$legacy_path" ]; then
+            if [ "$id" = systemd-unit ] &&
+                metadata_is_administrator_mask "$legacy_path"; then
+                legacy_state=admin-mask
+            elif metadata_is_trusted_regular "$legacy_path"; then
+                legacy_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+                if allowlist_contains "$id" "$legacy_hash"; then
+                    legacy_state=exact
+                elif [ "$protected_source" = true ]; then
+                    legacy_state=admin-file
+                else
+                    failures+=("legacy asset has modified or unknown bytes and was preserved: $legacy_path")
+                    legacy_state=invalid
+                fi
+            else
+                failures+=("legacy asset is linked, non-regular, multiply linked, wrongly owned, or not mode 0644 and was preserved: $legacy_path")
+                legacy_state=invalid
+            fi
+        fi
+        if [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; then
+            if metadata_is_trusted_regular "$quarantine_path"; then
+                quarantine_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+                if allowlist_contains "$id" "$quarantine_hash"; then
+                    quarantine_state=exact
+                else
+                    failures+=("migration quarantine has modified or unknown bytes and was preserved: $quarantine_path")
+                    quarantine_state=invalid
+                fi
+            else
+                failures+=("migration quarantine is linked, non-regular, multiply linked, wrongly owned, or not mode 0644 and was preserved: $quarantine_path")
+                quarantine_state=invalid
+            fi
+        fi
+        case "$legacy_state:$quarantine_state" in
+            absent:absent) ;;
+            exact:absent) candidates+=("$id|$legacy_path|$quarantine_path|$legacy_hash") ;;
+            absent:exact) interrupted+=("$id|$legacy_path|$quarantine_path|$quarantine_hash") ;;
+            exact:exact)
+                failures+=("both the legacy asset and its fixed migration quarantine exist and were preserved as ambiguous: $legacy_path and $quarantine_path")
+                ;;
+            admin-mask:absent) ;;
+            admin-file:absent) ;;
+            admin-mask:*)
+                failures+=("administrator systemd mask has an ambiguous migration quarantine peer and was preserved: $legacy_path and $quarantine_path")
+                ;;
+            admin-file:*)
+                failures+=("administrator system asset has an ambiguous migration quarantine peer and was preserved: $legacy_path and $quarantine_path")
+                ;;
+            invalid:* | *:invalid) ;;
+        esac
+    done
+
+    if [ "${#failures[@]}" -ne 0 ]; then
+        if [ "$recovery_completed" -ne 0 ]; then
+            echo "Error: system asset validation failed after interrupted-staging names were restored; no fixed quarantine was deleted." >&2
+            echo "Resolve the preserved paths and retry:" >&2
+        else
+            echo "Error: system asset validation failed; no legacy files were changed." >&2
+            echo "Reinstall Facelock or rerun 'sudo just install-files', resolve preserved /etc overrides, and retry:" >&2
+        fi
+        printf '  - %s\n' "${failures[@]}" >&2
+        exit 1
+    fi
+    if [ "$stage_only" = true ] && [ "$initial_inventory_recorded" = false ]; then
+        initial_interrupted=("${interrupted[@]}")
+        initial_inventory_recorded=true
+        arm_stage_transaction
+    fi
+    if [ "${#interrupted[@]}" -eq 0 ]; then
+        break
+    fi
+    if [ "$recovery_completed" -ne 0 ]; then
+        echo "Error: fixed migration state changed immediately after interrupted-staging recovery; exact known names were preserved for administrator review." >&2
+        exit 1
+    fi
+
+    for ((index=${#interrupted[@]} - 1; index >= 0; index--)); do
+        IFS='|' read -r id legacy_path quarantine_path _ <<<"${interrupted[$index]}"
+        if [ -e "$legacy_path" ] || [ -L "$legacy_path" ]; then
+            echo "Error: interrupted-staging recovery found a new public collision and preserved both names: $legacy_path and $quarantine_path" >&2
+            exit 1
+        fi
+        if ! metadata_is_trusted_regular "$quarantine_path"; then
+            echo "Error: interrupted-staging recovery quarantine changed and was preserved: $quarantine_path" >&2
+            exit 1
+        fi
+        quarantine_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+        if ! allowlist_contains "$id" "$quarantine_hash"; then
+            echo "Error: interrupted-staging recovery quarantine bytes changed and were preserved: $quarantine_path" >&2
+            exit 1
+        fi
+        if ! move_noreplace "$quarantine_path" "$legacy_path"; then
+            echo "Error: failed to restore interrupted migration quarantine without replacement; both names were preserved when present: $quarantine_path to $legacy_path" >&2
+            exit 1
+        fi
+        if ! metadata_is_trusted_regular "$legacy_path" ||
+            [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; then
+            echo "Error: interrupted-staging recovery reported success without restoring the exact fixed pair: $legacy_path and $quarantine_path" >&2
+            exit 1
+        fi
+        legacy_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+        if ! allowlist_contains "$id" "$legacy_hash"; then
+            echo "Error: interrupted-staging recovery restored changed bytes and preserved them: $legacy_path" >&2
+            exit 1
+        fi
+    done
+    recovery_completed=1
+done
+
+for candidate in "${candidates[@]}"; do
+    IFS='|' read -r id legacy_path quarantine_path legacy_hash <<<"$candidate"
+    staged+=("$id|$legacy_path|$quarantine_path|$legacy_hash")
+    # Revalidate immediately before removal.  Another privileged writer is
+    # outside this helper's trust boundary, but a stable-path change still
+    # fails closed instead of deleting newly ambiguous bytes.
+    if [ ! -e "$legacy_path" ] && [ ! -L "$legacy_path" ]; then
+        abort_staging "legacy asset disappeared after preflight and earlier candidates were rolled back: $legacy_path"
+    fi
+    if ! metadata_is_trusted_regular "$legacy_path"; then
+        abort_staging "legacy asset changed after preflight and earlier candidates were rolled back: $legacy_path"
+    fi
+    legacy_hash="$(sha256sum -- "$legacy_path" | awk '{print $1}')"
+    if ! allowlist_contains "$id" "$legacy_hash"; then
+        abort_staging "legacy asset changed after preflight and earlier candidates were rolled back: $legacy_path"
+    fi
+    if ! move_noreplace "$legacy_path" "$quarantine_path"; then
+        abort_staging "could not quarantine exact legacy asset without replacement; earlier candidates were rolled back: $legacy_path"
+    fi
+    if ! metadata_is_trusted_regular "$quarantine_path"; then
+        abort_staging "quarantined legacy asset failed metadata revalidation: $quarantine_path"
+    fi
+    quarantine_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+    if ! allowlist_contains "$id" "$quarantine_hash"; then
+        abort_staging "quarantined legacy asset failed digest revalidation: $quarantine_path"
+    fi
+done
+
+# Every legacy name is absent, but rollback remains possible until the fixed
+# quarantines are published by deletion. Revalidate the complete canonical set
+# and root-equivalent trust identity before crossing that boundary.
+if ! canonical_assets_are_valid; then
+    abort_staging "canonical system assets or their trusted identity changed during migration; every staged legacy asset was rolled back"
+fi
+
+for candidate in "${staged[@]}"; do
+    IFS='|' read -r id legacy_path quarantine_path _ <<<"$candidate"
+    if ! metadata_is_trusted_regular "$quarantine_path"; then
+        abort_staging "quarantine changed before publication: $quarantine_path"
+    fi
+    quarantine_hash="$(sha256sum -- "$quarantine_path" | awk '{print $1}')"
+    if ! allowlist_contains "$id" "$quarantine_hash"; then
+        abort_staging "quarantine bytes changed before publication: $quarantine_path"
+    fi
+done
+
+if [ "$stage_only" = true ]; then
+    for candidate in "${staged[@]}"; do
+        IFS='|' read -r _ legacy_path _ _ <<<"$candidate"
+        echo "Staged exact known legacy system asset $legacy_path"
+    done
+    stage_transaction_complete=true
+    trap - EXIT HUP INT TERM
+    exit 0
+fi
+
+for candidate in "${staged[@]}"; do
+    IFS='|' read -r id legacy_path quarantine_path _ <<<"$candidate"
+    rm -- "$quarantine_path"
+    echo "Removed exact known legacy system asset $legacy_path"
+done
+
+# A second privileged writer is outside the transaction's authority, but the
+# completed operation never reports healthy without a final canonical and
+# root-equivalent identity check.
+if ! canonical_assets_are_valid; then
+    echo "Error: canonical system assets or their trusted identity changed after migration." >&2
+    exit 1
+fi

--- a/scripts/source-install-daemon-lifecycle.sh
+++ b/scripts/source-install-daemon-lifecycle.sh
@@ -1,0 +1,2925 @@
+#!/usr/bin/env bash
+
+FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE=false
+FACELOCK_SOURCE_INSTALL_BARRIER_CREATED=false
+FACELOCK_SOURCE_INSTALL_PREPARED=false
+FACELOCK_SOURCE_INSTALL_RESTORING=false
+FACELOCK_SOURCE_INSTALL_CRITICAL=false
+FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL=0
+FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR=/run/systemd/system
+FACELOCK_SOURCE_INSTALL_BARRIER_PATH=
+FACELOCK_SOURCE_INSTALL_BARRIER_FD=
+FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH=
+FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED=false
+FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD=
+FACELOCK_SOURCE_INSTALL_STOP_SUCCEEDED=false
+FACELOCK_SOURCE_INSTALL_LOCK_HELD=false
+FACELOCK_SOURCE_INSTALL_LOCK_FD=
+FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=()
+FACELOCK_SOURCE_INSTALL_INSTALLED_ASSETS=()
+FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX=
+FACELOCK_SOURCE_INSTALL_TRUST_UID=
+FACELOCK_SOURCE_INSTALL_TRUST_GID=
+FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH=
+FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT=absent
+FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD=
+FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_PATH=
+FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT=absent
+FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD=
+FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK=false
+FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER=
+FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH=
+FACELOCK_SOURCE_INSTALL_INITIAL_UNIT_NOT_FOUND=false
+FACELOCK_SOURCE_INSTALL_INITIAL_DBUS_DEFINITION_ABSENT=false
+FACELOCK_SOURCE_INSTALL_LEGACY_PLAN=()
+FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED=false
+FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED=false
+FACELOCK_SOURCE_INSTALL_LEGACY_RECONCILIATION_FAILED=false
+FACELOCK_SOURCE_INSTALL_PERSISTENT_UNIT_PLANNED_RETIRE=false
+FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT=
+FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT="$(
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P
+)"
+
+facelock_source_install_stat() {
+    LC_ALL=C stat "$@"
+}
+
+facelock_source_install_retry() {
+    local attempt=1
+
+    while ! "$@"; do
+        if [ "$attempt" -ge 3 ]; then
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+}
+
+facelock_source_install_handle_signal() {
+    local signal="$1"
+    local status
+
+    case "$signal" in
+        HUP) status=129 ;;
+        INT) status=130 ;;
+        TERM) status=143 ;;
+        *) status=1 ;;
+    esac
+
+    if [ "$FACELOCK_SOURCE_INSTALL_CRITICAL" = true ] ||
+        [ "$FACELOCK_SOURCE_INSTALL_RESTORING" = true ]; then
+        FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL="$status"
+        return 0
+    fi
+    exit "$status"
+}
+
+facelock_source_install_arm_daemon_restore() {
+    trap 'facelock_source_install_exit_handler' EXIT
+    trap 'facelock_source_install_handle_signal HUP' HUP
+    trap 'facelock_source_install_handle_signal INT' INT
+    trap 'facelock_source_install_handle_signal TERM' TERM
+}
+
+facelock_source_install_default_assets() {
+    printf '%s\n' \
+        /etc/systemd/system.control/facelock-daemon.service \
+        /run/systemd/system.control/facelock-daemon.service \
+        /run/systemd/transient/facelock-daemon.service \
+        /run/systemd/generator.early/facelock-daemon.service \
+        /etc/systemd/system/facelock-daemon.service \
+        /etc/systemd/system.attached/facelock-daemon.service \
+        /run/systemd/system/facelock-daemon.service \
+        /run/systemd/system.attached/facelock-daemon.service \
+        /run/systemd/generator/facelock-daemon.service \
+        /usr/local/lib/systemd/system/facelock-daemon.service \
+        /usr/lib/systemd/system/facelock-daemon.service \
+        /lib/systemd/system/facelock-daemon.service \
+        /run/systemd/generator.late/facelock-daemon.service \
+        /etc/dbus-1/system-services/org.facelock.Daemon.service \
+        /run/dbus-1/system-services/org.facelock.Daemon.service \
+        /usr/local/share/dbus-1/system-services/org.facelock.Daemon.service \
+        /usr/share/dbus-1/system-services/org.facelock.Daemon.service \
+        /lib/dbus-1/system-services/org.facelock.Daemon.service
+}
+
+facelock_source_install_create_barrier() {
+    local barrier_dir="$1"
+    local had_noclobber=false
+    local create_status=0
+    local directory_mode original_umask
+
+    FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH="$barrier_dir"
+    if [ -L "$barrier_dir" ] || {
+        [ -e "$barrier_dir" ] && [ ! -d "$barrier_dir" ];
+    }; then
+        return 1
+    fi
+    facelock_source_install_parents_are_trusted \
+        "$barrier_dir" "${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}" || return 1
+    if [ ! -d "$barrier_dir" ]; then
+        if mkdir -m 0755 -- "$barrier_dir"; then
+            FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED=true
+            if ! exec {FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD}<"$barrier_dir"; then
+                rmdir -- "$barrier_dir" || true
+                FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED=false
+                return 1
+            fi
+        elif [ -L "$barrier_dir" ] || [ ! -d "$barrier_dir" ]; then
+            return 1
+        fi
+    fi
+    facelock_source_install_directory_is_trusted "$barrier_dir" || return 1
+    directory_mode="$(stat -Lc '%a' -- "$barrier_dir")" || return 1
+    [ "$directory_mode" = 755 ] || return 1
+
+    FACELOCK_SOURCE_INSTALL_BARRIER_PATH="$barrier_dir/facelock-daemon.service"
+    FACELOCK_SOURCE_INSTALL_BARRIER_FD=
+    case "$-" in
+        *C*) had_noclobber=true ;;
+    esac
+    original_umask="$(umask)" || return 1
+    umask 077
+    set -o noclobber
+    if { exec {FACELOCK_SOURCE_INSTALL_BARRIER_FD}> \
+        "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH"; } 2>/dev/null; then
+        FACELOCK_SOURCE_INSTALL_BARRIER_CREATED=true
+    else
+        create_status=$?
+    fi
+    if [ "$had_noclobber" = false ]; then
+        set +o noclobber
+    fi
+    umask "$original_umask"
+    if [ "$create_status" -eq 0 ] &&
+        ! facelock_source_install_owned_barrier_is_current; then
+        create_status=1
+    fi
+    return "$create_status"
+}
+
+facelock_source_install_owned_barrier_dir_is_current() {
+    [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD" ] &&
+        [ -d "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH" ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH" -ef \
+            "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD" ]
+}
+
+facelock_source_install_owned_barrier_is_current() {
+    local path_metadata fd_metadata uid gid mode links size kind
+
+    [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_FD" ] &&
+        [ -f "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ ! -s "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" -ef \
+            "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_FD" ] || return 1
+    path_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+        "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH")" || return 1
+    fd_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+        "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_FD")" || return 1
+    [ "$path_metadata" = "$fd_metadata" ] || return 1
+    IFS=: read -r _ _ uid gid mode links size kind <<<"$path_metadata"
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$mode" = 600 ] && [ "$links" -eq 1 ] && [ "$size" -eq 0 ] &&
+        [[ "$kind" = regular\ *file ]]
+}
+
+facelock_source_install_quarantined_barrier_is_current() {
+    local path_metadata fd_metadata uid gid mode links size kind
+
+    [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED" = true ] &&
+        [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] &&
+        [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_FD" ] &&
+        [ -f "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] &&
+        [ ! -s "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" -ef \
+            "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_FD" ] || return 1
+    path_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+        "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH")" || return 1
+    fd_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+        "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_FD")" || return 1
+    [ "$path_metadata" = "$fd_metadata" ] || return 1
+    IFS=: read -r _ _ uid gid mode links size kind <<<"$path_metadata"
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$mode" = 600 ] && [ "$links" -eq 1 ] && [ "$size" -eq 0 ] &&
+        [[ "$kind" = regular\ *file ]]
+}
+
+facelock_source_install_quarantine_owned_barrier() {
+    local quarantine_path
+
+    if [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED" = true ]; then
+        facelock_source_install_quarantined_barrier_is_current &&
+            [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+            [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ]
+        return
+    fi
+    if ! facelock_source_install_owned_barrier_is_current; then
+        return 1
+    fi
+    quarantine_path="${FACELOCK_SOURCE_INSTALL_BARRIER_PATH}.facelock-remove.$$.$RANDOM"
+    if [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; then
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH="$quarantine_path"
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=true
+    if mv -T --no-clobber -- \
+        "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" "$quarantine_path" &&
+        facelock_source_install_quarantined_barrier_is_current &&
+        [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ]; then
+        return 0
+    fi
+    if facelock_source_install_quarantined_barrier_is_current &&
+        [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ]; then
+        return 1
+    fi
+    if { [ -e "$quarantine_path" ] || [ -L "$quarantine_path" ]; } &&
+        [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+        mv -T --no-clobber -- "$quarantine_path" \
+            "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH"; then
+        FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+        FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+    elif [ ! -e "$quarantine_path" ] && [ ! -L "$quarantine_path" ]; then
+        FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+        FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+    fi
+    return 1
+}
+
+facelock_source_install_restore_quarantined_barrier() {
+    facelock_source_install_quarantined_barrier_is_current || return 1
+    if [ -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] ||
+        [ -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] ||
+        ! mv -T --no-clobber -- \
+            "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" \
+            "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ||
+        ! facelock_source_install_owned_barrier_is_current; then
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+}
+
+facelock_source_install_remove_quarantined_barrier() {
+    facelock_source_install_quarantined_barrier_is_current || return 1
+    if ! rm -f -- "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ||
+        [ -e "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] ||
+        [ -L "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ]; then
+        return 1
+    fi
+    exec {FACELOCK_SOURCE_INSTALL_BARRIER_FD}>&-
+    FACELOCK_SOURCE_INSTALL_BARRIER_FD=
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+}
+
+facelock_source_install_remove_owned_barrier_dir() {
+    local barrier_dir="$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH"
+    local quarantine_dir entry directory_mode
+
+    if ! facelock_source_install_owned_barrier_dir_is_current ||
+        ! facelock_source_install_directory_is_trusted "$barrier_dir" ||
+        ! directory_mode="$(facelock_source_install_stat -Lc '%a' -- "$barrier_dir")" ||
+        [ "$directory_mode" != 755 ] ||
+        { IFS= read -r -d '' entry < <(
+            find "$barrier_dir" -mindepth 1 -maxdepth 1 -print0 -quit
+        ) && [ -n "$entry" ]; }; then
+        return 1
+    fi
+    quarantine_dir="$barrier_dir.facelock-remove.$$.$RANDOM"
+    if [ -e "$quarantine_dir" ] || [ -L "$quarantine_dir" ]; then
+        return 1
+    fi
+    if ! mv -T --no-clobber -- "$barrier_dir" "$quarantine_dir" ||
+        [ ! "$quarantine_dir" -ef \
+            "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD" ] ||
+        ! facelock_source_install_directory_is_trusted "$quarantine_dir" ||
+        ! directory_mode="$(facelock_source_install_stat -Lc '%a' -- "$quarantine_dir")" ||
+        [ "$directory_mode" != 755 ] ||
+        { IFS= read -r -d '' entry < <(
+            find "$quarantine_dir" -mindepth 1 -maxdepth 1 -print0 -quit
+        ) && [ -n "$entry" ]; }; then
+        if { [ -e "$quarantine_dir" ] || [ -L "$quarantine_dir" ]; } &&
+            [ ! -e "$barrier_dir" ] && [ ! -L "$barrier_dir" ] &&
+            mv -T --no-clobber -- "$quarantine_dir" "$barrier_dir"; then
+            :
+        fi
+        return 1
+    fi
+    if ! rmdir -- "$quarantine_dir"; then
+        if [ ! -e "$barrier_dir" ] && [ ! -L "$barrier_dir" ]; then
+            mv -T --no-clobber -- "$quarantine_dir" "$barrier_dir" || true
+        fi
+        return 1
+    fi
+    exec {FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD}>&-
+    FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD=
+}
+
+facelock_source_install_ensure_lock_directory() {
+    local lock_dir="$1"
+    local boundary="${2:-/}"
+    local original_umask mode
+
+    facelock_source_install_existing_parents_are_trusted \
+        "$lock_dir/lifecycle.lock" "$boundary" || return 1
+    if [ ! -e "$lock_dir" ] && [ ! -L "$lock_dir" ]; then
+        original_umask="$(umask)"
+        umask 022
+        if ! mkdir -m 755 -- "$lock_dir"; then
+            umask "$original_umask"
+            [ -d "$lock_dir" ] && [ ! -L "$lock_dir" ] || return 1
+        else
+            umask "$original_umask"
+        fi
+    fi
+    facelock_source_install_directory_is_trusted "$lock_dir" &&
+        mode="$(facelock_source_install_stat -Lc '%a' -- "$lock_dir")" &&
+        [ "$mode" = 755 ] &&
+        facelock_source_install_parents_are_trusted \
+            "$lock_dir/lifecycle.lock" "$boundary"
+}
+
+facelock_source_install_acquire_lock() {
+    local lock_path="$1"
+    local boundary="${2:-/}"
+    local original_umask
+    local probe_path="$lock_path.facelock-lock.$$.$RANDOM"
+    local uid gid mode links size kind
+
+    facelock_source_install_parents_are_trusted "$lock_path" "$boundary" ||
+        return 1
+    if [ -e "$probe_path" ] || [ -L "$probe_path" ]; then
+        return 1
+    fi
+    original_umask="$(umask)"
+    umask 077
+    if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+        if ! ln -P -- "$lock_path" "$probe_path"; then
+            umask "$original_umask"
+            return 1
+        fi
+    else
+        local had_noclobber=false
+        case "$-" in
+            *C*) had_noclobber=true ;;
+        esac
+        set -o noclobber
+        if ! { : >"$probe_path"; } 2>/dev/null; then
+            [ "$had_noclobber" = true ] || set +o noclobber
+            umask "$original_umask"
+            return 1
+        fi
+        [ "$had_noclobber" = true ] || set +o noclobber
+        chmod 600 -- "$probe_path" || {
+            rm -f -- "$probe_path"
+            umask "$original_umask"
+            return 1
+        }
+        if ! ln -- "$probe_path" "$lock_path"; then
+            rm -f -- "$probe_path"
+            umask "$original_umask"
+            return 1
+        fi
+    fi
+    if [ -L "$probe_path" ] || [ ! -f "$probe_path" ] ||
+        ! IFS=: read -r uid gid mode links size kind < <(
+            facelock_source_install_stat -Lc '%u:%g:%a:%h:%s:%F' -- "$probe_path"
+        ) ||
+        [ "$uid" != "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] ||
+        [ "$gid" != "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] ||
+        [ "$mode" != 600 ] || [ "$links" -ne 2 ] || [ "$size" -ne 0 ]; then
+        rm -f -- "$probe_path"
+        umask "$original_umask"
+        return 1
+    fi
+    case "$kind" in
+        regular\ *file) ;;
+        *)
+            rm -f -- "$probe_path"
+            umask "$original_umask"
+            return 1
+            ;;
+    esac
+    if ! exec {FACELOCK_SOURCE_INSTALL_LOCK_FD}<>"$probe_path"; then
+        rm -f -- "$probe_path"
+        umask "$original_umask"
+        return 1
+    fi
+    umask "$original_umask"
+    if [ ! "$probe_path" -ef "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_LOCK_FD" ] ||
+        [ ! "$lock_path" -ef "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_LOCK_FD" ] ||
+        ! flock -n "$FACELOCK_SOURCE_INSTALL_LOCK_FD"; then
+        rm -f -- "$probe_path"
+        exec {FACELOCK_SOURCE_INSTALL_LOCK_FD}>&-
+        FACELOCK_SOURCE_INSTALL_LOCK_FD=
+        return 1
+    fi
+    if ! rm -f -- "$probe_path" ||
+        [ -L "$lock_path" ] || [ ! -f "$lock_path" ] ||
+        [ ! "$lock_path" -ef "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_LOCK_FD" ] ||
+        ! IFS=: read -r uid gid mode links size kind < <(
+            facelock_source_install_stat -Lc '%u:%g:%a:%h:%s:%F' -- \
+                "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_LOCK_FD"
+        ) ||
+        [ "$uid" != "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] ||
+        [ "$gid" != "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] ||
+        [ "$mode" != 600 ] || [ "$links" -ne 1 ] || [ "$size" -ne 0 ] ||
+        [[ "$kind" != regular\ *file ]]; then
+        exec {FACELOCK_SOURCE_INSTALL_LOCK_FD}>&-
+        FACELOCK_SOURCE_INSTALL_LOCK_FD=
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_LOCK_HELD=true
+    return 0
+}
+
+facelock_source_install_release_lock() {
+    if [ "$FACELOCK_SOURCE_INSTALL_LOCK_HELD" = true ]; then
+        exec {FACELOCK_SOURCE_INSTALL_LOCK_FD}>&-
+        FACELOCK_SOURCE_INSTALL_LOCK_FD=
+        FACELOCK_SOURCE_INSTALL_LOCK_HELD=false
+    fi
+}
+
+facelock_source_install_path_is_beneath() {
+    local path="$1"
+    local boundary="$2"
+
+    case "$path:$boundary" in
+        *'/../'* | *'/./'* | *'//'* | */..:* | */.:*) return 1 ;;
+    esac
+    if [ "$boundary" = / ]; then
+        case "$path" in
+            /*) return 0 ;;
+        esac
+    else
+        case "$path" in
+            "$boundary" | "$boundary"/*) return 0 ;;
+        esac
+    fi
+    return 1
+}
+
+facelock_source_install_directory_is_trusted() {
+    local path="$1"
+    local directory_fd
+    local mode uid gid kind
+    local status=0
+
+    [ -d "$path" ] && [ ! -L "$path" ] || return 1
+    exec {directory_fd}<"$path" || return 1
+    if [ ! "$path" -ef "/proc/$$/fd/$directory_fd" ] ||
+        ! IFS=: read -r uid gid mode kind < <(
+            facelock_source_install_stat -Lc '%u:%g:%a:%F' -- "/proc/$$/fd/$directory_fd"
+        ) ||
+        [ "$uid" != "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] ||
+        [ "$gid" != "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] ||
+        [ "$kind" != directory ] ||
+        [ "$((8#$mode & 8#022))" -ne 0 ]; then
+        status=1
+    fi
+    exec {directory_fd}>&-
+    return "$status"
+}
+
+facelock_source_install_standard_directory_alias_is_trusted() {
+    local path="$1"
+    local boundary="$2"
+    local lib_path usr_path usr_lib_path target uid gid links kind
+
+    if [ "$boundary" = / ]; then
+        lib_path=/lib
+        usr_path=/usr
+        usr_lib_path=/usr/lib
+    else
+        lib_path="$boundary/lib"
+        usr_path="$boundary/usr"
+        usr_lib_path="$boundary/usr/lib"
+    fi
+    [ "$path" = "$lib_path" ] && [ -L "$path" ] || return 1
+    IFS= read -r -d '' target < <(readlink -z -- "$path") || return 1
+    [ "$target" = usr/lib ] || return 1
+    IFS=: read -r uid gid links kind < <(
+        facelock_source_install_stat -c '%u:%g:%h:%F' -- "$path"
+    ) || return 1
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$links" -eq 1 ] &&
+        [ "$kind" = symbolic\ link ] &&
+        facelock_source_install_directory_is_trusted "$usr_path" &&
+        facelock_source_install_directory_is_trusted "$usr_lib_path"
+}
+
+facelock_source_install_existing_parents_are_trusted() {
+    local path="$1"
+    local boundary="$2"
+    local relative component current
+
+    facelock_source_install_path_is_beneath "$path" "$boundary" || return 1
+    facelock_source_install_directory_is_trusted "$boundary" || return 1
+    relative="${path#"$boundary"}"
+    relative="${relative#/}"
+    current="${boundary%/}"
+    [ -n "$current" ] || current=/
+    while [ -n "$relative" ]; do
+        component="${relative%%/*}"
+        if [ "$component" = "$relative" ]; then
+            break
+        fi
+        relative="${relative#*/}"
+        if [ "$current" = / ]; then
+            current="/$component"
+        else
+            current="$current/$component"
+        fi
+        if [ -L "$current" ]; then
+            facelock_source_install_standard_directory_alias_is_trusted \
+                "$current" "$boundary" || return 1
+            continue
+        fi
+        [ -e "$current" ] || return 0
+        facelock_source_install_directory_is_trusted "$current" || return 1
+    done
+}
+
+facelock_source_install_parents_are_trusted() {
+    local path="$1"
+    local boundary="$2"
+    local relative component current
+
+    facelock_source_install_path_is_beneath "$path" "$boundary" || return 1
+    facelock_source_install_directory_is_trusted "$boundary" || return 1
+    relative="${path#"$boundary"}"
+    relative="${relative#/}"
+    current="${boundary%/}"
+    [ -n "$current" ] || current=/
+    while [ -n "$relative" ]; do
+        component="${relative%%/*}"
+        if [ "$component" = "$relative" ]; then
+            break
+        fi
+        relative="${relative#*/}"
+        if [ "$current" = / ]; then
+            current="/$component"
+        else
+            current="$current/$component"
+        fi
+        if [ -L "$current" ]; then
+            facelock_source_install_standard_directory_alias_is_trusted \
+                "$current" "$boundary" || return 1
+        else
+            facelock_source_install_directory_is_trusted "$current" || return 1
+        fi
+    done
+}
+
+facelock_source_install_regular_file_is_trusted() {
+    local path="$1"
+    local boundary="$2"
+    local max_size="$3"
+    local require_executable="${4:-false}"
+    local file_fd
+    local uid gid mode links size kind
+    local status=0
+
+    facelock_source_install_parents_are_trusted "$path" "$boundary" || return 1
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    exec {file_fd}<"$path" || return 1
+    if [ ! "$path" -ef "/proc/$$/fd/$file_fd" ] ||
+        ! IFS=: read -r uid gid mode links size kind < <(
+            facelock_source_install_stat -Lc '%u:%g:%a:%h:%s:%F' -- "/proc/$$/fd/$file_fd"
+        ); then
+        status=1
+    else
+        case "$kind" in
+            regular\ *file) ;;
+            *) status=1 ;;
+        esac
+        if [ "$uid" != "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] ||
+            [ "$gid" != "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] ||
+            [ "$links" -ne 1 ] ||
+            [ "$size" -gt "$max_size" ] ||
+            [ "$((8#$mode & 8#022))" -ne 0 ] || {
+                [ "$require_executable" = true ] &&
+                    [ "$((8#$mode & 8#111))" -eq 0 ];
+            }; then
+            status=1
+        fi
+    fi
+    exec {file_fd}>&-
+    return "$status"
+}
+
+facelock_source_install_repository_file_is_trusted() {
+    local path="$1"
+    local max_size="$2"
+    local saved_uid="$FACELOCK_SOURCE_INSTALL_TRUST_UID"
+    local saved_gid="$FACELOCK_SOURCE_INSTALL_TRUST_GID"
+    local status=0
+
+    if ! IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+        FACELOCK_SOURCE_INSTALL_TRUST_GID < <(
+        stat -Lc '%u:%g' -- "$FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT"
+    ) || ! facelock_source_install_regular_file_is_trusted \
+        "$path" "$FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT" "$max_size"; then
+        status=1
+    fi
+    FACELOCK_SOURCE_INSTALL_TRUST_UID="$saved_uid"
+    FACELOCK_SOURCE_INSTALL_TRUST_GID="$saved_gid"
+    return "$status"
+}
+
+facelock_source_install_exec_status_value_is_bounded() {
+    local value="$1"
+
+    [ -n "$value" ] && [ "${#value}" -le 256 ] || return 1
+    case "$value" in
+        *$'\n'* | *$'\r'* | *';'* | *'{'* | *'}'*) return 1 ;;
+    esac
+}
+
+facelock_source_install_parse_structured_exec_start() {
+    local exec_start="$1"
+    local body field value index
+    local -a fields
+
+    FACELOCK_SOURCE_INSTALL_EXEC_PATH=
+    FACELOCK_SOURCE_INSTALL_EXEC_ARGV=
+    case "$exec_start" in
+        *$'\n'* | *$'\r'*) return 1 ;;
+    esac
+    case "$exec_start" in
+        '{ '*' }') ;;
+        *) return 1 ;;
+    esac
+    body="${exec_start#\{ }"
+    body="${body% \}}"
+    field="${body%"${body##*[![:space:]]}"}"
+    case "$field" in
+        *';') return 1 ;;
+    esac
+    IFS=';' read -r -a fields <<<"$body"
+    [ "${#fields[@]}" -eq 8 ] || return 1
+    for index in "${!fields[@]}"; do
+        field="${fields[$index]}"
+        field="${field#"${field%%[![:space:]]*}"}"
+        field="${field%"${field##*[![:space:]]}"}"
+        fields[index]="$field"
+    done
+    case "${fields[0]}" in
+        path=?*) FACELOCK_SOURCE_INSTALL_EXEC_PATH="${fields[0]#path=}" ;;
+        *) return 1 ;;
+    esac
+    case "${fields[1]}" in
+        'argv[]='?*) FACELOCK_SOURCE_INSTALL_EXEC_ARGV="${fields[1]#argv[]=}" ;;
+        *) return 1 ;;
+    esac
+    [ "${fields[2]}" = ignore_errors=no ] || return 1
+    for index in 3 4 6 7; do
+        case "$index:${fields[$index]}" in
+            3:start_time=*) value="${fields[$index]#start_time=}" ;;
+            4:stop_time=*) value="${fields[$index]#stop_time=}" ;;
+            6:code=*) value="${fields[$index]#code=}" ;;
+            7:status=*) value="${fields[$index]#status=}" ;;
+            *) return 1 ;;
+        esac
+        facelock_source_install_exec_status_value_is_bounded "$value" ||
+            return 1
+    done
+    [[ "${fields[5]}" =~ ^pid=[0-9]{1,20}$ ]] || return 1
+}
+
+facelock_source_install_effective_unit_is_trusted() {
+    local fragment_path="$1"
+    local exec_start="$2"
+    local drop_in_paths="$3"
+    local boundary="$4"
+    shift 4
+    local asset executable selected=false
+    # Leave headroom for optimized release builds while bounding file validation.
+    local daemon_max_size=268435456
+
+    [ -n "$fragment_path" ] && [ -z "$drop_in_paths" ] || return 1
+    case "$exec_start" in
+        '/usr/bin/facelock daemon') ;;
+        *)
+            facelock_source_install_parse_structured_exec_start \
+                "$exec_start" || return 1
+            [ "$FACELOCK_SOURCE_INSTALL_EXEC_PATH" = /usr/bin/facelock ] &&
+                [ "$FACELOCK_SOURCE_INSTALL_EXEC_ARGV" = \
+                    '/usr/bin/facelock daemon' ] || return 1
+            ;;
+    esac
+    executable="${boundary%/}/usr/bin/facelock"
+    facelock_source_install_regular_file_is_trusted \
+        "$executable" "$boundary" "$daemon_max_size" true || return 1
+    for asset in "$@"; do
+        case "$asset" in
+            */org.facelock.Daemon.service) continue ;;
+        esac
+        if [ "$fragment_path" = "$asset" ]; then
+            selected=true
+            break
+        fi
+    done
+    [ "$selected" = true ] &&
+        facelock_source_install_regular_file_is_trusted \
+            "$fragment_path" "$boundary" 1048576
+}
+
+facelock_source_install_dbus_runtime_assets_are_trusted() {
+    local id="$1"
+    local names="$2"
+    local exec_start="$3"
+    local fragment_path="$4"
+    local executable executable_path argv name
+    local boundary="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local prefix="$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX"
+    local broker_name=false dbus_name=false
+    local -a name_values
+
+    case "$exec_start" in
+        '{ '*' }')
+            facelock_source_install_parse_structured_exec_start \
+                "$exec_start" || return 1
+            executable="$FACELOCK_SOURCE_INSTALL_EXEC_PATH"
+            argv="$FACELOCK_SOURCE_INSTALL_EXEC_ARGV"
+            ;;
+        *)
+            executable="${exec_start%% *}"
+            argv="$exec_start"
+            ;;
+    esac
+    read -r -a name_values <<<"$names"
+    for name in "${name_values[@]}"; do
+        case "$name" in
+            dbus-broker.service)
+                [ "$broker_name" = false ] || return 1
+                broker_name=true
+                ;;
+            dbus.service)
+                [ "$dbus_name" = false ] || return 1
+                dbus_name=true
+                ;;
+            *) return 1 ;;
+        esac
+    done
+    case "$executable" in
+        /usr/bin/dbus-broker-launch)
+            [ "$id" = dbus-broker.service ] &&
+                [ "$broker_name" = true ] && [ "$dbus_name" = true ] &&
+                [ "${#name_values[@]}" -eq 2 ] || return 1
+            case "$argv" in
+                '/usr/bin/dbus-broker-launch --scope system' | \
+                    '/usr/bin/dbus-broker-launch --scope=system' | \
+                    '/usr/bin/dbus-broker-launch --scope system --audit' | \
+                    '/usr/bin/dbus-broker-launch --scope=system --audit') ;;
+                *) return 1 ;;
+            esac
+            case "$fragment_path" in
+                "$prefix/usr/lib/systemd/system/dbus-broker.service") ;;
+                "$prefix/lib/systemd/system/dbus-broker.service")
+                    facelock_source_install_standard_directory_alias_is_trusted \
+                        "$prefix/lib" "$boundary" || return 1
+                    ;;
+                *) return 1 ;;
+            esac
+            ;;
+        /usr/bin/dbus-daemon)
+            [ "$id" = dbus.service ] && [ "$broker_name" = false ] &&
+                [ "$dbus_name" = true ] &&
+                [ "${#name_values[@]}" -eq 1 ] || return 1
+            case "$exec_start" in
+                '{ '*' }')
+                    case "$argv" in
+                        '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only' | \
+                            'dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only' | \
+                            '@dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only') ;;
+                        *) return 1 ;;
+                    esac
+                    ;;
+                *)
+                    [ "$argv" = \
+                        '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only' ] ||
+                        return 1
+                    ;;
+            esac
+            case "$fragment_path" in
+                "$prefix/usr/lib/systemd/system/dbus.service") ;;
+                "$prefix/lib/systemd/system/dbus.service")
+                    facelock_source_install_standard_directory_alias_is_trusted \
+                        "$prefix/lib" "$boundary" || return 1
+                    ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+    executable_path="${prefix}${executable}"
+    facelock_source_install_regular_file_is_trusted \
+        "$executable_path" "$boundary" 16777216 &&
+        facelock_source_install_regular_file_is_trusted \
+            "$fragment_path" "$boundary" 1048576
+}
+
+facelock_source_install_dbus_uses_systemd_activation() {
+    local snapshot line id="" names="" following="" load_state=""
+    local active_state="" fragment_path="" drop_in_paths="" exec_start=""
+    local id_count=0 names_count=0 following_count=0 load_state_count=0
+    local active_state_count=0 fragment_path_count=0 drop_in_paths_count=0
+    local exec_start_count=0
+
+    if ! snapshot="$(systemctl show dbus.service \
+        --property=Id \
+        --property=Names \
+        --property=Following \
+        --property=LoadState \
+        --property=ActiveState \
+        --property=FragmentPath \
+        --property=DropInPaths \
+        --property=ExecStart \
+        --no-pager)"; then
+        return 1
+    fi
+    while IFS= read -r line; do
+        case "$line" in
+            Id=*)
+                id_count=$((id_count + 1))
+                id="${line#Id=}"
+                ;;
+            Names=*)
+                names_count=$((names_count + 1))
+                names="${line#Names=}"
+                ;;
+            Following=*)
+                following_count=$((following_count + 1))
+                following="${line#Following=}"
+                ;;
+            LoadState=*)
+                load_state_count=$((load_state_count + 1))
+                load_state="${line#LoadState=}"
+                ;;
+            ActiveState=*)
+                active_state_count=$((active_state_count + 1))
+                active_state="${line#ActiveState=}"
+                ;;
+            ExecStart=*)
+                exec_start_count=$((exec_start_count + 1))
+                exec_start="${line#ExecStart=}"
+                ;;
+            FragmentPath=*)
+                fragment_path_count=$((fragment_path_count + 1))
+                fragment_path="${line#FragmentPath=}"
+                ;;
+            DropInPaths=*)
+                drop_in_paths_count=$((drop_in_paths_count + 1))
+                drop_in_paths="${line#DropInPaths=}"
+                ;;
+            *) return 1 ;;
+        esac
+    done <<<"$snapshot"
+    [ "$id_count" -eq 1 ] && [ "$names_count" -eq 1 ] &&
+        [ "$following_count" -eq 1 ] && [ "$load_state_count" -eq 1 ] &&
+        [ "$active_state_count" -eq 1 ] &&
+        [ "$fragment_path_count" -eq 1 ] &&
+        [ "$drop_in_paths_count" -eq 1 ] &&
+        [ "$exec_start_count" -eq 1 ] ||
+        return 1
+    [ "$load_state" = loaded ] && [ "$active_state" = active ] &&
+        [ -z "$following" ] && [ -z "$drop_in_paths" ] || return 1
+    facelock_source_install_dbus_runtime_assets_are_trusted \
+        "$id" "$names" "$exec_start" "$fragment_path"
+}
+
+facelock_source_install_dbus_config_fragment_is_policy_only() {
+    local path="$1"
+    local boundary="$2"
+    local line
+
+    facelock_source_install_existing_parents_are_trusted \
+        "$path" "$boundary" || return 1
+    if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; }; then
+        return 1
+    fi
+    [ -e "$path" ] || return 0
+    facelock_source_install_regular_file_is_trusted \
+        "$path" "$boundary" 1048576 || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            *'<servicedir'* | *'<standard_system_servicedirs'* | \
+                *'<include'*) return 1 ;;
+        esac
+    done <"$path"
+}
+
+facelock_source_install_dbus_config_dir_is_policy_only() {
+    local directory="$1"
+    local boundary="$2"
+    local fragment
+
+    facelock_source_install_existing_parents_are_trusted \
+        "$directory" "$boundary" || return 1
+    if [ -L "$directory" ] || {
+        [ -e "$directory" ] && [ ! -d "$directory" ];
+    }; then
+        return 1
+    fi
+    [ -d "$directory" ] || return 0
+    facelock_source_install_directory_is_trusted "$directory" || return 1
+    for fragment in "$directory"/*.conf; do
+        if [ ! -e "$fragment" ] && [ ! -L "$fragment" ]; then
+            continue
+        fi
+        facelock_source_install_dbus_config_fragment_is_policy_only \
+            "$fragment" "$boundary" || return 1
+    done
+}
+
+facelock_source_install_dbus_config_is_standard() {
+    local layout_prefix="$1"
+    local main_config="$layout_prefix/usr/share/dbus-1/system.conf"
+    local boundary="${layout_prefix:-/}"
+    local line trimmed standard_dirs=0
+    local fragment directory
+    local -a fragments=(
+        "$layout_prefix/etc/dbus-1/system.conf"
+        "$layout_prefix/etc/dbus-1/system-local.conf"
+        "$layout_prefix/usr/share/dbus-1/contexts/dbus_contexts"
+    )
+    local -a directories=(
+        "$layout_prefix/usr/share/dbus-1/system.d"
+        "$layout_prefix/etc/dbus-1/system.d"
+    )
+
+    facelock_source_install_regular_file_is_trusted \
+        "$main_config" "$boundary" 1048576 || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        case "$trimmed" in
+            '<standard_system_servicedirs/>' | \
+                '<standard_system_servicedirs />')
+                standard_dirs=$((standard_dirs + 1))
+                ;;
+            '<include ignore_missing="yes">/etc/dbus-1/system.conf</include>' | \
+                '<includedir>system.d</includedir>' | \
+                '<includedir>/etc/dbus-1/system.d</includedir>' | \
+                '<include ignore_missing="yes">/etc/dbus-1/system-local.conf</include>' | \
+                '<include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>')
+                ;;
+            *'<servicedir'* | *'<standard_system_servicedirs'* | \
+                *'<include'*) return 1 ;;
+        esac
+    done <"$main_config"
+    [ "$standard_dirs" -eq 1 ] || return 1
+
+    for fragment in "${fragments[@]}"; do
+        facelock_source_install_dbus_config_fragment_is_policy_only \
+            "$fragment" "$boundary" || return 1
+    done
+    for directory in "${directories[@]}"; do
+        facelock_source_install_dbus_config_dir_is_policy_only \
+            "$directory" "$boundary" || return 1
+    done
+}
+
+facelock_source_install_dbus_line_is_ascii() {
+    local remaining="$1"
+    local byte
+    local LC_ALL=C
+
+    while [ -n "$remaining" ]; do
+        byte="${remaining:0:1}"
+        case "$byte" in
+            $'\t' | [[:print:]]) ;;
+            *) return 1 ;;
+        esac
+        remaining="${remaining:1}"
+    done
+}
+
+facelock_source_install_parse_dbus_definition() {
+    local path="$1"
+    local trusted_path="$path"
+    local boundary="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local definition_fd definition_size line key value
+    local bytes_read=0 final_line=false in_service=false
+    local repository_path=false status=0
+    local LC_ALL=C
+
+    FACELOCK_SOURCE_INSTALL_DBUS_SERVICE_SECTIONS=0
+    FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=true
+    FACELOCK_SOURCE_INSTALL_DBUS_NAMES=0
+    FACELOCK_SOURCE_INSTALL_DBUS_NAME=
+    FACELOCK_SOURCE_INSTALL_DBUS_TARGET_NAME_SEEN=false
+    FACELOCK_SOURCE_INSTALL_DBUS_EXECS=0
+    FACELOCK_SOURCE_INSTALL_DBUS_EXEC=
+    FACELOCK_SOURCE_INSTALL_DBUS_USERS=0
+    FACELOCK_SOURCE_INSTALL_DBUS_USER=
+    FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICES=0
+    FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICE=
+    case "$path" in
+        /*)
+            facelock_source_install_regular_file_is_trusted \
+                "$path" "$boundary" 65536 || return 1
+            ;;
+        *)
+            repository_path=true
+            trusted_path="$FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT/$path"
+            facelock_source_install_repository_file_is_trusted \
+                "$trusted_path" 65536 || return 1
+            ;;
+    esac
+    exec {definition_fd}<"$trusted_path" || return 1
+    if [ ! "$trusted_path" -ef "/proc/$$/fd/$definition_fd" ]; then
+        exec {definition_fd}>&-
+        return 1
+    fi
+    if ! definition_size="$(
+        stat -Lc '%s' -- "/proc/$$/fd/$definition_fd"
+    )"; then
+        exec {definition_fd}>&-
+        return 1
+    fi
+    while true; do
+        line=
+        final_line=false
+        if IFS= read -r -u "$definition_fd" line; then
+            bytes_read=$((bytes_read + ${#line} + 1))
+        else
+            bytes_read=$((bytes_read + ${#line}))
+            [ -n "$line" ] || break
+            final_line=true
+        fi
+        if [ "$final_line" = false ]; then
+            line="${line%$'\r'}"
+        fi
+        if ! facelock_source_install_dbus_line_is_ascii "$line"; then
+            FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=false
+            [ "$final_line" = false ] || break
+            continue
+        fi
+        if [[ "$line" =~ ^[[:blank:]]*$ ]]; then
+            [ "$final_line" = false ] || break
+            continue
+        fi
+        case "$line" in
+            \#*) ;;
+            '[D-BUS Service]')
+                FACELOCK_SOURCE_INSTALL_DBUS_SERVICE_SECTIONS=$((
+                    FACELOCK_SOURCE_INSTALL_DBUS_SERVICE_SECTIONS + 1
+                ))
+                in_service=true
+                ;;
+            \[*\])
+                FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=false
+                in_service=false
+                ;;
+            *=*)
+                if [ "$in_service" = true ]; then
+                    key="${line%%=*}"
+                    value="${line#*=}"
+                    key="${key%"${key##*[! ]}"}"
+                    value="${value#"${value%%[! ]*}"}"
+                    case "$key" in
+                        Name)
+                            FACELOCK_SOURCE_INSTALL_DBUS_NAMES=$((
+                                FACELOCK_SOURCE_INSTALL_DBUS_NAMES + 1
+                            ))
+                            FACELOCK_SOURCE_INSTALL_DBUS_NAME="$value"
+                            [ "$value" = org.facelock.Daemon ] &&
+                                FACELOCK_SOURCE_INSTALL_DBUS_TARGET_NAME_SEEN=true
+                            ;;
+                        Exec)
+                            FACELOCK_SOURCE_INSTALL_DBUS_EXECS=$((
+                                FACELOCK_SOURCE_INSTALL_DBUS_EXECS + 1
+                            ))
+                            FACELOCK_SOURCE_INSTALL_DBUS_EXEC="$value"
+                            ;;
+                        User)
+                            FACELOCK_SOURCE_INSTALL_DBUS_USERS=$((
+                                FACELOCK_SOURCE_INSTALL_DBUS_USERS + 1
+                            ))
+                            FACELOCK_SOURCE_INSTALL_DBUS_USER="$value"
+                            ;;
+                        SystemdService)
+                            FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICES=$((
+                                FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICES + 1
+                            ))
+                            FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICE="$value"
+                            ;;
+                        *)
+                            FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=false
+                            ;;
+                    esac
+                else
+                    FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=false
+                fi
+                ;;
+            *)
+                FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID=false
+                ;;
+        esac
+        [ "$final_line" = false ] || break
+    done
+    [ "$bytes_read" -eq "$definition_size" ] || status=1
+    if [ "$repository_path" = true ]; then
+        facelock_source_install_repository_file_is_trusted \
+            "$trusted_path" 65536 || status=1
+    else
+        facelock_source_install_regular_file_is_trusted \
+            "$trusted_path" "$boundary" 65536 || status=1
+    fi
+    [ "$trusted_path" -ef "/proc/$$/fd/$definition_fd" ] || status=1
+    exec {definition_fd}>&-
+    return "$status"
+}
+
+facelock_source_install_dbus_definition_delegates() {
+    local path="$1"
+
+    facelock_source_install_parse_dbus_definition "$path" &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_DEFINITION_VALID" = true ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_SERVICE_SECTIONS" -eq 1 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_NAMES" -eq 1 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_NAME" = org.facelock.Daemon ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_EXECS" -eq 1 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_EXEC" = \
+            '/usr/bin/facelock daemon' ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_USERS" -eq 1 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_USER" = root ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICES" -eq 1 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DBUS_SYSTEMD_SERVICE" = \
+            facelock-daemon.service ]
+}
+
+facelock_source_install_dbus_definition_is_safe() {
+    local asset directory previous_directory="" definition matched=0
+
+    for asset in "${FACELOCK_SOURCE_INSTALL_DBUS_ASSETS[@]}"; do
+        directory="${asset%/*}"
+        [ "$directory" = "$previous_directory" ] && continue
+        previous_directory="$directory"
+        facelock_source_install_existing_parents_are_trusted \
+            "$directory" \
+            "${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}" || return 1
+        if [ -e "$directory" ] || [ -L "$directory" ]; then
+            facelock_source_install_directory_is_trusted "$directory" || return 1
+        fi
+        matched=0
+        for definition in "$directory"/*.service; do
+            if [ ! -e "$definition" ] && [ ! -L "$definition" ]; then
+                continue
+            fi
+            if ! facelock_source_install_parse_dbus_definition "$definition"; then
+                return 1
+            fi
+            if [ "$FACELOCK_SOURCE_INSTALL_DBUS_TARGET_NAME_SEEN" = true ]; then
+                facelock_source_install_dbus_definition_delegates "$definition" ||
+                    return 1
+                matched=$((matched + 1))
+            fi
+        done
+        if [ "$matched" -gt 0 ]; then
+            [ "$matched" -eq 1 ]
+            return
+        fi
+    done
+    return 1
+}
+
+facelock_source_install_dbus_definition_is_absent() {
+    local asset directory previous_directory="" definition
+
+    for asset in "${FACELOCK_SOURCE_INSTALL_DBUS_ASSETS[@]}"; do
+        directory="${asset%/*}"
+        [ "$directory" = "$previous_directory" ] && continue
+        previous_directory="$directory"
+        facelock_source_install_existing_parents_are_trusted \
+            "$directory" \
+            "${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}" || return 1
+        if [ -e "$directory" ] || [ -L "$directory" ]; then
+            facelock_source_install_directory_is_trusted "$directory" || return 1
+        fi
+        for definition in "$directory"/*.service; do
+            if [ ! -e "$definition" ] && [ ! -L "$definition" ]; then
+                continue
+            fi
+            facelock_source_install_parse_dbus_definition "$definition" ||
+                return 1
+            [ "$FACELOCK_SOURCE_INSTALL_DBUS_TARGET_NAME_SEEN" = false ] ||
+                return 1
+        done
+    done
+    return 0
+}
+
+facelock_source_install_reload_dbus_activation() {
+    busctl --system call \
+        org.freedesktop.DBus \
+        /org/freedesktop/DBus \
+        org.freedesktop.DBus \
+        ReloadConfig >/dev/null
+}
+
+facelock_source_install_dbus_owner_matches_snapshot() {
+    local expected_owner=false
+
+    [ "$FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE" = true ] &&
+        expected_owner=true
+    facelock_source_install_dbus_owner_is "$expected_owner"
+}
+
+facelock_source_install_dbus_owner_is() {
+    local expected_owner="$1"
+    local owner
+
+    if ! owner="$(busctl --system call \
+        org.freedesktop.DBus \
+        /org/freedesktop/DBus \
+        org.freedesktop.DBus \
+        NameHasOwner \
+        s org.facelock.Daemon)"; then
+        return 1
+    fi
+    [ "$owner" = "b $expected_owner" ]
+}
+
+facelock_source_install_legacy_hash_is_known() {
+    local wanted_id="$1"
+    local wanted_hash="$2"
+    local manifest="$FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT/dist/legacy-system-assets.sha256"
+
+    [ -f "$manifest" ] && [ ! -L "$manifest" ] || return 1
+    awk -v wanted_id="$wanted_id" -v wanted_hash="$wanted_hash" '
+        /^[[:space:]]*(#|$)/ { next }
+        {
+            if (NF != 2 || length($2) != 64 || $2 !~ /^[0-9a-f]+$/) exit 2
+            if ($1 != "systemd-unit" && $1 != "dbus-policy" &&
+                $1 != "dbus-activation") exit 2
+            key=$1 ":" $2
+            if (seen[key]++) exit 2
+            if ($1 == wanted_id && $2 == wanted_hash) found=1
+        }
+        END { if (!found) exit 1 }
+    ' "$manifest"
+}
+
+facelock_source_install_legacy_identity() {
+    local path="$1"
+    local boundary="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local metadata digest_output digest uid gid mode links kind
+
+    facelock_source_install_parents_are_trusted "$path" "$boundary" || return 1
+    [ -f "$path" ] && [ ! -L "$path" ] || return 1
+    metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- "$path")" ||
+        return 1
+    IFS=: read -r _ _ uid gid mode links _ kind <<<"$metadata"
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$mode" = 644 ] && [ "$links" -eq 1 ] &&
+        [[ "$kind" = regular\ *file ]] || return 1
+    digest_output="$(sha256sum -- "$path")" || return 1
+    digest="${digest_output%% *}"
+    [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+    FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT="$metadata;$digest"
+}
+
+facelock_source_install_admin_mask_identity() {
+    local path="$1"
+    local boundary="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local metadata target uid gid mode links size kind
+
+    facelock_source_install_parents_are_trusted "$path" "$boundary" || return 1
+    metadata="$(facelock_source_install_stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$path")" ||
+        return 1
+    IFS=: read -r _ _ uid gid mode links size kind <<<"$metadata"
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$links" -eq 1 ] || return 1
+    if [ -L "$path" ]; then
+        [ "$kind" = symbolic\ link ] || return 1
+        IFS= read -r -d '' target < <(readlink -z -- "$path") || return 1
+        [ "$target" = /dev/null ] || return 1
+        FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT="symlink;$metadata;/dev/null"
+        return
+    fi
+    [ -f "$path" ] && [[ "$kind" = regular\ *file ]] &&
+        [ "$size" -eq 0 ] && [ "$((8#$mode & 8#022))" -eq 0 ] || return 1
+    FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT="regular;$metadata"
+}
+
+facelock_source_install_plan_legacy_assets() {
+    local prefix="$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX"
+    local record id public_relative quarantine_name public quarantine
+    local public_identity quarantine_identity public_digest quarantine_digest
+    local public_state quarantine_state
+    local -a assets=(
+        'systemd-unit|etc/systemd/system/facelock-daemon.service|.facelock-migrate-systemd-unit'
+        'dbus-policy|etc/dbus-1/system.d/org.facelock.Daemon.conf|.facelock-migrate-dbus-policy'
+        'dbus-activation|etc/dbus-1/system-services/org.facelock.Daemon.service|.facelock-migrate-dbus-activation'
+    )
+
+    FACELOCK_SOURCE_INSTALL_LEGACY_PLAN=()
+    FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED=false
+    FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED=false
+    FACELOCK_SOURCE_INSTALL_LEGACY_RECONCILIATION_FAILED=false
+    FACELOCK_SOURCE_INSTALL_PERSISTENT_UNIT_PLANNED_RETIRE=false
+    for record in "${assets[@]}"; do
+        IFS='|' read -r id public_relative quarantine_name <<<"$record"
+        public="${prefix}/${public_relative}"
+        [ -n "$prefix" ] || public="/$public_relative"
+        quarantine="${public%/*}/$quarantine_name"
+        facelock_source_install_existing_parents_are_trusted \
+            "$public" "${prefix:-/}" || return 1
+        public_state=absent
+        quarantine_state=absent
+        public_identity=
+        quarantine_identity=
+        if [ -e "$public" ] || [ -L "$public" ]; then
+            if [ "$id" = systemd-unit ] &&
+                facelock_source_install_admin_mask_identity "$public"; then
+                public_state=admin-mask
+                public_identity="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+            else
+                facelock_source_install_legacy_identity "$public" || return 1
+                public_identity="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+                public_digest="${public_identity##*;}"
+                if facelock_source_install_legacy_hash_is_known "$id" "$public_digest"; then
+                    public_state=exact
+                else
+                    public_state=admin-file
+                fi
+            fi
+        fi
+        if [ -e "$quarantine" ] || [ -L "$quarantine" ]; then
+            facelock_source_install_legacy_identity "$quarantine" || return 1
+            quarantine_identity="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+            quarantine_digest="${quarantine_identity##*;}"
+            facelock_source_install_legacy_hash_is_known "$id" "$quarantine_digest" ||
+                return 1
+            quarantine_state=exact
+        fi
+        case "$public_state:$quarantine_state" in
+            absent:absent)
+                FACELOCK_SOURCE_INSTALL_LEGACY_PLAN+=(
+                    "$id|$public|$quarantine|absent||"
+                )
+                ;;
+            exact:absent)
+                FACELOCK_SOURCE_INSTALL_LEGACY_PLAN+=(
+                    "$id|$public|$quarantine|candidate|$public_identity|"
+                )
+                if [ "$id" = systemd-unit ]; then
+                    FACELOCK_SOURCE_INSTALL_PERSISTENT_UNIT_PLANNED_RETIRE=true
+                fi
+                ;;
+            absent:exact)
+                FACELOCK_SOURCE_INSTALL_LEGACY_PLAN+=(
+                    "$id|$public|$quarantine|interrupted||$quarantine_identity"
+                )
+                ;;
+            admin-mask:absent)
+                FACELOCK_SOURCE_INSTALL_LEGACY_PLAN+=(
+                    "$id|$public|$quarantine|admin-mask|$public_identity|"
+                )
+                ;;
+            admin-file:absent)
+                FACELOCK_SOURCE_INSTALL_LEGACY_PLAN+=(
+                    "$id|$public|$quarantine|admin-file|$public_identity|"
+                )
+                ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+facelock_source_install_legacy_plan_is_current() {
+    local record id public quarantine state public_identity quarantine_identity
+    local current
+
+    for record in "${FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}"; do
+        IFS='|' read -r id public quarantine state public_identity quarantine_identity <<<"$record"
+        case "$state" in
+            absent)
+                [ ! -e "$public" ] && [ ! -L "$public" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            candidate)
+                facelock_source_install_legacy_identity "$public" || return 1
+                current="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+                [ "$current" = "$public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            interrupted)
+                [ ! -e "$public" ] && [ ! -L "$public" ] || return 1
+                facelock_source_install_legacy_identity "$quarantine" || return 1
+                current="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+                [ "$current" = "$quarantine_identity" ] || return 1
+                ;;
+            admin-mask)
+                facelock_source_install_admin_mask_identity "$public" || return 1
+                current="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+                [ "$current" = "$public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            admin-file)
+                facelock_source_install_legacy_identity "$public" || return 1
+                current="$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT"
+                [ "$current" = "$public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+facelock_source_install_record_legacy_migration() {
+    local record id public quarantine state _public_identity _quarantine_identity
+    local expected_identity
+
+    [ "${#FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}" -eq 3 ] || return 1
+    for record in "${FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}"; do
+        IFS='|' read -r id public quarantine state _public_identity _quarantine_identity <<<"$record"
+        case "$state" in
+            admin-mask)
+                facelock_source_install_admin_mask_identity "$public" &&
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            admin-file)
+                facelock_source_install_legacy_identity "$public" &&
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            candidate | interrupted)
+                [ ! -e "$public" ] && [ ! -L "$public" ] &&
+                    facelock_source_install_legacy_identity "$quarantine" || return 1
+                expected_identity="$_public_identity"
+                [ "$state" = candidate ] || expected_identity="$_quarantine_identity"
+                [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$expected_identity" ] ||
+                    return 1
+                ;;
+            absent)
+                [ ! -e "$public" ] && [ ! -L "$public" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+    FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED=true
+}
+
+facelock_source_install_invoke_legacy_stage() {
+    local layout_root="$1"
+
+    "$FACELOCK_SOURCE_INSTALL_REPOSITORY_ROOT/scripts/migrate-legacy-system-assets.sh" \
+        --source-protected --stage "$layout_root"
+}
+
+facelock_source_install_stage_and_record_legacy_migration() {
+    local layout_root="${1:-/}"
+    local expected_root="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local stage_status=0
+
+    [ "$layout_root" = "$expected_root" ] || return 1
+    [ "${#FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}" -eq 3 ] || return 1
+    [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = false ] || return 1
+    [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ] || return 1
+
+    # Bash normally defers a trapped signal while waiting for a foreground
+    # child, but the critical flag must already be set when that wait starts.
+    # Keep it set through the exact parent-side identity record so there is no
+    # successful-child/unrecorded-parent signal window.
+    FACELOCK_SOURCE_INSTALL_CRITICAL=true
+    if facelock_source_install_invoke_legacy_stage "$layout_root"; then
+        if [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ]; then
+            stage_status="$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL"
+        elif facelock_source_install_record_legacy_migration; then
+            stage_status=0
+        else
+            stage_status=$?
+        fi
+    else
+        stage_status=$?
+    fi
+    FACELOCK_SOURCE_INSTALL_CRITICAL=false
+
+    if [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ]; then
+        return "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL"
+    fi
+    return "$stage_status"
+}
+
+facelock_source_install_move_noreplace() {
+    local source="$1"
+    local destination="$2"
+
+    [ ! -e "$destination" ] && [ ! -L "$destination" ] || return 1
+    mv -Tn -- "$source" "$destination" || return 1
+    [ ! -e "$source" ] && [ ! -L "$source" ] &&
+        { [ -e "$destination" ] || [ -L "$destination" ]; }
+}
+
+facelock_source_install_rollback_legacy_migration() {
+    local index record id public quarantine state public_identity quarantine_identity
+    local expected_identity current rollback_failed=0
+
+    [ "${#FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}" -eq 3 ] || return 0
+    [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ] || return 1
+    for ((index=${#FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]} - 1; index >= 0; index--)); do
+        record="${FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[$index]}"
+        IFS='|' read -r id public quarantine state public_identity quarantine_identity <<<"$record"
+        case "$state" in
+            candidate)
+                expected_identity="$public_identity"
+                if [ -e "$public" ] || [ -L "$public" ]; then
+                    if [ -e "$quarantine" ] || [ -L "$quarantine" ] ||
+                        ! facelock_source_install_legacy_identity "$public" ||
+                        [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ]; then
+                        echo "Error: source-install rollback preserved an ambiguous legacy pair: $public and $quarantine" >&2
+                        rollback_failed=1
+                    fi
+                elif ! facelock_source_install_legacy_identity "$quarantine" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ] ||
+                    ! facelock_source_install_move_noreplace "$quarantine" "$public" ||
+                    ! facelock_source_install_legacy_identity "$public" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ]; then
+                    echo "Error: source-install rollback preserved an ambiguous legacy pair: $public and $quarantine" >&2
+                    rollback_failed=1
+                fi
+                ;;
+            interrupted)
+                expected_identity="$quarantine_identity"
+                if [ -e "$quarantine" ] || [ -L "$quarantine" ]; then
+                    if [ -e "$public" ] || [ -L "$public" ] ||
+                        ! facelock_source_install_legacy_identity "$quarantine" ||
+                        [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ]; then
+                        echo "Error: source-install rollback preserved a changed interrupted quarantine: $quarantine" >&2
+                        rollback_failed=1
+                    fi
+                elif ! facelock_source_install_legacy_identity "$public" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ] ||
+                    ! facelock_source_install_move_noreplace "$public" "$quarantine" ||
+                    ! facelock_source_install_legacy_identity "$quarantine" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$expected_identity" ]; then
+                    echo "Error: source-install rollback preserved a changed interrupted quarantine: $quarantine" >&2
+                    rollback_failed=1
+                fi
+                ;;
+            absent)
+                [ ! -e "$public" ] && [ ! -L "$public" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] ||
+                    rollback_failed=1
+                ;;
+            admin-mask)
+                if ! facelock_source_install_admin_mask_identity "$public" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$public_identity" ] ||
+                    [ -e "$quarantine" ] || [ -L "$quarantine" ]; then
+                    rollback_failed=1
+                fi
+                ;;
+            admin-file)
+                if ! facelock_source_install_legacy_identity "$public" ||
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" != "$public_identity" ] ||
+                    [ -e "$quarantine" ] || [ -L "$quarantine" ]; then
+                    rollback_failed=1
+                fi
+                ;;
+            *) rollback_failed=1 ;;
+        esac
+    done
+    if [ "$rollback_failed" -ne 0 ]; then
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED=false
+    facelock_source_install_legacy_plan_is_current
+}
+
+facelock_source_install_commit_legacy_migration() {
+    local record id public quarantine state public_identity quarantine_identity
+    local expected_identity
+
+    [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = true ] || return 0
+    [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ] || return 0
+    facelock_source_install_legacy_state_is_expected || return 1
+    for record in "${FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}"; do
+        IFS='|' read -r id public quarantine state public_identity quarantine_identity <<<"$record"
+        case "$state" in
+            candidate | interrupted)
+                expected_identity="$public_identity"
+                [ "$state" = candidate ] || expected_identity="$quarantine_identity"
+                facelock_source_install_legacy_identity "$quarantine" &&
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$expected_identity" ] ||
+                    return 1
+                rm -- "$quarantine" || return 1
+                [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                echo "Removed exact known legacy system asset $public"
+                ;;
+        esac
+    done
+    FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED=true
+    facelock_source_install_legacy_state_is_expected
+}
+
+facelock_source_install_legacy_state_is_expected() {
+    local record id public quarantine state _public_identity _quarantine_identity
+
+    if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = false ]; then
+        facelock_source_install_legacy_plan_is_current
+        return
+    fi
+    for record in "${FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}"; do
+        IFS='|' read -r id public quarantine state _public_identity _quarantine_identity <<<"$record"
+        case "$state" in
+            admin-mask)
+                facelock_source_install_admin_mask_identity "$public" &&
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            admin-file)
+                facelock_source_install_legacy_identity "$public" &&
+                    [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_public_identity" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            candidate | interrupted)
+                [ ! -e "$public" ] && [ ! -L "$public" ] || return 1
+                if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = true ]; then
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                else
+                    facelock_source_install_legacy_identity "$quarantine" || return 1
+                    if [ "$state" = candidate ]; then
+                        [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_public_identity" ] ||
+                            return 1
+                    else
+                        [ "$FACELOCK_SOURCE_INSTALL_IDENTITY_RESULT" = "$_quarantine_identity" ] ||
+                            return 1
+                    fi
+                fi
+                ;;
+            absent)
+                [ ! -e "$public" ] && [ ! -L "$public" ] &&
+                    [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+                ;;
+            *) return 1 ;;
+        esac
+    done
+}
+
+facelock_source_install_retired_persistent_unit_is_current() {
+    local snapshot="$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT"
+    local fd="$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD"
+    local expected_metadata current_metadata expected_digest digest_output current_digest
+    local expected_dev expected_ino expected_uid expected_gid expected_mode _expected_links
+    local expected_size expected_kind current_dev current_ino current_uid current_gid
+    local current_mode current_links current_size current_kind
+    local quarantine="${FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH%/*}/.facelock-migrate-systemd-unit"
+
+    [ "$FACELOCK_SOURCE_INSTALL_PERSISTENT_UNIT_PLANNED_RETIRE" = true ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = true ] &&
+        [[ "$snapshot" = ordinary:* ]] && [ -n "$fd" ] &&
+        [ ! -e "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH" ] || return 1
+    if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = true ]; then
+        [ ! -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+    else
+        [ -e "$quarantine" ] && [ ! -L "$quarantine" ] || return 1
+    fi
+    expected_metadata="${snapshot#*:}"
+    expected_metadata="${expected_metadata%:*}"
+    expected_digest="${snapshot##*:}"
+    current_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+        "/proc/$$/fd/$fd")" || return 1
+    IFS=: read -r expected_dev expected_ino expected_uid expected_gid expected_mode \
+        _expected_links expected_size expected_kind <<<"$expected_metadata"
+    IFS=: read -r current_dev current_ino current_uid current_gid current_mode \
+        current_links current_size current_kind <<<"$current_metadata"
+    [ "$current_dev:$current_ino:$current_uid:$current_gid:$current_mode:$current_size:$current_kind" = \
+        "$expected_dev:$expected_ino:$expected_uid:$expected_gid:$expected_mode:$expected_size:$expected_kind" ] ||
+        return 1
+    if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = true ]; then
+        [ "$current_links" -eq 0 ] || return 1
+    else
+        [ "$current_links" -eq 1 ] && [ "$quarantine" -ef "/proc/$$/fd/$fd" ] || return 1
+    fi
+    digest_output="$(sha256sum -- "/proc/$$/fd/$fd")" || return 1
+    current_digest="${digest_output%% *}"
+    [ "$current_digest" = "$expected_digest" ]
+}
+
+facelock_source_install_snapshot_physical_mask() {
+    local path="$1"
+    local snapshot_variable="$2"
+    local fd_variable="$3"
+    local boundary="${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}"
+    local first_metadata second_metadata target digest_output digest
+    local mask_fd=''
+    local uid gid mode links size kind
+
+    printf -v "$fd_variable" '%s' ''
+    facelock_source_install_existing_parents_are_trusted \
+        "$path" "$boundary" || return 1
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        printf -v "$snapshot_variable" '%s' absent
+        return 0
+    fi
+    facelock_source_install_parents_are_trusted "$path" "$boundary" || return 1
+    first_metadata="$(facelock_source_install_stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$path")" ||
+        return 1
+    IFS=: read -r _ _ uid gid mode links size kind <<<"$first_metadata"
+    [ "$uid" = "$FACELOCK_SOURCE_INSTALL_TRUST_UID" ] &&
+        [ "$gid" = "$FACELOCK_SOURCE_INSTALL_TRUST_GID" ] &&
+        [ "$links" -eq 1 ] || return 1
+    if [ -L "$path" ]; then
+        [ "$kind" = symbolic\ link ] || return 1
+        IFS= read -r -d '' target < <(readlink -z -- "$path") || return 1
+        [ "$target" = /dev/null ] || return 1
+        second_metadata="$(facelock_source_install_stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$path")" ||
+            return 1
+        [ "$first_metadata" = "$second_metadata" ] || return 1
+        printf -v "$snapshot_variable" 'mask-symlink:%s:/dev/null' \
+            "$first_metadata"
+        return 0
+    fi
+    [ -f "$path" ] && [[ "$kind" = regular\ *file ]] &&
+        [ "$size" -le 1048576 ] &&
+        [ "$((8#$mode & 8#022))" -eq 0 ] || return 1
+    exec {mask_fd}<"$path" || return 1
+    if [ ! "$path" -ef "/proc/$$/fd/$mask_fd" ] ||
+        [ "$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+            "/proc/$$/fd/$mask_fd")" != "$first_metadata" ]; then
+        exec {mask_fd}>&-
+        return 1
+    fi
+    if [ "$size" -eq 0 ]; then
+        printf -v "$snapshot_variable" 'mask-regular:%s:' "$first_metadata"
+    else
+        digest_output="$(sha256sum -- "/proc/$$/fd/$mask_fd")" || {
+            exec {mask_fd}>&-
+            return 1
+        }
+        digest="${digest_output%% *}"
+        [[ "$digest" =~ ^[0-9a-f]{64}$ ]] &&
+            [ "$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                "/proc/$$/fd/$mask_fd")" = "$first_metadata" ] &&
+            [ "$path" -ef "/proc/$$/fd/$mask_fd" ] || {
+            exec {mask_fd}>&-
+            return 1
+        }
+        printf -v "$snapshot_variable" 'ordinary:%s:%s' \
+            "$first_metadata" "$digest"
+    fi
+    printf -v "$fd_variable" '%s' "$mask_fd"
+}
+
+facelock_source_install_physical_mask_is_current() {
+    local path="$1"
+    local snapshot="$2"
+    local mask_fd="$3"
+    local expected_metadata expected_digest target current_metadata
+    local second_metadata digest_output current_digest
+
+    if [ "$snapshot" = absent ]; then
+        [ ! -e "$path" ] && [ ! -L "$path" ]
+        return
+    fi
+    expected_metadata="${snapshot#*:}"
+    expected_metadata="${expected_metadata%:*}"
+    case "$snapshot" in
+        mask-symlink:*)
+            [ -L "$path" ] || return 1
+            current_metadata="$(facelock_source_install_stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                "$path")" || return 1
+            [ "$current_metadata" = "$expected_metadata" ] || return 1
+            IFS= read -r -d '' target < <(readlink -z -- "$path") || return 1
+            [ "$target" = /dev/null ] || return 1
+            second_metadata="$(facelock_source_install_stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                "$path")" || return 1
+            [ "$second_metadata" = "$expected_metadata" ]
+            ;;
+        mask-regular:* | ordinary:*)
+            [ -n "$mask_fd" ] && [ -f "$path" ] && [ ! -L "$path" ] &&
+                [ "$path" -ef "/proc/$$/fd/$mask_fd" ] || return 1
+            current_metadata="$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                "$path")" || return 1
+            [ "$current_metadata" = "$expected_metadata" ] &&
+                [ "$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                    "/proc/$$/fd/$mask_fd")" = "$expected_metadata" ] ||
+                return 1
+            if [[ "$snapshot" = ordinary:* ]]; then
+                expected_digest="${snapshot##*:}"
+                digest_output="$(sha256sum -- "/proc/$$/fd/$mask_fd")" ||
+                    return 1
+                current_digest="${digest_output%% *}"
+                [ "$current_digest" = "$expected_digest" ] &&
+                    [ "$(facelock_source_install_stat -Lc '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+                        "/proc/$$/fd/$mask_fd")" = "$expected_metadata" ] &&
+                    [ "$path" -ef "/proc/$$/fd/$mask_fd" ]
+            fi
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+facelock_source_install_physical_masks_are_current() {
+    facelock_source_install_legacy_state_is_expected &&
+        { facelock_source_install_physical_mask_is_current \
+            "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH" \
+            "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT" \
+            "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD" ||
+            facelock_source_install_retired_persistent_unit_is_current; } &&
+        facelock_source_install_physical_mask_is_current \
+            "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_PATH" \
+            "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT" \
+            "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD"
+}
+
+facelock_source_install_release_physical_mask_fds() {
+    if [ -n "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD" ]; then
+        exec {FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD}>&-
+        FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD=
+    fi
+    if [ -n "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD" ]; then
+        exec {FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD}>&-
+        FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD=
+    fi
+}
+
+facelock_source_install_release_barrier_fds() {
+    if [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_FD" ]; then
+        exec {FACELOCK_SOURCE_INSTALL_BARRIER_FD}>&-
+        FACELOCK_SOURCE_INSTALL_BARRIER_FD=
+    fi
+    if [ -n "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD" ]; then
+        exec {FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD}>&-
+        FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD=
+    fi
+}
+
+facelock_source_install_unit_is_owned_barrier() {
+    local expected_active_state="$1"
+    local snapshot line load_state="" active_state="" fragment_path=""
+    local load_count=0 active_count=0 fragment_count=0
+
+    snapshot="$(systemctl show facelock-daemon.service \
+        --property=LoadState \
+        --property=ActiveState \
+        --property=FragmentPath \
+        --no-pager)" || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            LoadState=*)
+                load_count=$((load_count + 1))
+                load_state="${line#LoadState=}"
+                ;;
+            ActiveState=*)
+                active_count=$((active_count + 1))
+                active_state="${line#ActiveState=}"
+                ;;
+            FragmentPath=*)
+                fragment_count=$((fragment_count + 1))
+                fragment_path="${line#FragmentPath=}"
+                ;;
+            *) return 1 ;;
+        esac
+    done <<<"$snapshot"
+    [ "$load_count" -eq 1 ] && [ "$active_count" -eq 1 ] &&
+        [ "$fragment_count" -eq 1 ] &&
+        [ "$load_state" = masked ] &&
+        [ "$active_state" = "$expected_active_state" ] &&
+        [ "$fragment_path" = "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ]
+}
+
+facelock_source_install_control_topology_is_current() {
+    [ -n "$FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH" ] &&
+        [ ! -e "$FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH" ] &&
+        [ ! -L "$FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH" ] || return 1
+
+    if [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ]; then
+        if [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED" = true ]; then
+            [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+                [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+                facelock_source_install_quarantined_barrier_is_current
+        else
+            facelock_source_install_owned_barrier_is_current
+        fi
+    else
+        [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED" = false ] &&
+            [ -z "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH" ] &&
+            [ ! -e "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ] &&
+            [ ! -L "$FACELOCK_SOURCE_INSTALL_BARRIER_PATH" ]
+    fi
+}
+
+facelock_source_install_expected_dbus_definition_is_current() {
+    if [ "$FACELOCK_SOURCE_INSTALL_INITIAL_DBUS_DEFINITION_ABSENT" = true ]; then
+        facelock_source_install_dbus_definition_is_absent ||
+            facelock_source_install_dbus_definition_is_safe
+    else
+        facelock_source_install_dbus_definition_is_safe
+    fi
+}
+
+facelock_source_install_post_removal_state_is_safe() {
+    local expected_active_state="$1"
+    local expected_owner="$2"
+    local snapshot line load_state="" active_state="" unit_file_state=""
+    local fragment_path="" daemon_exec_start="" drop_in_paths=""
+    local load_count=0 active_count=0 unit_file_count=0 fragment_count=0
+    local exec_count=0 drop_in_count=0 expected_unit_file_state
+
+    snapshot="$(systemctl show facelock-daemon.service \
+        --property=LoadState \
+        --property=ActiveState \
+        --property=UnitFileState \
+        --property=FragmentPath \
+        --property=ExecStart \
+        --property=DropInPaths \
+        --no-pager)" || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            LoadState=*)
+                load_count=$((load_count + 1))
+                load_state="${line#LoadState=}"
+                ;;
+            ActiveState=*)
+                active_count=$((active_count + 1))
+                active_state="${line#ActiveState=}"
+                ;;
+            UnitFileState=*)
+                unit_file_count=$((unit_file_count + 1))
+                unit_file_state="${line#UnitFileState=}"
+                ;;
+            FragmentPath=*)
+                fragment_count=$((fragment_count + 1))
+                fragment_path="${line#FragmentPath=}"
+                ;;
+            ExecStart=*)
+                exec_count=$((exec_count + 1))
+                daemon_exec_start="${line#ExecStart=}"
+                ;;
+            DropInPaths=*)
+                drop_in_count=$((drop_in_count + 1))
+                drop_in_paths="${line#DropInPaths=}"
+                ;;
+            *) return 1 ;;
+        esac
+    done <<<"$snapshot"
+    [ "$load_count" -eq 1 ] && [ "$active_count" -eq 1 ] &&
+        [ "$unit_file_count" -eq 1 ] && [ "$fragment_count" -eq 1 ] &&
+        [ "$drop_in_count" -eq 1 ] &&
+        [ "$active_state" = "$expected_active_state" ] || return 1
+
+    if [ "$FACELOCK_SOURCE_INSTALL_INITIAL_UNIT_NOT_FOUND" = true ] &&
+        [ "$load_state" = not-found ]; then
+        [ "$expected_active_state" = inactive ] &&
+            [ "$load_state" = not-found ] && [ -z "$unit_file_state" ] &&
+            [ -z "$fragment_path" ] && [ "$exec_count" -eq 0 ] &&
+            [ -z "$drop_in_paths" ] || return 1
+    elif [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" = true ]; then
+        [ "$expected_active_state" = inactive ] && [ "$load_state" = masked ] &&
+            [ "$exec_count" -eq 0 ] && [ -z "$drop_in_paths" ] &&
+            [ "$fragment_path" = \
+                "$FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER" ] || return 1
+        if [ "$FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER" = \
+            "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH" ]; then
+            expected_unit_file_state=masked
+        else
+            expected_unit_file_state=masked-runtime
+        fi
+        [ "$unit_file_state" = "$expected_unit_file_state" ] || return 1
+    else
+        [ "$load_state" = loaded ] && [ "$exec_count" -eq 1 ] &&
+            [ -n "$daemon_exec_start" ] || return 1
+        case "$unit_file_state" in
+            enabled | enabled-runtime | linked | linked-runtime | alias | static | \
+                indirect | disabled | generated | transient) ;;
+            *) return 1 ;;
+        esac
+        facelock_source_install_effective_unit_is_trusted \
+            "$fragment_path" "$daemon_exec_start" "$drop_in_paths" \
+            "${FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX:-/}" \
+            "${FACELOCK_SOURCE_INSTALL_INSTALLED_ASSETS[@]}" || return 1
+    fi
+
+    facelock_source_install_control_topology_is_current &&
+        facelock_source_install_physical_masks_are_current &&
+        facelock_source_install_dbus_config_is_standard \
+            "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" &&
+        facelock_source_install_expected_dbus_definition_is_current &&
+        facelock_source_install_dbus_owner_is "$expected_owner"
+}
+
+facelock_source_install_restart_active_daemon() {
+    local attempt
+
+    for attempt in 1 2 3; do
+        facelock_source_install_post_removal_state_is_safe \
+            inactive false || return 1
+        if systemctl start facelock-daemon.service; then
+            facelock_source_install_post_removal_state_is_safe \
+                active true || return 1
+            return 0
+        fi
+    done
+    return 1
+}
+
+facelock_source_install_recover_owned_barrier() {
+    if [ "$FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED" = true ]; then
+        facelock_source_install_restore_quarantined_barrier || return 1
+    else
+        facelock_source_install_owned_barrier_is_current || return 1
+    fi
+    facelock_source_install_retry systemctl daemon-reload || return 1
+    facelock_source_install_control_topology_is_current &&
+        facelock_source_install_physical_masks_are_current &&
+        facelock_source_install_dbus_config_is_standard \
+            "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" &&
+        facelock_source_install_expected_dbus_definition_is_current || return 1
+    systemctl stop facelock-daemon.service || return 1
+    facelock_source_install_unit_is_owned_barrier inactive &&
+        facelock_source_install_dbus_owner_is false
+}
+
+facelock_source_install_prepare_offline_image() {
+    local image_root="${1:-/}"
+    local -a installed_assets
+    local asset executable target pid1_comm image_prefix build_root marker
+    local source_path visible_pid indicator surface address_name
+
+    case "$image_root" in
+        /*) ;;
+        *)
+            echo "Error: offline image root must be absolute; no files were changed." >&2
+            return 1
+            ;;
+    esac
+    image_prefix="${image_root%/}"
+    build_root="$image_prefix/build"
+    marker="$build_root/test/source-install-offline-image.marker"
+    if [ "${FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER:-}" != "$marker" ] ||
+        [ "$(pwd -P)" != "$build_root" ] ||
+        ! source_path="$(readlink -f -- "${BASH_SOURCE[0]}")" ||
+        [ "$source_path" != \
+            "$build_root/scripts/source-install-daemon-lifecycle.sh" ]; then
+        echo "Error: offline image mode is not the repository Containerfile invocation; no files were changed." >&2
+        return 1
+    fi
+    if ! IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+        FACELOCK_SOURCE_INSTALL_TRUST_GID < <(
+        stat -Lc '%u:%g' -- "$image_root"
+    ); then
+        echo "Error: offline image mode could not establish its image trust root; no files were changed." >&2
+        return 1
+    fi
+    for asset in \
+        "$build_root/scripts/source-install-daemon-lifecycle.sh" \
+        "$build_root/scripts/migrate-legacy-system-assets.sh" \
+        "$build_root/dist/legacy-system-assets.sha256" \
+        "$build_root/justfile" \
+        "$build_root/test/Containerfile" \
+        "$marker" \
+        "$build_root/dbus/org.facelock.Daemon.conf" \
+        "$build_root/dbus/org.facelock.Daemon.service" \
+        "$build_root/systemd/facelock-daemon.service"; do
+        if ! facelock_source_install_regular_file_is_trusted \
+            "$asset" "$image_root" 1048576; then
+            echo "Error: offline image mode found untrusted repository build input; no files were changed." >&2
+            return 1
+        fi
+    done
+    if [ "$(cat -- "$marker")" != \
+        facelock-repository-test-container-source-install-v1 ]; then
+        echo "Error: offline image mode found an invalid repository build marker; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_ensure_lock_directory \
+        "$image_prefix/run/facelock" "$image_root" ||
+        ! facelock_source_install_acquire_lock \
+            "$image_prefix/run/facelock/lifecycle.lock" "$image_root"; then
+        echo "Error: offline image mode could not acquire the source-install lifecycle lock; no files were changed." >&2
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$image_prefix"
+    if ! facelock_source_install_plan_legacy_assets; then
+        echo "Error: offline image mode found an unsafe legacy system-asset state; no files were changed." >&2
+        return 1
+    fi
+    if [ ! -e "$image_root/.dockerenv" ] &&
+        [ ! -e "$image_root/run/.containerenv" ]; then
+        echo "Error: offline image mode requires a container-build marker; no files were changed." >&2
+        return 1
+    fi
+    for surface in \
+        /run/systemd/system \
+        /run/systemd/private \
+        /run/systemd/notify \
+        /run/systemd/journal/socket \
+        /run/openrc \
+        /run/runit \
+        /run/s6 \
+        /run/dinitctl \
+        /run/initctl \
+        /dev/initctl; do
+        if [ -e "$image_prefix$surface" ] || [ -L "$image_prefix$surface" ]; then
+            echo "Error: offline image mode found a live service-manager surface; no files were changed." >&2
+            return 1
+        fi
+    done
+    for address_name in DBUS_SYSTEM_BUS_ADDRESS DBUS_STARTER_ADDRESS \
+        DBUS_SESSION_BUS_ADDRESS; do
+        if [ -n "${!address_name+x}" ]; then
+            echo "Error: offline image mode found a D-Bus address override; no files were changed." >&2
+            return 1
+        fi
+    done
+    if [ -e "$image_root/run/dbus/system_bus_socket" ] ||
+        [ -L "$image_root/run/dbus/system_bus_socket" ] ||
+        [ -e "$image_root/run/dbus/pid" ] ||
+        [ -L "$image_root/run/dbus/pid" ]; then
+        echo "Error: offline image mode found a system-bus activation surface; no files were changed." >&2
+        return 1
+    fi
+    if ! IFS= read -r pid1_comm <"$image_root/proc/1/comm"; then
+        echo "Error: offline image mode could not verify the container process namespace; no files were changed." >&2
+        return 1
+    fi
+    if [ "$pid1_comm" = systemd ]; then
+        echo "Error: offline image mode found systemd as PID 1; no files were changed." >&2
+        return 1
+    fi
+
+    mapfile -t installed_assets < <(facelock_source_install_default_assets)
+    FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=()
+    for asset in "${installed_assets[@]}"; do
+        case "$asset" in
+            */org.facelock.Daemon.service)
+                FACELOCK_SOURCE_INSTALL_DBUS_ASSETS+=("$image_prefix$asset")
+                ;;
+        esac
+        if [ -e "$image_prefix$asset" ] || [ -L "$image_prefix$asset" ]; then
+            echo "Error: offline image mode found an existing activation asset; no files were changed." >&2
+            return 1
+        fi
+    done
+    if ! facelock_source_install_dbus_definition_is_absent; then
+        echo "Error: offline image mode found an existing or unreadable D-Bus activation definition; no files were changed." >&2
+        return 1
+    fi
+    for indicator in \
+        /usr/bin/facelock \
+        /lib/security/pam_facelock.so \
+        /usr/lib/security/pam_facelock.so \
+        /etc/facelock \
+        /var/lib/facelock \
+        /var/log/facelock \
+        /usr/share/facelock \
+        /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+        /etc/dbus-1/system.d/org.facelock.Daemon.conf \
+        /usr/lib/tmpfiles.d/facelock.conf; do
+        if [ -e "$image_prefix$indicator" ] || [ -L "$image_prefix$indicator" ]; then
+            echo "Error: offline image mode found an existing Facelock install indicator; no files were changed." >&2
+            return 1
+        fi
+    done
+    for visible_pid in "$image_root"/proc/[0-9]*; do
+        [ -d "$visible_pid" ] || continue
+        executable="$visible_pid/exe"
+        if [ ! -L "$executable" ]; then
+            echo "Error: offline image mode could not inspect a visible process; no files were changed." >&2
+            return 1
+        fi
+        if ! target="$(readlink "$executable")"; then
+            echo "Error: offline image mode could not inspect a running process; no files were changed." >&2
+            return 1
+        fi
+        target="${target% (deleted)}"
+        if [ "${target##*/}" = facelock ]; then
+            echo "Error: offline image mode found a running facelock process; no files were changed." >&2
+            return 1
+        fi
+    done
+
+    FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE=false
+    FACELOCK_SOURCE_INSTALL_BARRIER_CREATED=false
+    FACELOCK_SOURCE_INSTALL_PREPARED=false
+}
+
+facelock_source_install_prepare_daemon() {
+    local systemd_runtime_dir="${1:-/run/systemd/system}"
+    local -a installed_assets
+    local layout_prefix runtime_root barrier_dir persistent_control_path
+    local persistent_mask_path runtime_mask_path
+    local snapshot line load_state="" active_state="" unit_file_state=""
+    local fragment_path="" daemon_exec_start="" drop_in_paths=""
+    local load_state_count=0 active_state_count=0 unit_file_state_count=0
+    local fragment_path_count=0 daemon_exec_start_count=0 drop_in_paths_count=0
+    local loaded_unit=false asset barrier_status=0
+
+    if [ "$#" -gt 1 ]; then
+        installed_assets=("${@:2}")
+    else
+        mapfile -t installed_assets < <(facelock_source_install_default_assets)
+    fi
+    FACELOCK_SOURCE_INSTALL_INSTALLED_ASSETS=("${installed_assets[@]}")
+    FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=()
+    for asset in "${installed_assets[@]}"; do
+        case "$asset" in
+            */org.facelock.Daemon.service)
+                FACELOCK_SOURCE_INSTALL_DBUS_ASSETS+=("$asset")
+                ;;
+        esac
+    done
+
+    FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE=false
+    FACELOCK_SOURCE_INSTALL_BARRIER_CREATED=false
+    FACELOCK_SOURCE_INSTALL_PREPARED=false
+    facelock_source_install_release_barrier_fds
+    FACELOCK_SOURCE_INSTALL_BARRIER_PATH=
+    FACELOCK_SOURCE_INSTALL_BARRIER_FD=
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINE_PATH=
+    FACELOCK_SOURCE_INSTALL_BARRIER_QUARANTINED=false
+    FACELOCK_SOURCE_INSTALL_BARRIER_DIR_PATH=
+    FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED=false
+    FACELOCK_SOURCE_INSTALL_BARRIER_DIR_FD=
+    FACELOCK_SOURCE_INSTALL_STOP_SUCCEEDED=false
+    FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH=
+    FACELOCK_SOURCE_INSTALL_INITIAL_UNIT_NOT_FOUND=false
+    FACELOCK_SOURCE_INSTALL_INITIAL_DBUS_DEFINITION_ABSENT=false
+    facelock_source_install_release_physical_mask_fds
+    FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT=absent
+    FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT=absent
+    FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK=false
+    FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER=
+    if [ ! -d "$systemd_runtime_dir" ]; then
+        echo "Error: systemd is unavailable, so no source-install activation barrier can be established; no files were changed." >&2
+        return 1
+    fi
+    case "$systemd_runtime_dir" in
+        /run/systemd/system) layout_prefix= ;;
+        */run/systemd/system)
+            layout_prefix="${systemd_runtime_dir%/run/systemd/system}"
+            ;;
+        *)
+            echo "Error: the systemd runtime layout is unsupported; no files were changed." >&2
+            return 1
+            ;;
+    esac
+    FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$layout_prefix"
+    if ! IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+        FACELOCK_SOURCE_INSTALL_TRUST_GID < <(
+        stat -Lc '%u:%g' -- "${layout_prefix:-/}"
+    ); then
+        echo "Error: the system layout trust root is unavailable; no files were changed." >&2
+        return 1
+    fi
+    runtime_root="$layout_prefix/run"
+    barrier_dir="$runtime_root/systemd/system.control"
+    persistent_control_path="$layout_prefix/etc/systemd/system.control/facelock-daemon.service"
+    persistent_mask_path="$layout_prefix/etc/systemd/system/facelock-daemon.service"
+    runtime_mask_path="$layout_prefix/run/systemd/system/facelock-daemon.service"
+    FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH="$persistent_mask_path"
+    FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_PATH="$runtime_mask_path"
+    FACELOCK_SOURCE_INSTALL_PERSISTENT_CONTROL_PATH="$persistent_control_path"
+    if ! facelock_source_install_ensure_lock_directory \
+        "$runtime_root/facelock" "${layout_prefix:-/}" ||
+        ! facelock_source_install_acquire_lock \
+            "$runtime_root/facelock/lifecycle.lock" "${layout_prefix:-/}"; then
+        echo "Error: another source install is already running or its lifecycle lock is unavailable; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_plan_legacy_assets; then
+        echo "Error: a historical system asset or migration quarantine is ambiguous or untrusted; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_snapshot_physical_mask \
+        "$persistent_mask_path" \
+        FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT \
+        FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD ||
+        ! facelock_source_install_snapshot_physical_mask \
+            "$runtime_mask_path" \
+            FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT \
+            FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD; then
+        echo "Error: an ordinary administrative unit asset is untrusted or unsupported; no files were changed." >&2
+        return 1
+    fi
+    case "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT" in
+        mask-*)
+            FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK=true
+            FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER="$persistent_mask_path"
+            ;;
+        ordinary:*) ;;
+        absent)
+            case "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT" in
+                mask-*)
+                    FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK=true
+                    FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER="$runtime_mask_path"
+                    ;;
+            esac
+            ;;
+    esac
+    if [ -e "$persistent_control_path" ] || [ -L "$persistent_control_path" ]; then
+        echo "Error: a higher-priority systemd control unit prevents a reliable activation barrier; no files were changed." >&2
+        return 1
+    fi
+    if [ -e "$barrier_dir/facelock-daemon.service" ] ||
+        [ -L "$barrier_dir/facelock-daemon.service" ]; then
+        echo "Error: an existing runtime systemd control unit prevents a reliable activation barrier; no files were changed." >&2
+        return 1
+    fi
+
+    if ! snapshot="$(systemctl show facelock-daemon.service \
+        --property=LoadState \
+        --property=ActiveState \
+        --property=UnitFileState \
+        --property=FragmentPath \
+        --property=ExecStart \
+        --property=DropInPaths \
+        --no-pager)"; then
+        echo "Error: could not determine facelock-daemon.service state; no files were changed." >&2
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        case "$line" in
+            LoadState=*)
+                load_state_count=$((load_state_count + 1))
+                load_state="${line#LoadState=}"
+                ;;
+            ActiveState=*)
+                active_state_count=$((active_state_count + 1))
+                active_state="${line#ActiveState=}"
+                ;;
+            UnitFileState=*)
+                unit_file_state_count=$((unit_file_state_count + 1))
+                unit_file_state="${line#UnitFileState=}"
+                ;;
+            FragmentPath=*)
+                fragment_path_count=$((fragment_path_count + 1))
+                fragment_path="${line#FragmentPath=}"
+                ;;
+            ExecStart=*)
+                daemon_exec_start_count=$((daemon_exec_start_count + 1))
+                daemon_exec_start="${line#ExecStart=}"
+                ;;
+            DropInPaths=*)
+                drop_in_paths_count=$((drop_in_paths_count + 1))
+                drop_in_paths="${line#DropInPaths=}"
+                ;;
+            *)
+                echo "Error: systemd returned an unexpected unit-state property; no files were changed." >&2
+                return 1
+                ;;
+        esac
+    done <<<"$snapshot"
+    if [ "$load_state_count" -ne 1 ] ||
+        [ "$active_state_count" -ne 1 ] ||
+        [ "$unit_file_state_count" -ne 1 ] ||
+        [ "$fragment_path_count" -ne 1 ] ||
+        [ "$daemon_exec_start_count" -gt 1 ] ||
+        [ "$drop_in_paths_count" -ne 1 ]; then
+        echo "Error: systemd returned duplicate or missing unit-state properties; no files were changed." >&2
+        return 1
+    fi
+
+    case "$load_state" in
+        loaded)
+            if [ "$daemon_exec_start_count" -ne 1 ] ||
+                [ -z "$daemon_exec_start" ]; then
+                echo "Error: systemd returned an incomplete loaded-unit state; no files were changed." >&2
+                return 1
+            fi
+            ;;
+        not-found)
+            if [ "$daemon_exec_start_count" -ne 0 ] ||
+                [ "$active_state" != inactive ] ||
+                [ -n "$unit_file_state" ] ||
+                [ -n "$fragment_path" ] ||
+                [ -n "$drop_in_paths" ]; then
+                echo "Error: systemd returned an inconsistent not-found unit state; no files were changed." >&2
+                return 1
+            fi
+            ;;
+        masked)
+            if [ "$daemon_exec_start_count" -ne 0 ] ||
+                [ "$active_state" != inactive ] ||
+                [ -n "$drop_in_paths" ]; then
+                echo "Error: systemd returned an inconsistent masked unit state; no files were changed." >&2
+                return 1
+            fi
+            if [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" != true ]; then
+                echo "Error: systemd reported a mask that does not match an ordinary administrative mask; no files were changed." >&2
+                return 1
+            fi
+            if [ "$FACELOCK_SOURCE_INSTALL_PHYSICAL_MASK_WINNER" = \
+                "$persistent_mask_path" ]; then
+                [ "$unit_file_state:$fragment_path" = \
+                    "masked:$persistent_mask_path" ] || {
+                    echo "Error: systemd returned an inconsistent mask for facelock-daemon.service; no files were changed." >&2
+                    return 1
+                }
+            else
+                [ "$unit_file_state:$fragment_path" = \
+                    "masked-runtime:$runtime_mask_path" ] || {
+                    echo "Error: systemd returned an inconsistent mask for facelock-daemon.service; no files were changed." >&2
+                    return 1
+                }
+            fi
+            ;;
+    esac
+
+    case "$unit_file_state" in
+        enabled | enabled-runtime | linked | linked-runtime | alias | masked | \
+            masked-runtime | static | indirect | disabled | generated | transient) ;;
+        "")
+            if [ "$load_state" != not-found ]; then
+                echo "Error: systemd returned an incomplete unit-file state; no files were changed." >&2
+                return 1
+            fi
+            ;;
+        *)
+            echo "Error: refusing source install for unknown unit-file state $unit_file_state; no files were changed." >&2
+            return 1
+            ;;
+    esac
+
+    case "$load_state:$active_state" in
+        loaded:active)
+            if [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" = true ]; then
+                echo "Error: an active facelock-daemon.service has an ordinary administrative mask and cannot be restored safely; no files were changed." >&2
+                return 1
+            fi
+            if ! facelock_source_install_effective_unit_is_trusted \
+                "$fragment_path" "$daemon_exec_start" "$drop_in_paths" \
+                "${layout_prefix:-/}" "${installed_assets[@]}"; then
+                echo "Error: the loaded facelock-daemon.service assets are inconsistent or untrusted; no files were changed." >&2
+                return 1
+            fi
+            FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE=true
+            loaded_unit=true
+            ;;
+        loaded:inactive)
+            if ! facelock_source_install_effective_unit_is_trusted \
+                "$fragment_path" "$daemon_exec_start" "$drop_in_paths" \
+                "${layout_prefix:-/}" "${installed_assets[@]}"; then
+                echo "Error: the loaded facelock-daemon.service assets are inconsistent or untrusted; no files were changed." >&2
+                return 1
+            fi
+            loaded_unit=true
+            ;;
+        not-found:inactive)
+            if [ "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT" != absent ] ||
+                [ "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT" != absent ]; then
+                echo "Error: systemd did not report an ordinary administrative unit asset; no files were changed." >&2
+                return 1
+            fi
+            for asset in "${installed_assets[@]}"; do
+                if [ -e "$asset" ] || [ -L "$asset" ]; then
+                    echo "Error: systemd did not load facelock-daemon.service although an install asset exists; no files were changed." >&2
+                    return 1
+                fi
+            done
+            if ! facelock_source_install_dbus_definition_is_absent; then
+                echo "Error: systemd did not load facelock-daemon.service although a D-Bus activation definition exists or is unreadable; no files were changed." >&2
+                return 1
+            fi
+            FACELOCK_SOURCE_INSTALL_INITIAL_UNIT_NOT_FOUND=true
+            FACELOCK_SOURCE_INSTALL_INITIAL_DBUS_DEFINITION_ABSENT=true
+            ;;
+        masked:inactive)
+            :
+            ;;
+        *)
+            echo "Error: refusing source install while facelock-daemon.service is $load_state/$active_state ($unit_file_state); no files were changed." >&2
+            return 1
+            ;;
+    esac
+
+    if [ "$loaded_unit" = true ]; then
+        case "$unit_file_state" in
+            masked | masked-runtime)
+                echo "Error: systemd returned a false loaded/masked unit schema; no files were changed." >&2
+                return 1
+                ;;
+        esac
+    fi
+    if ! facelock_source_install_dbus_uses_systemd_activation; then
+        echo "Error: D-Bus activation is unavailable or does not reliably delegate to systemd; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_dbus_config_is_standard "$layout_prefix"; then
+        echo "Error: the effective D-Bus activation configuration is custom or cannot be proven safe; no files were changed." >&2
+        return 1
+    fi
+    if [ "${#FACELOCK_SOURCE_INSTALL_DBUS_ASSETS[@]}" -eq 0 ] ||
+        ! facelock_source_install_dbus_definition_delegates \
+            dbus/org.facelock.Daemon.service || {
+        if [ "$loaded_unit" = true ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" = true ]; then
+            ! facelock_source_install_dbus_definition_is_safe
+        else
+            ! facelock_source_install_dbus_definition_is_absent
+        fi
+    }; then
+        echo "Error: the selected D-Bus activation definition does not delegate to facelock-daemon.service; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_retry \
+        facelock_source_install_reload_dbus_activation ||
+        ! facelock_source_install_dbus_owner_matches_snapshot; then
+        echo "Error: D-Bus activation state could not be synchronized with the daemon snapshot; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_dbus_config_is_standard "$layout_prefix" || {
+        if [ "$loaded_unit" = true ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" = true ]; then
+            ! facelock_source_install_dbus_definition_is_safe
+        else
+            ! facelock_source_install_dbus_definition_is_absent
+        fi
+    }; then
+        echo "Error: D-Bus activation configuration changed while its cache was synchronized; no files were changed." >&2
+        return 1
+    fi
+
+    if ! facelock_source_install_physical_masks_are_current; then
+        echo "Error: an ordinary administrative mask changed before the activation barrier was created; no files were changed." >&2
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_CRITICAL=true
+    if facelock_source_install_create_barrier "$barrier_dir"; then
+        barrier_status=0
+    else
+        barrier_status=$?
+    fi
+    FACELOCK_SOURCE_INSTALL_CRITICAL=false
+
+    if [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ]; then
+        return "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL"
+    fi
+    if [ "$barrier_status" -ne 0 ]; then
+        echo "Error: could not establish a runtime activation barrier; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_retry systemctl daemon-reload; then
+        echo "Error: could not load the temporary activation barrier after 3 attempts; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_physical_masks_are_current ||
+        ! facelock_source_install_owned_barrier_is_current ||
+        ! facelock_source_install_unit_is_owned_barrier "$active_state"; then
+        echo "Error: the temporary activation barrier was not the exact effective unit before stop; no files were changed." >&2
+        return 1
+    fi
+
+    if ! systemctl stop facelock-daemon.service; then
+        echo "Error: could not stop facelock-daemon.service; no files were changed." >&2
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_STOP_SUCCEEDED=true
+    if ! facelock_source_install_unit_is_owned_barrier inactive; then
+        echo "Error: the activation barrier could not be reconciled before source-install writes; no files were changed." >&2
+        return 1
+    fi
+    if ! facelock_source_install_physical_masks_are_current ||
+        ! facelock_source_install_owned_barrier_is_current ||
+        ! facelock_source_install_dbus_owner_is false ||
+        ! facelock_source_install_dbus_config_is_standard "$layout_prefix" || {
+        if [ "$loaded_unit" = true ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_HAS_PHYSICAL_MASK" = true ]; then
+            ! facelock_source_install_dbus_definition_is_safe
+        else
+            ! facelock_source_install_dbus_definition_is_absent
+        fi
+    }; then
+        echo "Error: the activation barrier could not be reconciled before source-install writes; no files were changed." >&2
+        return 1
+    fi
+    FACELOCK_SOURCE_INSTALL_PREPARED=true
+}
+
+facelock_source_install_restore_daemon() {
+    local systemd_runtime_dir="${1:-/run/systemd/system}"
+    local publication_allowed="${2:-false}"
+    local restore_status=0
+    local dbus_activation_safe=true
+    local expected_active_state=inactive
+    local expected_owner=false
+    local barrier_retired=false
+
+    if [ "$FACELOCK_SOURCE_INSTALL_STOP_SUCCEEDED" != true ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE" = true ]; then
+        expected_active_state=active
+        expected_owner=true
+    fi
+
+    if [ -d "$systemd_runtime_dir" ] && {
+        [ "$FACELOCK_SOURCE_INSTALL_PREPARED" = true ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED" = true ];
+    }; then
+        if ! facelock_source_install_retry systemctl daemon-reload; then
+            echo "Error: could not reload systemd after 3 attempts." >&2
+            dbus_activation_safe=false
+            restore_status=1
+        fi
+        if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_RECONCILIATION_FAILED" = true ]; then
+            echo "Error: an ambiguous legacy migration prefix could not be reconciled; the activation barrier was retained." >&2
+            dbus_activation_safe=false
+            restore_status=1
+        fi
+        if ! facelock_source_install_physical_masks_are_current ||
+            ! facelock_source_install_control_topology_is_current ||
+            ! facelock_source_install_dbus_config_is_standard \
+            "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" ||
+            ! facelock_source_install_expected_dbus_definition_is_current ||
+            ! facelock_source_install_retry \
+                facelock_source_install_reload_dbus_activation ||
+            ! facelock_source_install_dbus_config_is_standard \
+                "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" ||
+            ! facelock_source_install_expected_dbus_definition_is_current ||
+            { [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] &&
+                ! facelock_source_install_unit_is_owned_barrier \
+                    "$expected_active_state"; } ||
+            ! facelock_source_install_dbus_owner_is "$expected_owner" ||
+            { [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] &&
+                ! facelock_source_install_owned_barrier_is_current; }; then
+            echo "Error: could not safely reconcile the masked D-Bus activation state." >&2
+            dbus_activation_safe=false
+            restore_status=1
+        fi
+        if [ "$dbus_activation_safe" = true ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = true ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ]; then
+            if [ "$publication_allowed" != true ]; then
+                echo "Error: staged legacy system assets were not eligible for publication; the activation barrier was retained." >&2
+                dbus_activation_safe=false
+                restore_status=1
+            elif [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ]; then
+                if ! facelock_source_install_rollback_legacy_migration; then
+                    echo "Error: could not roll back staged legacy system assets after a deferred signal." >&2
+                fi
+                dbus_activation_safe=false
+                restore_status=1
+            elif ! facelock_source_install_commit_legacy_migration; then
+                echo "Error: could not publish staged legacy-system-asset retirement while activation remained barred." >&2
+                if facelock_source_install_rollback_legacy_migration; then
+                    if ! facelock_source_install_retry systemctl daemon-reload ||
+                        ! facelock_source_install_physical_masks_are_current ||
+                        ! facelock_source_install_control_topology_is_current ||
+                        ! facelock_source_install_retry \
+                            facelock_source_install_reload_dbus_activation ||
+                        ! facelock_source_install_dbus_config_is_standard \
+                            "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" ||
+                        ! facelock_source_install_expected_dbus_definition_is_current ||
+                        { [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] &&
+                            ! facelock_source_install_unit_is_owned_barrier \
+                                "$expected_active_state"; } ||
+                        ! facelock_source_install_dbus_owner_is "$expected_owner" ||
+                        { [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] &&
+                            ! facelock_source_install_owned_barrier_is_current; }; then
+                        echo "Error: rolled-back legacy system assets could not be reloaded and proved while activation remained barred." >&2
+                    fi
+                else
+                    echo "Error: migration publication failed and rollback was incomplete; the activation barrier was retained." >&2
+                fi
+                dbus_activation_safe=false
+                restore_status=1
+            elif ! facelock_source_install_physical_masks_are_current ||
+                ! facelock_source_install_control_topology_is_current ||
+                ! facelock_source_install_dbus_config_is_standard \
+                    "$FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX" ||
+                ! facelock_source_install_expected_dbus_definition_is_current ||
+                { [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ] &&
+                    ! facelock_source_install_unit_is_owned_barrier \
+                        "$expected_active_state"; } ||
+                ! facelock_source_install_dbus_owner_is "$expected_owner"; then
+                echo "Error: published legacy-system-asset retirement changed before barrier removal." >&2
+                dbus_activation_safe=false
+                restore_status=1
+            fi
+        fi
+        if [ "$dbus_activation_safe" = true ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = true ]; then
+            if ! facelock_source_install_physical_masks_are_current ||
+                ! facelock_source_install_control_topology_is_current; then
+                echo "Error: an ordinary administrative unit changed immediately before barrier removal." >&2
+                dbus_activation_safe=false
+                restore_status=1
+            elif ! facelock_source_install_retry \
+                facelock_source_install_quarantine_owned_barrier; then
+                echo "Error: could not quarantine the temporary activation barrier after 3 attempts." >&2
+                dbus_activation_safe=false
+                restore_status=1
+            elif ! facelock_source_install_physical_masks_are_current ||
+                ! facelock_source_install_control_topology_is_current; then
+                echo "Error: an ordinary administrative unit changed while the barrier was quarantined." >&2
+                dbus_activation_safe=false
+                restore_status=1
+                if ! facelock_source_install_recover_owned_barrier; then
+                    echo "Error: could not recover the manager-effective activation barrier." >&2
+                fi
+            elif ! facelock_source_install_retry systemctl daemon-reload; then
+                echo "Error: could not reload systemd after quarantining the activation barrier." >&2
+                dbus_activation_safe=false
+                restore_status=1
+                if ! facelock_source_install_recover_owned_barrier; then
+                    echo "Error: could not recover the manager-effective activation barrier." >&2
+                fi
+            elif ! facelock_source_install_post_removal_state_is_safe \
+                "$expected_active_state" "$expected_owner"; then
+                echo "Error: the post-removal manager or D-Bus state was not exact." >&2
+                dbus_activation_safe=false
+                restore_status=1
+                if ! facelock_source_install_recover_owned_barrier; then
+                    echo "Error: could not recover the manager-effective activation barrier." >&2
+                fi
+            elif facelock_source_install_retry \
+                facelock_source_install_remove_quarantined_barrier; then
+                FACELOCK_SOURCE_INSTALL_BARRIER_CREATED=false
+                barrier_retired=true
+            else
+                echo "Error: could not remove the quarantined activation barrier after 3 attempts." >&2
+                dbus_activation_safe=false
+                restore_status=1
+                if ! facelock_source_install_recover_owned_barrier; then
+                    echo "Error: could not recover the manager-effective activation barrier." >&2
+                fi
+            fi
+        fi
+        if [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = false ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED" = true ]; then
+            if facelock_source_install_remove_owned_barrier_dir; then
+                FACELOCK_SOURCE_INSTALL_BARRIER_DIR_CREATED=false
+            else
+                echo "Error: could not remove the temporary activation-barrier directory." >&2
+                dbus_activation_safe=false
+                restore_status=1
+            fi
+        fi
+        if [ "$barrier_retired" = true ] &&
+            [ "$dbus_activation_safe" = true ] &&
+            ! facelock_source_install_post_removal_state_is_safe \
+                "$expected_active_state" "$expected_owner"; then
+            echo "Error: the final manager, D-Bus, or administrator state changed before restart." >&2
+            dbus_activation_safe=false
+            restore_status=1
+        fi
+        if [ "$FACELOCK_SOURCE_INSTALL_DAEMON_WAS_ACTIVE" = true ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_STOP_SUCCEEDED" = true ] &&
+            [ "$barrier_retired" = true ] &&
+            [ "$dbus_activation_safe" = true ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_BARRIER_CREATED" = false ] &&
+            ! facelock_source_install_restart_active_daemon; then
+            echo "Error: could not restore the initially active daemon after 3 attempts." >&2
+            restore_status=1
+        fi
+    fi
+
+    FACELOCK_SOURCE_INSTALL_PREPARED=false
+    return "$restore_status"
+}
+
+facelock_source_install_finish_daemon() {
+    local original_status="$1"
+    local restore_status=0
+    local migration_status=0
+    local publication_allowed=false
+    local final_status="$original_status"
+
+    FACELOCK_SOURCE_INSTALL_RESTORING=true
+    if [ "${#FACELOCK_SOURCE_INSTALL_LEGACY_PLAN[@]}" -eq 3 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ] && {
+        [ "$original_status" -ne 0 ] ||
+            [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ];
+    }; then
+        if ! facelock_source_install_rollback_legacy_migration; then
+            echo "Error: could not roll back staged legacy system assets before daemon restoration." >&2
+            migration_status=1
+            FACELOCK_SOURCE_INSTALL_LEGACY_RECONCILIATION_FAILED=true
+        fi
+    fi
+    if [ "$original_status" -eq 0 ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -eq 0 ] &&
+        [ "$migration_status" -eq 0 ]; then
+        publication_allowed=true
+    fi
+    if facelock_source_install_restore_daemon \
+        "$FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR" \
+        "$publication_allowed"; then
+        restore_status=0
+    else
+        restore_status=$?
+    fi
+    if [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = true ] &&
+        [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_COMMITTED" = false ]; then
+        if [ -z "$FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR" ] &&
+            [ "$original_status" -eq 0 ] &&
+            [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -eq 0 ] &&
+            [ "$restore_status" -eq 0 ] && [ "$migration_status" -eq 0 ]; then
+            if ! facelock_source_install_commit_legacy_migration; then
+                echo "Error: could not publish staged offline legacy-system-asset retirement." >&2
+                migration_status=1
+                facelock_source_install_rollback_legacy_migration || true
+            fi
+        elif ! facelock_source_install_rollback_legacy_migration; then
+            echo "Error: could not roll back staged legacy system assets after daemon restoration failed." >&2
+            migration_status=1
+        fi
+    fi
+    facelock_source_install_release_lock
+    facelock_source_install_release_physical_mask_fds
+    facelock_source_install_release_barrier_fds
+
+    trap - EXIT HUP INT TERM
+    FACELOCK_SOURCE_INSTALL_RESTORING=false
+    if [ "$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL" -ne 0 ]; then
+        final_status="$FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL"
+    elif [ "$final_status" -eq 0 ] && [ "$restore_status" -ne 0 ]; then
+        final_status="$restore_status"
+    elif [ "$final_status" -eq 0 ] && [ "$migration_status" -ne 0 ]; then
+        final_status="$migration_status"
+    fi
+    return "$final_status"
+}
+
+facelock_source_install_exit_handler() {
+    local original_status="$?"
+    local final_status
+
+    set +e
+    facelock_source_install_finish_daemon "$original_status"
+    final_status=$?
+    exit "$final_status"
+}
+
+facelock_source_install_begin_daemon() {
+    local status
+
+    FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR="${1:-/run/systemd/system}"
+    FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL=0
+    facelock_source_install_arm_daemon_restore
+    if facelock_source_install_prepare_daemon "$@"; then
+        return 0
+    else
+        status=$?
+    fi
+
+    facelock_source_install_finish_daemon "$status"
+}
+
+facelock_source_install_begin() {
+    case "${FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE:-}" in
+        "") facelock_source_install_begin_daemon "$@" ;;
+        container-build)
+            local image_root="${1:-/}"
+            local status
+
+            FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR=
+            FACELOCK_SOURCE_INSTALL_DEFERRED_SIGNAL=0
+            facelock_source_install_arm_daemon_restore
+            if facelock_source_install_prepare_offline_image "$image_root"; then
+                return 0
+            else
+                status=$?
+            fi
+            facelock_source_install_finish_daemon "$status"
+            ;;
+        *)
+            echo "Error: unknown offline image mode; no files were changed." >&2
+            return 1
+            ;;
+    esac
+}
+
+facelock_source_install_complete_daemon() {
+    if [ "$#" -gt 0 ]; then
+        FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR="$1"
+    fi
+    facelock_source_install_finish_daemon 0
+}
+
+facelock_source_install_complete() {
+    case "${FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE:-}" in
+        "") facelock_source_install_complete_daemon "$@" ;;
+        container-build) facelock_source_install_finish_daemon 0 ;;
+        *)
+            echo "Error: unknown offline image mode." >&2
+            return 1
+            ;;
+    esac
+}

--- a/scripts/uninstall-system-assets.sh
+++ b/scripts/uninstall-system-assets.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+export LC_ALL=C
+
+if [ "${1:-/}" = / ]; then
+    PATH=/usr/bin:/bin
+    export PATH
+fi
+
+# Source uninstall owns only the canonical package/source paths. Historical
+# /etc copies are administrator state and are intentionally never inspected or
+# removed here; setup's reviewed migration is their only automatic retirement.
+
+layout_root="${1:-/}"
+case "$layout_root" in
+    /*) ;;
+    *)
+        echo "Error: system-asset layout root must be absolute; no files were changed." >&2
+        exit 1
+        ;;
+esac
+[ -d "$layout_root" ] && [ ! -L "$layout_root" ] || {
+    echo "Error: system-asset layout root is not a real directory; no files were changed." >&2
+    exit 1
+}
+layout_root="$(cd -- "$layout_root" && pwd -P)"
+layout_prefix="${layout_root%/}"
+
+if [ "$layout_root" = / ]; then
+    expected_uid=0
+    expected_gid=0
+else
+    IFS=: read -r expected_uid expected_gid < <(stat -c '%u:%g' -- "$layout_root") || {
+        echo "Error: could not establish the system-asset layout owner; no files were changed." >&2
+        exit 1
+    }
+fi
+
+canonical_assets=(
+    usr/lib/systemd/system/facelock-daemon.service \
+    usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+    usr/share/dbus-1/system-services/org.facelock.Daemon.service
+)
+
+layout_root_is_trusted() {
+    local uid gid mode kind
+
+    IFS=: read -r uid gid mode kind < <(
+        stat -c '%u:%g:%a:%F' -- "$layout_root"
+    ) || return 1
+    [ "$uid" = "$expected_uid" ] &&
+        [ "$gid" = "$expected_gid" ] &&
+        [ "$kind" = directory ] &&
+        [ "$((8#$mode & 8#022))" -eq 0 ]
+}
+
+canonical_parents_are_trusted() {
+    local relative="$1"
+    local parent_relative component current uid gid mode kind
+    local -a parent_components
+
+    parent_relative="${relative%/*}"
+    current="$layout_root"
+    IFS='/' read -r -a parent_components <<<"$parent_relative"
+    for component in "${parent_components[@]}"; do
+        [ -n "$component" ] && [ "$component" != . ] && [ "$component" != .. ] ||
+            return 1
+        current="${current%/}/$component"
+        if [ ! -e "$current" ] && [ ! -L "$current" ]; then
+            return 0
+        fi
+        IFS=: read -r uid gid mode kind < <(
+            stat -c '%u:%g:%a:%F' -- "$current"
+        ) || return 1
+        [ "$uid" = "$expected_uid" ] &&
+            [ "$gid" = "$expected_gid" ] &&
+            [ "$kind" = directory ] &&
+            [ "$((8#$mode & 8#022))" -eq 0 ] || return 1
+    done
+}
+
+canonical_is_trusted_or_absent() {
+    local relative="$1"
+    local path="$layout_prefix/$relative"
+    local uid gid mode links kind
+
+    canonical_parents_are_trusted "$relative" || return 1
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        return 0
+    fi
+    IFS=: read -r uid gid mode links kind < <(
+        stat -c '%u:%g:%a:%h:%F' -- "$path"
+    ) || return 1
+    [ "$uid" = "$expected_uid" ] &&
+        [ "$gid" = "$expected_gid" ] &&
+        [ "$mode" = 644 ] &&
+        [ "$links" -eq 1 ] &&
+        [ "$kind" = 'regular file' ]
+}
+
+failures=()
+removals=()
+if ! layout_root_is_trusted; then
+    failures+=("system-asset layout root is linked, untrusted, or writable: $layout_root")
+fi
+for canonical in "${canonical_assets[@]}"; do
+    canonical_path="$layout_prefix/$canonical"
+    if ! canonical_is_trusted_or_absent "$canonical"; then
+        failures+=("canonical asset or parent is linked, untrusted, multiply linked, or has unexpected metadata and was preserved: $canonical_path")
+    elif [ -e "$canonical_path" ] || [ -L "$canonical_path" ]; then
+        removals+=("$canonical_path")
+    fi
+done
+
+if [ "${#failures[@]}" -ne 0 ]; then
+    echo "Error: canonical system-asset validation failed; no files were changed:" >&2
+    printf '  - %s\n' "${failures[@]}" >&2
+    exit 1
+fi
+
+for canonical_path in "${removals[@]}"; do
+    rm -- "$canonical_path"
+done

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -14,6 +14,12 @@ RUN printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo
 # daemon by parsing it rather than by grepping the report a person reads.
 RUN pacman -Syu --noconfirm pam polkit sudo base-devel libxkbcommon just dbus onnxruntime-cpu protobuf python python-gobject sqlite jq && pacman -Scc --noconfirm
 
+# Give the disposable PID1 image a deterministic machine identity so
+# dbus-broker can establish the system bus without extra mounts.
+RUN rm -f /etc/machine-id && \
+    printf '%s\n' 0123456789abcdef0123456789abcdef > /etc/machine-id && \
+    chmod 0444 /etc/machine-id
+
 # Build pamtester from upstream source (curl and the toolchain come from base-devel above)
 COPY test/install-pamtester.sh /tmp/install-pamtester.sh
 RUN sh /tmp/install-pamtester.sh && rm -f /tmp/install-pamtester.sh
@@ -27,15 +33,21 @@ COPY target/release/libpam_facelock.so /build/target/release/libpam_facelock.so
 
 # Copy project files needed for install
 COPY justfile /build/justfile
+COPY scripts/source-install-daemon-lifecycle.sh /build/scripts/source-install-daemon-lifecycle.sh
+COPY scripts/migrate-legacy-system-assets.sh /build/scripts/migrate-legacy-system-assets.sh
 COPY config/ /build/config/
 COPY systemd/ /build/systemd/
 COPY dbus/ /build/dbus/
+COPY test/Containerfile /build/test/Containerfile
+COPY test/source-install-offline-image.marker /build/test/source-install-offline-image.marker
 COPY dist/ /build/dist/
 COPY models/ /build/models/
 WORKDIR /build
 
 # Install using the real install path
-RUN just install-files
+RUN FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \
+    FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER=/build/test/source-install-offline-image.marker \
+    just install-files
 
 # Copy models to the configured model_dir for integration tests
 RUN cp models/*.onnx /var/lib/facelock/models/ 2>/dev/null || true && \
@@ -49,6 +61,33 @@ COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
 
 # Fake daemon harness for the PAM peer-UID container test (plan 05)
 COPY test/fake-facelock-daemon.py /fake-facelock-daemon.py
+
+# Stable source-install lifecycle oracle for the booted real-systemd gate.
+COPY scripts/source-install-daemon-lifecycle.sh /source-install-lifecycle/scripts/source-install-daemon-lifecycle.sh
+COPY scripts/migrate-legacy-system-assets.sh /source-install-lifecycle/scripts/migrate-legacy-system-assets.sh
+COPY dist/legacy-system-assets.sha256 /source-install-lifecycle/dist/legacy-system-assets.sha256
+COPY dbus/org.facelock.Daemon.service /source-install-lifecycle/dbus/org.facelock.Daemon.service
+COPY test/fake-facelock-daemon.py /source-install-lifecycle/test/fake-facelock-daemon.py
+COPY test/source-install-daemon-lifecycle-systemd.sh /source-install-lifecycle/test/source-install-daemon-lifecycle-systemd.sh
+COPY test/source-install-daemon-stub.sh /source-install-lifecycle/test/source-install-daemon-stub.sh
+COPY test/source-install-daemon-stop-probe.sh /source-install-lifecycle/test/bin/systemctl
+COPY test/source-install-recipe-install-probe.sh /source-install-lifecycle/test/bin/install
+COPY test/source-install-recipe-install-probe.sh /source-install-lifecycle/test/fake-bin/install
+COPY test/source-install-recipe-install-probe.sh /source-install-lifecycle/test/source-install-recipe-install-probe.sh
+COPY test/source-install-recipe-fake-systemctl.sh /source-install-lifecycle/test/fake-bin/systemctl
+COPY test/source-install-recipe-fake-busctl.sh /source-install-lifecycle/test/fake-bin/busctl
+COPY test/source-install-recipe-fake-systemctl.sh /source-install-lifecycle/test/source-install-recipe-fake-systemctl.sh
+COPY test/source-install-recipe-fake-busctl.sh /source-install-lifecycle/test/source-install-recipe-fake-busctl.sh
+COPY test/source-install-daemon-test.service /source-install-lifecycle/test/source-install-daemon-test.service
+COPY justfile /source-install-lifecycle/repository/justfile
+COPY scripts/source-install-daemon-lifecycle.sh /source-install-lifecycle/repository/scripts/source-install-daemon-lifecycle.sh
+COPY scripts/migrate-legacy-system-assets.sh /source-install-lifecycle/repository/scripts/migrate-legacy-system-assets.sh
+COPY dist/legacy-system-assets.sha256 /source-install-lifecycle/repository/dist/legacy-system-assets.sha256
+COPY config/ /source-install-lifecycle/repository/config/
+COPY systemd/ /source-install-lifecycle/repository/systemd/
+COPY dbus/ /source-install-lifecycle/repository/dbus/
+COPY target/release/facelock /source-install-lifecycle/repository/target/release/facelock
+COPY target/release/libpam_facelock.so /source-install-lifecycle/repository/target/release/libpam_facelock.so
 
 # Install a minimal real libalpm package carrying the production hook and
 # scriptlet. The booted package test removes it only after the ordinary PAM
@@ -65,7 +104,14 @@ COPY test/run-oneshot-tests.sh /run-oneshot-tests.sh
 COPY test/run-layout-tests.sh /run-layout-tests.sh
 COPY test/arch-package-validate.sh /arch-package-validate.sh
 RUN chmod +x /run-tests.sh /run-integration-tests.sh /run-oneshot-tests.sh \
-    /run-layout-tests.sh /arch-package-validate.sh
+    /run-layout-tests.sh /arch-package-validate.sh \
+    /source-install-lifecycle/test/source-install-daemon-lifecycle-systemd.sh \
+    /source-install-lifecycle/test/source-install-daemon-stub.sh \
+    /source-install-lifecycle/test/bin/systemctl \
+    /source-install-lifecycle/test/bin/install \
+    /source-install-lifecycle/test/fake-bin/install \
+    /source-install-lifecycle/test/fake-bin/systemctl \
+    /source-install-lifecycle/test/fake-bin/busctl
 
 # Clean up build dir to save image size
 RUN rm -rf /build

--- a/test/Containerfile.deb-rebuild
+++ b/test/Containerfile.deb-rebuild
@@ -24,7 +24,11 @@ RUN case "$SUITE" in \
 
 COPY test/run-deb-offline-build.sh /usr/local/bin/run-deb-offline-build.sh
 COPY .github/workflows/scripts/run-networkless.sh /usr/local/libexec/facelock/run-networkless.sh
+COPY test/deb-package-contract.sh test/deb-maintscript-contract.sh /usr/local/libexec/facelock/test/
+COPY scripts/release-versions.sh /usr/local/libexec/facelock/scripts/release-versions.sh
 RUN chmod +x /usr/local/bin/run-deb-offline-build.sh \
-    /usr/local/libexec/facelock/run-networkless.sh
+    /usr/local/libexec/facelock/run-networkless.sh \
+    /usr/local/libexec/facelock/test/deb-package-contract.sh \
+    /usr/local/libexec/facelock/test/deb-maintscript-contract.sh
 
 ENTRYPOINT ["/usr/local/bin/run-deb-offline-build.sh"]

--- a/test/Containerfile.deb-runtime
+++ b/test/Containerfile.deb-runtime
@@ -1,5 +1,12 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS dependency-closure
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY test/deb-dependency-closure.sh /deb-dependency-closure.sh
+RUN chmod +x /deb-dependency-closure.sh
+
+FROM ${BASE_IMAGE} AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,22 +28,13 @@ RUN printf '%s\n' \
         'path-include=/usr/share/doc/facelock/**' \
         > /etc/dpkg/dpkg.cfg.d/zz-facelock-test-docs
 
-COPY facelock-test-package.deb /facelock-test-package.deb
-RUN cp /etc/pam.d/common-auth /tmp/common-auth.before && \
-    stat -c '%a %u %g' /etc/pam.d/common-auth > /tmp/common-auth.metadata.before && \
-    apt-get update && \
-    apt-get install -y /facelock-test-package.deb && \
-    cmp -s /etc/pam.d/common-auth /tmp/common-auth.before && \
-    test "$(stat -c '%a %u %g' /etc/pam.d/common-auth)" = "$(cat /tmp/common-auth.metadata.before)" && \
-    ! grep -q pam_facelock.so /etc/pam.d/common-auth && \
-    touch /facelock-common-auth-install-invariant && \
-    rm -f /tmp/common-auth.before /tmp/common-auth.metadata.before && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY test/pkg-validate.sh /pkg-validate.sh
+COPY test/deb-package-lifecycle.sh /deb-package-lifecycle.sh
 COPY test/polkit-agent-validate.sh /polkit-agent-validate.sh
 COPY test/tpm-pcr-e2e.sh /tpm-pcr-e2e.sh
-COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
-RUN chmod +x /pkg-validate.sh /polkit-agent-validate.sh /tpm-pcr-e2e.sh
+COPY test/pam.d/facelock-test /facelock-test.pam
+RUN chmod +x /pkg-validate.sh /deb-package-lifecycle.sh \
+        /polkit-agent-validate.sh /tpm-pcr-e2e.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 CMD ["/lib/systemd/systemd"]

--- a/test/build-deb-package-image.sh
+++ b/test/build-deb-package-image.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-suite="${1:?usage: build-deb-package-image.sh <trixie|resolute> <image>}"
-image="${2:?usage: build-deb-package-image.sh <trixie|resolute> <image>}"
-[ "$#" -eq 2 ] || {
-    echo "usage: build-deb-package-image.sh <trixie|resolute> <image>" >&2
+suite="${1:?usage: build-deb-package-image.sh <trixie|resolute> <image> <package-output>}"
+image="${2:?usage: build-deb-package-image.sh <trixie|resolute> <image> <package-output>}"
+package_output="${3:?usage: build-deb-package-image.sh <trixie|resolute> <image> <package-output>}"
+[ "$#" -eq 3 ] || {
+    echo "usage: build-deb-package-image.sh <trixie|resolute> <image> <package-output>" >&2
     exit 2
 }
 
@@ -13,6 +14,18 @@ case "$suite" in
     trixie|resolute) ;;
     *) echo "unsupported Debian package suite: $suite" >&2; exit 2 ;;
 esac
+
+package_parent="$(dirname "$package_output")"
+[ -d "$package_parent" ] || {
+    echo "package output parent does not exist: $package_parent" >&2
+    exit 1
+}
+package_parent="$(cd "$package_parent" && pwd)"
+package_output="$package_parent/$(basename "$package_output")"
+[ ! -e "$package_output" ] && [ ! -L "$package_output" ] || {
+    echo "package output already exists: $package_output" >&2
+    exit 1
+}
 
 base_image="$(python3 - "$repo_root/dist/release-matrix.json" "$suite" <<'PY'
 import json
@@ -40,6 +53,7 @@ trap 'rm -rf -- "$context" "$artifact_dir" "$rebuild_dir"' EXIT
 tar -C "$context" -cf "$context/facelock-git-metadata.tar" .git
 assembler_image="${image}-assembler"
 rebuild_image="${image}-rebuild"
+dependency_image="${image}-dependency-closure"
 podman build \
     --build-arg "BASE_IMAGE=$base_image" \
     --build-arg "SUITE=$suite" \
@@ -73,9 +87,19 @@ package_name="$(grep -E '\.deb$' "$manifest")"
     echo "Debian manifest must name exactly one binary package" >&2
     exit 1
 }
-cp -- "$artifact_dir/$package_name" "$context/facelock-test-package.deb"
+install -m 0444 -- "$artifact_dir/$package_name" "$package_output"
 podman build \
     --build-arg "BASE_IMAGE=$base_image" \
+    --target dependency-closure \
+    -t "$dependency_image" \
+    -f "$context/test/Containerfile.deb-runtime" \
+    "$context"
+podman run --rm \
+    -v "$package_output:/facelock-test-package.deb:ro,Z" \
+    "$dependency_image" /deb-dependency-closure.sh
+podman build \
+    --build-arg "BASE_IMAGE=$base_image" \
+    --target runtime \
     -t "$image" \
     -f "$context/test/Containerfile.deb-runtime" \
     "$context"

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -436,6 +436,72 @@ for arch_consumer in (".github/workflows/ci.yml", ".github/workflows/scripts/pub
     require_arch_mirror_before_each_pacman(arch_consumer)
 ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text()
 justfile = (ROOT / "justfile").read_text()
+
+
+def workflow_job_body(content: str, job_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        content,
+    )
+    require(match is not None, f"workflow omits required job: {job_name}")
+    return match.group("body")
+
+
+ci_agent_docs_job = workflow_job_body(ci_workflow, "agent-docs")
+release_deb_job = workflow_job_body(workflow, "build-deb")
+for package in ("just", "python", "ripgrep"):
+    require(
+        re.search(rf"(?m)^\s+{re.escape(package)}(?: \\)?\s*$", ci_agent_docs_job)
+        is not None,
+        f"CI agent-docs job must install {package} for Debian source-contract validation",
+    )
+for package in ("just", "python3", "ripgrep"):
+    require(
+        re.search(rf"(?m)^\s+{re.escape(package)}(?: \\)?\s*$", release_deb_job)
+        is not None,
+        f"release build-deb job must install {package} for Debian source-contract validation",
+    )
+require(
+    len(
+        re.findall(
+            r"(?m)^\s+run:\s+just test-deb-source-contract\s*$",
+            ci_agent_docs_job,
+        )
+    )
+    == 1,
+    "CI agent-docs job must run exactly one combined Debian source-contract target",
+)
+require(
+    len(
+        re.findall(
+            r"(?m)^\s+just test-deb-source-contract\s*$",
+            release_deb_job,
+        )
+    )
+    == 1,
+    "release build-deb job must run exactly one combined Debian source-contract target",
+)
+deb_source_contract_recipe = re.search(
+    r"(?m)^test-deb-source-contract:\s*\n(?P<body>(?:^[ \t].*(?:\n|\Z))*)",
+    justfile,
+)
+require(
+    deb_source_contract_recipe is not None,
+    "justfile omits the Debian source-contract target",
+)
+deb_source_contract_commands = [
+    line.strip()
+    for line in deb_source_contract_recipe.group("body").splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+]
+require(
+    deb_source_contract_commands
+    == [
+        "bash test/deb-source-contract.sh",
+        "python3 test/deb-source-contract-test.py",
+    ],
+    "just Debian source-contract target must run the exact shell and mutation commands",
+)
 live_channel_command = "python3 test/check-live-release-channels.py"
 require(live_channel_command in ci_workflow, "CI does not compare live release channels with the checked-in authority")
 require(live_channel_command in justfile, "release preflight does not compare live release channels with the checked-in authority")
@@ -642,10 +708,7 @@ for phrase in debian_source_phrases:
     require(phrase in normalized_contracts, f"system contracts omit Debian source policy: {phrase}")
 
 compatibility_paths = ("docs/compatibility.md", "book/src/compatibility.md")
-compatibility_support_floor = (
-    "Debian-family support starts at Debian 13+ and Ubuntu 26.04+; "
-    "older Debian and Ubuntu releases are unsupported."
-)
+compatibility_support_floor = debian_support_phrase
 tested_debian_family_rows = (
     "| Debian 13 (Trixie) | systemd | daemon + D-Bus activation | Booted package gate |",
     "| Ubuntu 26.04 LTS (Resolute) | systemd | daemon + D-Bus activation | Booted package gate |",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -641,9 +641,42 @@ for phrase in debian_source_phrases:
     require(phrase in normalized_releasing, f"release documentation omits Debian source policy: {phrase}")
     require(phrase in normalized_contracts, f"system contracts omit Debian source policy: {phrase}")
 
+compatibility_paths = ("docs/compatibility.md", "book/src/compatibility.md")
+compatibility_support_floor = (
+    "Debian-family support starts at Debian 13+ and Ubuntu 26.04+; "
+    "older Debian and Ubuntu releases are unsupported."
+)
+tested_debian_family_rows = (
+    "| Debian 13 (Trixie) | systemd | daemon + D-Bus activation | Booted package gate |",
+    "| Ubuntu 26.04 LTS (Resolute) | systemd | daemon + D-Bus activation | Booted package gate |",
+)
+debian_family_row = re.compile(r"(?m)^\|[ \t]*(?:Debian|Ubuntu)\b.*\|[ \t]*$")
+for relative_path in compatibility_paths:
+    content = (ROOT / relative_path).read_text()
+    tested_match = re.search(
+        r"(?ms)^## Tested Distributions\s*$\n(.*?)(?=^#{1,6}\s|\Z)",
+        content,
+    )
+    require(tested_match is not None, f"{relative_path} omits the tested distributions section")
+    untested_match = re.search(
+        r"(?ms)^### Expected to Work \(untested\)\s*$\n(.*?)(?=^#{1,6}\s|\Z)",
+        content,
+    )
+    require(untested_match is not None, f"{relative_path} omits the untested distributions section")
+    untested_debian_family_rows = tuple(debian_family_row.findall(untested_match.group(1)))
+    require(not untested_debian_family_rows, f"{relative_path} classifies a supported Debian-family row as untested")
+    normalized_content = re.sub(r"\s+", " ", content)
+    require(
+        compatibility_support_floor in normalized_content,
+        f"{relative_path} omits the exact Debian-family support floor",
+    )
+    actual_tested_debian_family_rows = tuple(debian_family_row.findall(tested_match.group(1)))
+    require(
+        actual_tested_debian_family_rows == tested_debian_family_rows,
+        f"{relative_path} tested Debian-family rows differ: {actual_tested_debian_family_rows!r}",
+    )
+
 compatibility = (ROOT / "docs/compatibility.md").read_text()
-require("Ubuntu 26.04+" in compatibility, "compatibility guide retains an older Ubuntu support floor")
-require("Debian 13+" in compatibility, "compatibility guide retains an older Debian support floor")
 require("Ubuntu 22.04+" not in compatibility, "compatibility guide still claims Ubuntu 22.04 support")
 require("Debian 12+" not in compatibility, "compatibility guide still claims Debian 12 support")
 
@@ -678,10 +711,7 @@ for relative_path in (
     "website/index.html",
 ):
     require("1.88+" in (ROOT / relative_path).read_text(), f"{relative_path} omits the Rust 1.88+ floor")
-book_compatibility = (ROOT / "book/src/compatibility.md").read_text()
-require("Ubuntu 26.04+" in book_compatibility, "book compatibility guide omits Ubuntu 26.04+")
-require("Debian 13+" in book_compatibility, "book compatibility guide omits Debian 13+")
-for relative_path in ("docs/compatibility.md", "book/src/compatibility.md"):
+for relative_path in compatibility_paths:
     require(
         "download-binaries" not in (ROOT / relative_path).read_text(),
         f"{relative_path} falsely claims that the disabled ort download-binaries feature supplies the runtime",

--- a/test/check-source-install-lifecycle-test.py
+++ b/test/check-source-install-lifecycle-test.py
@@ -1,0 +1,1158 @@
+#!/usr/bin/env python3
+"""Regression mutations for the source-install lifecycle structure checker."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "test/check-source-install-lifecycle.py"
+JUSTFILE = REPO_ROOT / "justfile"
+CONTAINERFILE = REPO_ROOT / "test/Containerfile"
+SYSTEMD_LIFECYCLE_RUNNER = (
+    REPO_ROOT / "test/run-source-install-daemon-lifecycle-systemd.sh"
+)
+SYSTEMD_LIFECYCLE_HARNESS = (
+    REPO_ROOT / "test/source-install-daemon-lifecycle-systemd.sh"
+)
+SOURCE_LIFECYCLE_TEST = REPO_ROOT / "test/source-install-daemon-lifecycle.sh"
+CONTAINER_HELPER_COPY = (
+    b"COPY scripts/source-install-daemon-lifecycle.sh "
+    b"/build/scripts/source-install-daemon-lifecycle.sh"
+)
+BOOTED_LIFECYCLE_FIXTURE_COPIES = (
+    b"COPY test/source-install-recipe-install-probe.sh "
+    b"/source-install-lifecycle/test/source-install-recipe-install-probe.sh",
+    b"COPY test/source-install-recipe-fake-systemctl.sh "
+    b"/source-install-lifecycle/test/source-install-recipe-fake-systemctl.sh",
+    b"COPY test/source-install-recipe-fake-busctl.sh "
+    b"/source-install-lifecycle/test/source-install-recipe-fake-busctl.sh",
+)
+CONTAINER_INSTALL_LINE = "    just install-files"
+SOURCE_LINE = "    source scripts/source-install-daemon-lifecycle.sh"
+BEGIN_LINE = "    facelock_source_install_begin"
+COMPLETE_LINE = "    facelock_source_install_complete"
+STATUS_LINE = "    if $NEEDS_SETUP || $NEEDS_ORT; then"
+INSTALL_FILES_STRICT_MODE = (
+    "\ninstall-files:\n    #!/usr/bin/bash -p\n    set -euo pipefail"
+)
+POSTLUDE_BLANK_LINES = '    echo ""\n    echo ""'
+INSTALL_FILES_SHEBANG = "\ninstall-files:\n    #!/usr/bin/bash -p\n"
+RECIPE_CASE_NAME = re.compile(r"\b(recipe-[a-z0-9-]+)\b")
+
+
+def dispatched_recipe_cases(body: str) -> list[str]:
+    cases: list[str] = []
+    for line in body.splitlines():
+        if not re.match(r"^\s*recipe-[a-z0-9-]+", line):
+            continue
+        case_pattern = line.split(")", 1)[0]
+        cases.extend(RECIPE_CASE_NAME.findall(case_pattern))
+    return cases
+
+
+class SourceInstallLifecycleCheckerTests(unittest.TestCase):
+    def install_files_bash(self, justfile: bytes) -> bytes:
+        lines = justfile.split(b"\n")
+        start = lines.index(b"install-files:") + 1
+        recipe: list[bytes] = []
+        for line in lines[start:]:
+            if line and not line.startswith((b" ", b"\t", b"#")):
+                break
+            recipe.append(line[4:] if line.startswith(b"    ") else line)
+        return b"\n".join(recipe) + b"\n"
+
+    def assert_valid_bash(self, name: str, justfile: str) -> None:
+        result = subprocess.run(
+            ["bash", "-n"],
+            input=self.install_files_bash(justfile.encode()),
+            check=False,
+            capture_output=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{name} mutation is not valid Bash:\n{result.stderr.decode()}",
+        )
+
+    def run_checker(
+        self,
+        justfile: pathlib.Path,
+        containerfile: pathlib.Path = CONTAINERFILE,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(CHECKER), str(justfile), str(containerfile)],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_mutation_rejected(
+        self,
+        name: str,
+        needle: str,
+        replacement: str,
+        expected_diagnostic: str | None = None,
+    ) -> None:
+        original = JUSTFILE.read_bytes().decode()
+        self.assertEqual(
+            original.count(needle),
+            1,
+            f"mutation needle count changed for {name}: {needle!r}",
+        )
+        mutated = original.replace(needle, replacement, 1)
+        self.assert_valid_bash(name, mutated)
+        with tempfile.TemporaryDirectory(prefix="facelock-lifecycle-checker-") as temp:
+            mutated_path = pathlib.Path(temp) / "justfile"
+            mutated_path.write_bytes(mutated.encode())
+            result = self.run_checker(mutated_path)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            f"checker accepted {name} mutation",
+        )
+        diagnostic = "source-install lifecycle structure:"
+        if expected_diagnostic is not None:
+            diagnostic += f" {expected_diagnostic}"
+        self.assertIn(diagnostic, result.stderr, f"checker did not diagnose {name} mutation")
+        self.assertNotIn("Traceback", result.stderr)
+
+    def assert_control_cannot_create_checker_only_begin(
+        self, name: str, control: str, expected_byte: int
+    ) -> None:
+        original = JUSTFILE.read_bytes().decode()
+        mutated = original.replace(
+            BEGIN_LINE,
+            "    # checker-comment" + control + BEGIN_LINE,
+            1,
+        )
+        self.assert_valid_bash(name, mutated)
+
+        with tempfile.TemporaryDirectory(prefix="facelock-lifecycle-checker-") as temp:
+            mutated_path = pathlib.Path(temp) / "justfile"
+            mutated_path.write_bytes(mutated.encode())
+            dry_run = subprocess.run(
+                [
+                    "just",
+                    "--dry-run",
+                    "--justfile",
+                    str(mutated_path),
+                    "--working-directory",
+                    str(REPO_ROOT),
+                    "install-files",
+                ],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+            )
+            result = self.run_checker(mutated_path)
+
+        self.assertEqual(dry_run.returncode, 0, dry_run.stderr.decode())
+        active_lines = [
+            line.strip(b" \t")
+            for line in (dry_run.stdout + dry_run.stderr).split(b"\n")
+        ]
+        self.assertNotIn(BEGIN_LINE.strip(" \t").encode(), active_lines)
+        self.assertIn(
+            b"install -Dm755 target/release/facelock /usr/bin/facelock",
+            active_lines,
+        )
+        self.assertNotEqual(result.returncode, 0, f"checker accepted {name} mutation")
+        self.assertIn(
+            "source-install lifecycle structure: "
+            f"disallowed control byte 0x{expected_byte:02x}",
+            result.stderr,
+        )
+        self.assertNotIn("Traceback", result.stderr)
+
+    def assert_unicode_whitespace_cannot_normalize_begin(
+        self, name: str, whitespace: str
+    ) -> None:
+        original = JUSTFILE.read_bytes().decode()
+        mutated = original.replace(BEGIN_LINE, BEGIN_LINE + whitespace, 1)
+        self.assert_valid_bash(name, mutated)
+
+        with tempfile.TemporaryDirectory(prefix="facelock-lifecycle-checker-") as temp:
+            mutated_path = pathlib.Path(temp) / "justfile"
+            mutated_path.write_bytes(mutated.encode())
+            dry_run = subprocess.run(
+                [
+                    "just",
+                    "--dry-run",
+                    "--justfile",
+                    str(mutated_path),
+                    "--working-directory",
+                    str(REPO_ROOT),
+                    "install-files",
+                ],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+            )
+            result = self.run_checker(mutated_path)
+
+        self.assertEqual(dry_run.returncode, 0, dry_run.stderr.decode())
+        active_lines = [
+            line.strip(b" \t")
+            for line in (dry_run.stdout + dry_run.stderr).split(b"\n")
+        ]
+        canonical_begin = BEGIN_LINE.encode().strip(b" \t")
+        self.assertNotIn(canonical_begin, active_lines)
+        self.assertIn(canonical_begin + whitespace.encode(), active_lines)
+        self.assertIn(
+            b"install -Dm755 target/release/facelock /usr/bin/facelock",
+            active_lines,
+        )
+        self.assertNotEqual(result.returncode, 0, f"checker accepted {name} mutation")
+        self.assertIn(
+            "source-install lifecycle structure: disallowed Unicode whitespace "
+            f"U+{ord(whitespace):04X}",
+            result.stderr,
+        )
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_canonical_files_are_accepted(self) -> None:
+        result = self.run_checker(JUSTFILE)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_justfile_startup_environment_exports_are_rejected(self) -> None:
+        original = JUSTFILE.read_bytes().decode()
+        for variable in ("BASH_ENV", "ENV"):
+            with self.subTest(variable=variable):
+                mutated = f'export {variable} := "/tmp/facelock-hook"\n' + original
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "justfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    dry_run = subprocess.run(
+                        [
+                            "just",
+                            "--dry-run",
+                            "--justfile",
+                            str(mutated_path),
+                            "--working-directory",
+                            str(REPO_ROOT),
+                            "install-files",
+                        ],
+                        cwd=REPO_ROOT,
+                        check=False,
+                        capture_output=True,
+                    )
+                    result = self.run_checker(mutated_path)
+                self.assertEqual(dry_run.returncode, 0, dry_run.stderr.decode())
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "source-install lifecycle structure: shell startup "
+                    "environment is forbidden in Justfile",
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_privileged_bash_shebang_ignores_caller_bash_env(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="facelock-lifecycle-bash-env-"
+        ) as temp:
+            temp_path = pathlib.Path(temp)
+            hook = temp_path / "hook.sh"
+            marker = temp_path / "hook-ran"
+            probe = temp_path / "justfile"
+            hook.write_text(f"touch -- {shlex.quote(str(marker))}\n")
+            probe.write_text(
+                "probe:\n"
+                "    #!/usr/bin/bash -p\n"
+                "    set -euo pipefail\n"
+                f"    test ! -e {shlex.quote(str(marker))}\n"
+            )
+            result = subprocess.run(
+                [
+                    "just",
+                    "--justfile",
+                    str(probe),
+                    "--working-directory",
+                    str(temp_path),
+                    "probe",
+                ],
+                cwd=REPO_ROOT,
+                env={
+                    **os.environ,
+                    "BASH_ENV": str(hook),
+                    "XDG_RUNTIME_DIR": str(temp_path),
+                },
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            marker_was_created = marker.exists()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(marker_was_created, "privileged Bash processed caller BASH_ENV")
+
+    def test_lone_cr_cannot_create_a_checker_only_lifecycle_begin(self) -> None:
+        self.assert_control_cannot_create_checker_only_begin(
+            "lone CR checker-only lifecycle begin", "\r", 0x0D
+        )
+
+    def test_vertical_tab_cannot_create_a_checker_only_lifecycle_begin(self) -> None:
+        self.assert_control_cannot_create_checker_only_begin(
+            "vertical tab checker-only lifecycle begin", "\v", 0x0B
+        )
+
+    def test_unicode_whitespace_cannot_create_a_checker_only_begin(self) -> None:
+        candidates = {
+            "no-break space": "\u00a0",
+            "figure space": "\u2007",
+            "line separator": "\u2028",
+            "paragraph separator": "\u2029",
+            "narrow no-break space": "\u202f",
+            "ideographic space": "\u3000",
+        }
+        for name, whitespace in candidates.items():
+            with self.subTest(name=name):
+                self.assert_unicode_whitespace_cannot_normalize_begin(
+                    name, whitespace
+                )
+
+    def test_other_disallowed_justfile_controls_are_rejected_before_parsing(
+        self,
+    ) -> None:
+        original = JUSTFILE.read_bytes()
+        needle = BEGIN_LINE.encode()
+        for byte in (0x00, 0x01, 0x0C, 0x1F, 0x7F):
+            with self.subTest(byte=f"0x{byte:02x}"):
+                mutated = original.replace(
+                    needle,
+                    b"    # checker-comment" + bytes((byte,)) + needle,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "justfile"
+                    mutated_path.write_bytes(mutated)
+                    result = self.run_checker(mutated_path)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "source-install lifecycle structure: "
+                    f"disallowed control byte 0x{byte:02x}",
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_crlf_is_rejected_by_the_lf_only_input_policy(self) -> None:
+        mutated = JUSTFILE.read_bytes().replace(b"\n", b"\r\n", 1)
+        with tempfile.TemporaryDirectory(prefix="facelock-lifecycle-checker-") as temp:
+            mutated_path = pathlib.Path(temp) / "justfile"
+            mutated_path.write_bytes(mutated)
+            result = self.run_checker(mutated_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "source-install lifecycle structure: disallowed control byte 0x0d",
+            result.stderr,
+        )
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_invalid_utf8_has_a_controlled_diagnostic(self) -> None:
+        mutated = b"\xff" + JUSTFILE.read_bytes()
+        with tempfile.TemporaryDirectory(prefix="facelock-lifecycle-checker-") as temp:
+            mutated_path = pathlib.Path(temp) / "justfile"
+            mutated_path.write_bytes(mutated)
+            result = self.run_checker(mutated_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is not valid UTF-8", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_containerfile_control_cannot_create_a_checker_only_copy(self) -> None:
+        original = CONTAINERFILE.read_bytes()
+        for byte in (0x0B, 0x0D):
+            with self.subTest(byte=f"0x{byte:02x}"):
+                mutated = original.replace(
+                    CONTAINER_HELPER_COPY,
+                    b"# checker-comment"
+                    + bytes((byte,))
+                    + CONTAINER_HELPER_COPY,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated)
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "source-install lifecycle structure: "
+                    f"disallowed control byte 0x{byte:02x}",
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_booted_lifecycle_fixture_sources_are_required(self) -> None:
+        original = CONTAINERFILE.read_bytes()
+        candidate = original + b"\n" + b"\n".join(
+            copy_line
+            for copy_line in BOOTED_LIFECYCLE_FIXTURE_COPIES
+            if copy_line not in original
+        ) + b"\n"
+        for copy_line in BOOTED_LIFECYCLE_FIXTURE_COPIES:
+            with self.subTest(copy_line=copy_line.decode()):
+                self.assertEqual(candidate.count(copy_line), 1)
+                mutated = candidate.replace(copy_line + b"\n", b"", 1)
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated)
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "source-install lifecycle structure: missing booted systemd "
+                    "lifecycle fixture copy",
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_source_lifecycle_runs_booted_recipe_dispatch_contract(self) -> None:
+        source = SOURCE_LIFECYCLE_TEST.read_text()
+        self.assertIn(
+            'python3 "$repo_root/test/check-source-install-lifecycle-test.py"',
+            source,
+        )
+
+    def test_recipe_dispatch_parser_ignores_comments_and_preserves_duplicates(
+        self,
+    ) -> None:
+        body = """
+            recipe-alpha | recipe-beta) # recipe-comment-spoof
+            recipe-alpha)
+        """
+        self.assertEqual(
+            dispatched_recipe_cases(body),
+            ["recipe-alpha", "recipe-beta", "recipe-alpha"],
+        )
+
+    def test_booted_recipe_inventory_reaches_top_level_dispatch(self) -> None:
+        runner = SYSTEMD_LIFECYCLE_RUNNER.read_text()
+        harness = SYSTEMD_LIFECYCLE_HARNESS.read_text()
+        runner_inventory = re.search(
+            r"^cases=\(\n(?P<body>.*?)^\)", runner, re.MULTILINE | re.DOTALL
+        )
+        recipe_dispatch = re.search(
+            r"^run_recipe_case\(\) \{.*?^\s+case \"\$case_name\" in\n"
+            r"(?P<body>.*?)^\s+esac",
+            harness,
+            re.MULTILINE | re.DOTALL,
+        )
+        top_level_dispatch = re.search(
+            r"^case \"\$case_name\" in\n(?P<body>.*?)^esac\n\nexpected_success",
+            harness,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(runner_inventory)
+        self.assertIsNotNone(recipe_dispatch)
+        self.assertIsNotNone(top_level_dispatch)
+
+        runner_cases = re.findall(
+            r"^\s*(recipe-[a-z0-9-]+)\s*$",
+            runner_inventory.group("body"),
+            re.MULTILINE,
+        )
+        recipe_cases = dispatched_recipe_cases(recipe_dispatch.group("body"))
+        top_level_cases = dispatched_recipe_cases(top_level_dispatch.group("body"))
+        for name, cases in (
+            ("runner", runner_cases),
+            ("run_recipe_case", recipe_cases),
+            ("top-level", top_level_cases),
+        ):
+            with self.subTest(dispatch=name):
+                self.assertEqual(
+                    len(cases),
+                    len(set(cases)),
+                    f"{name} recipe dispatch contains duplicate case labels",
+                )
+        self.assertEqual(set(runner_cases), set(recipe_cases))
+        self.assertEqual(set(runner_cases), set(top_level_cases))
+
+    def test_booted_recipe_dispatch_rejects_comment_and_duplicate_mutations(
+        self,
+    ) -> None:
+        runner = SYSTEMD_LIFECYCLE_RUNNER.read_text()
+        harness = SYSTEMD_LIFECYCLE_HARNESS.read_text()
+        runner_inventory = re.search(
+            r"^cases=\(\n(?P<body>.*?)^\)", runner, re.MULTILINE | re.DOTALL
+        )
+        top_level_dispatch = re.search(
+            r"^case \"\$case_name\" in\n(?P<body>.*?)^esac\n\nexpected_success",
+            harness,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(runner_inventory)
+        self.assertIsNotNone(top_level_dispatch)
+        runner_cases = re.findall(
+            r"^\s*(recipe-[a-z0-9-]+)\s*$",
+            runner_inventory.group("body"),
+            re.MULTILINE,
+        )
+        route = (
+            "recipe-known-legacy-retired | recipe-admin-overrides-preserved | \\\n"
+            "        recipe-fake-manager-overrides-preserved)"
+        )
+        top_level = top_level_dispatch.group("body")
+        self.assertEqual(top_level.count(route), 1)
+
+        comment_mutation = top_level.replace(
+            route,
+            "recipe-admin-overrides-preserved | \\\n"
+            "        recipe-fake-manager-overrides-preserved)\n"
+            "    # recipe-known-legacy-retired",
+            1,
+        )
+        comment_cases = dispatched_recipe_cases(comment_mutation)
+        self.assertNotEqual(set(runner_cases), set(comment_cases))
+
+        duplicate_mutation = top_level.replace(
+            "recipe-known-legacy-retired | recipe-admin-overrides-preserved",
+            "recipe-known-legacy-retired | recipe-known-legacy-retired | "
+            "recipe-admin-overrides-preserved",
+            1,
+        )
+        duplicate_cases = dispatched_recipe_cases(duplicate_mutation)
+        self.assertNotEqual(len(duplicate_cases), len(set(duplicate_cases)))
+
+    def test_normalized_extra_container_install_invocations_are_rejected(
+        self,
+    ) -> None:
+        mutations = {
+            "quote-concatenated argument": (
+                'just install"-files"',
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "backslash-escaped argument": (
+                r"just install\-files",
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "prefix operator-adjacent invocation": (
+                'true&&just install"-files"',
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "suffix operator-adjacent invocation": (
+                'just install"-files"&&true',
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "or-list operator-adjacent invocation": (
+                'false||just install"-files"',
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "pipeline operator-adjacent invocation": (
+                'printf x|just install"-files"',
+                "sh",
+                "expected the offline-image command to be the only active "
+                "install-files invocation",
+            ),
+            "ANSI-C quoted argument": (
+                "just install$'-files'",
+                "bash",
+                "unsupported shell quote syntax in Containerfile",
+            ),
+            "localized quoted argument": (
+                'just install$"-files"',
+                "bash",
+                "unsupported shell quote syntax in Containerfile",
+            ),
+        }
+        original = CONTAINERFILE.read_bytes().decode()
+        for name, (payload, shell, expected_diagnostic) in mutations.items():
+            with self.subTest(name=name):
+                shell_result = subprocess.run(
+                    [
+                        shell,
+                        "-c",
+                        'just() { printf "%s\\n" "$1"; }\n' + payload,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(shell_result.returncode, 0, shell_result.stderr)
+                self.assertEqual(shell_result.stdout, "install-files\n")
+
+                mutated = original.replace(
+                    CONTAINER_INSTALL_LINE,
+                    CONTAINER_INSTALL_LINE + "\nRUN " + payload,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0, f"checker accepted {name}")
+                self.assertIn(
+                    "source-install lifecycle structure: " + expected_diagnostic,
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_continued_extra_container_install_invocations_are_rejected(
+        self,
+    ) -> None:
+        payloads = {
+            "continued command argument": "just \\\n    install-files",
+            "continued quote-concatenated command and argument": (
+                'ju"st" \\\n    install"-files"'
+            ),
+            "continued split argument": "just install\\\n-files",
+        }
+        original = CONTAINERFILE.read_bytes().decode()
+        expected_diagnostic = (
+            "expected the offline-image command to be the only active "
+            "install-files invocation"
+        )
+        for name, payload in payloads.items():
+            with self.subTest(name=name):
+                shell_result = subprocess.run(
+                    [
+                        "sh",
+                        "-c",
+                        'just() { printf "%s\\n" "$1"; }\n' + payload,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(shell_result.returncode, 0, shell_result.stderr)
+                self.assertEqual(shell_result.stdout, "install-files\n")
+
+                mutated = original.replace(
+                    CONTAINER_INSTALL_LINE,
+                    CONTAINER_INSTALL_LINE + "\nRUN " + payload,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0, f"checker accepted {name}")
+                self.assertIn(
+                    "source-install lifecycle structure: " + expected_diagnostic,
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_nested_shell_container_install_invocations_are_rejected(self) -> None:
+        payloads = {
+            "bash command string": "bash -c 'just install-files'",
+            "sh command string": 'sh -c "just install-files"',
+            "combined shell options": (
+                "/usr/bin/env bash -lc 'set -e; just install-files'"
+            ),
+            "nested command string": (
+                "bash -c \"sh -c 'just install-files'\""
+            ),
+        }
+        original = CONTAINERFILE.read_bytes().decode()
+        expected_diagnostic = (
+            "expected the offline-image command to be the only active "
+            "install-files invocation"
+        )
+        for name, payload in payloads.items():
+            with self.subTest(name=name):
+                mutated = original.replace(
+                    CONTAINER_INSTALL_LINE,
+                    CONTAINER_INSTALL_LINE + "\nRUN " + payload,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0, f"checker accepted {name}")
+                self.assertIn(
+                    "source-install lifecycle structure: " + expected_diagnostic,
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_shell_startup_environment_injection_is_rejected(self) -> None:
+        payloads = {
+            "Docker ENV BASH_ENV assignment": "ENV BASH_ENV=/tmp/facelock-hook",
+            "Docker legacy ENV assignment": "ENV ENV /tmp/facelock-hook",
+            "Docker ARG BASH_ENV assignment": "ARG BASH_ENV=/tmp/facelock-hook",
+            "RUN environment assignment": (
+                "RUN BASH_ENV=/tmp/facelock-hook just install-files"
+            ),
+            "shell export": "RUN export ENV=/tmp/facelock-hook",
+        }
+        original = CONTAINERFILE.read_bytes().decode()
+        for name, payload in payloads.items():
+            with self.subTest(name=name):
+                mutated = original.replace(
+                    "RUN FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \\",
+                    payload
+                    + "\nRUN FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \\",
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0, f"checker accepted {name}")
+                self.assertIn(
+                    "source-install lifecycle structure: shell startup "
+                    "environment is forbidden",
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_just_options_cannot_hide_extra_container_install_invocations(
+        self,
+    ) -> None:
+        mutations = {
+            "Just option terminator": (
+                "just -- install-files",
+                ["just", "--dry-run", "--", "install-files"],
+            ),
+            "ordinary Just option": (
+                "just --dry-run install-files",
+                ["just", "--dry-run", "install-files"],
+            ),
+        }
+        original = CONTAINERFILE.read_bytes().decode()
+        expected_diagnostic = (
+            "expected the offline-image command to be the only active "
+            "install-files invocation"
+        )
+        for name, (payload, just_command) in mutations.items():
+            with self.subTest(name=name):
+                dry_run = subprocess.run(
+                    just_command,
+                    cwd=REPO_ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+                expanded_recipe = dry_run.stdout + dry_run.stderr
+                self.assertIn("facelock_source_install_begin", expanded_recipe)
+                self.assertIn(
+                    "install -Dm755 target/release/facelock /usr/bin/facelock",
+                    expanded_recipe,
+                )
+
+                mutated = original.replace(
+                    CONTAINER_INSTALL_LINE,
+                    CONTAINER_INSTALL_LINE + "\nRUN " + payload,
+                    1,
+                )
+                with tempfile.TemporaryDirectory(
+                    prefix="facelock-lifecycle-checker-"
+                ) as temp:
+                    mutated_path = pathlib.Path(temp) / "Containerfile"
+                    mutated_path.write_bytes(mutated.encode())
+                    result = self.run_checker(JUSTFILE, mutated_path)
+                self.assertNotEqual(result.returncode, 0, f"checker accepted {name}")
+                self.assertIn(
+                    "source-install lifecycle structure: " + expected_diagnostic,
+                    result.stderr,
+                )
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_blank_cannot_precede_install_files_shebang(self) -> None:
+        self.assert_mutation_rejected(
+            "blank before install-files shebang",
+            INSTALL_FILES_SHEBANG,
+            "\ninstall-files:\n\n    #!/usr/bin/bash -p\n",
+            "install-files recipe must start with the exact Bash shebang",
+        )
+
+    def test_comment_cannot_precede_install_files_shebang(self) -> None:
+        self.assert_mutation_rejected(
+            "comment before install-files shebang",
+            INSTALL_FILES_SHEBANG,
+            "\ninstall-files:\n"
+            "    # unexpected leading comment\n"
+            "    #!/usr/bin/bash -p\n",
+            "install-files recipe must start with the exact Bash shebang",
+        )
+
+    def test_install_files_shebang_is_required(self) -> None:
+        self.assert_mutation_rejected(
+            "missing install-files shebang",
+            INSTALL_FILES_SHEBANG,
+            "\ninstall-files:\n",
+            "install-files recipe must start with the exact Bash shebang",
+        )
+
+    def test_install_files_shebang_cannot_use_sh(self) -> None:
+        self.assert_mutation_rejected(
+            "replaced install-files shebang",
+            INSTALL_FILES_SHEBANG,
+            "\ninstall-files:\n    #!/bin/sh\n",
+            "install-files recipe must start with the exact Bash shebang",
+        )
+
+    def test_ignored_comment_backslash_is_rejected_before_strict_mode(self) -> None:
+        self.assert_mutation_rejected(
+            "ignored comment has ambiguous trailing backslash before strict mode",
+            INSTALL_FILES_STRICT_MODE,
+            "\ninstall-files:\n"
+            "    #!/usr/bin/bash -p\n"
+            "    # ambiguous trailing backslash "
+            + "\\"
+            + "\n    set -euo pipefail",
+            "install-files line has ambiguous comment/backslash syntax",
+        )
+
+    def test_ignored_comment_backslash_is_rejected_in_postlude(self) -> None:
+        self.assert_mutation_rejected(
+            "ignored comment has ambiguous trailing backslash in postlude",
+            POSTLUDE_BLANK_LINES,
+            '    echo ""\n'
+            "    # ambiguous trailing backslash "
+            + "\\"
+            + '\n    echo ""',
+            "install-files line has ambiguous comment/backslash syntax",
+        )
+
+    def test_inline_comment_backslash_cannot_hide_heredoc(self) -> None:
+        self.assert_mutation_rejected(
+            "inline comment backslash hides completion heredoc",
+            COMPLETE_LINE,
+            "    : # inline comment is terminal in Bash "
+            + "\\"
+            + "\n    : <<facelock_source_install_complete\n"
+            + "        fi\n"
+            + COMPLETE_LINE,
+            "install-files line has ambiguous comment/backslash syntax",
+        )
+
+    def test_normalized_systemctl_literals_are_rejected(self) -> None:
+        mutations = {
+            "quoted command literal": '    sys"tem"ctl daemon-reload',
+            "quoted absolute command literal": '    /usr/bin/sys"tem"ctl daemon-reload',
+            "quoted assignment literal": '    lifecycle_manager=sys"tem"ctl',
+        }
+        for name, command in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(
+                    name,
+                    BEGIN_LINE,
+                    BEGIN_LINE + "\n" + command,
+                    "systemctl literal is forbidden",
+                )
+
+    def test_lifecycle_interval_bypass_mechanisms_are_rejected(self) -> None:
+        mutations = {
+            "exec replaces install shell": "    exec /bin/true",
+            "exit trap cleared": "    trap - EXIT",
+            "exit trap replaced": "    trap ':' EXIT",
+            "completion function unset": (
+                "    unset -f facelock_source_install_complete"
+            ),
+            "completion function redefined": (
+                "    facelock_source_install_complete() { :; }"
+            ),
+        }
+        for name, command in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(
+                    name,
+                    BEGIN_LINE,
+                    BEGIN_LINE + "\n" + command,
+                    "unexpected active lifecycle install interval command",
+                )
+
+    def test_alternative_asset_writers_are_rejected(self) -> None:
+        mutations = {
+            "rsync legacy unit writer": (
+                "    rsync -a systemd/facelock-daemon.service "
+                "/etc/systemd/system/facelock-daemon.service"
+            ),
+            "cp legacy D-Bus writer": (
+                "    cp dbus/org.facelock.Daemon.conf "
+                "/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+            ),
+            "shell redirection legacy activation writer": (
+                "    printf '%s\\n' '[D-BUS Service]' > "
+                "/etc/dbus-1/system-services/org.facelock.Daemon.service"
+            ),
+        }
+        for name, command in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(
+                    name,
+                    BEGIN_LINE,
+                    BEGIN_LINE + "\n" + command,
+                    "unexpected active lifecycle install interval command",
+                )
+
+    def test_unsupported_bash_quotes_cannot_hide_systemctl_literals(self) -> None:
+        mutations = {
+            "ANSI-C quoted literal": "    sys$'\\x74em'ctl daemon-reload",
+            "localized quoted literal": '    sys$"tem"ctl daemon-reload',
+        }
+        for name, command in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(
+                    name,
+                    BEGIN_LINE,
+                    BEGIN_LINE + "\n" + command,
+                    "unexpected active lifecycle install interval command",
+                )
+
+    def test_pre_boundary_shell_bypasses_are_rejected(self) -> None:
+        mutations = {
+            "assignment command substitution": (
+                SOURCE_LINE,
+                "    hidden=$(touch /tmp/facelock-before-boundary)\n" + SOURCE_LINE,
+            ),
+            "glued control operator": (
+                SOURCE_LINE,
+                "    true;touch /tmp/facelock-before-boundary\n" + SOURCE_LINE,
+            ),
+            "unlisted unlink command": (
+                SOURCE_LINE,
+                "    unlink /tmp/facelock-before-boundary\n" + SOURCE_LINE,
+            ),
+            "glued redirection": (
+                SOURCE_LINE,
+                "    printf owned>/tmp/facelock-before-boundary\n" + SOURCE_LINE,
+            ),
+            "process substitution": (
+                SOURCE_LINE,
+                "    : < <(touch /tmp/facelock-before-boundary)\n" + SOURCE_LINE,
+            ),
+            "arbitrary assignment": (
+                SOURCE_LINE,
+                "    LD_PRELOAD=/tmp/facelock-before-boundary.so\n" + SOURCE_LINE,
+            ),
+            "extra source command": (
+                SOURCE_LINE,
+                "    source /tmp/facelock-before-boundary.sh\n" + SOURCE_LINE,
+            ),
+            "and-list absorbs source": (
+                SOURCE_LINE,
+                "    false &&\n" + SOURCE_LINE,
+            ),
+            "or-list absorbs source": (
+                SOURCE_LINE,
+                "    true ||\n" + SOURCE_LINE,
+            ),
+            "pipeline subshell absorbs source": (
+                SOURCE_LINE,
+                "    true |\n" + SOURCE_LINE,
+            ),
+            "stderr pipeline subshell absorbs source": (
+                SOURCE_LINE,
+                "    true |&\n" + SOURCE_LINE,
+            ),
+            "folded and-list absorbs source": (
+                SOURCE_LINE,
+                "    false &" + "\\" + "\n    &\n" + SOURCE_LINE,
+            ),
+            "folded or-list absorbs source": (
+                SOURCE_LINE,
+                "    true |" + "\\" + "\n    |\n" + SOURCE_LINE,
+            ),
+            "folded pipeline absorbs source": (
+                SOURCE_LINE,
+                "    true " + "\\" + "\n    |\n" + SOURCE_LINE,
+            ),
+            "folded stderr pipeline absorbs source": (
+                SOURCE_LINE,
+                "    true |" + "\\" + "\n    &\n" + SOURCE_LINE,
+            ),
+            "heredoc absorbs source and begin": (
+                SOURCE_LINE,
+                "    : <<facelock_source_install_begin\n" + SOURCE_LINE,
+            ),
+            "folded heredoc absorbs source and begin": (
+                SOURCE_LINE,
+                "    : <"
+                + "\\"
+                + "\n    <facelock_source_install_begin\n"
+                + SOURCE_LINE,
+            ),
+            "boundaries wrapped in false branch": (
+                SOURCE_LINE + "\n" + BEGIN_LINE,
+                "    if false; then\n"
+                + SOURCE_LINE
+                + "\n"
+                + BEGIN_LINE
+                + "\n    fi",
+            ),
+            "dynamic compound command": (
+                SOURCE_LINE,
+                "    lifecycle_tool=touch\n"
+                "    if \"$lifecycle_tool\" /tmp/facelock-before-boundary; then :; fi\n"
+                + SOURCE_LINE,
+            ),
+            "function command": (
+                SOURCE_LINE,
+                "    lifecycle_hidden() { touch /tmp/facelock-before-boundary; }\n"
+                "    lifecycle_hidden\n"
+                + SOURCE_LINE,
+            ),
+            "continued command absorbs begin": (
+                BEGIN_LINE,
+                "    true "
+                + "\\"
+                + "\n"
+                + BEGIN_LINE
+                + "\n    touch /tmp/facelock-before-boundary",
+            ),
+        }
+        for name, (needle, replacement) in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(name, needle, replacement)
+
+    def test_post_completion_shell_bypasses_are_rejected(self) -> None:
+        mutations = {
+            "assignment command substitution": (
+                COMPLETE_LINE,
+                COMPLETE_LINE
+                + "\n    hidden=$(touch /tmp/facelock-after-boundary)",
+            ),
+            "glued control operator": (
+                COMPLETE_LINE,
+                COMPLETE_LINE + "\n    true;touch /tmp/facelock-after-boundary",
+            ),
+            "unlisted unlink command": (
+                COMPLETE_LINE,
+                COMPLETE_LINE + "\n    unlink /tmp/facelock-after-boundary",
+            ),
+            "glued redirection": (
+                COMPLETE_LINE,
+                COMPLETE_LINE
+                + "\n    printf owned>/tmp/facelock-after-boundary",
+            ),
+            "process substitution": (
+                COMPLETE_LINE,
+                COMPLETE_LINE + "\n    : < <(touch /tmp/facelock-after-boundary)",
+            ),
+            "arbitrary assignment": (
+                COMPLETE_LINE,
+                COMPLETE_LINE
+                + "\n    LD_PRELOAD=/tmp/facelock-after-boundary.so",
+            ),
+            "extra source command": (
+                COMPLETE_LINE,
+                COMPLETE_LINE + "\n    source /tmp/facelock-after-boundary.sh",
+            ),
+            "dynamic compound command": (
+                COMPLETE_LINE,
+                COMPLETE_LINE
+                + "\n    lifecycle_tool=touch\n"
+                "    if \"$lifecycle_tool\" /tmp/facelock-after-boundary; then :; fi",
+            ),
+            "approved dynamic command reassigned": (
+                STATUS_LINE,
+                "    NEEDS_SETUP=touch\n" + STATUS_LINE,
+            ),
+            "function command": (
+                COMPLETE_LINE,
+                COMPLETE_LINE
+                + "\n    lifecycle_hidden() { touch /tmp/facelock-after-boundary; }\n"
+                "    lifecycle_hidden",
+            ),
+            "continued command absorbs completion": (
+                COMPLETE_LINE,
+                "    true "
+                + "\\"
+                + "\n"
+                + COMPLETE_LINE
+                + "\n    touch /tmp/facelock-after-boundary",
+            ),
+            "and-list continuation absorbs completion": (
+                COMPLETE_LINE,
+                "    false && " + "\\" + "\n" + COMPLETE_LINE,
+            ),
+            "or-list continuation absorbs completion": (
+                COMPLETE_LINE,
+                "    true || " + "\\" + "\n" + COMPLETE_LINE,
+            ),
+            "pipeline continuation absorbs completion": (
+                COMPLETE_LINE,
+                "    true | " + "\\" + "\n" + COMPLETE_LINE,
+            ),
+            "stderr pipeline continuation absorbs completion": (
+                COMPLETE_LINE,
+                "    true |& " + "\\" + "\n" + COMPLETE_LINE,
+            ),
+            "and-list absorbs completion": (
+                COMPLETE_LINE,
+                "    false &&\n" + COMPLETE_LINE,
+            ),
+            "or-list absorbs completion": (
+                COMPLETE_LINE,
+                "    true ||\n" + COMPLETE_LINE,
+            ),
+            "pipeline subshell absorbs completion": (
+                COMPLETE_LINE,
+                "    true |\n" + COMPLETE_LINE,
+            ),
+            "stderr pipeline subshell absorbs completion": (
+                COMPLETE_LINE,
+                "    true |&\n" + COMPLETE_LINE,
+            ),
+            "folded and-list absorbs completion": (
+                COMPLETE_LINE,
+                "    false &" + "\\" + "\n    &\n" + COMPLETE_LINE,
+            ),
+            "folded or-list absorbs completion": (
+                COMPLETE_LINE,
+                "    true |" + "\\" + "\n    |\n" + COMPLETE_LINE,
+            ),
+            "folded stderr pipeline absorbs completion": (
+                COMPLETE_LINE,
+                "    true |" + "\\" + "\n    &\n" + COMPLETE_LINE,
+            ),
+            "completion wrapped in false branch": (
+                COMPLETE_LINE,
+                "    if false; then\n" + COMPLETE_LINE + "\n    fi",
+            ),
+            "folded heredoc absorbs completion through canonical delimiter": (
+                COMPLETE_LINE,
+                "    : <"
+                + "\\"
+                + "\n    <fi\n"
+                + "        fi\n"
+                + COMPLETE_LINE,
+            ),
+            "heredoc absorbs completion": (
+                COMPLETE_LINE,
+                "    : <<facelock_source_install_complete\n" + COMPLETE_LINE,
+            ),
+        }
+        for name, (needle, replacement) in mutations.items():
+            with self.subTest(name=name):
+                self.assert_mutation_rejected(name, needle, replacement)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/check-source-install-lifecycle.py
+++ b/test/check-source-install-lifecycle.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Validate the executable structure of the just install-files recipe."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import shlex
+import sys
+import unicodedata
+
+
+SOURCE_COMMAND = ["source", "scripts/source-install-daemon-lifecycle.sh"]
+BEGIN_COMMAND = ["facelock_source_install_begin"]
+COMPLETE_COMMAND = ["facelock_source_install_complete"]
+DBUS_ACTIVATION_COMMAND = [
+    "install",
+    "-Dm644",
+    "dbus/org.facelock.Daemon.service",
+    "/usr/share/dbus-1/system-services/org.facelock.Daemon.service",
+]
+CONTAINER_HELPER_COPY = (
+    "COPY scripts/source-install-daemon-lifecycle.sh "
+    "/build/scripts/source-install-daemon-lifecycle.sh"
+)
+CONTAINER_MIGRATION_HELPER_COPY = (
+    "COPY scripts/migrate-legacy-system-assets.sh "
+    "/build/scripts/migrate-legacy-system-assets.sh"
+)
+CONTAINER_LEGACY_MANIFEST_COPY = "COPY dist/ /build/dist/"
+CONTAINER_MARKER_COPY = (
+    "COPY test/source-install-offline-image.marker "
+    "/build/test/source-install-offline-image.marker"
+)
+CONTAINER_BOOTED_LIFECYCLE_FIXTURE_COPIES = (
+    "COPY test/source-install-recipe-install-probe.sh "
+    "/source-install-lifecycle/test/source-install-recipe-install-probe.sh",
+    "COPY test/source-install-recipe-fake-systemctl.sh "
+    "/source-install-lifecycle/test/source-install-recipe-fake-systemctl.sh",
+    "COPY test/source-install-recipe-fake-busctl.sh "
+    "/source-install-lifecycle/test/source-install-recipe-fake-busctl.sh",
+)
+CONTAINER_OFFLINE_PREFIX = "RUN FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \\"
+CONTAINER_OFFLINE_MARKER = (
+    "FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER="
+    "/build/test/source-install-offline-image.marker \\"
+)
+SHELL_PUNCTUATION = "();<>|&{}"
+SHELL_BOUNDARY_CONTINUATIONS = frozenset({"&&", "||", "|", "|&"})
+SHELL_COMMAND_NAMES = frozenset({"bash", "dash", "sh"})
+SHELL_STARTUP_ENV_NAMES = frozenset({"BASH_ENV", "ENV"})
+MAX_NESTED_SHELL_DEPTH = 8
+ASCII_BLANKS = " \t"
+EXPECTED_SHEBANG = "    #!/usr/bin/bash -p"
+EXPECTED_PRIVILEGED_ENTRYPOINTS = (
+    "    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just install-files",
+    "    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just uninstall-files",
+)
+SHELL_STARTUP_ENV_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])(?:BASH_ENV|ENV)(?![A-Za-z0-9_])"
+)
+EXPECTED_PRELUDE = (
+    "set -euo pipefail",
+    "PATH=/usr/bin:/bin",
+    "export PATH",
+    "for f in target/release/facelock target/release/libpam_facelock.so; do",
+    '[ -f "$f" ] || { echo "Error: $f not found. Run \'just build-release\' first."; exit 1; }',
+    "done",
+    "source scripts/source-install-daemon-lifecycle.sh",
+    "facelock_source_install_begin",
+)
+EXPECTED_INSTALL_INTERVAL = (
+    "facelock_source_install_begin",
+    "install -Dm755 target/release/facelock /usr/bin/facelock",
+    "install -Dm755 target/release/libpam_facelock.so /lib/security/pam_facelock.so",
+    "install -Dm644 config/facelock.toml /etc/facelock/config.toml.default",
+    "[ -f /etc/facelock/config.toml ] || cp /etc/facelock/config.toml.default /etc/facelock/config.toml",
+    "install -dm755 /usr/share/facelock/quirks.d",
+    "install -Dm644 config/quirks.d/*.toml /usr/share/facelock/quirks.d/",
+    "if [ -d target/locale ]; then",
+    "(cd target/locale && find . -name '*.mo' | while read -r mo; do",
+    'install -Dm644 "$mo" "/usr/share/locale/${mo#./}"',
+    "done)",
+    "fi",
+    "install -Dm644 systemd/facelock-daemon.service /usr/lib/systemd/system/facelock-daemon.service",
+    "install -Dm644 dbus/org.facelock.Daemon.conf /usr/share/dbus-1/system.d/org.facelock.Daemon.conf",
+    "install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service",
+    "facelock_source_install_stage_and_record_legacy_migration /",
+    "[ -f target/release/facelock-polkit-agent ] && install -Dm755 target/release/facelock-polkit-agent /usr/bin/facelock-polkit-agent || true",
+    "install -dm711 -o root -g root /var/lib/facelock",
+    "install -dm755 -o root -g root /var/lib/facelock/models",
+    "install -dm711 -o root -g root /var/lib/facelock/enrolled",
+    "install -dm700 -o root -g root /var/lib/facelock/pam-backups",
+    "install -dm700 -o root -g root /var/log/facelock",
+    "install -dm700 -o root -g root /var/log/facelock/snapshots",
+    "[ -d /etc/facelock ] && chown root:root /etc/facelock && chmod 755 /etc/facelock || true",
+    "[ -f /etc/facelock/config.toml ] && chown root:root /etc/facelock/config.toml && chmod 644 /etc/facelock/config.toml || true",
+    "[ -f /etc/facelock/config.toml.default ] && chown root:root /etc/facelock/config.toml.default && chmod 644 /etc/facelock/config.toml.default || true",
+    "[ -d /var/lib/facelock ] && chown root:root /var/lib/facelock && chmod 711 /var/lib/facelock || true",
+    "[ -d /var/lib/facelock/models ] && chown root:root /var/lib/facelock/models && chmod 755 /var/lib/facelock/models || true",
+    "[ -d /var/lib/facelock/enrolled ] && chown root:root /var/lib/facelock/enrolled && chmod 711 /var/lib/facelock/enrolled || true",
+    "[ -d /var/lib/facelock/pam-backups ] && chown root:root /var/lib/facelock/pam-backups && chmod 700 /var/lib/facelock/pam-backups || true",
+    "[ -d /var/log/facelock ] && chown root:root /var/log/facelock && chmod 700 /var/log/facelock || true",
+    "[ -d /var/log/facelock/snapshots ] && chown root:root /var/log/facelock/snapshots && chmod 700 /var/log/facelock/snapshots || true",
+    "[ -f /var/log/facelock/audit.jsonl ] && chown root:root /var/log/facelock/audit.jsonl && chmod 600 /var/log/facelock/audit.jsonl || true",
+    "[ -d /run/facelock ] && chown root:root /run/facelock 2>/dev/null || true",
+    "[ -d /var/lib/facelock/models ] && chmod 644 /var/lib/facelock/models/*.onnx 2>/dev/null || true",
+    "[ -f /var/lib/facelock/facelock.db ] && chown root:root /var/lib/facelock/facelock.db && chmod 600 /var/lib/facelock/facelock.db || true",
+    "[ -f /var/lib/facelock/facelock.db-wal ] && chown root:root /var/lib/facelock/facelock.db-wal && chmod 600 /var/lib/facelock/facelock.db-wal || true",
+    "[ -f /var/lib/facelock/facelock.db-shm ] && chown root:root /var/lib/facelock/facelock.db-shm && chmod 600 /var/lib/facelock/facelock.db-shm || true",
+    "if getent group facelock >/dev/null 2>&1; then",
+    "groupdel facelock 2>/dev/null || true",
+    "fi",
+    "facelock_source_install_complete",
+)
+EXPECTED_POSTLUDE = (
+    "facelock_source_install_complete",
+    "if [ -d /run/systemd/system ]; then",
+    'echo "D-Bus activation enabled."',
+    "fi",
+    'echo ""',
+    'echo ""',
+    "NEEDS_SETUP=false",
+    "NEEDS_ORT=false",
+    "if ! ls /var/lib/facelock/models/*.onnx >/dev/null 2>&1; then",
+    "NEEDS_SETUP=true",
+    "fi",
+    "if [ ! -f /etc/facelock/config.toml ]; then",
+    "NEEDS_SETUP=true",
+    "fi",
+    "if ! grep -qs pam_facelock /etc/pam.d/sudo 2>/dev/null; then",
+    "NEEDS_SETUP=true",
+    "fi",
+    "if [ ! -f /usr/lib/libonnxruntime.so ] && \\",
+    "[ ! -f /usr/lib64/libonnxruntime.so ] && \\",
+    "[ ! -f /usr/lib/facelock/libonnxruntime.so ]; then",
+    "NEEDS_ORT=true",
+    "fi",
+    "if $NEEDS_SETUP || $NEEDS_ORT; then",
+    'echo "Installed."',
+    "if $NEEDS_ORT; then",
+    'echo ""',
+    'echo "Requires: onnxruntime (pacman -S onnxruntime-cpu)"',
+    'echo "Optional: onnxruntime-opt-cuda (NVIDIA) or onnxruntime-opt-rocm (AMD)"',
+    "fi",
+    "if $NEEDS_SETUP; then",
+    'echo ""',
+    'echo "Run \'sudo facelock setup\' to complete configuration."',
+    'echo "  (downloads models, configures PAM services, enrolls your face)"',
+    "fi",
+    "else",
+    'echo "Installed and up to date."',
+    "fi",
+)
+
+
+def fail(message: str) -> None:
+    print(f"source-install lifecycle structure: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def ascii_strip(text: str) -> str:
+    return text.strip(ASCII_BLANKS)
+
+
+def ascii_lstrip(text: str) -> str:
+    return text.lstrip(ASCII_BLANKS)
+
+
+def ascii_rstrip(text: str) -> str:
+    return text.rstrip(ASCII_BLANKS)
+
+
+def physical_lines(path: pathlib.Path) -> list[str]:
+    content = path.read_bytes()
+    for offset, byte in enumerate(content):
+        if byte == 0x7F or (byte < 0x20 and byte not in {0x09, 0x0A}):
+            fail(
+                f"disallowed control byte 0x{byte:02x} in {path} "
+                f"at byte {offset}"
+            )
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        fail(f"{path} is not valid UTF-8: {error}")
+    for character in text:
+        codepoint = ord(character)
+        if 0x80 <= codepoint <= 0x9F:
+            fail(f"disallowed control character U+{codepoint:04X} in {path}")
+        if character not in ASCII_BLANKS + "\n" and unicodedata.category(
+            character
+        ).startswith("Z"):
+            fail(f"disallowed Unicode whitespace U+{codepoint:04X} in {path}")
+    return text.split("\n")
+
+
+def install_recipe(
+    path: pathlib.Path, lines: list[str] | None = None
+) -> list[tuple[int, str]]:
+    if lines is None:
+        lines = physical_lines(path)
+    try:
+        start = lines.index("install-files:") + 1
+    except ValueError:
+        fail(f"{path} has no install-files recipe")
+
+    body: list[tuple[int, str]] = []
+    for index in range(start, len(lines)):
+        line = lines[index]
+        if line and not line.startswith((" ", "\t", "#")):
+            break
+        body.append((index + 1, line))
+    return body
+
+
+def shell_tokens(line_number: int, line: str) -> list[str]:
+    code = ascii_strip(line)
+    if not code or code.startswith("#"):
+        return []
+    if code.endswith("\\"):
+        code = ascii_rstrip(code[:-1])
+    try:
+        return shlex.split(code, comments=True, posix=True)
+    except ValueError as error:
+        fail(f"cannot parse install-files line {line_number}: {error}")
+
+
+def shell_scan_tokens(line_number: int, line: str) -> list[str]:
+    code = ascii_strip(line)
+    if not code or code.startswith("#"):
+        return []
+    lexer = shlex.shlex(
+        code,
+        posix=True,
+        punctuation_chars=SHELL_PUNCTUATION,
+    )
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    try:
+        return list(lexer)
+    except ValueError as error:
+        fail(f"cannot analyze install-files line {line_number}: {error}")
+
+
+def container_shell_tokens(line_number: int, line: str) -> list[str]:
+    code = ascii_strip(line)
+    if "$'" in code or '$"' in code:
+        fail(f"unsupported shell quote syntax in Containerfile on line {line_number}")
+    lexer = shlex.shlex(
+        code,
+        posix=True,
+        punctuation_chars=SHELL_PUNCTUATION,
+    )
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    try:
+        return list(lexer)
+    except ValueError as error:
+        fail(f"cannot parse Containerfile line {line_number}: {error}")
+
+
+def count_container_install_invocations(
+    line_number: int,
+    tokens: list[str],
+    depth: int = 0,
+) -> int:
+    if depth > MAX_NESTED_SHELL_DEPTH:
+        fail(
+            "nested Containerfile shell command depth exceeds "
+            f"{MAX_NESTED_SHELL_DEPTH} on line {line_number}"
+        )
+
+    count = sum(
+        1
+        for index, token in enumerate(tokens)
+        if pathlib.PurePosixPath(token).name == "just"
+        and "install-files" in tokens[index + 1 :]
+    )
+
+    for index, token in enumerate(tokens):
+        if pathlib.PurePosixPath(token).name not in SHELL_COMMAND_NAMES:
+            continue
+        option_index = index + 1
+        while option_index < len(tokens):
+            option = tokens[option_index]
+            is_command_option = option == "-c" or (
+                option.startswith("-")
+                and not option.startswith("--")
+                and "c" in option[1:]
+            )
+            if is_command_option:
+                if option_index + 1 >= len(tokens):
+                    fail(
+                        "Containerfile shell -c has no command string on line "
+                        f"{line_number}"
+                    )
+                nested = container_shell_tokens(
+                    line_number, tokens[option_index + 1]
+                )
+                count += count_container_install_invocations(
+                    line_number, nested, depth + 1
+                )
+                break
+            if not option.startswith("-"):
+                break
+            option_index += 1
+    return count
+
+
+def logical_container_commands(
+    active: list[tuple[int, str]],
+) -> list[tuple[int, str]]:
+    commands: list[tuple[int, str]] = []
+    start_line: int | None = None
+    command = ""
+
+    for line_number, physical_line in active:
+        if start_line is None:
+            start_line = line_number
+        if ends_with_shell_continuation(physical_line):
+            command += physical_line[:-1]
+            continue
+        command += physical_line
+        commands.append((start_line, command))
+        start_line = None
+        command = ""
+
+    if start_line is not None:
+        commands.append((start_line, command))
+    return commands
+
+
+def ends_with_shell_continuation(line: str) -> bool:
+    trailing_backslashes = len(line) - len(line.rstrip("\\"))
+    return trailing_backslashes % 2 == 1
+
+
+def logical_shell_lines(recipe: list[tuple[int, str]]) -> list[tuple[int, str]]:
+    logical_lines: list[tuple[int, str]] = []
+    start_line: int | None = None
+    logical_line = ""
+
+    for line_number, recipe_line in recipe:
+        shell_line = (
+            recipe_line[4:] if recipe_line.startswith("    ") else recipe_line
+        )
+        if start_line is None:
+            start_line = line_number
+        if ends_with_shell_continuation(shell_line):
+            logical_line += shell_line[:-1]
+            continue
+        logical_line += shell_line
+        logical_lines.append((start_line, logical_line))
+        start_line = None
+        logical_line = ""
+
+    if start_line is not None:
+        logical_lines.append((start_line, logical_line))
+    return logical_lines
+
+
+def one_exact_command(
+    parsed: list[tuple[int, list[str]]], command: list[str], description: str
+) -> int:
+    matches = [line for line, tokens in parsed if tokens == command]
+    if len(matches) != 1:
+        fail(f"expected one active {description}, found {len(matches)}")
+    return matches[0]
+
+
+def exact_active_lines(
+    actual: list[tuple[int, str]], expected: tuple[str, ...], description: str
+) -> None:
+    if tuple(text for _, text in actual) == expected:
+        return
+    for index, expected_text in enumerate(expected):
+        if index >= len(actual):
+            fail(f"missing expected active {description} command: {expected_text}")
+        line_number, actual_text = actual[index]
+        if actual_text != expected_text:
+            fail(
+                f"unexpected active {description} command on line {line_number}: "
+                f"{actual_text}"
+            )
+    line_number, actual_text = actual[len(expected)]
+    fail(
+        f"unexpected extra active {description} command on line {line_number}: "
+        f"{actual_text}"
+    )
+
+
+def check(path: pathlib.Path) -> None:
+    lines = physical_lines(path)
+    for entrypoint in EXPECTED_PRIVILEGED_ENTRYPOINTS:
+        if lines.count(entrypoint) != 1:
+            fail(f"expected one exact privileged entrypoint: {entrypoint.strip()}")
+    for line_number, line in enumerate(lines, start=1):
+        code = ascii_lstrip(line)
+        if not code or code.startswith("#"):
+            continue
+        if SHELL_STARTUP_ENV_PATTERN.search(code):
+            fail(
+                "shell startup environment is forbidden in Justfile "
+                f"on line {line_number}"
+            )
+    recipe = install_recipe(path, lines)
+    if not recipe or recipe[0][1] != EXPECTED_SHEBANG:
+        fail("install-files recipe must start with the exact Bash shebang")
+    for line_number, line in recipe:
+        if "#" in line and ends_with_shell_continuation(line):
+            fail(
+                "install-files line has ambiguous comment/backslash syntax "
+                f"on line {line_number}"
+            )
+    parsed = [
+        (line_number, shell_tokens(line_number, line))
+        for line_number, line in recipe
+    ]
+    recipe_lines = dict(recipe)
+    active = [
+        (line_number, ascii_strip(line))
+        for line_number, line in recipe
+        if ascii_strip(line) and not ascii_lstrip(line).startswith("#")
+    ]
+
+    source_line = one_exact_command(
+        parsed, SOURCE_COMMAND, "lifecycle helper source command"
+    )
+    begin_line = one_exact_command(parsed, BEGIN_COMMAND, "lifecycle begin command")
+    complete_line = one_exact_command(parsed, COMPLETE_COMMAND, "lifecycle complete command")
+    one_exact_command(parsed, DBUS_ACTIVATION_COMMAND, "D-Bus activation install command")
+
+    if source_line >= begin_line:
+        fail("lifecycle helper must be sourced before lifecycle begin")
+    if begin_line >= complete_line:
+        fail("lifecycle completion must follow lifecycle begin")
+
+    exact_active_lines(
+        [(line_number, line) for line_number, line in active if line_number <= begin_line],
+        EXPECTED_PRELUDE,
+        "prelude",
+    )
+    exact_active_lines(
+        [
+            (line_number, line)
+            for line_number, line in active
+            if line_number >= complete_line
+        ],
+        EXPECTED_POSTLUDE,
+        "post-completion",
+    )
+
+    for boundary_line, description, expected_predecessor in (
+        (source_line, "lifecycle helper source", "done"),
+        (
+            begin_line,
+            "lifecycle begin",
+            "source scripts/source-install-daemon-lifecycle.sh",
+        ),
+        (complete_line, "lifecycle completion", "fi"),
+    ):
+        if ascii_rstrip(recipe_lines[boundary_line]).endswith("\\") or ascii_rstrip(
+            recipe_lines.get(
+            boundary_line - 1, ""
+            )
+        ).endswith("\\"):
+            fail(f"{description} must be a complete shell command")
+        previous_active_line = max(
+            line_number
+            for line_number, _ in active
+            if line_number < boundary_line
+        )
+        previous_tokens = shell_scan_tokens(
+            previous_active_line, recipe_lines[previous_active_line]
+        )
+        if (
+            previous_tokens
+            and previous_tokens[-1] in SHELL_BOUNDARY_CONTINUATIONS
+        ):
+            fail(f"{description} must not continue a preceding shell command")
+        if ascii_strip(recipe_lines[previous_active_line]) != expected_predecessor:
+            fail(f"{description} does not follow its canonical predecessor")
+
+    for line_number, code in logical_shell_lines(recipe):
+        scan_tokens = shell_scan_tokens(line_number, code)
+        if not scan_tokens:
+            continue
+        if "systemctl" in code or any("systemctl" in token for token in scan_tokens):
+            fail(f"systemctl literal is forbidden on line {line_number}")
+        if "<<" in scan_tokens:
+            fail(f"shell heredoc can absorb a lifecycle boundary on line {line_number}")
+
+    exact_active_lines(
+        [
+            (line_number, line)
+            for line_number, line in active
+            if begin_line <= line_number <= complete_line
+        ],
+        EXPECTED_INSTALL_INTERVAL,
+        "lifecycle install interval",
+    )
+
+
+def check_containerfile(path: pathlib.Path) -> None:
+    active = [
+        (index, ascii_strip(line))
+        for index, line in enumerate(physical_lines(path), start=1)
+        if ascii_strip(line) and not ascii_lstrip(line).startswith("#")
+    ]
+    helper_lines = [line for line, text in active if text == CONTAINER_HELPER_COPY]
+    migration_helper_lines = [
+        line for line, text in active if text == CONTAINER_MIGRATION_HELPER_COPY
+    ]
+    manifest_lines = [
+        line for line, text in active if text == CONTAINER_LEGACY_MANIFEST_COPY
+    ]
+    marker_lines = [line for line, text in active if text == CONTAINER_MARKER_COPY]
+    for fixture_copy in CONTAINER_BOOTED_LIFECYCLE_FIXTURE_COPIES:
+        fixture_lines = [line for line, text in active if text == fixture_copy]
+        if len(fixture_lines) != 1:
+            fail(
+                "missing booted systemd lifecycle fixture copy: "
+                f"{fixture_copy}"
+            )
+    install_lines = [
+        line
+        for line, text in active
+        if text == CONTAINER_OFFLINE_PREFIX
+        and any(
+            later_text == CONTAINER_OFFLINE_MARKER
+            for later_line, later_text in active
+            if later_line == line + 1
+        )
+        and any(
+            later_text == "just install-files"
+            for later_line, later_text in active
+            if later_line == line + 2
+        )
+    ]
+    install_invocations: list[int] = []
+    for line, command in logical_container_commands(active):
+        tokens = container_shell_tokens(line, command)
+        for token in tokens:
+            if token.partition("=")[0] in SHELL_STARTUP_ENV_NAMES:
+                fail(
+                    "shell startup environment is forbidden in Containerfile "
+                    f"on line {line}"
+                )
+        install_invocations.extend(
+            [line] * count_container_install_invocations(line, tokens)
+        )
+    if len(helper_lines) != 1:
+        fail(
+            "expected one active offline-image lifecycle helper copy, "
+            f"found {len(helper_lines)}"
+        )
+    if len(migration_helper_lines) != 1:
+        fail(
+            "expected one active offline-image legacy migration helper copy, "
+            f"found {len(migration_helper_lines)}"
+        )
+    if len(manifest_lines) != 1:
+        fail(
+            "expected one active offline-image legacy digest manifest copy, "
+            f"found {len(manifest_lines)}"
+        )
+    if len(marker_lines) != 1:
+        fail(f"expected one active offline-image marker copy, found {len(marker_lines)}")
+    if len(install_lines) != 1:
+        fail(
+            "expected one active offline-image install command, "
+            f"found {len(install_lines)}"
+        )
+    if len(install_invocations) != 1:
+        fail(
+            "expected the offline-image command to be the only active "
+            f"install-files invocation, found {len(install_invocations)}"
+        )
+    if max(
+        helper_lines[0],
+        migration_helper_lines[0],
+        manifest_lines[0],
+        marker_lines[0],
+    ) >= install_lines[0]:
+        fail(
+            "offline-image lifecycle helpers, manifest, and marker copies "
+            "must precede install-files"
+        )
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} JUSTFILE CONTAINERFILE", file=sys.stderr)
+        return 2
+    check(pathlib.Path(sys.argv[1]))
+    check_containerfile(pathlib.Path(sys.argv[2]))
+    print("source-install lifecycle structure: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/deb-dependency-closure.sh
+++ b/test/deb-dependency-closure.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Prove the exact candidate resolves and configures from a pristine suite base,
+# before the separate systemd/PAM/TPM harness installs overlapping packages.
+set -euo pipefail
+
+PACKAGE=/facelock-test-package.deb
+APT_LOG=/tmp/facelock-dependency-closure-apt.log
+
+fail() {
+    echo "FAIL [Debian dependency closure]: $*" >&2
+    exit 1
+}
+
+[ -f "$PACKAGE" ] && [ ! -L "$PACKAGE" ] ||
+    fail "candidate package is not a regular file"
+[ "$(stat -c %a "$PACKAGE")" = 444 ] ||
+    fail "candidate package must be mounted mode 0444"
+mount_options="$(awk -v target="$PACKAGE" '$5 == target { print $6; exit }' \
+    /proc/self/mountinfo)"
+case ",$mount_options," in
+    *,ro,*) ;;
+    *) fail "candidate package is not an exact read-only mount: $mount_options" ;;
+esac
+if dpkg-query -W -f='${db:Status-Status}\n' facelock 2>/dev/null |
+    grep -qx installed; then
+    fail "clean dependency stage already contains Facelock"
+fi
+
+candidate_hash="$(sha256sum "$PACKAGE" | cut -d' ' -f1)"
+before_packages="$(dpkg-query -W -f='${binary:Package}\n' | wc -l)"
+: >"$APT_LOG"
+apt-get update >>"$APT_LOG" 2>&1
+if ! apt-get install -y --no-install-recommends "$PACKAGE" >>"$APT_LOG" 2>&1; then
+    cat "$APT_LOG" >&2
+    fail "APT could not resolve the exact candidate from the pristine suite base"
+fi
+if grep -Eqi \
+    'correcting dependencies|fix-broken|unmet dependencies|dependency problems - leaving unconfigured' \
+    "$APT_LOG"; then
+    cat "$APT_LOG" >&2
+    fail "APT repaired or masked an incomplete dependency transaction"
+fi
+
+candidate_version="$(dpkg-deb --field "$PACKAGE" Version)"
+[ "$(dpkg-query -W -f='${db:Status-Status}' facelock)" = installed ] ||
+    fail "candidate is not fully installed"
+[ "$(dpkg-query -W -f='${Version}' facelock)" = "$candidate_version" ] ||
+    fail "installed version does not match the exact candidate"
+after_packages="$(dpkg-query -W -f='${binary:Package}\n' | wc -l)"
+[ "$after_packages" -gt "$((before_packages + 1))" ] ||
+    fail "clean-base transaction did not install any dependency package"
+[ -z "$(dpkg --audit)" ] || fail "dpkg reports an incomplete transaction"
+apt-get check >>"$APT_LOG" 2>&1 || {
+    cat "$APT_LOG" >&2
+    fail "APT dependency closure is not healthy after candidate installation"
+}
+
+for elf in \
+    /usr/bin/facelock \
+    /usr/bin/facelock-polkit-agent \
+    /lib/security/pam_facelock.so \
+    /usr/lib/facelock/libonnxruntime.so; do
+    [ -f "$elf" ] || fail "installed ELF payload missing: $elf"
+    if ldd "$elf" 2>&1 | grep -Fq 'not found'; then
+        ldd "$elf" >&2 || true
+        fail "installed ELF payload has an unresolved library: $elf"
+    fi
+done
+/usr/bin/facelock --version >/dev/null ||
+    fail "installed CLI cannot execute after dependency resolution"
+[ "$(sha256sum "$PACKAGE" | cut -d' ' -f1)" = "$candidate_hash" ] ||
+    fail "read-only candidate changed during dependency validation"
+
+echo "TEST: Debian exact candidate resolves from pristine suite base ... PASS"

--- a/test/deb-maintscript-contract.sh
+++ b/test/deb-maintscript-contract.sh
@@ -15,11 +15,34 @@ dpkg-deb --control "$package" "$control_root"
 
 [ -f "$control_root/postinst" ] || fail "package has no generated postinst"
 
-if grep -Eq \
-    'deb-systemd-invoke[[:space:]]+(start|restart)|systemctl[[:space:]].*(enable|start)' \
-    "$control_root/postinst"; then
+tmpfiles_create_count="$(grep -Ec '^[[:space:]]*systemd-tmpfiles[[:space:]].*--create' \
+    "$control_root/postinst")"
+[ "$tmpfiles_create_count" -eq 1 ] ||
+    fail "generated postinst must contain only dh_installtmpfiles' package-scoped create"
+grep -Eq '^[[:space:]]*systemd-tmpfiles[[:space:]].*--create[[:space:]]+facelock\.conf([[:space:]]|$)' \
+    "$control_root/postinst" ||
+    fail "generated postinst must activate only facelock.conf"
+
+if grep -Eq 'deb-systemd-invoke[[:space:]]+(start|restart)' "$control_root/postinst" ||
+   grep -Eq 'systemctl[[:space:]]+([^[:space:]]+[[:space:]]+)*(enable|start)([[:space:]]|$)' \
+       "$control_root/postinst"; then
     fail "postinst starts or unconditionally enables facelock-daemon before explicit activation"
 fi
+
+active_line="$(grep -n -m1 -Fx '           systemctl is-active --quiet facelock-daemon.service; then' \
+    "$control_root/postinst" | cut -d: -f1 || true)"
+restart_line="$(grep -n -m1 -Fx '            systemctl try-restart facelock-daemon.service 2>/dev/null || true' \
+    "$control_root/postinst" | cut -d: -f1 || true)"
+[ "$(grep -Fxc '           systemctl is-active --quiet facelock-daemon.service; then' \
+    "$control_root/postinst")" -eq 1 ] &&
+    [ "$(grep -Fxc '            systemctl try-restart facelock-daemon.service 2>/dev/null || true' \
+        "$control_root/postinst")" -eq 1 ] ||
+    fail "postinst must contain one exact active-only restart guard"
+[ -n "$active_line" ] && [ -n "$restart_line" ] &&
+    [ "$restart_line" -eq "$((active_line + 1))" ] ||
+    fail "postinst must guard the single daemon try-restart with an adjacent is-active check"
+[ "$(grep -Ec 'systemctl[[:space:]].*restart' "$control_root/postinst")" -eq 1 ] ||
+    fail "postinst must contain exactly one guarded systemctl restart"
 
 # With --no-enable, debhelper still preserves an existing enabled state during
 # upgrades. Permit only that generated debian-installed + was-enabled path;
@@ -54,5 +77,38 @@ while IFS= read -r line || [ -n "$line" ]; do
             ;;
     esac
 done <"$control_root/postinst"
+
+[ -f "$control_root/prerm" ] || fail "package has no generated prerm"
+[ -f "$control_root/postrm" ] || fail "package has no generated postrm"
+if grep -Eq 'systemctl[[:space:]]+(stop|disable)[[:space:]]+facelock-daemon' \
+    "$control_root/prerm"; then
+    fail "prerm must not manually stop or disable facelock-daemon"
+fi
+[ "$(grep -Ec "^[[:space:]]*deb-systemd-invoke stop 'facelock-daemon\.service' >/dev/null \|\| true$" \
+    "$control_root/prerm")" -eq 1 ] ||
+    fail "generated prerm must contain one debhelper-owned service stop"
+profile_probe_line="$(grep -n -m1 -F 'facelock pam shared-profile-status' \
+    "$control_root/prerm" | cut -d: -f1 || true)"
+cleanup_preflight_line="$(grep -n -m1 -F 'facelock pam remove --all --dry-run' \
+    "$control_root/prerm" | cut -d: -f1 || true)"
+cleanup_line="$(grep -n -F 'facelock pam remove --all' "$control_root/prerm" |
+    tail -n1 | cut -d: -f1 || true)"
+generated_stop_line="$(grep -n -m1 -F "deb-systemd-invoke stop 'facelock-daemon.service'" \
+    "$control_root/prerm" | cut -d: -f1 || true)"
+[ -n "$profile_probe_line" ] && [ -n "$cleanup_preflight_line" ] &&
+    [ -n "$cleanup_line" ] && [ -n "$generated_stop_line" ] &&
+    [ "$profile_probe_line" -lt "$cleanup_preflight_line" ] &&
+    [ "$cleanup_preflight_line" -lt "$cleanup_line" ] &&
+    [ "$cleanup_line" -lt "$generated_stop_line" ] ||
+    fail "generated prerm must clean PAM before debhelper stops the service"
+if grep -Fq "deb-systemd-helper purge 'facelock-daemon.service'" "$control_root/prerm"; then
+    fail "prerm must not purge enabled state during ordinary removal"
+fi
+# Match the generated script's literal positional parameter.
+# shellcheck disable=SC2016
+if ! grep -Fq 'if [ "$1" = "purge" ]; then' "$control_root/postrm" ||
+   ! grep -Fq "deb-systemd-helper purge 'facelock-daemon.service'" "$control_root/postrm"; then
+    fail "generated postrm must reserve service-state purge for package purge"
+fi
 
 echo "deb maintscript contract: ok"

--- a/test/deb-maintscript-contract.sh
+++ b/test/deb-maintscript-contract.sh
@@ -80,6 +80,19 @@ done <"$control_root/postinst"
 
 [ -f "$control_root/prerm" ] || fail "package has no generated prerm"
 [ -f "$control_root/postrm" ] || fail "package has no generated postrm"
+[ -f "$control_root/conffiles" ] || fail "package has no generated conffiles record"
+mapfile -t conffiles < <(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    "$control_root/conffiles" | sed '/^$/d')
+[ "${#conffiles[@]}" -eq 1 ] &&
+    [ "${conffiles[0]}" = /etc/facelock/config.toml ] ||
+    fail "generated conffiles must contain only /etc/facelock/config.toml"
+grep -Fq 'facelock_renameat2_syscall=316' "$control_root/postrm" ||
+    fail "generated postrm omits the self-contained no-replace purge helper"
+grep -Fq 'run_lifecycle_helper purge' "$control_root/postrm" ||
+    fail "generated postrm does not dispatch bounded cleanup on purge"
+if grep -Fq '#DEBHELPER#' "$control_root/postrm"; then
+    fail "generated postrm retains an unresolved debhelper marker"
+fi
 if grep -Eq 'systemctl[[:space:]]+(stop|disable)[[:space:]]+facelock-daemon' \
     "$control_root/prerm"; then
     fail "prerm must not manually stop or disable facelock-daemon"
@@ -109,6 +122,11 @@ fi
 if ! grep -Fq 'if [ "$1" = "purge" ]; then' "$control_root/postrm" ||
    ! grep -Fq "deb-systemd-helper purge 'facelock-daemon.service'" "$control_root/postrm"; then
     fail "generated postrm must reserve service-state purge for package purge"
+fi
+if grep -Fq '/usr/bin/facelock' "$control_root/postrm" ||
+   grep -Eq '^[[:space:]]*facelock[[:space:]]+(data|pam|setup|daemon)([[:space:]]|$)' \
+       "$control_root/postrm"; then
+    fail "generated postrm must not invoke the removed Facelock payload"
 fi
 
 echo "deb maintscript contract: ok"

--- a/test/deb-package-contract-test.sh
+++ b/test/deb-package-contract-test.sh
@@ -62,11 +62,14 @@ case "${1:-}" in
     --control)
         destination="${3:?}"
         mkdir -p "$destination"
-        if [ -f "${2:?}.postinst" ]; then
-            cp "${2:?}.postinst" "$destination/postinst"
-        else
-            printf '%s\n' '#!/bin/sh' 'exit 0' >"$destination/postinst"
-        fi
+        package="${2:?}"
+        for script in postinst prerm postrm; do
+            if [ -f "$package.$script" ]; then
+                cp "$package.$script" "$destination/$script"
+            else
+                printf '%s\n' '#!/bin/sh' 'exit 0' >"$destination/$script"
+            fi
+        done
         ;;
     *) exit 2 ;;
 esac
@@ -107,6 +110,29 @@ create_fixture() {
 
     printf '%s\n' buildinfo >"$root/${binary_basename}.buildinfo"
     printf '%s\n' package >"$root/${binary_basename}.deb"
+    cat >"$root/${binary_basename}.deb.postinst" <<'SH'
+#!/bin/sh
+if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+fi
+systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
+SH
+    cat >"$root/${binary_basename}.deb.prerm" <<'SH'
+#!/bin/sh
+facelock pam shared-profile-status
+facelock pam remove --all --dry-run
+facelock pam remove --all
+if [ -z "$DPKG_ROOT" ] && [ "$1" = remove ] && [ -d /run/systemd/system ]; then
+    deb-systemd-invoke stop 'facelock-daemon.service' >/dev/null || true
+fi
+SH
+    cat >"$root/${binary_basename}.deb.postrm" <<'SH'
+#!/bin/sh
+if [ "$1" = "purge" ]; then
+    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
+fi
+SH
     {
         printf '%s\n' \
             'Format: 1.8' \
@@ -179,6 +205,11 @@ if [ "$1" = configure ]; then
         fi
     fi
 fi
+if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+fi
+systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
 SH
 PATH="$fixture_root/bin:$PATH" \
     bash "$contract" --manifest "$conditional_enable/$manifest_name" >/dev/null
@@ -188,6 +219,11 @@ cp -a "$baseline" "$unconditional_enable"
 cat >"$unconditional_enable/facelock_0.1.4-1~ubuntu26.04.1_amd64.deb.postinst" <<'SH'
 #!/bin/sh
 deb-systemd-helper enable 'facelock-daemon.service' >/dev/null || true
+if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+fi
+systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
 SH
 assert_rejected "accepted unconditional service enablement" \
     env PATH="$fixture_root/bin:$PATH" bash "$contract" \
@@ -198,6 +234,11 @@ cp -a "$baseline" "$automatic_start"
 cat >"$automatic_start/facelock_0.1.4-1~ubuntu26.04.1_amd64.deb.postinst" <<'SH'
 #!/bin/sh
 deb-systemd-invoke start 'facelock-daemon.service' >/dev/null || true
+if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+fi
+systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
 SH
 assert_rejected "accepted automatic service startup" \
     env PATH="$fixture_root/bin:$PATH" bash "$contract" \

--- a/test/deb-package-contract-test.sh
+++ b/test/deb-package-contract-test.sh
@@ -21,6 +21,11 @@ assert_rejected() {
 fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-package-contract.XXXXXX")"
 trap 'rm -rf -- "$fixture_root"' EXIT
 mkdir -p "$fixture_root/bin"
+cat >"$fixture_root/generated-postrm-helper" <<'SH'
+if [ "$1" = "purge" ]; then
+    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
+fi
+SH
 
 cat >"$fixture_root/bin/dpkg-deb" <<'SH'
 #!/usr/bin/env bash
@@ -70,6 +75,9 @@ case "${1:-}" in
                 printf '%s\n' '#!/bin/sh' 'exit 0' >"$destination/$script"
             fi
         done
+        if [ -f "$package.conffiles" ]; then
+            cp "$package.conffiles" "$destination/conffiles"
+        fi
         ;;
     *) exit 2 ;;
 esac
@@ -127,12 +135,11 @@ if [ -z "$DPKG_ROOT" ] && [ "$1" = remove ] && [ -d /run/systemd/system ]; then
     deb-systemd-invoke stop 'facelock-daemon.service' >/dev/null || true
 fi
 SH
-    cat >"$root/${binary_basename}.deb.postrm" <<'SH'
-#!/bin/sh
-if [ "$1" = "purge" ]; then
-    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
-fi
-SH
+    sed -e "/^#DEBHELPER#$/r $fixture_root/generated-postrm-helper" \
+        -e '/^#DEBHELPER#$/d' "$repo_root/debian/postrm" \
+        >"$root/${binary_basename}.deb.postrm"
+    printf '%s\n' '/etc/facelock/config.toml' \
+        >"$root/${binary_basename}.deb.conffiles"
     {
         printf '%s\n' \
             'Format: 1.8' \
@@ -213,6 +220,23 @@ systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || tru
 SH
 PATH="$fixture_root/bin:$PATH" \
     bash "$contract" --manifest "$conditional_enable/$manifest_name" >/dev/null
+
+missing_conffile="$fixture_root/missing-conffile"
+cp -a "$baseline" "$missing_conffile"
+rm "$missing_conffile/facelock_0.1.4-1~ubuntu26.04.1_amd64.deb.conffiles"
+assert_rejected "accepted a package without the native Facelock conffile record" \
+    env PATH="$fixture_root/bin:$PATH" bash "$contract" \
+    --manifest "$missing_conffile/$manifest_name"
+
+payload_dependent_purge="$fixture_root/payload-dependent-purge"
+cp -a "$baseline" "$payload_dependent_purge"
+# Match the fixture's literal maintainer-script positional parameter.
+# shellcheck disable=SC2016
+sed -i '/if \[ "$1" = "purge" \]; then/a\    /usr/bin/facelock data purge' \
+    "$payload_dependent_purge/facelock_0.1.4-1~ubuntu26.04.1_amd64.deb.postrm"
+assert_rejected "accepted a postrm purge that invokes the removed package payload" \
+    env PATH="$fixture_root/bin:$PATH" bash "$contract" \
+    --manifest "$payload_dependent_purge/$manifest_name"
 
 unconditional_enable="$fixture_root/unconditional-enable"
 cp -a "$baseline" "$unconditional_enable"

--- a/test/deb-package-lifecycle.sh
+++ b/test/deb-package-lifecycle.sh
@@ -1,0 +1,966 @@
+#!/usr/bin/env bash
+# Booted Debian/Ubuntu proof for the exact candidate .deb. The package is
+# mounted read-only at runtime; it is never installed while the image is built.
+set -euo pipefail
+
+PACKAGE=/facelock-test-package.deb
+STATE_ROOT=/run/facelock-deb-lifecycle
+PAM_SERVICE=facelock-deb-lifecycle
+PAM_PATH="/etc/pam.d/$PAM_SERVICE"
+PAM_RETAINED=/var/lib/facelock/pam-backups/lifecycle-retained-provenance
+EXTERNAL_SENTINEL=/srv/facelock-lifecycle-external
+COMMON_AUTH=/etc/pam.d/common-auth
+APT_LOG=/tmp/facelock-deb-lifecycle-apt.log
+DB_HOLDER_PID=
+
+phase="${1:-}"
+case "$phase" in
+    install|install-remove-reinstall|versioned-upgrade-inactive|versioned-upgrade-active|purge) ;;
+    *)
+        echo "usage: $0 {install|install-remove-reinstall|versioned-upgrade-inactive|versioned-upgrade-active|purge}" >&2
+        exit 2
+        ;;
+esac
+
+fail() {
+    echo "FAIL [Debian $phase lifecycle]: $*" >&2
+    exit 1
+}
+
+pass() {
+    printf 'TEST: Debian %s ... PASS\n' "$1"
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    [ "$actual" = "$expected" ] ||
+        fail "$label: expected '$expected', got '$actual'"
+}
+
+assert_regular() {
+    local path="$1"
+    [ -f "$path" ] && [ ! -L "$path" ] || fail "not a regular file: $path"
+}
+
+record_failure() {
+    echo "FAIL [Debian $phase lifecycle]: $*" >&2
+    failed=1
+}
+
+assert_trusted_inert_anchor() {
+    local root="$1" expected_mode="$2"
+    local mount_target
+
+    if [ ! -d "$root" ] || [ -L "$root" ]; then
+        record_failure "fixed root is not an inert directory anchor: $root"
+        return
+    fi
+    if [ "$(stat -c '%a:%u:%g' -- "$root")" != "$expected_mode:0:0" ]; then
+        record_failure \
+            "fixed root has unsafe metadata: $root ($(stat -c '%a:%u:%g' -- "$root"))"
+    fi
+    if [ "$(stat -c %d -- "$root")" != "$(stat -c %d -- "$(dirname "$root")")" ]; then
+        record_failure "fixed root crosses its parent device: $root"
+    fi
+    mount_target="$(findmnt -n -o TARGET --target "$root")"
+    if [ "$mount_target" = "$root" ]; then
+        record_failure "fixed root is a mount point: $root"
+    fi
+}
+
+assert_absent_or_trusted_inert_anchor() {
+    local root="$1" expected_mode="$2"
+
+    if [ ! -e "$root" ] && [ ! -L "$root" ]; then
+        return
+    fi
+    assert_trusted_inert_anchor "$root" "$expected_mode"
+}
+
+assert_no_purge_eligible_children() {
+    local root="$1" path allowed candidate
+    shift
+
+    if [ ! -e "$root" ] && [ ! -L "$root" ]; then
+        return
+    fi
+
+    while IFS= read -r -d '' path; do
+        allowed=0
+        for candidate in "$@"; do
+            if [ "$path" = "$candidate" ]; then
+                allowed=1
+                break
+            fi
+        done
+        if [ "$allowed" -eq 0 ]; then
+            record_failure "purge-eligible child survived below $root: $path"
+        fi
+    done < <(find "$root" -xdev -mindepth 1 -print0)
+}
+
+artifact_hash() {
+    sha256sum -- "$PACKAGE" | cut -d' ' -f1
+}
+
+assert_exact_artifact_mount() {
+    local mount_target mount_options
+    assert_regular "$PACKAGE"
+    mount_target="$(findmnt -n -o TARGET --target "$PACKAGE")"
+    assert_eq "$PACKAGE" "$mount_target" "candidate mount target"
+    mount_options="$(findmnt -n -o OPTIONS --target "$PACKAGE")"
+    case ",$mount_options," in
+        *,ro,*) ;;
+        *) fail "candidate package mount is writable: $mount_options" ;;
+    esac
+    [ "$(stat -c %a "$PACKAGE")" = 444 ] ||
+        fail "candidate package must be emitted mode 0444"
+    assert_eq facelock "$(dpkg-deb --field "$PACKAGE" Package)" \
+        "candidate package name"
+}
+
+assert_dpkg_healthy() {
+    local audit
+    audit="$(dpkg --audit)"
+    [ -z "$audit" ] || fail "dpkg reports an incomplete transaction: $audit"
+}
+
+assert_no_repair_masking() {
+    if grep -Eqi \
+        'correcting dependencies|fix-broken|unmet dependencies|dependency problems - leaving unconfigured' \
+        "$APT_LOG"; then
+        cat "$APT_LOG" >&2
+        fail "APT repaired or masked an incomplete package transaction"
+    fi
+}
+
+apt_transaction() {
+    : >"$APT_LOG"
+    DEBIAN_FRONTEND=noninteractive apt-get update >>"$APT_LOG" 2>&1
+    if ! DEBIAN_FRONTEND=noninteractive apt-get "$@" >>"$APT_LOG" 2>&1; then
+        cat "$APT_LOG" >&2
+        fail "APT transaction failed: apt-get $*"
+    fi
+    assert_no_repair_masking
+    assert_dpkg_healthy
+}
+
+assert_not_installed() {
+    if dpkg-query -W -f='${db:Status-Status}\n' facelock 2>/dev/null |
+        grep -qx installed; then
+        fail "facelock was installed before the runtime transaction"
+    fi
+}
+
+assert_installed_candidate() {
+    local expected_version actual_version
+    expected_version="$(dpkg-deb --field "$PACKAGE" Version)"
+    actual_version="$(dpkg-query -W -f='${Version}' facelock)"
+    assert_eq "$expected_version" "$actual_version" "installed candidate version"
+    assert_eq installed \
+        "$(dpkg-query -W -f='${db:Status-Status}' facelock)" \
+        "installed candidate status"
+}
+
+assert_installed_payload_metadata() {
+    local data_tar
+    data_tar="$(mktemp "${TMPDIR:-/tmp}/facelock-installed-data.XXXXXX.tar")"
+    dpkg-deb --fsys-tarfile "$PACKAGE" >"$data_tar"
+    if ! python3 - "$data_tar" <<'PY'
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+import tarfile
+
+
+def normalized_path(raw):
+    name = raw
+    while name.startswith("./"):
+        name = name[2:]
+    if not name or name == ".":
+        return None
+    parts = name.split("/")
+    if name.startswith("/") or any(part in ("", ".", "..") for part in parts):
+        raise SystemExit(f"unsafe package data path: {raw}")
+    return "/" + name
+
+
+def dpkg_attributes_path(search_output, package, path):
+    for owner_line in search_output.splitlines():
+        owner_list, separator, owned_path = owner_line.rpartition(": ")
+        if not separator or owned_path != path:
+            continue
+        for package_spec in owner_list.split(", "):
+            if package_spec.split(":", 1)[0] == package:
+                return True
+    return False
+
+
+if not dpkg_attributes_path(
+    "base-files, libc6:amd64, facelock: /etc", "facelock", "/etc"
+):
+    raise SystemExit("shared parent directory ownership parser regression")
+if dpkg_attributes_path(
+    "base-files, libc6:amd64: /etc", "facelock", "/etc"
+):
+    raise SystemExit("shared parent directory ownership false positive")
+
+
+listed = subprocess.run(
+    ["dpkg-query", "-L", "facelock"],
+    check=True,
+    text=True,
+    stdout=subprocess.PIPE,
+).stdout.splitlines()
+listed_paths = {path.rstrip("/") or "/" for path in listed if path not in ("", "/.")}
+checked = 0
+archive_paths = set()
+with tarfile.open(sys.argv[1], mode="r:") as archive:
+    members = archive.getmembers()
+    for member in members:
+        path = normalized_path(member.name)
+        if path is None:
+            continue
+        archive_paths.add(path.rstrip("/") or "/")
+        ownership = subprocess.run(
+            ["dpkg-query", "--search", "--", path],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if ownership.returncode != 0 or not dpkg_attributes_path(
+            ownership.stdout, "facelock", path
+        ):
+            raise SystemExit(f"dpkg does not attribute package payload to facelock: {path}")
+        package_private_directories = (
+            "/etc/facelock",
+            "/usr/lib/facelock",
+            "/usr/share/doc/facelock",
+            "/usr/share/facelock",
+        )
+        if member.isdir() and not any(
+            path == root or path.startswith(root + "/")
+            for root in package_private_directories
+        ):
+            # dpkg data archives repeat shared ancestor directories. Native
+            # usrmerge may resolve one of those through a system-owned symlink,
+            # so its live metadata is not exclusively controlled by Facelock.
+            continue
+        info = os.lstat(path)
+        actual_mode = stat.S_IMODE(info.st_mode)
+        expected_mode = member.mode & 0o7777
+        if (info.st_uid, info.st_gid) != (member.uid, member.gid):
+            raise SystemExit(
+                f"installed owner differs from package archive: {path}: "
+                f"{info.st_uid}:{info.st_gid} != {member.uid}:{member.gid}"
+            )
+        if (member.uid, member.gid) != (0, 0):
+            raise SystemExit(f"package data is not root-owned: {path}")
+        if actual_mode != expected_mode:
+            raise SystemExit(
+                f"installed mode differs from package archive: {path}: "
+                f"{actual_mode:o} != {expected_mode:o}"
+            )
+        if not member.issym() and actual_mode & 0o022:
+            raise SystemExit(f"package data is group/world writable: {path}")
+        if member.isdir():
+            if not stat.S_ISDIR(info.st_mode):
+                raise SystemExit(f"installed package directory changed type: {path}")
+        elif member.isfile():
+            if not stat.S_ISREG(info.st_mode):
+                raise SystemExit(f"installed package file changed type: {path}")
+            archived = archive.extractfile(member)
+            if archived is None:
+                raise SystemExit(f"package archive file cannot be read: {path}")
+            archived_hash = hashlib.sha256(archived.read()).hexdigest()
+            descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+            try:
+                live_info = os.fstat(descriptor)
+                if (live_info.st_dev, live_info.st_ino) != (info.st_dev, info.st_ino):
+                    raise SystemExit(f"installed package file changed during proof: {path}")
+                live_hash = hashlib.sha256()
+                while chunk := os.read(descriptor, 1024 * 1024):
+                    live_hash.update(chunk)
+            finally:
+                os.close(descriptor)
+            if live_hash.hexdigest() != archived_hash:
+                raise SystemExit(f"installed package file bytes differ from archive: {path}")
+        elif member.issym():
+            if not stat.S_ISLNK(info.st_mode) or os.readlink(path) != member.linkname:
+                raise SystemExit(f"installed package symlink differs: {path}")
+        elif member.islnk():
+            target = normalized_path(member.linkname)
+            if target is None or not stat.S_ISREG(info.st_mode) or not os.path.samefile(path, target):
+                raise SystemExit(f"installed package hard link differs: {path}")
+        else:
+            raise SystemExit(f"unsupported package data type: {path}")
+        checked += 1
+if archive_paths != listed_paths:
+    missing = sorted(archive_paths - listed_paths)
+    extra = sorted(listed_paths - archive_paths)
+    raise SystemExit(
+        "dpkg package list differs from data archive: "
+        f"missing={missing!r}, extra={extra!r}"
+    )
+if checked == 0:
+    raise SystemExit("package data archive is empty")
+print(f"verified {checked} installed package paths and dpkg ownership against archive metadata and bytes")
+PY
+    then
+        rm -f -- "$data_tar"
+        fail "installed package ownership/mode/type metadata is unsafe or differs from the candidate"
+    fi
+    rm -f -- "$data_tar"
+}
+
+snapshot_file() {
+    local path="$1"
+    assert_regular "$path"
+    stat -c '%n|%F|%a|%u|%g|%s' -- "$path"
+    sha256sum -- "$path"
+}
+
+snapshot_enrollment_database_state() {
+    python3 - <<'PY'
+import hashlib
+import sqlite3
+
+
+connection = sqlite3.connect(
+    "file:/var/lib/facelock/facelock.db?mode=ro", uri=True
+)
+model_count = connection.execute(
+    "SELECT COUNT(*) FROM face_models"
+).fetchone()[0]
+embedding_count = connection.execute(
+    "SELECT COUNT(*) FROM face_embeddings"
+).fetchone()[0]
+rows = connection.execute(
+    "SELECT fm.user, fm.label, fm.created_at, fm.embedder_model, "
+    "fm.device_id, fe.embedding, fe.sealed "
+    "FROM face_models AS fm "
+    "JOIN face_embeddings AS fe ON fe.model_id = fm.id "
+    "WHERE fm.user = ? ORDER BY fm.id, fe.id",
+    ("testuser",),
+).fetchall()
+connection.close()
+
+if (model_count, embedding_count) != (1, 1):
+    raise SystemExit(
+        "expected exactly one model and one embedding row, got "
+        f"models={model_count}, embeddings={embedding_count}"
+    )
+if len(rows) != 1:
+    raise SystemExit(
+        f"expected exactly one authoritative testuser enrollment row, got {len(rows)}"
+    )
+user, label, created_at, embedder_model, device_id, embedding, sealed = rows[0]
+expected = ("testuser", "lifecycle-retained", 1700000000, "", None, 0)
+actual = (user, label, created_at, embedder_model, device_id, sealed)
+if actual != expected:
+    raise SystemExit(f"unexpected authoritative enrollment metadata: {actual!r}")
+if len(embedding) != 512 * 4:
+    raise SystemExit(f"unexpected enrollment embedding size: {len(embedding)}")
+embedding_digest = hashlib.sha256(embedding).hexdigest()
+expected_embedding_digest = (
+    "82a0081de4c338fc91c362ed4d2ab615bca1dd45152aaa713322b5482078ddee"
+)
+if embedding_digest != expected_embedding_digest:
+    raise SystemExit(
+        f"unexpected enrollment embedding digest: {embedding_digest}"
+    )
+print(
+    "enrollment-row|"
+    f"user={user}|label={label}|created_at={created_at}|"
+    f"embedder_model={embedder_model}|device_id=null|sealed={sealed}|"
+    f"embedding_sha256={embedding_digest}"
+)
+PY
+}
+
+snapshot_enrollment_marker() {
+    local path="$1" expected_uid expected_gid
+    assert_regular "$path"
+    expected_uid="$(id -u testuser)"
+    expected_gid="$(id -g testuser)"
+    assert_eq "600:$expected_uid:$expected_gid" \
+        "$(stat -c '%a:%u:%g' -- "$path")" \
+        "enrollment marker metadata for $path"
+    python3 - "$path" "$expected_uid" "$expected_gid" <<'PY'
+import datetime
+import json
+import os
+import stat
+import sys
+
+
+path = sys.argv[1]
+expected_uid = int(sys.argv[2])
+expected_gid = int(sys.argv[3])
+descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+try:
+    info = os.fstat(descriptor)
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        raise SystemExit(f"enrollment marker is not a single-link regular file: {path}")
+    if stat.S_IMODE(info.st_mode) != 0o600:
+        raise SystemExit(f"enrollment marker has wrong mode: {path}")
+    if (info.st_uid, info.st_gid) != (expected_uid, expected_gid):
+        raise SystemExit(f"enrollment marker has wrong owner: {path}")
+    with os.fdopen(descriptor, encoding="utf-8") as handle:
+        descriptor = -1
+        marker = json.load(handle)
+finally:
+    if descriptor >= 0:
+        os.close(descriptor)
+
+if set(marker) != {"models", "updated"}:
+    raise SystemExit(f"enrollment marker has unexpected fields: {sorted(marker)!r}")
+if type(marker["models"]) is not int or marker["models"] != 1:
+    raise SystemExit(f"enrollment marker has wrong model count: {marker['models']!r}")
+updated = marker["updated"]
+if not isinstance(updated, str) or not updated:
+    raise SystemExit("enrollment marker timestamp is empty or not a string")
+try:
+    parsed = datetime.datetime.fromisoformat(updated.replace("Z", "+00:00"))
+except ValueError as error:
+    raise SystemExit(f"enrollment marker timestamp is invalid: {updated!r}") from error
+if parsed.tzinfo is None:
+    raise SystemExit(f"enrollment marker timestamp has no timezone: {updated!r}")
+
+print(
+    f"{path}|regular file|600|{expected_uid}|{expected_gid}|"
+    "models=1|updated=valid"
+)
+PY
+}
+
+snapshot_retained_state() {
+    local path
+    for path in \
+        /etc/facelock/config.toml \
+        /etc/facelock/encryption.key \
+        /etc/facelock/encryption.key.sealed \
+        /var/lib/facelock/facelock.db \
+        /var/lib/facelock/facelock.db-wal \
+        /var/lib/facelock/facelock.db-shm \
+        /var/lib/facelock/models/lifecycle-model.onnx \
+        /var/lib/facelock/enrolled/testuser \
+        /var/lib/facelock/setup.complete \
+        "$PAM_RETAINED" \
+        /var/log/facelock/audit.jsonl \
+        /var/log/facelock/snapshots/lifecycle.jpg; do
+        snapshot_file "$path"
+    done
+}
+
+snapshot_versioned_upgrade_state() {
+    local path
+
+    for path in \
+        /etc/facelock/config.toml \
+        /etc/facelock/encryption.key \
+        /etc/facelock/encryption.key.sealed \
+        /var/lib/facelock/facelock.db \
+        /var/lib/facelock/setup.complete \
+        "$PAM_RETAINED" \
+        /var/log/facelock/audit.jsonl \
+        /var/log/facelock/snapshots/lifecycle.jpg; do
+        snapshot_file "$path"
+    done
+    snapshot_enrollment_database_state
+    snapshot_enrollment_marker /var/lib/facelock/enrolled/testuser
+    while IFS= read -r path; do
+        snapshot_file "$path"
+    done < <(
+        find /etc/facelock /var/lib/facelock /var/log/facelock \
+            -xdev -maxdepth 1 -type f \
+            -name 'lifecycle-versioned-upgrade-*' -print |
+            LC_ALL=C sort
+    )
+}
+
+make_lower_package() {
+    local label="$1" label_token candidate_version lower_root
+
+    label_token="${label//-/}"
+    candidate_version="$(dpkg-deb --field "$PACKAGE" Version)"
+    lower_version="${candidate_version}~facelock.${label_token}"
+    dpkg --compare-versions "$lower_version" lt "$candidate_version" ||
+        fail "controlled upgrade seed is not older: $lower_version >= $candidate_version"
+    lower_root="$STATE_ROOT/lower-$label"
+    lower_package="$STATE_ROOT/facelock-$label-lower.deb"
+    [ ! -e "$lower_root" ] && [ ! -e "$lower_package" ] ||
+        fail "controlled lower-version fixture already exists: $label"
+    dpkg-deb --raw-extract "$PACKAGE" "$lower_root"
+    sed -i -E "s/^Version:.*/Version: $lower_version/" "$lower_root/DEBIAN/control"
+    [ "$(sed -n 's/^Version: //p' "$lower_root/DEBIAN/control")" = "$lower_version" ] ||
+        fail "could not set controlled lower package version"
+    dpkg-deb --build --root-owner-group "$lower_root" "$lower_package" >/dev/null
+    [ "$(dpkg-deb --field "$lower_package" Version)" = "$lower_version" ] ||
+        fail "rebuilt upgrade seed has the wrong version"
+}
+
+create_versioned_upgrade_state() {
+    local label="$1" path
+
+    install -d -m0755 /etc/facelock
+    install -d -m0711 /var/lib/facelock
+    install -d -m0700 /var/lib/facelock/pam-backups /var/log/facelock
+    if [ ! -e "$PAM_RETAINED" ] && [ ! -L "$PAM_RETAINED" ]; then
+        printf '%s\n' retained-provenance >"$PAM_RETAINED"
+        chmod 0600 "$PAM_RETAINED"
+    fi
+    for path in \
+        "/etc/facelock/lifecycle-versioned-upgrade-$label" \
+        "/var/lib/facelock/lifecycle-versioned-upgrade-$label" \
+        "/var/log/facelock/lifecycle-versioned-upgrade-$label"; do
+        printf '%s\n' "$label retained state" >"$path"
+        chmod 0600 "$path"
+    done
+}
+
+exercise_one_versioned_upgrade() {
+    local activity="$1" enablement="$2" label before_hash candidate_version
+    local before_start="" after_start="" actual_enablement
+
+    label="$activity-$enablement"
+    assert_installed_candidate
+    before_hash="$(artifact_hash)"
+    candidate_version="$(dpkg-deb --field "$PACKAGE" Version)"
+
+    apt_transaction remove -y facelock
+    assert_not_installed
+    make_lower_package "$label"
+    apt_transaction install -y --no-install-recommends "$lower_package"
+    assert_eq "$lower_version" "$(dpkg-query -W -f='${Version}' facelock)" \
+        "controlled lower package version"
+
+    case "$enablement" in
+        enabled) systemctl enable facelock-daemon.service >/dev/null ;;
+        disabled) systemctl disable facelock-daemon.service >/dev/null 2>&1 || true ;;
+        *) fail "invalid versioned-upgrade enablement fixture: $enablement" ;;
+    esac
+    case "$activity" in
+        active)
+            if ! grep -Eq '^[[:space:]]*path[[:space:]]*=' /etc/facelock/config.toml; then
+                sed -i '/^\[device\]/a path = "/dev/video0"' /etc/facelock/config.toml
+            fi
+            systemctl start facelock-daemon.service
+            systemctl is-active --quiet facelock-daemon.service ||
+                fail "controlled lower-version daemon did not start"
+            before_start="$(systemctl show -p ExecMainStartTimestampMonotonic --value \
+                facelock-daemon.service)"
+            ;;
+        inactive)
+            systemctl stop facelock-daemon.service >/dev/null 2>&1 || true
+            ! systemctl is-active --quiet facelock-daemon.service ||
+                fail "controlled lower-version daemon remained active"
+            ;;
+        *) fail "invalid versioned-upgrade activity fixture: $activity" ;;
+    esac
+    actual_enablement="$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)"
+    assert_eq "$enablement" "$actual_enablement" \
+        "controlled lower-version service enablement"
+
+    create_versioned_upgrade_state "$label"
+    snapshot_versioned_upgrade_state >"$STATE_ROOT/upgrade-$label.before"
+    apt_transaction install -y --no-install-recommends "$PACKAGE"
+    grep -Fq "Unpacking facelock ($candidate_version) over ($lower_version)" "$APT_LOG" || {
+        cat "$APT_LOG" >&2
+        fail "APT did not report a genuine lower-to-candidate versioned upgrade"
+    }
+    assert_installed_candidate
+    snapshot_versioned_upgrade_state >"$STATE_ROOT/upgrade-$label.after"
+    cmp -s "$STATE_ROOT/upgrade-$label.before" "$STATE_ROOT/upgrade-$label.after" || {
+        diff -u "$STATE_ROOT/upgrade-$label.before" \
+            "$STATE_ROOT/upgrade-$label.after" >&2 || true
+        fail "versioned upgrade changed retained state: $label"
+    }
+    assert_eq "$before_hash" "$(artifact_hash)" \
+        "candidate artifact digest after versioned upgrade"
+    actual_enablement="$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)"
+    assert_eq "$enablement" "$actual_enablement" \
+        "candidate service enablement after versioned upgrade"
+    if [ "$activity" = active ]; then
+        systemctl is-active --quiet facelock-daemon.service ||
+            fail "active daemon stopped across versioned upgrade"
+        after_start="$(systemctl show -p ExecMainStartTimestampMonotonic --value \
+            facelock-daemon.service)"
+        [ -n "$before_start" ] && [ -n "$after_start" ] &&
+            [ "$before_start" != "$after_start" ] ||
+            fail "active daemon was not restarted by the versioned upgrade"
+    else
+        ! systemctl is-active --quiet facelock-daemon.service ||
+            fail "inactive daemon started across versioned upgrade"
+    fi
+    pass "genuine $activity/$enablement lower-to-candidate upgrade"
+}
+
+restore_validator_service_baseline() {
+    systemctl stop facelock-daemon.service >/dev/null 2>&1 || true
+    systemctl disable facelock-daemon.service >/dev/null 2>&1 || true
+    ! systemctl is-active --quiet facelock-daemon.service ||
+        fail "daemon remained active after the versioned-upgrade matrix"
+    assert_eq disabled \
+        "$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)" \
+        "service enablement after the versioned-upgrade matrix"
+}
+
+exercise_versioned_upgrade_matrix() {
+    local activity="$1" enablement
+
+    for enablement in disabled enabled; do
+        exercise_one_versioned_upgrade "$activity" "$enablement"
+    done
+    # The inactive and active phases together prove that a genuine, ordered
+    # versioned upgrade preserves active/inactive and enabled/disabled state.
+    # Leave the exact candidate in the fresh-install state expected by the
+    # shared package validator; the matrix assertions above have already
+    # captured and compared every requested service state across the upgrade.
+    restore_validator_service_baseline
+}
+
+assert_tmpfiles_layout() {
+    local expected path
+    while read -r expected path; do
+        [ -d "$path" ] && [ ! -L "$path" ] || fail "tmpfiles directory missing: $path"
+        assert_eq "$expected" "$(stat -c '%a:%u:%g' "$path")" \
+            "tmpfiles metadata for $path"
+    done <<'EOF'
+755:0:0 /run/facelock
+711:0:0 /var/lib/facelock
+755:0:0 /var/lib/facelock/models
+711:0:0 /var/lib/facelock/enrolled
+700:0:0 /var/lib/facelock/pam-backups
+700:0:0 /var/log/facelock
+700:0:0 /var/log/facelock/snapshots
+EOF
+}
+
+assert_static_payload_absent() {
+    local path
+    for path in \
+        /usr/bin/facelock \
+        /lib/security/pam_facelock.so \
+        /usr/lib/security/pam_facelock.so \
+        /usr/lib/systemd/system/facelock-daemon.service \
+        /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+        /usr/share/dbus-1/system-services/org.facelock.Daemon.service \
+        /usr/lib/tmpfiles.d/facelock.conf \
+        /usr/share/pam-configs/facelock \
+        /usr/lib/facelock/libonnxruntime.so; do
+        [ ! -e "$path" ] && [ ! -L "$path" ] ||
+            fail "package-owned static payload survived removal: $path"
+    done
+}
+
+assert_password_fallback() {
+    printf '%s\n' test |
+        timeout --foreground 30 pamtester "$PAM_SERVICE" testuser authenticate \
+            >/dev/null 2>&1 ||
+        fail "correct password did not succeed after biometric failure"
+    if printf '%s\n' wrong-password |
+        timeout --foreground 30 pamtester "$PAM_SERVICE" testuser authenticate \
+            >/dev/null 2>&1; then
+        fail "wrong password authenticated through $PAM_SERVICE"
+    fi
+}
+
+fresh_install() {
+    local common_hash common_metadata before_hash
+    assert_exact_artifact_mount
+    assert_not_installed
+    before_hash="$(artifact_hash)"
+    common_hash="$(sha256sum "$COMMON_AUTH" | cut -d' ' -f1)"
+    common_metadata="$(stat -c '%a:%u:%g' "$COMMON_AUTH")"
+
+    apt_transaction install -y --no-install-recommends "$PACKAGE"
+
+    assert_installed_candidate
+    assert_installed_payload_metadata
+    assert_eq "$before_hash" "$(artifact_hash)" "candidate artifact digest after install"
+    assert_eq "$common_hash" "$(sha256sum "$COMMON_AUTH" | cut -d' ' -f1)" \
+        "common-auth bytes after fresh install"
+    assert_eq "$common_metadata" "$(stat -c '%a:%u:%g' "$COMMON_AUTH")" \
+        "common-auth metadata after fresh install"
+    ! grep -q pam_facelock.so "$COMMON_AUTH" ||
+        fail "fresh install activated Facelock in common-auth"
+    assert_tmpfiles_layout
+    if [ -d /run/systemd/system ]; then
+        [ "$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)" = disabled ] ||
+            fail "fresh install enabled facelock-daemon"
+        ! systemctl is-active --quiet facelock-daemon.service ||
+            fail "fresh install started facelock-daemon"
+    fi
+    touch /facelock-common-auth-install-invariant
+    pass "exact artifact installs at runtime without PAM or service activation"
+}
+
+create_retained_state() {
+    local auth_status=0
+
+    printf '\n# facelock lifecycle administrator marker\n' >>/etc/facelock/config.toml
+    if ! grep -Eq '^[[:space:]]*path[[:space:]]*=' /etc/facelock/config.toml; then
+        sed -i '/^\[device\]/a path = "/dev/video0"' /etc/facelock/config.toml
+    fi
+    facelock auth --user testuser >/dev/null 2>&1 || auth_status=$?
+    assert_eq 2 "$auth_status" \
+        "one-shot fixture initialization for an unenrolled user"
+    if [ ! -s /etc/facelock/encryption.key ]; then
+        dd if=/dev/urandom of=/etc/facelock/encryption.key bs=32 count=1 status=none
+    fi
+    chmod 0600 /etc/facelock/encryption.key
+    printf '%s\n' sealed-key > /etc/facelock/encryption.key.sealed
+    chmod 0600 /etc/facelock/encryption.key.sealed
+    python3 - "$STATE_ROOT/database.ready" "$STATE_ROOT/database.stop" <<'PY' &
+import pathlib
+import sqlite3
+import struct
+import sys
+import time
+
+ready = pathlib.Path(sys.argv[1])
+stop = pathlib.Path(sys.argv[2])
+connection = sqlite3.connect("/var/lib/facelock/facelock.db")
+connection.execute("PRAGMA journal_mode=WAL")
+connection.execute(
+    "CREATE TABLE IF NOT EXISTS lifecycle_retained "
+    "(value TEXT NOT NULL)"
+)
+connection.execute(
+    "INSERT INTO lifecycle_retained (value) VALUES (?)",
+    ("ordinary-remove-preservation",),
+)
+connection.execute(
+    "INSERT INTO face_models "
+    "(user, label, created_at, embedder_model, device_id) "
+    "VALUES (?, ?, ?, ?, ?)",
+    ("testuser", "lifecycle-retained", 1700000000, "", None),
+)
+model_id = connection.execute(
+    "SELECT id FROM face_models WHERE user = ? AND label = ?",
+    ("testuser", "lifecycle-retained"),
+).fetchone()[0]
+embedding = struct.pack("<512f", *((index + 1) / 512 for index in range(512)))
+connection.execute(
+    "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (?, ?, ?)",
+    (model_id, embedding, 0),
+)
+connection.commit()
+ready.touch()
+while not stop.exists():
+    time.sleep(0.1)
+connection.close()
+PY
+    DB_HOLDER_PID=$!
+    for _ in $(seq 1 100); do
+        if [ -f "$STATE_ROOT/database.ready" ] &&
+           [ -s /var/lib/facelock/facelock.db-wal ] &&
+           [ -s /var/lib/facelock/facelock.db-shm ]; then
+            break
+        fi
+        sleep 0.1
+    done
+    [ -f "$STATE_ROOT/database.ready" ] || fail "SQLite fixture did not become ready"
+    [ -s /var/lib/facelock/facelock.db-wal ] || fail "SQLite WAL fixture is empty"
+    [ -s /var/lib/facelock/facelock.db-shm ] || fail "SQLite SHM fixture is empty"
+    chmod 0600 /var/lib/facelock/facelock.db*
+    printf '%s\n' model > /var/lib/facelock/models/lifecycle-model.onnx
+    chmod 0644 /var/lib/facelock/models/lifecycle-model.onnx
+    printf '%s\n' \
+        '{"models":1,"updated":"2026-01-01T00:00:00Z"}' \
+        > /var/lib/facelock/enrolled/testuser
+    chown testuser:testuser /var/lib/facelock/enrolled/testuser
+    chmod 0600 /var/lib/facelock/enrolled/testuser
+    printf '%s\n' complete > /var/lib/facelock/setup.complete
+    chmod 0600 /var/lib/facelock/setup.complete
+    printf '%s\n' retained-provenance >"$PAM_RETAINED"
+    chmod 0600 "$PAM_RETAINED"
+    printf '%s\n' audit > /var/log/facelock/audit.jsonl
+    printf '%s\n' snapshot > /var/log/facelock/snapshots/lifecycle.jpg
+    chmod 0600 /var/log/facelock/audit.jsonl \
+        /var/log/facelock/snapshots/lifecycle.jpg
+}
+
+exercise_remove_reinstall() {
+    local before_hash backup common_hash common_metadata leaf_hash leaf_metadata
+    install -Dm0644 /dev/stdin "$PAM_PATH" <<'EOF'
+#%PAM-1.0
+auth      required pam_unix.so
+account   required pam_permit.so
+EOF
+    leaf_hash="$(sha256sum "$PAM_PATH" | cut -d' ' -f1)"
+    leaf_metadata="$(stat -c '%a:%u:%g' "$PAM_PATH")"
+    common_hash="$(sha256sum "$COMMON_AUTH" | cut -d' ' -f1)"
+    common_metadata="$(stat -c '%a:%u:%g' "$COMMON_AUTH")"
+    facelock pam add --service "$PAM_SERVICE" --no-confirm >/dev/null
+    grep -q pam_facelock.so "$PAM_PATH" || fail "direct PAM setup did not edit $PAM_PATH"
+    assert_password_fallback
+    backup="$(find /var/lib/facelock/pam-backups -maxdepth 1 -type f \
+        -name "$PAM_SERVICE.*" ! -name '*.json' -print -quit)"
+    [ -n "$backup" ] && [ -f "$backup.json" ] ||
+        fail "direct PAM setup did not create backup and provenance"
+
+    # pamtester may D-Bus activate the daemon while proving password fallback.
+    # Stop it before materializing byte-exact database sidecars: an open SQLite
+    # connection is otherwise allowed to checkpoint and remove an idle WAL.
+    if [ -d /run/systemd/system ]; then
+        systemctl stop facelock-daemon.service
+    fi
+    install -d -m0700 "$STATE_ROOT"
+    create_retained_state
+    snapshot_retained_state >"$STATE_ROOT/retained.before"
+    before_hash="$(artifact_hash)"
+    if [ -d /run/systemd/system ]; then
+        systemctl enable facelock-daemon.service >/dev/null
+    fi
+
+    apt_transaction remove -y facelock
+
+    assert_not_installed
+    assert_static_payload_absent
+    snapshot_retained_state >"$STATE_ROOT/retained.after-remove"
+    cmp -s "$STATE_ROOT/retained.before" "$STATE_ROOT/retained.after-remove" || {
+        diff -u "$STATE_ROOT/retained.before" "$STATE_ROOT/retained.after-remove" >&2 || true
+        fail "ordinary removal changed retained biometric, configuration, or PAM state"
+    }
+    assert_eq "$leaf_hash" "$(sha256sum "$PAM_PATH" | cut -d' ' -f1)" \
+        "direct PAM leaf bytes after removal"
+    assert_eq "$leaf_metadata" "$(stat -c '%a:%u:%g' "$PAM_PATH")" \
+        "direct PAM leaf metadata after removal"
+    ! grep -q pam_facelock.so "$PAM_PATH" || fail "ordinary removal retained a direct PAM rule"
+    [ ! -e "$backup" ] && [ ! -e "$backup.json" ] ||
+        fail "successful direct PAM cleanup retained obsolete provenance"
+    assert_eq "$common_hash" "$(sha256sum "$COMMON_AUTH" | cut -d' ' -f1)" \
+        "common-auth bytes after ordinary removal"
+    assert_eq "$common_metadata" "$(stat -c '%a:%u:%g' "$COMMON_AUTH")" \
+        "common-auth metadata after ordinary removal"
+    pass "ordinary remove deletes static payload and preserves all retained state"
+
+    apt_transaction install -y --no-install-recommends "$PACKAGE"
+
+    assert_installed_candidate
+    assert_eq "$before_hash" "$(artifact_hash)" "candidate artifact digest after reinstall"
+    snapshot_retained_state >"$STATE_ROOT/retained.after-reinstall"
+    cmp -s "$STATE_ROOT/retained.before" "$STATE_ROOT/retained.after-reinstall" || {
+        diff -u "$STATE_ROOT/retained.before" "$STATE_ROOT/retained.after-reinstall" >&2 || true
+        fail "reinstall changed retained biometric, configuration, or PAM state"
+    }
+    touch "$STATE_ROOT/database.stop"
+    wait "$DB_HOLDER_PID"
+    python3 - <<'PY'
+import sqlite3
+
+connection = sqlite3.connect("/var/lib/facelock/facelock.db")
+assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
+connection.close()
+PY
+    # This arbitrary payload proved model-file preservation, but it is not an
+    # inference fixture. Remove it before the shared validator stages and loads
+    # the checkout's reviewed ONNX models.
+    rm -f /var/lib/facelock/models/lifecycle-model.onnx
+    if [ -d /run/systemd/system ]; then
+        systemctl is-enabled --quiet facelock-daemon.service ||
+            fail "reinstall did not preserve administrator enablement"
+        systemctl disable facelock-daemon.service >/dev/null
+    fi
+    assert_password_fallback
+    pass "reinstall reuses retained state and the exact immutable artifact"
+}
+
+exercise_purge() {
+    local before_hash failed=0 safe_child
+    assert_exact_artifact_mount
+    assert_not_installed
+    before_hash="$(artifact_hash)"
+
+    # The preceding package validator ends with ordinary remove. Add safe state
+    # to every fixed root so purge cannot pass by inspecting empty directories.
+    install -d -m0700 "$STATE_ROOT"
+    install -d -m0755 /etc/facelock/lifecycle-purge-directory
+    printf '%s\n' purge-etc > /etc/facelock/lifecycle-purge-directory/state
+    chmod 0600 /etc/facelock/lifecycle-purge-directory/state
+    install -d -m0700 /var/lib/facelock/pam-backups
+    printf '%s\n' purge-pam >"$PAM_RETAINED"
+    chmod 0600 "$PAM_RETAINED"
+    install -d -m0755 /var/lib/facelock/lifecycle-purge-directory
+    printf '%s\n' purge-db > /var/lib/facelock/lifecycle-purge-directory/state
+    chmod 0600 /var/lib/facelock/lifecycle-purge-directory/state
+    install -d -m0700 /var/log/facelock/snapshots
+    printf '%s\n' purge-log > /var/log/facelock/snapshots/lifecycle-purge-state
+    chmod 0600 /var/log/facelock/snapshots/lifecycle-purge-state
+    printf '%s\n' external-sentinel >"$EXTERNAL_SENTINEL"
+    chmod 0600 "$EXTERNAL_SENTINEL"
+    snapshot_file "$PAM_RETAINED" >"$STATE_ROOT/pam-purge.before"
+    snapshot_file "$EXTERNAL_SENTINEL" >"$STATE_ROOT/external-purge.before"
+
+    apt_transaction purge -y facelock
+
+    if dpkg-query -W facelock >/dev/null 2>&1; then
+        echo "FAIL [Debian purge lifecycle]: dpkg retained a facelock package record" >&2
+        failed=1
+    fi
+    for safe_child in \
+        /etc/facelock/lifecycle-purge-directory/state \
+        /etc/facelock/lifecycle-purge-directory \
+        /var/lib/facelock/lifecycle-purge-directory/state \
+        /var/lib/facelock/lifecycle-purge-directory \
+        /var/log/facelock/snapshots/lifecycle-purge-state; do
+        if [ -e "$safe_child" ] || [ -L "$safe_child" ]; then
+            record_failure "known purge-eligible child survived: $safe_child"
+        fi
+    done
+    # The helper never removes a compiled root. After it returns, dpkg may
+    # remove the now-empty conffile parent that it owns at /etc/facelock.
+    assert_absent_or_trusted_inert_anchor /etc/facelock 755
+    assert_trusted_inert_anchor /var/lib/facelock 711
+    assert_trusted_inert_anchor /var/log/facelock 700
+    assert_trusted_inert_anchor /var/lib/facelock/pam-backups 700
+    assert_no_purge_eligible_children /etc/facelock
+    assert_no_purge_eligible_children /var/lib/facelock \
+        /var/lib/facelock/pam-backups "$PAM_RETAINED"
+    assert_no_purge_eligible_children /var/log/facelock
+    if [ "$(stat -c %h -- "$PAM_RETAINED")" != 1 ]; then
+        record_failure "opaque PAM rollback remnant is hard-linked"
+    fi
+    snapshot_file "$PAM_RETAINED" >"$STATE_ROOT/pam-purge.after"
+    if ! cmp -s "$STATE_ROOT/pam-purge.before" "$STATE_ROOT/pam-purge.after"; then
+        diff -u "$STATE_ROOT/pam-purge.before" "$STATE_ROOT/pam-purge.after" >&2 || true
+        record_failure "purge changed opaque non-empty PAM rollback state"
+    fi
+    snapshot_file "$EXTERNAL_SENTINEL" >"$STATE_ROOT/external-purge.after"
+    if ! cmp -s "$STATE_ROOT/external-purge.before" "$STATE_ROOT/external-purge.after"; then
+        diff -u "$STATE_ROOT/external-purge.before" "$STATE_ROOT/external-purge.after" >&2 || true
+        record_failure "purge changed state outside the compiled fixed roots"
+    fi
+    assert_eq "$before_hash" "$(artifact_hash)" "candidate artifact digest after purge"
+    if [ -d /run/systemd/system ] &&
+       systemctl is-enabled --quiet facelock-daemon.service 2>/dev/null; then
+        echo "FAIL [Debian purge lifecycle]: purge retained daemon enablement" >&2
+        failed=1
+    fi
+    [ "$failed" -eq 0 ] || exit 1
+    pass "purge clears eligible contents and preserves trusted opaque remnants"
+}
+
+case "$phase" in
+    install)
+        fresh_install
+        ;;
+    install-remove-reinstall)
+        fresh_install
+        exercise_remove_reinstall
+        ;;
+    versioned-upgrade-inactive)
+        exercise_versioned_upgrade_matrix inactive
+        ;;
+    versioned-upgrade-active)
+        exercise_versioned_upgrade_matrix active
+        ;;
+    purge)
+        exercise_purge
+        ;;
+esac

--- a/test/deb-source-contract-test.py
+++ b/test/deb-source-contract-test.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Regression mutations for executable Debian lifecycle operations."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SOURCE_CONTRACT = REPO_ROOT / "test/deb-source-contract.sh"
+LIFECYCLE = REPO_ROOT / "test/deb-package-lifecycle.sh"
+PACKAGE_VALIDATOR = REPO_ROOT / "test/pkg-validate.sh"
+
+
+class DebianSourceContractTests(unittest.TestCase):
+    def run_contract(
+        self,
+        lifecycle: pathlib.Path = LIFECYCLE,
+        package_validator: pathlib.Path = PACKAGE_VALIDATOR,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["FACELOCK_DEB_LIFECYCLE"] = str(lifecycle)
+        environment["FACELOCK_PACKAGE_VALIDATOR"] = str(package_validator)
+        return subprocess.run(
+            ["bash", str(SOURCE_CONTRACT)],
+            cwd=REPO_ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_mutation_rejected(
+        self,
+        name: str,
+        needle: str,
+        replacement: str,
+        expected_diagnostic: str,
+    ) -> None:
+        original = LIFECYCLE.read_text()
+        self.assertEqual(
+            original.count(needle),
+            1,
+            f"mutation needle count changed for {name}: {needle!r}",
+        )
+        mutated = original.replace(needle, replacement, 1)
+        with tempfile.TemporaryDirectory(prefix="facelock-deb-source-contract-") as temp:
+            lifecycle = pathlib.Path(temp) / "deb-package-lifecycle.sh"
+            lifecycle.write_text(mutated)
+            result = self.run_contract(lifecycle)
+        self.assertNotEqual(result.returncode, 0, f"contract accepted {name} mutation")
+        self.assertIn(
+            f"deb source contract: {expected_diagnostic}",
+            result.stderr,
+            f"contract did not diagnose {name} mutation",
+        )
+
+    def test_canonical_lifecycle_is_accepted(self) -> None:
+        result = self.run_contract(LIFECYCLE)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def assert_package_validator_mutation_rejected(
+        self,
+        name: str,
+        needle: str,
+        replacement: str,
+        expected_diagnostic: str,
+        *,
+        scope: str = "helper",
+        occurrence: int = 1,
+        expected_count: int = 1,
+    ) -> None:
+        original = PACKAGE_VALIDATOR.read_text()
+        function_start = original.index("verify_debian_packaged_pam_profile() {\n")
+        function_end = original.index("\n}\n", function_start) + len("\n}\n")
+        if scope == "helper":
+            target_start = function_start
+            target_end = function_end
+        elif scope == "file":
+            target_start = 0
+            target_end = len(original)
+        else:
+            self.fail(f"unknown package-validator mutation scope: {scope}")
+        target = original[target_start:target_end]
+        self.assertEqual(
+            target.count(needle),
+            expected_count,
+            f"mutation needle count changed for {name}: {needle!r}",
+        )
+        self.assertGreaterEqual(occurrence, 1)
+        self.assertLessEqual(occurrence, expected_count)
+        offset = 0
+        for _ in range(occurrence):
+            offset = target.index(needle, offset)
+            if _ + 1 < occurrence:
+                offset += len(needle)
+        mutated_target = target[:offset] + replacement + target[offset + len(needle) :]
+        mutated = original[:target_start] + mutated_target + original[target_end:]
+        with tempfile.TemporaryDirectory(prefix="facelock-deb-source-contract-") as temp:
+            package_validator = pathlib.Path(temp) / "pkg-validate.sh"
+            package_validator.write_text(mutated)
+            result = self.run_contract(package_validator=package_validator)
+        self.assertNotEqual(result.returncode, 0, f"contract accepted {name} mutation")
+        self.assertIn(
+            f"deb source contract: {expected_diagnostic}",
+            result.stderr,
+            f"contract did not diagnose {name} mutation",
+        )
+
+    def assert_package_validator_line_mutations_rejected(
+        self,
+        name: str,
+        needle: str,
+        spoof: str,
+        expected_diagnostic: str,
+        **kwargs: object,
+    ) -> None:
+        mutations = {
+            "removed": "",
+            "commented": f"# {needle}",
+            "spoofed": spoof,
+        }
+        for mutation, replacement in mutations.items():
+            with self.subTest(operation=name, mutation=mutation):
+                self.assert_package_validator_mutation_rejected(
+                    f"{mutation} {name}",
+                    needle,
+                    replacement,
+                    expected_diagnostic,
+                    **kwargs,
+                )
+
+    def run_contract_with_package_validator_text(
+        self, text: str
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory(prefix="facelock-deb-source-contract-") as temp:
+            package_validator = pathlib.Path(temp) / "pkg-validate.sh"
+            package_validator.write_text(text)
+            return self.run_contract(package_validator=package_validator)
+
+    def test_packaged_profile_verifier_identifier_has_one_canonical_topology(self) -> None:
+        original = PACKAGE_VALIDATOR.read_text()
+        function_start = original.index("verify_debian_packaged_pam_profile() {\n")
+        function_end = original.index("\n}\n", function_start) + len("\n}\n")
+        extra_occurrences = {
+            "exact duplicate": "\nverify_debian_packaged_pam_profile() {\n    :\n}\n",
+            "trailing-comment signature": (
+                "\nverify_debian_packaged_pam_profile() { # later override\n"
+                "    :\n"
+                "}\n"
+            ),
+            "split-line signature": (
+                "\nverify_debian_packaged_pam_profile()\n"
+                "{\n"
+                "    :\n"
+                "}\n"
+            ),
+            "function-form signature": (
+                "\nfunction verify_debian_packaged_pam_profile {\n"
+                "    :\n"
+                "}\n"
+            ),
+            "eval string": (
+                "\neval 'verify_debian_packaged_pam_profile() { :; }'\n"
+            ),
+            "comment": "\n# verify_debian_packaged_pam_profile() {\n# }\n",
+            "command comment": (
+                "\ntrue # verify_debian_packaged_pam_profile() {\n"
+                "true # }\n"
+            ),
+        }
+        diagnostic = (
+            "deb source contract: packaged PAM profile verifier identifier must occur "
+            "exactly at its canonical definition, export, and invocation"
+        )
+        for name, extra in extra_occurrences.items():
+            with self.subTest(extra=name):
+                mutated = original[:function_end] + extra + original[function_end:]
+                result = self.run_contract_with_package_validator_text(mutated)
+                self.assertNotEqual(
+                    result.returncode,
+                    0,
+                    f"contract accepted extra packaged-profile identifier in {name}",
+                )
+                self.assertIn(diagnostic, result.stderr)
+
+    def test_packaged_profile_reinstall_must_be_an_executable_full_line(self) -> None:
+        self.assert_package_validator_line_mutations_rejected(
+            "exact package reinstall",
+            "    apt-get install -y --reinstall /facelock-test-package.deb || failed=1\n",
+            "    true # apt-get install -y --reinstall /facelock-test-package.deb || failed=1\n",
+            "packaged PAM profile verifier must execute exactly one full-line reinstall",
+        )
+
+    def test_packaged_profile_pass_label_must_invoke_verifier_directly(self) -> None:
+        self.assert_package_validator_line_mutations_rejected(
+            "direct verifier invocation",
+            '        "verify_debian_packaged_pam_profile"\n',
+            "        true # verify_debian_packaged_pam_profile\n",
+            "packaged PAM profile PASS label must invoke its verifier directly",
+            scope="file",
+        )
+
+    def test_packaged_profile_state_blocks_require_real_systemd_guards(self) -> None:
+        guard = "    if [ -d /run/systemd/system ]; then\n"
+        for occurrence, phase in ((1, "before"), (2, "after")):
+            self.assert_package_validator_line_mutations_rejected(
+                f"real {phase}-reinstall systemd guard",
+                guard,
+                "    if false; then # [ -d /run/systemd/system ]\n",
+                "packaged PAM profile verifier must use exact systemd guards",
+                occurrence=occurrence,
+                expected_count=2,
+            )
+
+    def test_packaged_profile_state_captures_are_failure_checked(self) -> None:
+        captures = {
+            "expected ActiveState": (
+                '        if ! active_before="$(systemctl show --property=ActiveState '
+                '--value facelock-daemon.service 2>/dev/null)"; then\n',
+                '        active_before="$(systemctl is-active facelock-daemon '
+                '2>/dev/null || true)"\n',
+            ),
+            "expected UnitFileState": (
+                '        if ! enabled_before="$(systemctl show --property=UnitFileState '
+                '--value facelock-daemon.service 2>/dev/null)"; then\n',
+                '        enabled_before="$(systemctl is-enabled facelock-daemon '
+                '2>/dev/null || true)"\n',
+            ),
+            "actual ActiveState": (
+                '        if ! active_after="$(systemctl show --property=ActiveState '
+                '--value facelock-daemon.service 2>/dev/null)"; then\n',
+                '        active_after="$(systemctl is-active facelock-daemon '
+                '2>/dev/null || true)"\n',
+            ),
+            "actual UnitFileState": (
+                '        if ! enabled_after="$(systemctl show --property=UnitFileState '
+                '--value facelock-daemon.service 2>/dev/null)"; then\n',
+                '        enabled_after="$(systemctl is-enabled facelock-daemon '
+                '2>/dev/null || true)"\n',
+            ),
+        }
+        for phase, (needle, spoof) in captures.items():
+            self.assert_package_validator_line_mutations_rejected(
+                f"failure-checked {phase} capture",
+                needle,
+                spoof,
+                "packaged PAM profile verifier must failure-check nonempty state "
+                "and emit labeled diagnostics",
+            )
+
+    def test_packaged_profile_state_captures_must_reject_empty_output(self) -> None:
+        checks = (
+            '        elif [ -z "$active_before" ]; then\n',
+            '        elif [ -z "$enabled_before" ]; then\n',
+            '        elif [ -z "$active_after" ]; then\n',
+            '        elif [ -z "$enabled_after" ]; then\n',
+        )
+        for check in checks:
+            self.assert_package_validator_line_mutations_rejected(
+                f"nonempty check {check.strip()}",
+                check,
+                f"        elif false; then # {check.strip()}\n",
+                "packaged PAM profile verifier must failure-check nonempty state "
+                "and emit labeled diagnostics",
+            )
+
+    def test_packaged_profile_state_comparisons_cannot_be_fixed_or_vacuous(self) -> None:
+        comparisons = {
+            "ActiveState": (
+                '        elif [ "$active_after" != "$active_before" ]; then\n',
+                "        elif false; then # fixed inactive state\n",
+            ),
+            "UnitFileState": (
+                '        elif [ "$enabled_after" != "$enabled_before" ]; then\n',
+                "        elif false; then # fixed disabled state\n",
+            ),
+        }
+        for property_name, (needle, spoof) in comparisons.items():
+            self.assert_package_validator_line_mutations_rejected(
+                f"exact {property_name} comparison",
+                needle,
+                spoof,
+                "packaged PAM profile verifier must failure-check nonempty state "
+                "and emit labeled diagnostics",
+            )
+
+    def test_packaged_profile_state_failures_emit_labeled_diagnostics(self) -> None:
+        diagnostics = (
+            "            printf '%s\\n' 'packaged PAM profile reinstall ActiveState: "
+            "expected=<nonempty-before> actual=<command-error>' >&2\n",
+            "            printf '%s\\n' 'packaged PAM profile reinstall UnitFileState: "
+            "expected=<nonempty-before> actual=<empty>' >&2\n",
+            "            printf 'packaged PAM profile reinstall ActiveState: expected=%s "
+            "actual=<command-error>\\n' \"$active_before\" >&2\n",
+            "            printf 'packaged PAM profile reinstall UnitFileState: expected=%s "
+            "actual=%s\\n' \"$enabled_before\" \"$enabled_after\" >&2\n",
+        )
+        for diagnostic in diagnostics:
+            self.assert_package_validator_line_mutations_rejected(
+                f"labeled diagnostic {diagnostic.strip()}",
+                diagnostic,
+                f"            : # {diagnostic.strip()}\n",
+                "packaged PAM profile verifier must failure-check nonempty state "
+                "and emit labeled diagnostics",
+            )
+
+    def test_packaged_profile_state_failures_remain_failed(self) -> None:
+        failure = "            failed=1\n"
+        for occurrence in (1, 4, 5, 10):
+            self.assert_package_validator_line_mutations_rejected(
+                f"failed state result {occurrence}",
+                failure,
+                "            true # failed=1\n",
+                "packaged PAM profile verifier must failure-check nonempty state "
+                "and emit labeled diagnostics",
+                occurrence=occurrence,
+                expected_count=10,
+            )
+
+    def test_required_lifecycle_operations_cannot_be_removed_or_commented(self) -> None:
+        operations = {
+            "authoritative enrollment snapshot": (
+                "    snapshot_enrollment_database_state\n",
+                "Debian lifecycle must snapshot authoritative enrollment rows "
+                "across versioned upgrades",
+            ),
+            "enrollment marker snapshot": (
+                "    snapshot_enrollment_marker "
+                "/var/lib/facelock/enrolled/testuser\n",
+                "Debian lifecycle must snapshot enrollment-marker semantics "
+                "across versioned upgrades",
+            ),
+            "authoritative model insert": (
+                "connection.execute(\n"
+                '    "INSERT INTO face_models "\n'
+                '    "(user, label, created_at, embedder_model, device_id) "\n'
+                '    "VALUES (?, ?, ?, ?, ?)",\n'
+                '    ("testuser", "lifecycle-retained", 1700000000, "", None),\n'
+                ")\n",
+                "Debian retained-state fixture must seed an authoritative enrolled model",
+            ),
+            "model embedding insert": (
+                "connection.execute(\n"
+                '    "INSERT INTO face_embeddings (model_id, embedding, sealed) '
+                'VALUES (?, ?, ?)",\n'
+                "    (model_id, embedding, 0),\n"
+                ")\n",
+                "Debian retained-state fixture must seed the enrolled model embedding",
+            ),
+            "deterministic embedding construction": (
+                'embedding = struct.pack("<512f", *((index + 1) / 512 '
+                "for index in range(512)))\n",
+                "Debian retained-state fixture must seed deterministic nonzero "
+                "embedding data",
+            ),
+            "authoritative model count": (
+                "model_count = connection.execute(\n"
+                '    "SELECT COUNT(*) FROM face_models"\n'
+                ").fetchone()[0]\n",
+                "Debian enrollment snapshot must count authoritative model rows "
+                "separately",
+            ),
+            "embedding row count": (
+                "embedding_count = connection.execute(\n"
+                '    "SELECT COUNT(*) FROM face_embeddings"\n'
+                ").fetchone()[0]\n",
+                "Debian enrollment snapshot must count embedding rows separately",
+            ),
+            "separate enrollment row cardinality assertion": (
+                "if (model_count, embedding_count) != (1, 1):\n",
+                "Debian enrollment snapshot must enforce separate authoritative "
+                "row counts",
+            ),
+            "expected embedding digest": (
+                "expected_embedding_digest = (\n"
+                '    "82a0081de4c338fc91c362ed4d2ab615bca1dd45152aaa713322b5482078ddee"\n'
+                ")\n",
+                "Debian enrollment snapshot must assert the deterministic "
+                "embedding digest",
+            ),
+            "embedding digest comparison": (
+                "if embedding_digest != expected_embedding_digest:\n",
+                "Debian enrollment snapshot must compare the deterministic "
+                "embedding digest",
+            ),
+            "exact integer marker model count": (
+                'if type(marker["models"]) is not int or marker["models"] != 1:\n',
+                "Debian enrollment snapshot must require an exact integer marker "
+                "model count",
+            ),
+        }
+        for operation, (needle, diagnostic) in operations.items():
+            for mutation in ("removed", "commented"):
+                with self.subTest(operation=operation, mutation=mutation):
+                    if mutation == "removed":
+                        replacement = ""
+                    else:
+                        replacement = "".join(
+                            f"# {line}" if line else "#\n"
+                            for line in needle.splitlines(keepends=True)
+                        )
+                    self.assert_mutation_rejected(
+                        f"{mutation} {operation}",
+                        needle,
+                        replacement,
+                        diagnostic,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/deb-source-contract.sh
+++ b/test/deb-source-contract.sh
@@ -31,13 +31,51 @@ grep -Eq '^Default:[[:space:]]*no[[:space:]]*$' debian/pam-auth-update ||
     fail "Debian pam-auth-update profile must be opt-in"
 grep -Fq 'pam-auth-update --package' debian/postinst ||
     fail "Debian postinst must register/update the opt-in PAM profile"
-grep -Fq 'pam-auth-update --remove facelock' debian/prerm ||
-    fail "Debian prerm must retire the packaged PAM profile"
+if grep -Eq 'systemd-tmpfiles[[:space:]].*--create' debian/postinst; then
+    fail "Debian source postinst must leave package-scoped tmpfiles activation to dh_installtmpfiles"
+fi
+[ "$(grep -Foc '#DEBHELPER#' debian/postinst)" -eq 1 ] ||
+    fail "Debian postinst must contain exactly one debhelper substitution marker"
+grep -Fq 'systemctl is-active --quiet facelock-daemon.service' debian/postinst ||
+    fail "Debian postinst must distinguish an already-active daemon"
+grep -Fq 'systemctl try-restart facelock-daemon.service' debian/postinst ||
+    fail "Debian postinst must restart only an already-active daemon"
+grep -Fq 'facelock pam shared-profile-status' debian/prerm ||
+    fail "Debian prerm must refuse removal while the shared profile is selected"
+if grep -Fq 'pam-auth-update --remove facelock' debian/prerm; then
+    fail "Debian prerm must not silently disable an administrator-selected shared profile"
+fi
+grep -Fq 'facelock pam remove --all --dry-run' debian/prerm ||
+    fail "Debian prerm must preflight direct PAM cleanup before any mutation"
 grep -Fq 'facelock pam remove --all' debian/prerm ||
     fail "Debian prerm must delegate direct-edit cleanup to pam remove --all"
 if grep -Eq 'FACELOCK_PAM_SERVICES=|sed -i .pam_facelock' debian/prerm; then
     fail "Debian prerm must not carry a fixed PAM service list or raw sed cleanup"
 fi
+profile_probe_line="$(grep -n -m1 -F 'facelock pam shared-profile-status' debian/prerm | cut -d: -f1)"
+cleanup_preflight_line="$(grep -n -m1 -F 'facelock pam remove --all --dry-run' debian/prerm | cut -d: -f1)"
+cleanup_line="$(grep -n -F 'facelock pam remove --all' debian/prerm | tail -n1 | cut -d: -f1)"
+debhelper_line="$(grep -n -m1 -Fx '#DEBHELPER#' debian/prerm | cut -d: -f1)"
+if grep -Eq 'systemctl[[:space:]]+(stop|disable)[[:space:]]+facelock-daemon' debian/prerm; then
+    fail "Debian source prerm must delegate service stop and purge state to debhelper"
+fi
+[ "$(grep -Foc '#DEBHELPER#' debian/prerm)" -eq 1 ] ||
+    fail "Debian prerm must contain exactly one debhelper substitution marker"
+[ "$profile_probe_line" -lt "$cleanup_preflight_line" ] &&
+    [ "$cleanup_preflight_line" -lt "$cleanup_line" ] &&
+    [ "$cleanup_line" -lt "$debhelper_line" ] ||
+    fail "Debian prerm must probe, preflight and clean PAM before generated service lifecycle handling"
+
+grep -Fq 'dh_installsystemd --no-enable --no-start' debian/rules ||
+    fail "Debian build must keep fresh installs disabled and inactive"
+grep -Fq "deb-systemd-invoke stop 'facelock-daemon.service'" debian/rules ||
+    fail "Debian build must probe for the exact generated daemon stop"
+grep -Fq '/usr/share/debhelper/autoscripts/prerm-systemd-restart' debian/rules ||
+    fail "Debian build must reuse debhelper's canonical remove-stop template"
+grep -Fq 'debian/.debhelper/generated/facelock/prerm.*' debian/rules ||
+    fail "Debian build must detect modern generated prerm fragments before adding a compatibility stop"
+grep -Fq "s/#UNITFILES#/'facelock-daemon.service'/" debian/rules ||
+    fail "Debian compatibility stop must remain scoped to the exact daemon unit"
 
 [ ! -e dist/debian ] || fail "retired dist/debian metadata still exists"
 [ ! -e debian/compat ] || fail "debhelper compat must be declared once, in Build-Depends"
@@ -194,8 +232,41 @@ grep -Fq 'PAM module executes through the synthetic service' test/pkg-validate.s
     fail "package validation must prove pam_facelock executes, not accept a generic PAM failure"
 grep -Fq 'missing PAM module control is rejected' test/pkg-validate.sh ||
     fail "package validation must prove its PAM execution assertion rejects a missing module"
-grep -Fq 'packaged opt-in PAM profile enables, falls back to password, and restores common-auth' test/pkg-validate.sh ||
+grep -Fq 'packaged opt-in PAM profile survives reinstall, falls back to password, and restores common-auth' test/pkg-validate.sh ||
     fail "Debian package validation must exercise the shipped pam-auth-update profile"
+grep -Fq 'active administrator-selected profile blocks removal, preserves PAM, and allows verified migration retry' test/pkg-validate.sh ||
+    fail "Debian package validation must preserve selected shared profiles across removal refusal"
+active_profile_guard_line="$(grep -n -m1 -F '"active administrator-selected profile blocks removal, preserves PAM, and allows verified migration retry"' test/pkg-validate.sh | cut -d: -f1)"
+active_profile_guard_invocation_line="$(grep -n -m1 -Fx \
+    '        "verify_debian_active_profile_removal_guard"' test/pkg-validate.sh |
+    cut -d: -f1 || true)"
+[ -n "$active_profile_guard_invocation_line" ] &&
+    [ "$active_profile_guard_invocation_line" -eq "$((active_profile_guard_line + 1))" ] ||
+    fail "active-profile removal PASS label must invoke the checked guard directly"
+# Match the runner's literal variable spelling, not this contract's value.
+# shellcheck disable=SC2016
+blocker_create_line="$(grep -n -m1 -F 'cat > "$PACKAGE_BLOCKER_PAM"' test/pkg-validate.sh | cut -d: -f1)"
+[ "$active_profile_guard_invocation_line" -lt "$blocker_create_line" ] ||
+    fail "active-profile removal validation must run before creating the unmanaged blocker"
+removal_guard_body="$(sed -n '/^verify_debian_active_profile_removal_guard()/,/^}/p' test/pkg-validate.sh)"
+printf '%s\n' "$removal_guard_body" | grep -Fq 'facelock pam shared-profile-status' ||
+    fail "active-profile removal validation must assert the profile-specific status"
+printf '%s\n' "$removal_guard_body" | grep -Fq 'refusing package removal because the pam-auth-update profile is active' ||
+    fail "active-profile removal validation must assert the profile-specific diagnostic"
+printf '%s\n' "$removal_guard_body" | grep -Fq 'common-auth-removal.active.metadata' ||
+    fail "active-profile removal validation must preserve common-auth metadata"
+printf '%s\n' "$removal_guard_body" | grep -Fq 'pam-state-removal.active.metadata' ||
+    fail "active-profile removal validation must preserve pam-auth-update state metadata"
+disable_profile_line="$(printf '%s\n' "$removal_guard_body" |
+    grep -n -m1 -F 'pam-auth-update --disable facelock --force' | cut -d: -f1)"
+verify_password_line="$(printf '%s\n' "$removal_guard_body" |
+    grep -n -m1 -F 'pamtester facelock-profile-removal-test testuser authenticate' | cut -d: -f1)"
+[ "$disable_profile_line" -lt "$verify_password_line" ] ||
+    fail "Debian removal validation must test passwords after disabling the shared profile"
+grep -Fq 'Debian reinstall restarts only active daemons and preserves enabled state' test/pkg-validate.sh ||
+    fail "Debian package validation must exercise active/inactive and enabled/disabled reinstall state"
+grep -Fq 'ordinary Debian remove preserves enabled state across reinstall' test/pkg-validate.sh ||
+    fail "Debian package validation must prove ordinary removal preserves service enablement"
 grep -Fq 'pam-auth-update --enable facelock --force' test/pkg-validate.sh ||
     fail "Debian package validation must enable the packaged profile through pam-auth-update"
 grep -Fq 'pam-auth-update --disable facelock --force' test/pkg-validate.sh ||

--- a/test/deb-source-contract.sh
+++ b/test/deb-source-contract.sh
@@ -5,6 +5,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 control_path="${FACELOCK_DEBIAN_CONTROL:-debian/control}"
 workflow_path="${FACELOCK_RELEASE_WORKFLOW:-.github/workflows/release.yml}"
+lifecycle_path="${FACELOCK_DEB_LIFECYCLE:-test/deb-package-lifecycle.sh}"
+package_validator_path="${FACELOCK_PACKAGE_VALIDATOR:-test/pkg-validate.sh}"
 
 fail() {
     echo "deb source contract: $*" >&2
@@ -36,6 +38,11 @@ if grep -Eq 'systemd-tmpfiles[[:space:]].*--create' debian/postinst; then
 fi
 [ "$(grep -Foc '#DEBHELPER#' debian/postinst)" -eq 1 ] ||
     fail "Debian postinst must contain exactly one debhelper substitution marker"
+[ -x debian/postrm ] || fail "Debian postrm must be executable"
+[ "$(grep -Foc '#DEBHELPER#' debian/postrm)" -eq 1 ] ||
+    fail "Debian postrm must contain exactly one debhelper substitution marker"
+grep -Fq 'facelock_renameat2_syscall=316' debian/postrm ||
+    fail "Debian postrm must carry the audited amd64 no-replace purge helper"
 grep -Fq 'systemctl is-active --quiet facelock-daemon.service' debian/postinst ||
     fail "Debian postinst must distinguish an already-active daemon"
 grep -Fq 'systemctl try-restart facelock-daemon.service' debian/postinst ||
@@ -88,6 +95,8 @@ compat_count="$(grep -Eic 'debhelper-compat[[:space:]]*\(=[[:space:]]*13\)' "$co
 [ "$compat_count" -eq 1 ] || fail "expected exactly one debhelper-compat (= 13) declaration"
 grep -Eq '^Rules-Requires-Root:[[:space:]]*no[[:space:]]*$' "$control_path" ||
     fail "debian/control must declare Rules-Requires-Root: no"
+grep -Eq '^Architecture:[[:space:]]*amd64[[:space:]]*$' "$control_path" ||
+    fail "raw postrm renameat2 syscall must remain bound to amd64"
 [ "$(tr -d '\r\n' < debian/source/format)" = "3.0 (quilt)" ] ||
     fail "debian/source/format must be 3.0 (quilt)"
 
@@ -207,6 +216,8 @@ for helper in \
     test/prepare-deb-test-context.sh \
     test/run-deb-offline-build.sh \
     test/build-deb-package-image.sh \
+    test/deb-dependency-closure.sh \
+    test/deb-package-lifecycle.sh \
     test/verify-deb-test-context.sh \
     test/deb-maintscript-contract.sh \
     test/cargo-vendor-contract.sh \
@@ -214,6 +225,20 @@ for helper in \
     test/publish-directory-atomic.py; do
     [ -x "$helper" ] || fail "$helper must be an executable package-gate helper"
 done
+
+grep -Eq '^FROM \$\{BASE_IMAGE\} AS dependency-closure$' \
+    test/Containerfile.deb-runtime ||
+    fail "Debian runtime fixture must expose a clean-base dependency-closure stage"
+# shellcheck disable=SC2016
+dependency_stage="$(sed -n \
+    '/^FROM \${BASE_IMAGE} AS dependency-closure$/,/^FROM \${BASE_IMAGE} AS runtime$/p' \
+    test/Containerfile.deb-runtime)"
+if printf '%s\n' "$dependency_stage" | grep -Eq 'apt-get[[:space:]]+install'; then
+    fail "Debian dependency-closure stage must not preinstall candidate dependencies"
+fi
+grep -Fq 'COPY test/deb-dependency-closure.sh /deb-dependency-closure.sh' \
+    test/Containerfile.deb-runtime ||
+    fail "Debian clean-base stage must include its exact-artifact closure probe"
 
 for containerfile in \
     test/Containerfile.deb-assemble \
@@ -226,14 +251,321 @@ grep -Fq 'path-include=/usr/share/doc/facelock/**' test/Containerfile.deb-runtim
     fail "Debian runtime fixture must preserve Facelock legal/provenance documents"
 grep -Fq '> /etc/dpkg/dpkg.cfg.d/zz-facelock-test-docs' test/Containerfile.deb-runtime ||
     fail "Debian runtime fixture's Facelock include must sort after base-image exclusions"
-grep -Fq '/facelock-common-auth-install-invariant' test/Containerfile.deb-runtime ||
-    fail "Debian runtime fixture must prove fresh install leaves common-auth unchanged"
+grep -Fq 'COPY test/deb-package-lifecycle.sh /deb-package-lifecycle.sh' \
+    test/Containerfile.deb-runtime ||
+    fail "Debian runtime fixture must include the exact-artifact lifecycle helper"
+if grep -Eq 'COPY[[:space:]]+facelock-test-package\.deb|apt-get[[:space:]]+install[[:space:]].*/facelock-test-package\.deb' \
+    test/Containerfile.deb-runtime; then
+    fail "Debian runtime fixture must not bake in or preinstall the candidate package"
+fi
+for lifecycle_phase in \
+    install-remove-reinstall \
+    versioned-upgrade-inactive \
+    versioned-upgrade-active \
+    purge; do
+    grep -Fq "/deb-package-lifecycle.sh $lifecycle_phase" \
+        test/run-pkg-validate-systemd.sh ||
+        fail "booted package runner must execute Debian lifecycle phase: $lifecycle_phase"
+done
+grep -Fq -- '--target dependency-closure' test/build-deb-package-image.sh ||
+    fail "Debian builder must materialize the clean dependency-closure stage"
+# shellcheck disable=SC2016
+grep -Fq '"$dependency_image" /deb-dependency-closure.sh' \
+    test/build-deb-package-image.sh ||
+    fail "Debian builder must validate dependency closure before the harness image"
+# Match literal runner/build-helper source, not values in this contract.
+# shellcheck disable=SC2016
+grep -Fq '$PACKAGE:/facelock-test-package.deb:ro,Z' \
+    test/run-pkg-validate-systemd.sh ||
+    fail "booted Debian runner must bind the exact package read-only"
+# shellcheck disable=SC2016
+grep -Fq 'install -m 0444 -- "$artifact_dir/$package_name" "$package_output"' \
+    test/build-deb-package-image.sh ||
+    fail "Debian builder must emit a non-writable exact package for runtime binding"
+# shellcheck disable=SC2016
+grep -Fq -- '--target "$PACKAGE"' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must verify that its candidate artifact is a mount"
+# shellcheck disable=SC2016
+grep -Fq 'apt_transaction install -y --no-install-recommends "$PACKAGE"' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must install the exact runtime-bound package through APT"
+grep -Fq 'snapshot_retained_state' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must compare retained state across ordinary removal and reinstall"
+grep -Fq '/var/lib/facelock/pam-backups/lifecycle-retained-provenance' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must preserve a non-empty PAM provenance directory on remove"
+grep -Fq 'apt_transaction purge -y facelock' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must exercise the native package purge transaction"
+# shellcheck disable=SC2016
+grep -Fq 'lower_version="${candidate_version}~facelock.${label_token}"' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must derive a controlled lower version from the candidate"
+# shellcheck disable=SC2016
+grep -Fq 'dpkg --compare-versions "$lower_version" lt "$candidate_version"' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must prove its upgrade seed sorts below the candidate"
+grep -Fq 'versioned upgrade preserves active/inactive and enabled/disabled state' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must exercise the four genuine service-upgrade states"
+upgrade_snapshot_body="$(sed -n \
+    '/^snapshot_versioned_upgrade_state()/,/^}/p' \
+    "$lifecycle_path")"
+printf '%s\n' "$upgrade_snapshot_body" |
+    grep -Eq '^[[:space:]]*snapshot_enrollment_database_state[[:space:]]*$' ||
+    fail "Debian lifecycle must snapshot authoritative enrollment rows across versioned upgrades"
+printf '%s\n' "$upgrade_snapshot_body" |
+    grep -Eq '^[[:space:]]*snapshot_enrollment_marker /var/lib/facelock/enrolled/testuser[[:space:]]*$' ||
+    fail "Debian lifecycle must snapshot enrollment-marker semantics across versioned upgrades"
+retained_state_body="$(sed -n \
+    '/^create_retained_state()/,/^}/p' \
+    "$lifecycle_path")"
+printf '%s\n' "$retained_state_body" |
+    grep -Eq '^[[:space:]]*"INSERT INTO face_models "[[:space:]]*$' ||
+    fail "Debian retained-state fixture must seed an authoritative enrolled model"
+printf '%s\n' "$retained_state_body" |
+    grep -Eq '^[[:space:]]*"INSERT INTO face_embeddings \(model_id, embedding, sealed\) VALUES \(\?, \?, \?\)",[[:space:]]*$' ||
+    fail "Debian retained-state fixture must seed the enrolled model embedding"
+printf '%s\n' "$retained_state_body" |
+    grep -Eq '^[[:space:]]*embedding = struct\.pack\("<512f", .*range\(512\).*\)[[:space:]]*$' ||
+    fail "Debian retained-state fixture must seed deterministic nonzero embedding data"
+database_snapshot_body="$(sed -n \
+    '/^snapshot_enrollment_database_state()/,/^}/p' \
+    "$lifecycle_path")"
+printf '%s\n' "$database_snapshot_body" |
+    grep -Eq '^[[:space:]]*"SELECT COUNT\(\*\) FROM face_models"[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must count authoritative model rows separately"
+printf '%s\n' "$database_snapshot_body" |
+    grep -Eq '^[[:space:]]*"SELECT COUNT\(\*\) FROM face_embeddings"[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must count embedding rows separately"
+printf '%s\n' "$database_snapshot_body" |
+    grep -Eq '^[[:space:]]*if \(model_count, embedding_count\) != \(1, 1\):[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must enforce separate authoritative row counts"
+printf '%s\n' "$database_snapshot_body" |
+    grep -Eq '^[[:space:]]*"82a0081de4c338fc91c362ed4d2ab615bca1dd45152aaa713322b5482078ddee"[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must assert the deterministic embedding digest"
+printf '%s\n' "$database_snapshot_body" |
+    grep -Eq '^[[:space:]]*if embedding_digest != expected_embedding_digest:[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must compare the deterministic embedding digest"
+marker_snapshot_body="$(sed -n \
+    '/^snapshot_enrollment_marker()/,/^}/p' \
+    "$lifecycle_path")"
+printf '%s\n' "$marker_snapshot_body" |
+    grep -Eq '^[[:space:]]*if type\(marker\["models"\]\) is not int or marker\["models"\] != 1:[[:space:]]*$' ||
+    fail "Debian enrollment snapshot must require an exact integer marker model count"
+grep -Fq 'restore_validator_service_baseline' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must restore the validator service baseline after its upgrade matrix"
+# shellcheck disable=SC2016
+grep -Fq 'Unpacking facelock ($candidate_version) over ($lower_version)' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must prove APT performed a versioned upgrade"
+grep -Fq 'assert_trusted_inert_anchor' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must verify trusted inert purge-root anchors"
+grep -Fq 'assert_absent_or_trusted_inert_anchor /etc/facelock 755' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must accept only absent-or-trusted native conffile root state"
+grep -Fq 'assert_no_purge_eligible_children' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject any purge-eligible child left below an anchor"
+grep -Fq 'fixed root crosses its parent device' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject a fixed-root device crossing"
+grep -Fq 'fixed root is a mount point' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject a fixed-root mount crossing"
+grep -Fq 'opaque PAM rollback remnant is hard-linked' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject linked opaque PAM rollback state"
+# shellcheck disable=SC2016
+grep -Fq 'snapshot_file "$PAM_RETAINED"' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must preserve opaque non-empty PAM rollback state on purge"
+# shellcheck disable=SC2016
+grep -Fq 'snapshot_file "$EXTERNAL_SENTINEL"' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must preserve external state byte-for-byte on purge"
+for purge_root in /etc/facelock /var/lib/facelock /var/log/facelock; do
+    grep -Fq "$purge_root" test/deb-package-lifecycle.sh ||
+        fail "Debian lifecycle must assert the fixed purge root: $purge_root"
+done
+grep -Fq 'compare_control_archives' test/run-deb-offline-build.sh ||
+    fail "offline Debian rebuild must compare release and rebuilt control archives"
+grep -Fq 'write_data_archive_inventory' test/run-deb-offline-build.sh ||
+    fail "offline Debian rebuild must compare data archive mode/UID/GID metadata"
+grep -Fq 'assert_installed_payload_metadata' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must compare installed ownership/modes with the candidate archive"
+grep -Fq 'package data is group/world writable' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject unsafe writable package payload metadata"
+grep -Fq 'installed package file bytes differ from archive' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must compare every installed regular file with the archive bytes"
+grep -Fq 'dpkg package list differs from data archive' test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must prove dpkg list parity with the candidate data archive"
+grep -Fq 'dpkg does not attribute package payload to facelock' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must prove dpkg ownership for every candidate payload entry"
+grep -Fq 'base-files, libc6:amd64, facelock: /etc' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must regression-test shared parent directory ownership"
+grep -Fq 'base-files, libc6:amd64: /etc' \
+    test/deb-package-lifecycle.sh ||
+    fail "Debian lifecycle must reject shared parent ownership without Facelock"
+# shellcheck disable=SC2016
+grep -Fq 'deb-package-contract.sh" "$rebuilt_deb"' test/run-deb-offline-build.sh ||
+    fail "offline Debian rebuild must validate its generated control archive"
 grep -Fq 'PAM module executes through the synthetic service' test/pkg-validate.sh ||
     fail "package validation must prove pam_facelock executes, not accept a generic PAM failure"
 grep -Fq 'missing PAM module control is rejected' test/pkg-validate.sh ||
     fail "package validation must prove its PAM execution assertion rejects a missing module"
+grep -Fq 'run_test "facelock-polkit-agent binary is installed"' test/pkg-validate.sh ||
+    fail "package validation must require the shipped polkit agent"
+grep -Fq 'run_test "quirks database files are installed"' test/pkg-validate.sh ||
+    fail "package validation must require the shipped quirks database"
+# shellcheck disable=SC2016
+grep -Fq 'UNEXPECTED_SKIP=$((SKIP - ALLOWED_SKIP))' test/pkg-validate.sh ||
+    fail "mandatory package validation must classify every non-opted-out skip as failure"
+grep -Fq 'allowed-partial' test/pkg-validate.sh ||
+    fail "package validation must distinguish explicit model-only partial skips"
+grep -Fq 'unexpected skip(s) make package validation incomplete' test/pkg-validate.sh ||
+    fail "package validation must fail loudly on unexpected skipped coverage"
+grep -Fq 'Any other skipped assertion fails package validation.' docs/security.md ||
+    fail "security documentation must state the mandatory no-skip package policy"
 grep -Fq 'packaged opt-in PAM profile survives reinstall, falls back to password, and restores common-auth' test/pkg-validate.sh ||
     fail "Debian package validation must exercise the shipped pam-auth-update profile"
+python3 - "$package_validator_path" <<'PY'
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"deb source contract: {message}")
+
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+lines = text.splitlines()
+identifier = "verify_debian_packaged_pam_profile"
+definition = "verify_debian_packaged_pam_profile() {"
+export = (
+    "export -f verify_debian_packaged_pam_profile "
+    "verify_debian_active_profile_removal_guard"
+)
+invocation = '        "verify_debian_packaged_pam_profile"'
+definition_lines = [index for index, line in enumerate(lines) if line == definition]
+export_lines = [index for index, line in enumerate(lines) if line == export]
+invocation_lines = [index for index, line in enumerate(lines) if line == invocation]
+if len(invocation_lines) != 1:
+    fail("packaged PAM profile PASS label must invoke its verifier directly")
+if (
+    text.count(identifier) != 3
+    or len(definition_lines) != 1
+    or len(export_lines) != 1
+):
+    fail(
+        "packaged PAM profile verifier identifier must occur exactly at its "
+        "canonical definition, export, and invocation"
+    )
+helper_start = definition_lines[0]
+# Nested command-group closing braces in this helper are indented. Under that
+# enforced topology, its first unindented full-line brace is the matching close.
+closing_lines = [
+    index
+    for index in range(helper_start + 1, len(lines))
+    if lines[index] == "}"
+]
+if not closing_lines:
+    fail("Debian package validation must define the packaged PAM profile verifier")
+helper_end = closing_lines[0]
+helper = lines[helper_start : helper_end + 1]
+
+reinstall = "    apt-get install -y --reinstall /facelock-test-package.deb || failed=1"
+reinstall_lines = [index for index, line in enumerate(helper) if line == reinstall]
+if len(reinstall_lines) != 1:
+    fail("packaged PAM profile verifier must execute exactly one full-line reinstall")
+reinstall_line = reinstall_lines[0]
+
+label = (
+    '    run_test "packaged opt-in PAM profile survives reinstall, falls back to '
+    'password, and restores common-auth" ' + chr(92)
+)
+label_lines = [index for index, line in enumerate(lines) if line == label]
+if (
+    len(label_lines) != 1
+    or invocation_lines[0] != label_lines[0] + 1
+):
+    fail("packaged PAM profile PASS label must invoke its verifier directly")
+
+guard = "    if [ -d /run/systemd/system ]; then"
+guard_lines = [index for index, line in enumerate(helper) if line == guard]
+if len(guard_lines) != 2:
+    fail("packaged PAM profile verifier must use exact systemd guards")
+
+state_diagnostic = (
+    "packaged PAM profile verifier must failure-check nonempty state and emit "
+    "labeled diagnostics"
+)
+
+
+def require_block(source: list[str], block: list[str]) -> int:
+    positions = [
+        index
+        for index in range(len(source) - len(block) + 1)
+        if source[index : index + len(block)] == block
+    ]
+    if len(positions) != 1:
+        fail(state_diagnostic)
+    return positions[0]
+
+
+before_active = """        if ! active_before="$(systemctl show --property=ActiveState --value facelock-daemon.service 2>/dev/null)"; then
+            printf '%s\\n' 'packaged PAM profile reinstall ActiveState: expected=<nonempty-before> actual=<command-error>' >&2
+            failed=1
+        elif [ -z "$active_before" ]; then
+            printf '%s\\n' 'packaged PAM profile reinstall ActiveState: expected=<nonempty-before> actual=<empty>' >&2
+            failed=1
+        fi""".splitlines()
+before_enabled = """        if ! enabled_before="$(systemctl show --property=UnitFileState --value facelock-daemon.service 2>/dev/null)"; then
+            printf '%s\\n' 'packaged PAM profile reinstall UnitFileState: expected=<nonempty-before> actual=<command-error>' >&2
+            failed=1
+        elif [ -z "$enabled_before" ]; then
+            printf '%s\\n' 'packaged PAM profile reinstall UnitFileState: expected=<nonempty-before> actual=<empty>' >&2
+            failed=1
+        fi""".splitlines()
+after_active = """        if ! active_after="$(systemctl show --property=ActiveState --value facelock-daemon.service 2>/dev/null)"; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=<command-error>\\n' "$active_before" >&2
+            failed=1
+        elif [ -z "$active_after" ]; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=<empty>\\n' "$active_before" >&2
+            failed=1
+        elif [ "$active_after" != "$active_before" ]; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=%s\\n' "$active_before" "$active_after" >&2
+            failed=1
+        fi""".splitlines()
+after_enabled = """        if ! enabled_after="$(systemctl show --property=UnitFileState --value facelock-daemon.service 2>/dev/null)"; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=<command-error>\\n' "$enabled_before" >&2
+            failed=1
+        elif [ -z "$enabled_after" ]; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=<empty>\\n' "$enabled_before" >&2
+            failed=1
+        elif [ "$enabled_after" != "$enabled_before" ]; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=%s\\n' "$enabled_before" "$enabled_after" >&2
+            failed=1
+        fi""".splitlines()
+
+before_active_line = require_block(helper, before_active)
+before_enabled_line = require_block(helper, before_enabled)
+after_active_line = require_block(helper, after_active)
+after_enabled_line = require_block(helper, after_enabled)
+
+
+def outer_guard_end(start: int) -> int:
+    try:
+        return helper.index("    fi", start + 1)
+    except ValueError:
+        fail("packaged PAM profile verifier must use exact systemd guards")
+
+
+before_guard, after_guard = guard_lines
+before_guard_end = outer_guard_end(before_guard)
+after_guard_end = outer_guard_end(after_guard)
+if not (
+    before_guard < before_active_line < before_enabled_line < before_guard_end
+    and reinstall_line == before_guard_end + 1
+    and reinstall_line < after_guard < after_active_line < after_enabled_line < after_guard_end
+):
+    fail("packaged PAM profile verifier must capture state around its exact reinstall")
+PY
 grep -Fq 'active administrator-selected profile blocks removal, preserves PAM, and allows verified migration retry' test/pkg-validate.sh ||
     fail "Debian package validation must preserve selected shared profiles across removal refusal"
 active_profile_guard_line="$(grep -n -m1 -F '"active administrator-selected profile blocks removal, preserves PAM, and allows verified migration retry"' test/pkg-validate.sh | cut -d: -f1)"
@@ -568,8 +900,13 @@ grep -Fq -- '--manifest' test/deb-package-contract.sh ||
 if grep -Fq 'sed "s#^#$OUTPUT_DIR/#"' .github/workflows/scripts/build-deb.sh; then
     fail "generated manifest must contain portable exact basenames, not build-host paths"
 fi
-grep -Fq 'bash test/deb-source-contract.sh' .github/workflows/release.yml ||
-    fail "release workflow must run the Debian source contract before packaging"
+for workflow in .github/workflows/ci.yml .github/workflows/release.yml; do
+    grep -Eq '^[[:space:]]*(run:[[:space:]]+)?just test-deb-source-contract[[:space:]]*$' "$workflow" ||
+        fail "$workflow must run the combined Debian source-contract target"
+    if grep -Eq '^[[:space:]]*(run:[[:space:]]+)?bash test/deb-source-contract\.sh[[:space:]]*$' "$workflow"; then
+        fail "$workflow must not bypass Debian source-contract mutation tests"
+    fi
+done
 grep -Fq 'bash test/deb-package-contract.sh --manifest' .github/workflows/release.yml ||
     fail "release workflow must validate the exact generated package manifest"
 # Match the literal workflow staging expression.
@@ -578,6 +915,14 @@ grep -Fq -- '--stage "$PWD/debian-upload"' .github/workflows/release.yml ||
     fail "release workflow must stage uploads only from the exact generated manifest"
 grep -Eq '^test-deb-source-contract:' justfile ||
     fail "justfile must expose the Debian source contract"
+deb_source_contract_recipe="$(sed -n \
+    '/^test-deb-source-contract:/,/^[^[:space:]#].*:/p' justfile)"
+printf '%s\n' "$deb_source_contract_recipe" |
+    grep -Eq '^[[:space:]]*bash test/deb-source-contract\.sh[[:space:]]*$' ||
+    fail "just Debian source-contract target must run the shell contract"
+printf '%s\n' "$deb_source_contract_recipe" |
+    grep -Eq '^[[:space:]]*python3 test/deb-source-contract-test\.py[[:space:]]*$' ||
+    fail "just Debian source-contract target must run mutation tests"
 grep -Eq '^test-deb-package-contract[[:space:]]+manifest:' justfile ||
     fail "justfile must expose manifest-driven Debian package validation"
 grep -Eq '^test-deb-package-contract-test:' justfile ||

--- a/test/debian-postrm-purge.sh
+++ b/test/debian-postrm-purge.sh
@@ -1,0 +1,1111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# CI's documentation container runs as root, while the maintainer script
+# deliberately disables its disposable-root override for privileged callers.
+# Re-exec the fixture matrix as the checkout owner (or nobody for a root-owned
+# checkout) so the production guard remains real.
+if [ "$(/usr/bin/id -u)" -eq 0 ] && [ -z "${FACELOCK_PURGE_TEST_REEXEC:-}" ]; then
+    test_uid="$(stat -c %u "$repo_root")"
+    test_gid="$(stat -c %g "$repo_root")"
+    if [ "$test_uid" -eq 0 ]; then
+        test_uid="$(/usr/bin/id -u nobody)"
+        test_gid="$(/usr/bin/id -g nobody)"
+    fi
+    exec /usr/bin/setpriv \
+        --reuid="$test_uid" \
+        --regid="$test_gid" \
+        --clear-groups \
+        env FACELOCK_PURGE_TEST_REEXEC=1 bash "$0" "$@"
+fi
+
+postrm="$repo_root/debian/postrm"
+tmp_root="$(mktemp -d)"
+failures=0
+
+cleanup() {
+    chmod -R u+rwx "$tmp_root" 2>/dev/null || true
+    rm -rf -- "$tmp_root"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    failures=$((failures + 1))
+}
+
+assert_exists() {
+    local path="$1"
+    local context="$2"
+
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        fail "$context: expected $path to remain"
+    fi
+}
+
+assert_absent() {
+    local path="$1"
+    local context="$2"
+
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        fail "$context: expected $path to be removed"
+    fi
+}
+
+assert_output_contains() {
+    local path="$1"
+    local expected="$2"
+    local context="$3"
+
+    if ! grep -Fq -- "$expected" "$path"; then
+        fail "$context: missing output: $expected"
+    fi
+}
+
+assert_output_not_contains() {
+    local path="$1"
+    local unexpected="$2"
+    local context="$3"
+
+    if grep -Fq -- "$unexpected" "$path"; then
+        fail "$context: unexpected output: $unexpected"
+    fi
+}
+
+new_case() {
+    local name="$1"
+    local root="$tmp_root/$name"
+
+    install -d -m 0700 "$root"
+    printf '%s\n' "$root"
+}
+
+make_roots() {
+    local root="$1"
+
+    install -d -m 0755 "$root/etc/facelock"
+    install -d -m 0711 "$root/var/lib/facelock"
+    install -d -m 0700 "$root/var/log/facelock"
+}
+
+run_postrm() {
+    local root="$1"
+    local argument="$2"
+    local stdout="$root/stdout"
+    local stderr="$root/stderr"
+    shift 2
+
+    if ! env \
+        FACELOCK_PURGE_TEST_ROOT="$root" \
+        FACELOCK_PURGE_TEST_UID="$(id -u)" \
+        FACELOCK_PURGE_TEST_GID="$(id -g)" \
+        "$@" \
+        sh "$postrm" "$argument" >"$stdout" 2>"$stderr"; then
+        fail "$argument under $root returned non-zero"
+    fi
+}
+
+start_paused_postrm() {
+    local root="$1"
+    local control="$2"
+
+    env \
+        FACELOCK_PURGE_TEST_ROOT="$root" \
+        FACELOCK_PURGE_TEST_UID="$(id -u)" \
+        FACELOCK_PURGE_TEST_GID="$(id -g)" \
+        FACELOCK_PURGE_TEST_PAUSE_ROOT=/var/lib/facelock \
+        FACELOCK_PURGE_TEST_PAUSE_DIR="$control" \
+        sh "$postrm" purge >"$root/stdout" 2>"$root/stderr" &
+    paused_postrm_pid=$!
+}
+
+start_point_paused_postrm() {
+    local root="$1"
+    local control="$2"
+    local argument="$3"
+    local point="$4"
+    local logical="$5"
+
+    env \
+        FACELOCK_PURGE_TEST_ROOT="$root" \
+        FACELOCK_PURGE_TEST_UID="$(id -u)" \
+        FACELOCK_PURGE_TEST_GID="$(id -g)" \
+        FACELOCK_PURGE_TEST_PAUSE_DIR="$control" \
+        FACELOCK_PURGE_TEST_PAUSE_POINT="$point" \
+        FACELOCK_PURGE_TEST_PAUSE_LOGICAL="$logical" \
+        sh "$postrm" "$argument" >"$root/stdout" 2>"$root/stderr" &
+    paused_postrm_pid=$!
+}
+
+wait_for_pause() {
+    local control="$1"
+    local attempt
+
+    for ((attempt = 0; attempt < 500; attempt++)); do
+        if [ -e "$control/ready" ]; then
+            return 0
+        fi
+        if ! kill -0 "$paused_postrm_pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.01
+    done
+    return 1
+}
+
+finish_paused_postrm() {
+    local control="$1"
+
+    : >"$control/resume"
+    if ! wait "$paused_postrm_pid"; then
+        fail "paused purge returned non-zero"
+    fi
+}
+
+finish_paused_postrm_bounded() {
+    local control="$1"
+    local unblock_fifo="${2:-}"
+    local attempt
+
+    : >"$control/resume"
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if ! kill -0 "$paused_postrm_pid" 2>/dev/null; then
+            if ! wait "$paused_postrm_pid"; then
+                fail "paused purge returned non-zero"
+            fi
+            return
+        fi
+        sleep 0.01
+    done
+
+    fail "paused lifecycle helper did not finish within one second"
+    if [ -n "$unblock_fifo" ]; then
+        printf 'unblock\n' >"$unblock_fifo" &
+        unblock_writer_pid=$!
+    fi
+    if ! wait "$paused_postrm_pid"; then
+        fail "paused purge returned non-zero after deadlock recovery"
+    fi
+    if [ -n "${unblock_writer_pid:-}" ]; then
+        wait "$unblock_writer_pid" || true
+        unset unblock_writer_pid
+    fi
+}
+
+# A complete safe tree is removed, including the deliberately user-owned
+# enrollment-marker leaf. Names outside the three compiled roots are inert.
+case_root="$(new_case safe-tree)"
+make_roots "$case_root"
+install -d -m 0755 "$case_root/var/lib/facelock/models"
+install -d -m 0711 "$case_root/var/lib/facelock/enrolled"
+install -d -m 0700 "$case_root/var/log/facelock/snapshots"
+printf 'db\n' >"$case_root/var/lib/facelock/facelock.db"
+printf 'model\n' >"$case_root/var/lib/facelock/models/scrfd.onnx"
+printf 'marker\n' >"$case_root/var/lib/facelock/enrolled/alice"
+chmod 0600 "$case_root/var/lib/facelock/enrolled/alice"
+printf 'key\n' >"$case_root/etc/facelock/encryption.key"
+printf 'audit\n' >"$case_root/var/log/facelock/audit.jsonl"
+install -d -m 0700 "$case_root/outside"
+printf 'sentinel\n' >"$case_root/outside/sentinel"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock" "safe purge root anchor"
+assert_exists "$case_root/var/lib/facelock" "safe purge root anchor"
+assert_exists "$case_root/var/log/facelock" "safe purge root anchor"
+assert_absent "$case_root/etc/facelock/encryption.key" "safe purge key"
+assert_absent "$case_root/var/lib/facelock/facelock.db" "safe purge database"
+assert_absent "$case_root/var/lib/facelock/enrolled/alice" "safe purge marker"
+assert_absent "$case_root/var/log/facelock/audit.jsonl" "safe purge audit"
+assert_exists "$case_root/outside/sentinel" "fixed-root confinement"
+
+# Enrollment markers are the sole deliberate ownership exception: the daemon
+# chowns each direct marker to its user. fakeroot lets an unprivileged fixture
+# present that ownership to the real embedded Perl traversal.
+case_root="$(new_case user-owned-marker)"
+# The single-quoted script is intentionally expanded by its child bash.
+# shellcheck disable=SC2016
+if ! command -v fakeroot >/dev/null 2>&1; then
+    fail "fakeroot is required to exercise user-owned enrollment markers"
+elif ! fakeroot bash -c '
+    set -euo pipefail
+    root="$1"
+    postrm="$2"
+    install -d -m 0755 "$root/etc/facelock"
+    install -d -m 0711 "$root/var/lib/facelock/enrolled"
+    install -d -m 0700 "$root/var/log/facelock"
+    printf "marker\n" >"$root/var/lib/facelock/enrolled/alice"
+    chmod 0600 "$root/var/lib/facelock/enrolled/alice"
+    chown 1234:1234 "$root/var/lib/facelock/enrolled/alice" 2>/dev/null || true
+    test "$(stat -c %u:%g "$root/var/lib/facelock/enrolled/alice")" = 1234:1234
+    env \
+        FACELOCK_PURGE_TEST_ROOT="$root" \
+        FACELOCK_PURGE_TEST_UID=0 \
+        FACELOCK_PURGE_TEST_GID=0 \
+        sh "$postrm" purge >"$root/stdout" 2>"$root/stderr"
+    ! test -e "$root/var/lib/facelock/enrolled/alice"
+' _ "$case_root" "$postrm"; then
+    fail "safe direct user-owned enrollment marker was not removed"
+fi
+
+# Wrong ownership on one ordinary descendant is refused without preventing a
+# safe sibling from being removed. This complements the traversal-anchor case
+# below and exercises the per-entry ownership branch under fakeroot.
+case_root="$(new_case wrong-owner-descendant)"
+# shellcheck disable=SC2016
+if ! command -v fakeroot >/dev/null 2>&1; then
+    fail "fakeroot is required to exercise wrong-owner descendants"
+elif ! fakeroot bash -c '
+    set -euo pipefail
+    root="$1"
+    postrm="$2"
+    install -d -m 0755 "$root/etc/facelock"
+    install -d -m 0711 "$root/var/lib/facelock"
+    install -d -m 0700 "$root/var/log/facelock"
+    printf "keep\n" >"$root/var/lib/facelock/wrong-owner"
+    printf "remove\n" >"$root/var/lib/facelock/safe"
+    chown 1234:1234 "$root/var/lib/facelock/wrong-owner" 2>/dev/null || true
+    test "$(stat -c %u:%g "$root/var/lib/facelock/wrong-owner")" = 1234:1234
+    env \
+        FACELOCK_PURGE_TEST_ROOT="$root" \
+        FACELOCK_PURGE_TEST_UID=0 \
+        FACELOCK_PURGE_TEST_GID=0 \
+        sh "$postrm" purge >"$root/stdout" 2>"$root/stderr"
+    test -e "$root/var/lib/facelock/wrong-owner"
+    ! test -e "$root/var/lib/facelock/safe"
+' _ "$case_root" "$postrm"; then
+    fail "wrong-owner descendant isolation failed"
+fi
+
+# Ordinary remove remains preservation-only.
+case_root="$(new_case ordinary-remove)"
+make_roots "$case_root"
+printf 'db\n' >"$case_root/var/lib/facelock/facelock.db"
+run_postrm "$case_root" remove
+assert_exists "$case_root/var/lib/facelock/facelock.db" "ordinary remove"
+assert_output_contains "$case_root/stdout" \
+    "Ordinary removal preserves user data" "ordinary remove"
+assert_output_contains "$case_root/stdout" \
+    "If package purge was requested" "ordinary remove"
+
+# remove sees the conffile before dpkg's purge phase removes it, so it reports
+# configured external state without touching either the config or the target.
+case_root="$(new_case ordinary-remove-external)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/srv/external-models"
+printf 'sentinel\n' >"$case_root/srv/external-models/sentinel"
+printf '%s\n' '[daemon]' 'model_dir = "/srv/external-models"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" remove
+assert_exists "$case_root/etc/facelock/config.toml" "remove conffile preservation"
+assert_exists "$case_root/srv/external-models/sentinel" "remove external-path preservation"
+assert_output_contains "$case_root/stderr" \
+    "daemon.model_dir=/srv/external-models" "remove external report"
+
+# Facelock's TOML parser accepts dotted keys at the document root. The bounded
+# maintainer-script classifier must not silently miss the same configured path.
+case_root="$(new_case dotted-external-path)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/srv/dotted-models"
+printf 'sentinel\n' >"$case_root/srv/dotted-models/sentinel"
+printf '%s\n' 'daemon.model_dir = "/srv/dotted-models"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" remove
+assert_exists "$case_root/srv/dotted-models/sentinel" "dotted external path"
+assert_output_contains "$case_root/stderr" \
+    "daemon.model_dir=/srv/dotted-models" "dotted external report"
+
+# Dotted keys remain relative to their active table. This is a nested
+# notification value, not the root daemon.model_dir field.
+case_root="$(new_case scoped-dotted-path)"
+make_roots "$case_root"
+printf '%s\n' '[notification]' 'daemon.model_dir = "/srv/not-root-daemon"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" remove
+assert_output_not_contains "$case_root/stderr" \
+    "daemon.model_dir=/srv/not-root-daemon" "table-scoped dotted key"
+
+# Quoted table and key names have the same TOML meaning as their bare forms.
+case_root="$(new_case quoted-external-path)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/srv/quoted-models"
+printf 'sentinel\n' >"$case_root/srv/quoted-models/sentinel"
+printf '%s\n' '["daemon"]' '"model_dir" = "/srv/quoted-models"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" remove
+assert_exists "$case_root/srv/quoted-models/sentinel" "quoted external path"
+assert_output_contains "$case_root/stderr" \
+    "daemon.model_dir=/srv/quoted-models" "quoted external report"
+
+# Multiline strings are valid TOML but deliberately outside the bounded value
+# decoder. They must produce a controlled classification warning rather than
+# silently disappearing from the removal report.
+case_root="$(new_case multiline-external-path)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/srv/multiline-models"
+printf 'sentinel\n' >"$case_root/srv/multiline-models/sentinel"
+printf '%s\n' \
+    'daemon.model_dir = """' \
+    '/srv/multiline-models"""' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" remove
+assert_exists "$case_root/srv/multiline-models/sentinel" "multiline external path"
+assert_output_contains "$case_root/stderr" \
+    "configuration could not be fully classified" "multiline classification warning"
+
+# A root symlink and a descendant symlink are both retained without touching
+# their outside targets. Safe siblings may still be removed.
+case_root="$(new_case symlinks)"
+install -d -m 0700 "$case_root/outside-root"
+printf 'root sentinel\n' >"$case_root/outside-root/sentinel"
+install -d -m 0755 "$case_root/etc"
+ln -s "$case_root/outside-root" "$case_root/etc/facelock"
+install -d -m 0711 "$case_root/var/lib/facelock"
+install -d -m 0700 "$case_root/var/log/facelock"
+printf 'outside child\n' >"$case_root/outside-child"
+ln -s "$case_root/outside-child" "$case_root/var/lib/facelock/escape"
+printf 'safe\n' >"$case_root/var/lib/facelock/safe"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock" "symlink root refusal"
+assert_exists "$case_root/outside-root/sentinel" "symlink root target"
+assert_exists "$case_root/var/lib/facelock/escape" "symlink descendant refusal"
+assert_exists "$case_root/outside-child" "symlink descendant target"
+assert_absent "$case_root/var/lib/facelock/safe" "cleanup around symlink"
+assert_output_contains "$case_root/stderr" "/etc/facelock" "symlink root report"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/escape" "symlink child report"
+
+# Every fixed ancestor is opened without following links. A symlink at
+# /var/lib therefore cannot redirect the compiled state root into another tree.
+case_root="$(new_case intermediate-ancestor-symlink)"
+install -d -m 0755 "$case_root/etc/facelock"
+install -d -m 0755 "$case_root/var"
+install -d -m 0700 "$case_root/var/log/facelock"
+install -d -m 0711 "$case_root/outside-lib/facelock"
+printf 'outside sentinel\n' >"$case_root/outside-lib/facelock/sentinel"
+ln -s "$case_root/outside-lib" "$case_root/var/lib"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib" "intermediate ancestor symlink"
+assert_exists "$case_root/outside-lib/facelock/sentinel" \
+    "intermediate ancestor symlink target"
+assert_output_contains "$case_root/stderr" "/var/lib" \
+    "intermediate ancestor symlink report"
+
+# Once the root descriptor is pinned, replacing the public root pathname with
+# a symlink cannot redirect child deletion. The pause is available only under
+# the unprivileged disposable-root test override.
+case_root="$(new_case opened-root-replacement)"
+make_roots "$case_root"
+printf 'opened root child\n' >"$case_root/var/lib/facelock/opened-child"
+install -d -m 0700 "$case_root/outside-root" "$case_root/control"
+printf 'outside sentinel\n' >"$case_root/outside-root/sentinel"
+start_paused_postrm "$case_root" "$case_root/control"
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/var/lib/facelock" "$case_root/var/lib/opened-facelock"
+    ln -s "$case_root/outside-root" "$case_root/var/lib/facelock"
+    finish_paused_postrm "$case_root/control"
+else
+    fail "purge did not pause after opening the compiled root"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/outside-root/sentinel" "opened root replacement target"
+assert_exists "$case_root/var/lib/facelock" "opened root replacement link"
+assert_exists "$case_root/var/lib/opened-facelock/opened-child" \
+    "opened root replacement moved original"
+
+# Replacing a public parent after the root is open is equally inert: all child
+# operations remain relative to the retained original parent/root handles.
+case_root="$(new_case opened-parent-replacement)"
+make_roots "$case_root"
+printf 'opened root child\n' >"$case_root/var/lib/facelock/opened-child"
+install -d -m 0700 "$case_root/outside-lib/facelock" "$case_root/control"
+printf 'outside sentinel\n' >"$case_root/outside-lib/facelock/sentinel"
+start_paused_postrm "$case_root" "$case_root/control"
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/var/lib" "$case_root/var/lib-opened"
+    ln -s "$case_root/outside-lib" "$case_root/var/lib"
+    finish_paused_postrm "$case_root/control"
+else
+    fail "purge did not pause after opening the root below its parent"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/outside-lib/facelock/sentinel" "opened parent replacement target"
+assert_exists "$case_root/var/lib" "opened parent replacement link"
+assert_exists "$case_root/var/lib-opened/facelock/opened-child" \
+    "opened parent replacement moved original"
+
+# A regular entry replaced after verification must be quarantined and proved
+# by identity before deletion. Neither the moved original nor the replacement
+# may be deleted by the check-to-operation gap.
+case_root="$(new_case regular-pre-quarantine-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-regular-quarantine /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/var/lib/facelock/victim" "$case_root/moved-original"
+    printf 'replacement\n' >"$case_root/var/lib/facelock/victim"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before regular-entry quarantine"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/moved-original" "regular swap moved original"
+assert_exists "$case_root/var/lib/facelock/victim" "regular swap replacement"
+
+# Selecting an absent quarantine name is not deletion authority. A collision
+# created after name selection but before the move must never be overwritten;
+# the helper may use a later no-replace candidate for the admitted source.
+case_root="$(new_case regular-quarantine-name-collision)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+read -r victim_device victim_inode < <(
+    stat -c '%d %i' "$case_root/var/lib/facelock/victim"
+)
+quarantine_name="$(printf '.facelock-purge-%x-%x-%02x' \
+    "$victim_device" "$victim_inode" 0)"
+quarantine_path="$case_root/var/lib/facelock/$quarantine_name"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-regular-quarantine-move /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    ln -s "$case_root/outside-collision-target" "$quarantine_path"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause after selecting a regular quarantine name"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$quarantine_path" "regular quarantine collision"
+assert_absent "$case_root/var/lib/facelock/victim" \
+    "regular source admitted after collision"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/$quarantine_name (quarantine name collision)" \
+    "regular quarantine collision report"
+
+# No replacing-rename fallback is permitted when the exact kernel primitive is
+# unavailable. The disposable-only syscall override proves fail-closed state.
+case_root="$(new_case renameat2-unavailable)"
+make_roots "$case_root"
+printf 'retain\n' >"$case_root/var/lib/facelock/victim"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_RENAMEAT2_SYSCALL=999999
+assert_exists "$case_root/var/lib/facelock/victim" \
+    "unsupported atomic quarantine primitive"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/victim (cannot quarantine entry atomically:" \
+    "unsupported atomic quarantine diagnostic"
+
+# The post-rename identity proof is load-bearing too: replacing the quarantine
+# name must preserve both the verified original and the substituted object.
+case_root="$(new_case regular-post-quarantine-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    after-regular-quarantine /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    quarantine_path="$(find "$case_root/var/lib/facelock" -maxdepth 1 \
+        -type f -name '.facelock-purge-*' -print -quit)"
+    if [ -z "$quarantine_path" ]; then
+        fail "purge paused without a regular-file quarantine"
+    else
+        mv "$quarantine_path" "$case_root/quarantined-original"
+        printf 'replacement\n' >"$quarantine_path"
+    fi
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause after regular-entry quarantine"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/quarantined-original" \
+    "post-quarantine swap moved original"
+assert_exists "$case_root/var/lib/facelock/victim" \
+    "post-quarantine swap replacement"
+
+# Recovery uses the same no-replace primitive. A public name created at the
+# restore boundary must preserve both that replacement and the quarantined
+# original instead of silently replacing either object.
+case_root="$(new_case regular-recovery-name-collision)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+read -r victim_device victim_inode < <(
+    stat -c '%d %i' "$case_root/var/lib/facelock/victim"
+)
+quarantine_name="$(printf '.facelock-purge-%x-%x-%02x' \
+    "$victim_device" "$victim_inode" 0)"
+quarantine_path="$case_root/var/lib/facelock/$quarantine_name"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-regular-restore-move /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    printf 'public replacement\n' >"$case_root/var/lib/facelock/victim"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before regular quarantine recovery"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/var/lib/facelock/victim" \
+    "regular recovery public collision"
+assert_exists "$quarantine_path" "regular recovery quarantined original"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/victim (replacement appeared while the verified entry was quarantined)" \
+    "regular recovery public collision report"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/$quarantine_name (quarantined entry retained for recovery)" \
+    "regular recovery quarantine report"
+
+# The admitted inode stays open through unlink. A hard link introduced at the
+# commit boundary cannot be erased through an unknown path, but the remaining
+# link must be detected and reported instead of claiming complete deletion.
+case_root="$(new_case regular-final-hardlink)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-regular-delete /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    quarantine_path="$(find "$case_root/var/lib/facelock" -maxdepth 1 \
+        -type f -name '.facelock-purge-*' -print -quit)"
+    if [ -z "$quarantine_path" ]; then
+        fail "purge paused without a final regular quarantine"
+    else
+        ln "$quarantine_path" "$case_root/outside-hardlink"
+    fi
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before regular quarantine deletion"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/outside-hardlink" "post-unlink external hard link"
+assert_absent "$case_root/var/lib/facelock/victim" \
+    "post-unlink public source"
+assert_output_contains "$case_root/stderr" \
+    "external hard-link remnant retained: /var/lib/facelock/victim (inode remains linked after quarantine unlink)" \
+    "post-unlink hard-link report"
+
+# Opening a path that changed from regular to FIFO must be nonblocking. A
+# blocked maintainer script would strand dpkg, even though post-open identity
+# validation would eventually reject the FIFO.
+case_root="$(new_case config-fifo-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf '%s\n' '[daemon]' 'model_dir = "/srv/original"' \
+    >"$case_root/etc/facelock/config.toml"
+start_point_paused_postrm "$case_root" "$case_root/control" remove \
+    before-config-open /etc/facelock/config.toml
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/etc/facelock/config.toml" "$case_root/config-original"
+    mkfifo "$case_root/etc/facelock/config.toml"
+    finish_paused_postrm_bounded "$case_root/control" \
+        "$case_root/etc/facelock/config.toml"
+else
+    fail "remove did not pause before configuration open"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/config-original" "configuration FIFO swap original"
+assert_exists "$case_root/etc/facelock/config.toml" \
+    "configuration FIFO swap replacement"
+
+case_root="$(new_case regular-fifo-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+printf 'original\n' >"$case_root/var/lib/facelock/victim"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-regular-open /var/lib/facelock/victim
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/var/lib/facelock/victim" "$case_root/regular-original"
+    mkfifo "$case_root/var/lib/facelock/victim"
+    finish_paused_postrm_bounded "$case_root/control" \
+        "$case_root/var/lib/facelock/victim"
+else
+    fail "purge did not pause before regular-file open"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/regular-original" "regular FIFO swap original"
+assert_exists "$case_root/var/lib/facelock/victim" \
+    "regular FIFO swap replacement"
+
+# Empty-directory removal has the same final path race as regular unlinking.
+# A replacement installed after validation must survive, and the verified
+# original moved outside the compiled root must remain untouched.
+case_root="$(new_case directory-pre-quarantine-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+install -d -m 0700 "$case_root/var/lib/facelock/empty"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-directory-quarantine /var/lib/facelock/empty
+if wait_for_pause "$case_root/control"; then
+    mv "$case_root/var/lib/facelock/empty" "$case_root/moved-empty"
+    install -d -m 0700 "$case_root/var/lib/facelock/empty"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before directory quarantine"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/moved-empty" "directory swap moved original"
+assert_exists "$case_root/var/lib/facelock/empty" "directory swap replacement"
+
+case_root="$(new_case directory-quarantine-name-collision)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+install -d -m 0700 "$case_root/var/lib/facelock/empty"
+read -r empty_device empty_inode < <(
+    stat -c '%d %i' "$case_root/var/lib/facelock/empty"
+)
+quarantine_name="$(printf '.facelock-purge-%x-%x-%02x' \
+    "$empty_device" "$empty_inode" 0)"
+quarantine_path="$case_root/var/lib/facelock/$quarantine_name"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-directory-quarantine-move /var/lib/facelock/empty
+if wait_for_pause "$case_root/control"; then
+    ln -s "$case_root/outside-directory-collision" "$quarantine_path"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause after selecting a directory quarantine name"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$quarantine_path" "directory quarantine collision"
+assert_absent "$case_root/var/lib/facelock/empty" \
+    "empty directory admitted after collision"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/$quarantine_name (quarantine name collision)" \
+    "directory quarantine collision report"
+
+case_root="$(new_case directory-post-quarantine-swap)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+install -d -m 0700 "$case_root/var/lib/facelock/empty"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    after-directory-quarantine /var/lib/facelock/empty
+if wait_for_pause "$case_root/control"; then
+    quarantine_path="$(find "$case_root/var/lib/facelock" -maxdepth 1 \
+        -type d -name '.facelock-purge-*' -print -quit)"
+    if [ -z "$quarantine_path" ]; then
+        fail "purge paused without a directory quarantine"
+    else
+        mv "$quarantine_path" "$case_root/quarantined-empty-original"
+        install -d -m 0700 "$quarantine_path"
+    fi
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause after directory quarantine"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/quarantined-empty-original" \
+    "post-quarantine directory moved original"
+assert_exists "$case_root/var/lib/facelock/empty" \
+    "post-quarantine directory replacement"
+
+case_root="$(new_case directory-recovery-name-collision)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+install -d -m 0700 "$case_root/var/lib/facelock/empty"
+read -r empty_device empty_inode < <(
+    stat -c '%d %i' "$case_root/var/lib/facelock/empty"
+)
+quarantine_name="$(printf '.facelock-purge-%x-%x-%02x' \
+    "$empty_device" "$empty_inode" 0)"
+quarantine_path="$case_root/var/lib/facelock/$quarantine_name"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-directory-restore-move /var/lib/facelock/empty
+if wait_for_pause "$case_root/control"; then
+    install -d -m 0700 "$case_root/var/lib/facelock/empty"
+    printf 'replacement\n' >"$case_root/var/lib/facelock/empty/sentinel"
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before directory quarantine recovery"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/var/lib/facelock/empty/sentinel" \
+    "directory recovery public collision"
+assert_exists "$quarantine_path" "directory recovery quarantined original"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/empty (replacement appeared while the verified directory was quarantined)" \
+    "directory recovery public collision report"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/$quarantine_name (quarantined directory retained for recovery)" \
+    "directory recovery quarantine report"
+
+# A directory that gains a child immediately before rmdir is not empty and
+# must be restored atomically instead of being stranded at its hidden name.
+case_root="$(new_case directory-final-nonempty)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/control"
+install -d -m 0700 "$case_root/var/lib/facelock/empty"
+start_point_paused_postrm "$case_root" "$case_root/control" purge \
+    before-directory-delete /var/lib/facelock/empty
+if wait_for_pause "$case_root/control"; then
+    quarantine_path="$(find "$case_root/var/lib/facelock" -maxdepth 1 \
+        -type d -name '.facelock-purge-*' -print -quit)"
+    if [ -z "$quarantine_path" ]; then
+        fail "purge paused without a final directory quarantine"
+    else
+        printf 'late child\n' >"$quarantine_path/late-child"
+    fi
+    finish_paused_postrm_bounded "$case_root/control"
+else
+    fail "purge did not pause before directory quarantine deletion"
+    wait "$paused_postrm_pid" || true
+fi
+assert_exists "$case_root/var/lib/facelock/empty/late-child" \
+    "nonempty quarantine restored directory"
+if find "$case_root/var/lib/facelock" -maxdepth 1 \
+    -type d -name '.facelock-purge-*' -print -quit | grep -q .; then
+    fail "nonempty directory remained stranded under a quarantine name"
+fi
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/empty (directory changed during quarantine and was restored)" \
+    "nonempty directory recovery report"
+
+# PAM rollback/provenance belongs to the earlier binary-backed cleanup. If any
+# entry remains by postrm, the self-contained purge must treat the directory as
+# opaque evidence rather than interpreting or generically deleting its files.
+case_root="$(new_case nonempty-pam-backups)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/pam-backups"
+printf 'administrator rollback bytes\n' \
+    >"$case_root/var/lib/facelock/pam-backups/administrator-note"
+printf '{"state":"unknown"}\n' \
+    >"$case_root/var/lib/facelock/pam-backups/unresolved.json"
+chmod 0600 "$case_root/var/lib/facelock/pam-backups/administrator-note" \
+    "$case_root/var/lib/facelock/pam-backups/unresolved.json"
+printf 'safe sibling\n' >"$case_root/var/lib/facelock/safe"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib/facelock/pam-backups/administrator-note" \
+    "opaque PAM rollback bytes"
+assert_exists "$case_root/var/lib/facelock/pam-backups/unresolved.json" \
+    "opaque PAM provenance"
+assert_absent "$case_root/var/lib/facelock/safe" \
+    "safe sibling around PAM rollback state"
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/pam-backups (PAM rollback state remains after removal cleanup)" \
+    "opaque PAM rollback report"
+
+# The exact rollback path is itself opaque unless it is a trusted empty
+# directory. A hostile or damaged regular-file replacement must not be treated
+# as ordinary state merely because its bytes happen to be safely openable.
+case_root="$(new_case regular-pam-backups)"
+make_roots "$case_root"
+printf 'opaque rollback-path replacement\n' \
+    >"$case_root/var/lib/facelock/pam-backups"
+chmod 0600 "$case_root/var/lib/facelock/pam-backups"
+sha256sum "$case_root/var/lib/facelock/pam-backups" \
+    >"$case_root/pam-backups.sha256"
+pam_backups_metadata="$(
+    stat -c '%F|%u|%g|%a|%h|%s' \
+        "$case_root/var/lib/facelock/pam-backups"
+)"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib/facelock/pam-backups" \
+    "opaque regular PAM rollback path"
+if ! sha256sum -c --status "$case_root/pam-backups.sha256"; then
+    fail "opaque regular PAM rollback path bytes changed"
+fi
+if [ "$(stat -c '%F|%u|%g|%a|%h|%s' \
+    "$case_root/var/lib/facelock/pam-backups")" != "$pam_backups_metadata" ]; then
+    fail "opaque regular PAM rollback path metadata changed"
+fi
+assert_output_contains "$case_root/stderr" \
+    "/var/lib/facelock/pam-backups (PAM rollback state path is not a trusted empty directory)" \
+    "opaque regular PAM rollback path report"
+
+case_root="$(new_case empty-pam-backups)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/pam-backups"
+run_postrm "$case_root" purge
+assert_absent "$case_root/var/lib/facelock/pam-backups" \
+    "empty PAM rollback directory"
+
+# A multiply-linked regular file is retained and the second name is unchanged.
+case_root="$(new_case hardlink)"
+make_roots "$case_root"
+printf 'shared\n' >"$case_root/outside-hardlink"
+ln "$case_root/outside-hardlink" "$case_root/var/lib/facelock/shared"
+printf 'safe\n' >"$case_root/var/lib/facelock/safe"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib/facelock/shared" "hard-link refusal"
+assert_exists "$case_root/outside-hardlink" "hard-link outside name"
+assert_absent "$case_root/var/lib/facelock/safe" "cleanup around hard link"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/shared" "hard-link report"
+
+# Ownership is proven relative to the production root owner. The test override
+# makes an otherwise ordinary fixture model a wrong-owner root.
+case_root="$(new_case wrong-owner)"
+make_roots "$case_root"
+printf 'keep\n' >"$case_root/var/lib/facelock/keep"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_UID=424242 FACELOCK_PURGE_TEST_GID=424242
+assert_exists "$case_root/var/lib/facelock/keep" "wrong-owner root refusal"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock" "wrong-owner report"
+
+# Mount points are rejected even when a bind mount would share st_dev with its
+# parent. A synthetic mountinfo file exercises the same parser without a host
+# mount or namespace mutation.
+case_root="$(new_case mountpoint)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/mounted"
+printf 'mounted\n' >"$case_root/var/lib/facelock/mounted/keep"
+printf 'safe\n' >"$case_root/var/lib/facelock/safe"
+printf '31 24 0:25 / %s rw,relatime - tmpfs tmpfs rw\n' \
+    "$case_root/var/lib/facelock/mounted" >"$case_root/mountinfo"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MOUNTINFO="$case_root/mountinfo"
+assert_exists "$case_root/var/lib/facelock/mounted/keep" "mount-point refusal"
+assert_absent "$case_root/var/lib/facelock/safe" "cleanup around mount point"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/mounted" "mount-point report"
+
+# mountinfo's path field uses octal escapes. Decode them before comparison so
+# a same-device bind mounted on a name with whitespace cannot evade the gate.
+case_root="$(new_case mountpoint-escaped)"
+make_roots "$case_root"
+mount_path="$case_root/var/lib/facelock/mounted space"
+install -d -m 0700 "$mount_path"
+printf 'mounted\n' >"$mount_path/keep"
+escaped_mount="${mount_path// /\\040}"
+printf '31 24 0:25 / %s rw,relatime - tmpfs tmpfs rw\n' \
+    "$escaped_mount" >"$case_root/mountinfo"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MOUNTINFO="$case_root/mountinfo"
+assert_exists "$mount_path/keep" "escaped mount-point refusal"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/mounted space" \
+    "escaped mount-point report"
+
+# If mount topology cannot be proven, the helper conservatively reports every
+# compiled root without probing public paths, preserves all state, and still
+# lets the package-manager lifecycle finish.
+case_root="$(new_case missing-mountinfo)"
+make_roots "$case_root"
+printf 'keep\n' >"$case_root/var/lib/facelock/keep"
+run_postrm "$case_root" purge \
+    FACELOCK_PURGE_TEST_MOUNTINFO="$case_root/does-not-exist"
+assert_exists "$case_root/var/lib/facelock/keep" "missing mountinfo refusal"
+assert_output_contains "$case_root/stderr" "mount topology is unavailable" \
+    "missing mountinfo report"
+
+# An unlink failure is reported, other roots are still attempted, and purge
+# remains successful so dpkg is not stranded in a half-purged state.
+case_root="$(new_case partial-failure)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/readonly"
+printf 'blocked\n' >"$case_root/var/lib/facelock/readonly/blocked"
+chmod 0555 "$case_root/var/lib/facelock/readonly"
+printf 'safe\n' >"$case_root/etc/facelock/safe"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib/facelock/readonly/blocked" "partial failure remnant"
+assert_absent "$case_root/etc/facelock/safe" "partial failure isolation"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/readonly/blocked" "partial failure report"
+
+# Unsafe directories and non-regular leaves are retained independently while
+# safe siblings continue to be removed.
+case_root="$(new_case unsafe-node-types)"
+make_roots "$case_root"
+install -d -m 0775 "$case_root/var/lib/facelock/group-writable"
+printf 'keep\n' >"$case_root/var/lib/facelock/group-writable/keep"
+mkfifo "$case_root/var/lib/facelock/pipe"
+printf 'safe\n' >"$case_root/var/lib/facelock/safe"
+run_postrm "$case_root" purge
+assert_exists "$case_root/var/lib/facelock/group-writable/keep" \
+    "unsafe directory mode refusal"
+assert_exists "$case_root/var/lib/facelock/pipe" "special-file refusal"
+assert_absent "$case_root/var/lib/facelock/safe" "cleanup around unsafe node types"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/group-writable" \
+    "unsafe directory mode report"
+assert_output_contains "$case_root/stderr" "/var/lib/facelock/pipe" \
+    "special-file report"
+
+# Traversal limits are inclusive. A directory exactly at the configured test
+# depth remains eligible, while the next directory is retained and reported.
+case_root="$(new_case depth-limit-boundary)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/one/two"
+printf 'at boundary\n' >"$case_root/var/lib/facelock/one/two/leaf"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MAX_DEPTH=2
+assert_absent "$case_root/var/lib/facelock/one/two/leaf" \
+    "inclusive traversal depth boundary"
+
+case_root="$(new_case depth-limit-refusal)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/var/lib/facelock/one/two/three"
+printf 'beyond boundary\n' >"$case_root/var/lib/facelock/one/two/three/keep"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MAX_DEPTH=2
+assert_exists "$case_root/var/lib/facelock/one/two/three/keep" \
+    "traversal depth refusal"
+assert_output_contains "$case_root/stderr" "depth limit exceeded (2)" \
+    "traversal depth report"
+
+# The node ceiling is likewise inclusive and stops an oversized traversal
+# without unbounded enumeration or Perl recursion diagnostics.
+case_root="$(new_case node-limit-boundary)"
+make_roots "$case_root"
+printf 'one\n' >"$case_root/var/lib/facelock/one"
+printf 'two\n' >"$case_root/var/lib/facelock/two"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MAX_NODES=2
+assert_absent "$case_root/var/lib/facelock/one" "inclusive traversal node boundary"
+assert_absent "$case_root/var/lib/facelock/two" "inclusive traversal node boundary"
+
+case_root="$(new_case node-limit-refusal)"
+make_roots "$case_root"
+printf 'one\n' >"$case_root/var/lib/facelock/one"
+printf 'two\n' >"$case_root/var/lib/facelock/two"
+printf 'three\n' >"$case_root/var/lib/facelock/three"
+run_postrm "$case_root" purge FACELOCK_PURGE_TEST_MAX_NODES=2
+if [ -d "$case_root/var/lib/facelock" ]; then
+    remaining_nodes="$(find "$case_root/var/lib/facelock" -mindepth 1 -maxdepth 1 | wc -l)"
+else
+    remaining_nodes=0
+fi
+if [ "$remaining_nodes" -ne 1 ]; then
+    fail "node limit refusal: expected exactly one retained child, found $remaining_nodes"
+fi
+assert_output_contains "$case_root/stderr" "node limit exceeded (2)" \
+    "traversal node report"
+assert_output_contains "$case_root/stderr" \
+    "facelock purge: remnant retained: /var/lib/facelock (node limit exceeded (2))" \
+    "traversal retained-root report"
+if grep -Fq -- "Deep recursion" "$case_root/stderr"; then
+    fail "bounded traversal emitted a raw Perl recursion warning"
+fi
+
+# A compiled root that is not a directory is itself an exact reported remnant.
+case_root="$(new_case non-directory-root)"
+install -d -m 0755 "$case_root/etc"
+printf 'keep\n' >"$case_root/etc/facelock"
+install -d -m 0711 "$case_root/var/lib/facelock"
+install -d -m 0700 "$case_root/var/log/facelock"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock" "non-directory root refusal"
+assert_output_contains "$case_root/stderr" "/etc/facelock" \
+    "non-directory root report"
+
+# Only the six configured path fields are classified. External values are
+# named and left untouched; values lexically inside compiled roots are eligible
+# for the bounded traversal and are not described as external.
+case_root="$(new_case external-paths)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/srv/facelock/models"
+printf 'external sentinel\n' >"$case_root/srv/facelock/models/sentinel"
+printf 'external db\n' >"$case_root/var/lib/external.db"
+printf '%s\n' \
+    '[daemon]' \
+    'model_dir = "/srv/facelock/models"' \
+    '[storage]' \
+    'db_path = "/var/lib/facelock/../external.db"' \
+    '[encryption]' \
+    'key_path = "/keys/facelock.key"' \
+    'sealed_key_path = "/keys/facelock.sealed"' \
+    '[audit]' \
+    'path = "/logs/facelock.jsonl"' \
+    '[snapshots]' \
+    'dir = "/snapshots/facelock"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" purge
+assert_exists "$case_root/srv/facelock/models/sentinel" "external configured path"
+assert_exists "$case_root/var/lib/external.db" "lexically external database path"
+assert_output_contains "$case_root/stderr" "daemon.model_dir=/srv/facelock/models" "external model report"
+assert_output_contains "$case_root/stderr" \
+    "storage.db_path=/var/lib/facelock/../external.db" "lexical external report"
+assert_output_contains "$case_root/stderr" "encryption.key_path=/keys/facelock.key" "external key report"
+assert_output_contains "$case_root/stderr" "encryption.sealed_key_path=/keys/facelock.sealed" "external sealed-key report"
+assert_output_contains "$case_root/stderr" "audit.path=/logs/facelock.jsonl" "external audit report"
+assert_output_contains "$case_root/stderr" "snapshots.dir=/snapshots/facelock" "external snapshot report"
+
+case_root="$(new_case configured-inside-root)"
+make_roots "$case_root"
+printf '%s\n' '[storage]' 'db_path = "/var/lib/facelock/facelock.db"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" purge
+if grep -Fq -- "storage.db_path=/var/lib/facelock/facelock.db" "$case_root/stderr"; then
+    fail "inside configured database path was reported as external"
+fi
+
+# Basic-string escapes are decoded for classification but control characters
+# are escaped again before diagnostics reach a terminal or package-manager log.
+case_root="$(new_case external-control-path)"
+make_roots "$case_root"
+printf '%s\n' '[daemon]' 'model_dir = "/srv/line\nbreak"' \
+    >"$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" purge
+assert_output_contains "$case_root/stderr" \
+    'daemon.model_dir=/srv/line\x0abreak' "external control-path report"
+
+# A multiply-linked conffile is not trusted for parsing or deletion. Its other
+# name and all bytes remain available as provenance for manual inspection.
+case_root="$(new_case hardlinked-config)"
+make_roots "$case_root"
+printf '%s\n' '[daemon]' 'model_dir = "/srv/external"' \
+    >"$case_root/etc/facelock/config.toml"
+ln "$case_root/etc/facelock/config.toml" "$case_root/config-second-name"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock/config.toml" "hard-linked config refusal"
+assert_exists "$case_root/config-second-name" "hard-linked config provenance"
+assert_output_contains "$case_root/stderr" "/etc/facelock/config.toml" \
+    "hard-linked config report"
+
+# A configuration object that classification explicitly reports as retained
+# must not be removed by the generic fixed-root walk later in the same purge.
+case_root="$(new_case oversized-config)"
+make_roots "$case_root"
+truncate -s 1048577 "$case_root/etc/facelock/config.toml"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock/config.toml" "oversized config retention"
+assert_output_contains "$case_root/stderr" "/etc/facelock/config.toml" \
+    "oversized config report"
+
+case_root="$(new_case directory-config)"
+make_roots "$case_root"
+install -d -m 0700 "$case_root/etc/facelock/config.toml"
+printf 'directory sentinel\n' >"$case_root/etc/facelock/config.toml/sentinel"
+run_postrm "$case_root" purge
+assert_exists "$case_root/etc/facelock/config.toml/sentinel" \
+    "directory config retention"
+assert_output_contains "$case_root/stderr" "/etc/facelock/config.toml" \
+    "directory config report"
+
+# /etc/pam.d is outside the recursive roots. An incomplete service edit and its
+# rollback provenance survive purge byte-for-byte.
+case_root="$(new_case pam-provenance)"
+make_roots "$case_root"
+install -d -m 0755 "$case_root/etc/pam.d"
+printf 'auth sufficient pam_facelock.so\nauth required pam_unix.so\n' \
+    >"$case_root/etc/pam.d/sudo"
+printf 'auth required pam_unix.so\n' >"$case_root/etc/pam.d/sudo.facelock-backup"
+sha256sum "$case_root/etc/pam.d/sudo" "$case_root/etc/pam.d/sudo.facelock-backup" \
+    >"$case_root/pam.sha256"
+run_postrm "$case_root" purge
+if ! sha256sum -c --status "$case_root/pam.sha256"; then
+    fail "purge changed incomplete PAM integration or provenance"
+fi
+
+# Missing roots and a repeated purge are both successful no-ops.
+case_root="$(new_case idempotent)"
+run_postrm "$case_root" purge
+run_postrm "$case_root" purge
+
+# The canonical native source must ship this exact self-contained maintainer
+# script. test/deb-maintscript-contract.sh separately proves that debhelper
+# expands it into the binary package control archive.
+[ -x "$postrm" ] || fail "native Debian postrm is not executable"
+[ "$(grep -Foc '#DEBHELPER#' "$postrm")" -eq 1 ] ||
+    fail "native Debian postrm must contain exactly one debhelper marker"
+if grep -Eq '^Depends:.*perl-base' "$repo_root/debian/control"; then
+    fail "package metadata redundantly depends on the Essential perl-base package"
+fi
+# shellcheck disable=SC2016
+if ! grep -Fq '$opened[0] != $root->{dev}' "$postrm"; then
+    fail "purge helper omits the independent root-device comparison"
+fi
+# shellcheck disable=SC2016
+if ! grep -Fq 'facelock_renameat2_syscall=316' "$postrm" ||
+    ! grep -Fq 'syscall($renameat2_syscall, $parent_fd' "$postrm"; then
+    fail "purge helper omits the audited amd64 renameat2 syscall"
+fi
+if grep -Eq '(^|[^[:alnum:]_])rename[[:space:]]*\(' "$postrm"; then
+    fail "purge helper contains a replacing Perl rename call"
+fi
+if ! grep -Eq '^Architecture:[[:space:]]*amd64[[:space:]]*$' \
+    "$repo_root/debian/control"; then
+    fail "raw renameat2 syscall is not bound to amd64 package metadata"
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "debian postrm purge: $failures failure(s)" >&2
+    exit 1
+fi
+
+echo "debian postrm purge: OK"

--- a/test/legacy-system-assets.sh
+++ b/test/legacy-system-assets.sh
@@ -1,0 +1,605 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_root/scripts/migrate-legacy-system-assets.sh"
+uninstall_helper="$repo_root/scripts/uninstall-system-assets.sh"
+manifest="$repo_root/dist/legacy-system-assets.sha256"
+justfile="$repo_root/justfile"
+postinst="$repo_root/debian/postinst"
+containerfile="$repo_root/test/Containerfile"
+
+fail() {
+    echo "legacy system assets: $*" >&2
+    exit 1
+}
+
+[ -f "$helper" ] || fail "missing source-install migration helper"
+[ -f "$uninstall_helper" ] || fail "missing source-uninstall system-asset helper"
+[ -f "$manifest" ] || fail "missing reviewed digest allowlist"
+grep -Fq 'COPY scripts/migrate-legacy-system-assets.sh /build/scripts/migrate-legacy-system-assets.sh' \
+    "$containerfile" ||
+    fail "source-install container omits the migration helper"
+
+helper_call_line="$(grep -n -m1 -F 'facelock_source_install_stage_and_record_legacy_migration /' "$justfile" |
+    cut -d: -f1 || true)"
+[ -n "$helper_call_line" ] || fail "install-files does not invoke exact legacy migration"
+for install_needle in \
+    'install -Dm644 systemd/facelock-daemon.service /usr/lib/systemd/system/facelock-daemon.service' \
+    'install -Dm644 dbus/org.facelock.Daemon.conf /usr/share/dbus-1/system.d/org.facelock.Daemon.conf' \
+    'install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service'; do
+    install_line="$(grep -n -m1 -F "$install_needle" "$justfile" | cut -d: -f1 || true)"
+    [ -n "$install_line" ] && [ "$install_line" -lt "$helper_call_line" ] ||
+        fail "install-files must write every canonical asset before migration"
+done
+if rg -n "grep -q '(ExecStart=/usr/bin/facelock daemon|org.facelock.Daemon)'" \
+    "$justfile" "$postinst" "$repo_root/dist/facelock.install" \
+    "$repo_root/dist/facelock.spec" >/dev/null; then
+    fail "marker-based legacy asset overwrite remains in source/package install logic"
+fi
+if grep -Eq 'install[[:space:]].*/etc/(systemd/system|dbus-1/)' "$postinst"; then
+    fail "Debian postinst still writes legacy /etc service assets"
+fi
+grep -Fq 'scripts/uninstall-system-assets.sh /' "$justfile" ||
+    fail "uninstall-files does not use the fixed system-asset helper"
+uninstall_recipe="$(sed -n '/^uninstall-files:/,/^[[:alnum:]_-][[:alnum:]_-]*:/p' "$justfile")"
+for historical in \
+    /etc/systemd/system/facelock-daemon.service \
+    /etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    /etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    if grep -Fq "$historical" <<<"$uninstall_recipe"; then
+        fail "uninstall-files still targets historical system asset $historical"
+    fi
+done
+
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-legacy-system-assets.XXXXXX")"
+trap 'rm -rf -- "$tmp_root"' EXIT
+
+seed_canonical() {
+    local root="$1"
+    install -Dm644 "$repo_root/systemd/facelock-daemon.service" \
+        "$root/usr/lib/systemd/system/facelock-daemon.service"
+    install -Dm644 "$repo_root/dbus/org.facelock.Daemon.conf" \
+        "$root/usr/share/dbus-1/system.d/org.facelock.Daemon.conf"
+    install -Dm644 "$repo_root/dbus/org.facelock.Daemon.service" \
+        "$root/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+}
+
+seed_legacy_current() {
+    local root="$1"
+
+    install -Dm644 "$repo_root/systemd/facelock-daemon.service" \
+        "$root/etc/systemd/system/facelock-daemon.service"
+    install -Dm644 "$repo_root/dbus/org.facelock.Daemon.conf" \
+        "$root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+    install -Dm644 "$repo_root/dbus/org.facelock.Daemon.service" \
+        "$root/etc/dbus-1/system-services/org.facelock.Daemon.service"
+}
+
+snapshot_canonical() {
+    local root="$1"
+    for path in \
+        usr/lib/systemd/system/facelock-daemon.service \
+        usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+        usr/share/dbus-1/system-services/org.facelock.Daemon.service; do
+        stat -c '%u:%g:%a:%h' "$root/$path"
+        sha256sum "$root/$path"
+    done
+}
+
+case_root="$tmp_root/exact"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+before="$(snapshot_canonical "$case_root")"
+install -Dm644 "$repo_root/dbus/org.facelock.Daemon.conf" \
+    "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+install -Dm644 "$repo_root/dbus/org.facelock.Daemon.service" \
+    "$case_root/etc/dbus-1/system-services/org.facelock.Daemon.service"
+mkdir -p "$case_root/etc/systemd/system"
+cat >"$case_root/etc/systemd/system/facelock-daemon.service" <<'UNIT'
+[Unit]
+Description=Facelock Face Authentication Daemon
+After=local-fs.target
+
+[Service]
+Type=dbus
+BusName=org.facelock.Daemon
+ExecStart=/usr/bin/facelock daemon
+StandardOutput=journal
+StandardError=journal
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=1024
+
+# Phase 1: Filesystem isolation
+ProtectSystem=strict
+# ProtectHome=yes also hides /run/user/, breaking desktop notifications
+# (daemon sends notify-send via runuser to /run/user/<uid>/bus).
+# Use InaccessiblePaths instead to protect /home and /root without
+# affecting /run/user/.
+InaccessiblePaths=/home /root
+ReadWritePaths=/var/lib/facelock /var/log/facelock
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+# Phase 2: Kernel hardening
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+
+# Phase 2.5: Device access
+# DevicePolicy=closed/auto both use cgroup device ACLs which hide /dev/video*
+# from stat(), breaking camera auto-detection. Omitted — the daemon only needs
+# /dev/video* and /dev/tpmrm0, both protected by standard Unix permissions.
+# ProtectSystem=strict already prevents writing to /dev/.
+
+# Deferred: MemoryDenyWriteExecute=yes breaks ONNX Runtime JIT.
+# Phase 3 (seccomp, capabilities, network) deferred to future work.
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+"$helper" "$case_root"
+[ ! -e "$case_root/etc/systemd/system/facelock-daemon.service" ] ||
+    fail "stale exact unit was not migrated"
+[ ! -e "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf" ] ||
+    fail "current exact policy was not migrated"
+[ ! -e "$case_root/etc/dbus-1/system-services/org.facelock.Daemon.service" ] ||
+    fail "current exact activation definition was not migrated"
+[ "$(snapshot_canonical "$case_root")" = "$before" ] ||
+    fail "migration changed canonical bytes or metadata"
+"$helper" "$case_root"
+
+case_root="$tmp_root/ambiguous"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+install -Dm644 "$repo_root/systemd/facelock-daemon.service" \
+    "$case_root/etc/systemd/system/facelock-daemon.service"
+install -Dm644 /dev/null \
+    "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+printf '%s\n' 'administrator policy' \
+    >"$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "modified legacy policy was accepted"
+fi
+[ -f "$case_root/etc/systemd/system/facelock-daemon.service" ] ||
+    fail "whole-set preflight removed an exact peer before rejecting ambiguity"
+grep -Fq 'administrator policy' \
+    "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf" ||
+    fail "modified policy was not preserved"
+
+for linked in symlink hardlink; do
+    case_root="$tmp_root/$linked"
+    mkdir -p "$case_root"
+    seed_canonical "$case_root"
+    legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+    outside="$case_root/outside-unit"
+    mkdir -p "${legacy%/*}"
+    cp "$repo_root/systemd/facelock-daemon.service" "$outside"
+    if [ "$linked" = symlink ]; then
+        ln -s "$outside" "$legacy"
+    else
+        ln "$outside" "$legacy"
+    fi
+    if "$helper" "$case_root" >/dev/null 2>&1; then
+        fail "$linked legacy unit was accepted"
+    fi
+    [ -e "$legacy" ] || [ -L "$legacy" ] || fail "$linked legacy unit was removed"
+    cmp -s "$outside" "$repo_root/systemd/facelock-daemon.service" ||
+        fail "$linked outside target changed"
+done
+
+case_root="$tmp_root/parent-symlink"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+outside_dir="$case_root/outside-policy-dir"
+mkdir -p "$outside_dir" "$case_root/etc/dbus-1"
+cp "$repo_root/dbus/org.facelock.Daemon.conf" \
+    "$outside_dir/org.facelock.Daemon.conf"
+ln -s "$outside_dir" "$case_root/etc/dbus-1/system.d"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "symlinked legacy parent was accepted"
+fi
+cmp -s "$outside_dir/org.facelock.Daemon.conf" \
+    "$repo_root/dbus/org.facelock.Daemon.conf" ||
+    fail "symlinked legacy parent target changed"
+
+case_root="$tmp_root/canonical-mode"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+chmod 0600 "$case_root/usr/lib/systemd/system/facelock-daemon.service"
+install -Dm644 "$repo_root/dbus/org.facelock.Daemon.conf" \
+    "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "wrong canonical mode was accepted"
+fi
+[ -f "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf" ] ||
+    fail "canonical preflight failure removed an exact legacy file"
+
+case_root="$tmp_root/late-stage-rollback"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+real_mv="$(command -v mv)"
+shim_bin="$tmp_root/late-stage-bin"
+mkdir -p "$shim_bin"
+cat >"$shim_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "$FACELOCK_MV_COUNT" ]; then
+    read -r count <"$FACELOCK_MV_COUNT"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FACELOCK_MV_COUNT"
+if [ "$count" -eq 2 ]; then
+    exit 73
+fi
+exec "$FACELOCK_REAL_MV" "$@"
+EOF
+chmod 0755 "$shim_bin/mv"
+if PATH="$shim_bin:$PATH" \
+    FACELOCK_REAL_MV="$real_mv" \
+    FACELOCK_MV_COUNT="$tmp_root/late-stage-mv-count" \
+    "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "late migration-stage failure unexpectedly succeeded"
+fi
+for asset in \
+    etc/systemd/system/facelock-daemon.service \
+    etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    [ -f "$case_root/$asset" ] ||
+        fail "late stage failure did not roll back $asset"
+done
+if find "$case_root/etc" -name '.facelock-migrate-*' -print -quit | grep -q .; then
+    fail "late stage rollback left a migration quarantine behind"
+fi
+
+case_root="$tmp_root/stage-process-group-interrupt"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+real_mv="$(command -v mv)"
+shim_bin="$tmp_root/stage-process-group-interrupt-bin"
+mkdir -p "$shim_bin"
+cat >"$shim_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+count=0
+[ ! -f "$FACELOCK_MV_COUNT" ] || read -r count <"$FACELOCK_MV_COUNT"
+count=$((count + 1))
+printf '%s\n' "$count" >"$FACELOCK_MV_COUNT"
+"$FACELOCK_REAL_MV" "$@"
+if [ "$count" -eq 1 ]; then
+    kill -INT 0
+fi
+EOF
+chmod 0755 "$shim_bin/mv"
+set +e
+setsid env PATH="$shim_bin:$PATH" \
+    FACELOCK_REAL_MV="$real_mv" \
+    FACELOCK_MV_COUNT="$tmp_root/stage-process-group-interrupt-count" \
+    "$helper" --source-protected --stage "$case_root" >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -eq 130 ] ||
+    fail "process-group interrupt exited $status instead of 130"
+for asset in \
+    etc/systemd/system/facelock-daemon.service \
+    etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    [ -f "$case_root/$asset" ] ||
+        fail "process-group interrupt did not restore $asset"
+done
+if find "$case_root/etc" -name '.facelock-migrate-*' -print -quit | grep -q .; then
+    fail "process-group interrupt left a migration quarantine behind"
+fi
+
+case_root="$tmp_root/rollback-collision"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+shim_bin="$tmp_root/rollback-collision-bin"
+mkdir -p "$shim_bin"
+cat >"$shim_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "$FACELOCK_MV_COUNT" ]; then
+    read -r count <"$FACELOCK_MV_COUNT"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FACELOCK_MV_COUNT"
+if [ "$count" -eq 2 ]; then
+    printf '%s\n' 'administrator replacement' >"$FACELOCK_FIRST_LEGACY"
+    exit 73
+fi
+exec "$FACELOCK_REAL_MV" "$@"
+EOF
+chmod 0755 "$shim_bin/mv"
+first_legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+first_quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+rollback_log="$tmp_root/rollback-collision.log"
+if PATH="$shim_bin:$PATH" \
+    FACELOCK_REAL_MV="$real_mv" \
+    FACELOCK_MV_COUNT="$tmp_root/rollback-collision-mv-count" \
+    FACELOCK_FIRST_LEGACY="$first_legacy" \
+    "$helper" "$case_root" >"$rollback_log" 2>&1; then
+    fail "rollback collision unexpectedly succeeded"
+fi
+grep -Fqx 'administrator replacement' "$first_legacy" ||
+    fail "rollback overwrote an administrator replacement"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$first_quarantine" ||
+    fail "rollback collision did not preserve the exact quarantine"
+grep -Fq 'rollback collision preserved both names' "$rollback_log" ||
+    fail "rollback collision was not reported"
+grep -Fq 'migration rollback was incomplete' "$rollback_log" ||
+    fail "incomplete rollback was not reported"
+
+case_root="$tmp_root/quarantine-collision"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+collision="$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy"
+printf '%s\n' 'administrator collision sentinel' >"$collision"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "migration accepted a quarantine-name collision"
+fi
+grep -Fqx 'administrator collision sentinel' "$collision" ||
+    fail "migration changed a quarantine collision"
+for asset in \
+    etc/systemd/system/facelock-daemon.service \
+    etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    [ -f "$case_root/$asset" ] ||
+        fail "quarantine collision did not preserve $asset"
+done
+
+case_root="$tmp_root/interrupted-staging-recovery"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+mv -- \
+    "$case_root/etc/systemd/system/facelock-daemon.service" \
+    "$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+mv -- \
+    "$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf" \
+    "$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy"
+"$helper" "$case_root"
+for asset in \
+    etc/systemd/system/facelock-daemon.service \
+    etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    [ ! -e "$case_root/$asset" ] && [ ! -L "$case_root/$asset" ] ||
+        fail "interrupted staging recovery retained legacy asset $asset"
+done
+if find "$case_root/etc" -name '.facelock-migrate-*' -print -quit | grep -q .; then
+    fail "interrupted staging recovery retained a fixed quarantine"
+fi
+
+case_root="$tmp_root/interrupted-staging-ambiguous-peer"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+interrupted_legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+interrupted_quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+mv -- "$interrupted_legacy" "$interrupted_quarantine"
+ambiguous_peer="$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+printf '%s\n' 'administrator policy' >"$ambiguous_peer"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "interrupted staging recovery accepted an ambiguous peer"
+fi
+[ ! -e "$interrupted_legacy" ] && [ ! -L "$interrupted_legacy" ] ||
+    fail "whole-set recovery preflight restored before finding an ambiguous peer"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$interrupted_quarantine" ||
+    fail "whole-set recovery preflight changed the interrupted quarantine"
+grep -Fqx 'administrator policy' "$ambiguous_peer" ||
+    fail "whole-set recovery preflight changed the ambiguous peer"
+
+case_root="$tmp_root/interrupted-staging-dual-name"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+dual_legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+dual_quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+cp -- "$dual_legacy" "$dual_quarantine"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "interrupted staging recovery accepted a dual-name state"
+fi
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$dual_legacy" ||
+    fail "dual-name recovery changed the public legacy asset"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$dual_quarantine" ||
+    fail "dual-name recovery changed the quarantine"
+
+case_root="$tmp_root/interrupted-staging-unknown-quarantine"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+unknown_legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+unknown_quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+mv -- "$unknown_legacy" "$unknown_quarantine"
+printf '%s\n' 'unknown quarantine' >"$unknown_quarantine"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    fail "interrupted staging recovery accepted an unknown quarantine"
+fi
+[ ! -e "$unknown_legacy" ] && [ ! -L "$unknown_legacy" ] ||
+    fail "unknown-quarantine preflight recreated a public name"
+grep -Fqx 'unknown quarantine' "$unknown_quarantine" ||
+    fail "unknown-quarantine preflight changed the quarantine"
+
+case_root="$tmp_root/interrupted-staging-recovery-collision"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+interrupted_legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+interrupted_quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+mv -- "$interrupted_legacy" "$interrupted_quarantine"
+shim_bin="$tmp_root/recovery-collision-bin"
+mkdir -p "$shim_bin"
+cat >"$shim_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = -Tn ] && [ "$4" = "$FACELOCK_RECOVERY_LEGACY" ]; then
+    printf '%s\n' 'administrator replacement' >"$FACELOCK_RECOVERY_LEGACY"
+fi
+exec "$FACELOCK_REAL_MV" "$@"
+EOF
+chmod 0755 "$shim_bin/mv"
+recovery_log="$tmp_root/recovery-collision.log"
+if PATH="$shim_bin:$PATH" \
+    FACELOCK_REAL_MV="$real_mv" \
+    FACELOCK_RECOVERY_LEGACY="$interrupted_legacy" \
+    "$helper" "$case_root" >"$recovery_log" 2>&1; then
+    fail "interrupted staging recovery overwrote a concurrent collision"
+fi
+grep -Fqx 'administrator replacement' "$interrupted_legacy" ||
+    fail "interrupted staging recovery changed a concurrent public replacement"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$interrupted_quarantine" ||
+    fail "interrupted staging recovery changed its quarantine after collision"
+grep -Fq 'without replacement' "$recovery_log" ||
+    fail "interrupted staging recovery collision was not reported"
+
+case_root="$tmp_root/untrusted-layout-root"
+mkdir -p "$case_root"
+seed_canonical "$case_root"
+seed_legacy_current "$case_root"
+chmod 0777 "$case_root"
+if "$helper" "$case_root" >/dev/null 2>&1; then
+    chmod 0700 "$case_root"
+    fail "migration trusted a group/world-writable layout root"
+fi
+chmod 0700 "$case_root"
+[ -f "$case_root/etc/systemd/system/facelock-daemon.service" ] ||
+    fail "untrusted layout root did not preserve the legacy unit"
+
+seed_uninstall_case() {
+    local root="$1"
+
+    seed_canonical "$root"
+    install -Dm755 /dev/null "$root/usr/bin/facelock"
+}
+
+assert_canonical_assets_removed() {
+    local root="$1"
+
+    for asset in \
+        usr/lib/systemd/system/facelock-daemon.service \
+        usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+        usr/share/dbus-1/system-services/org.facelock.Daemon.service; do
+        [ ! -e "$root/$asset" ] && [ ! -L "$root/$asset" ] ||
+            fail "source uninstall retained canonical asset $asset"
+    done
+}
+
+assert_canonical_assets_present() {
+    local root="$1"
+
+    for asset in \
+        usr/lib/systemd/system/facelock-daemon.service \
+        usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+        usr/share/dbus-1/system-services/org.facelock.Daemon.service; do
+        [ -e "$root/$asset" ] || [ -L "$root/$asset" ] ||
+            fail "source uninstall changed canonical peer $asset after failed preflight"
+    done
+}
+
+case_root="$tmp_root/uninstall-exact"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+seed_legacy_current "$case_root"
+"$uninstall_helper" "$case_root"
+assert_canonical_assets_removed "$case_root"
+for asset in \
+    systemd-unit:systemd/facelock-daemon.service:etc/systemd/system/facelock-daemon.service \
+    dbus-policy:dbus/org.facelock.Daemon.conf:etc/dbus-1/system.d/org.facelock.Daemon.conf \
+    dbus-activation:dbus/org.facelock.Daemon.service:etc/dbus-1/system-services/org.facelock.Daemon.service; do
+    IFS=: read -r id source legacy <<<"$asset"
+    cmp -s "$repo_root/$source" "$case_root/$legacy" ||
+        fail "source uninstall changed exact regular legacy asset $id"
+done
+
+case_root="$tmp_root/uninstall-canonical-direct-symlink"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+canonical="$case_root/usr/share/dbus-1/system.d/org.facelock.Daemon.conf"
+outside="$case_root/outside-canonical-policy"
+cp "$repo_root/dbus/org.facelock.Daemon.conf" "$outside"
+rm -- "$canonical"
+ln -s "$outside" "$canonical"
+if "$uninstall_helper" "$case_root" >/dev/null 2>&1; then
+    fail "source uninstall accepted a linked canonical target"
+fi
+assert_canonical_assets_present "$case_root"
+[ -L "$canonical" ] || fail "source uninstall removed a linked canonical target"
+cmp -s "$repo_root/dbus/org.facelock.Daemon.conf" "$outside" ||
+    fail "source uninstall changed the direct-link outside sentinel"
+
+case_root="$tmp_root/uninstall-canonical-parent-symlink"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+canonical_parent="$case_root/usr/lib/systemd/system"
+outside_dir="$case_root/outside-canonical-systemd"
+outside="$outside_dir/facelock-daemon.service"
+mkdir -p "$outside_dir"
+cp "$repo_root/systemd/facelock-daemon.service" "$outside"
+rm -- "$canonical_parent/facelock-daemon.service"
+rmdir -- "$canonical_parent"
+ln -s "$outside_dir" "$canonical_parent"
+if "$uninstall_helper" "$case_root" >/dev/null 2>&1; then
+    fail "source uninstall accepted a linked canonical parent"
+fi
+assert_canonical_assets_present "$case_root"
+[ -L "$canonical_parent" ] || fail "source uninstall changed a linked canonical parent"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$outside" ||
+    fail "source uninstall removed the canonical parent-link outside sentinel"
+
+case_root="$tmp_root/uninstall-symlink"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+outside="$case_root/outside-unit"
+mkdir -p "${legacy%/*}"
+cp "$repo_root/systemd/facelock-daemon.service" "$outside"
+ln -s "$outside" "$legacy"
+"$uninstall_helper" "$case_root"
+assert_canonical_assets_removed "$case_root"
+[ -L "$legacy" ] || fail "source uninstall removed a direct legacy symlink"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$outside" ||
+    fail "source uninstall changed a direct-symlink target"
+
+case_root="$tmp_root/uninstall-hardlink"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+legacy="$case_root/etc/systemd/system/facelock-daemon.service"
+outside="$case_root/outside-unit"
+mkdir -p "${legacy%/*}"
+cp "$repo_root/systemd/facelock-daemon.service" "$outside"
+ln "$outside" "$legacy"
+before_links="$(stat -c %h "$outside")"
+"$uninstall_helper" "$case_root"
+assert_canonical_assets_removed "$case_root"
+[ -f "$legacy" ] || fail "source uninstall removed a legacy hardlink"
+[ "$(stat -c %h "$outside")" = "$before_links" ] ||
+    fail "source uninstall changed the legacy hardlink count"
+
+case_root="$tmp_root/uninstall-parent-symlink"
+mkdir -p "$case_root"
+seed_uninstall_case "$case_root"
+outside_dir="$case_root/outside-systemd"
+outside="$outside_dir/facelock-daemon.service"
+mkdir -p "$outside_dir" "$case_root/etc/systemd"
+cp "$repo_root/systemd/facelock-daemon.service" "$outside"
+ln -s "$outside_dir" "$case_root/etc/systemd/system"
+"$uninstall_helper" "$case_root"
+assert_canonical_assets_removed "$case_root"
+[ -L "$case_root/etc/systemd/system" ] ||
+    fail "source uninstall removed a symlinked legacy parent"
+cmp -s "$repo_root/systemd/facelock-daemon.service" "$outside" ||
+    fail "source uninstall changed the outside parent-symlink sentinel"
+
+echo "legacy system assets: ok"

--- a/test/lifecycle-ownership-contract.sh
+++ b/test/lifecycle-ownership-contract.sh
@@ -191,6 +191,14 @@ require_lifecycle_row() {
     done
 }
 
+require_security_text() {
+    local text="$1"
+
+    if ! grep -Fq -- "$text" <<<"$security_prose"; then
+        fail "docs/security.md must contain: $text"
+    fi
+}
+
 reject_state_purge_command() {
     local path="$1"
     local unsafe_lines
@@ -225,8 +233,8 @@ lifecycle_prose="$(tr '\n' ' ' <<<"$lifecycle_section")"
 # Freeze status and the ownership classes are scoped to the lifecycle section,
 # not satisfied by an unrelated mention elsewhere in this large contract file.
 require_lifecycle_text "This is the Wave 0 ownership freeze for issue #232."
-require_lifecycle_text "does not claim that the current"
-require_lifecycle_text "Debian purge script already implements the bounded purge"
+require_lifecycle_text "Debian post-removal script implements the bounded purge"
+require_lifecycle_text "Ordinary \`remove\` remains preservation-only"
 require_lifecycle_text "Ordinary removal is not data deletion."
 require_lifecycle_row "Package-owned static integration" \
     "Remove through the package manager" \
@@ -267,6 +275,7 @@ require_lifecycle_row "\`just uninstall\`" \
 
 require_lifecycle_text "PAM provenance and rollback files are not biometric state."
 require_lifecycle_text "Preserve PAM provenance when cleanup is incomplete"
+require_lifecycle_text "retains and reports the entire opaque subtree"
 require_lifecycle_text "The only purge roots are the compiled Facelock roots"
 require_lifecycle_text "Configured paths outside those roots are external remnants"
 require_lifecycle_text "leave them untouched, report that they were refused as external"
@@ -277,9 +286,46 @@ require_lifecycle_text "must not strand package-manager state"
 require_lifecycle_text "does not promise secure erasure"
 require_lifecycle_text "Debian \`postrm purge\` is self-contained"
 require_lifecycle_text "never invokes the already-removed \`facelock\` binary"
+require_lifecycle_text "single-link regular files"
+require_lifecycle_text "direct children of \`/var/lib/facelock/enrolled\`"
+require_lifecycle_text "Mount IDs from \`/proc/self/fdinfo\`"
+require_lifecycle_text "with \`O_DIRECTORY|O_NOFOLLOW\` descriptors"
+require_lifecycle_text "through \`/proc/self/fd/<fd>\`"
+require_lifecycle_text "dotted and quoted key or table components"
+require_lifecycle_text "TOML table scope intact"
+require_lifecycle_text "configuration could not be fully classified"
+require_lifecycle_text "opens regular candidates with \`O_NONBLOCK|O_NOFOLLOW\`"
+require_lifecycle_text "atomic no-replace"
+require_lifecycle_text "no inode-conditional \`unlinkat\` or \`rmdirat\`"
+require_lifecycle_text "same-authority process"
+require_lifecycle_text "helper never removes the three compiled root directories"
+require_lifecycle_text "64 descendant-directory levels"
+require_lifecycle_text "10,000 inspected entries"
+require_lifecycle_text "whole root subtree as retained"
+require_lifecycle_text "returns success after reporting safety refusals"
+
+security_prose="$(tr '\n' ' ' <"$repo_root/docs/security.md")"
+require_security_text "Debian purge traversal"
+require_security_text "treats the directory as an opaque subtree"
+require_security_text "never grants deletion authority to configured paths"
+require_security_text "root-owned, non-group/world-writable directory chain"
+require_security_text "single-link regular file"
+require_security_text "direct user-owned enrollment marker"
+require_security_text "opens every fixed-prefix and root component"
+require_security_text "opens regular candidates with \`O_NONBLOCK|O_NOFOLLOW\`"
+require_security_text "Mount IDs from \`/proc/self/fdinfo\`"
+require_security_text "against \`/proc/self/mountinfo\`"
+require_security_text "renameat2(RENAME_NOREPLACE)"
+require_security_text "no identity-conditional unlink"
+require_security_text "same-authority writer"
+require_security_text "helper never removes the three compiled root directories"
+require_security_text "64 descendant directory levels"
+require_security_text "10,000 inspected entries"
 
 for guide in docs/quickstart.md book/src/quickstart.md; do
     require_text "$guide" "Package lifecycle and retained data"
+    require_text "$guide" "Debian purge removes only provably safe entries"
+    require_text "$guide" "Unsafe or externally configured remnants are retained"
 done
 
 lifecycle_messages=(
@@ -301,10 +347,15 @@ done
 
 for message in "${lifecycle_messages[@]}"; do
     reject_text "$message" "To remove all face data"
-    require_text "$message" "Retained state cleanup is intentionally not automated."
     require_text "$message" "Cleanup must stay within the fixed roots above, leave configured external paths untouched, and refuse links or mount crossings."
     require_text "$message" "Filesystem deletion does not securely erase SSDs, snapshots, or backups."
 done
+
+for message in justfile dist/facelock.spec dist/facelock.install; do
+    require_text "$message" "Retained state cleanup is intentionally not automated."
+done
+require_text debian/postrm "Ordinary removal does not automate retained-state cleanup."
+require_text debian/postrm "If package purge was requested, a later maintainer-script phase attempts the bounded cleanup described below."
 
 if [ "$failures" -ne 0 ]; then
     echo "lifecycle ownership contract: $failures failure(s)" >&2

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 PASS=0
 FAIL=0
 SKIP=0
+ALLOWED_SKIP=0
 
 # Record an assertion (or a whole block of them) that did not run.
 #
@@ -16,9 +17,14 @@ SKIP=0
 skip_test() {
     local name="$1"
     local reason="$2"
+    local classification="${3:-mandatory}"
 
     echo "SKIP: $name ($reason)"
     SKIP=$((SKIP + 1))
+    if [ "$classification" = allowed-partial ] &&
+       [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = 1 ]; then
+        ALLOWED_SKIP=$((ALLOWED_SKIP + 1))
+    fi
 }
 
 run_test() {
@@ -40,18 +46,6 @@ run_test() {
         echo "FAIL (exit=$result, expected=$expected_result)"
         cat /tmp/test-output
         FAIL=$((FAIL + 1))
-    fi
-}
-
-run_warn_check() {
-    local name="$1"
-    local cmd="$2"
-
-    echo -n "WARN: $name ... "
-    if bash -c "$cmd" > /tmp/test-output 2>&1; then
-        echo "present"
-    else
-        echo "missing"
     fi
 }
 
@@ -155,6 +149,7 @@ verify_debian_packaged_pam_profile() {
     local bad_output=/tmp/facelock-common-auth-profile.bad
     local active=/tmp/facelock-common-auth-profile.active
     local selected=/tmp/facelock-pam-state-profile.active
+    local active_before="" enabled_before="" active_after="" enabled_after=""
     local failed=0 service_path=/etc/pam.d/facelock-profile-test
 
     cp -- /etc/pam.d/common-auth "$before" || return 1
@@ -168,12 +163,46 @@ verify_debian_packaged_pam_profile() {
         /etc/pam.d/common-auth || failed=1
     cp -- /etc/pam.d/common-auth "$active" || failed=1
     cp -- /var/lib/pam/auth "$selected" || failed=1
+    if [ -d /run/systemd/system ]; then
+        if ! active_before="$(systemctl show --property=ActiveState --value facelock-daemon.service 2>/dev/null)"; then
+            printf '%s\n' 'packaged PAM profile reinstall ActiveState: expected=<nonempty-before> actual=<command-error>' >&2
+            failed=1
+        elif [ -z "$active_before" ]; then
+            printf '%s\n' 'packaged PAM profile reinstall ActiveState: expected=<nonempty-before> actual=<empty>' >&2
+            failed=1
+        fi
+        if ! enabled_before="$(systemctl show --property=UnitFileState --value facelock-daemon.service 2>/dev/null)"; then
+            printf '%s\n' 'packaged PAM profile reinstall UnitFileState: expected=<nonempty-before> actual=<command-error>' >&2
+            failed=1
+        elif [ -z "$enabled_before" ]; then
+            printf '%s\n' 'packaged PAM profile reinstall UnitFileState: expected=<nonempty-before> actual=<empty>' >&2
+            failed=1
+        fi
+    fi
     apt-get install -y --reinstall /facelock-test-package.deb || failed=1
     cmp -s "$active" /etc/pam.d/common-auth || failed=1
     cmp -s "$selected" /var/lib/pam/auth || failed=1
     if [ -d /run/systemd/system ]; then
-        ! systemctl is-active --quiet facelock-daemon || failed=1
-        [ "$(systemctl is-enabled facelock-daemon 2>/dev/null || true)" = disabled ] || failed=1
+        if ! active_after="$(systemctl show --property=ActiveState --value facelock-daemon.service 2>/dev/null)"; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=<command-error>\n' "$active_before" >&2
+            failed=1
+        elif [ -z "$active_after" ]; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=<empty>\n' "$active_before" >&2
+            failed=1
+        elif [ "$active_after" != "$active_before" ]; then
+            printf 'packaged PAM profile reinstall ActiveState: expected=%s actual=%s\n' "$active_before" "$active_after" >&2
+            failed=1
+        fi
+        if ! enabled_after="$(systemctl show --property=UnitFileState --value facelock-daemon.service 2>/dev/null)"; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=<command-error>\n' "$enabled_before" >&2
+            failed=1
+        elif [ -z "$enabled_after" ]; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=<empty>\n' "$enabled_before" >&2
+            failed=1
+        elif [ "$enabled_after" != "$enabled_before" ]; then
+            printf 'packaged PAM profile reinstall UnitFileState: expected=%s actual=%s\n' "$enabled_before" "$enabled_after" >&2
+            failed=1
+        fi
     fi
 
     if ! printf '%s\n' test | LC_ALL=C timeout 30 \
@@ -304,8 +333,9 @@ case "$PACKAGE_FORMAT" in
         ;;
 esac
 
-run_warn_check "facelock-polkit-agent binary" "[ -x /usr/bin/facelock-polkit-agent ]"
-run_warn_check "quirks database files" "ls /usr/share/facelock/quirks.d/*.toml >/dev/null 2>&1"
+run_test "facelock-polkit-agent binary is installed" "[ -x /usr/bin/facelock-polkit-agent ]"
+run_test "quirks database files are installed" \
+    "find /usr/share/facelock/quirks.d -maxdepth 1 -type f -name '*.toml' -print -quit | grep -q ."
 
 run_test "PAM module exports pam_sm_authenticate" "nm -D \"$PAM_MODULE_PATH\" | grep -q pam_sm_authenticate"
 run_test "PAM module exports pam_sm_setcred" "nm -D \"$PAM_MODULE_PATH\" | grep -q pam_sm_setcred"
@@ -567,11 +597,12 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         # Explicitly asked for a partial run. Name every assertion that is not
         # running so the results line has to account for them.
         no_models="no ONNX models at /var/lib/facelock/models, FACELOCK_ALLOW_MISSING_MODELS=1"
-        skip_test "facelock-daemon starts under hardened unit" "$no_models"
-        skip_test "facelock-daemon answers on D-Bus" "$no_models"
-        skip_test "runtime: no daemon thread holds CAP_CHOWN while serving" "$no_models"
+        skip_test "facelock-daemon starts under hardened unit" "$no_models" allowed-partial
+        skip_test "facelock-daemon answers on D-Bus" "$no_models" allowed-partial
+        skip_test "runtime: no daemon thread holds CAP_CHOWN while serving" "$no_models" allowed-partial
         if [ "$PACKAGE_FORMAT" = deb ]; then
-            skip_test "Debian reinstall restarts only active daemons and preserves enabled state" "$no_models"
+            skip_test "Debian reinstall restarts only active daemons and preserves enabled state" \
+                "$no_models" allowed-partial
         fi
     else
         # Under a booted systemd, missing models are a broken invocation, not a
@@ -765,11 +796,21 @@ rm -f "$PACKAGE_OWNED_PAM" "$PACKAGE_BLOCKER_PAM" \
     /tmp/facelock-package-owned.sha /tmp/facelock-package-blocker.sha \
     /tmp/facelock-common-auth.before
 
+UNEXPECTED_SKIP=$((SKIP - ALLOWED_SKIP))
+if [ "$UNEXPECTED_SKIP" -gt 0 ]; then
+    echo "FAIL: $UNEXPECTED_SKIP unexpected skip(s) make package validation incomplete"
+    FAIL=$((FAIL + UNEXPECTED_SKIP))
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
 if [ "$SKIP" -gt 0 ]; then
-    echo "NOTE: $SKIP assertion(s)/block(s) above did not run — this run proves less"
-    echo "      than a full one. Grep the log for '^SKIP:' to see which."
+    if [ "$UNEXPECTED_SKIP" -gt 0 ]; then
+        echo "ERROR: skipped mandatory coverage is a package-validation failure"
+    else
+        echo "NOTE: $ALLOWED_SKIP model-dependent assertion(s) were skipped by the explicit"
+        echo "      FACELOCK_ALLOW_MISSING_MODELS=1 partial-run opt-out."
+    fi
 fi
 
 if [ "$FAIL" -gt 0 ]; then

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -153,6 +153,8 @@ verify_debian_packaged_pam_profile() {
     local before_metadata=/tmp/facelock-common-auth-profile.metadata.before
     local good_output=/tmp/facelock-common-auth-profile.good
     local bad_output=/tmp/facelock-common-auth-profile.bad
+    local active=/tmp/facelock-common-auth-profile.active
+    local selected=/tmp/facelock-pam-state-profile.active
     local failed=0 service_path=/etc/pam.d/facelock-profile-test
 
     cp -- /etc/pam.d/common-auth "$before" || return 1
@@ -164,6 +166,15 @@ verify_debian_packaged_pam_profile() {
     pam-auth-update --enable facelock --force || failed=1
     grep -Eq '^[[:space:]]*auth[[:space:]].*pam_facelock\.so([[:space:]]|$)' \
         /etc/pam.d/common-auth || failed=1
+    cp -- /etc/pam.d/common-auth "$active" || failed=1
+    cp -- /var/lib/pam/auth "$selected" || failed=1
+    apt-get install -y --reinstall /facelock-test-package.deb || failed=1
+    cmp -s "$active" /etc/pam.d/common-auth || failed=1
+    cmp -s "$selected" /var/lib/pam/auth || failed=1
+    if [ -d /run/systemd/system ]; then
+        ! systemctl is-active --quiet facelock-daemon || failed=1
+        [ "$(systemctl is-enabled facelock-daemon 2>/dev/null || true)" = disabled ] || failed=1
+    fi
 
     if ! printf '%s\n' test | LC_ALL=C timeout 30 \
         pamtester facelock-profile-test testuser authenticate >"$good_output" 2>&1; then
@@ -184,12 +195,97 @@ verify_debian_packaged_pam_profile() {
     [ "$(stat -c '%a %u %g' /etc/pam.d/common-auth)" = "$(cat "$before_metadata")" ] || failed=1
     ! grep -q pam_facelock\.so /etc/pam.d/common-auth || failed=1
 
-    rm -f -- "$before" "$before_metadata" "$good_output" "$bad_output" "$service_path"
+    rm -f -- "$before" "$before_metadata" "$good_output" "$bad_output" \
+        "$active" "$selected" "$service_path"
+    return "$failed"
+}
+
+verify_debian_active_profile_removal_guard() {
+    local inactive=/tmp/facelock-common-auth-removal.inactive
+    local inactive_metadata=/tmp/facelock-common-auth-removal.inactive.metadata
+    local inactive_selected=/tmp/facelock-pam-state-removal.inactive
+    local inactive_selected_metadata=/tmp/facelock-pam-state-removal.inactive.metadata
+    local active=/tmp/facelock-common-auth-removal.active
+    local active_metadata=/tmp/facelock-common-auth-removal.active.metadata
+    local selected=/tmp/facelock-pam-state-removal.active
+    local selected_metadata=/tmp/facelock-pam-state-removal.active.metadata
+    local profile=/tmp/facelock-pam-profile-removal
+    local profile_metadata=/tmp/facelock-pam-profile-removal.metadata
+    local remove_output=/tmp/facelock-profile-removal.dpkg
+    local profile_status_output=/tmp/facelock-profile-removal.status
+    local good_output=/tmp/facelock-common-auth-removal.good
+    local bad_output=/tmp/facelock-common-auth-removal.bad
+    local service_path=/etc/pam.d/facelock-profile-removal-test
+    local active_before enabled_before failed=0
+
+    cp -- /etc/pam.d/common-auth "$inactive" || return 1
+    stat -c '%a %u %g' /etc/pam.d/common-auth >"$inactive_metadata" || return 1
+    cp -- /var/lib/pam/auth "$inactive_selected" || return 1
+    stat -c '%a %u %g' /var/lib/pam/auth >"$inactive_selected_metadata" || return 1
+    printf '%s\n' \
+        'auth include common-auth' \
+        'account required pam_permit.so' >"$service_path" || return 1
+    pam-auth-update --enable facelock --force || failed=1
+    cp -- /etc/pam.d/common-auth "$active" || failed=1
+    stat -c '%a %u %g' /etc/pam.d/common-auth >"$active_metadata" || failed=1
+    cp -- /var/lib/pam/auth "$selected" || failed=1
+    stat -c '%a %u %g' /var/lib/pam/auth >"$selected_metadata" || failed=1
+    cp -- /usr/share/pam-configs/facelock "$profile" || failed=1
+    stat -c '%a %u %g' /usr/share/pam-configs/facelock >"$profile_metadata" || failed=1
+    if [ -d /run/systemd/system ]; then
+        active_before="$(systemctl is-active facelock-daemon 2>/dev/null || true)"
+        enabled_before="$(systemctl is-enabled facelock-daemon 2>/dev/null || true)"
+    fi
+
+    if ! facelock pam shared-profile-status >"$profile_status_output" 2>&1; then
+        failed=1
+    fi
+    [ ! -s "$profile_status_output" ] || failed=1
+    if dpkg -r facelock >"$remove_output" 2>&1; then
+        failed=1
+    fi
+    grep -Fq 'facelock: refusing package removal because the pam-auth-update profile is active.' \
+        "$remove_output" || failed=1
+    grep -Fq "run 'sudo pam-auth-update --disable facelock'" "$remove_output" || failed=1
+    cmp -s "$active" /etc/pam.d/common-auth || failed=1
+    [ "$(stat -c '%a %u %g' /etc/pam.d/common-auth)" = "$(cat "$active_metadata")" ] || failed=1
+    cmp -s "$selected" /var/lib/pam/auth || failed=1
+    [ "$(stat -c '%a %u %g' /var/lib/pam/auth)" = "$(cat "$selected_metadata")" ] || failed=1
+    cmp -s "$profile" /usr/share/pam-configs/facelock || failed=1
+    [ "$(stat -c '%a %u %g' /usr/share/pam-configs/facelock)" = "$(cat "$profile_metadata")" ] || failed=1
+    dpkg-query -W -f='${db:Status-Status}\n' facelock 2>/dev/null | grep -qx installed || failed=1
+    [ -x /usr/bin/facelock ] || failed=1
+    [ -f "$PAM_MODULE_PATH" ] || failed=1
+    if [ -d /run/systemd/system ]; then
+        [ "$(systemctl is-active facelock-daemon 2>/dev/null || true)" = "$active_before" ] || failed=1
+        [ "$(systemctl is-enabled facelock-daemon 2>/dev/null || true)" = "$enabled_before" ] || failed=1
+    fi
+
+    pam-auth-update --disable facelock --force || failed=1
+    cmp -s "$inactive" /etc/pam.d/common-auth || failed=1
+    [ "$(stat -c '%a %u %g' /etc/pam.d/common-auth)" = "$(cat "$inactive_metadata")" ] || failed=1
+    cmp -s "$inactive_selected" /var/lib/pam/auth || failed=1
+    [ "$(stat -c '%a %u %g' /var/lib/pam/auth)" = "$(cat "$inactive_selected_metadata")" ] || failed=1
+    if ! printf '%s\n' test | LC_ALL=C timeout 30 \
+        pamtester facelock-profile-removal-test testuser authenticate >"$good_output" 2>&1; then
+        failed=1
+    fi
+    grep -Fq 'successfully authenticated' "$good_output" || failed=1
+    if printf '%s\n' wrong | LC_ALL=C timeout 30 \
+        pamtester facelock-profile-removal-test testuser authenticate >"$bad_output" 2>&1; then
+        failed=1
+    fi
+    grep -Fq 'Authentication failure' "$bad_output" || failed=1
+
+    rm -f -- "$inactive" "$inactive_metadata" "$inactive_selected" \
+        "$inactive_selected_metadata" "$active" "$active_metadata" "$selected" \
+        "$selected_metadata" "$profile" "$profile_metadata" "$remove_output" \
+        "$profile_status_output" "$good_output" "$bad_output" "$service_path"
     return "$failed"
 }
 
 export -f pam_facelock_executes pam_missing_module_control_is_rejected
-export -f verify_debian_packaged_pam_profile
+export -f verify_debian_packaged_pam_profile verify_debian_active_profile_removal_guard
 
 echo "=== Facelock Package Validation ==="
 echo ""
@@ -248,7 +344,7 @@ else
 fi
 
 if [ "$PACKAGE_FORMAT" = deb ]; then
-    run_test "packaged opt-in PAM profile enables, falls back to password, and restores common-auth" \
+    run_test "packaged opt-in PAM profile survives reinstall, falls back to password, and restores common-auth" \
         "verify_debian_packaged_pam_profile"
 fi
 
@@ -364,6 +460,40 @@ daemon_threads_without_cap_chown() {
 }
 export -f daemon_threads_without_cap_chown
 
+verify_debian_reinstall_service_lifecycle() {
+    local before after failed=0
+
+    systemctl disable facelock-daemon >/dev/null 2>&1 || failed=1
+    systemctl start facelock-daemon || failed=1
+    before="$(unit_prop ExecMainStartTimestampMonotonic)"
+    apt-get install -y --reinstall /facelock-test-package.deb || failed=1
+    after="$(unit_prop ExecMainStartTimestampMonotonic)"
+    systemctl is-active --quiet facelock-daemon || failed=1
+    [ "$(systemctl is-enabled facelock-daemon 2>/dev/null || true)" = disabled ] || failed=1
+    [ -n "$before" ] && [ -n "$after" ] && [ "$before" != "$after" ] || failed=1
+
+    systemctl enable facelock-daemon >/dev/null 2>&1 || failed=1
+    before="$after"
+    apt-get install -y --reinstall /facelock-test-package.deb || failed=1
+    after="$(unit_prop ExecMainStartTimestampMonotonic)"
+    systemctl is-active --quiet facelock-daemon || failed=1
+    systemctl is-enabled --quiet facelock-daemon || failed=1
+    [ -n "$after" ] && [ "$before" != "$after" ] || failed=1
+
+    systemctl stop facelock-daemon || failed=1
+    apt-get install -y --reinstall /facelock-test-package.deb || failed=1
+    ! systemctl is-active --quiet facelock-daemon || failed=1
+    systemctl is-enabled --quiet facelock-daemon || failed=1
+
+    systemctl disable facelock-daemon >/dev/null 2>&1 || failed=1
+    apt-get install -y --reinstall /facelock-test-package.deb || failed=1
+    ! systemctl is-active --quiet facelock-daemon || failed=1
+    [ "$(systemctl is-enabled facelock-daemon 2>/dev/null || true)" = disabled ] || failed=1
+
+    return "$failed"
+}
+export -f verify_debian_reinstall_service_lifecycle
+
 if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1; then
     # Not empty: the notification privilege-drop needs CAP_SETUID+CAP_SETGID
     # (ambient, to survive the exec into runuser), and startup needs CAP_CHOWN
@@ -428,6 +558,10 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         # CAP_CHOWN is "never held while authenticating anyone" — this is the
         # assertion that makes the promise checkable.
         run_test "runtime: no daemon thread holds CAP_CHOWN while serving" "daemon_threads_without_cap_chown"
+        if [ "$PACKAGE_FORMAT" = deb ]; then
+            run_test "Debian reinstall restarts only active daemons and preserves enabled state" \
+                "verify_debian_reinstall_service_lifecycle"
+        fi
         systemctl stop facelock-daemon 2>/dev/null || true
     elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
         # Explicitly asked for a partial run. Name every assertion that is not
@@ -436,6 +570,9 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         skip_test "facelock-daemon starts under hardened unit" "$no_models"
         skip_test "facelock-daemon answers on D-Bus" "$no_models"
         skip_test "runtime: no daemon thread holds CAP_CHOWN while serving" "$no_models"
+        if [ "$PACKAGE_FORMAT" = deb ]; then
+            skip_test "Debian reinstall restarts only active daemons and preserves enabled state" "$no_models"
+        fi
     else
         # Under a booted systemd, missing models are a broken invocation, not a
         # property of the environment: the whole reason to boot systemd here is
@@ -444,8 +581,9 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
         # that never started a daemon — and the assertion it dropped is the
         # only one that can catch a per-thread capability regression. Fail.
         echo "FAIL: daemon-start block did not run (no ONNX models at /var/lib/facelock/models)"
-        echo "      Missing: the daemon start, its D-Bus Ping, and the runtime"
-        echo "      CAP_CHOWN thread walk — the regression pin for the per-thread"
+        echo "      Missing: the daemon start, its D-Bus Ping, the runtime CAP_CHOWN"
+        echo "      thread walk, and Debian service reinstall lifecycle — the pins for"
+        echo "      active-only restart and the per-thread"
         echo "      capability drop. The unit: CapabilityBoundingSet assertions above"
         echo "      read systemd configuration only and pass either way."
         echo "      Fix: run from a checkout with the ONNX models present"
@@ -463,6 +601,13 @@ fi
 # Package removal test — must come last since it removes the package
 echo ""
 echo "=== Package Removal Test ==="
+
+if [ "$PACKAGE_FORMAT" = deb ]; then
+    run_test "fresh Debian install leaves common-auth unchanged and Facelock-free" \
+        "[ -f /facelock-common-auth-install-invariant ] && ! grep -q pam_facelock.so /etc/pam.d/common-auth"
+    run_test "active administrator-selected profile blocks removal, preserves PAM, and allows verified migration retry" \
+        "verify_debian_active_profile_removal_guard"
+fi
 
 PACKAGE_OWNED_PAM=/etc/pam.d/facelock-package-owned
 PACKAGE_BLOCKER_PAM=/etc/pam.d/facelock-package-blocker
@@ -491,8 +636,6 @@ rm -rf /var/lib/facelock/models
 export ORT_DYLIB_PATH=/facelock-test-missing-onnxruntime.so
 
 if [ "$PACKAGE_FORMAT" = deb ]; then
-    run_test "fresh Debian install leaves common-auth unchanged and Facelock-free" \
-        "[ -f /facelock-common-auth-install-invariant ] && ! grep -q pam_facelock.so /etc/pam.d/common-auth"
     sha256sum /etc/pam.d/common-auth > /tmp/facelock-common-auth.before
     run_test "dpkg removal aborts on an unmanaged PAM reference" \
         "! dpkg -r facelock"
@@ -527,6 +670,8 @@ if [ "$PACKAGE_FORMAT" = deb ]; then
     run_test "apt wrapper preserves blocker bytes after abort" \
         "sha256sum -c --status /tmp/facelock-package-blocker.sha"
     rm -f "$PACKAGE_BLOCKER_PAM"
+    run_test "ordinary Debian removal starts with the daemon enabled" \
+        "systemctl enable facelock-daemon.service"
     run_test "Package removal via dpkg" "dpkg -r facelock"
     run_test "recognized arbitrary PAM edit cleaned before dpkg removes the module" \
         "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
@@ -534,8 +679,8 @@ if [ "$PACKAGE_FORMAT" = deb ]; then
     run_test "PAM module removed after dpkg -r" \
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
     run_test "Config preserved after dpkg -r (conffile)" "[ -f /etc/facelock/config.toml ]"
-    run_test "facelock reinstalls before apt-get wrapper success" \
-        "apt-get install -y /facelock-test-package.deb"
+    run_test "ordinary Debian remove preserves enabled state across reinstall" \
+        "apt-get install -y /facelock-test-package.deb && systemctl is-enabled --quiet facelock-daemon.service"
     cat > "$PACKAGE_OWNED_PAM" <<'EOF'
 #%PAM-1.0
 auth      sufficient pam_facelock.so

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -338,6 +338,23 @@ assert_matrix_mutation_rejected() {
     echo "release matrix mutation case: $context rejected"
 }
 
+assert_matrix_mutation_rejected \
+    "CI Debian source-contract target invocation" \
+    ".github/workflows/ci.yml" \
+    's/run: just test-deb-source-contract/run: just test-deb-source-contract-disabled/'
+assert_matrix_mutation_rejected \
+    "release Debian source-contract target invocation" \
+    ".github/workflows/release.yml" \
+    's/just test-deb-source-contract/just test-deb-source-contract-disabled/'
+assert_matrix_mutation_rejected \
+    "Debian source-contract shell recipe command" \
+    "justfile" \
+    's@    bash test/deb-source-contract.sh@    bash test/deb-source-contract-disabled.sh@'
+assert_matrix_mutation_rejected \
+    "Debian source-contract mutation recipe command" \
+    "justfile" \
+    's@    python3 test/deb-source-contract-test.py@    python3 test/deb-source-contract-test-disabled.py@'
+
 assert_matrix_payload_mutation_rejected_with_diagnostic() {
     local context="$1"
     local relative_file="$2"
@@ -774,8 +791,18 @@ esac
 assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0-alpha.1 unused
 
 apt_recipe_root="$tmp_root/apt-recipe-root"
-mkdir -p "$apt_recipe_root/dist/apt/conf" "$apt_recipe_root/scripts" "$apt_recipe_root/test"
+mkdir -p \
+    "$apt_recipe_root/debian" \
+    "$apt_recipe_root/dist/apt/conf" \
+    "$apt_recipe_root/scripts" \
+    "$apt_recipe_root/test"
 cp "$repo_root/justfile" "$apt_recipe_root/"
+cp "$repo_root/debian/postrm" "$apt_recipe_root/debian/"
+cat >"$apt_recipe_root/debian/generated-postrm-helper" <<'SCRIPT'
+if [ "$1" = "purge" ]; then
+    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
+fi
+SCRIPT
 cp "$repo_root/dist/apt/conf/distributions" "$apt_recipe_root/dist/apt/conf/"
 cp "$repo_root/scripts/release-versions.sh" "$apt_recipe_root/scripts/"
 cp "$repo_root/test/deb-package-contract.sh" \
@@ -887,12 +914,9 @@ if [ -z "$DPKG_ROOT" ] && [ "$1" = remove ] && [ -d /run/systemd/system ]; then
     deb-systemd-invoke stop 'facelock-daemon.service' >/dev/null || true
 fi
 SCRIPT
-        cat >"$3/postrm" <<'SCRIPT'
-#!/bin/sh
-if [ "$1" = "purge" ]; then
-    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
-fi
-SCRIPT
+        sed -e '/^#DEBHELPER#$/r debian/generated-postrm-helper' \
+            -e '/^#DEBHELPER#$/d' debian/postrm >"$3/postrm"
+        printf '%s\n' '/etc/facelock/config.toml' >"$3/conffiles"
         ;;
     *) exit 2 ;;
 esac

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -565,6 +565,14 @@ assert_matrix_mutation_rejected \
     "crates/facelock-cli/src/commands/pam.rs" \
     '/pub const DEFAULT_PAM_SERVICE/s/"sudo"/"doas"/'
 assert_matrix_mutation_rejected \
+    "docs compatibility extra Debian tested row" \
+    "docs/compatibility.md" \
+    '/| Debian 13 (Trixie) |/a\| Debian 12 (Bookworm) | systemd | daemon + D-Bus activation | Booted package gate |'
+assert_matrix_mutation_rejected \
+    "book compatibility extra Ubuntu tested row" \
+    "book/src/compatibility.md" \
+    '/| Ubuntu 26.04 LTS (Resolute) |/a\| Ubuntu Noble | systemd | daemon + D-Bus activation | Booted package gate |'
+assert_matrix_mutation_rejected \
     "trixie workflow variant axis reintroduced" \
     ".github/workflows/release.yml" \
     '0,/- suite: trixie/a\            variant: legacy'
@@ -862,7 +870,29 @@ case "${1:-}" in
         ;;
     --control)
         mkdir -p "${3:?}"
-        printf '%s\n' '#!/bin/sh' 'exit 0' >"$3/postinst"
+        cat >"$3/postinst" <<'SCRIPT'
+#!/bin/sh
+if [ -d /run/systemd/system ] && \
+           systemctl is-active --quiet facelock-daemon.service; then
+            systemctl try-restart facelock-daemon.service 2>/dev/null || true
+fi
+systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
+SCRIPT
+        cat >"$3/prerm" <<'SCRIPT'
+#!/bin/sh
+facelock pam shared-profile-status
+facelock pam remove --all --dry-run
+facelock pam remove --all
+if [ -z "$DPKG_ROOT" ] && [ "$1" = remove ] && [ -d /run/systemd/system ]; then
+    deb-systemd-invoke stop 'facelock-daemon.service' >/dev/null || true
+fi
+SCRIPT
+        cat >"$3/postrm" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "purge" ]; then
+    deb-systemd-helper purge 'facelock-daemon.service' >/dev/null || true
+fi
+SCRIPT
         ;;
     *) exit 2 ;;
 esac

--- a/test/run-deb-offline-build.sh
+++ b/test/run-deb-offline-build.sh
@@ -41,6 +41,34 @@ exact_manifest() {
     printf '%s\n' "${manifests[0]}"
 }
 
+write_data_archive_inventory() {
+    local package="$1" output="$2" data_tar
+    data_tar="$(mktemp "${TMPDIR:-/tmp}/facelock-deb-data.XXXXXX.tar")"
+    dpkg-deb --fsys-tarfile "$package" >"$data_tar"
+    python3 - "$data_tar" >"$output" <<'PY'
+import sys
+import tarfile
+
+with tarfile.open(sys.argv[1], mode="r:") as archive:
+    for member in sorted(archive.getmembers(), key=lambda item: item.name):
+        if member.isdir():
+            kind = "directory"
+        elif member.isfile():
+            kind = "regular"
+        elif member.issym():
+            kind = "symlink"
+        elif member.islnk():
+            kind = "hardlink"
+        else:
+            kind = f"type-{member.type!r}"
+        print(
+            f"{member.name}\t{kind}\t{member.mode:o}\t{member.uid}\t"
+            f"{member.gid}\t{member.size}\t{member.linkname}"
+        )
+PY
+    rm -f -- "$data_tar"
+}
+
 compare_packages() {
     local release_deb="$1"
     local rebuilt_deb="$2"
@@ -80,6 +108,55 @@ compare_packages() {
         echo "offline Debian build: installed hash differences follow" >&2
         diff -u "$comparison_root/release.hashes" "$comparison_root/rebuilt.hashes" >&2 || true
         fail "clean rebuild changed installed file bytes"
+    fi
+    write_data_archive_inventory \
+        "$release_deb" "$comparison_root/release.archive-metadata"
+    write_data_archive_inventory \
+        "$rebuilt_deb" "$comparison_root/rebuilt.archive-metadata"
+    if ! cmp -s \
+        "$comparison_root/release.archive-metadata" \
+        "$comparison_root/rebuilt.archive-metadata"; then
+        echo "offline Debian build: data archive metadata differences follow" >&2
+        diff -u \
+            "$comparison_root/release.archive-metadata" \
+            "$comparison_root/rebuilt.archive-metadata" >&2 || true
+        fail "clean rebuild changed data path/type/mode/UID/GID/link inventory"
+    fi
+    rm -rf -- "$comparison_root"
+}
+
+compare_control_archives() {
+    local release_deb="$1"
+    local rebuilt_deb="$2"
+    local comparison_root release_root rebuilt_root
+    comparison_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-control-compare.XXXXXX")"
+    release_root="$comparison_root/release"
+    rebuilt_root="$comparison_root/rebuilt"
+    mkdir "$release_root" "$rebuilt_root"
+    dpkg-deb --control "$release_deb" "$release_root"
+    dpkg-deb --control "$rebuilt_deb" "$rebuilt_root"
+    (
+        cd "$release_root"
+        find . -mindepth 1 -printf '%P %y %m %l\n' | LC_ALL=C sort
+    ) >"$comparison_root/release.paths"
+    (
+        cd "$rebuilt_root"
+        find . -mindepth 1 -printf '%P %y %m %l\n' | LC_ALL=C sort
+    ) >"$comparison_root/rebuilt.paths"
+    cmp -s "$comparison_root/release.paths" "$comparison_root/rebuilt.paths" ||
+        fail "clean rebuild changed control path/type/mode/link inventory"
+    (
+        cd "$release_root"
+        find . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum
+    ) >"$comparison_root/release.hashes"
+    (
+        cd "$rebuilt_root"
+        find . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum
+    ) >"$comparison_root/rebuilt.hashes"
+    if ! cmp -s "$comparison_root/release.hashes" "$comparison_root/rebuilt.hashes"; then
+        echo "offline Debian build: control hash differences follow" >&2
+        diff -u "$comparison_root/release.hashes" "$comparison_root/rebuilt.hashes" >&2 || true
+        fail "clean rebuild changed control archive bytes"
     fi
     rm -rf -- "$comparison_root"
 }
@@ -130,6 +207,8 @@ case "$mode" in
         rebuilt_deb="$rebuild_root/facelock_${package_version}_${architecture}.deb"
         [ -f "$rebuilt_deb" ] || fail "clean rebuild did not emit expected deb: $rebuilt_deb"
         compare_packages "$release_deb" "$rebuilt_deb"
+        compare_control_archives "$release_deb" "$rebuilt_deb"
+        bash "/usr/local/libexec/facelock/test/deb-package-contract.sh" "$rebuilt_deb"
         cp -- "$rebuilt_deb" "$output_dir/"
         ;;
     *)

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -7,10 +7,28 @@
 # the daemon inside the sandbox, and probe the seccomp/address-family
 # restrictions with transient units.
 #
-# Usage: test/run-pkg-validate-systemd.sh <image>
+# Usage: test/run-pkg-validate-systemd.sh <image> [exact-package.deb]
 set -euo pipefail
 
-IMAGE="${1:?usage: run-pkg-validate-systemd.sh <image>}"
+IMAGE="${1:?usage: run-pkg-validate-systemd.sh <image> [exact-package.deb]}"
+PACKAGE="${2:-}"
+[ "$#" -le 2 ] || {
+    echo "usage: run-pkg-validate-systemd.sh <image> [exact-package.deb]" >&2
+    exit 2
+}
+package_mount=()
+if [ -n "$PACKAGE" ]; then
+    [ -f "$PACKAGE" ] && [ ! -L "$PACKAGE" ] || {
+        echo "exact Debian package is not a regular file: $PACKAGE" >&2
+        exit 1
+    }
+    PACKAGE="$(cd "$(dirname "$PACKAGE")" && pwd)/$(basename "$PACKAGE")"
+    [ "$(stat -c %a "$PACKAGE")" = 444 ] || {
+        echo "exact Debian package must have mode 0444: $PACKAGE" >&2
+        exit 1
+    }
+    package_mount=(-v "$PACKAGE:/facelock-test-package.deb:ro,Z")
+fi
 
 # Bind-mount repo ONNX models so the daemon-start test can run: `facelock
 # daemon` loads models at startup. Models are large and gitignored, so a fresh
@@ -50,7 +68,7 @@ fi
 #   ProtectProc=/ProcSubset= (they need a fresh procfs mount, which the
 #   kernel refuses when parts of /proc are overmounted).
 cid=$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
-    "${mounts[@]}" "$IMAGE" /lib/systemd/systemd)
+    "${mounts[@]}" "${package_mount[@]}" "$IMAGE" /lib/systemd/systemd)
 trap 'podman rm -f "$cid" >/dev/null 2>&1 || true' EXIT
 
 # Wait for systemd to finish booting (degraded is fine — minimal containers
@@ -71,7 +89,8 @@ fi
 
 # Never expose checkout files at Facelock's mutable runtime path. Copy only
 # model payloads from the read-only mount into this disposable container after
-# systemd has booted; package tests may then safely exercise lifecycle cleanup.
+# systemd has booted. The genuine active-service upgrade cases need the daemon
+# to load them before the shared package validator begins.
 if [ "${#onnx[@]}" -gt 0 ]; then
     podman exec "$cid" sh -eu -c '
         install -d -m 0755 /var/lib/facelock/models
@@ -82,8 +101,30 @@ if [ "${#onnx[@]}" -gt 0 ]; then
     '
 fi
 
+if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
+    [ -n "$PACKAGE" ] || {
+        echo "ERROR: Debian lifecycle image requires an exact package argument" >&2
+        exit 1
+    }
+    podman exec "$cid" /deb-package-lifecycle.sh install-remove-reinstall
+    podman exec "$cid" /deb-package-lifecycle.sh versioned-upgrade-inactive
+    if [ "${#onnx[@]}" -gt 0 ]; then
+        podman exec "$cid" /deb-package-lifecycle.sh versioned-upgrade-active
+    elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = 1 ]; then
+        echo "SKIP: Debian active-service versioned upgrades (no ONNX models, FACELOCK_ALLOW_MISSING_MODELS=1)" >&2
+    else
+        echo "ERROR: Debian active-service versioned upgrades require the reviewed ONNX models" >&2
+        exit 1
+    fi
+    podman exec "$cid" install -m 0644 /facelock-test.pam /etc/pam.d/facelock-test
+fi
+
 if podman exec "$cid" test -x /rpm-service-pam-lifecycle.sh; then
     podman exec "$cid" /rpm-service-pam-lifecycle.sh
 fi
 
 podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh
+
+if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
+    podman exec "$cid" /deb-package-lifecycle.sh purge
+fi

--- a/test/run-source-install-daemon-lifecycle-systemd.sh
+++ b/test/run-source-install-daemon-lifecycle-systemd.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image=${1:?usage: run-source-install-daemon-lifecycle-systemd.sh <image>}
+cases=(
+    unmasked-active
+    unmasked-inactive
+    first-install
+    persistent-symlink-mask
+    persistent-regular-mask
+    runtime-symlink-mask
+    runtime-regular-mask
+    both-masks
+    stale-persistent-mask
+    stale-runtime-mask
+    persistent-override-runtime-mask
+    persistent-mask-runtime-override
+    active-stale-mask-refused
+    active-effective-mask-refused
+    manager-disk-mismatch-refused
+    persistent-control-conflict
+    runtime-control-conflict
+    cleanup-initial-reload-failure
+    cleanup-final-reload-failure
+    cleanup-mask-race
+    cleanup-definition-race
+    cleanup-fragment-race
+    cleanup-owner-race
+    cleanup-pre-restart-mask-race
+    recipe-admin-overrides-preserved
+    recipe-fake-manager-overrides-preserved
+    recipe-known-legacy-retired
+    recipe-first-install-failure-retry
+    recipe-first-install-hup-retry
+)
+if [ "$#" -gt 1 ]; then
+    cases=("$2")
+fi
+
+for case_name in "${cases[@]}"; do
+    container="$(podman run -d --rm --systemd=always \
+        "$image" /usr/lib/systemd/systemd)"
+    cleanup() {
+        podman rm -f "$container" >/dev/null 2>&1 || true
+    }
+    trap cleanup EXIT
+
+    booted=
+    for _ in $(seq 1 120); do
+        state="$(podman exec "$container" \
+            systemctl is-system-running 2>/dev/null || true)"
+        case "$state" in
+            running | degraded)
+                if podman exec "$container" busctl --system call \
+                    org.freedesktop.DBus /org/freedesktop/DBus \
+                    org.freedesktop.DBus NameHasOwner s \
+                    org.facelock.Daemon >/dev/null 2>&1; then
+                    booted=true
+                    break
+                fi
+                ;;
+        esac
+        sleep 1
+    done
+    if [ "$booted" != true ]; then
+        podman exec "$container" systemctl --failed --no-pager 2>&1 || true
+        exit 1
+    fi
+
+    if ! podman exec "$container" \
+        /source-install-lifecycle/test/source-install-daemon-lifecycle-systemd.sh \
+        "$case_name"; then
+        podman logs "$container" 2>&1 || true
+        exit 1
+    fi
+    cleanup
+    trap - EXIT
+done
+
+echo "source-install daemon lifecycle real systemd: OK"

--- a/test/source-install-daemon-lifecycle-systemd.sh
+++ b/test/source-install-daemon-lifecycle-systemd.sh
@@ -1,0 +1,636 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case_name=${1:?usage: source-install-daemon-lifecycle-systemd.sh <case>}
+root=/source-install-lifecycle
+lifecycle=$root/scripts/source-install-daemon-lifecycle.sh
+unit=/usr/lib/systemd/system/facelock-daemon.service
+definition=/usr/share/dbus-1/system-services/org.facelock.Daemon.service
+persistent_mask=/etc/systemd/system/facelock-daemon.service
+runtime_mask=/run/systemd/system/facelock-daemon.service
+persistent_control=/etc/systemd/system.control/facelock-daemon.service
+runtime_control=/run/systemd/system.control/facelock-daemon.service
+barrier=/run/systemd/system.control/facelock-daemon.service
+
+fail() {
+    echo "source-install real systemd ($case_name): $*" >&2
+    systemctl show facelock-daemon.service --no-pager >&2 || true
+    exit 1
+}
+
+owner_is() {
+    local expected=$1
+    [ "$(busctl --system call org.freedesktop.DBus /org/freedesktop/DBus \
+        org.freedesktop.DBus NameHasOwner s org.facelock.Daemon)" = \
+        "b $expected" ]
+}
+
+unit_state_is() {
+    local expected_load=$1
+    local expected_active=$2
+    local expected_fragment=$3
+    local snapshot
+    snapshot="$(systemctl show facelock-daemon.service \
+        --property=LoadState --property=ActiveState --property=FragmentPath \
+        --no-pager)"
+    [ "$snapshot" = "$(printf '%s\n' \
+        "LoadState=$expected_load" \
+        "ActiveState=$expected_active" \
+        "FragmentPath=$expected_fragment")" ]
+}
+
+stat_mask() {
+    local path=$1
+    stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$path"
+    if [ -L "$path" ]; then
+        readlink -- "$path"
+    fi
+}
+
+file_identity() {
+    stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$1"
+    sha256sum -- "$1" | awk '{print $1}'
+}
+
+install_test_assets() {
+    install -m755 "$root/test/source-install-daemon-stub.sh" /usr/bin/facelock
+    install -m644 "$root/test/source-install-daemon-test.service" "$unit"
+    install -m644 "$root/dbus/org.facelock.Daemon.service" "$definition"
+}
+
+prepare_recipe_assets() {
+    local repository=$root/repository
+
+    /usr/bin/install -m755 "$root/test/source-install-daemon-stub.sh" \
+        "$repository/target/release/facelock"
+    /usr/bin/install -m644 /lib/security/pam_facelock.so \
+        "$repository/target/release/libpam_facelock.so"
+}
+
+run_install_recipe() {
+    (
+        cd "$root/repository"
+        /usr/bin/just --justfile "$root/repository/justfile" \
+            install-files
+    )
+}
+
+install_fixed_path_recipe_probes() {
+    local fake_manager=${1:-false}
+
+    if [ ! -e /usr/bin/install.facelock-real ]; then
+        /usr/bin/mv /usr/bin/install /usr/bin/install.facelock-real
+        /usr/bin/cp "$root/test/source-install-recipe-install-probe.sh" \
+            /usr/bin/install
+        /usr/bin/chmod 755 /usr/bin/install
+    fi
+    export FACELOCK_RECIPE_REAL_INSTALL=/usr/bin/install.facelock-real
+    if [ "$fake_manager" = true ]; then
+        /usr/bin/mv /usr/bin/systemctl /usr/bin/systemctl.facelock-real
+        /usr/bin/mv /usr/bin/busctl /usr/bin/busctl.facelock-real
+        /usr/bin/cp "$root/test/source-install-recipe-fake-systemctl.sh" \
+            /usr/bin/systemctl
+        /usr/bin/cp "$root/test/source-install-recipe-fake-busctl.sh" \
+            /usr/bin/busctl
+        /usr/bin/chmod 755 /usr/bin/systemctl /usr/bin/busctl
+    fi
+}
+
+run_recipe_case() {
+    local fault=${1:-}
+    local first_write_marker=/run/facelock-source-install-recipe-first-write
+    local binary_before expected_status status
+
+    prepare_recipe_assets
+    rm -f "$first_write_marker"
+    case "$case_name" in
+        recipe-known-legacy-retired)
+            mkdir -p /etc/systemd/system /etc/dbus-1/system.d \
+                /etc/dbus-1/system-services
+            /usr/bin/install -m644 \
+                "$root/repository/systemd/facelock-daemon.service" \
+                "$persistent_mask"
+            /usr/bin/install -m644 \
+                "$root/repository/dbus/org.facelock.Daemon.conf" \
+                /etc/dbus-1/system.d/org.facelock.Daemon.conf
+            /usr/bin/install -m644 \
+                "$root/repository/dbus/org.facelock.Daemon.service" \
+                /etc/dbus-1/system-services/org.facelock.Daemon.service
+            systemctl daemon-reload
+            systemctl start facelock-daemon.service
+            owner_is true || fail "known-legacy oracle did not own its D-Bus name"
+            install_fixed_path_recipe_probes false
+            run_install_recipe || fail "known-legacy actual install-files recipe failed"
+            for path in \
+                "$persistent_mask" \
+                /etc/dbus-1/system.d/org.facelock.Daemon.conf \
+                /etc/dbus-1/system-services/org.facelock.Daemon.service \
+                /etc/systemd/system/.facelock-migrate-systemd-unit \
+                /etc/dbus-1/system.d/.facelock-migrate-dbus-policy \
+                /etc/dbus-1/system-services/.facelock-migrate-dbus-activation; do
+                [ ! -e "$path" ] && [ ! -L "$path" ] ||
+                    fail "known-legacy recipe retained $path"
+            done
+            systemctl is-active --quiet facelock-daemon.service ||
+                fail "known-legacy recipe did not restore the active daemon"
+            owner_is true || fail "known-legacy recipe did not restore the D-Bus owner"
+            ;;
+        recipe-admin-overrides-preserved | recipe-fake-manager-overrides-preserved)
+            if [ "$case_name" = recipe-fake-manager-overrides-preserved ]; then
+                export FACELOCK_RECIPE_FAKE_STATE_DIR=/run/facelock-recipe-fake-manager
+                mkdir -p "$FACELOCK_RECIPE_FAKE_STATE_DIR"
+                printf '%s\n' active >"$FACELOCK_RECIPE_FAKE_STATE_DIR/active-state"
+            fi
+            mkdir -p /etc/systemd/system /etc/dbus-1/system.d \
+                /etc/dbus-1/system-services
+            {
+                cat "$root/test/source-install-daemon-test.service"
+                printf '%s\n' '# historical administrator unit'
+            } >"$persistent_mask"
+            {
+                cat "$root/dbus/org.facelock.Daemon.service"
+                printf '%s\n' '# historical administrator activation definition'
+            } >/etc/dbus-1/system-services/org.facelock.Daemon.service
+            printf '%s\n' \
+                '<busconfig>' \
+                '  <policy user="root"><allow own="org.facelock.Daemon"/></policy>' \
+                '  <policy context="default"><allow send_destination="org.facelock.Daemon"/></policy>' \
+                '  <!-- historical administrator policy -->' \
+                '</busconfig>' >/etc/dbus-1/system.d/org.facelock.Daemon.conf
+            chmod 0644 "$persistent_mask" \
+                /etc/dbus-1/system-services/org.facelock.Daemon.service \
+                /etc/dbus-1/system.d/org.facelock.Daemon.conf
+            unit_before="$(file_identity "$persistent_mask")"
+            definition_before="$(file_identity \
+                /etc/dbus-1/system-services/org.facelock.Daemon.service)"
+            policy_before="$(file_identity \
+                /etc/dbus-1/system.d/org.facelock.Daemon.conf)"
+            if [ "$case_name" = recipe-admin-overrides-preserved ]; then
+                systemctl daemon-reload
+                systemctl start facelock-daemon.service
+                install_fixed_path_recipe_probes false
+            else
+                install_fixed_path_recipe_probes true
+            fi
+            run_install_recipe || fail "actual install-files recipe failed"
+            [ "$(file_identity "$persistent_mask")" = "$unit_before" ] ||
+                fail "actual recipe changed the historical administrator unit"
+            [ "$(file_identity /etc/dbus-1/system-services/org.facelock.Daemon.service)" = \
+                "$definition_before" ] ||
+                fail "actual recipe changed the historical D-Bus definition"
+            [ "$(file_identity /etc/dbus-1/system.d/org.facelock.Daemon.conf)" = \
+                "$policy_before" ] ||
+                fail "actual recipe changed the historical D-Bus policy"
+            cmp -s "$root/repository/systemd/facelock-daemon.service" "$unit" ||
+                fail "actual recipe did not install the canonical /usr unit"
+            cmp -s "$root/repository/dbus/org.facelock.Daemon.service" \
+                "$definition" ||
+                fail "actual recipe did not install the canonical /usr D-Bus definition"
+            if [ "$case_name" = recipe-admin-overrides-preserved ]; then
+                systemctl is-active --quiet facelock-daemon.service ||
+                    fail "actual recipe did not restore the active daemon"
+                owner_is true || fail "actual recipe did not restore the D-Bus owner"
+            else
+                [ "$(cat "$FACELOCK_RECIPE_FAKE_STATE_DIR/active-state")" = active ] ||
+                    fail "fake-manager recipe did not restore the active state"
+            fi
+            ;;
+        recipe-first-install-failure-retry | recipe-first-install-hup-retry)
+            rm -f "$unit" "$definition" "$persistent_mask" \
+                /etc/dbus-1/system-services/org.facelock.Daemon.service \
+                /etc/dbus-1/system.d/org.facelock.Daemon.conf
+            systemctl daemon-reload
+            unit_state_is not-found inactive '' ||
+                fail "first-install recipe oracle was not absent"
+            binary_before="$(file_identity /usr/bin/facelock)"
+            set +e
+            export FACELOCK_RECIPE_FIRST_WRITE_FAULT="$fault"
+            export FACELOCK_RECIPE_FIRST_WRITE_MARKER="$first_write_marker"
+            install_fixed_path_recipe_probes false
+            run_install_recipe
+            status=$?
+            set -e
+            unset FACELOCK_RECIPE_FIRST_WRITE_FAULT \
+                FACELOCK_RECIPE_FIRST_WRITE_MARKER
+            case "$fault" in
+                failure) expected_status=1 ;;
+                HUP) expected_status=129 ;;
+                *) fail "unknown first-write fault $fault" ;;
+            esac
+            [ "$status" -eq "$expected_status" ] ||
+                fail "first-write $fault exited $status, expected $expected_status"
+            [ -e "$first_write_marker" ] ||
+                fail "first-write $fault did not reach the injected boundary"
+            [ "$(file_identity /usr/bin/facelock)" = "$binary_before" ] ||
+                fail "first-write $fault changed the first asset"
+            [ ! -e "$unit" ] && [ ! -e "$definition" ] ||
+                fail "first-write $fault reached a later activation asset"
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+                fail "first-write $fault left the barrier installed"
+            unit_state_is not-found inactive '' ||
+                fail "first-write $fault did not restore the absent manager state"
+            owner_is false || fail "first-write $fault acquired the D-Bus name"
+            run_install_recipe || fail "retry after first-write $fault failed"
+            cmp -s "$root/repository/systemd/facelock-daemon.service" "$unit" ||
+                fail "retry after first-write $fault missed the /usr unit"
+            cmp -s "$root/repository/dbus/org.facelock.Daemon.service" \
+                "$definition" ||
+                fail "retry after first-write $fault missed the D-Bus definition"
+            ! systemctl is-active --quiet facelock-daemon.service ||
+                fail "retry after first-write $fault activated an initially absent daemon"
+            owner_is false ||
+                fail "retry after first-write $fault acquired the D-Bus name"
+            ;;
+    esac
+    [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+        fail "actual recipe left its barrier installed"
+    flock -n /run/facelock/lifecycle.lock true ||
+        fail "actual recipe left the lifecycle lock held"
+    [ "$(stat -c '%U:%G:%a:%F' /run/facelock)" = \
+        'root:root:755:directory' ] ||
+        fail "actual recipe left an unsafe canonical lifecycle lock directory"
+    [ "$(stat -c '%U:%G:%a:%h:%s:%F' /run/facelock/lifecycle.lock)" = \
+        'root:root:600:1:0:regular empty file' ] ||
+        fail "actual recipe left an unsafe canonical lifecycle lock"
+}
+
+make_mask() {
+    local path=$1
+    local kind=$2
+    mkdir -p "${path%/*}"
+    case "$kind" in
+        symlink) ln -s /dev/null "$path" ;;
+        regular) install -m644 /dev/null "$path" ;;
+        *) fail "unknown mask kind $kind" ;;
+    esac
+}
+
+pin_inactive_loaded_unit() {
+    local enabled_state
+    printf '%s\n' \
+        '[Unit]' \
+        'Wants=facelock-daemon.service' \
+        'After=facelock-daemon.service' \
+        > /run/systemd/system/facelock-source-pin.target
+    systemctl daemon-reload
+    systemctl start facelock-source-pin.target
+    systemctl stop facelock-daemon.service
+    [ "$(systemctl show facelock-daemon.service \
+        --property=LoadState --value --no-pager)" = loaded ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=ActiveState --value --no-pager)" = inactive ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=UnitFileState --value --no-pager)" = static ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=FragmentPath --value --no-pager)" = "$unit" ] ||
+        fail "could not pin the loaded/inactive oracle"
+    enabled_state="$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)"
+    [ "$enabled_state" = static ] || fail "pinned oracle was not initially static"
+}
+
+assert_stale_mask_oracle() {
+    local expected_enabled=$1
+    local enabled_state
+    [ "$(systemctl show facelock-daemon.service \
+        --property=LoadState --value --no-pager)" = loaded ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=ActiveState --value --no-pager)" = inactive ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=UnitFileState --value --no-pager)" = static ] &&
+        [ "$(systemctl show facelock-daemon.service \
+            --property=FragmentPath --value --no-pager)" = "$unit" ] ||
+        fail "mask unexpectedly changed the cached unit"
+    enabled_state="$(systemctl is-enabled facelock-daemon.service 2>/dev/null || true)"
+    [ "$enabled_state" = "$expected_enabled" ] ||
+        fail "disk mask did not have expected enablement state $expected_enabled"
+}
+
+install_test_assets
+rm -f "$persistent_mask" "$runtime_mask" "$persistent_control" \
+    "$runtime_control" /run/facelock-source-install-stop-proof
+systemctl daemon-reload
+systemctl stop facelock-daemon.service
+owner_is false || fail "daemon owned the bus before setup"
+
+case "$case_name" in
+    recipe-known-legacy-retired | recipe-admin-overrides-preserved | \
+        recipe-fake-manager-overrides-preserved)
+        run_recipe_case
+        echo "source-install real systemd ($case_name): OK"
+        exit 0
+        ;;
+    recipe-first-install-failure-retry)
+        run_recipe_case failure
+        echo "source-install real systemd ($case_name): OK"
+        exit 0
+        ;;
+    recipe-first-install-hup-retry)
+        run_recipe_case HUP
+        echo "source-install real systemd ($case_name): OK"
+        exit 0
+        ;;
+esac
+
+expected_success=true
+expected_cleanup_success=true
+initial_active=false
+expected_final_fragment=$unit
+cleanup_fault=
+case "$case_name" in
+    unmasked-active)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        ;;
+    unmasked-inactive) ;;
+    first-install)
+        rm -f "$unit" "$definition"
+        systemctl daemon-reload
+        ;;
+    persistent-symlink-mask)
+        make_mask "$persistent_mask" symlink
+        systemctl daemon-reload
+        expected_final_fragment=$persistent_mask
+        ;;
+    persistent-regular-mask)
+        make_mask "$persistent_mask" regular
+        systemctl daemon-reload
+        expected_final_fragment=$persistent_mask
+        ;;
+    runtime-symlink-mask)
+        make_mask "$runtime_mask" symlink
+        systemctl daemon-reload
+        expected_final_fragment=$runtime_mask
+        ;;
+    runtime-regular-mask)
+        make_mask "$runtime_mask" regular
+        systemctl daemon-reload
+        expected_final_fragment=$runtime_mask
+        ;;
+    both-masks)
+        make_mask "$persistent_mask" symlink
+        make_mask "$runtime_mask" regular
+        systemctl daemon-reload
+        expected_final_fragment=$persistent_mask
+        ;;
+    stale-persistent-mask)
+        pin_inactive_loaded_unit
+        make_mask "$persistent_mask" symlink
+        assert_stale_mask_oracle masked
+        expected_final_fragment=$persistent_mask
+        ;;
+    stale-runtime-mask)
+        pin_inactive_loaded_unit
+        make_mask "$runtime_mask" regular
+        assert_stale_mask_oracle masked-runtime
+        expected_final_fragment=$runtime_mask
+        ;;
+    persistent-override-runtime-mask)
+        install -m644 "$root/test/source-install-daemon-test.service" \
+            "$persistent_mask"
+        make_mask "$runtime_mask" symlink
+        systemctl daemon-reload
+        expected_final_fragment=$persistent_mask
+        ;;
+    persistent-mask-runtime-override)
+        make_mask "$persistent_mask" symlink
+        install -m644 "$root/test/source-install-daemon-test.service" \
+            "$runtime_mask"
+        systemctl daemon-reload
+        expected_final_fragment=$persistent_mask
+        ;;
+    active-stale-mask-refused)
+        systemctl start facelock-daemon.service
+        make_mask "$persistent_mask" symlink
+        expected_success=false
+        initial_active=true
+        ;;
+    active-effective-mask-refused)
+        systemctl start facelock-daemon.service
+        make_mask "$runtime_mask" symlink
+        systemctl daemon-reload
+        expected_success=false
+        initial_active=true
+        ;;
+    manager-disk-mismatch-refused)
+        pin_inactive_loaded_unit
+        make_mask "$persistent_mask" symlink
+        systemctl daemon-reload
+        unit_state_is masked inactive "$persistent_mask" ||
+            fail "manager did not load the persistent mismatch oracle"
+        [ "$(systemctl show facelock-daemon.service \
+            --property=UnitFileState --value --no-pager)" = masked ] ||
+            fail "persistent mismatch oracle had the wrong unit-file state"
+        rm -f "$persistent_mask"
+        unit_state_is masked inactive "$persistent_mask" ||
+            fail "manager discarded the mismatch oracle after unlink"
+        [ "$(systemctl show facelock-daemon.service \
+            --property=UnitFileState --value --no-pager)" = masked ] ||
+            fail "unlinked mismatch oracle had the wrong unit-file state"
+        expected_success=false
+        ;;
+    persistent-control-conflict)
+        mkdir -p "${persistent_control%/*}"
+        : >"$persistent_control"
+        chmod 600 "$persistent_control"
+        expected_success=false
+        ;;
+    runtime-control-conflict)
+        mkdir -p "${runtime_control%/*}"
+        : >"$runtime_control"
+        chmod 600 "$runtime_control"
+        expected_success=false
+        ;;
+    cleanup-initial-reload-failure)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault=fail-cleanup-reload
+        ;;
+    cleanup-final-reload-failure)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault=fail-final-reload
+        ;;
+    cleanup-mask-race)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault=cleanup-mask-race
+        ;;
+    cleanup-definition-race)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault='definition-race'
+        ;;
+    cleanup-fragment-race)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault='fragment-race'
+        ;;
+    cleanup-owner-race)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault='owner-race'
+        ;;
+    cleanup-pre-restart-mask-race)
+        systemctl start facelock-daemon.service
+        initial_active=true
+        expected_cleanup_success=false
+        cleanup_fault=pre-restart-mask-race
+        ;;
+    *) fail "unknown case" ;;
+esac
+
+persistent_before=absent
+runtime_before=absent
+persistent_control_before=absent
+runtime_control_before=absent
+[ ! -e "$persistent_mask" ] && [ ! -L "$persistent_mask" ] ||
+    persistent_before="$(stat_mask "$persistent_mask")"
+[ ! -e "$runtime_mask" ] && [ ! -L "$runtime_mask" ] ||
+    runtime_before="$(stat_mask "$runtime_mask")"
+[ ! -e "$persistent_control" ] && [ ! -L "$persistent_control" ] ||
+    persistent_control_before="$(stat_mask "$persistent_control")"
+[ ! -e "$runtime_control" ] && [ ! -L "$runtime_control" ] ||
+    runtime_control_before="$(stat_mask "$runtime_control")"
+
+# shellcheck source=scripts/source-install-daemon-lifecycle.sh
+source "$lifecycle"
+export PATH="$root/test/bin:$PATH"
+if [ "$expected_success" = false ]; then
+    set +e
+    facelock_source_install_begin_daemon /run/systemd/system "$unit" \
+        "$definition" "$persistent_mask" "$runtime_mask"
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] || fail "unsafe state was admitted"
+    [ "$initial_active" != true ] || owner_is true ||
+        fail "refusal stopped the initially active daemon"
+    if [ "$runtime_control_before" = absent ]; then
+        [ ! -e "$runtime_control" ] && [ ! -L "$runtime_control" ] ||
+            fail "refusal left an owned barrier"
+    else
+        [ "$(stat_mask "$runtime_control")" = \
+            "$runtime_control_before" ] ||
+            fail "refusal changed the runtime control conflict"
+    fi
+    if [ "$persistent_control_before" = absent ]; then
+        [ ! -e "$persistent_control" ] && [ ! -L "$persistent_control" ] ||
+            fail "refusal created a persistent control unit"
+    else
+        [ "$(stat_mask "$persistent_control")" = \
+            "$persistent_control_before" ] ||
+            fail "refusal changed the persistent control conflict"
+    fi
+    exit 0
+fi
+
+facelock_source_install_begin_daemon /run/systemd/system "$unit" \
+    "$definition" "$persistent_mask" "$runtime_mask"
+unit_state_is masked inactive "$barrier" ||
+    fail "owned barrier was not exact and inactive after stop"
+owner_is false || fail "daemon retained its bus name before writes"
+if [ "$initial_active" = true ]; then
+    [ -e /run/facelock-source-install-stop-proof ] ||
+        fail "stop probe did not observe the owned fragment"
+fi
+if systemctl start facelock-daemon.service; then
+    fail "direct activation crossed the barrier"
+fi
+if busctl --system call org.freedesktop.DBus /org/freedesktop/DBus \
+    org.freedesktop.DBus StartServiceByName su org.facelock.Daemon 0; then
+    fail "D-Bus activation crossed the barrier"
+fi
+systemctl daemon-reload
+unit_state_is masked inactive "$barrier" ||
+    fail "extra reload displaced the owned barrier"
+if systemctl start facelock-daemon.service; then
+    fail "direct activation crossed the reloaded barrier"
+fi
+owner_is false || fail "D-Bus owner appeared while barrier was loaded"
+if busctl --system call org.freedesktop.DBus /org/freedesktop/DBus \
+    org.freedesktop.DBus StartServiceByName su org.facelock.Daemon 0; then
+    fail "D-Bus activation crossed the reloaded barrier"
+fi
+
+if [ "$case_name" = first-install ]; then
+    install -m644 "$root/test/source-install-daemon-test.service" "$unit"
+    install -m644 "$root/dbus/org.facelock.Daemon.service" "$definition"
+fi
+if [ -n "$cleanup_fault" ]; then
+    : >"/run/facelock-source-install-$cleanup_fault"
+fi
+if [ "$expected_cleanup_success" = true ]; then
+    facelock_source_install_complete_daemon /run/systemd/system
+else
+    set +e
+    facelock_source_install_complete_daemon /run/systemd/system
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] || fail "unsafe cleanup state was accepted"
+    ! systemctl is-active --quiet facelock-daemon.service ||
+        fail "cleanup failure restarted the initially active daemon"
+    case "$case_name" in
+        cleanup-initial-reload-failure | cleanup-final-reload-failure | \
+            cleanup-mask-race | cleanup-definition-race | cleanup-owner-race)
+            unit_state_is masked inactive "$barrier" ||
+                fail "cleanup failure did not retain the owned manager barrier"
+            ;;
+        cleanup-fragment-race)
+            [ -f "$persistent_control" ] && [ ! -s "$persistent_control" ] ||
+                fail "cleanup changed the concurrent persistent control unit"
+            unit_state_is masked inactive "$persistent_control" ||
+                fail "cleanup fragment race did not retain the foreign winner"
+            ;;
+        cleanup-pre-restart-mask-race)
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+                fail "last-window race recreated a retired barrier"
+            [ -L "$runtime_mask" ] &&
+                [ "$(readlink -- "$runtime_mask")" = /dev/null ] ||
+                fail "cleanup changed the concurrent runtime mask"
+            unit_state_is masked inactive "$runtime_mask" ||
+                fail "last-window race did not retain the administrator mask"
+            ;;
+    esac
+    if [ "$case_name" = cleanup-owner-race ]; then
+        owner_is true || fail "owner-race fixture did not retain its direct owner"
+    else
+        owner_is false || fail "cleanup failure activated the daemon bus name"
+    fi
+    exit 0
+fi
+
+[ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+    fail "owned barrier remained after completion"
+if [ "$persistent_before" != absent ]; then
+    [ "$(stat_mask "$persistent_mask")" = "$persistent_before" ] ||
+        fail "persistent mask identity changed"
+fi
+if [ "$runtime_before" != absent ]; then
+    [ "$(stat_mask "$runtime_mask")" = "$runtime_before" ] ||
+        fail "runtime mask identity changed"
+fi
+if [ "$initial_active" = true ]; then
+    systemctl is-active --quiet facelock-daemon.service ||
+        fail "initially active daemon was not restored"
+    owner_is true || fail "restored daemon did not own its bus name"
+else
+    ! systemctl is-active --quiet facelock-daemon.service ||
+        fail "initially inactive daemon was activated"
+    owner_is false || fail "inactive daemon acquired its bus name"
+fi
+expected_final_load=loaded
+if [ -L "$expected_final_fragment" ] || {
+    [ -f "$expected_final_fragment" ] && [ ! -s "$expected_final_fragment" ];
+}; then
+    expected_final_load=masked
+fi
+unit_state_is "$expected_final_load" \
+    "$([ "$initial_active" = true ] && printf active || printf inactive)" \
+    "$expected_final_fragment" || fail "final manager winner/state was wrong"
+
+echo "source-install real systemd ($case_name): OK"

--- a/test/source-install-daemon-lifecycle.sh
+++ b/test/source-install-daemon-lifecycle.sh
@@ -1,0 +1,4774 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+justfile="$repo_root/justfile"
+lifecycle_script="$repo_root/scripts/source-install-daemon-lifecycle.sh"
+lifecycle_checker="$repo_root/test/check-source-install-lifecycle.py"
+containerfile="$repo_root/test/Containerfile"
+
+fail() {
+    echo "source-install daemon lifecycle: $*" >&2
+    exit 1
+}
+
+assert_lock_available() {
+    local name="$1"
+    local lock_path="$2"
+    local lock_dir="${lock_path%/*}"
+
+    flock -n "$lock_path" true || fail "$name left the source-install lifecycle lock held"
+    [ -d "$lock_dir" ] && [ ! -L "$lock_dir" ] ||
+        fail "$name left an unsafe lifecycle lock directory"
+    [ "$(stat -c '%a' "$lock_dir")" = 755 ] ||
+        fail "$name left a wrongly permissioned lifecycle lock directory"
+    [ "$(stat -c '%u:%g' "$lock_dir")" = \
+        "$(stat -c '%u:%g' "${lock_path%/run/*}")" ] ||
+        fail "$name left a wrongly owned lifecycle lock directory"
+    [ "$(stat -c '%a' "$lock_path")" = 600 ] ||
+        fail "$name left a non-private source-install lifecycle lock"
+    [ "$(stat -c '%h' "$lock_path")" = 1 ] ||
+        fail "$name left a multiply-linked source-install lifecycle lock"
+    [ "$(stat -c '%u:%g' "$lock_path")" = \
+        "$(stat -c '%u:%g' "${lock_path%/run/*}")" ] ||
+        fail "$name left a wrongly owned source-install lifecycle lock"
+}
+
+legacy_lock_literal='facelock-source-install'".lock"
+! grep -Fq "$legacy_lock_literal" "$lifecycle_script" ||
+    fail "lifecycle helper retains the retired source-only lock literal"
+python3 - "$lifecycle_script" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+start = text.index("facelock_source_install_restore_daemon() {")
+end = text.index("facelock_source_install_finish_daemon() {", start)
+restore = text[start:end]
+commit = restore.index("facelock_source_install_commit_legacy_migration")
+barrier_removal = restore.index("facelock_source_install_quarantine_owned_barrier")
+restart = restore.index("facelock_source_install_restart_active_daemon")
+if not commit < barrier_removal < restart:
+    raise SystemExit(
+        "legacy publication must precede barrier removal and daemon restart"
+    )
+rollback = restore.index("facelock_source_install_rollback_legacy_migration", commit)
+reload_after_rollback = restore.index("systemctl daemon-reload", rollback)
+dbus_after_rollback = restore.index(
+    "facelock_source_install_reload_dbus_activation", reload_after_rollback
+)
+if not rollback < reload_after_rollback < dbus_after_rollback:
+    raise SystemExit("rollback must be followed by manager and D-Bus revalidation")
+if 'local publication_allowed="${2:-false}"' not in restore:
+    raise SystemExit("daemon restoration lacks an explicit publication authorization")
+stage_start = text.index(
+    "facelock_source_install_stage_and_record_legacy_migration() {"
+)
+stage_end = text.index("\n}\n", stage_start)
+stage = text[stage_start:stage_end]
+critical_on = stage.index("FACELOCK_SOURCE_INSTALL_CRITICAL=true")
+invoke = stage.index("facelock_source_install_invoke_legacy_stage")
+record = stage.index("facelock_source_install_record_legacy_migration", invoke)
+critical_off = stage.index("FACELOCK_SOURCE_INSTALL_CRITICAL=false", record)
+if not critical_on < invoke < record < critical_off:
+    raise SystemExit("legacy stage and exact record must share one signal-critical interval")
+PY
+
+[ -f "$lifecycle_script" ] ||
+    fail "missing scripts/source-install-daemon-lifecycle.sh"
+[ -f "$lifecycle_checker" ] ||
+    fail "missing test/check-source-install-lifecycle.py"
+
+python3 "$lifecycle_checker" "$justfile" "$containerfile"
+python3 "$repo_root/test/check-source-install-lifecycle-test.py"
+
+default_assets_actual="$(
+    # The path is resolved from this script.
+    # shellcheck disable=SC1090,SC1091
+    source "$lifecycle_script"
+    facelock_source_install_default_assets
+)"
+default_assets_expected="$(printf '%s\n' \
+    /etc/systemd/system.control/facelock-daemon.service \
+    /run/systemd/system.control/facelock-daemon.service \
+    /run/systemd/transient/facelock-daemon.service \
+    /run/systemd/generator.early/facelock-daemon.service \
+    /etc/systemd/system/facelock-daemon.service \
+    /etc/systemd/system.attached/facelock-daemon.service \
+    /run/systemd/system/facelock-daemon.service \
+    /run/systemd/system.attached/facelock-daemon.service \
+    /run/systemd/generator/facelock-daemon.service \
+    /usr/local/lib/systemd/system/facelock-daemon.service \
+    /usr/lib/systemd/system/facelock-daemon.service \
+    /lib/systemd/system/facelock-daemon.service \
+    /run/systemd/generator.late/facelock-daemon.service \
+    /etc/dbus-1/system-services/org.facelock.Daemon.service \
+    /run/dbus-1/system-services/org.facelock.Daemon.service \
+    /usr/local/share/dbus-1/system-services/org.facelock.Daemon.service \
+    /usr/share/dbus-1/system-services/org.facelock.Daemon.service \
+    /lib/dbus-1/system-services/org.facelock.Daemon.service)"
+[ "$default_assets_actual" = "$default_assets_expected" ] ||
+    fail "default activation-asset search paths are incomplete or reordered"
+
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-source-install-daemon.XXXXXX")"
+trap 'rm -rf -- "$tmp_root"' EXIT
+mkdir -p "$tmp_root/bin" "$tmp_root/run/systemd/system" \
+    "$tmp_root/run/systemd/system.control"
+
+mkdir -p "$tmp_root/locale-bin" "$tmp_root/locale-trusted-directory"
+cat >"$tmp_root/locale-bin/stat" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "${LC_ALL:-}" = C ] || exit 97
+exec "$FACELOCK_REAL_STAT" "$@"
+SH
+chmod 755 "$tmp_root/locale-bin/stat"
+FACELOCK_REAL_STAT="$(command -v stat)" \
+    PATH="$tmp_root/locale-bin:$PATH" \
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_TRUST_UID="$("$FACELOCK_REAL_STAT" -c %u -- "$2")"
+        FACELOCK_SOURCE_INSTALL_TRUST_GID="$("$FACELOCK_REAL_STAT" -c %g -- "$2")"
+        facelock_source_install_directory_is_trusted "$2"
+    ' _ "$lifecycle_script" "$tmp_root/locale-trusted-directory" ||
+    fail "lifecycle metadata checks depend on the caller locale"
+
+assert_recipe_mutation_rejected() {
+    local name="$1"
+    local needle="$2"
+    local replacement="$3"
+    local mutated="$tmp_root/$name.justfile"
+    local output="$tmp_root/$name.output"
+
+    python3 - "$justfile" "$mutated" "$needle" "$replacement" <<'PY'
+import pathlib
+import sys
+
+source, destination, needle, replacement = sys.argv[1:]
+text = pathlib.Path(source).read_text()
+if text.count(needle) != 1:
+    raise SystemExit(f"mutation needle count is {text.count(needle)}, expected 1: {needle!r}")
+pathlib.Path(destination).write_text(text.replace(needle, replacement, 1))
+PY
+
+    if python3 "$lifecycle_checker" "$mutated" "$containerfile" >"$output" 2>&1; then
+        fail "structural checker accepted $name mutation"
+    fi
+    echo "source-install lifecycle mutation rejected: $name"
+}
+
+assert_recipe_mutation_rejected before_boundary \
+    '    facelock_source_install_begin' \
+    $'    touch /tmp/facelock-before-boundary\n    facelock_source_install_begin'
+assert_recipe_mutation_rejected after_boundary \
+    '    facelock_source_install_complete' \
+    $'    facelock_source_install_complete\n    touch /tmp/facelock-after-boundary'
+assert_recipe_mutation_rejected prefixed_systemctl \
+    '    # Binaries' \
+    $'    command systemctl enable facelock-daemon.service\n\n    # Binaries'
+assert_recipe_mutation_rejected absolute_systemctl \
+    '    # Binaries' \
+    $'    /usr/bin/systemctl enable facelock-daemon.service\n\n    # Binaries'
+assert_recipe_mutation_rejected assigned_systemctl \
+    '    # Binaries' \
+    $'    manager=systemctl\n    "$manager" enable facelock-daemon.service\n\n    # Binaries'
+assert_recipe_mutation_rejected interpreter_before_boundary \
+    '    source scripts/source-install-daemon-lifecycle.sh' \
+    $'    python3 -c "open(\047/tmp/unsafe\047, \047w\047)"\n    source scripts/source-install-daemon-lifecycle.sh'
+assert_recipe_mutation_rejected sed_before_boundary \
+    '    source scripts/source-install-daemon-lifecycle.sh' \
+    $'    sed -i s/old/new/ /tmp/unsafe\n    source scripts/source-install-daemon-lifecycle.sh'
+assert_recipe_mutation_rejected redirection_before_boundary \
+    '    source scripts/source-install-daemon-lifecycle.sh' \
+    $'    echo unsafe >/tmp/facelock-before-boundary\n    source scripts/source-install-daemon-lifecycle.sh'
+assert_recipe_mutation_rejected commented_activation \
+    '    install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service' \
+    '    # install -Dm644 dbus/org.facelock.Daemon.service /usr/share/dbus-1/system-services/org.facelock.Daemon.service'
+assert_recipe_mutation_rejected extra_cp_writer \
+    '    # Binaries' \
+    $'    cp /tmp/unsafe /usr/bin/facelock\n\n    # Binaries'
+assert_recipe_mutation_rejected extra_install_writer \
+    '    # Binaries' \
+    $'    install -Dm755 /tmp/unsafe /usr/bin/facelock\n\n    # Binaries'
+assert_recipe_mutation_rejected extra_rsync_writer \
+    '    # Binaries' \
+    $'    rsync /tmp/unsafe /usr/bin/facelock\n\n    # Binaries'
+assert_recipe_mutation_rejected relative_privileged_sudo \
+    '    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just install-files' \
+    '    sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just install-files'
+assert_recipe_mutation_rejected relative_privileged_env \
+    '    /usr/bin/sudo /usr/bin/env PATH=/usr/bin:/bin /usr/bin/just uninstall-files' \
+    '    /usr/bin/sudo env PATH=/usr/bin:/bin /usr/bin/just uninstall-files'
+
+assert_container_mutation_rejected() {
+    local name="$1"
+    local needle="$2"
+    local replacement="$3"
+    local mutated="$tmp_root/$name.Containerfile"
+    local output="$tmp_root/$name.output"
+
+    python3 - "$containerfile" "$mutated" "$needle" "$replacement" <<'PY'
+import pathlib
+import sys
+
+source, destination, needle, replacement = sys.argv[1:]
+text = pathlib.Path(source).read_text()
+if text.count(needle) != 1:
+    raise SystemExit(f"mutation needle count is {text.count(needle)}, expected 1: {needle!r}")
+pathlib.Path(destination).write_text(text.replace(needle, replacement, 1))
+PY
+
+    if python3 "$lifecycle_checker" "$justfile" "$mutated" >"$output" 2>&1; then
+        fail "structural checker accepted $name mutation"
+    fi
+    echo "source-install lifecycle mutation rejected: $name"
+}
+
+assert_container_mutation_rejected commented_container_helper \
+    'COPY scripts/source-install-daemon-lifecycle.sh /build/scripts/source-install-daemon-lifecycle.sh' \
+    '# COPY scripts/source-install-daemon-lifecycle.sh /build/scripts/source-install-daemon-lifecycle.sh'
+assert_container_mutation_rejected commented_container_migration_helper \
+    'COPY scripts/migrate-legacy-system-assets.sh /build/scripts/migrate-legacy-system-assets.sh' \
+    '# COPY scripts/migrate-legacy-system-assets.sh /build/scripts/migrate-legacy-system-assets.sh'
+assert_container_mutation_rejected commented_container_legacy_manifest \
+    'COPY dist/ /build/dist/' \
+    '# COPY dist/ /build/dist/'
+assert_container_mutation_rejected commented_container_marker \
+    'COPY test/source-install-offline-image.marker /build/test/source-install-offline-image.marker' \
+    '# COPY test/source-install-offline-image.marker /build/test/source-install-offline-image.marker'
+assert_container_mutation_rejected ordinary_container_install \
+    "RUN FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \\" \
+    "RUN just install-files \\"
+assert_container_mutation_rejected extra_container_install \
+    '    just install-files' \
+    $'    just install-files\nRUN just install-files'
+
+cat >"$tmp_root/bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'systemctl' >>"$FACELOCK_SYSTEMCTL_LOG"
+printf ' %s' "$@" >>"$FACELOCK_SYSTEMCTL_LOG"
+printf '\n' >>"$FACELOCK_SYSTEMCTL_LOG"
+
+layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+if [ "$*" = 'start facelock-daemon.service' ]; then
+    : >"$layout_prefix/start-attempted"
+fi
+if [ "${FACELOCK_REQUIRE_RESTORE_LOCK:-false}" = true ] &&
+    [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+    [ -n "${FACELOCK_LOCK_PATH:-}" ] &&
+    flock -n "$FACELOCK_LOCK_PATH" true; then
+    echo "restoration command ran without the lifecycle lock" >&2
+    exit 96
+fi
+
+if [ "${1:-}" = show ]; then
+    case "${2:-}" in
+        facelock-daemon.service)
+            if [ "$*" = 'show facelock-daemon.service --property=LoadState --property=ActiveState --property=FragmentPath --no-pager' ]; then
+                layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+                manager_fragment_path="${FACELOCK_MANAGER_FRAGMENT_PATH:-$layout_prefix/manager-fragment-path}"
+                manager_fragment=
+                [ ! -f "$manager_fragment_path" ] ||
+                    manager_fragment="$(cat "$manager_fragment_path")"
+                case "${FACELOCK_BARRIER_SNAPSHOT_MUTATION:-none}" in
+                    none) ;;
+                    blank) manager_fragment= ;;
+                    wrong)
+                        manager_fragment="$layout_prefix/etc/systemd/system/facelock-daemon.service"
+                        ;;
+                    duplicate)
+                        printf 'LoadState=masked\nActiveState=%s\nFragmentPath=%s\nFragmentPath=%s\n' \
+                            "$([ -f "$layout_prefix/active-state" ] && cat "$layout_prefix/active-state" || printf '%s' "$FACELOCK_ACTIVE_STATE")" \
+                            "$manager_fragment" "$manager_fragment"
+                        exit 0
+                        ;;
+                    *) exit 98 ;;
+                esac
+                if [ "$(cat "$FACELOCK_MANAGER_MASK_STATE")" = masked ]; then
+                    printf 'LoadState=masked\n'
+                else
+                    printf 'LoadState=%s\n' "$FACELOCK_LOAD_STATE"
+                fi
+                if [ -f "$layout_prefix/active-state" ]; then
+                    printf 'ActiveState=%s\n' "$(cat "$layout_prefix/active-state")"
+                else
+                    printf 'ActiveState=%s\n' "$FACELOCK_ACTIVE_STATE"
+                fi
+                printf 'FragmentPath=%s\n' "$manager_fragment"
+                if [ ! -e "$layout_prefix/stop-observed" ] &&
+                    [ "$manager_fragment" = \
+                        "$layout_prefix/run/systemd/system.control/facelock-daemon.service" ]; then
+                    : >"$layout_prefix/prestop-proof-observed"
+                fi
+                exit 0
+            fi
+            if [ "$*" = 'show facelock-daemon.service --property=LoadState --property=ActiveState --no-pager' ]; then
+                if [ "$(cat "$FACELOCK_MANAGER_MASK_STATE")" = masked ]; then
+                    printf 'LoadState=masked\n'
+                else
+                    printf 'LoadState=%s\n' "$FACELOCK_LOAD_STATE"
+                fi
+                layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+                if [ -f "$layout_prefix/active-state" ]; then
+                    printf 'ActiveState=%s\n' "$(cat "$layout_prefix/active-state")"
+                else
+                    printf 'ActiveState=%s\n' "$FACELOCK_ACTIVE_STATE"
+                fi
+                exit 0
+            fi
+            if [ "$FACELOCK_SHOW_STATUS" -ne 0 ]; then
+                exit "$FACELOCK_SHOW_STATUS"
+            fi
+            layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+            barrier="$layout_prefix/run/systemd/system.control/facelock-daemon.service"
+            if [ -e "$layout_prefix/start-attempted" ] &&
+                [ -n "${FACELOCK_MUTATE_MASK_BEFORE_START_RETRY:-}" ] &&
+                [ ! -e "$layout_prefix/start-retry-mask-mutated" ]; then
+                : >"$layout_prefix/start-retry-mask-mutated"
+                rm -f -- "$FACELOCK_MUTATE_MASK_BEFORE_START_RETRY"
+                ln -s /dev/null "$FACELOCK_MUTATE_MASK_BEFORE_START_RETRY"
+                printf '%s\n' masked >"$FACELOCK_MANAGER_MASK_STATE"
+                printf '%s\n' "$FACELOCK_MUTATE_MASK_BEFORE_START_RETRY" \
+                    >"${FACELOCK_MANAGER_FRAGMENT_PATH:-$layout_prefix/manager-fragment-path}"
+            fi
+            if { [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] ||
+                [ -e "$layout_prefix/stop-observed" ] ||
+                compgen -G "$barrier.facelock-remove.*" >/dev/null; } &&
+                [ ! -e "$barrier" ] && [ ! -L "$barrier" ]; then
+                manager_fragment_path="${FACELOCK_MANAGER_FRAGMENT_PATH:-$layout_prefix/manager-fragment-path}"
+                manager_fragment=
+                [ ! -f "$manager_fragment_path" ] ||
+                    manager_fragment="$(cat "$manager_fragment_path")"
+                if [ "$(cat "$FACELOCK_MANAGER_MASK_STATE")" = masked ]; then
+                    printf 'LoadState=masked\nActiveState=%s\n' \
+                        "$([ -f "$layout_prefix/active-state" ] && \
+                            cat "$layout_prefix/active-state" || \
+                            printf '%s' "$FACELOCK_ACTIVE_STATE")"
+                    case "$manager_fragment" in
+                        "$layout_prefix/etc/systemd/system/"*)
+                            printf 'UnitFileState=masked\n'
+                            ;;
+                        *) printf 'UnitFileState=masked-runtime\n' ;;
+                    esac
+                    printf 'FragmentPath=%s\nDropInPaths=\n' "$manager_fragment"
+                elif [ "$FACELOCK_LOAD_STATE" = not-found ] &&
+                    [ -z "$manager_fragment" ]; then
+                    printf '%s\n' \
+                        'LoadState=not-found' \
+                        'ActiveState=inactive' \
+                        'UnitFileState=' \
+                        'FragmentPath=' \
+                        'DropInPaths='
+                else
+                    printf 'LoadState=loaded\nActiveState=%s\n' \
+                        "$([ -f "$layout_prefix/active-state" ] && \
+                            cat "$layout_prefix/active-state" || \
+                            printf '%s' "$FACELOCK_ACTIVE_STATE")"
+                    printf 'UnitFileState=%s\nFragmentPath=%s\nExecStart=%s\nDropInPaths=%s\n' \
+                        "${FACELOCK_UNIT_FILE_STATE:-static}" \
+                        "$manager_fragment" \
+                        "${FACELOCK_DAEMON_EXEC_START:-/usr/bin/facelock daemon}" \
+                        "${FACELOCK_DROP_IN_PATHS:-}"
+                fi
+                exit 0
+            fi
+            if [ -n "${FACELOCK_SERVICE_SNAPSHOT_OVERRIDE:-}" ]; then
+                printf '%s\n' "$FACELOCK_SERVICE_SNAPSHOT_OVERRIDE"
+            else
+                layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+                fragment_path="${FACELOCK_FRAGMENT_PATH_OVERRIDE:-}"
+                if [ -z "$fragment_path" ]; then
+                    case "$FACELOCK_LOAD_STATE:${FACELOCK_MASK_STATE:+$(cat "$FACELOCK_MASK_STATE")}" in
+                        masked:runtime)
+                            fragment_path="$layout_prefix/run/systemd/system/facelock-daemon.service"
+                            ;;
+                        masked:persistent)
+                            fragment_path="$layout_prefix/etc/systemd/system/facelock-daemon.service"
+                            ;;
+                        *)
+                            for candidate in \
+                                "$layout_prefix/assets/facelock-daemon.service" \
+                                "$layout_prefix/facelock-daemon.service" \
+                                "$layout_prefix/usr/lib/systemd/system/facelock-daemon.service"; do
+                                if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+                                    fragment_path="$candidate"
+                                    break
+                                fi
+                            done
+                            ;;
+                    esac
+                fi
+                printf 'LoadState=%s\n' "$FACELOCK_LOAD_STATE"
+                printf 'ActiveState=%s\n' "$FACELOCK_ACTIVE_STATE"
+                printf 'UnitFileState=%s\n' "$FACELOCK_UNIT_FILE_STATE"
+                printf 'FragmentPath=%s\n' "$fragment_path"
+                if [ "$FACELOCK_LOAD_STATE" = loaded ]; then
+                    printf 'ExecStart=%s\n' \
+                        "${FACELOCK_DAEMON_EXEC_START:-/usr/bin/facelock daemon}"
+                fi
+                printf 'DropInPaths=%s\n' "${FACELOCK_DROP_IN_PATHS:-}"
+            fi
+            ;;
+        dbus.service)
+            if [ "${FACELOCK_DBUS_SHOW_STATUS:-0}" -ne 0 ]; then
+                exit "$FACELOCK_DBUS_SHOW_STATUS"
+            fi
+            if [ -n "${FACELOCK_DBUS_SNAPSHOT_OVERRIDE:-}" ]; then
+                printf '%s\n' "$FACELOCK_DBUS_SNAPSHOT_OVERRIDE"
+            else
+                printf 'Id=%s\n' "${FACELOCK_DBUS_ID:-dbus-broker.service}"
+                printf 'Names=%s\n' \
+                    "${FACELOCK_DBUS_NAMES:-dbus-broker.service dbus.service}"
+                printf 'Following=%s\n' "${FACELOCK_DBUS_FOLLOWING:-}"
+                printf 'LoadState=%s\n' "${FACELOCK_DBUS_LOAD_STATE:-loaded}"
+                printf 'ActiveState=%s\n' "${FACELOCK_DBUS_ACTIVE_STATE:-active}"
+                layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+                printf 'FragmentPath=%s\n' \
+                    "${FACELOCK_DBUS_FRAGMENT_PATH:-$layout_prefix/usr/lib/systemd/system/dbus-broker.service}"
+                printf 'DropInPaths=%s\n' "${FACELOCK_DBUS_DROP_IN_PATHS:-}"
+                printf 'ExecStart=%s\n' \
+                    "${FACELOCK_DBUS_EXEC_START:-/usr/bin/dbus-broker-launch --scope system}"
+            fi
+            ;;
+    esac
+fi
+
+if [ -n "${FACELOCK_FAIL_COMMAND:-}" ] &&
+    { [ "${FACELOCK_FAIL_BEFORE_WRITE:-false}" = true ] ||
+        [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ]; } &&
+    [ "$*" = "$FACELOCK_FAIL_COMMAND" ] &&
+    [ "$(cat "$FACELOCK_FAILURES_REMAINING")" -gt 0 ]; then
+    remaining="$(cat "$FACELOCK_FAILURES_REMAINING")"
+    printf '%s\n' "$((remaining - 1))" >"$FACELOCK_FAILURES_REMAINING"
+    exit 1
+fi
+
+case "${1:-}" in
+    mask | unmask)
+        echo "systemctl must not own the source-install barrier" >&2
+        exit 97
+        ;;
+    start)
+        if [ "$(cat "$FACELOCK_MANAGER_MASK_STATE")" != none ]; then
+            exit 1
+        fi
+        layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+        printf '%s\n' active >"$layout_prefix/active-state"
+        if [ -n "${FACELOCK_DBUS_SERVICE_TO_MUTATE_AFTER_START:-}" ]; then
+            printf '%s\n' \
+                '[D-BUS Service]' \
+                'Name=org.facelock.Daemon' \
+                'Exec=/usr/bin/facelock daemon' \
+                >"$FACELOCK_DBUS_SERVICE_TO_MUTATE_AFTER_START"
+        fi
+        ;;
+    stop)
+        layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+        if [ "${FACELOCK_REQUIRE_PRESTOP_PROOF:-false}" = true ] &&
+            [ ! -e "$layout_prefix/prestop-proof-observed" ]; then
+            echo "stop occurred before the owned barrier was proven" >&2
+            exit 96
+        fi
+        printf '%s\n' inactive >"$layout_prefix/active-state"
+        : >"$layout_prefix/stop-observed"
+        if [ -n "${FACELOCK_MUTATE_MASK_AFTER_STOP:-}" ]; then
+            unlink -- "$FACELOCK_MUTATE_MASK_AFTER_STOP"
+            ln -s /dev/zero "$FACELOCK_MUTATE_MASK_AFTER_STOP"
+        fi
+        case "${FACELOCK_MUTATE_AFTER_STOP:-}" in
+            config)
+                printf '%s\n' \
+                    '<busconfig>' \
+                    '<servicedir>/opt/post-stop-services</servicedir>' \
+                    '<standard_system_servicedirs/>' \
+                    '</busconfig>' \
+                    >"$layout_prefix/usr/share/dbus-1/system.conf"
+                ;;
+            definition)
+                printf '%s\n' \
+                    '[D-BUS Service]' \
+                    'Name=org.facelock.Daemon' \
+                    'Exec=/usr/bin/facelock daemon' \
+                    >"$layout_prefix/assets/org.facelock.Daemon.service"
+                ;;
+        esac
+        ;;
+    daemon-reload)
+        layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+        manager_fragment_path="${FACELOCK_MANAGER_FRAGMENT_PATH:-$layout_prefix/manager-fragment-path}"
+        persistent_control_dir="${FACELOCK_PERSISTENT_CONTROL_DIR:-$layout_prefix/etc/systemd/system.control}"
+        runtime_control_dir="${FACELOCK_RUNTIME_CONTROL_DIR:-$layout_prefix/run/systemd/system.control}"
+        barrier="$runtime_control_dir/facelock-daemon.service"
+        if [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] &&
+            [ "${FACELOCK_FAIL_FINAL_RELOAD:-false}" = true ]; then
+            exit 1
+        fi
+        if [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+            [ -n "${FACELOCK_MUTATE_MASK_ON_CLEANUP_RELOAD:-}" ] &&
+            [ ! -e "$layout_prefix/cleanup-mask-mutated" ]; then
+            : >"$layout_prefix/cleanup-mask-mutated"
+            rm -f -- "$FACELOCK_MUTATE_MASK_ON_CLEANUP_RELOAD"
+            ln -s /dev/null "$FACELOCK_MUTATE_MASK_ON_CLEANUP_RELOAD"
+        fi
+        if [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] &&
+            [ "${FACELOCK_MUTATE_DBUS_ON_FINAL_RELOAD:-false}" = true ] &&
+            [ ! -e "$layout_prefix/final-dbus-mutated" ]; then
+            : >"$layout_prefix/final-dbus-mutated"
+            printf '%s\n' \
+                '<busconfig>' \
+                '<servicedir>/opt/post-removal-services</servicedir>' \
+                '<standard_system_servicedirs/>' \
+                '</busconfig>' \
+                >"$layout_prefix/usr/share/dbus-1/system.conf"
+        fi
+        selected_unit=
+        for candidate in \
+            "$persistent_control_dir/facelock-daemon.service" \
+            "$runtime_control_dir/facelock-daemon.service" \
+            "$layout_prefix/etc/systemd/system/facelock-daemon.service" \
+            "$FACELOCK_RUNTIME_DIR/facelock-daemon.service"; do
+            if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+                selected_unit="$candidate"
+                break
+            fi
+        done
+        if [ -z "$selected_unit" ]; then
+            for candidate in \
+                "${FACELOCK_FRAGMENT_PATH_OVERRIDE:-}" \
+                "$layout_prefix/assets/facelock-daemon.service" \
+                "$layout_prefix/usr/lib/systemd/system/facelock-daemon.service"; do
+                [ -n "$candidate" ] || continue
+                if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+                    selected_unit="$candidate"
+                    break
+                fi
+            done
+        fi
+        if [ "${FACELOCK_IGNORE_BARRIER:-false}" = true ]; then
+            printf '%s\n' none >"$FACELOCK_MANAGER_MASK_STATE"
+            : >"$manager_fragment_path"
+        elif [ -n "$selected_unit" ] && {
+            { [ -L "$selected_unit" ] &&
+                [ "$(readlink -- "$selected_unit")" = /dev/null ]; } ||
+                { [ -f "$selected_unit" ] && [ ! -s "$selected_unit" ] && {
+                    [ "$selected_unit" = \
+                        "$persistent_control_dir/facelock-daemon.service" ] ||
+                        [ "$selected_unit" = \
+                            "$runtime_control_dir/facelock-daemon.service" ] ||
+                        [ "$selected_unit" = \
+                            "$layout_prefix/etc/systemd/system/facelock-daemon.service" ] ||
+                        [ "$selected_unit" = \
+                            "$FACELOCK_RUNTIME_DIR/facelock-daemon.service" ];
+                }; };
+        }; then
+            printf '%s\n' masked >"$FACELOCK_MANAGER_MASK_STATE"
+            printf '%s\n' "$selected_unit" >"$manager_fragment_path"
+        else
+            printf '%s\n' none >"$FACELOCK_MANAGER_MASK_STATE"
+            printf '%s\n' "$selected_unit" >"$manager_fragment_path"
+        fi
+        if [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] &&
+            [ -n "${FACELOCK_FINAL_FRAGMENT_OVERRIDE:-}" ]; then
+            printf '%s\n' "$FACELOCK_FINAL_FRAGMENT_OVERRIDE" \
+                >"$manager_fragment_path"
+        fi
+        if [ -n "${FACELOCK_MUTATE_BARRIER_ON_RELOAD:-}" ] &&
+            [ ! -e "$layout_prefix/barrier-reload-mutated" ]; then
+            : >"$layout_prefix/barrier-reload-mutated"
+            printf 'tampered\n' >>"$FACELOCK_MUTATE_BARRIER_ON_RELOAD"
+        fi
+        ;;
+esac
+SH
+chmod +x "$tmp_root/bin/systemctl"
+
+cat >"$tmp_root/bin/busctl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'busctl' >>"$FACELOCK_SYSTEMCTL_LOG"
+printf ' %s' "$@" >>"$FACELOCK_SYSTEMCTL_LOG"
+printf '\n' >>"$FACELOCK_SYSTEMCTL_LOG"
+
+case "$*" in
+    *' ReloadConfig')
+        layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+        reload_count_file="$layout_prefix/dbus-reload-count"
+        reload_count=0
+        [ ! -f "$reload_count_file" ] || reload_count="$(cat "$reload_count_file")"
+        reload_count=$((reload_count + 1))
+        printf '%s\n' "$reload_count" >"$reload_count_file"
+        if [ "${FACELOCK_DBUS_TAMPER_ON_RELOAD:-false}" = true ] ||
+            [ "${FACELOCK_DBUS_TAMPER_ON_RELOAD_NUMBER:-0}" -eq "$reload_count" ]; then
+            printf '%s\n' \
+                '<busconfig>' \
+                '<servicedir>/opt/admin-dbus-services</servicedir>' \
+                '<standard_system_servicedirs/>' \
+                '</busconfig>' \
+                >"$layout_prefix/usr/share/dbus-1/system.conf"
+        fi
+        if [ "${FACELOCK_OWNER_AFTER_CLEANUP_RELOAD:-false}" = true ] &&
+            [ "$reload_count" -ge 2 ]; then
+            : >"$layout_prefix/cleanup-owner"
+        fi
+        exit "${FACELOCK_BUSCTL_RELOAD_STATUS:-0}"
+        ;;
+    *' NameHasOwner s org.facelock.Daemon')
+        layout_prefix="${FACELOCK_RUNTIME_DIR%/run/systemd/system}"
+        barrier="$layout_prefix/run/systemd/system.control/facelock-daemon.service"
+        if [ -n "${FACELOCK_MUTATE_MASK_ON_OWNER:-}" ] &&
+            [ ! -e "$layout_prefix/owner-mask-mutated" ]; then
+            : >"$layout_prefix/owner-mask-mutated"
+            unlink -- "$FACELOCK_MUTATE_MASK_ON_OWNER"
+            ln -s /dev/zero "$FACELOCK_MUTATE_MASK_ON_OWNER"
+        fi
+        if [ -n "${FACELOCK_MUTATE_ORDINARY_ON_OWNER:-}" ] &&
+            [ ! -e "$layout_prefix/owner-ordinary-mutated" ]; then
+            : >"$layout_prefix/owner-ordinary-mutated"
+            printf '%s\n' '[Service]' \
+                'ExecStart=/usr/bin/facelock daemox' \
+                >"$FACELOCK_MUTATE_ORDINARY_ON_OWNER"
+        fi
+        if [ -e "${FACELOCK_AFTER_WRITE_FILE:-/nonexistent}" ] &&
+            [ ! -e "$barrier" ] && [ ! -L "$barrier" ] &&
+            [ "${FACELOCK_OWNER_AFTER_FINAL_RELOAD:-false}" = true ]; then
+            printf 'b true\n'
+        elif [ -e "$layout_prefix/cleanup-owner" ]; then
+            printf 'b true\n'
+        elif [ "${FACELOCK_OWNER_AFTER_STOP:-false}" = true ] &&
+            [ -e "$layout_prefix/stop-observed" ]; then
+            printf 'b true\n'
+        elif [ "${FACELOCK_DBUS_OWNER_OVERRIDE:-}" = true ]; then
+            printf 'b true\n'
+        elif [ "${FACELOCK_DBUS_OWNER_OVERRIDE:-}" = false ]; then
+            printf 'b false\n'
+        elif [ -f "$layout_prefix/active-state" ]; then
+            printf 'b %s\n' "$([ "$(cat "$layout_prefix/active-state")" = active ] && printf true || printf false)"
+        elif [ "$FACELOCK_ACTIVE_STATE" = active ]; then
+            printf 'b true\n'
+        else
+            printf 'b false\n'
+        fi
+        ;;
+    *) exit 2 ;;
+esac
+SH
+chmod +x "$tmp_root/bin/busctl"
+
+cat >"$tmp_root/bin/dbus-activate" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+systemctl start facelock-daemon.service
+SH
+chmod +x "$tmp_root/bin/dbus-activate"
+
+cat >"$tmp_root/bin/mv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${FACELOCK_REPLACE_BEFORE_QUARANTINE:-}" ]; then
+    source_path="${@: -2:1}"
+    if [ "$source_path" = "$FACELOCK_REPLACE_BEFORE_QUARANTINE" ]; then
+        if [ "${FACELOCK_REPLACE_DIRECTORY_BEFORE_QUARANTINE:-false}" = true ]; then
+            /usr/bin/rmdir -- "$source_path"
+            /usr/bin/mkdir -m 0755 -- "$source_path"
+            : >"$source_path/replacement"
+        else
+            /usr/bin/rm -f -- "$source_path"
+            printf '%s\n' replacement >"$source_path"
+        fi
+    fi
+fi
+if [ -n "${FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE:-}" ]; then
+    source_path="${@: -2:1}"
+    case "$source_path" in
+        */system.control/facelock-daemon.service)
+            if [ ! -e "${FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE}.mutated" ]; then
+                : >"${FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE}.mutated"
+                rm -f -- "$FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE"
+                ln -s /dev/null "$FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE"
+            fi
+            ;;
+    esac
+fi
+if [ -n "${FACELOCK_MUTATE_MASK_BEFORE_RESTART:-}" ]; then
+    source_path="${@: -2:1}"
+    case "$source_path" in
+        */system.control)
+            if [ ! -e "${FACELOCK_MUTATE_MASK_BEFORE_RESTART}.mutated" ]; then
+                : >"${FACELOCK_MUTATE_MASK_BEFORE_RESTART}.mutated"
+                rm -f -- "$FACELOCK_MUTATE_MASK_BEFORE_RESTART"
+                ln -s /dev/null "$FACELOCK_MUTATE_MASK_BEFORE_RESTART"
+            fi
+            ;;
+    esac
+fi
+if [ -n "${FACELOCK_ADD_ENTRY_BEFORE_DIRECTORY_QUARANTINE:-}" ]; then
+    source_path="${@: -2:1}"
+    if [ "$source_path" = \
+        "$FACELOCK_ADD_ENTRY_BEFORE_DIRECTORY_QUARANTINE" ]; then
+        : >"$source_path/administrator-unit.service"
+    fi
+fi
+if [ "${FACELOCK_MOVE_BARRIER_THEN_FAIL:-false}" = true ]; then
+    source_path="${@: -2:1}"
+    case "$source_path" in
+        */system.control/facelock-daemon.service)
+            marker="${source_path%/run/systemd/system.control/*}/move-then-fail-fired"
+            if [ ! -e "$marker" ]; then
+                : >"$marker"
+                /usr/bin/mv "$@"
+                exit 1
+            fi
+            ;;
+    esac
+fi
+exec /usr/bin/mv "$@"
+SH
+chmod +x "$tmp_root/bin/mv"
+
+cat >"$tmp_root/bin/rm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${@: -1}"
+if [ -n "${FACELOCK_FAIL_MIGRATION_UNLINK_NUMBER:-}" ]; then
+    case "$target" in
+        */.facelock-migrate-*)
+            count=0
+            [ ! -f "$FACELOCK_MIGRATION_UNLINK_COUNT" ] ||
+                count="$(cat "$FACELOCK_MIGRATION_UNLINK_COUNT")"
+            count=$((count + 1))
+            printf '%s\n' "$count" >"$FACELOCK_MIGRATION_UNLINK_COUNT"
+            if [ "$count" -eq "$FACELOCK_FAIL_MIGRATION_UNLINK_NUMBER" ]; then
+                exit 71
+            fi
+            ;;
+    esac
+fi
+case "${FACELOCK_BARRIER_REMOVE_FAULT:-none}:$target" in
+    before:*.facelock-remove.*)
+        exit 1
+        ;;
+    after:*.facelock-remove.*)
+        marker="${target%/*}/barrier-remove-after-fired"
+        if [ ! -e "$marker" ]; then
+            : >"$marker"
+            /usr/bin/rm "$@"
+            exit 1
+        fi
+        ;;
+esac
+exec /usr/bin/rm "$@"
+SH
+chmod +x "$tmp_root/bin/rm"
+
+cat >"$tmp_root/bin/mkdir" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+/usr/bin/mkdir "$@"
+target="${@: -1}"
+if [ -n "${FACELOCK_MUTATE_CREATED_BARRIER_DIR:-}" ] &&
+    [ "$target" = "$FACELOCK_MUTATE_CREATED_BARRIER_DIR" ]; then
+    chmod 0777 -- "$target"
+fi
+SH
+chmod +x "$tmp_root/bin/mkdir"
+
+mkdir -p "$tmp_root/readlink-fail-bin"
+cat >"$tmp_root/readlink-fail-bin/readlink" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "$tmp_root/readlink-fail-bin/readlink"
+
+write_dbus_service() {
+    local path="$1"
+    local delegation="${2:-systemd}"
+
+    {
+        printf '%s\n' '[D-BUS Service]'
+        printf '%s\n' 'Name=org.facelock.Daemon'
+        printf '%s\n' 'Exec=/usr/bin/facelock daemon'
+        printf '%s\n' 'User=root'
+        if [ "$delegation" = systemd ]; then
+            printf '%s\n' 'SystemdService=facelock-daemon.service'
+        fi
+    } >"$path"
+}
+
+write_standard_dbus_config() {
+    local root="$1"
+
+    mkdir -p "$root/usr/share/dbus-1" "$root/usr/bin" \
+        "$root/usr/lib/systemd/system"
+    : >"$root/usr/bin/dbus-broker-launch"
+    : >"$root/usr/bin/facelock"
+    chmod 755 "$root/usr/bin/dbus-broker-launch" "$root/usr/bin/facelock"
+    : >"$root/usr/lib/systemd/system/dbus-broker.service"
+    printf '%s\n' \
+        '<busconfig>' \
+        '  <standard_system_servicedirs/>' \
+        '  <include ignore_missing="yes">/etc/dbus-1/system.conf</include>' \
+        '  <includedir>system.d</includedir>' \
+        '  <includedir>/etc/dbus-1/system.d</includedir>' \
+        '  <include ignore_missing="yes">/etc/dbus-1/system-local.conf</include>' \
+        '  <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>' \
+        '</busconfig>' >"$root/usr/share/dbus-1/system.conf"
+}
+
+run_case() {
+    local name="$1"
+    local load_state="$2"
+    local active_state="$3"
+    local unit_file_state="$4"
+    local show_status="$5"
+    local assets="$6"
+    local expected_status="$7"
+    local initial_mask="$8"
+    local inject_activation="$9"
+    local expected="${10}"
+    local control_conflict="${11:-none}"
+    local ignore_barrier="${12:-false}"
+    local busctl_reload_status="${13:-0}"
+    local dbus_owner_override="${14:-}"
+    local dbus_tamper_on_reload="${15:-false}"
+    local retain_barrier="${16:-false}"
+    local case_root="$tmp_root/$name"
+    local actual="$case_root/actual"
+    local expected_path="$case_root/expected"
+    local stderr_path="$case_root/stderr"
+    local mask_state="$case_root/mask-state"
+    local manager_mask_state="$case_root/manager-mask-state"
+    local manager_fragment_path="$case_root/manager-fragment-path"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local runtime_unit="$case_root/run/systemd/system/facelock-daemon.service"
+    local persistent_unit="$case_root/etc/systemd/system/facelock-daemon.service"
+    local persistent_mask_before runtime_mask_before
+    local persistent_target_before runtime_target_before
+    local fragment_path_override=
+    local status
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/etc/systemd/system.control" \
+        "$case_root/run/systemd/system" \
+        "$case_root/run/systemd/system.control" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    case "$assets" in
+        present)
+            : >"$case_root/assets/facelock-daemon.service"
+            write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+            ;;
+        direct)
+            : >"$case_root/assets/facelock-daemon.service"
+            write_dbus_service \
+                "$case_root/assets/org.facelock.Daemon.service" direct
+            ;;
+        unit_symlink)
+            ln -s /dev/null "$case_root/assets/facelock-daemon.service"
+            write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+            ;;
+        alternate)
+            write_dbus_service "$case_root/assets/alternate.service"
+            ;;
+    esac
+
+    : >"$actual"
+    if [ -n "$expected" ]; then
+        printf '%s\n' "$expected" >"$expected_path"
+    else
+        : >"$expected_path"
+    fi
+    printf '%s\n' none >"$mask_state"
+    if [ "$load_state" = masked ]; then
+        printf '%s\n' masked >"$manager_mask_state"
+    else
+        printf '%s\n' none >"$manager_mask_state"
+    fi
+    : >"$manager_fragment_path"
+    case "$initial_mask" in
+        runtime | runtime-symlink)
+            ln -s /dev/null "$runtime_unit"
+            printf '%s\n' runtime >"$mask_state"
+            ;;
+        runtime-regular)
+            : >"$runtime_unit"
+            chmod 644 "$runtime_unit"
+            printf '%s\n' runtime >"$mask_state"
+            ;;
+        persistent | persistent-symlink)
+            ln -s /dev/null "$persistent_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        persistent-regular)
+            : >"$persistent_unit"
+            chmod 644 "$persistent_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        both-symlink)
+            ln -s /dev/null "$persistent_unit"
+            ln -s /dev/null "$runtime_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        both-regular)
+            : >"$persistent_unit"
+            : >"$runtime_unit"
+            chmod 644 "$persistent_unit" "$runtime_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        persistent-symlink-runtime-regular)
+            ln -s /dev/null "$persistent_unit"
+            : >"$runtime_unit"
+            chmod 644 "$runtime_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        persistent-regular-runtime-symlink)
+            : >"$persistent_unit"
+            chmod 644 "$persistent_unit"
+            ln -s /dev/null "$runtime_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        nonmask-runtime | runtime-override)
+            printf '%s\n' '[Service]' 'ExecStart=/usr/bin/facelock daemon' \
+                >"$runtime_unit"
+            fragment_path_override="$runtime_unit"
+            ;;
+        persistent-override)
+            printf '%s\n' '[Service]' 'ExecStart=/usr/bin/facelock daemon' \
+                >"$persistent_unit"
+            fragment_path_override="$persistent_unit"
+            ;;
+        persistent-override-runtime-mask)
+            printf '%s\n' '[Service]' 'ExecStart=/usr/bin/facelock daemon' \
+                >"$persistent_unit"
+            ln -s /dev/null "$runtime_unit"
+            fragment_path_override="$persistent_unit"
+            ;;
+        persistent-mask-runtime-override)
+            ln -s /dev/null "$persistent_unit"
+            printf '%s\n' '[Service]' 'ExecStart=/usr/bin/facelock daemon' \
+                >"$runtime_unit"
+            printf '%s\n' persistent >"$mask_state"
+            ;;
+        dangling-runtime)
+            ln -s /missing-facelock-mask "$runtime_unit"
+            ;;
+        untrusted-runtime)
+            : >"$runtime_unit"
+            chmod 666 "$runtime_unit"
+            ;;
+        none) ;;
+        *) fail "$name has unknown physical mask layout $initial_mask" ;;
+    esac
+    persistent_mask_before=absent
+    persistent_target_before=
+    runtime_mask_before=absent
+    runtime_target_before=
+    if [ -e "$persistent_unit" ] || [ -L "$persistent_unit" ]; then
+        persistent_mask_before="$(stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+            "$persistent_unit")"
+        [ ! -L "$persistent_unit" ] ||
+            persistent_target_before="$(readlink -- "$persistent_unit")"
+    fi
+    if [ -e "$runtime_unit" ] || [ -L "$runtime_unit" ]; then
+        runtime_mask_before="$(stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- \
+            "$runtime_unit")"
+        [ ! -L "$runtime_unit" ] ||
+            runtime_target_before="$(readlink -- "$runtime_unit")"
+    fi
+    if [ "$load_state" = masked ]; then
+        case "$(cat "$mask_state")" in
+            persistent) printf '%s\n' "$persistent_unit" >"$manager_fragment_path" ;;
+            runtime) printf '%s\n' "$runtime_unit" >"$manager_fragment_path" ;;
+        esac
+    fi
+    case "$control_conflict" in
+        persistent)
+            printf '%s\n' override >"$case_root/etc/systemd/system.control/facelock-daemon.service"
+            ;;
+        runtime)
+            printf '%s\n' override >"$barrier"
+            ;;
+    esac
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$actual" \
+        FACELOCK_SHOW_STATUS="$show_status" \
+        FACELOCK_LOAD_STATE="$load_state" \
+        FACELOCK_ACTIVE_STATE="$active_state" \
+        FACELOCK_UNIT_FILE_STATE="$unit_file_state" \
+        FACELOCK_MASK_STATE="$mask_state" \
+        FACELOCK_MANAGER_MASK_STATE="$manager_mask_state" \
+        FACELOCK_MANAGER_FRAGMENT_PATH="$manager_fragment_path" \
+        FACELOCK_FRAGMENT_PATH_OVERRIDE="$fragment_path_override" \
+        FACELOCK_IGNORE_BARRIER="$ignore_barrier" \
+        FACELOCK_REQUIRE_PRESTOP_PROOF=true \
+        FACELOCK_BUSCTL_RELOAD_STATUS="$busctl_reload_status" \
+        FACELOCK_DBUS_OWNER_OVERRIDE="$dbus_owner_override" \
+        FACELOCK_DBUS_TAMPER_ON_RELOAD="$dbus_tamper_on_reload" \
+        FACELOCK_PERSISTENT_CONTROL_DIR="$case_root/etc/systemd/system.control" \
+        FACELOCK_RUNTIME_CONTROL_DIR="$case_root/run/systemd/system.control" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            layout_prefix="${2%/run/systemd/system}"
+            facelock_source_install_begin_daemon "$2" "$3" "$4" \
+                "$layout_prefix/etc/systemd/system/facelock-daemon.service" \
+                "$layout_prefix/run/systemd/system/facelock-daemon.service"
+            barrier_dir="${2%/system}/system.control"
+            barrier="$barrier_dir/facelock-daemon.service"
+            [ -f "$barrier" ]
+            [ ! -L "$barrier" ]
+            [ ! -s "$barrier" ]
+            path_metadata="$(stat -Lc "%d:%i:%u:%g:%a:%h:%s:%F" -- "$barrier")"
+            fd_metadata="$(stat -Lc "%d:%i:%u:%g:%a:%h:%s:%F" -- "/proc/$$/fd/$FACELOCK_SOURCE_INSTALL_BARRIER_FD")"
+            [ "$path_metadata" = "$fd_metadata" ]
+            IFS=: read -r _ _ uid gid mode links size kind <<<"$path_metadata"
+            [ "$uid:$gid" = "$(stat -Lc "%u:%g" -- "${2%/run/systemd/system}")" ]
+            [ "$mode" = 600 ]
+            [ "$links" -eq 1 ]
+            [ "$size" -eq 0 ]
+            [[ "$kind" = regular\ *file ]]
+            if [ "$5" = yes ]; then
+                if dbus-activate; then
+                    echo "activation escaped the source-install barrier" >&2
+                    exit 90
+                fi
+            fi
+            case "$7" in
+                absent)
+                    : >"$3"
+                    printf "%s\n" \
+                        "[D-BUS Service]" \
+                        "Name=org.facelock.Daemon" \
+                        "Exec=/usr/bin/facelock daemon" \
+                        "User=root" \
+                        "SystemdService=facelock-daemon.service" >"$4"
+                    ;;
+            esac
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+            [ ! -e "$barrier" ]
+            [ ! -L "$barrier" ]
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        "$inject_activation" \
+        "$initial_mask" \
+        "$assets" \
+        2>"$stderr_path"
+    status=$?
+    set -e
+
+    if [ "$expected_status" = success ] && [ "$status" -ne 0 ]; then
+        cat "$stderr_path" >&2
+        fail "$name unexpectedly failed with status $status"
+    fi
+    if [ "$expected_status" = failure ] && [ "$status" -eq 0 ]; then
+        fail "$name unexpectedly succeeded"
+    fi
+    if [ "$expected_status" = success ] && [ -s "$stderr_path" ]; then
+        cat "$stderr_path" >&2
+        fail "$name wrote unexpected stderr"
+    fi
+    if [ "$expected_status" = failure ] &&
+        ! grep -Fq 'no files were changed' "$stderr_path"; then
+        cat "$stderr_path" >&2
+        fail "$name did not explain its pre-mutation refusal"
+    fi
+
+    diff -u "$expected_path" "$actual" ||
+        fail "$name command ordering or activation state changed"
+    if [ "$persistent_mask_before" != absent ]; then
+        [ "$(stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$persistent_unit")" = \
+            "$persistent_mask_before" ] || fail "$name changed persistent mask metadata"
+        [ ! -L "$persistent_unit" ] ||
+            [ "$(readlink -- "$persistent_unit")" = "$persistent_target_before" ] ||
+            fail "$name changed persistent mask target"
+    fi
+    if [ "$runtime_mask_before" != absent ]; then
+        [ "$(stat -c '%d:%i:%u:%g:%a:%h:%s:%F' -- "$runtime_unit")" = \
+            "$runtime_mask_before" ] || fail "$name changed runtime mask metadata"
+        [ ! -L "$runtime_unit" ] ||
+            [ "$(readlink -- "$runtime_unit")" = "$runtime_target_before" ] ||
+            fail "$name changed runtime mask target"
+    fi
+    case "$control_conflict:$load_state:$initial_mask" in
+        persistent:*)
+            [ -f "$case_root/etc/systemd/system.control/facelock-daemon.service" ] &&
+                [ "$(cat "$case_root/etc/systemd/system.control/facelock-daemon.service")" = override ] ||
+                fail "$name changed the pre-existing control unit"
+            ;;
+        runtime:*)
+            [ -f "$barrier" ] && [ "$(cat "$barrier")" = override ] ||
+                fail "$name changed the pre-existing control unit"
+            ;;
+        none:*:runtime | none:*:runtime-symlink)
+            [ -L "$runtime_unit" ] && [ "$(readlink "$runtime_unit")" = /dev/null ] ||
+                fail "$name changed the pre-existing runtime mask"
+            ;;
+        none:*:runtime-regular)
+            [ -f "$runtime_unit" ] && [ ! -s "$runtime_unit" ] &&
+                [ ! -L "$runtime_unit" ] ||
+                fail "$name changed the pre-existing runtime regular mask"
+            ;;
+        none:*:persistent | none:*:persistent-symlink)
+            [ -L "$persistent_unit" ] &&
+                [ "$(readlink "$persistent_unit")" = /dev/null ] ||
+                fail "$name changed the pre-existing persistent mask"
+            ;;
+        none:*:persistent-regular)
+            [ -f "$persistent_unit" ] && [ ! -s "$persistent_unit" ] &&
+                [ ! -L "$persistent_unit" ] ||
+                fail "$name changed the pre-existing persistent regular mask"
+            ;;
+        none:*:both-symlink)
+            [ -L "$persistent_unit" ] && [ "$(readlink "$persistent_unit")" = /dev/null ] &&
+                [ -L "$runtime_unit" ] && [ "$(readlink "$runtime_unit")" = /dev/null ] ||
+                fail "$name changed one of the pre-existing masks"
+            ;;
+        none:*:both-regular)
+            [ -f "$persistent_unit" ] && [ ! -s "$persistent_unit" ] &&
+                [ ! -L "$persistent_unit" ] &&
+                [ -f "$runtime_unit" ] && [ ! -s "$runtime_unit" ] &&
+                [ ! -L "$runtime_unit" ] ||
+                fail "$name changed one of the pre-existing regular masks"
+            ;;
+        none:*:none)
+            if [ "$retain_barrier" != true ]; then
+                [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+                    fail "$name left its owned activation barrier installed"
+            fi
+            ;;
+    esac
+    if [ "$expected_status" = success ] &&
+        [ "$(cat "$mask_state")" != none ]; then
+        [ "$(cat "$manager_mask_state")" = masked ] ||
+            fail "$name did not restore the manager's administrative mask state"
+        case "$(cat "$mask_state")" in
+            persistent)
+                [ "$(cat "$manager_fragment_path")" = "$persistent_unit" ] ||
+                    fail "$name did not restore the persistent mask winner"
+                ;;
+            runtime)
+                [ "$(cat "$manager_fragment_path")" = "$runtime_unit" ] ||
+                    fail "$name did not restore the runtime mask winner"
+                ;;
+        esac
+    elif [ "$expected_status" = success ]; then
+        [ "$(cat "$manager_mask_state")" = none ] ||
+            fail "$name left the manager masked after removing its barrier"
+        case "$initial_mask" in
+            runtime-override | nonmask-runtime)
+                [ "$(cat "$manager_fragment_path")" = "$runtime_unit" ] ||
+                    fail "$name did not restore the runtime override winner"
+                ;;
+            persistent-override | persistent-override-runtime-mask)
+                [ "$(cat "$manager_fragment_path")" = "$persistent_unit" ] ||
+                    fail "$name did not restore the persistent override winner"
+                ;;
+        esac
+    fi
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+show_command='systemctl show facelock-daemon.service --property=LoadState --property=ActiveState --property=UnitFileState --property=FragmentPath --property=ExecStart --property=DropInPaths --no-pager'
+dbus_show_command='systemctl show dbus.service --property=Id --property=Names --property=Following --property=LoadState --property=ActiveState --property=FragmentPath --property=DropInPaths --property=ExecStart --no-pager'
+barrier_show_command='systemctl show facelock-daemon.service --property=LoadState --property=ActiveState --property=FragmentPath --no-pager'
+dbus_reload_command='busctl --system call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig'
+dbus_owner_command='busctl --system call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus NameHasOwner s org.facelock.Daemon'
+
+run_daemon_exec_topology_case() {
+    local name="$1"
+    local exec_start="$2"
+    local expected_status="$3"
+    local mutation="${4:-none}"
+    local case_root="$tmp_root/$name"
+    local unit="$case_root/assets/facelock-daemon.service"
+    local executable="$case_root/usr/bin/facelock"
+    local status
+
+    mkdir -p "$case_root/assets" "$case_root/usr/bin"
+    : >"$unit"
+    : >"$executable"
+    chmod 755 "$executable"
+    case "$mutation" in
+        none) ;;
+        missing) rm -f "$executable" ;;
+        symlink)
+            rm -f "$executable"
+            ln -s /usr/bin/false "$executable"
+            ;;
+        hardlink) ln "$executable" "$case_root/facelock-alias" ;;
+        group_writable) chmod 775 "$executable" ;;
+        world_writable) chmod 757 "$executable" ;;
+        non_executable) chmod 644 "$executable" ;;
+        owner_executable) chmod 700 "$executable" ;;
+        parent_untrusted) chmod 777 "$case_root/usr/bin" ;;
+        size_above_16m) truncate -s 16777217 "$executable" ;;
+        size_256m) truncate -s 268435456 "$executable" ;;
+        size_above_256m) truncate -s 268435457 "$executable" ;;
+        *) fail "$name has unknown daemon executable mutation $mutation" ;;
+    esac
+
+    set +e
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        facelock_source_install_effective_unit_is_trusted \
+            "$3" "$4" "" "$2" "$3"
+    ' _ "$lifecycle_script" "$case_root" "$unit" "$exec_start"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "$name exited $status, expected $expected_status"
+}
+
+daemon_structured_exec='{ path=/usr/bin/facelock ; argv[]=/usr/bin/facelock daemon ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }'
+run_daemon_exec_topology_case daemon_exec_plain \
+    '/usr/bin/facelock daemon' 0
+run_daemon_exec_topology_case daemon_exec_structured \
+    "$daemon_structured_exec" 0
+run_daemon_exec_topology_case daemon_exec_prefix \
+    "prefix $daemon_structured_exec" 1
+run_daemon_exec_topology_case daemon_exec_suffix \
+    "$daemon_structured_exec suffix" 1
+run_daemon_exec_topology_case daemon_exec_extra_record \
+    "$daemon_structured_exec ; $daemon_structured_exec" 1
+run_daemon_exec_topology_case daemon_exec_extra_argv \
+    '{ path=/usr/bin/facelock ; argv[]=/usr/bin/facelock daemon --unsafe ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 1
+run_daemon_exec_topology_case daemon_exec_wrong_path \
+    '/usr/local/bin/facelock daemon' 1
+run_daemon_exec_topology_case daemon_exec_substring_only \
+    '{ unexpected=yes ; path=/usr/bin/facelock ; argv[]=/usr/bin/facelock daemon ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 1
+run_daemon_exec_topology_case daemon_exec_ignore_errors \
+    '{ path=/usr/bin/facelock ; argv[]=/usr/bin/facelock daemon ; ignore_errors=yes ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 1
+run_daemon_exec_topology_case daemon_exec_trailing_semicolon \
+    '{ path=/usr/bin/facelock ; argv[]=/usr/bin/facelock daemon ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 ; }' 1
+run_daemon_exec_topology_case daemon_exec_status_cr_suffix \
+    "${daemon_structured_exec% \}}"$'\r }' 1
+run_daemon_exec_topology_case daemon_exec_status_lf_suffix \
+    "${daemon_structured_exec% \}}"$'\n }' 1
+run_daemon_exec_topology_case daemon_exec_empty '' 1
+run_daemon_exec_topology_case daemon_executable_missing \
+    '/usr/bin/facelock daemon' 1 missing
+run_daemon_exec_topology_case daemon_executable_symlink \
+    '/usr/bin/facelock daemon' 1 symlink
+run_daemon_exec_topology_case daemon_executable_hardlink \
+    '/usr/bin/facelock daemon' 1 hardlink
+run_daemon_exec_topology_case daemon_executable_group_writable \
+    '/usr/bin/facelock daemon' 1 group_writable
+run_daemon_exec_topology_case daemon_executable_world_writable \
+    '/usr/bin/facelock daemon' 1 world_writable
+run_daemon_exec_topology_case daemon_executable_non_executable \
+    '/usr/bin/facelock daemon' 1 non_executable
+run_daemon_exec_topology_case daemon_executable_owner_executable \
+    '/usr/bin/facelock daemon' 0 owner_executable
+run_daemon_exec_topology_case daemon_executable_parent_untrusted \
+    '/usr/bin/facelock daemon' 1 parent_untrusted
+run_daemon_exec_topology_case daemon_executable_above_16m \
+    '/usr/bin/facelock daemon' 0 size_above_16m
+run_daemon_exec_topology_case daemon_executable_256m \
+    '/usr/bin/facelock daemon' 0 size_256m
+run_daemon_exec_topology_case daemon_executable_above_256m \
+    '/usr/bin/facelock daemon' 1 size_above_256m
+
+write_dbus_snapshot() {
+    local topology="$1"
+    local mutation="$2"
+    local exec_start="$3"
+    local id names fragment_path
+    local following="" load_state=loaded active_state=active drop_in_paths=""
+    local key value
+    local -a keys=(Id Names Following LoadState ActiveState FragmentPath DropInPaths ExecStart)
+
+    case "$topology" in
+        broker)
+            id=dbus-broker.service
+            names='dbus-broker.service dbus.service'
+            fragment_path='@CASE_ROOT@/usr/lib/systemd/system/dbus-broker.service'
+            ;;
+        daemon)
+            id=dbus.service
+            names=dbus.service
+            fragment_path='@CASE_ROOT@/usr/lib/systemd/system/dbus.service'
+            ;;
+        *) fail "unknown D-Bus topology $topology" ;;
+    esac
+    case "$mutation" in
+        none) ;;
+        following) following=dbus.socket ;;
+        not_loaded) load_state=not-found ;;
+        inactive) active_state=inactive ;;
+        drop_in) drop_in_paths='@CASE_ROOT@/etc/systemd/system/dbus.service.d/override.conf' ;;
+        names_reverse) names='dbus.service dbus-broker.service' ;;
+        names_extra) names="$names dbus-extra.service" ;;
+        names_duplicate) names="$names dbus.service" ;;
+        wrong_id) id=dbus.service ;;
+        wrong_fragment) fragment_path='@CASE_ROOT@/usr/lib/systemd/system/dbus.service' ;;
+        lib_fragment) fragment_path="${fragment_path/\/usr\/lib\//\/lib\/}" ;;
+        unknown | missing_* | duplicate_*) ;;
+        *) fail "unknown D-Bus snapshot mutation $mutation" ;;
+    esac
+
+    for key in "${keys[@]}"; do
+        [ "$mutation" != "missing_$key" ] || continue
+        case "$key" in
+            Id) value="$id" ;;
+            Names) value="$names" ;;
+            Following) value="$following" ;;
+            LoadState) value="$load_state" ;;
+            ActiveState) value="$active_state" ;;
+            FragmentPath) value="$fragment_path" ;;
+            DropInPaths) value="$drop_in_paths" ;;
+            ExecStart) value="$exec_start" ;;
+        esac
+        printf '%s=%s\n' "$key" "$value"
+        if [ "$mutation" = "duplicate_$key" ]; then
+            printf '%s=%s\n' "$key" "$value"
+        fi
+    done
+    if [ "$mutation" = unknown ]; then
+        printf 'Unexpected=value\n'
+    fi
+}
+
+run_dbus_topology_case() {
+    local name="$1"
+    local topology="$2"
+    local mutation="$3"
+    local exec_start="$4"
+    local expected_status="$5"
+    local asset_mutation="${6:-none}"
+    local case_root="$tmp_root/$name"
+    local executable fragment_path snapshot status
+
+    mkdir -p "$case_root/run/systemd/system"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/usr/bin/dbus-daemon"
+    chmod 755 "$case_root/usr/bin/dbus-daemon"
+    : >"$case_root/usr/lib/systemd/system/dbus.service"
+    case "$topology" in
+        broker)
+            executable="$case_root/usr/bin/dbus-broker-launch"
+            fragment_path="$case_root/usr/lib/systemd/system/dbus-broker.service"
+            ;;
+        daemon)
+            executable="$case_root/usr/bin/dbus-daemon"
+            fragment_path="$case_root/usr/lib/systemd/system/dbus.service"
+            ;;
+    esac
+    case "$asset_mutation" in
+        none) ;;
+        executable_missing) rm -f "$executable" ;;
+        executable_symlink)
+            rm -f "$executable"
+            ln -s /usr/bin/false "$executable"
+            ;;
+        executable_hardlink) ln "$executable" "$case_root/dbus-executable-alias" ;;
+        executable_mode) chmod 777 "$executable" ;;
+        executable_parent_mode) chmod 777 "$case_root/usr/bin" ;;
+        fragment_symlink)
+            rm -f "$fragment_path"
+            ln -s /dev/null "$fragment_path"
+            ;;
+        fragment_hardlink) ln "$fragment_path" "$case_root/dbus-fragment-alias" ;;
+        fragment_mode) chmod 666 "$fragment_path" ;;
+        fragment_size) truncate -s 1048577 "$fragment_path" ;;
+        fragment_parent_mode) chmod 777 "$case_root/usr/lib/systemd/system" ;;
+        fragment_merged_lib)
+            ln -s usr/lib "$case_root/lib"
+            fragment_path="${fragment_path/\/usr\/lib\//\/lib\/}"
+            ;;
+        fragment_newline_alias)
+            mkdir -p "$case_root/usr/"$'lib\n/systemd/system'
+            : >"$case_root/usr/"$'lib\n/systemd/system/'"${fragment_path##*/}"
+            ln -s $'usr/lib\n' "$case_root/lib"
+            fragment_path="${fragment_path/\/usr\/lib\//\/lib\/}"
+            ;;
+        fragment_independent_lib)
+            fragment_path="${fragment_path/\/usr\/lib\//\/lib\/}"
+            mkdir -p "${fragment_path%/*}"
+            : >"$fragment_path"
+            ;;
+        *) fail "$name has unknown D-Bus asset mutation $asset_mutation" ;;
+    esac
+    snapshot="$(write_dbus_snapshot "$topology" "$mutation" "$exec_start")"
+    snapshot="${snapshot//@CASE_ROOT@/$case_root}"
+    : >"$case_root/actual"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_DBUS_SNAPSHOT_OVERRIDE="$snapshot" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+            IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+                FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+            facelock_source_install_dbus_uses_systemd_activation
+        ' _ "$lifecycle_script" "$case_root"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "$name exited $status, expected $expected_status"
+    [ "$(cat "$case_root/actual")" = "$dbus_show_command" ] ||
+        fail "$name used an unexpected manager query"
+}
+
+broker_structured_exec='{ path=/usr/bin/dbus-broker-launch ; argv[]=/usr/bin/dbus-broker-launch --scope system --audit ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }'
+dbus_daemon_args='--system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only'
+run_dbus_topology_case dbus_broker_scope_space broker none \
+    '/usr/bin/dbus-broker-launch --scope system' 0
+run_dbus_topology_case dbus_broker_scope_equals broker none \
+    '/usr/bin/dbus-broker-launch --scope=system' 0
+run_dbus_topology_case dbus_broker_audit broker none \
+    '/usr/bin/dbus-broker-launch --scope system --audit' 0
+run_dbus_topology_case dbus_broker_equals_audit broker none \
+    '/usr/bin/dbus-broker-launch --scope=system --audit' 0
+run_dbus_topology_case dbus_broker_structured broker none \
+    "$broker_structured_exec" 0
+run_dbus_topology_case dbus_broker_structured_trailing_semicolon broker none \
+    '{ path=/usr/bin/dbus-broker-launch ; argv[]=/usr/bin/dbus-broker-launch --scope system ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 ; }' 1
+run_dbus_topology_case dbus_broker_structured_scope_space broker none \
+    '{ path=/usr/bin/dbus-broker-launch ; argv[]=/usr/bin/dbus-broker-launch --scope system ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 0
+run_dbus_topology_case dbus_broker_structured_scope_equals broker none \
+    '{ path=/usr/bin/dbus-broker-launch ; argv[]=/usr/bin/dbus-broker-launch --scope=system ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 0
+run_dbus_topology_case dbus_broker_structured_equals_audit broker none \
+    '{ path=/usr/bin/dbus-broker-launch ; argv[]=/usr/bin/dbus-broker-launch --scope=system --audit ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }' 0
+run_dbus_topology_case dbus_broker_names_reordered broker names_reverse \
+    '/usr/bin/dbus-broker-launch --scope system' 0
+for dbus_daemon_argv0 in /usr/bin/dbus-daemon dbus-daemon @dbus-daemon; do
+    run_dbus_topology_case \
+        "dbus_daemon_structured_${dbus_daemon_argv0//[^[:alnum:]]/_}" daemon none \
+        "{ path=/usr/bin/dbus-daemon ; argv[]=$dbus_daemon_argv0 $dbus_daemon_args ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }" 0
+done
+run_dbus_topology_case dbus_daemon_plain daemon none \
+    "/usr/bin/dbus-daemon $dbus_daemon_args" 0
+run_dbus_topology_case dbus_broker_merged_lib broker lib_fragment \
+    '/usr/bin/dbus-broker-launch --scope system' 0 fragment_merged_lib
+run_dbus_topology_case dbus_daemon_merged_lib daemon lib_fragment \
+    "/usr/bin/dbus-daemon $dbus_daemon_args" 0 fragment_merged_lib
+run_dbus_topology_case dbus_broker_independent_lib broker lib_fragment \
+    '/usr/bin/dbus-broker-launch --scope system' 1 fragment_independent_lib
+run_dbus_topology_case dbus_broker_newline_lib_alias broker lib_fragment \
+    '/usr/bin/dbus-broker-launch --scope system' 1 fragment_newline_alias
+
+for dbus_property in Id Names Following LoadState ActiveState FragmentPath DropInPaths ExecStart; do
+    run_dbus_topology_case "dbus_missing_${dbus_property,,}" broker \
+        "missing_$dbus_property" '/usr/bin/dbus-broker-launch --scope system' 1
+    run_dbus_topology_case "dbus_duplicate_${dbus_property,,}" broker \
+        "duplicate_$dbus_property" '/usr/bin/dbus-broker-launch --scope system' 1
+done
+run_dbus_topology_case dbus_unknown_property broker unknown \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_following_unit broker following \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_not_loaded broker not_loaded \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_not_active broker inactive \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_drop_in broker drop_in \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_names_extra broker names_extra \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_names_duplicate broker names_duplicate \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_wrong_id broker wrong_id \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_wrong_fragment broker wrong_fragment \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_topology_case dbus_executable_mismatch broker none \
+    "/usr/bin/dbus-daemon $dbus_daemon_args" 1
+run_dbus_topology_case dbus_broker_extra_arg broker none \
+    '/usr/bin/dbus-broker-launch --scope system --verbose' 1
+run_dbus_topology_case dbus_broker_reordered broker none \
+    '/usr/bin/dbus-broker-launch --audit --scope system' 1
+run_dbus_topology_case dbus_daemon_reordered daemon none \
+    '/usr/bin/dbus-daemon --system --nofork --address=systemd: --nopidfile --systemd-activation --syslog-only' 1
+run_dbus_topology_case dbus_daemon_wrong_structured_path daemon none \
+    "{ path=/usr/local/bin/dbus-daemon ; argv[]=/usr/bin/dbus-daemon $dbus_daemon_args ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }" 1
+for dbus_asset_mutation in executable_missing executable_symlink \
+    executable_hardlink executable_mode executable_parent_mode \
+    fragment_symlink fragment_hardlink fragment_mode fragment_size \
+    fragment_parent_mode; do
+    run_dbus_topology_case "dbus_$dbus_asset_mutation" broker none \
+        '/usr/bin/dbus-broker-launch --scope system' 1 "$dbus_asset_mutation"
+done
+
+run_dbus_definition_topology_case() {
+    local name="$1"
+    local expected_status="$2"
+    local content="$3"
+    local case_root="$tmp_root/$name"
+    local definition="$case_root/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+    local status
+
+    mkdir -p "${definition%/*}"
+    printf '%s\n' "$content" >"$definition"
+
+    set +e
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        facelock_source_install_dbus_definition_delegates "$3"
+    ' _ "$lifecycle_script" "$case_root" "$definition"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "$name exited $status, expected $expected_status"
+}
+
+run_private_dbus_name_precedence_case() (
+    set -euo pipefail
+
+    local case_name="$1"
+    local definition_name="$2"
+    local description="$3"
+    local case_root="$tmp_root/$case_name"
+    local higher_dir="$case_root/higher"
+    local lower_dir="$case_root/lower"
+    local higher_definition="$higher_dir/org.facelock.Daemon.service"
+    local lower_definition="$lower_dir/org.facelock.Daemon.service"
+    local higher_executable="$case_root/activate-higher"
+    local lower_executable="$case_root/activate-lower"
+    local higher_marker="$case_root/higher.marker"
+    local lower_marker="$case_root/lower.marker"
+    local socket_path="$case_root/bus"
+    local config="$case_root/bus.conf"
+    local bus_pid="" status
+
+    cleanup_private_bus() {
+        if [ -n "$bus_pid" ] && kill -0 "$bus_pid" 2>/dev/null; then
+            kill "$bus_pid" 2>/dev/null || true
+            wait "$bus_pid" 2>/dev/null || true
+        fi
+    }
+    trap cleanup_private_bus EXIT HUP INT TERM
+
+    mkdir -p "$higher_dir" "$lower_dir"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        "printf '%s\\n' higher >'$higher_marker'" >"$higher_executable"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        "printf '%s\\n' lower >'$lower_marker'" >"$lower_executable"
+    chmod 755 "$higher_executable" "$lower_executable"
+    printf '%s\n' \
+        '[D-BUS Service]' \
+        "Name=$definition_name" \
+        "Exec=$higher_executable" \
+        'SystemdService=facelock-daemon.service' >"$higher_definition"
+    printf '%s\n' \
+        '[D-BUS Service]' \
+        'Name=org.facelock.Daemon' \
+        "Exec=$lower_executable" >"$lower_definition"
+    printf '%s\n' \
+        '<busconfig>' \
+        '  <type>session</type>' \
+        "  <listen>unix:path=$socket_path</listen>" \
+        '  <auth>EXTERNAL</auth>' \
+        '  <policy context="default">' \
+        '    <allow send_destination="*"/>' \
+        '    <allow receive_sender="*"/>' \
+        '    <allow own="*"/>' \
+        '  </policy>' \
+        "  <servicedir>$higher_dir</servicedir>" \
+        "  <servicedir>$lower_dir</servicedir>" \
+        '</busconfig>' >"$config"
+
+    dbus-daemon --config-file="$config" --nofork --nopidfile \
+        >"$case_root/dbus.log" 2>&1 &
+    bus_pid=$!
+    for _ in {1..100}; do
+        [ -S "$socket_path" ] && break
+        kill -0 "$bus_pid" 2>/dev/null || break
+        sleep 0.01
+    done
+    [ -S "$socket_path" ] || {
+        cat "$case_root/dbus.log" >&2
+        fail "private D-Bus precedence bus did not start"
+    }
+    timeout 5s dbus-send --bus="unix:path=$socket_path" \
+        --type=method_call --dest=org.facelock.Daemon \
+        / org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1 || true
+    for _ in {1..100}; do
+        [ -e "$lower_marker" ] && break
+        sleep 0.01
+    done
+    [ -e "$lower_marker" ] || {
+        cat "$case_root/dbus.log" >&2
+        fail "private D-Bus did not select the lower exact direct definition"
+    }
+    [ ! -e "$higher_marker" ] ||
+        fail "private D-Bus selected the higher $description definition"
+    cleanup_private_bus
+    bus_pid=""
+
+    printf '%s\n' \
+        '[D-BUS Service]' \
+        "Name=$definition_name" \
+        'Exec=/usr/bin/facelock daemon' \
+        'User=root' \
+        'SystemdService=facelock-daemon.service' >"$higher_definition"
+    set +e
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=("$3" "$4")
+        facelock_source_install_dbus_definition_is_safe
+    ' _ "$lifecycle_script" "$case_root" \
+        "$higher_definition" "$lower_definition"
+    status=$?
+    set -e
+    [ "$status" -eq 1 ] ||
+        fail "helper accepted a higher $description definition over lower direct activation"
+)
+
+run_private_dbus_name_precedence_case \
+    dbus_private_trailing_name_precedence \
+    'org.facelock.Daemon   ' trailing-space
+run_private_dbus_name_precedence_case \
+    dbus_private_leading_tab_name_precedence \
+    $' \torg.facelock.Daemon' leading-tab
+
+canonical_dbus_definition="$(printf '%s\n' \
+    '[D-BUS Service]' \
+    'Name=org.facelock.Daemon' \
+    'Exec=/usr/bin/facelock daemon' \
+    'User=root' \
+    'SystemdService=facelock-daemon.service')"
+run_dbus_definition_topology_case dbus_definition_exact 0 \
+    "$canonical_dbus_definition"
+run_dbus_definition_topology_case dbus_definition_comments 0 \
+    "$(printf '%s\n' \
+        '# trusted service definition' \
+        '' \
+        '[D-BUS Service]' \
+        '# exact activation contract' \
+        'Name=org.facelock.Daemon' \
+        'Exec=/usr/bin/facelock daemon' \
+        'User=root' \
+        'SystemdService=facelock-daemon.service')"
+run_dbus_definition_topology_case dbus_definition_compatible_whitespace 0 \
+    "$(printf '%s\n' \
+        '   ' \
+        '[D-BUS Service]' \
+        'Name   =   org.facelock.Daemon' \
+        'Exec =   /usr/bin/facelock daemon' \
+        'User  =  root' \
+        'SystemdService = facelock-daemon.service')"
+run_dbus_definition_topology_case dbus_definition_leading_name_tab 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/$'Name=\torg.facelock.Daemon'}"
+run_dbus_definition_topology_case dbus_definition_leading_exec_tab 1 \
+    "${canonical_dbus_definition/Exec=\/usr\/bin\/facelock daemon/$'Exec=\t/usr/bin/facelock daemon'}"
+run_dbus_definition_topology_case dbus_definition_leading_user_tab 1 \
+    "${canonical_dbus_definition/User=root/$'User=\troot'}"
+run_dbus_definition_topology_case dbus_definition_leading_systemd_service_tab 1 \
+    "${canonical_dbus_definition/SystemdService=facelock-daemon.service/$'SystemdService=\tfacelock-daemon.service'}"
+run_dbus_definition_topology_case dbus_definition_trailing_name_spaces 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/Name=org.facelock.Daemon   }"
+run_dbus_definition_topology_case dbus_definition_trailing_exec_spaces 1 \
+    "${canonical_dbus_definition/Exec=\/usr\/bin\/facelock daemon/Exec=\/usr\/bin\/facelock daemon   }"
+run_dbus_definition_topology_case dbus_definition_trailing_user_spaces 1 \
+    "${canonical_dbus_definition/User=root/User=root   }"
+run_dbus_definition_topology_case dbus_definition_trailing_systemd_service_spaces 1 \
+    "${canonical_dbus_definition/SystemdService=facelock-daemon.service/SystemdService=facelock-daemon.service   }"
+run_dbus_definition_topology_case dbus_definition_trailing_name_tab 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/$'Name=org.facelock.Daemon\t'}"
+run_dbus_definition_topology_case dbus_definition_trailing_exec_tab 1 \
+    "${canonical_dbus_definition/Exec=\/usr\/bin\/facelock daemon/$'Exec=/usr/bin/facelock daemon\t'}"
+run_dbus_definition_topology_case dbus_definition_trailing_user_tab 1 \
+    "${canonical_dbus_definition/User=root/$'User=root\t'}"
+run_dbus_definition_topology_case dbus_definition_trailing_systemd_service_tab 1 \
+    "${canonical_dbus_definition/SystemdService=facelock-daemon.service/$'SystemdService=facelock-daemon.service\t'}"
+run_dbus_definition_topology_case dbus_definition_semicolon_comment 1 \
+    $'; rejected comment\n'"$canonical_dbus_definition"
+run_dbus_definition_topology_case dbus_definition_indented_comment 1 \
+    $' # rejected comment\n'"$canonical_dbus_definition"
+run_dbus_definition_topology_case dbus_definition_indented_section 1 \
+    "${canonical_dbus_definition/'[D-BUS Service]'/' [D-BUS Service]'}"
+run_dbus_definition_topology_case dbus_definition_leading_whitespace_key 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/ Name=org.facelock.Daemon}"
+run_dbus_definition_topology_case dbus_definition_tab_before_equals 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/$'Name\t=org.facelock.Daemon'}"
+run_dbus_definition_topology_case dbus_definition_missing_name 1 \
+    "${canonical_dbus_definition//$'Name=org.facelock.Daemon\n'/}"
+run_dbus_definition_topology_case dbus_definition_duplicate_name 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/$'Name=org.facelock.Daemon\nName=org.facelock.Daemon'}"
+run_dbus_definition_topology_case dbus_definition_wrong_name 1 \
+    "${canonical_dbus_definition/Name=org.facelock.Daemon/Name=org.facelock.Other}"
+run_dbus_definition_topology_case dbus_definition_missing_exec 1 \
+    "${canonical_dbus_definition//$'Exec=/usr/bin/facelock daemon\n'/}"
+run_dbus_definition_topology_case dbus_definition_duplicate_exec 1 \
+    "${canonical_dbus_definition/Exec=\/usr\/bin\/facelock daemon/$'Exec=/usr/bin/facelock daemon\nExec=/usr/bin/facelock daemon'}"
+run_dbus_definition_topology_case dbus_definition_wrong_exec 1 \
+    "${canonical_dbus_definition/Exec=\/usr\/bin\/facelock daemon/Exec=\/usr\/local\/bin\/facelock daemon}"
+run_dbus_definition_topology_case dbus_definition_missing_user 1 \
+    "${canonical_dbus_definition//$'User=root\n'/}"
+run_dbus_definition_topology_case dbus_definition_duplicate_user 1 \
+    "${canonical_dbus_definition/User=root/$'User=root\nUser=root'}"
+run_dbus_definition_topology_case dbus_definition_wrong_user 1 \
+    "${canonical_dbus_definition/User=root/User=facelock}"
+run_dbus_definition_topology_case dbus_definition_missing_systemd_service 1 \
+    "${canonical_dbus_definition//$'SystemdService=facelock-daemon.service'/}"
+run_dbus_definition_topology_case dbus_definition_duplicate_systemd_service 1 \
+    "$canonical_dbus_definition"$'\nSystemdService=facelock-daemon.service'
+run_dbus_definition_topology_case dbus_definition_wrong_systemd_service 1 \
+    "${canonical_dbus_definition/SystemdService=facelock-daemon.service/SystemdService=other.service}"
+run_dbus_definition_topology_case dbus_definition_unknown_key 1 \
+    "$canonical_dbus_definition"$'\nActivationPolicy=permissive'
+run_dbus_definition_topology_case dbus_definition_duplicate_section 1 \
+    "$canonical_dbus_definition"$'\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service'
+run_dbus_definition_topology_case dbus_definition_extra_section 1 \
+    "$canonical_dbus_definition"$'\n[Other]\nName=org.facelock.Daemon'
+run_dbus_definition_topology_case dbus_definition_pre_section_known_key 1 \
+    $'Exec=/usr/bin/false\n'"$canonical_dbus_definition"
+run_dbus_definition_topology_case dbus_definition_pre_section_unknown_key 1 \
+    $'ActivationPolicy=permissive\n'"$canonical_dbus_definition"
+
+run_dbus_definition_raw_byte_case() {
+    local name="$1"
+    local mutation="$2"
+    local expected_status="${3:-1}"
+    local case_root="$tmp_root/$name"
+    local definition="$case_root/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+    local payload status
+
+    case "$mutation" in
+        malformed_preamble)
+            payload='malformed preamble\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        ff_comment)
+            payload='# invalid byte: \xff\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        truncated_multibyte_comment)
+            payload='# truncated sequence: \xc3\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        canonical_crlf)
+            payload='[D-BUS Service]\r\nName=org.facelock.Daemon\r\nExec=/usr/bin/facelock daemon\r\nUser=root\r\nSystemdService=facelock-daemon.service\r\n'
+            ;;
+        embedded_cr_comment)
+            payload='# embedded\rreturn\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        control_comment)
+            payload='# control: \x01\n[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        unterminated_trailing_cr)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\r'
+            ;;
+        nul_name_key)
+            payload='[D-BUS Service]\nNa\0me=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_exec_key)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nEx\0ec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_user_key)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUs\0er=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_systemd_service_key)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemd\0Service=facelock-daemon.service\n'
+            ;;
+        nul_name_value)
+            payload='[D-BUS Service]\nName=org.facelock.\0Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_exec_value)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock\0 daemon\nUser=root\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_user_value)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=ro\0ot\nSystemdService=facelock-daemon.service\n'
+            ;;
+        nul_systemd_service_value)
+            payload='[D-BUS Service]\nName=org.facelock.Daemon\nExec=/usr/bin/facelock daemon\nUser=root\nSystemdService=facelock-daemon.\0service\n'
+            ;;
+        *) fail "$name has unknown raw D-Bus mutation $mutation" ;;
+    esac
+    mkdir -p "${definition%/*}"
+    printf '%b' "$payload" >"$definition"
+
+    set +e
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        facelock_source_install_dbus_definition_delegates "$3"
+    ' _ "$lifecycle_script" "$case_root" "$definition"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] ||
+        fail "$name exited $status, expected $expected_status for raw bytes"
+}
+
+run_dbus_definition_raw_byte_case dbus_definition_malformed_preamble \
+    malformed_preamble
+run_dbus_definition_raw_byte_case dbus_definition_ff_comment ff_comment
+run_dbus_definition_raw_byte_case dbus_definition_truncated_multibyte_comment \
+    truncated_multibyte_comment
+run_dbus_definition_raw_byte_case dbus_definition_canonical_crlf \
+    canonical_crlf 0
+run_dbus_definition_raw_byte_case dbus_definition_embedded_cr_comment \
+    embedded_cr_comment
+run_dbus_definition_raw_byte_case dbus_definition_control_comment \
+    control_comment
+run_dbus_definition_raw_byte_case dbus_definition_unterminated_trailing_cr \
+    unterminated_trailing_cr
+for dbus_definition_nul_mutation in nul_name_key nul_exec_key nul_user_key \
+    nul_systemd_service_key nul_name_value nul_exec_value nul_user_value \
+    nul_systemd_service_value; do
+    run_dbus_definition_raw_byte_case \
+        "dbus_definition_$dbus_definition_nul_mutation" \
+        "$dbus_definition_nul_mutation"
+done
+
+inactive_barrier_success_log="$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case active loaded active disabled 0 present success none yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case inactive_disabled loaded inactive disabled 0 present success none yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+        "$barrier_show_command" \
+        "$dbus_owner_command" \
+        'systemctl daemon-reload' \
+        "$show_command" \
+        "$dbus_owner_command" \
+        "$show_command" \
+        "$dbus_owner_command")"
+
+run_case probe_error loaded inactive disabled 1 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case transitional loaded activating enabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case failed_state loaded failed enabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case bad_unit_file_state loaded inactive bad 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case unknown_unit_file_state loaded inactive future-state 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case missing_unit_file_state loaded inactive '' 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case first_install not-found inactive '' 0 absent success none yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case inconsistent_not_found not-found inactive '' 0 present failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case first_install_alternate not-found inactive '' 0 alternate failure none no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case inactive_runtime_mask masked inactive masked-runtime 0 present success runtime yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case inactive_persistent_mask masked inactive masked 0 present success persistent yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case inactive_runtime_regular_mask masked inactive masked-runtime 0 present \
+    success runtime-regular yes "$inactive_barrier_success_log"
+run_case inactive_persistent_regular_mask masked inactive masked 0 present \
+    success persistent-regular yes "$inactive_barrier_success_log"
+run_case inactive_both_symlink_masks masked inactive masked 0 present \
+    success both-symlink yes "$inactive_barrier_success_log"
+run_case inactive_both_regular_masks masked inactive masked 0 present \
+    success both-regular yes "$inactive_barrier_success_log"
+run_case inactive_persistent_symlink_runtime_regular_masks masked inactive masked \
+    0 present success persistent-symlink-runtime-regular yes \
+    "$inactive_barrier_success_log"
+run_case inactive_persistent_regular_runtime_symlink_masks masked inactive masked \
+    0 present success persistent-regular-runtime-symlink yes \
+    "$inactive_barrier_success_log"
+
+run_case stale_runtime_symlink_mask loaded inactive disabled 0 present \
+    success runtime-symlink yes "$inactive_barrier_success_log"
+run_case stale_runtime_regular_mask loaded inactive disabled 0 present \
+    success runtime-regular yes "$inactive_barrier_success_log"
+run_case stale_persistent_symlink_mask loaded inactive disabled 0 present \
+    success persistent-symlink yes "$inactive_barrier_success_log"
+run_case stale_persistent_regular_mask loaded inactive disabled 0 present \
+    success persistent-regular yes "$inactive_barrier_success_log"
+run_case stale_both_masks loaded inactive disabled 0 present \
+    success both-symlink yes "$inactive_barrier_success_log"
+run_case stale_static_persistent_mask loaded inactive static 0 present \
+    success persistent-symlink yes "$inactive_barrier_success_log"
+
+run_case loaded_inactive_persistent_mask loaded inactive masked 0 present failure persistent no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case loaded_inactive_runtime_mask_false_schema loaded inactive masked-runtime 0 \
+    present failure runtime no "$(printf '%s\n' "$show_command")"
+
+run_case active_admin_mask loaded active disabled 0 present failure runtime no "$(printf '%s\n' \
+    "$show_command")"
+
+run_case active_persistent_admin_mask loaded active enabled 0 present failure \
+    persistent no "$(printf '%s\n' "$show_command")"
+run_case active_effective_mask masked active masked-runtime 0 present failure \
+    runtime no "$(printf '%s\n' "$show_command")"
+run_case not_found_with_mask not-found inactive '' 0 absent failure runtime no \
+    "$(printf '%s\n' "$show_command")"
+run_case manager_mask_without_disk masked inactive masked 0 present failure none no \
+    "$(printf '%s\n' "$show_command")"
+run_case manager_runtime_disk_persistent masked inactive masked-runtime 0 present \
+    failure persistent no "$(printf '%s\n' "$show_command")"
+run_case manager_persistent_disk_runtime masked inactive masked 0 present failure \
+    runtime no "$(printf '%s\n' "$show_command")"
+
+run_case runtime_override_preserved_by_identity loaded inactive disabled 0 present \
+    success runtime-override yes "$inactive_barrier_success_log"
+run_case persistent_override_preserved loaded inactive enabled 0 present \
+    success persistent-override yes "$inactive_barrier_success_log"
+run_case persistent_override_beats_runtime_mask loaded inactive enabled 0 present \
+    success persistent-override-runtime-mask yes "$inactive_barrier_success_log"
+run_case persistent_mask_beats_runtime_override masked inactive masked 0 present \
+    success persistent-mask-runtime-override yes "$inactive_barrier_success_log"
+run_case dangling_runtime_refused loaded inactive disabled 0 present failure \
+    dangling-runtime no ''
+run_case untrusted_runtime_refused loaded inactive disabled 0 present failure \
+    untrusted-runtime no ''
+
+run_case persistent_control_conflict_with_mask loaded inactive disabled 0 present \
+    failure runtime no '' persistent
+run_case runtime_control_conflict_with_mask loaded inactive disabled 0 present \
+    failure persistent no '' runtime
+
+run_revalidation_refusal_case() {
+    local name="$1"
+    local fault="$2"
+    local case_root="$tmp_root/$name"
+    local runtime_mask="$case_root/run/systemd/system/facelock-daemon.service"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/etc/systemd/system.control" \
+        "$case_root/run/systemd/system" \
+        "$case_root/run/systemd/system.control" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    : >"$case_root/manager-fragment-path"
+    case "$fault" in
+        mask_before_create | mask_after_stop)
+            ln -s /dev/null "$runtime_mask"
+            printf '%s\n' runtime >"$case_root/mask-state"
+            ;;
+        ordinary_content_before_create)
+            printf '%s\n' '[Service]' \
+                'ExecStart=/usr/bin/facelock daemon' >"$runtime_mask"
+            ;;
+    esac
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_MANAGER_FRAGMENT_PATH="$case_root/manager-fragment-path" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_PERSISTENT_CONTROL_DIR="$case_root/etc/systemd/system.control" \
+        FACELOCK_RUNTIME_CONTROL_DIR="$case_root/run/systemd/system.control" \
+        FACELOCK_REQUIRE_PRESTOP_PROOF=true \
+        FACELOCK_BARRIER_SNAPSHOT_MUTATION="$(case "$fault" in \
+            fragment_blank) printf blank ;; fragment_wrong) printf wrong ;; \
+            fragment_duplicate) printf duplicate ;; *) printf none ;; esac)" \
+        FACELOCK_MUTATE_BARRIER_ON_RELOAD="$([ "$fault" = barrier_content ] && \
+            printf '%s' "$barrier")" \
+        FACELOCK_MUTATE_MASK_ON_OWNER="$([ "$fault" = mask_before_create ] && \
+            printf '%s' "$runtime_mask")" \
+        FACELOCK_MUTATE_ORDINARY_ON_OWNER="$([ "$fault" = ordinary_content_before_create ] && \
+            printf '%s' "$runtime_mask")" \
+        FACELOCK_FRAGMENT_PATH_OVERRIDE="$([ "$fault" = ordinary_content_before_create ] && \
+            printf '%s' "$runtime_mask")" \
+        FACELOCK_MUTATE_MASK_AFTER_STOP="$([ "$fault" = mask_after_stop ] && \
+            printf '%s' "$runtime_mask")" \
+        FACELOCK_OWNER_AFTER_STOP="$([ "$fault" = owner_after_stop ] && \
+            printf true || printf false)" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4" "$5"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        "$runtime_mask" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    ! grep -Fxq write "$case_root/actual" || fail "$name crossed the write boundary"
+    case "$fault" in
+        mask_after_stop | owner_after_stop)
+            grep -Fxq 'systemctl stop facelock-daemon.service' \
+                "$case_root/actual" || fail "$name did not reach its post-stop check"
+            ;;
+        *)
+            ! grep -Fxq 'systemctl stop facelock-daemon.service' \
+                "$case_root/actual" || fail "$name stopped before its pre-stop proof"
+            ;;
+    esac
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_revalidation_refusal_case barrier_fragment_blank fragment_blank
+run_revalidation_refusal_case barrier_fragment_wrong fragment_wrong
+run_revalidation_refusal_case barrier_fragment_duplicate fragment_duplicate
+run_revalidation_refusal_case barrier_content_changed barrier_content
+run_revalidation_refusal_case mask_changed_before_barrier mask_before_create
+run_revalidation_refusal_case ordinary_changed_before_barrier \
+    ordinary_content_before_create
+run_revalidation_refusal_case mask_changed_after_stop mask_after_stop
+run_revalidation_refusal_case dbus_owned_after_stop owner_after_stop
+
+run_initial_reload_retry_case() {
+    local failures="$1"
+    local case_root="$tmp_root/initial_reload_retry_$failures"
+    local attempts status
+
+    mkdir -p "$case_root/etc/systemd/system.control" \
+        "$case_root/run/systemd/system" \
+        "$case_root/run/systemd/system.control" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    : >"$case_root/manager-fragment-path"
+    printf '%s\n' "$failures" >"$case_root/failures-remaining"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_MANAGER_FRAGMENT_PATH="$case_root/manager-fragment-path" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_PERSISTENT_CONTROL_DIR="$case_root/etc/systemd/system.control" \
+        FACELOCK_RUNTIME_CONTROL_DIR="$case_root/run/systemd/system.control" \
+        FACELOCK_REQUIRE_PRESTOP_PROOF=true \
+        FACELOCK_FAIL_BEFORE_WRITE=true \
+        FACELOCK_FAIL_COMMAND=daemon-reload \
+        FACELOCK_FAILURES_REMAINING="$case_root/failures-remaining" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || {
+        cat "$case_root/stderr" >&2
+        fail "initial reload with $failures failures did not recover"
+    }
+    attempts="$(awk '
+        $0 == "systemctl stop facelock-daemon.service" { exit }
+        $0 == "systemctl daemon-reload" { count++ }
+        END { print count + 0 }
+    ' "$case_root/actual")"
+    [ "$attempts" -eq "$((failures + 1))" ] ||
+        fail "initial reload with $failures failures used $attempts attempts"
+    grep -Fxq write "$case_root/actual" ||
+        fail "initial reload retry $failures never reached writes"
+    assert_lock_available "initial_reload_retry_$failures" \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_initial_reload_retry_case 1
+run_initial_reload_retry_case 2
+
+run_case runtime_override_preserved loaded inactive disabled 0 present success runtime yes "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    'write' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_case persistent_control_conflict loaded inactive disabled 0 present failure none no '' persistent
+
+run_case runtime_control_conflict loaded inactive disabled 0 present failure none no '' runtime
+
+run_case direct_dbus_definition loaded inactive disabled 0 direct failure none no "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command")"
+
+run_case symlinked_loaded_unit loaded inactive disabled 0 unit_symlink failure none no \
+    "$show_command"
+
+run_selected_definition_cardinality_case() {
+    local name="$1"
+    local layout="$2"
+    local case_root="$tmp_root/$name"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    case "$layout" in
+        zero) ;;
+        duplicate)
+            write_dbus_service \
+                "$case_root/assets/org.facelock.Daemon.service"
+            write_dbus_service "$case_root/assets/alternate.service"
+            ;;
+    esac
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    [ "$(cat "$case_root/actual")" = "$(printf '%s\n' \
+        "$show_command" "$dbus_show_command")" ] ||
+        fail "$name crossed the lifecycle mutation boundary"
+    grep -Fq 'selected D-Bus activation definition' "$case_root/stderr" ||
+        fail "$name lacked a selected-definition diagnostic"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_selected_definition_cardinality_case dbus_zero_selected zero
+run_selected_definition_cardinality_case dbus_duplicate_selected duplicate
+
+run_malformed_snapshot_case() {
+    local name="$1"
+    local target="$2"
+    local snapshot="$3"
+    local expected_diagnostic="${4:-}"
+    local asset_layout="${5:-present}"
+    local case_root="$tmp_root/$name"
+    local status
+
+    snapshot="${snapshot//@CASE_ROOT@/$case_root}"
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    case "$asset_layout" in
+        present)
+            : >"$case_root/assets/facelock-daemon.service"
+            write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+            ;;
+        absent) ;;
+        *) fail "$name has unknown asset layout $asset_layout" ;;
+    esac
+    if [ "$target" = service ] &&
+        grep -Fqx 'LoadState=masked' <<<"$snapshot"; then
+        if grep -Fq "$case_root/run/systemd/system/facelock-daemon.service" \
+            <<<"$snapshot"; then
+            ln -s /dev/null \
+                "$case_root/run/systemd/system/facelock-daemon.service"
+        else
+            ln -s /dev/null \
+                "$case_root/etc/systemd/system/facelock-daemon.service"
+        fi
+    fi
+    : >"$case_root/actual"
+
+    set +e
+    if [ "$target" = service ]; then
+        PATH="$tmp_root/bin:$PATH" \
+            FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+            FACELOCK_SHOW_STATUS=0 \
+            FACELOCK_LOAD_STATE=loaded \
+            FACELOCK_ACTIVE_STATE=inactive \
+            FACELOCK_UNIT_FILE_STATE=disabled \
+            FACELOCK_SERVICE_SNAPSHOT_OVERRIDE="$snapshot" \
+            FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+            bash -c 'set -euo pipefail; source "$1"; facelock_source_install_begin_daemon "$2" "$3" "$4"' _ \
+            "$lifecycle_script" "$case_root/run/systemd/system" \
+            "$case_root/assets/facelock-daemon.service" \
+            "$case_root/assets/org.facelock.Daemon.service" \
+            2>"$case_root/stderr"
+    else
+        PATH="$tmp_root/bin:$PATH" \
+            FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+            FACELOCK_SHOW_STATUS=0 \
+            FACELOCK_LOAD_STATE=loaded \
+            FACELOCK_ACTIVE_STATE=inactive \
+            FACELOCK_UNIT_FILE_STATE=disabled \
+            FACELOCK_DBUS_SNAPSHOT_OVERRIDE="$snapshot" \
+            FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+            bash -c 'set -euo pipefail; source "$1"; facelock_source_install_begin_daemon "$2" "$3" "$4"' _ \
+            "$lifecycle_script" "$case_root/run/systemd/system" \
+            "$case_root/assets/facelock-daemon.service" \
+            "$case_root/assets/org.facelock.Daemon.service" \
+            2>"$case_root/stderr"
+    fi
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name accepted a malformed manager snapshot"
+    if [ -n "$expected_diagnostic" ]; then
+        grep -Fq "$expected_diagnostic" "$case_root/stderr" ||
+            fail "$name lacked its state-schema diagnostic"
+    fi
+    if [ "$target" = service ]; then
+        [ "$(cat "$case_root/actual")" = "$show_command" ] ||
+            fail "$name crossed the lifecycle mutation boundary"
+    else
+        [ "$(cat "$case_root/actual")" = "$(printf '%s\n' \
+            "$show_command" "$dbus_show_command")" ] ||
+            fail "$name crossed the lifecycle mutation boundary"
+    fi
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_malformed_snapshot_case service_duplicate_load service "$(printf '%s\n' \
+    'LoadState=not-found' 'LoadState=loaded' 'ActiveState=inactive' \
+    'UnitFileState=disabled' 'FragmentPath=/usr/lib/systemd/system/facelock-daemon.service' \
+    'ExecStart=/usr/bin/facelock daemon' 'DropInPaths=')"
+run_malformed_snapshot_case service_missing_active service "$(printf '%s\n' \
+    'LoadState=loaded' 'UnitFileState=disabled')"
+run_malformed_snapshot_case loaded_missing_exec_start service "$(printf '%s\n' \
+    'LoadState=loaded' 'ActiveState=inactive' 'UnitFileState=disabled' \
+    'FragmentPath=/usr/lib/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'incomplete loaded-unit state'
+run_malformed_snapshot_case loaded_empty_exec_start service "$(printf '%s\n' \
+    'LoadState=loaded' 'ActiveState=inactive' 'UnitFileState=disabled' \
+    'FragmentPath=/usr/lib/systemd/system/facelock-daemon.service' \
+    'ExecStart=' 'DropInPaths=')" 'incomplete loaded-unit state'
+run_malformed_snapshot_case loaded_duplicate_exec_start service "$(printf '%s\n' \
+    'LoadState=loaded' 'ActiveState=inactive' 'UnitFileState=disabled' \
+    'FragmentPath=/usr/lib/systemd/system/facelock-daemon.service' \
+    'ExecStart=/usr/bin/facelock daemon' \
+    'ExecStart=/usr/bin/facelock daemon' 'DropInPaths=')" \
+    'duplicate or missing unit-state properties'
+run_malformed_snapshot_case not_found_duplicate_active service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'ActiveState=inactive' \
+    'UnitFileState=' 'FragmentPath=' 'DropInPaths=')" \
+    'duplicate or missing unit-state properties' absent
+run_malformed_snapshot_case not_found_unexpected_exec_start service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'UnitFileState=' \
+    'FragmentPath=' 'ExecStart=/usr/bin/facelock daemon' 'DropInPaths=')" \
+    'inconsistent not-found unit state' absent
+run_malformed_snapshot_case not_found_unexpected_empty_exec_start service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'UnitFileState=' \
+    'FragmentPath=' 'ExecStart=' 'DropInPaths=')" \
+    'inconsistent not-found unit state' absent
+run_malformed_snapshot_case not_found_unexpected_unit_file_state service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'UnitFileState=not-found' \
+    'FragmentPath=' 'DropInPaths=')" 'inconsistent not-found unit state' absent
+run_malformed_snapshot_case not_found_unexpected_fragment service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'UnitFileState=' \
+    'FragmentPath=@CASE_ROOT@/usr/lib/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'inconsistent not-found unit state' absent
+run_malformed_snapshot_case not_found_unexpected_drop_in service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=inactive' 'UnitFileState=' \
+    'FragmentPath=' \
+    'DropInPaths=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service.d/override.conf')" \
+    'inconsistent not-found unit state' absent
+run_malformed_snapshot_case not_found_unexpected_active_state service "$(printf '%s\n' \
+    'LoadState=not-found' 'ActiveState=active' 'UnitFileState=' \
+    'FragmentPath=' 'DropInPaths=')" 'inconsistent not-found unit state' absent
+run_malformed_snapshot_case masked_duplicate_fragment service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'duplicate or missing unit-state properties'
+run_malformed_snapshot_case masked_unexpected_exec_start service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'ExecStart=/usr/bin/facelock daemon' 'DropInPaths=')" \
+    'inconsistent masked unit state'
+run_malformed_snapshot_case masked_unexpected_empty_exec_start service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'ExecStart=' 'DropInPaths=')" 'inconsistent masked unit state'
+run_malformed_snapshot_case masked_missing_unit_file_state service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'duplicate or missing unit-state properties'
+run_malformed_snapshot_case masked_unknown_unit_file_state service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=future-mask' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'inconsistent mask for facelock-daemon.service'
+run_malformed_snapshot_case masked_missing_fragment service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=' 'DropInPaths=')" 'inconsistent mask for facelock-daemon.service'
+run_malformed_snapshot_case masked_unexpected_drop_in service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'DropInPaths=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service.d/override.conf')" \
+    'inconsistent masked unit state'
+run_malformed_snapshot_case masked_runtime_with_persistent_fragment service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked-runtime' \
+    'FragmentPath=@CASE_ROOT@/etc/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'inconsistent mask for facelock-daemon.service'
+run_malformed_snapshot_case masked_persistent_with_runtime_fragment service "$(printf '%s\n' \
+    'LoadState=masked' 'ActiveState=inactive' 'UnitFileState=masked' \
+    'FragmentPath=@CASE_ROOT@/run/systemd/system/facelock-daemon.service' \
+    'DropInPaths=')" 'inconsistent mask for facelock-daemon.service'
+run_malformed_snapshot_case dbus_duplicate_active dbus "$(printf '%s\n' \
+    'ActiveState=inactive' 'ActiveState=active' \
+    'ExecStart=/usr/bin/dbus-broker-launch --scope system')"
+run_malformed_snapshot_case dbus_missing_exec dbus 'ActiveState=active'
+
+run_case dbus_reload_error loaded inactive disabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_reload_command" \
+    "$dbus_reload_command")" none false 1
+
+run_case dbus_owner_mismatch loaded inactive disabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command")" none false 0 true
+
+run_case dbus_config_changed_during_reload loaded inactive disabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command")" none false 0 '' true
+
+run_dbus_precedence_case() {
+    local name="$1"
+    local layout="$2"
+    local case_root="$tmp_root/$name"
+    local high="$case_root/etc/dbus-1/system-services/org.facelock.Daemon.service"
+    local low="$case_root/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "${high%/*}" "${low%/*}"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/facelock-daemon.service"
+    if [ "$layout" = higher_directory ]; then
+        write_dbus_service "$high" direct
+    else
+        write_dbus_service "$high"
+        write_dbus_service "${high%/*}/alternate.service" direct
+    fi
+    write_dbus_service "$low"
+    : >"$case_root/actual"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4" "$5"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/facelock-daemon.service" \
+        "$high" "$low" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    [ "$(cat "$case_root/actual")" = "$(printf '%s\n' \
+        "$show_command" "$dbus_show_command")" ] ||
+        fail "$name did not honor D-Bus activation selection"
+    grep -Fq 'selected D-Bus activation definition' "$case_root/stderr" ||
+        fail "$name lacked a delegation diagnostic"
+    assert_lock_available "$name" \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_dbus_precedence_case dbus_higher_directory higher_directory
+run_dbus_precedence_case dbus_same_directory same_directory
+
+run_custom_dbus_servicedir_case() {
+    local case_root="$tmp_root/dbus_custom_servicedir"
+    local custom_dir="$case_root/opt/admin-dbus-services"
+    local selected="$case_root/usr/share/dbus-1/system-services/org.facelock.Daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$custom_dir" \
+        "${selected%/*}" "$case_root/usr/share/dbus-1" \
+        "$case_root/etc/dbus-1" "$case_root/usr/bin" \
+        "$case_root/usr/lib/systemd/system"
+    : >"$case_root/usr/bin/dbus-broker-launch"
+    : >"$case_root/usr/bin/facelock"
+    chmod 755 "$case_root/usr/bin/dbus-broker-launch" \
+        "$case_root/usr/bin/facelock"
+    : >"$case_root/usr/lib/systemd/system/dbus-broker.service"
+    : >"$case_root/facelock-daemon.service"
+    write_dbus_service "$selected"
+    write_dbus_service "$custom_dir/facelock-direct.service" direct
+    printf '%s\n' \
+        '<busconfig>' \
+        '  <include ignore_missing="yes">/etc/dbus-1/system.conf</include>' \
+        '  <standard_system_servicedirs/>' \
+        '</busconfig>' >"$case_root/usr/share/dbus-1/system.conf"
+    printf '%s\n' \
+        '<busconfig>' \
+        '  <servicedir>/opt/admin-dbus-services</servicedir>' \
+        '</busconfig>' >"$case_root/etc/dbus-1/system.conf"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/facelock-daemon.service" \
+        "$selected" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] ||
+        fail "custom D-Bus servicedir did not fail closed"
+    ! grep -Fxq write "$case_root/actual" ||
+        fail "custom D-Bus servicedir allowed lifecycle mutation"
+    grep -Fq 'D-Bus activation configuration' "$case_root/stderr" ||
+        fail "custom D-Bus servicedir lacked a configuration diagnostic"
+    assert_lock_available dbus_custom_servicedir \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_custom_dbus_servicedir_case
+
+run_case barrier_not_applied loaded inactive disabled 0 present failure none no "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command")" none true 0 '' false true
+
+run_dbus_proof_failure_case() {
+    local name="$1"
+    local active_state="$2"
+    local exec_start="$3"
+    local show_status="$4"
+    local case_root="$tmp_root/$name"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_DBUS_SHOW_STATUS="$show_status" \
+        FACELOCK_DBUS_ACTIVE_STATE="$active_state" \
+        FACELOCK_DBUS_EXEC_START="$exec_start" \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name exited $status instead of failing closed"
+    [ ! -e "$case_root/run/systemd/system.control/facelock-daemon.service" ] ||
+        fail "$name established a barrier before proving D-Bus delegation"
+    [ "$(cat "$case_root/actual")" = "$(printf '%s\n' \
+        "$show_command" "$dbus_show_command")" ] ||
+        fail "$name command ordering changed"
+    grep -Fq 'D-Bus activation' "$case_root/stderr" ||
+        fail "$name lacked a D-Bus activation diagnostic"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_dbus_proof_failure_case dbus_probe_error active \
+    '/usr/bin/dbus-broker-launch --scope system' 1
+run_dbus_proof_failure_case dbus_inactive inactive \
+    '/usr/bin/dbus-broker-launch --scope system' 0
+run_dbus_proof_failure_case dbus_direct_exec active \
+    '/usr/bin/dbus-daemon --system' 0
+run_dbus_proof_failure_case dbus_daemon_wrong_scope active \
+    '/usr/bin/dbus-daemon --session --systemd-activation' 0
+run_dbus_proof_failure_case dbus_custom_config active \
+    '/usr/bin/dbus-broker-launch --scope system --config-file=/opt/system.conf' 0
+
+run_path_trust_case() {
+    local name="$1"
+    local mutation="$2"
+    local case_root="$tmp_root/$name"
+    local unit="$case_root/assets/facelock-daemon.service"
+    local definition="$case_root/assets/org.facelock.Daemon.service"
+    local config="$case_root/usr/share/dbus-1/system.conf"
+    local executable="$case_root/usr/bin/dbus-broker-launch"
+    local dbus_fragment="$case_root/usr/lib/systemd/system/dbus-broker.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$unit"
+    write_dbus_service "$definition"
+    case "$mutation" in
+        unit_hardlink) ln "$unit" "$case_root/unit-alias" ;;
+        unit_mode) chmod 666 "$unit" ;;
+        unit_size) truncate -s 1048577 "$unit" ;;
+        unit_parent_mode) chmod 777 "$case_root/assets" ;;
+        config_symlink)
+            mv "$config" "$case_root/config-target"
+            ln -s "$case_root/config-target" "$config"
+            ;;
+        config_hardlink) ln "$config" "$case_root/config-alias" ;;
+        config_mode) chmod 666 "$config" ;;
+        config_size) truncate -s 1048577 "$config" ;;
+        config_parent_mode) chmod 777 "$case_root/usr/share/dbus-1" ;;
+        config_include_parent_symlink)
+            mkdir -p "$case_root/etc"
+            ln -s "$case_root/missing-dbus-config" "$case_root/etc/dbus-1"
+            ;;
+        definition_symlink)
+            mv "$definition" "$case_root/definition-target"
+            ln -s "$case_root/definition-target" "$definition"
+            ;;
+        definition_hardlink) ln "$definition" "$case_root/definition-alias" ;;
+        definition_mode) chmod 666 "$definition" ;;
+        definition_size) truncate -s 65537 "$definition" ;;
+        executable_symlink)
+            rm "$executable"
+            ln -s /usr/bin/false "$executable"
+            ;;
+        executable_hardlink) ln "$executable" "$case_root/executable-alias" ;;
+        executable_mode) chmod 777 "$executable" ;;
+        executable_size) truncate -s 16777217 "$executable" ;;
+        dbus_fragment_symlink)
+            rm "$dbus_fragment"
+            ln -s /dev/null "$dbus_fragment"
+            ;;
+        dbus_fragment_hardlink) ln "$dbus_fragment" "$case_root/dbus-fragment-alias" ;;
+        dbus_fragment_mode) chmod 666 "$dbus_fragment" ;;
+        barrier_dir_mode)
+            mkdir -p "$case_root/run/systemd/system.control"
+            chmod 777 "$case_root/run/systemd/system.control"
+            ;;
+    esac
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$unit" "$definition" 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name accepted untrusted path metadata"
+    ! grep -Fxq write "$case_root/actual" ||
+        fail "$name crossed the lifecycle mutation boundary"
+    [ ! -e "$case_root/run/systemd/system.control/facelock-daemon.service" ] ||
+        fail "$name left an activation barrier"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+for path_trust_mutation in \
+    unit_hardlink unit_mode unit_size unit_parent_mode \
+    config_symlink config_hardlink config_mode config_size config_parent_mode \
+    config_include_parent_symlink \
+    definition_symlink definition_hardlink definition_mode definition_size \
+    executable_symlink executable_hardlink executable_mode executable_size \
+    dbus_fragment_symlink dbus_fragment_hardlink dbus_fragment_mode \
+    barrier_dir_mode; do
+run_path_trust_case "path_trust_$path_trust_mutation" "$path_trust_mutation"
+done
+
+run_created_barrier_directory_recovery_case() {
+    local name=created_barrier_directory_trust_race
+    local case_root="$tmp_root/$name"
+    local barrier_dir="$case_root/run/systemd/system.control"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_MUTATE_CREATED_BARRIER_DIR="$barrier_dir" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name admitted a raced control directory"
+    [ -d "$barrier_dir" ] && [ ! -L "$barrier_dir" ] &&
+        [ "$(stat -c '%a' -- "$barrier_dir")" = 777 ] ||
+        fail "$name moved or deleted the concurrently changed public directory"
+    ! grep -Fxq write "$case_root/actual" ||
+        fail "$name crossed the lifecycle mutation boundary"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_created_barrier_directory_recovery_case
+
+run_merged_usr_alias_case() {
+    local case_root="$tmp_root/merged_usr_alias"
+    local bad_root="$tmp_root/noncanonical_lib_alias"
+
+    mkdir -p "$case_root/usr/lib/dbus-1/system-services"
+    ln -s usr/lib "$case_root/lib"
+    printf '%s\n' \
+        '[D-BUS Service]' \
+        'Name=org.example.Harmless' \
+        'SystemdService=example.service' \
+        >"$case_root/usr/lib/dbus-1/system-services/org.example.Harmless.service"
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=(
+            "$2/lib/dbus-1/system-services/org.facelock.Daemon.service"
+        )
+        facelock_source_install_dbus_definition_is_absent
+    ' _ "$lifecycle_script" "$case_root" ||
+        fail "canonical merged-/usr lib alias was rejected"
+
+    mkdir -p "$bad_root/usr/local/lib/dbus-1/system-services"
+    ln -s usr/local/lib "$bad_root/lib"
+    if bash -c '
+        set -euo pipefail
+        source "$1"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$2"
+        IFS=: read -r FACELOCK_SOURCE_INSTALL_TRUST_UID \
+            FACELOCK_SOURCE_INSTALL_TRUST_GID < <(stat -Lc "%u:%g" -- "$2")
+        FACELOCK_SOURCE_INSTALL_DBUS_ASSETS=(
+            "$2/lib/dbus-1/system-services/org.facelock.Daemon.service"
+        )
+        facelock_source_install_dbus_definition_is_absent
+    ' _ "$lifecycle_script" "$bad_root"; then
+        fail "noncanonical lib alias was accepted"
+    fi
+}
+
+run_merged_usr_alias_case
+
+run_post_stop_reconciliation_case() {
+    local name="$1"
+    local mutation="$2"
+    local case_root="$tmp_root/$name"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_MUTATE_AFTER_STOP="$mutation" \
+        FACELOCK_OWNER_AFTER_STOP="$([ "$mutation" = owner ] && printf true || printf false)" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    ! grep -Fxq write "$case_root/actual" ||
+        fail "$name crossed the lifecycle mutation boundary"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_post_stop_reconciliation_case post_stop_config_mutation config
+run_post_stop_reconciliation_case post_stop_definition_mutation definition
+run_post_stop_reconciliation_case post_stop_owner owner
+
+run_missing_systemd_case() {
+    local case_root="$tmp_root/missing_systemd"
+    local status
+
+    mkdir -p "$case_root/assets"
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >"$5"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        "$case_root/write"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "missing systemd runtime exited $status instead of failing closed"
+    [ ! -e "$case_root/write" ] || fail "missing systemd runtime allowed a source-install write"
+    [ ! -e "$case_root/actual" ] || fail "missing systemd runtime invoked systemctl"
+}
+
+run_missing_systemd_case
+
+run_invalid_lock_directory_case() {
+    local kind="$1"
+    local name="invalid_lock_directory_$kind"
+    local case_root="$tmp_root/$name"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    case "$kind" in
+        writable)
+            mkdir "$case_root/run/facelock"
+            chmod 777 "$case_root/run/facelock"
+            ;;
+        symlink)
+            mkdir "$case_root/lock-dir-target"
+            ln -s "$case_root/lock-dir-target" "$case_root/run/facelock"
+            ;;
+        *) fail "$name has an unknown fixture" ;;
+    esac
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name was accepted"
+    [ ! -e "$case_root/actual" ] || fail "$name allowed a manager probe"
+    [ ! -e "$case_root/run/facelock/lifecycle.lock" ] ||
+        fail "$name created a lock through an unsafe directory"
+}
+
+run_invalid_lock_directory_case writable
+run_invalid_lock_directory_case symlink
+
+run_busy_lock_case() {
+    local case_root="$tmp_root/busy_lock"
+    local lock_path="$case_root/run/facelock/lifecycle.lock"
+    local holder_pid status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$lock_path"
+    chmod 600 "$lock_path"
+    # Positional parameters belong to the child shell.
+    # shellcheck disable=SC2016
+    flock -n "$lock_path" bash -c '
+        : >"$1"
+        while [ ! -e "$2" ]; do sleep 0.01; done
+    ' _ "$case_root/ready" "$case_root/release" &
+    holder_pid=$!
+    while [ ! -e "$case_root/ready" ]; do sleep 0.01; done
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+    : >"$case_root/release"
+    wait "$holder_pid"
+
+    [ "$status" -eq 1 ] || fail "concurrent source install exited $status instead of failing closed"
+    [ ! -e "$case_root/actual" ] || fail "concurrent source install probed after lock refusal"
+    grep -Fq 'another source install is already running' "$case_root/stderr" ||
+        fail "concurrent source install lacked a lock diagnostic"
+    assert_lock_available busy_lock "$lock_path"
+}
+
+run_busy_lock_case
+
+run_invalid_lock_case() {
+    local case_root="$tmp_root/invalid_lock"
+    local lock_path="$case_root/run/facelock/lifecycle.lock"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    mkfifo -m 600 "$lock_path"
+
+    set +e
+    # Positional parameters belong to the child shell.
+    # shellcheck disable=SC2016
+    timeout 2s env \
+        PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] ||
+        fail "invalid lifecycle lock exited $status instead of promptly failing closed"
+    [ ! -e "$case_root/actual" ] || fail "invalid lifecycle lock allowed a state probe"
+    [ -p "$lock_path" ] || fail "invalid lifecycle lock was changed"
+    grep -Fq 'lifecycle lock is unavailable' "$case_root/stderr" ||
+        fail "invalid lifecycle lock lacked a refusal diagnostic"
+}
+
+run_invalid_lock_case
+
+run_hardlinked_lock_case() {
+    local case_root="$tmp_root/hardlinked_lock"
+    local lock_path="$case_root/run/facelock/lifecycle.lock"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/run/facelock" \
+        "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$lock_path"
+    chmod 600 "$lock_path"
+    ln "$lock_path" "$case_root/lock-alias"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c 'set -euo pipefail; source "$1"; facelock_source_install_begin_daemon "$2" "$3" "$4"' _ \
+        "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "hard-linked lifecycle lock was accepted"
+    [ ! -e "$case_root/actual" ] || fail "hard-linked lifecycle lock allowed a probe"
+    [ "$(stat -c '%h' "$lock_path")" = 2 ] ||
+        fail "hard-linked lifecycle lock was changed"
+}
+
+run_hardlinked_lock_case
+
+run_offline_image_case() {
+    local name="$1"
+    local surface="$2"
+    local expected_status="$3"
+    local case_root="$tmp_root/offline_$name"
+    local status
+    local busy_fd=
+
+    mkdir -p "$case_root/proc/1" "$case_root/run/dbus" "$case_root/run/systemd" \
+        "$case_root/build/scripts" "$case_root/build/test" \
+        "$case_root/build/dbus" "$case_root/build/systemd" \
+        "$case_root/build/dist"
+    printf '%s\n' buildkit >"$case_root/proc/1/comm"
+    ln -s /usr/bin/buildkit "$case_root/proc/1/exe"
+    : >"$case_root/.dockerenv"
+    cp "$lifecycle_script" "$case_root/build/scripts/source-install-daemon-lifecycle.sh"
+    cp "$repo_root/scripts/migrate-legacy-system-assets.sh" \
+        "$case_root/build/scripts/migrate-legacy-system-assets.sh"
+    cp "$repo_root/dist/legacy-system-assets.sha256" "$case_root/build/dist/"
+    cp "$justfile" "$case_root/build/justfile"
+    cp "$containerfile" "$case_root/build/test/Containerfile"
+    cp "$repo_root/test/source-install-offline-image.marker" \
+        "$case_root/build/test/source-install-offline-image.marker"
+    cp "$repo_root/dbus/org.facelock.Daemon.conf" "$case_root/build/dbus/"
+    cp "$repo_root/dbus/org.facelock.Daemon.service" "$case_root/build/dbus/"
+    cp "$repo_root/systemd/facelock-daemon.service" "$case_root/build/systemd/"
+    case "$surface" in
+        clean) ;;
+        no_marker) rm -f "$case_root/.dockerenv" ;;
+        no_repository_marker)
+            rm -f "$case_root/build/test/source-install-offline-image.marker"
+            ;;
+        bad_repository_marker)
+            printf '%s\n' forged >"$case_root/build/test/source-install-offline-image.marker"
+            ;;
+        missing_pid1_exe) rm -f "$case_root/proc/1/exe" ;;
+        systemd_runtime) mkdir -p "$case_root/run/systemd/system" ;;
+        systemd_manager) : >"$case_root/run/systemd/private" ;;
+        dbus_socket) : >"$case_root/run/dbus/system_bus_socket" ;;
+        other_manager) mkdir -p "$case_root/run/openrc" ;;
+        installed_binary)
+            mkdir -p "$case_root/usr/bin"
+            : >"$case_root/usr/bin/facelock"
+            ;;
+        activation_asset)
+            mkdir -p "$case_root/usr/local/share/dbus-1/system-services"
+            : >"$case_root/usr/local/share/dbus-1/system-services/org.facelock.Daemon.service"
+            ;;
+        alternate_activation_asset)
+            mkdir -p "$case_root/etc/dbus-1/system-services"
+            write_dbus_service \
+                "$case_root/etc/dbus-1/system-services/alternate.service" direct
+            ;;
+        unrelated_activation_asset)
+            mkdir -p "$case_root/etc/dbus-1/system-services"
+            printf '%s\n' \
+                '[D-BUS Service]' \
+                'Exec=/usr/bin/unrelated' \
+                'Name=org.example.Unrelated' \
+                >"$case_root/etc/dbus-1/system-services/unrelated.service"
+            ;;
+        daemon_process)
+            mkdir -p "$case_root/proc/23"
+            ln -s /usr/bin/facelock "$case_root/proc/23/exe"
+            ;;
+        unreadable_process)
+            mkdir -p "$case_root/proc/23"
+            ln -s /usr/bin/unrelated "$case_root/proc/23/exe"
+            ;;
+        systemd_pid1) printf '%s\n' systemd >"$case_root/proc/1/comm" ;;
+        busy_lock)
+            mkdir -p "$case_root/run/facelock"
+            : >"$case_root/run/facelock/lifecycle.lock"
+            chmod 600 "$case_root/run/facelock/lifecycle.lock"
+            exec {busy_fd}<>"$case_root/run/facelock/lifecycle.lock"
+            flock -n "$busy_fd"
+            ;;
+    esac
+
+    set +e
+    if [ "$surface" = dbus_override ]; then
+        # Positional parameters belong to the child shell.
+        # shellcheck disable=SC2016
+        env -u DBUS_STARTER_ADDRESS -u DBUS_SESSION_BUS_ADDRESS \
+            DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/fake-system-bus \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER="$case_root/build/test/source-install-offline-image.marker" \
+            bash -c '
+                set -euo pipefail
+                cd "$2/build"
+                source "$1"
+                facelock_source_install_begin "$2"
+                printf "%s\n" write >"$3"
+                facelock_source_install_complete
+            ' _ "$case_root/build/scripts/source-install-daemon-lifecycle.sh" "$case_root" "$case_root/write" \
+            2>"$case_root/stderr"
+        status=$?
+    elif [ "$surface" = unreadable_process ]; then
+        # Positional parameters belong to the child shell.
+        # shellcheck disable=SC2016
+        env -u DBUS_SYSTEM_BUS_ADDRESS -u DBUS_STARTER_ADDRESS \
+            -u DBUS_SESSION_BUS_ADDRESS \
+            PATH="$tmp_root/readlink-fail-bin:$PATH" \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER="$case_root/build/test/source-install-offline-image.marker" \
+            bash -c '
+                set -euo pipefail
+                cd "$2/build"
+                source "$1"
+                facelock_source_install_begin "$2"
+                printf "%s\n" write >"$3"
+                facelock_source_install_complete
+            ' _ "$case_root/build/scripts/source-install-daemon-lifecycle.sh" "$case_root" "$case_root/write" \
+            2>"$case_root/stderr"
+        status=$?
+    else
+        # Positional parameters belong to the child shell.
+        # shellcheck disable=SC2016
+        env -u DBUS_SYSTEM_BUS_ADDRESS -u DBUS_STARTER_ADDRESS \
+            -u DBUS_SESSION_BUS_ADDRESS \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_IMAGE=container-build \
+            FACELOCK_SOURCE_INSTALL_OFFLINE_MARKER="$case_root/build/test/source-install-offline-image.marker" \
+            bash -c '
+                set -euo pipefail
+                cd "$2/build"
+                source "$1"
+                facelock_source_install_begin "$2"
+                printf "%s\n" write >"$3"
+                facelock_source_install_complete
+            ' _ "$case_root/build/scripts/source-install-daemon-lifecycle.sh" "$case_root" "$case_root/write" \
+            2>"$case_root/stderr"
+        status=$?
+    fi
+    set -e
+    if [ -n "$busy_fd" ]; then
+        exec {busy_fd}>&-
+    fi
+
+    [ "$status" -eq "$expected_status" ] ||
+        { cat "$case_root/stderr" >&2; fail "offline image $name exited $status, expected $expected_status"; }
+    if [ "$expected_status" -eq 0 ]; then
+        [ -f "$case_root/write" ] || fail "clean offline image did not proceed"
+        [ ! -s "$case_root/stderr" ] || fail "clean offline image wrote unexpected stderr"
+        assert_lock_available "$name" \
+            "$case_root/run/facelock/lifecycle.lock"
+    else
+        [ ! -e "$case_root/write" ] || fail "offline image $name allowed a write"
+        grep -Fq 'offline image' "$case_root/stderr" ||
+            fail "offline image $name lacked a refusal diagnostic"
+    fi
+}
+
+run_offline_image_case clean clean 0
+run_offline_image_case no_marker no_marker 1
+run_offline_image_case no_repository_marker no_repository_marker 1
+run_offline_image_case bad_repository_marker bad_repository_marker 1
+run_offline_image_case missing_pid1_exe missing_pid1_exe 1
+run_offline_image_case systemd_runtime systemd_runtime 1
+run_offline_image_case systemd_manager systemd_manager 1
+run_offline_image_case dbus_socket dbus_socket 1
+run_offline_image_case other_manager other_manager 1
+run_offline_image_case installed_binary installed_binary 1
+run_offline_image_case dbus_override dbus_override 1
+run_offline_image_case activation_asset activation_asset 1
+run_offline_image_case alternate_activation_asset alternate_activation_asset 1
+run_offline_image_case unrelated_activation_asset unrelated_activation_asset 0
+run_offline_image_case daemon_process daemon_process 1
+run_offline_image_case unreadable_process unreadable_process 1
+run_offline_image_case systemd_pid1 systemd_pid1 1
+run_offline_image_case busy_lock busy_lock 1
+
+run_prepare_failure_case() {
+    local name="$1"
+    local fail_command="$2"
+    local expected="$3"
+    local failure_count="${4:-1}"
+    local case_root="$tmp_root/$name"
+    local actual="$case_root/actual"
+    local expected_path="$case_root/expected"
+    local mask_state="$case_root/mask-state"
+    local manager_mask_state="$case_root/manager-mask-state"
+    local failures_remaining="$case_root/failures-remaining"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$actual"
+    printf '%s\n' "$expected" >"$expected_path"
+    printf '%s\n' none >"$mask_state"
+    printf '%s\n' none >"$manager_mask_state"
+    printf '%s\n' "$failure_count" >"$failures_remaining"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$mask_state" \
+        FACELOCK_MANAGER_MASK_STATE="$manager_mask_state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_FAIL_BEFORE_WRITE=true \
+        FACELOCK_FAIL_COMMAND="$fail_command" \
+        FACELOCK_FAILURES_REMAINING="$failures_remaining" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] ||
+        fail "$name exited $status instead of reporting preparation failure"
+    [ "$(cat "$mask_state")" = none ] ||
+        fail "$name left the temporary activation barrier installed"
+    [ ! -e "$case_root/run/systemd/system.control/facelock-daemon.service" ] ||
+        fail "$name left the owned activation barrier installed"
+    diff -u "$expected_path" "$actual" ||
+        fail "$name preparation-failure restoration ordering changed"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_prepare_failure_case barrier_reload_failure daemon-reload "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    'systemctl daemon-reload' \
+    'systemctl daemon-reload' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")" 3
+
+run_prepare_failure_case stop_failure 'stop facelock-daemon.service' "$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_barrier_tamper_case() {
+    local case_root="$tmp_root/barrier_tamper"
+    local actual="$case_root/actual"
+    local expected="$case_root/expected"
+    local mask_state="$case_root/mask-state"
+    local manager_mask_state="$case_root/manager-mask-state"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$actual"
+    printf '%s\n' none >"$mask_state"
+    printf '%s\n' none >"$manager_mask_state"
+    printf '%s\n' \
+        "$show_command" \
+        "$dbus_show_command" \
+        "$dbus_reload_command" \
+        "$dbus_owner_command" \
+        'systemctl daemon-reload' \
+        "$barrier_show_command" \
+        'systemctl stop facelock-daemon.service' \
+        "$barrier_show_command" \
+        "$dbus_owner_command" \
+        'write' \
+        'systemctl daemon-reload' >"$expected"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$mask_state" \
+        FACELOCK_MANAGER_MASK_STATE="$manager_mask_state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            rm -f -- "$5"
+            ln -s /dev/null "$5"
+            facelock_source_install_complete_daemon "$2"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        "$barrier" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "changed barrier exited $status instead of failing closed"
+    [ -L "$barrier" ] && [ "$(readlink "$barrier")" = /dev/null ] ||
+        fail "cleanup removed or changed a barrier it did not own"
+    grep -Fq 'safely reconcile the masked D-Bus activation state' "$case_root/stderr" ||
+        fail "changed barrier failure lacked a cleanup diagnostic"
+    diff -u "$expected" "$actual" ||
+        fail "changed barrier cleanup attempted to reactivate the daemon"
+    assert_lock_available barrier_tamper "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_barrier_tamper_case
+
+run_barrier_quarantine_race_case() {
+    local name="${1:-barrier_quarantine_race}"
+    local race="${2:-replacement}"
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_REPLACE_BEFORE_QUARANTINE="$([ "$race" = replacement ] && \
+            printf '%s' "$barrier" || printf '')" \
+        FACELOCK_MOVE_BARRIER_THEN_FAIL="$([ "$race" = move_then_fail ] && \
+            printf true || printf false)" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    if [ "$race" = replacement ]; then
+        [ "$status" -eq 1 ] || fail "$name did not fail closed"
+        [ -f "$barrier" ] && [ "$(cat "$barrier")" = replacement ] ||
+            fail "$name did not restore the raced replacement to its public path"
+        [ "$(cat "$case_root/manager-mask-state")" = masked ] ||
+            fail "$name reloaded away the cached manager mask"
+        ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+            fail "$name restarted the daemon"
+    else
+        [ "$status" -eq 0 ] || fail "$name did not recover the completed move"
+        [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+            fail "$name left the owned barrier installed"
+        grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+            fail "$name did not restore the initially active daemon"
+    fi
+    assert_lock_available "$name" \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_barrier_quarantine_race_case
+run_barrier_quarantine_race_case barrier_quarantine_move_then_fail \
+    move_then_fail
+
+run_barrier_directory_quarantine_race_case() {
+    local case_root="$tmp_root/barrier_directory_quarantine_race"
+    local barrier_dir="$case_root/run/systemd/system.control"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_REPLACE_BEFORE_QUARANTINE="$barrier_dir" \
+        FACELOCK_REPLACE_DIRECTORY_BEFORE_QUARANTINE=true \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "barrier-directory quarantine race did not fail closed"
+    [ -f "$barrier_dir/replacement" ] ||
+        fail "barrier-directory quarantine race did not restore the replacement directory"
+    assert_lock_available barrier_directory_quarantine_race \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_barrier_directory_quarantine_race_case
+
+run_barrier_directory_unrelated_entry_case() {
+    local name=barrier_directory_unrelated_entry
+    local case_root="$tmp_root/$name"
+    local barrier_dir="$case_root/run/systemd/system.control"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_ADD_ENTRY_BEFORE_DIRECTORY_QUARANTINE="$barrier_dir" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    [ -f "$barrier_dir/administrator-unit.service" ] ||
+        fail "$name moved or deleted the unrelated public entry"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_barrier_directory_unrelated_entry_case
+
+run_dbus_tamper_case() {
+    local name="$1"
+    local tamper="$2"
+    local case_root="$tmp_root/$name"
+    local actual="$case_root/actual"
+    local dbus_service="$case_root/assets/org.facelock.Daemon.service"
+    local dbus_config="$case_root/usr/share/dbus-1/system.conf"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$dbus_service"
+    : >"$actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            case "$6" in
+                definition)
+                    printf "%s\n" \
+                        "[D-BUS Service]" \
+                        "Name=org.facelock.Daemon" \
+                        "Exec=/usr/bin/facelock daemon" >"$4"
+                    ;;
+                config)
+                    printf "%s\n" \
+                        "<busconfig>" \
+                        "<servicedir>/opt/admin-dbus-services</servicedir>" \
+                        "<standard_system_servicedirs/>" \
+                        "</busconfig>" >"$5"
+                    ;;
+            esac
+            facelock_source_install_complete_daemon "$2"
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$dbus_service" \
+        "$dbus_config" \
+        "$tamper" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "changed D-Bus $tamper did not fail closed"
+    [ -f "$barrier" ] && [ ! -s "$barrier" ] ||
+        fail "changed D-Bus $tamper removed the systemd barrier"
+    [ "$(cat "$actual")" = "$(printf '%s\n' \
+        "$show_command" "$dbus_show_command" \
+        "$dbus_reload_command" "$dbus_owner_command" \
+        'systemctl daemon-reload' "$barrier_show_command" \
+        'systemctl stop facelock-daemon.service' \
+        "$barrier_show_command" "$dbus_owner_command" 'write' \
+        'systemctl daemon-reload')" ] ||
+        fail "changed D-Bus $tamper attempted unsafe cleanup or restart"
+    grep -Fq 'safely reconcile the masked D-Bus activation state' \
+        "$case_root/stderr" ||
+        fail "changed D-Bus $tamper lacked a cleanup diagnostic"
+    assert_lock_available "$name" \
+        "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_dbus_tamper_case dbus_definition_tamper definition
+run_dbus_tamper_case dbus_config_tamper config
+
+run_cleanup_reload_reconciliation_case() {
+    local name="$1"
+    local fault="$2"
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_DBUS_TAMPER_ON_RELOAD_NUMBER="$([ "$fault" = config ] && printf 2 || printf 0)" \
+        FACELOCK_OWNER_AFTER_CLEANUP_RELOAD="$([ "$fault" = owner ] && printf true || printf false)" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not fail closed"
+    [ -f "$barrier" ] && [ ! -s "$barrier" ] ||
+        fail "$name removed the barrier after unsafe cache reload"
+    ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+        fail "$name restarted after unsafe cache reload"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_cleanup_reload_reconciliation_case cleanup_reload_config_mutation config
+run_cleanup_reload_reconciliation_case cleanup_reload_owner owner
+
+run_cleanup_state_machine_refusal_case() {
+    local name="$1"
+    local fault="$2"
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local runtime_mask="$case_root/run/systemd/system/facelock-daemon.service"
+    local after_write="$case_root/after-write"
+    local failures_remaining="$case_root/failures-remaining"
+    local expect_recovered_barrier="${3:-true}"
+    local status
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    printf '%s\n' 0 >"$failures_remaining"
+    if [ "$fault" = initial_reload ]; then
+        printf '%s\n' 3 >"$failures_remaining"
+    fi
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_AFTER_WRITE_FILE="$after_write" \
+        FACELOCK_FAIL_COMMAND="$([ "$fault" = initial_reload ] && \
+            printf daemon-reload || printf '')" \
+        FACELOCK_FAILURES_REMAINING="$failures_remaining" \
+        FACELOCK_FAIL_FINAL_RELOAD="$([ "$fault" = final_reload ] && \
+            printf true || printf false)" \
+        FACELOCK_MUTATE_MASK_ON_CLEANUP_RELOAD="$([ "$fault" = cleanup_mask ] && \
+            printf '%s' "$runtime_mask" || printf '')" \
+        FACELOCK_MUTATE_MASK_BEFORE_QUARANTINE="$([ "$fault" = quarantine_mask ] && \
+            printf '%s' "$runtime_mask" || printf '')" \
+        FACELOCK_FINAL_FRAGMENT_OVERRIDE="$([ "$fault" = final_fragment ] && \
+            printf '%s' "$case_root/run/systemd/transient/facelock-daemon.service" || printf '')" \
+        FACELOCK_OWNER_AFTER_FINAL_RELOAD="$([ "$fault" = final_owner ] && \
+            printf true || printf false)" \
+        FACELOCK_MUTATE_DBUS_ON_FINAL_RELOAD="$([ "$fault" = final_dbus ] && \
+            printf true || printf false)" \
+        FACELOCK_BARRIER_REMOVE_FAULT="$(case "$fault" in \
+            removal_before) printf before ;; removal_after) printf after ;; \
+            *) printf none ;; esac)" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            : >"$FACELOCK_AFTER_WRITE_FILE"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not report unsafe cleanup"
+    if [ "$expect_recovered_barrier" = true ]; then
+        [ -f "$barrier" ] && [ ! -L "$barrier" ] && [ ! -s "$barrier" ] ||
+            fail "$name did not recover the owned barrier"
+        [ "$(cat "$case_root/manager-mask-state")" = masked ] ||
+            fail "$name did not retain the manager-effective barrier"
+    else
+        [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+            fail "$name recreated a barrier after losing its held inode"
+    fi
+    ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+        fail "$name restarted without complete cleanup proof"
+    if [ "$fault" = cleanup_mask ] || [ "$fault" = quarantine_mask ]; then
+        [ -L "$runtime_mask" ] && [ "$(readlink -- "$runtime_mask")" = /dev/null ] ||
+            fail "$name changed the concurrently installed administrator mask"
+    fi
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_cleanup_state_machine_refusal_case cleanup_initial_reload_exhausted initial_reload
+run_cleanup_state_machine_refusal_case cleanup_final_reload_exhausted final_reload
+run_cleanup_state_machine_refusal_case cleanup_mask_changed_on_reload cleanup_mask
+run_cleanup_state_machine_refusal_case cleanup_mask_changed_before_quarantine \
+    quarantine_mask
+run_cleanup_state_machine_refusal_case cleanup_final_fragment_mismatch final_fragment
+run_cleanup_state_machine_refusal_case cleanup_final_owner_race final_owner
+run_cleanup_state_machine_refusal_case cleanup_final_dbus_race final_dbus
+run_cleanup_state_machine_refusal_case cleanup_barrier_remove_refused \
+    removal_before
+run_cleanup_state_machine_refusal_case cleanup_barrier_removed_but_unconfirmed \
+    removal_after false
+
+run_first_install_unconfirmed_recovery_case() {
+    local name=first_install_unconfirmed_barrier_recovery
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local failures_remaining="$case_root/failures-remaining"
+    local status
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    printf '%s\n' 3 >"$failures_remaining"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=not-found \
+        FACELOCK_ACTIVE_STATE=inactive \
+        FACELOCK_UNIT_FILE_STATE='' \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_FAIL_COMMAND=daemon-reload \
+        FACELOCK_FAIL_BEFORE_WRITE=true \
+        FACELOCK_FAILURES_REMAINING="$failures_remaining" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name lost the preparation failure status"
+    [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+        fail "$name did not retire its created-but-unconfirmed barrier"
+    ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+        fail "$name attempted to start a daemon that was initially absent"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_first_install_unconfirmed_recovery_case
+
+run_final_restart_window_refusal_case() {
+    local name=cleanup_pre_restart_mask_race
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local runtime_mask="$case_root/run/systemd/system/facelock-daemon.service"
+    local after_write="$case_root/after-write"
+    local status
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_AFTER_WRITE_FILE="$after_write" \
+        FACELOCK_MUTATE_MASK_BEFORE_RESTART="$runtime_mask" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            : >"$FACELOCK_AFTER_WRITE_FILE"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name did not reject the last-window race"
+    [ ! -e "$barrier" ] && [ ! -L "$barrier" ] ||
+        fail "$name unexpectedly recreated the retired barrier"
+    [ -L "$runtime_mask" ] && [ "$(readlink -- "$runtime_mask")" = /dev/null ] ||
+        fail "$name changed the concurrently installed administrator mask"
+    ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+        fail "$name restarted after the last cleanup proof changed"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_final_restart_window_refusal_case
+
+run_restart_proof_refusal_case() {
+    local name="$1"
+    local fault="$2"
+    local case_root="$tmp_root/$name"
+    local runtime_mask="$case_root/run/systemd/system/facelock-daemon.service"
+    local dbus_service="$case_root/assets/org.facelock.Daemon.service"
+    local failures_remaining="$case_root/failures-remaining"
+    local after_write="$case_root/after-write"
+    local status start_count
+
+    mkdir -p "$case_root/etc/systemd/system" \
+        "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$dbus_service"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    printf '%s\n' "$([ "$fault" = retry_mask ] && printf 1 || printf 0)" \
+        >"$failures_remaining"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_AFTER_WRITE_FILE="$after_write" \
+        FACELOCK_FAIL_COMMAND="$([ "$fault" = retry_mask ] && \
+            printf 'start facelock-daemon.service' || printf '')" \
+        FACELOCK_FAILURES_REMAINING="$failures_remaining" \
+        FACELOCK_MUTATE_MASK_BEFORE_START_RETRY="$([ "$fault" = retry_mask ] && \
+            printf '%s' "$runtime_mask" || printf '')" \
+        FACELOCK_DBUS_SERVICE_TO_MUTATE_AFTER_START="$([ "$fault" = post_start_dbus ] && \
+            printf '%s' "$dbus_service" || printf '')" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            : >"$FACELOCK_AFTER_WRITE_FILE"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" "$dbus_service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 1 ] || fail "$name accepted an unproved restart state"
+    start_count="$(grep -Fxc 'systemctl start facelock-daemon.service' \
+        "$case_root/actual" || true)"
+    [ "$start_count" -eq 1 ] || fail "$name issued $start_count restart attempts"
+    if [ "$fault" = retry_mask ]; then
+        [ -L "$runtime_mask" ] && [ "$(readlink -- "$runtime_mask")" = /dev/null ] ||
+            fail "$name changed the concurrent administrator mask"
+    fi
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_restart_proof_refusal_case restart_retry_mask_race retry_mask
+run_restart_proof_refusal_case restart_post_start_dbus_race post_start_dbus
+
+run_release_signal_window_case() {
+    local name=release_signal_restores_once
+    local case_root="$tmp_root/$name"
+    local after_write="$case_root/after-write"
+    local release_count="$case_root/release-count"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$case_root/actual"
+    : >"$release_count"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_AFTER_WRITE_FILE="$after_write" \
+        FACELOCK_REQUIRE_RESTORE_LOCK=true \
+        FACELOCK_LOCK_PATH="$case_root/run/facelock/lifecycle.lock" \
+        FACELOCK_RELEASE_COUNT="$release_count" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_release_lock() {
+                if [ "$FACELOCK_SOURCE_INSTALL_LOCK_HELD" = true ]; then
+                    exec {FACELOCK_SOURCE_INSTALL_LOCK_FD}>&-
+                    FACELOCK_SOURCE_INSTALL_LOCK_FD=
+                    FACELOCK_SOURCE_INSTALL_LOCK_HELD=false
+                fi
+                printf "release\n" >>"$FACELOCK_RELEASE_COUNT"
+                if [ ! -e "${FACELOCK_RELEASE_COUNT}.signaled" ]; then
+                    : >"${FACELOCK_RELEASE_COUNT}.signaled"
+                    kill -HUP "$$"
+                fi
+            }
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            : >"$FACELOCK_AFTER_WRITE_FILE"
+            facelock_source_install_complete_daemon "$2"
+        ' _ "$lifecycle_script" "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 129 ] || fail "$name exited $status instead of 129"
+    [ "$(grep -c '^release$' "$release_count")" -eq 1 ] ||
+        fail "$name re-entered restoration after lock release"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+run_release_signal_window_case
+
+run_restoration_case() {
+    local name="$1"
+    local trigger="$2"
+    local fail_command="$3"
+    local failure_count="$4"
+    local expected_status="$5"
+    local expected="$6"
+    local case_root="$tmp_root/$name"
+    local actual="$case_root/actual"
+    local expected_path="$case_root/expected"
+    local stderr_path="$case_root/stderr"
+    local mask_state="$case_root/mask-state"
+    local manager_mask_state="$case_root/manager-mask-state"
+    local after_write="$case_root/after-write"
+    local failures_remaining="$case_root/failures-remaining"
+    local status
+
+    mkdir -p "$case_root/run/systemd/system" "$case_root/assets"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/assets/facelock-daemon.service"
+    write_dbus_service "$case_root/assets/org.facelock.Daemon.service"
+    : >"$actual"
+    printf '%s\n' "$expected" >"$expected_path"
+    printf '%s\n' none >"$mask_state"
+    printf '%s\n' none >"$manager_mask_state"
+    printf '%s\n' "$failure_count" >"$failures_remaining"
+
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$mask_state" \
+        FACELOCK_MANAGER_MASK_STATE="$manager_mask_state" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_AFTER_WRITE_FILE="$after_write" \
+        FACELOCK_FAIL_COMMAND="$fail_command" \
+        FACELOCK_FAILURES_REMAINING="$failures_remaining" \
+        bash -c '
+            set -euo pipefail
+            source "$1"
+            facelock_source_install_begin_daemon "$2" "$3" "$4"
+            printf "%s\n" write >>"$FACELOCK_SYSTEMCTL_LOG"
+            : >"$FACELOCK_AFTER_WRITE_FILE"
+            case "$5" in
+                write_failure) false ;;
+                HUP | INT | TERM) kill -s "$5" "$$" ;;
+                complete) facelock_source_install_complete_daemon "$2" ;;
+            esac
+        ' _ \
+        "$lifecycle_script" \
+        "$case_root/run/systemd/system" \
+        "$case_root/assets/facelock-daemon.service" \
+        "$case_root/assets/org.facelock.Daemon.service" \
+        "$trigger" \
+        2>"$stderr_path"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] || {
+        cat "$stderr_path" >&2
+        fail "$name exited $status, expected $expected_status"
+    }
+    [ "$(cat "$mask_state")" = none ] ||
+        fail "$name left the temporary activation barrier installed"
+    [ ! -e "$case_root/run/systemd/system.control/facelock-daemon.service" ] ||
+        fail "$name left the owned activation barrier installed"
+    diff -u "$expected_path" "$actual" ||
+        fail "$name restoration ordering changed"
+    assert_lock_available "$name" "$case_root/run/facelock/lifecycle.lock"
+}
+
+active_prepare_log="$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_show_command" \
+    "$dbus_reload_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$barrier_show_command" \
+    'systemctl stop facelock-daemon.service' \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'write')"
+active_restore_before_restart_log="$(printf '%s\n' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command")"
+active_restore_log="$active_restore_before_restart_log
+$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service')"
+active_restore_log="$active_restore_log
+$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_restoration_case write_failure write_failure '' 0 1 \
+    "$active_prepare_log
+$active_restore_log"
+run_restoration_case hangup HUP '' 0 129 \
+    "$active_prepare_log
+$active_restore_log"
+run_restoration_case interrupt INT '' 0 130 \
+    "$active_prepare_log
+$active_restore_log"
+run_restoration_case terminate TERM '' 0 143 \
+    "$active_prepare_log
+$active_restore_log"
+
+run_restoration_case reload_retry complete 'daemon-reload' 1 0 \
+    "$active_prepare_log
+$(printf '%s\n' \
+    'systemctl daemon-reload' \
+    'systemctl daemon-reload' \
+    "$dbus_reload_command" \
+    "$barrier_show_command" \
+    "$dbus_owner_command" \
+    'systemctl daemon-reload' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command" \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_restoration_case start_retry complete 'start facelock-daemon.service' 1 0 \
+    "$active_prepare_log
+$active_restore_before_restart_log
+$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command")"
+
+run_restoration_case start_exhausted complete 'start facelock-daemon.service' 3 1 \
+    "$active_prepare_log
+$active_restore_before_restart_log
+$(printf '%s\n' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service' \
+    "$show_command" \
+    "$dbus_owner_command" \
+    'systemctl start facelock-daemon.service')"
+
+seed_known_legacy_assets() {
+    local case_root="$1"
+    local record source_relative canonical_relative legacy_relative
+    local -a assets=(
+        'systemd-unit|systemd/facelock-daemon.service|usr/lib/systemd/system/facelock-daemon.service|etc/systemd/system/facelock-daemon.service'
+        'dbus-policy|dbus/org.facelock.Daemon.conf|usr/share/dbus-1/system.d/org.facelock.Daemon.conf|etc/dbus-1/system.d/org.facelock.Daemon.conf'
+        'dbus-activation|dbus/org.facelock.Daemon.service|usr/share/dbus-1/system-services/org.facelock.Daemon.service|etc/dbus-1/system-services/org.facelock.Daemon.service'
+    )
+
+    mkdir -p "$case_root/usr/lib/systemd/system" \
+        "$case_root/usr/share/dbus-1/system.d" \
+        "$case_root/usr/share/dbus-1/system-services" \
+        "$case_root/etc/systemd/system" \
+        "$case_root/etc/dbus-1/system.d" \
+        "$case_root/etc/dbus-1/system-services" \
+        "$case_root/run/systemd/system"
+    for record in "${assets[@]}"; do
+        IFS='|' read -r _ source_relative canonical_relative legacy_relative <<<"$record"
+        install -m 644 "$repo_root/$source_relative" "$case_root/$canonical_relative"
+        install -m 644 "$repo_root/$source_relative" "$case_root/$legacy_relative"
+    done
+}
+
+run_planned_legacy_retirement_case() {
+    local name=planned_legacy_retirement
+    local case_root="$tmp_root/$name"
+    local record legacy_relative
+    local -a assets=(
+        'systemd-unit|systemd/facelock-daemon.service|usr/lib/systemd/system/facelock-daemon.service|etc/systemd/system/facelock-daemon.service'
+        'dbus-policy|dbus/org.facelock.Daemon.conf|usr/share/dbus-1/system.d/org.facelock.Daemon.conf|etc/dbus-1/system.d/org.facelock.Daemon.conf'
+        'dbus-activation|dbus/org.facelock.Daemon.service|usr/share/dbus-1/system-services/org.facelock.Daemon.service|etc/dbus-1/system-services/org.facelock.Daemon.service'
+    )
+
+    seed_known_legacy_assets "$case_root"
+
+    {
+        set -euo pipefail
+        # shellcheck disable=SC1090,SC1091
+        source "$lifecycle_script"
+        export FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$case_root"
+        export FACELOCK_SOURCE_INSTALL_TRUST_UID
+        FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$case_root")"
+        export FACELOCK_SOURCE_INSTALL_TRUST_GID
+        FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$case_root")"
+        FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH="$case_root/etc/systemd/system/facelock-daemon.service"
+        FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_PATH="$case_root/run/systemd/system/facelock-daemon.service"
+
+        facelock_source_install_plan_legacy_assets || {
+            echo "$name: planning failed" >&2
+            exit 1
+        }
+        [ "$FACELOCK_SOURCE_INSTALL_PERSISTENT_UNIT_PLANNED_RETIRE" = true ] || {
+            echo "$name: persistent retirement was not planned" >&2
+            exit 1
+        }
+        facelock_source_install_snapshot_physical_mask \
+            "$FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_PATH" \
+            FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_SNAPSHOT \
+            FACELOCK_SOURCE_INSTALL_PERSISTENT_MASK_FD || {
+            echo "$name: persistent snapshot failed" >&2
+            exit 1
+        }
+        facelock_source_install_snapshot_physical_mask \
+            "$FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_PATH" \
+            FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_SNAPSHOT \
+            FACELOCK_SOURCE_INSTALL_RUNTIME_MASK_FD || {
+            echo "$name: runtime snapshot failed" >&2
+            exit 1
+        }
+
+        "$repo_root/scripts/migrate-legacy-system-assets.sh" \
+            --source-protected --stage "$case_root" || {
+            echo "$name: staging failed" >&2
+            exit 1
+        }
+        facelock_source_install_record_legacy_migration || {
+            echo "$name: staged identity recording failed" >&2
+            exit 1
+        }
+        facelock_source_install_physical_masks_are_current || {
+            echo "$name: staged physical identity proof failed" >&2
+            exit 1
+        }
+        [ -f "$case_root/etc/systemd/system/.facelock-migrate-systemd-unit" ]
+        [ -f "$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy" ]
+        [ -f "$case_root/etc/dbus-1/system-services/.facelock-migrate-dbus-activation" ]
+        facelock_source_install_commit_legacy_migration || {
+            echo "$name: commit failed" >&2
+            exit 1
+        }
+        facelock_source_install_physical_masks_are_current || {
+            echo "$name: committed physical identity proof failed" >&2
+            exit 1
+        }
+        facelock_source_install_release_physical_mask_fds
+    } || fail "$name did not accept the planned exact-known retirement"
+
+    for record in "${assets[@]}"; do
+        IFS='|' read -r _ _ _ legacy_relative <<<"$record"
+        [ ! -e "$case_root/$legacy_relative" ] && [ ! -L "$case_root/$legacy_relative" ] ||
+            fail "$name retained $legacy_relative"
+    done
+    [ ! -e "$case_root/etc/systemd/system/.facelock-migrate-systemd-unit" ] ||
+        fail "$name retained the systemd quarantine"
+    [ ! -e "$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy" ] ||
+        fail "$name retained the D-Bus policy quarantine"
+    [ ! -e "$case_root/etc/dbus-1/system-services/.facelock-migrate-dbus-activation" ] ||
+        fail "$name retained the D-Bus activation quarantine"
+}
+
+run_planned_legacy_retirement_case
+
+run_modified_dbus_admin_case() {
+    local name=modified_dbus_admin
+    local case_root="$tmp_root/$name"
+    local policy="$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+    local activation="$case_root/etc/dbus-1/system-services/org.facelock.Daemon.service"
+
+    seed_known_legacy_assets "$case_root"
+    printf '%s\n' 'administrator policy' >"$policy"
+    cat >"$activation" <<'EOF'
+[D-BUS Service]
+Name=org.facelock.Daemon
+SystemdService=facelock-daemon.service
+EOF
+    chmod 644 "$policy" "$activation"
+
+    {
+        set -euo pipefail
+        # shellcheck disable=SC1090,SC1091
+        source "$lifecycle_script"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$case_root"
+        FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$case_root")"
+        FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$case_root")"
+        facelock_source_install_plan_legacy_assets
+        "$repo_root/scripts/migrate-legacy-system-assets.sh" \
+            --source-protected --stage "$case_root"
+        facelock_source_install_record_legacy_migration
+        facelock_source_install_commit_legacy_migration
+    } || fail "$name rejected trusted administrator D-Bus definitions"
+
+    [ "$(cat "$policy")" = 'administrator policy' ] ||
+        fail "$name changed the administrator D-Bus policy"
+    grep -Fxq 'SystemdService=facelock-daemon.service' "$activation" ||
+        fail "$name changed the administrator D-Bus activation definition"
+    [ ! -e "$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy" ] ||
+        fail "$name created a policy quarantine"
+    [ ! -e "$case_root/etc/dbus-1/system-services/.facelock-migrate-dbus-activation" ] ||
+        fail "$name created an activation quarantine"
+}
+
+run_modified_dbus_admin_case
+
+run_commit_failure_rolls_back_case() {
+    local name=commit_failure_rolls_back
+    local case_root="$tmp_root/$name"
+    local status
+
+    seed_known_legacy_assets "$case_root"
+    set +e
+    CASE_ROOT="$case_root" REPO_ROOT="$repo_root" LIFECYCLE_SCRIPT="$lifecycle_script" \
+        bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$CASE_ROOT"
+            FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$CASE_ROOT")"
+            facelock_source_install_plan_legacy_assets
+            "$REPO_ROOT/scripts/migrate-legacy-system-assets.sh" \
+                --source-protected --stage "$CASE_ROOT"
+            facelock_source_install_record_legacy_migration
+            rm() {
+                case "${*: -1}" in
+                    */.facelock-migrate-*) return 1 ;;
+                    *) command rm "$@" ;;
+                esac
+            }
+            if facelock_source_install_commit_legacy_migration; then
+                exit 97
+            fi
+            facelock_source_install_rollback_legacy_migration
+        ' 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || {
+        cat "$case_root/stderr" >&2
+        fail "$name failed to restore staged assets"
+    }
+    for legacy in \
+        etc/systemd/system/facelock-daemon.service \
+        etc/dbus-1/system.d/org.facelock.Daemon.conf \
+        etc/dbus-1/system-services/org.facelock.Daemon.service; do
+        [ -f "$case_root/$legacy" ] || fail "$name did not restore $legacy"
+    done
+}
+
+run_commit_failure_rolls_back_case
+
+run_after_stage_rollback_case() {
+    local trigger="$1"
+    local expected_status="$2"
+    local name="rollback_after_stage_$trigger"
+    local case_root="$tmp_root/$name"
+    local status
+
+    seed_known_legacy_assets "$case_root"
+    set +e
+    CASE_ROOT="$case_root" REPO_ROOT="$repo_root" LIFECYCLE_SCRIPT="$lifecycle_script" \
+        bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$CASE_ROOT"
+            FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$CASE_ROOT")"
+            facelock_source_install_plan_legacy_assets
+            "$REPO_ROOT/scripts/migrate-legacy-system-assets.sh" \
+                --source-protected --stage "$CASE_ROOT"
+            facelock_source_install_record_legacy_migration
+            FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR=
+            if [ "$1" = signal ]; then
+                facelock_source_install_arm_daemon_restore
+                kill -TERM "$$"
+                exit 99
+            fi
+            facelock_source_install_finish_daemon 1
+        ' _ "$trigger" 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] || {
+        cat "$case_root/stderr" >&2
+        fail "$name exited $status, expected $expected_status"
+    }
+    for legacy in \
+        etc/systemd/system/facelock-daemon.service \
+        etc/dbus-1/system.d/org.facelock.Daemon.conf \
+        etc/dbus-1/system-services/org.facelock.Daemon.service; do
+        [ -f "$case_root/$legacy" ] || fail "$name did not restore $legacy"
+    done
+    [ ! -e "$case_root/etc/systemd/system/.facelock-migrate-systemd-unit" ] ||
+        fail "$name retained the systemd quarantine"
+    [ ! -e "$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy" ] ||
+        fail "$name retained the D-Bus policy quarantine"
+    [ ! -e "$case_root/etc/dbus-1/system-services/.facelock-migrate-dbus-activation" ] ||
+        fail "$name retained the D-Bus activation quarantine"
+}
+
+run_after_stage_rollback_case failure 1
+run_after_stage_rollback_case signal 143
+
+run_rollback_collision_never_publishes_case() {
+    local name=rollback_collision_never_publishes
+    local case_root="$tmp_root/$name"
+    local output="$case_root/output"
+    local status
+
+    seed_known_legacy_assets "$case_root"
+    set +e
+    CASE_ROOT="$case_root" REPO_ROOT="$repo_root" LIFECYCLE_SCRIPT="$lifecycle_script" \
+        bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$CASE_ROOT"
+            FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$CASE_ROOT")"
+            facelock_source_install_plan_legacy_assets
+            "$REPO_ROOT/scripts/migrate-legacy-system-assets.sh" \
+                --source-protected --stage "$CASE_ROOT"
+            facelock_source_install_record_legacy_migration
+            printf "%s\n" collision >"$CASE_ROOT/etc/systemd/system/facelock-daemon.service"
+            chmod 644 "$CASE_ROOT/etc/systemd/system/facelock-daemon.service"
+            FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR=
+            facelock_source_install_finish_daemon 1
+        ' >"$output" 2>&1
+    status=$?
+    set -e
+
+    [ "$status" -ne 0 ] || fail "$name unexpectedly succeeded"
+    [ -f "$case_root/etc/systemd/system/.facelock-migrate-systemd-unit" ] ||
+        fail "$name unlinked the rollback-blocked quarantine"
+    ! grep -Fq 'Removed exact known legacy system asset' "$output" ||
+        fail "$name entered publication after rollback failed"
+}
+
+run_rollback_collision_never_publishes_case
+
+run_unrecorded_mixed_prefix_recovery_case() {
+    local name=unrecorded_mixed_prefix_recovery
+    local case_root="$tmp_root/$name"
+    local public quarantine
+
+    seed_known_legacy_assets "$case_root"
+    public="$case_root/etc/systemd/system/facelock-daemon.service"
+    quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+    {
+        set -euo pipefail
+        # shellcheck disable=SC1090,SC1091
+        source "$lifecycle_script"
+        FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$case_root"
+        FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$case_root")"
+        FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$case_root")"
+        facelock_source_install_plan_legacy_assets
+        mv -Tn -- "$public" "$quarantine"
+        [ "$FACELOCK_SOURCE_INSTALL_LEGACY_MIGRATION_RECORDED" = false ]
+        facelock_source_install_rollback_legacy_migration
+    } || fail "$name could not reconcile a staged-but-unrecorded prefix"
+    [ -f "$public" ] && [ ! -e "$quarantine" ] ||
+        fail "$name did not restore the preplanned public identity"
+}
+
+run_unrecorded_mixed_prefix_recovery_case
+
+run_unrecorded_interrupted_recovery_case() {
+    local name=unrecorded_initial_interrupted_recovery
+    local case_root="$tmp_root/$name"
+    local public quarantine
+
+    seed_known_legacy_assets "$case_root"
+    public="$case_root/etc/dbus-1/system.d/org.facelock.Daemon.conf"
+    quarantine="$case_root/etc/dbus-1/system.d/.facelock-migrate-dbus-policy"
+    mv -Tn -- "$public" "$quarantine"
+    {
+        set -euo pipefail
+        # shellcheck disable=SC1090,SC1091
+        source "$lifecycle_script"
+        export FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$case_root"
+        export FACELOCK_SOURCE_INSTALL_TRUST_UID
+        FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$case_root")"
+        export FACELOCK_SOURCE_INSTALL_TRUST_GID
+        FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$case_root")"
+        facelock_source_install_plan_legacy_assets
+        mv -Tn -- "$quarantine" "$public"
+        facelock_source_install_rollback_legacy_migration
+    } || fail "$name could not restore the initial interrupted quarantine"
+    [ ! -e "$public" ] && [ -f "$quarantine" ] ||
+        fail "$name changed the preplanned interrupted identity"
+}
+
+run_unrecorded_interrupted_recovery_case
+
+run_unrecorded_mixed_prefix_collision_case() {
+    local name=unrecorded_mixed_prefix_collision
+    local case_root="$tmp_root/$name"
+    local public quarantine status
+
+    seed_known_legacy_assets "$case_root"
+    public="$case_root/etc/systemd/system/facelock-daemon.service"
+    quarantine="$case_root/etc/systemd/system/.facelock-migrate-systemd-unit"
+    set +e
+    CASE_ROOT="$case_root" PUBLIC="$public" QUARANTINE="$quarantine" \
+        LIFECYCLE_SCRIPT="$lifecycle_script" bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$CASE_ROOT"
+            FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$CASE_ROOT")"
+            facelock_source_install_plan_legacy_assets
+            mv -Tn -- "$PUBLIC" "$QUARANTINE"
+            printf "%s\n" collision >"$PUBLIC"
+            chmod 644 "$PUBLIC"
+            ! facelock_source_install_rollback_legacy_migration
+        ' 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || fail "$name did not reject the ambiguous pair"
+    [ -f "$public" ] && [ -f "$quarantine" ] ||
+        fail "$name did not preserve both ambiguous names"
+}
+
+run_unrecorded_mixed_prefix_collision_case
+
+run_parent_signal_during_stage_case() {
+    local signal="$1"
+    local expected_status="$2"
+    local name="parent_${signal,,}_during_stage"
+    local case_root="$tmp_root/$name"
+    local status
+
+    seed_known_legacy_assets "$case_root"
+    set +e
+    CASE_ROOT="$case_root" REPO_ROOT="$repo_root" \
+        LIFECYCLE_SCRIPT="$lifecycle_script" FACELOCK_TEST_SIGNAL="$signal" \
+        bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            FACELOCK_SOURCE_INSTALL_DBUS_LAYOUT_PREFIX="$CASE_ROOT"
+            FACELOCK_SOURCE_INSTALL_TRUST_UID="$(stat -c %u -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_TRUST_GID="$(stat -c %g -- "$CASE_ROOT")"
+            FACELOCK_SOURCE_INSTALL_SYSTEMD_RUNTIME_DIR=
+            facelock_source_install_plan_legacy_assets
+            facelock_source_install_arm_daemon_restore
+            facelock_source_install_invoke_legacy_stage() {
+                "$REPO_ROOT/scripts/migrate-legacy-system-assets.sh" \
+                    --source-protected --stage "$1" &
+                child=$!
+                kill -s "$FACELOCK_TEST_SIGNAL" "$$"
+                wait "$child"
+            }
+            facelock_source_install_stage_and_record_legacy_migration "$CASE_ROOT"
+        ' 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -eq "$expected_status" ] || {
+        cat "$case_root/stderr" >&2
+        fail "$name exited $status, expected $expected_status"
+    }
+    for legacy in \
+        etc/systemd/system/facelock-daemon.service \
+        etc/dbus-1/system.d/org.facelock.Daemon.conf \
+        etc/dbus-1/system-services/org.facelock.Daemon.service; do
+        [ -f "$case_root/$legacy" ] || fail "$name did not restore $legacy"
+    done
+    ! find "$case_root/etc" -name '.facelock-migrate-*' -print -quit | grep -q . ||
+        fail "$name retained a candidate quarantine"
+}
+
+run_parent_signal_during_stage_case TERM 143
+run_parent_signal_during_stage_case HUP 129
+
+run_partial_commit_retains_barrier_case() {
+    local name=partial_commit_retains_barrier
+    local case_root="$tmp_root/$name"
+    local barrier="$case_root/run/systemd/system.control/facelock-daemon.service"
+    local status
+
+    seed_known_legacy_assets "$case_root"
+    write_standard_dbus_config "$case_root"
+    : >"$case_root/actual"
+    printf '%s\n' none >"$case_root/mask-state"
+    printf '%s\n' none >"$case_root/manager-mask-state"
+    set +e
+    PATH="$tmp_root/bin:$PATH" \
+        FACELOCK_SYSTEMCTL_LOG="$case_root/actual" \
+        FACELOCK_SHOW_STATUS=0 \
+        FACELOCK_LOAD_STATE=loaded \
+        FACELOCK_ACTIVE_STATE=active \
+        FACELOCK_UNIT_FILE_STATE=disabled \
+        FACELOCK_MASK_STATE="$case_root/mask-state" \
+        FACELOCK_MANAGER_MASK_STATE="$case_root/manager-mask-state" \
+        FACELOCK_FRAGMENT_PATH_OVERRIDE="$case_root/etc/systemd/system/facelock-daemon.service" \
+        FACELOCK_RUNTIME_DIR="$case_root/run/systemd/system" \
+        FACELOCK_FAIL_MIGRATION_UNLINK_NUMBER=2 \
+        FACELOCK_MIGRATION_UNLINK_COUNT="$case_root/migration-unlink-count" \
+        CASE_ROOT="$case_root" REPO_ROOT="$repo_root" \
+        LIFECYCLE_SCRIPT="$lifecycle_script" bash -c '
+            set -euo pipefail
+            source "$LIFECYCLE_SCRIPT"
+            facelock_source_install_begin_daemon \
+                "$CASE_ROOT/run/systemd/system" \
+                "$CASE_ROOT/usr/lib/systemd/system/facelock-daemon.service" \
+                "$CASE_ROOT/usr/share/dbus-1/system-services/org.facelock.Daemon.service" \
+                "$CASE_ROOT/etc/systemd/system/facelock-daemon.service" \
+                "$CASE_ROOT/etc/dbus-1/system-services/org.facelock.Daemon.service"
+            facelock_source_install_stage_and_record_legacy_migration "$CASE_ROOT"
+            facelock_source_install_complete_daemon "$CASE_ROOT/run/systemd/system"
+        ' 2>"$case_root/stderr"
+    status=$?
+    set -e
+
+    [ "$status" -ne 0 ] || fail "$name unexpectedly succeeded"
+    [ -f "$barrier" ] && [ ! -L "$barrier" ] && [ ! -s "$barrier" ] ||
+        fail "$name did not retain the activation barrier"
+    [ "$(cat "$case_root/manager-mask-state")" = masked ] ||
+        fail "$name did not retain the manager-effective barrier"
+    ! grep -Fq 'systemctl start facelock-daemon.service' "$case_root/actual" ||
+        fail "$name restarted after partial migration publication"
+}
+
+run_partial_commit_retains_barrier_case
+
+echo "source-install daemon lifecycle: OK"

--- a/test/source-install-daemon-stop-probe.sh
+++ b/test/source-install-daemon-stop-probe.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+barrier=/run/systemd/system.control/facelock-daemon.service
+runtime_mask=/run/systemd/system/facelock-daemon.service
+
+if [ "$*" = 'daemon-reload' ]; then
+    if [ -e /run/facelock-source-install-fail-cleanup-reload ] &&
+        [ -e "$barrier" ]; then
+        exit 1
+    fi
+    if [ -e /run/facelock-source-install-fail-final-reload ] &&
+        [ ! -e "$barrier" ] && [ ! -L "$barrier" ]; then
+        exit 1
+    fi
+    if [ -e /run/facelock-source-install-cleanup-mask-race ] &&
+        [ -e "$barrier" ]; then
+        rm -f -- /run/facelock-source-install-cleanup-mask-race
+        ln -s /dev/null "$runtime_mask"
+    fi
+    if [ -e /run/facelock-source-install-definition-race ] &&
+        [ -e "$barrier" ]; then
+        rm -f -- /run/facelock-source-install-definition-race
+        printf '%s\n' \
+            '[D-BUS Service]' \
+            'Name=org.facelock.Daemon' \
+            'Exec=/usr/bin/facelock daemon' \
+            'User=root' \
+            >/usr/share/dbus-1/system-services/org.facelock.Daemon.service
+    fi
+    if [ -e /run/facelock-source-install-fragment-race ] &&
+        [ -e "$barrier" ]; then
+        rm -f -- /run/facelock-source-install-fragment-race
+        mkdir -p /etc/systemd/system.control
+        install -m600 /dev/null \
+            /etc/systemd/system.control/facelock-daemon.service
+    fi
+    if [ -e /run/facelock-source-install-owner-race ] &&
+        [ -e "$barrier" ]; then
+        rm -f -- /run/facelock-source-install-owner-race
+        /usr/bin/facelock daemon \
+            >/run/facelock-source-install-owner-race.log 2>&1 &
+        for _ in $(seq 1 50); do
+            if [ "$(busctl --system call org.freedesktop.DBus \
+                /org/freedesktop/DBus org.freedesktop.DBus NameHasOwner \
+                s org.facelock.Daemon)" = 'b true' ]; then
+                break
+            fi
+            sleep 0.02
+        done
+    fi
+fi
+
+if [ "${1:-}" = show ] &&
+    [ -e /run/facelock-source-install-pre-restart-mask-race ] &&
+    [ ! -e "$barrier" ] && [ ! -L "$barrier" ] &&
+    ! compgen -G "$barrier.facelock-remove.*" >/dev/null; then
+    rm -f -- /run/facelock-source-install-pre-restart-mask-race
+    ln -s /dev/null "$runtime_mask"
+    /usr/bin/systemctl daemon-reload
+fi
+
+if [ "$*" = 'stop facelock-daemon.service' ]; then
+    fragment="$(/usr/bin/systemctl show facelock-daemon.service \
+        --property=FragmentPath --value --no-pager)"
+    [ "$fragment" = "$barrier" ]
+    touch /run/facelock-source-install-stop-proof
+fi
+
+exec /usr/bin/systemctl "$@"

--- a/test/source-install-daemon-stub.sh
+++ b/test/source-install-daemon-stub.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 1 ] && [ "$1" = daemon ]; then
+    exec /usr/bin/python3 \
+        /source-install-lifecycle/test/fake-facelock-daemon.py
+fi
+
+echo "source-install daemon stub only supports daemon mode" >&2
+exit 64

--- a/test/source-install-daemon-test.service
+++ b/test/source-install-daemon-test.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Facelock source-install lifecycle test daemon
+After=dbus.service
+
+[Service]
+Type=dbus
+BusName=org.facelock.Daemon
+ExecStart=/usr/bin/facelock daemon

--- a/test/source-install-offline-image.marker
+++ b/test/source-install-offline-image.marker
@@ -1,0 +1,1 @@
+facelock-repository-test-container-source-install-v1

--- a/test/source-install-recipe-fake-busctl.sh
+++ b/test/source-install-recipe-fake-busctl.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+PATH=/usr/bin:/bin
+export PATH
+
+case "$*" in
+    *' ReloadConfig') ;;
+    *' NameHasOwner s org.facelock.Daemon')
+        if [ "$(cat "${FACELOCK_RECIPE_FAKE_STATE_DIR:?}/active-state")" = active ]; then
+            printf '%s\n' 'b true'
+        else
+            printf '%s\n' 'b false'
+        fi
+        ;;
+    *) exit 2 ;;
+esac

--- a/test/source-install-recipe-fake-systemctl.sh
+++ b/test/source-install-recipe-fake-systemctl.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+PATH=/usr/bin:/bin
+export PATH
+
+state_dir=${FACELOCK_RECIPE_FAKE_STATE_DIR:?}
+state_file=$state_dir/active-state
+barrier=/run/systemd/system.control/facelock-daemon.service
+
+case "${1:-}" in
+    show)
+        case "${2:-}" in
+            dbus.service)
+                printf '%s\n' \
+                    'Id=dbus-broker.service' \
+                    'Names=dbus-broker.service dbus.service' \
+                    'Following=' \
+                    'LoadState=loaded' \
+                    'ActiveState=active' \
+                    'FragmentPath=/usr/lib/systemd/system/dbus-broker.service' \
+                    'DropInPaths=' \
+                    'ExecStart=/usr/bin/dbus-broker-launch --scope system'
+                ;;
+            facelock-daemon.service)
+                active_state=$(cat "$state_file")
+                if [ -e "$barrier" ]; then
+                    printf 'LoadState=masked\nActiveState=%s\n' "$active_state"
+                    case "$*" in
+                        *--property=UnitFileState*)
+                            printf '%s\n' \
+                                'UnitFileState=masked-runtime' \
+                                "FragmentPath=$barrier" \
+                                'DropInPaths='
+                            ;;
+                        *) printf 'FragmentPath=%s\n' "$barrier" ;;
+                    esac
+                else
+                    fragment=
+                    for candidate in /etc/systemd/system/facelock-daemon.service \
+                        /usr/lib/systemd/system/facelock-daemon.service; do
+                        if [ -e "$candidate" ]; then
+                            fragment=$candidate
+                            break
+                        fi
+                    done
+                    if [ -z "$fragment" ]; then
+                        printf '%s\n' \
+                            'LoadState=not-found' \
+                            'ActiveState=inactive' \
+                            'UnitFileState=' \
+                            'FragmentPath=' \
+                            'DropInPaths='
+                    else
+                        printf '%s\n' \
+                            'LoadState=loaded' \
+                            "ActiveState=$active_state" \
+                            'UnitFileState=static' \
+                            "FragmentPath=$fragment" \
+                            'ExecStart=/usr/bin/facelock daemon' \
+                            'DropInPaths='
+                    fi
+                fi
+                ;;
+            *) exit 2 ;;
+        esac
+        ;;
+    daemon-reload) ;;
+    stop) printf '%s\n' inactive >"$state_file" ;;
+    start)
+        [ ! -e "$barrier" ] || exit 1
+        printf '%s\n' active >"$state_file"
+        ;;
+    *) exit 2 ;;
+esac

--- a/test/source-install-recipe-install-probe.sh
+++ b/test/source-install-recipe-install-probe.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash -p
+set -euo pipefail
+PATH=/usr/bin:/bin
+export PATH
+
+if [ "${1:-}" = -Dm755 ] && {
+    [ "${2:-}" = target/release/facelock ] ||
+        [ "${2:-}" = "/source-install-lifecycle/repository/target/release/facelock" ];
+} &&
+    [ "${3:-}" = /usr/bin/facelock ] &&
+    [ -n "${FACELOCK_RECIPE_FIRST_WRITE_FAULT:-}" ] &&
+    [ ! -e "${FACELOCK_RECIPE_FIRST_WRITE_MARKER:?}" ]; then
+    : >"$FACELOCK_RECIPE_FIRST_WRITE_MARKER"
+    case "$FACELOCK_RECIPE_FIRST_WRITE_FAULT" in
+        failure) exit 1 ;;
+        HUP)
+            kill -HUP "$PPID"
+            exit 129
+            ;;
+        *) exit 98 ;;
+    esac
+fi
+
+exec "${FACELOCK_RECIPE_REAL_INSTALL:-/usr/bin/install}" "$@"


### PR DESCRIPTION
## Why

Package and source installs must preserve administrator-owned PAM and service state while supported Debian artifacts remain deterministic across install, upgrade, and removal.

## Changes

- validate package-owned systemd and D-Bus assets without overwriting them
- retire only exact known legacy assets through transactional rollback-safe cleanup
- keep PAM edits service-scoped and leave authselect shared profiles untouched
- preserve Debian daemon and PAM state across Trixie and Resolute lifecycles
- build supported Debian source packages from pinned offline vendor inputs

## Validation

- run just check
- run just test-release-matrix
- run just test-rpm-authselect
- run just test-rpm-pkg
- run just test-deb-trixie-pkg
- run just test-deb-resolute-pkg