### PR TITLE
fix(cli): make daemon run's root check scripted, not interactive

### DIFF
--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -437,6 +437,8 @@ Run or restart the persistent authentication daemon. Bare `facelock daemon` is `
 
 Run the daemon in the foreground. Requires root — it opens the camera and the face database. Normally managed by systemd, not run manually.
 
+Run as non-root it hard-errors with the `sudo` hint and never offers to re-exec, even from a terminal: the service unit that normally invokes it has nobody to answer a prompt. `daemon restart` still prompts.
+
 ```bash
 sudo facelock daemon                         # use default config
 sudo facelock daemon run                     # the same, spelled out

--- a/crates/facelock-cli/src/commands/daemon.rs
+++ b/crates/facelock-cli/src/commands/daemon.rs
@@ -295,7 +295,11 @@ pub fn restart() -> anyhow::Result<()> {
 /// `paths::config_path()` both read — so startup, the live reload and the
 /// mtime watch cannot disagree about which file is the config.
 pub fn run(notifier_factory: NotifierFactory, verbose: u8) -> anyhow::Result<()> {
-    crate::ipc_client::require_root("sudo facelock daemon run")?;
+    // Scripted, not interactive (issue #188): every shipped service unit
+    // invokes this verb, and a unit has nobody to answer "Re-run with sudo?
+    // [Y/n]" — the prompt would be a hang, not a convenience. `daemon
+    // restart` above stays interactive because a human types it.
+    crate::ipc_client::require_root_scripted("sudo facelock daemon run")?;
 
     // Init tracing (the daemon is the one caller that wants targets rendered,
     // and the one that keeps INFO by default: the journal is its reader, and

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -54,9 +54,9 @@ pub fn require_root(hint: &str) -> anyhow::Result<()> {
 /// Like [`require_root`], but never offers an interactive re-exec prompt.
 ///
 /// For commands that are typically invoked non-interactively or scripted
-/// (`facelock audit`; `facelock daemon` has its own equivalent check) — a
-/// "Re-run with sudo? [Y/n]" prompt would just hang a script instead of
-/// failing loudly.
+/// (`facelock audit`, `facelock pam add|remove`, and `facelock daemon run` —
+/// which every shipped service unit invokes) — a "Re-run with sudo? [Y/n]"
+/// prompt would just hang a script instead of failing loudly.
 pub fn require_root_scripted(hint: &str) -> anyhow::Result<()> {
     if Uid::current().is_root() {
         return Ok(());

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -140,6 +140,112 @@ fn tpm_reseal_refuses_before_root_non_root() {
 }
 
 #[test]
+fn daemon_run_refuses_before_root_non_root() {
+    // The tracing line `run` emits right after the root check is the tightest
+    // ordering witness available: the subscriber is not even installed until
+    // the check has passed.
+    assert_refuses_before_output(&["daemon", "run"], &["facelock daemon starting"]);
+}
+
+/// Open a pty pair, returning `(controller, device)` — the ends historically
+/// called master and slave.
+fn open_pty() -> (std::fs::File, std::fs::File) {
+    let mut controller = -1;
+    let mut device = -1;
+    // SAFETY: both fds are out-params written before `openpty` returns 0, and
+    // the null `name`/`termp`/`winp` arguments each mean "default" per
+    // openpty(3).
+    let rc = unsafe {
+        libc::openpty(
+            &mut controller,
+            &mut device,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+
+    // SAFETY: `openpty` returned 0, so both are fresh owned fds and nothing
+    // else holds them.
+    unsafe {
+        (
+            std::os::fd::FromRawFd::from_raw_fd(controller),
+            std::os::fd::FromRawFd::from_raw_fd(device),
+        )
+    }
+}
+
+/// DEC-6: `daemon run` is the **hard error only** escalation class — it never
+/// offers `Re-run with sudo? [Y/n]`, even with a terminal attached, because
+/// every shipped service unit invokes it and a unit has nobody to answer
+/// (issue #188).
+///
+/// This needs a real pty. The `assert_refuses_before_output` rows above close
+/// stdin, which drives `require_root` down its *non-interactive* branch too —
+/// so they pass under either escalation class and cannot tell them apart. A
+/// regression to `require_root` here does not fail fast: it blocks forever on
+/// a prompt nobody will answer, which is why the wait is bounded and a
+/// timeout is the assertion.
+#[test]
+fn daemon_run_never_prompts_with_a_tty_attached() {
+    use std::io::Read;
+    use std::time::{Duration, Instant};
+
+    if nix::unistd::Uid::effective().is_root() {
+        eprintln!("skipping: as root `daemon run` starts the daemon instead of refusing");
+        return;
+    }
+
+    let (mut controller, device) = open_pty();
+    let mut child = facelock_bin()
+        .args(["daemon", "run"])
+        .stdin(Stdio::from(device.try_clone().expect("dup pty device")))
+        .stdout(Stdio::from(device.try_clone().expect("dup pty device")))
+        // The parent keeps no device fd, so reads on the controller see EOF
+        // once the child exits rather than hanging on an open write end.
+        .stderr(Stdio::from(device))
+        .spawn()
+        .expect("failed to spawn facelock daemon run");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        match child.try_wait().expect("try_wait on facelock daemon run") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "`facelock daemon run` never exited as a non-root user with a TTY \
+                     attached: it is blocked on the interactive sudo prompt, which the \
+                     hard-error class forbids (expected require_root_scripted)"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+
+    // Reading the controller ends in EIO once the last device fd closes;
+    // bytes already read are kept, so the error is the end of the stream.
+    let mut raw = Vec::new();
+    let _ = controller.read_to_end(&mut raw);
+    let out = String::from_utf8_lossy(&raw);
+
+    assert!(!status.success(), "should refuse non-root, got: {status}");
+    assert!(out.contains("Root required"), "got: {out}");
+    // Asserted without the preceding newline: the pty translates it to CRLF.
+    assert!(out.contains("Run: sudo facelock daemon run"), "got: {out}");
+    assert!(
+        !out.contains("Re-run with sudo"),
+        "`daemon run` must not offer the interactive re-exec, got: {out}"
+    );
+    assert!(
+        !out.contains("facelock daemon starting"),
+        "the root check must run before anything else, got: {out}"
+    );
+}
+
+#[test]
 fn list_refuses_before_root_non_root() {
     assert_refuses_before_output(
         &["list", "--user", "nonexistent-test-user"],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -472,6 +472,10 @@ Run or restart the persistent authentication daemon. Bare `facelock daemon` is
 Run the daemon in the foreground. Requires root — it opens the camera and the
 face database. Normally managed by systemd, not run manually.
 
+Run as non-root it hard-errors with the `sudo` hint and never offers to
+re-exec, even from a terminal: the service unit that normally invokes it has
+nobody to answer a prompt. `daemon restart` still prompts.
+
 ```bash
 sudo facelock daemon                         # use default config
 sudo facelock daemon run                     # the same, spelled out

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1719,27 +1719,24 @@ command uses exactly one:
 
 - **Interactive prompt.** `setup`, `enroll`, `test`, `preview`, `bench`,
   `tpm` (including `tpm encrypt`, `tpm decrypt` and `tpm reseal`),
-  `daemon run`, `daemon restart`, `config edit`, `remove`, `clear`, `list`,
+  `daemon restart`, `config edit`, `remove`, `clear`, `list`,
   `status`, `devices`. Run as non-root with a TTY attached,
   these ask `Root required. Re-run with sudo? [Y/n]` and re-exec via `sudo`
   on yes. Run as non-root with no TTY (scripted, piped, or closed stdin),
   they hard-error instead — `Root required.\n  Run: sudo facelock <cmd>` —
   rather than hang waiting for input that will never arrive
   (`ipc_client::require_root`).
-- **Hard error only.** `facelock pam add`, `facelock pam remove` and
-  `facelock audit` never offer the interactive prompt at all, even with a TTY
-  attached — each is typically invoked non-interactively or by a wrapper,
-  where a stray confirmation prompt is a hang, not a convenience
-  (`ipc_client::require_root_scripted`).
+- **Hard error only.** `facelock daemon run`, `facelock pam add`,
+  `facelock pam remove` and `facelock audit` never offer the interactive
+  prompt at all, even with a TTY attached — each is typically invoked
+  non-interactively or by a wrapper, where a stray confirmation prompt is a
+  hang, not a convenience (`ipc_client::require_root_scripted`).
 
-`facelock daemon run` is listed above under **interactive prompt** because
-that is what `commands::daemon::run` calls (`ipc_client::require_root`), not
-because a service manager should ever meet a prompt. Earlier revisions of this
-table claimed it was hard-error-only; the code has always said otherwise, and
-this row now matches the code. Under systemd there is no TTY, so the branch
-taken is the hard error either way.
-[#188](https://github.com/tyvsmith/facelock/issues/188) tracks whether it
-should be scripted.
+`facelock daemon run` is in the hard-error class because every shipped
+service unit invokes it, and a service manager must never be what a
+confirmation prompt is waiting on. `daemon restart` keeps the prompt: a human
+types it. Run by hand as a non-root user, `daemon run` refuses with the same
+`Run: sudo facelock daemon run` hint a unit would get, TTY or not.
 
 `facelock pam add|remove` are in the hard-error class because the surface they
 replace was: standalone `setup --pam` bailed from its own root check rather


### PR DESCRIPTION
## Summary

- switch `daemon run` to `ipc_client::require_root_scripted`
- keep `daemon restart` interactive, since a human types it
- move the `daemon run` row into the hard-error class in `docs/contracts.md` and drop the paragraph that held the mismatch open
- pin the class with a pty-backed smoke test; the existing closed-stdin rows pass under either class and cannot tell them apart

## Why

`facelock daemon run` called the interactive `require_root`, so a non-root
invocation with a TTY attached asked "Root required. Re-run with sudo? [Y/n]"
and blocked on the answer. Every shipped service unit invokes that verb, and a
unit has nobody to type one. The refusal has to be immediate.

## Validation

- `just check`
- mutation check: re-ran the new pty test against the old `require_root` call

Fixes #188
