### PR TITLE
docs(gpu): drop the nonexistent onnxruntime-opt-openvino package

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ GPU support is runtime-only -- no special build flags needed. Install a GPU-enab
 |------------|---------------|--------------|
 | NVIDIA | `onnxruntime-opt-cuda` | `"cuda"` |
 | AMD | `onnxruntime-opt-rocm` | `"rocm"` |
-| Intel | `onnxruntime-opt-openvino` | `"openvino"` |
+| Intel | none packaged | `"openvino"` |
 
-Supports CUDA, ROCm, and OpenVINO execution providers. CPU is the default.
+Supports CUDA, ROCm, and OpenVINO execution providers. CPU is the default. Arch packages no OpenVINO build of ONNX Runtime, in the repositories or the AUR. Build ONNX Runtime with the OpenVINO execution provider yourself to use `execution_provider = "openvino"`. See [GPU acceleration](book/src/gpu.md).
 
 ### Uninstall
 

--- a/book/src/gpu.md
+++ b/book/src/gpu.md
@@ -10,15 +10,16 @@ GPU support in Facelock is **runtime-only** -- no special build flags or recompi
 |------------|-------------------|---------------|
 | NVIDIA | `onnxruntime-opt-cuda` | Install CUDA toolkit + ONNX Runtime with CUDA provider |
 | AMD | `onnxruntime-opt-rocm` | Install ROCm runtime + ONNX Runtime with ROCm provider |
-| Intel | `onnxruntime-opt-openvino` | Install OpenVINO runtime + ONNX Runtime with OpenVINO provider |
+| Intel | none packaged | Install OpenVINO runtime + ONNX Runtime with OpenVINO provider |
 
 On Arch Linux:
 
 ```bash
 sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
 sudo pacman -S onnxruntime-opt-rocm      # AMD
-sudo pacman -S onnxruntime-opt-openvino  # Intel
 ```
+
+Arch packages no OpenVINO build of ONNX Runtime, in the repositories or the AUR. Build ONNX Runtime with the OpenVINO execution provider yourself to use `execution_provider = "openvino"`.
 
 ### 2. Set the execution provider
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -131,8 +131,9 @@ For manual configuration, install a GPU-enabled ONNX Runtime package:
 ```bash
 sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
 sudo pacman -S onnxruntime-opt-rocm      # AMD
-sudo pacman -S onnxruntime-opt-openvino  # Intel
 ```
+
+Arch packages no OpenVINO build of ONNX Runtime, in the repositories or the AUR. Build ONNX Runtime with the OpenVINO execution provider yourself to use `execution_provider = "openvino"`.
 
 Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, or `"openvino"`. CPU is the default.
 

--- a/config/facelock.toml
+++ b/config/facelock.toml
@@ -117,8 +117,8 @@
 # Values: "cpu", "cuda", "rocm", "openvino"
 # GPU providers require installing a GPU-enabled ONNX Runtime package:
 #   NVIDIA:  sudo pacman -S onnxruntime-opt-cuda
-#   AMD:     install onnxruntime with ROCm support
-#   Intel:   install openvino runtime
+#   AMD:     sudo pacman -S onnxruntime-opt-rocm
+#   Intel:   no Arch package; build ONNX Runtime with the OpenVINO provider
 # Default: "cpu"
 # execution_provider = "cpu"
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,8 +79,9 @@ For manual configuration, install a GPU-enabled ONNX Runtime package:
 ```bash
 sudo pacman -S onnxruntime-opt-cuda      # NVIDIA
 sudo pacman -S onnxruntime-opt-rocm      # AMD
-sudo pacman -S onnxruntime-opt-openvino  # Intel
 ```
+
+Arch packages no OpenVINO build of ONNX Runtime, in the repositories or the AUR. Build ONNX Runtime with the OpenVINO execution provider yourself to use `execution_provider = "openvino"`.
 
 Set `execution_provider` in `/etc/facelock/config.toml` to `"cuda"`, `"rocm"`, or `"openvino"`. CPU is the default.
 


### PR DESCRIPTION
- drop `onnxruntime-opt-openvino` from the Intel GPU row and the pacman lines; the package exists in no Arch repository and no AUR, so the Intel setup path ended in `target not found` (reported with a screenshot in basecamp/omarchy#5212)
- point Intel users at building ONNX Runtime with the OpenVINO execution provider, reusing the wording `book/src/gpu.md` already carries in its Other Distros column
- fix the same defect in the shipped `config/facelock.toml` comment block, where the Intel row told you to install the OpenVINO runtime alone; its AMD row now names `onnxruntime-opt-rocm` the way the NVIDIA row names its package
- keep `execution_provider = "openvino"` documented as valid; the provider stays wired in `facelock-face` and `facelock-cli`
- touch both quickstart copies, `docs/` and `book/src/`, since they drift independently

## Validation

- `just check`, which includes the `config/facelock.toml` conformance tests
- confirmed the new template comment lines introduce no `=`, so the uncomment-every-example expansion and its pinned skipped-prose count are unchanged
- grepped for consumers of the replaced comment strings; packaging installs the file verbatim and reads nothing from it

Fixes #209
