### PR TITLE
fix(i18n): flag multi-line msgids as python-brace-format

### DIFF
--- a/justfile
+++ b/justfile
@@ -738,15 +738,25 @@ pot:
     # *scanner language* knows, and --language=C knows only c-format — the flag
     # is accepted and silently dropped (verified against gettext 1.0). The seam
     # uses exactly one placeholder syntax (`{lower_snake}`, see `fill` in
-    # message/mod.rs), so matching it here is precise, and the check below
-    # makes gettext itself confirm every flag we wrote is truthful.
+    # message/mod.rs), so matching it here is precise, and the two checks below
+    # confirm the flags and the placeholders agree in both directions.
+    #
+    # An entry's msgid can span several physical lines: gettext splits a
+    # template at every embedded newline into a bare `msgid ""` opener plus one
+    # continuation string per line. The scan therefore reassembles each msgid
+    # before matching — testing the opener alone silently skips every
+    # multi-line template, which is what it did until #186.
     awk '
         { buf[NR] = $0 }
         END {
             for (i = 2; i <= NR; i++)
-                if (buf[i] ~ /^msgid "/ && buf[i] ~ /\{[a-z_][a-z0-9_]*\}/) {
-                    if (buf[i-1] ~ /^#,/) sub(/$/, ", python-brace-format", buf[i-1])
-                    else buf[i-1] = buf[i-1] "\n#, python-brace-format"
+                if (buf[i] ~ /^msgid "/) {
+                    text = buf[i]
+                    for (j = i + 1; j <= NR && buf[j] ~ /^"/; j++) text = text buf[j]
+                    if (text ~ /\{[a-z_][a-z0-9_]*\}/) {
+                        if (buf[i-1] ~ /^#,/) sub(/$/, ", python-brace-format", buf[i-1])
+                        else buf[i-1] = buf[i-1] "\n#, python-brace-format"
+                    }
                 }
             for (i = 1; i <= NR; i++) print buf[i]
         }
@@ -758,6 +768,27 @@ pot:
     # with an unbalanced brace in prose would fail here rather than in a
     # translator's catalog.
     msgen po/facelock.pot | msgfmt --check-format -o /dev/null -
+
+    # That check is one-directional: it proves the flags we wrote are truthful,
+    # never that we wrote them all, and a missing flag is silent — the
+    # placeholders just go unvalidated forever. Assert the other direction
+    # here, streaming the entries rather than reusing the pass above so a bug
+    # in one is not a bug in both.
+    awk '
+        BEGIN      { bad = 0 }
+        /^$/       { flagged = 0 }
+        /^#,/      { flagged = ($0 ~ /python-brace-format/) }
+        /^msgid "/ { in_msgid = 1; braced = 0; start = NR }
+        /^msgstr/  {
+            if (in_msgid && braced && !flagged) {
+                printf "error: msgid at line %d carries a {placeholder} but no python-brace-format flag\n", start > "/dev/stderr"
+                bad = 1
+            }
+            in_msgid = 0
+        }
+        in_msgid && /\{[a-z_][a-z0-9_]*\}/ { braced = 1 }
+        END { exit bad }
+    ' po/facelock.pot
 
     xgettext --language=C --keyword=gettext --from-code=UTF-8 --no-wrap \
         --package-name=pam_facelock --copyright-holder="Facelock Contributors" \

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 14:07-0700\n"
+"POT-Creation-Date: 2026-08-22 19:51-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,6 +28,7 @@ msgid "invalid config at {path}: {error}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/access.rs:46
+#, python-brace-format
 msgid ""
 "Root required.\n"
 "  Run: {hint}"
@@ -100,6 +101,7 @@ msgid "--camera=auto found no video devices; check that the camera is connected 
 msgstr ""
 
 #: crates/facelock-cli/src/message/device.rs:78
+#, python-brace-format
 msgid ""
 "--camera=auto found no IR-capable camera among the detected devices:\n"
 "{listed}\n"
@@ -107,6 +109,7 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/device.rs:84
+#, python-brace-format
 msgid ""
 "--camera=auto found {count} IR-capable cameras:\n"
 "{listed}\n"
@@ -144,6 +147,7 @@ msgid "  Detected: {detail}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/device.rs:111
+#, python-brace-format
 msgid ""
 "  ⚠ Could not query the ONNX Runtime for available providers: {error}\n"
 "    Selecting cpu. Re-run with an explicit --execution-provider once the\n"
@@ -241,12 +245,14 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/face.rs:118
+#, python-brace-format
 msgid ""
 "Face recognition models not found in {dir}.\n"
 "Run `sudo facelock setup` to download them."
 msgstr ""
 
 #: crates/facelock-cli/src/message/face.rs:124
+#, python-brace-format
 msgid ""
 "Note: existing models don't use the configured embedder '{embedder}'.\n"
 "Old enrollments will not work with the new embedder. Consider removing them with 'facelock remove'.\n"
@@ -262,6 +268,7 @@ msgid "Look at the camera. Slowly turn your head left and right."
 msgstr ""
 
 #: crates/facelock-cli/src/message/face.rs:141
+#, python-brace-format
 msgid ""
 "\n"
 "Face enrolled successfully!\n"
@@ -271,6 +278,7 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/face.rs:151
+#, python-brace-format
 msgid ""
 "\n"
 "Warning: user '{user}' has {count} face models. Consider removing old ones with 'facelock remove'."
@@ -393,12 +401,14 @@ msgid "Face auth failed: {reason}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:292
+#, python-brace-format
 msgid ""
 "  Skipping PAM configuration (--no-pam).\n"
 "  No file under {dir} is read or modified."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:298
+#, python-brace-format
 msgid ""
 "  PAM module not found. Tried: {paths}\n"
 "  Install it first, then run: sudo facelock setup --pam"
@@ -415,6 +425,7 @@ msgid "  No supported PAM service files found in {dir}/."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:312
+#, python-brace-format
 msgid ""
 "  The following line will be added to each selected /etc/pam.d/<service>:\n"
 "\n"
@@ -466,6 +477,7 @@ msgid "no 'auth' line found — inserted at the top of the file"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:352
+#, python-brace-format
 msgid ""
 "\n"
 "About to modify {path}:\n"
@@ -490,6 +502,7 @@ msgid "Backed up {path} -> {backup}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:375
+#, python-brace-format
 msgid ""
 "Installed facelock PAM line into {path}\n"
 "\n"
@@ -514,12 +527,14 @@ msgid "PAM service file absent: {path}. Nothing to remove."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:396
+#, python-brace-format
 msgid ""
 "Backup exists at {backup}\n"
 "To restore: sudo cp {backup} {path}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:406
+#, python-brace-format
 msgid ""
 "\n"
 "About to create {path} from the vendor file {vendor}:\n"
@@ -530,6 +545,7 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:421
+#, python-brace-format
 msgid ""
 "Created {path} from {vendor} with the facelock PAM line.\n"
 "This local override shadows the vendor file and will not track vendor updates.\n"
@@ -540,24 +556,28 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:431
+#, python-brace-format
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Deleted unchanged local override; {vendor} is authoritative again."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:437
+#, python-brace-format
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because administrator or vendor drift no longer matches {vendor}."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:443
+#, python-brace-format
 msgid ""
 "Removed facelock PAM line from {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:449
+#, python-brace-format
 msgid ""
 "No facelock PAM line found in {path}.\n"
 "Kept local override because the vendor source is absent: {vendor}."
@@ -584,12 +604,14 @@ msgid "Would create {path} from {vendor} with the facelock PAM line ({hint})."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:479
+#, python-brace-format
 msgid ""
 "Cannot create the local override {path}: {dir} is not writable ({error}).\n"
 "The vendor copy of this service is package-owned, so facelock will not edit it in place."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:489
+#, python-brace-format
 msgid ""
 "\n"
 "==> facelock PAM line for manual extension to other services:\n"
@@ -603,24 +625,28 @@ msgid "Invalid PAM service name '{service}': a service is one file name under /e
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:501
+#, python-brace-format
 msgid ""
 "Refusing to touch {path}: it is a symlink to {target}. PAM service links are never followed beneath {dir}.\n"
 "Edit the real service file directly, or the tool that generates it — authselect regenerates system-auth and password-auth from /etc/authselect."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:511
+#, python-brace-format
 msgid ""
 "Refusing to touch {path}: it is one of {links} names for the same file, so an edit here would change a file outside /etc/pam.d that facelock cannot name.\n"
 "Break the link first: sudo cp -p {path} {path}.new && sudo mv {path}.new {path}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:517
+#, python-brace-format
 msgid ""
 "Refusing to modify '{service}': this is a sensitive PAM service.\n"
 "Re-run with {remedy} to accept the risk of locking yourself out."
 msgstr ""
 
 #: crates/facelock-cli/src/message/pam.rs:523
+#, python-brace-format
 msgid ""
 "PAM module not found. Tried: {paths}\n"
 "Install it first: cargo build --release -p pam-facelock && sudo cp target/release/libpam_facelock.so {path}"
@@ -701,6 +727,7 @@ msgid "No directory on the search path could be read: {dirs}."
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:193
+#, python-brace-format
 msgid ""
 "\n"
 "  Facelock v{version}\n"
@@ -789,6 +816,7 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:215
+#, python-brace-format
 msgid ""
 "  Camera detection failed: {error}\n"
 "  You can configure the camera later in the config file.\n"
@@ -796,48 +824,56 @@ msgid ""
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:221
+#, python-brace-format
 msgid ""
 "  Model quality selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:227
+#, python-brace-format
 msgid ""
 "  Inference device selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:233
+#, python-brace-format
 msgid ""
 "  Model download failed: {error}\n"
 "  You can retry later with: sudo facelock setup --non-interactive"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:243
+#, python-brace-format
 msgid ""
 "  Encryption setup failed: {error}\n"
 "  You can configure encryption later with: sudo facelock tpm encrypt --generate-key"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:249
+#, python-brace-format
 msgid ""
 "  Enrollment failed: {error}\n"
 "  You can enroll later with: facelock enroll"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:254
+#, python-brace-format
 msgid ""
 "  Test failed: {error}\n"
 "  You can test later with: facelock test"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:259
+#, python-brace-format
 msgid ""
 "  Systemd setup failed: {error}\n"
 "  You can enable it later with: sudo facelock setup --systemd"
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:265
+#, python-brace-format
 msgid ""
 "  PAM setup failed: {error}\n"
 "  You can configure PAM later with: sudo facelock setup --pam"
@@ -1042,6 +1078,7 @@ msgid "  [ok] AES-256-GCM encryption enabled."
 msgstr ""
 
 #: crates/facelock-cli/src/message/setup.rs:372
+#, python-brace-format
 msgid ""
 "\n"
 "  WARNING: encrypted face models already exist in {db_path} but the\n"
@@ -1352,6 +1389,7 @@ msgid "  facelock-daemon is running."
 msgstr ""
 
 #: crates/facelock-cli/src/message/system.rs:61
+#, python-brace-format
 msgid ""
 "  facelock-daemon did not answer within {seconds}s.\n"
 "  Continuing with direct camera access; check: systemctl status facelock-daemon"


### PR DESCRIPTION
## Summary

- reassemble each msgid from its continuation lines before scanning it for `{placeholder}`
- flag the 38 multi-line entries that carried placeholders with no `python-brace-format`
- fail `just pot` when an entry carries a placeholder and no flag, the mirror of the existing `msgen` check

## Why

The scan asked a single physical line to be both a `msgid "` opener and a placeholder carrier. gettext splits a template at every embedded newline into a bare `msgid ""` opener plus one continuation string per line, so no multi-line entry could satisfy both halves. Those 38 msgids reached translators unvalidated, and `msgfmt --check` would accept a catalog that dropped or typoed `{error}` in any of them.

## Validation

- `just check`
- `just pot` run three times, plus the CI catalog-freshness gate command
- both awk programs under mawk, which is what `ubuntu-latest` resolves `awk` to

Fixes #186
