### PR TITLE
ci: pin every GitHub Action to a commit SHA and stop automerging bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,12 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions",
-      "automerge": true
+      "description": [
+        "Never automerge. Every action is pinned to a commit SHA (#235), and an",
+        "automerged digest bump unpins it again the following Monday without anyone",
+        "reading the diff. Release workflows hold signing secrets, so a human reviews",
+        "the new SHA before it can run."
+      ]
     }
   ],
   "schedule": ["before 9am on monday"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
             pam \
             tpm2-tss
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -93,7 +93,7 @@ jobs:
           cargo build --release -p facelock-cli --features tpm
 
       - name: Upload release binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-binaries
           path: |
@@ -119,10 +119,10 @@ jobs:
             git \
             rust
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache cargo registry and cargo-audit build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -153,10 +153,10 @@ jobs:
             tpm2-tss \
             swtpm
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Start swtpm
         run: |
@@ -191,7 +191,7 @@ jobs:
             ripgrep \
             util-linux
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -232,7 +232,7 @@ jobs:
             gettext \
             just
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # This is the only job that runs git against the checkout itself (the
       # others only run cargo/just), and inside a container git refuses it:
@@ -284,10 +284,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download release binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-binaries
           path: target/release

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install mdBook
         run: |
           MDBOOK_VERSION="0.4.44"
@@ -51,7 +51,7 @@ jobs:
             echo "This is expected before the first stable release with APT publishing."
           fi
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       rpm-version: ${{ steps.release.outputs.rpm-version }}
       rpm-counter: ${{ steps.release.outputs.rpm-counter }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate tag, package metadata, channels, and target matrix
         id: release
@@ -38,16 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: metadata
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: .github/workflows/scripts/install-ubuntu-deps.sh
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable @ 2026-08-05
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Build release
         run: cargo build --release --workspace
@@ -63,13 +63,13 @@ jobs:
           cd release && sha256sum * > SHA256SUMS
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-binaries
           path: release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           # Publish the release with a PAT, not the default GITHUB_TOKEN.
           # Releases created by GITHUB_TOKEN do not trigger downstream
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: metadata
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download ONNX Runtime for bundling
         run: |
@@ -101,7 +101,7 @@ jobs:
           scripts/prepare-ort-bundle.sh component-tar onnxruntime onnxruntime-bundle.tar.xz
 
       - name: Upload ORT artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: onnxruntime-bundle.tar.xz
           archive: false
@@ -111,12 +111,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: metadata
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install pinned source-preparation toolchain
         # Immutable action implementation; the explicit patch release matches
         # the 1.95 channel selected by rust-toolchain.toml.
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable @ 2026-08-05
         with:
           toolchain: 1.95.0
 
@@ -126,7 +126,7 @@ jobs:
           scripts/prepare-cargo-vendor.sh component-tar cargo-vendor cargo-vendor-bundle.tar.xz
 
       - name: Upload Cargo vendor artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: cargo-vendor-bundle.tar.xz
           archive: false
@@ -157,7 +157,7 @@ jobs:
             ca-certificates \
             git
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -203,7 +203,7 @@ jobs:
           dpkg-checkbuilddeps
 
       - name: Download ORT bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: onnxruntime-bundle.tar.xz
           path: .
@@ -216,7 +216,7 @@ jobs:
         run: scripts/prepare-ort-bundle.sh verify onnxruntime
 
       - name: Download Cargo vendor bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-vendor-bundle.tar.xz
           path: .
@@ -270,13 +270,13 @@ jobs:
           done < "$manifest"
 
       - name: Upload exact Debian artifact set
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-deb-${{ matrix.suite }}
           path: debian-upload/
 
       - name: Upload .deb to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: debian-upload/*.deb
 
@@ -287,7 +287,7 @@ jobs:
     container:
       image: registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install build dependencies
         run: |
@@ -301,7 +301,7 @@ jobs:
             tpm2-tss-devel
 
       - name: Download ORT bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: onnxruntime-bundle.tar.xz
           path: .
@@ -326,7 +326,7 @@ jobs:
         run: .github/workflows/scripts/validate-rpm.sh "$(ls *.rpm | head -1)" direct
 
       - name: Upload .rpm to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: "*.rpm"
 
@@ -335,10 +335,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: metadata
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
@@ -359,7 +359,7 @@ jobs:
     needs: [metadata, build, build-deb, build-rpm]
     if: ${{ needs.metadata.outputs.prerelease == 'false' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compute source tarball checksum
         id: checksum
@@ -378,19 +378,19 @@ jobs:
     needs: [metadata, build-deb]
     if: ${{ needs.metadata.outputs.prerelease == 'false' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y reprepro gnupg
 
       - name: Download trixie .deb artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-deb-trixie
           path: debs/trixie
 
       - name: Download resolute .deb artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-deb-resolute
           path: debs/resolute
@@ -431,7 +431,7 @@ jobs:
           echo "APT repo tarball: $(du -h apt-repo.tar.gz | cut -f1)"
 
       - name: Upload APT repo to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: apt-repo.tar.gz
 


### PR DESCRIPTION
## Summary

- pin all 44 `uses:` refs across `ci.yml`, `release.yml`, `pages.yml`, `claude.yml`, and `claude-code-review.yml` to 40-character commit SHAs
- carry the release tag in a trailing comment (`# v7.0.1`), the format Renovate reads and rewrites, so the ref stays legible and the tag stays current
- pin `dtolnay/rust-toolchain@stable` to its branch head, commented `# stable @ 2026-08-05`
- drop `automerge` from the `github-actions` Renovate rule; the two halves are one unit, since an automerged digest bump unpins every action the following Monday
- keep the Renovate grouping, the Monday schedule, and every cargo rule as they are
- leave job logic, step order, and `with:` blocks untouched

## Why

A mutable tag lets an upstream repository move the ref underneath us, so a retagged or compromised release runs with the workflow's permissions on the next job. #235 lists pinning release Actions by commit in its scope, but that step needs none of the staging or signing prerequisites the rest of the issue blocks on. Pinning first also keeps it from colliding with the CI changes queued behind #235, several of which add jobs to these same files.

## Validation

- re-resolved every pinned SHA against its upstream repository, and confirmed the commented tag resolves to the same commit
- validated `renovate.json` against `renovate-schema.json`
- `just check`
- `test/check-agent-docs.py`, which gates `release.yml` job names against the release skill

Refs #235
