### PR TITLE
fix(daemon): wipe decrypted embeddings on preview and bench paths

### DIFF
--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -9,7 +9,7 @@ use facelock_camera::capture::Camera;
 use facelock_camera::device::{is_ir_camera, validate_device};
 use facelock_camera::{QuirksDb, ResolvedCamera};
 use facelock_core::Config;
-use facelock_core::types::{FaceEmbedding, cosine_similarity};
+use facelock_core::types::{FaceEmbedding, Wiped, cosine_similarity};
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 
@@ -162,7 +162,10 @@ fn cmd_cold_auth() -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = store.get_user_embeddings(&user)?;
+    // Plaintext templates (this standalone tool reads only unencrypted
+    // stores), zeroized when the guard drops — early bails and panics
+    // included (#214).
+    let embeddings = Wiped::new(store.get_user_embeddings(&user)?);
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock add`.",
@@ -211,7 +214,10 @@ fn cmd_warm_auth() -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = store.get_user_embeddings(&user)?;
+    // Plaintext templates (this standalone tool reads only unencrypted
+    // stores), zeroized when the guard drops — early bails and panics
+    // included (#214).
+    let embeddings = Wiped::new(store.get_user_embeddings(&user)?);
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock add`.",
@@ -403,7 +409,10 @@ fn cmd_calibrate() -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let enrolled = store.get_user_embeddings(&user)?;
+    // Plaintext templates (this standalone tool reads only unencrypted
+    // stores), zeroized when the guard drops — early bails and panics
+    // included (#214).
+    let enrolled = Wiped::new(store.get_user_embeddings(&user)?);
     if enrolled.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock add`.",
@@ -437,7 +446,7 @@ fn cmd_calibrate() -> Result<()> {
     // Compute all similarities between live and enrolled embeddings
     let mut similarities: Vec<f32> = Vec::new();
     for live_emb in &live_embeddings {
-        for (_, enrolled_emb) in &enrolled {
+        for (_, enrolled_emb) in enrolled.iter() {
             similarities.push(cosine_similarity(live_emb, enrolled_emb));
         }
     }
@@ -710,7 +719,10 @@ fn cmd_report() -> Result<()> {
     // Warm auth benchmark
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
-    let embeddings = store.get_user_embeddings(&user)?;
+    // Plaintext templates (this standalone tool reads only unencrypted
+    // stores), zeroized when the guard drops — early bails and panics
+    // included (#214).
+    let embeddings = Wiped::new(store.get_user_embeddings(&user)?);
     let has_enrolled = !embeddings.is_empty();
 
     let warm_auth_ms = if has_enrolled {

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -9,7 +9,7 @@ use tracing::{info, warn};
 
 use facelock_camera::Camera;
 use facelock_core::Config;
-use facelock_core::types::{FaceEmbedding, cosine_similarity};
+use facelock_core::types::{FaceEmbedding, Wiped, cosine_similarity};
 use facelock_face::FaceEngine;
 use facelock_store::FaceStore;
 
@@ -116,7 +116,9 @@ fn cmd_cold_auth(config: &Config) -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
+    // Decrypted templates (the CLI's decryption-aware load), zeroized when
+    // the guard drops — early bails and panics included (#141).
+    let embeddings = Wiped::new(direct::load_user_embeddings(&store, config, &user)?);
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -178,7 +180,9 @@ fn cmd_warm_auth(config: &Config) -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
+    // Decrypted templates (the CLI's decryption-aware load), zeroized when
+    // the guard drops — early bails and panics included (#141).
+    let embeddings = Wiped::new(direct::load_user_embeddings(&store, config, &user)?);
     if embeddings.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -363,7 +367,9 @@ fn cmd_calibrate(config: &Config) -> Result<()> {
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
 
-    let enrolled = direct::load_user_embeddings(&store, config, &user)?;
+    // Decrypted templates (the CLI's decryption-aware load), zeroized when
+    // the guard drops — early bails and panics included (#141).
+    let enrolled = Wiped::new(direct::load_user_embeddings(&store, config, &user)?);
     if enrolled.is_empty() {
         bail!(
             "No enrolled faces for user '{}'. Enroll first with `facelock enroll`.",
@@ -397,7 +403,7 @@ fn cmd_calibrate(config: &Config) -> Result<()> {
     // Compute all similarities between live and enrolled embeddings
     let mut similarities: Vec<f32> = Vec::new();
     for live_emb in &live_embeddings {
-        for (_, enrolled_emb) in &enrolled {
+        for (_, enrolled_emb) in enrolled.iter() {
             similarities.push(cosine_similarity(live_emb, enrolled_emb));
         }
     }
@@ -696,7 +702,9 @@ fn cmd_report(config: &Config) -> Result<()> {
     // Warm auth benchmark
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("Failed to open face store")?;
-    let embeddings = direct::load_user_embeddings(&store, config, &user)?;
+    // Decrypted templates (the CLI's decryption-aware load), zeroized when
+    // the guard drops — early bails and panics included (#141).
+    let embeddings = Wiped::new(direct::load_user_embeddings(&store, config, &user)?);
     let has_enrolled = !embeddings.is_empty();
 
     let warm_auth_ms = if has_enrolled {

--- a/crates/facelock-cli/src/commands/preview/text_only.rs
+++ b/crates/facelock-cli/src/commands/preview/text_only.rs
@@ -128,18 +128,22 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
     // a store of biometric templates that `open_existing` exists to prevent.
     // An absent database is simply "nothing enrolled yet", which preview can
     // still render: every face just comes back unrecognized.
-    let stored = match crate::direct::open_store_existing(config) {
-        Ok(store) => crate::direct::load_user_embeddings(&store, config, user)?,
-        Err(facelock_store::StoreError::Absent { .. }) => {
-            // stderr, not stdout: this is the notice that used to corrupt
-            // the frame stream (see the module docs).
-            warn(&FaceMessage::NoModelsEnrolled {
-                user: user.to_string(),
-            });
-            Vec::new()
-        }
-        Err(e) => return Err(e.into()),
-    };
+    // Decrypted templates, zeroized when the guard drops — Ctrl+C return and
+    // unwind alike. The set outlives the whole preview loop (loaded once, not
+    // per frame), which is exactly why it must not outlive the function too.
+    let stored =
+        facelock_core::types::Wiped::new(match crate::direct::open_store_existing(config) {
+            Ok(store) => crate::direct::load_user_embeddings(&store, config, user)?,
+            Err(facelock_store::StoreError::Absent { .. }) => {
+                // stderr, not stdout: this is the notice that used to corrupt
+                // the frame stream (see the module docs).
+                warn(&FaceMessage::NoModelsEnrolled {
+                    user: user.to_string(),
+                });
+                Vec::new()
+            }
+            Err(e) => return Err(e.into()),
+        });
     let threshold = config.recognition.threshold;
 
     let mut frame_count: u64 = 0;
@@ -172,7 +176,7 @@ pub fn run_direct(config: &facelock_core::Config, user: &str) -> anyhow::Result<
             .iter()
             .map(|(det, embedding)| {
                 let mut best_sim: f32 = 0.0;
-                for (_, stored_emb) in &stored {
+                for (_, stored_emb) in stored.iter() {
                     let sim = cosine_similarity(embedding, stored_emb);
                     if sim > best_sim {
                         best_sim = sim;

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -60,6 +60,53 @@ pub fn zeroize_stored_embeddings(stored: &mut [(u32, FaceEmbedding)]) {
     }
 }
 
+/// Plaintext embeddings wiped when the guard leaves scope — on every return
+/// path *and* on an unwind, which hand-written per-return-site wipes cannot
+/// cover (D11).
+///
+/// Generic over how the plaintext is held so the one guard covers every
+/// holder in the workspace: a caller's buffer (`&mut [_]`, borrowed) and an
+/// owned set (`Vec<_>`). `zeroize`'s own `Zeroizing` cannot: it needs
+/// `T: Zeroize`, which `(u32, FaceEmbedding)` is not.
+///
+/// The plaintext is reachable only through `Deref` to a shared slice: a
+/// holder can compare against the embeddings but cannot move them back out
+/// from under the wipe.
+pub struct Wiped<T>(T)
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>;
+
+impl<T> Wiped<T>
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+{
+    /// Take ownership of `inner`; every embedding in it is zeroized when the
+    /// guard drops.
+    pub fn new(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> std::ops::Deref for Wiped<T>
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+{
+    type Target = [(u32, FaceEmbedding)];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Drop for Wiped<T>
+where
+    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+{
+    fn drop(&mut self) {
+        zeroize_stored_embeddings(self.0.as_mut());
+    }
+}
+
 /// A stored face model (metadata only, without embedding)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FaceModelInfo {
@@ -774,6 +821,60 @@ mod tests {
                     "embedding for model {id} at [{i}] should be zeroed"
                 );
             }
+        }
+    }
+
+    /// The guard is readable while alive and the plaintext is gone once it
+    /// drops — the borrowed-buffer form, where the caller's own allocation
+    /// can be inspected after the guard is gone.
+    #[test]
+    fn wiped_zeroizes_the_borrowed_buffer_on_drop() {
+        let mut stored = vec![(1u32, [1.0f32; 512]), (2u32, [2.0f32; 512])];
+
+        {
+            let guard = Wiped::new(stored.as_mut_slice());
+            assert_eq!(guard.len(), 2);
+            assert_eq!(guard[0].1[0], 1.0, "guard must deref to the plaintext");
+        }
+
+        for (id, emb) in &stored {
+            assert!(
+                emb.iter().all(|&v| v == 0.0),
+                "embedding for model {id} must be zeroized after the guard drops"
+            );
+        }
+    }
+
+    /// The owned form (`Wiped<Vec<_>>`) that compare sets and caches use.
+    /// Its wipe runs through the same `Drop` impl the borrowed-slice tests
+    /// observe; freed memory cannot be inspected, so this pins the part the
+    /// owned form adds — the guard takes ownership and still derefs.
+    #[test]
+    fn wiped_owns_a_vec_and_derefs_to_it() {
+        let guard = Wiped::new(vec![(7u32, [3.0f32; 512])]);
+        assert_eq!(guard.len(), 1);
+        assert_eq!(guard[0].0, 7);
+        assert_eq!(guard[0].1[511], 3.0);
+    }
+
+    /// The reason the guard exists (D11): a panic between load and wipe must
+    /// still zeroize. Hand-written per-return-site wipes cannot cover this
+    /// path.
+    #[test]
+    fn wiped_zeroizes_on_unwind() {
+        let mut stored = vec![(1u32, [1.0f32; 512]), (2u32, [-4.0f32; 512])];
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = Wiped::new(stored.as_mut_slice());
+            panic!("simulated failure while holding plaintext embeddings");
+        }));
+        assert!(result.is_err(), "the closure must have panicked");
+
+        for (id, emb) in &stored {
+            assert!(
+                emb.iter().all(|&v| v == 0.0),
+                "embedding for model {id} must be zeroized on the unwind path"
+            );
         }
     }
 

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -7,8 +7,8 @@ use facelock_core::config::{Config, SnapshotConfig};
 use facelock_core::fs_security::{ensure_dir, ensure_private_dir, write_file};
 use facelock_core::traits::{CameraSource, FaceProcessor};
 use facelock_core::types::{
-    AuthFailureReason, CameraCaps, FaceEmbedding, Frame, FrameVarianceWindow, MatchResult,
-    best_match, device_allowed_model_ids, zeroize_stored_embeddings,
+    AuthFailureReason, CameraCaps, FaceEmbedding, Frame, FrameVarianceWindow, MatchResult, Wiped,
+    best_match, device_allowed_model_ids,
 };
 use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
@@ -463,38 +463,6 @@ fn save_snapshot(snapshot_config: &SnapshotConfig, user: &str, similarity: f32, 
     debug!(path = %path.display(), "saved auth snapshot");
 }
 
-/// Plaintext embeddings wiped when the guard leaves scope — on every return
-/// path *and* on an unwind, which the hand-written per-return-site wipes this
-/// replaces could not cover (D11).
-///
-/// Generic over how the plaintext is held so the same guard covers both sets
-/// this module handles: the caller's buffer (`&mut [_]`, borrowed) and the
-/// device-filtered compare set (`Vec<_>`, owned). `zeroize`'s own `Zeroizing`
-/// cannot: it needs `T: Zeroize`, which `(u32, FaceEmbedding)` is not.
-struct Wiped<T>(T)
-where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>;
-
-impl<T> std::ops::Deref for Wiped<T>
-where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
-{
-    type Target = [(u32, FaceEmbedding)];
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-impl<T> Drop for Wiped<T>
-where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
-{
-    fn drop(&mut self) {
-        zeroize_stored_embeddings(self.0.as_mut());
-    }
-}
-
 /// Run the camera-based authentication loop with pre-loaded (decrypted) embeddings.
 ///
 /// This is the only entry point: callers MUST load embeddings through their
@@ -533,7 +501,7 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     source: AuditSource,
     cancel: &CancelToken,
 ) -> AuthOutcome {
-    let stored = Wiped(stored);
+    let stored = Wiped::new(stored);
     let device_is_ir = camera.capabilities().is_ir;
     let ir_texture_scale = camera.capabilities().ir_texture_scale;
     let live_fingerprint = camera.capabilities().fingerprint.clone();
@@ -583,7 +551,7 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     // a lockout. Fail SOFT by construction.
     let policy = config.security.device_binding_policy();
     let allowed = device_allowed_model_ids(models, &live_fingerprint, &policy);
-    let compare_set = Wiped(
+    let compare_set = Wiped::new(
         stored
             .iter()
             .filter(|(id, _)| allowed.contains(id))

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -1192,8 +1192,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             .as_ref()
             .is_none_or(|cached| cached.user != user)
         {
-            // Assigning drops — and thereby zeroizes — any other user's set
-            // before the new one is loaded.
+            // The RHS loads first, so another user's outgoing set and the new
+            // one are briefly both resident; completing the assignment then
+            // drops — and thereby zeroizes — the old one.
             self.preview_embeddings = match self.load_user_embeddings(user) {
                 Ok(embeddings) => Some(PreviewEmbeddings {
                     user: user.to_string(),

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -4,7 +4,7 @@ use facelock_camera::MMAP_BUFFERS;
 use facelock_core::config::{Config, DeviceConfig, EncryptionMethod};
 use facelock_core::ipc::PreviewFace;
 use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::best_match;
+use facelock_core::types::{FaceEmbedding, Wiped, best_match};
 use facelock_store::FaceStore;
 use image::codecs::jpeg::JpegEncoder;
 use tracing::{debug, info, warn};
@@ -550,6 +550,28 @@ impl<C: CameraSource> CameraLease<C> {
             self.camera = None;
         }
     }
+
+    /// Whether a camera stream is currently open — in flight or held warm.
+    /// The preview embedding cache lives no longer than this is true.
+    fn holds_camera(&self) -> bool {
+        self.camera.is_some()
+    }
+}
+
+/// Decrypted embeddings held for the active preview stream.
+///
+/// `PreviewDetectFrame` is one D-Bus request per frame at roughly 10 fps, and
+/// loading through [`Handler::load_user_embeddings`] decrypts the stored
+/// templates — on a TPM-sealed store, a TPM round-trip — so a per-frame load
+/// is both a performance bug and a per-frame plaintext exposure that nothing
+/// ever wiped (#141). The set is loaded once per preview session instead and
+/// zeroized ([`Wiped`]) when the session ends: the camera closes (warm hold
+/// expired, released, shutdown), the daemon's own store mutates, or a frame
+/// arrives for a different user.
+struct PreviewEmbeddings {
+    /// The user the set was loaded for; a request for anyone else drops it.
+    user: String,
+    embeddings: Wiped<Vec<(u32, FaceEmbedding)>>,
 }
 
 pub struct Handler<C: CameraSource, E: FaceProcessor> {
@@ -576,6 +598,9 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     /// encryption method. `Some` means enroll must fail CLOSED rather than
     /// silently downgrade to plaintext biometric storage (auth is unaffected).
     sealer_init_error: Option<String>,
+    /// Per-preview-session compare set (see [`PreviewEmbeddings`]). `None`
+    /// between preview sessions; setting it back to `None` zeroizes the set.
+    preview_embeddings: Option<PreviewEmbeddings>,
 }
 
 impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
@@ -695,14 +720,23 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             tpm_sealer,
             software_sealer,
             sealer_init_error,
+            preview_embeddings: None,
         })
     }
 
     /// Close the camera if its warm hold has run out. Called from the
     /// daemon's [`CAMERA_POLL_INTERVAL`] tick; a tick that finds the handler
     /// locked simply misses, because the deadline is absolute.
+    ///
+    /// This tick is also the backstop that ends a preview session no other
+    /// arm noticed ending: whenever the camera turns out to be closed —
+    /// however it closed — the preview compare set is zeroized with it, at
+    /// most one poll interval later.
     pub fn expire_camera(&mut self, now: Instant) {
         self.lease.expire(now);
+        if !self.lease.holds_camera() {
+            self.preview_embeddings = None;
+        }
     }
 
     /// Load user embeddings, decrypting TPM-sealed or software-encrypted blobs
@@ -769,12 +803,16 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             DaemonRequest::Shutdown => {
                 info!("shutdown requested via IPC");
                 self.lease.release();
+                self.preview_embeddings = None;
                 self.shutdown_requested = true;
                 DaemonResponse::Ok
             }
 
             DaemonRequest::ReleaseCamera => {
+                // The CLI sends this when a preview exits; the session's
+                // decrypted compare set goes out with the camera.
                 self.lease.release();
+                self.preview_embeddings = None;
                 DaemonResponse::Ok
             }
 
@@ -829,6 +867,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     cancel,
                 );
                 self.lease.finish(Outcome::from(&result), &self.config);
+                // The store may have gained a template; drop (and zeroize)
+                // any preview compare set so the next frame sees it.
+                self.preview_embeddings = None;
                 result.into()
             }
 
@@ -840,6 +881,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             },
 
             DaemonRequest::RemoveModel { user, model_id } => {
+                // A deleted template must not live on — matchable — in the
+                // preview cache; the next preview frame reloads.
+                self.preview_embeddings = None;
                 match self.store.remove_model(&user, model_id) {
                     Ok(_) => DaemonResponse::Removed,
                     Err(e) => DaemonResponse::Error {
@@ -848,12 +892,17 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 }
             }
 
-            DaemonRequest::ClearModels { user } => match self.store.clear_user(&user) {
-                Ok(_) => DaemonResponse::Removed,
-                Err(e) => DaemonResponse::Error {
-                    message: format!("storage error: {e}"),
-                },
-            },
+            DaemonRequest::ClearModels { user } => {
+                // Same as RemoveModel: the cached copy of a cleared user's
+                // templates is zeroized with the rows.
+                self.preview_embeddings = None;
+                match self.store.clear_user(&user) {
+                    Ok(_) => DaemonResponse::Removed,
+                    Err(e) => DaemonResponse::Error {
+                        message: format!("storage error: {e}"),
+                    },
+                }
+            }
 
             DaemonRequest::ListDevices => {
                 use facelock_camera::{IrSource, QuirksDb, classify_ir_sources, list_devices};
@@ -1134,13 +1183,38 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             }
         };
 
-        let stored = self.load_user_embeddings(user).unwrap_or_default();
+        // Load the compare set once per preview session, not per frame (see
+        // [`PreviewEmbeddings`]). A load failure is not cached: this frame
+        // compares against nothing (every face unrecognized, as before) and
+        // the next frame retries.
+        if self
+            .preview_embeddings
+            .as_ref()
+            .is_none_or(|cached| cached.user != user)
+        {
+            // Assigning drops — and thereby zeroizes — any other user's set
+            // before the new one is loaded.
+            self.preview_embeddings = match self.load_user_embeddings(user) {
+                Ok(embeddings) => Some(PreviewEmbeddings {
+                    user: user.to_string(),
+                    embeddings: Wiped::new(embeddings),
+                }),
+                Err(e) => {
+                    debug!("could not load embeddings for preview: {e:?}");
+                    None
+                }
+            };
+        }
+        let stored: &[(u32, FaceEmbedding)] = match self.preview_embeddings.as_ref() {
+            Some(cached) => &cached.embeddings,
+            None => &[],
+        };
         let threshold = self.config.recognition.threshold;
 
         detections
             .into_iter()
             .map(|(det, embedding)| {
-                let (best_sim, _) = best_match(&embedding, &stored);
+                let (best_sim, _) = best_match(&embedding, stored);
                 PreviewFace {
                     x: det.bbox.x,
                     y: det.bbox.y,

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1283,3 +1283,146 @@ fn a_success_hold_is_what_lets_the_next_authentication_skip_the_reopen() {
         cleanup_db(&db_path);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Preview embedding cache (#141): the decrypted compare set is loaded once
+// per preview session — not once per PreviewDetectFrame — and is dropped
+// (zeroized, see facelock-core's `Wiped` tests) when the session ends.
+// The probes below flip the store *behind the handler's back* between
+// frames: a face that stays recognized proves the set was NOT reloaded,
+// and a face that stops being recognized proves the cached set is gone.
+// ---------------------------------------------------------------------------
+
+/// A handler with one enrolled `previewuser` template whose engine sees that
+/// exact face in every frame.
+fn preview_handler() -> facelock_daemon::handler::Handler<MockCamera, MockFaceEngine> {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let config = test_config();
+    let emb = fixtures::known_embedding(7);
+    let store = FaceStore::open_memory().unwrap();
+    store.add_model("previewuser", "front", &emb, "").unwrap();
+    let rate_limiter = RateLimiter::new(
+        config.security.rate_limit.max_attempts,
+        config.security.rate_limit.window_secs,
+    );
+    let factory: MockCameraFactory = Box::new(|_cfg| Ok(MockCamera::bright(64, 64, 20)));
+
+    Handler::new(
+        config,
+        MockFaceEngine::one_face(emb),
+        store,
+        rate_limiter,
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap()
+}
+
+/// One `PreviewDetectFrame` for `user`; returns whether its single face was
+/// recognized against whatever compare set the handler used.
+fn preview_frame_recognized(
+    handler: &mut facelock_daemon::handler::Handler<MockCamera, MockFaceEngine>,
+    user: &str,
+) -> bool {
+    let resp = handler.handle(DaemonRequest::PreviewDetectFrame { user: user.into() });
+    match resp {
+        DaemonResponse::DetectFrame { faces, .. } => {
+            assert_eq!(faces.len(), 1, "the mock engine reports exactly one face");
+            faces[0].recognized
+        }
+        other => panic!("expected a detect frame, got: {other:?}"),
+    }
+}
+
+#[test]
+fn preview_detect_loads_the_compare_set_once_per_session() {
+    let mut handler = preview_handler();
+
+    assert!(
+        preview_frame_recognized(&mut handler, "previewuser"),
+        "sanity: the enrolled face must be recognized on the first frame"
+    );
+
+    // Clear the store directly, bypassing the handler. A per-frame reload
+    // (the old behavior — a decrypt, and on a TPM-sealed store a TPM
+    // round-trip, per frame) would now come back empty.
+    handler.store.clear_user("previewuser").unwrap();
+
+    assert!(
+        preview_frame_recognized(&mut handler, "previewuser"),
+        "the second frame must compare against the session's cached set, not a per-frame reload"
+    );
+}
+
+#[test]
+fn release_camera_ends_the_preview_session() {
+    let mut handler = preview_handler();
+
+    assert!(preview_frame_recognized(&mut handler, "previewuser"));
+    handler.store.clear_user("previewuser").unwrap();
+
+    // The CLI sends this when a preview exits; the cached set must not
+    // survive it.
+    let resp = handler.handle(DaemonRequest::ReleaseCamera);
+    assert!(matches!(resp, DaemonResponse::Ok));
+
+    assert!(
+        !preview_frame_recognized(&mut handler, "previewuser"),
+        "after ReleaseCamera the next session must reload from the (now empty) store"
+    );
+}
+
+#[test]
+fn camera_hold_expiry_ends_the_preview_session() {
+    let mut handler = preview_handler();
+
+    assert!(preview_frame_recognized(&mut handler, "previewuser"));
+    handler.store.clear_user("previewuser").unwrap();
+
+    // The poll tick that finds the warm hold expired is the backstop that
+    // bounds a crashed preview client: the camera closes and the decrypted
+    // compare set goes with it.
+    handler.expire_camera(std::time::Instant::now() + std::time::Duration::from_secs(600));
+
+    assert!(
+        !preview_frame_recognized(&mut handler, "previewuser"),
+        "an expired warm hold must drop the cached compare set with the camera"
+    );
+}
+
+#[test]
+fn clearing_models_through_the_handler_ends_the_preview_session() {
+    let mut handler = preview_handler();
+
+    assert!(preview_frame_recognized(&mut handler, "previewuser"));
+
+    // Deleting templates through the handler must not leave a matchable
+    // cached copy resident.
+    let resp = handler.handle(DaemonRequest::ClearModels {
+        user: "previewuser".into(),
+    });
+    assert!(matches!(resp, DaemonResponse::Removed));
+
+    assert!(
+        !preview_frame_recognized(&mut handler, "previewuser"),
+        "a cleared user's templates must not keep matching from the preview cache"
+    );
+}
+
+#[test]
+fn preview_for_a_different_user_swaps_the_compare_set() {
+    let mut handler = preview_handler();
+
+    assert!(preview_frame_recognized(&mut handler, "previewuser"));
+    assert!(
+        !preview_frame_recognized(&mut handler, "otheruser"),
+        "a user with no templates must not inherit the previous user's set"
+    );
+    assert!(
+        preview_frame_recognized(&mut handler, "previewuser"),
+        "switching back must reload the first user's set"
+    );
+}

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1426,3 +1426,49 @@ fn preview_for_a_different_user_swaps_the_compare_set() {
         "switching back must reload the first user's set"
     );
 }
+
+#[test]
+fn removing_a_model_through_the_handler_ends_the_preview_session() {
+    let mut handler = preview_handler();
+
+    assert!(preview_frame_recognized(&mut handler, "previewuser"));
+
+    // Deleting one template through the handler must not leave a matchable
+    // cached copy resident — the ClearModels twin, for the single-model arm.
+    let models = handler.store.list_models("previewuser").unwrap();
+    assert_eq!(models.len(), 1, "sanity: exactly one enrolled template");
+    let resp = handler.handle(DaemonRequest::RemoveModel {
+        user: "previewuser".into(),
+        model_id: models[0].id,
+    });
+    assert!(matches!(resp, DaemonResponse::Removed));
+
+    assert!(
+        !preview_frame_recognized(&mut handler, "previewuser"),
+        "a removed template must not keep matching from the preview cache"
+    );
+}
+
+#[test]
+fn a_failed_compare_set_load_is_not_cached() {
+    let mut handler = preview_handler();
+
+    // A wrong-size blob fails the whole load (a partial compare set would
+    // silently narrow matching), so this frame compares against nothing...
+    let bad = handler
+        .store
+        .add_model_raw("previewuser", "corrupt", &[0u8; 16], false, "")
+        .unwrap();
+    assert!(
+        !preview_frame_recognized(&mut handler, "previewuser"),
+        "a failed load must degrade to an empty compare set"
+    );
+
+    // ...and the failure is not cached as the session's result: once the
+    // corrupt row is gone the next frame retries the load.
+    assert!(handler.store.remove_model("previewuser", bad).unwrap());
+    assert!(
+        preview_frame_recognized(&mut handler, "previewuser"),
+        "the frame after the store is repaired must reload, not serve a cached failure"
+    );
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -549,11 +549,14 @@ plaintext biometric templates unless `security.allow_plaintext = true`, and warn
 when it does. This never affects auth — a decrypt failure degrades to the password fallback,
 never a lockout.
 
-**In memory**, every decrypted template set lives inside a drop guard (`Wiped` in
-`facelock-core`) that zeroizes it on every exit path, unwind included: the authentication
-loop's compare set, the daemon's preview compare set (loaded once per preview session — not
-once per frame — and wiped when the camera closes, the store changes, or the user changes),
-and the `facelock bench` / `facelock-bench` benchmark paths.
+**In memory**, the long-lived compare sets are held in a drop guard (`Wiped` in
+`facelock-core`) that zeroizes them on every exit path, unwind included: the authentication
+loop's caller buffer and device-filtered compare set, the daemon's preview compare set
+(loaded once per preview session — not once per frame — and wiped when the camera closes,
+the store changes through the daemon, or the user changes), and the sets held by the
+`facelock bench` and `facelock-bench` benchmark paths. This covers the sets that persist
+across frames; transient copies elsewhere in the load and decrypt paths are not all
+guarded yet.
 
 **Hard device binding (opt-in, `security.bind_device_aad`).** When enabled, the enrolling
 camera's `device_id` is folded into the AES-GCM Additional Authenticated Data, so a template

--- a/docs/security.md
+++ b/docs/security.md
@@ -549,6 +549,12 @@ plaintext biometric templates unless `security.allow_plaintext = true`, and warn
 when it does. This never affects auth — a decrypt failure degrades to the password fallback,
 never a lockout.
 
+**In memory**, every decrypted template set lives inside a drop guard (`Wiped` in
+`facelock-core`) that zeroizes it on every exit path, unwind included: the authentication
+loop's compare set, the daemon's preview compare set (loaded once per preview session — not
+once per frame — and wiped when the camera closes, the store changes, or the user changes),
+and the `facelock bench` / `facelock-bench` benchmark paths.
+
 **Hard device binding (opt-in, `security.bind_device_aad`).** When enabled, the enrolling
 camera's `device_id` is folded into the AES-GCM Additional Authenticated Data, so a template
 sealed under one camera cannot be decrypted under another — the cryptographic complement to


### PR DESCRIPTION
## Summary

- move the D11 `Wiped` drop guard from `facelock-daemon` into `facelock-core`, one implementation, now public
- load the daemon's preview compare set once per preview session instead of decrypting per frame (on a TPM-sealed store, a TPM round-trip per frame), and zeroize it when the camera closes, the store mutates through the handler, or a frame arrives for another user
- wrap the sets held by direct-mode `facelock preview --json`, the `facelock bench` subcommand (the decryption-aware load), and the standalone `facelock-bench` tool (plaintext-only stores) in the guard
- pin the wipe in tests: drop and unwind paths in `facelock-core`, preview session lifecycle in the daemon integration tests

## Why

The guard covered only the authentication loop. The daemon's `PreviewDetectFrame` handler, the direct text preview, and both bench tools all held template sets they never wiped, and the CLI paths hold decrypted ones. Plaintext biometric embeddings therefore lingered in process memory after every preview and benchmark run.

## Validation

- `just check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just check-pam-standalone` for the PAM dependency ceiling after the `Wiped` move

Closes #214
Refs #141 (part 1, the wipe half, only; the oneshot exit-code mapping is a separate PR)
