### PR TITLE
fix(cli): run the root check before the shared config load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,6 +551,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Root refusal now precedes config-state errors** (#191): for the commands
+  dispatched through the shared config parse (`enroll`, `remove`, `clear`,
+  `list`, `test`, `preview`, `devices`, `bench`, `tpm …`, `audit`), the root
+  check moved into `main`'s dispatch gate, ahead of the config read. A
+  non-root caller with a missing or broken config now gets `Root required`
+  (or the sudo re-exec offer) instead of "no config file at …", restoring
+  the C6 ordering guarantee. Escalation hints are unchanged, `audit` keeps
+  its hard-error (never-prompt) class, and `status` still renders a broken
+  config as a finding, after its own root check.
+
 - **Debian PAM and daemon package lifecycle is opt-in and state-preserving**
   (#224): direct `pam add`/`setup --pam` now refuses an already-selected exact
   `pam-auth-update` profile before writing, using fixed-root no-follow evidence

--- a/crates/facelock-cli/src/commands/audit.rs
+++ b/crates/facelock-cli/src/commands/audit.rs
@@ -5,9 +5,10 @@ use anyhow::{Context, Result};
 use facelock_core::config::Config;
 
 pub fn run(config: &Config, tail: bool, lines: usize) -> Result<()> {
-    // DEC-6: `audit` is typically invoked scripted/non-interactively, so it
-    // hard-errors rather than offering the usual sudo re-exec prompt.
-    crate::ipc_client::require_root_scripted("sudo facelock audit")?;
+    // DEC-6: `audit` is typically invoked scripted/non-interactively, so
+    // its row in `main`'s `require_root_for` gate (C6) is the hard-error
+    // class (`require_root_scripted`) — a refusal, never a sudo re-exec
+    // prompt.
 
     if !config.audit.enabled {
         println!("Audit logging is not enabled.");

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -61,8 +61,9 @@ pub enum BenchCommand {
 pub fn run(config: &Config, command: BenchCommand) -> Result<()> {
     // DEC-6: `bench` is root by default (direct-mode access needs the 0600
     // root:root database regardless of subcommand, and auth benchmarks may
-    // need TPM access besides). Supersedes the old TPM-only conditional check.
-    crate::ipc_client::require_root("sudo facelock bench <subcommand>")?;
+    // need TPM access besides); root is established by `main`'s
+    // `require_root_for` gate (C6). Supersedes the old TPM-only conditional
+    // check.
 
     match command {
         BenchCommand::ColdAuth => cmd_cold_auth(config),

--- a/crates/facelock-cli/src/commands/clear.rs
+++ b/crates/facelock-cli/src/commands/clear.rs
@@ -5,10 +5,9 @@ use crate::ipc_client;
 use crate::message::{FaceMessage, Terminal};
 
 pub fn run(config: &Config, user: Option<String>, yes: bool) -> anyhow::Result<()> {
-    // ClearModels is root-only on the daemon side too, so demand root up front.
-    // Otherwise the user gets prompted Y/N first and only then hits AccessDenied.
-    ipc_client::require_root("sudo facelock clear")?;
-
+    // ClearModels is root-only on the daemon side too; root is demanded up
+    // front by `main`'s `require_root_for` gate (C6) — otherwise the user
+    // would be prompted Y/N first and only then hit AccessDenied.
     let user = ipc_client::resolve_user(user.as_deref());
 
     // One selection for the whole command (D1): the old code probed the bus

--- a/crates/facelock-cli/src/commands/devices.rs
+++ b/crates/facelock-cli/src/commands/devices.rs
@@ -2,11 +2,10 @@ use facelock_core::Config;
 use facelock_core::ipc::IpcDeviceInfo;
 
 use crate::backend::Backend;
-use crate::ipc_client;
 
 pub fn run(config: &Config, json: bool) -> anyhow::Result<()> {
-    // DEC-6/N13: `ListDevices` is root-only now (was facelock-group).
-    ipc_client::require_root("sudo facelock devices")?;
+    // DEC-6/N13: `ListDevices` is root-only now (was facelock-group); root
+    // is established by `main`'s `require_root_for` gate (C6).
 
     // One selection, one enumeration (D1); both transports render here. The
     // renderers used to live twice — this one and a direct copy that printed

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -37,8 +37,8 @@ fn obtain_sealer(config: &Config) -> Result<facelock_tpm::SoftwareSealer> {
 }
 
 pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm encrypt")?;
-
+    // Root is established by `main`'s `require_root_for` gate (C6) before
+    // `tpm::run` dispatches here.
     if generate_key {
         match config.encryption.method {
             EncryptionMethod::Tpm => {
@@ -144,8 +144,8 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
 }
 
 pub fn run_decrypt(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm decrypt")?;
-
+    // Root is established by `main`'s `require_root_for` gate (C6) before
+    // `tpm::run` dispatches here.
     // `open_existing`, never `create`: nothing to encrypt or decrypt means a
     // missing database is an error to report, not a file to bring into being
     // at whatever path a typo'd config names.

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -6,19 +6,34 @@ use crate::backend::Backend;
 use crate::ipc_client;
 use crate::message::{FaceMessage, Terminal, fail};
 
+/// The escalation hint `main`'s root gate (C6) names for `enroll`. When the
+/// setup marker is absent (and `--skip-setup-check` not given), the remedy
+/// the refusal names is `setup` — the command [`run`] will offer to execute
+/// it — rather than `enroll` itself.
+pub fn sudo_hint(skip_setup_check: bool) -> &'static str {
+    if !skip_setup_check && !std::path::Path::new(super::setup::SETUP_COMPLETE_MARKER).exists() {
+        "sudo facelock setup"
+    } else {
+        "sudo facelock enroll"
+    }
+}
+
 pub fn run(
     config: &Config,
     user: Option<String>,
     label: Option<String>,
     skip_setup_check: bool,
 ) -> anyhow::Result<()> {
+    // Root is established by `main`'s `require_root_for` gate, ahead of the
+    // config parse (C6, issue #191); `sudo_hint` below picks the spelling
+    // that gate escalates with.
+    //
     // Setup gate: prompt user if setup hasn't been run.
     // Setup includes model downloads, encryption, and face enrollment,
     // so if setup runs successfully we're done — no need to enroll again.
     if !skip_setup_check {
         let marker = std::path::Path::new(super::setup::SETUP_COMPLETE_MARKER);
         if !marker.exists() {
-            ipc_client::require_root("sudo facelock setup")?;
             Terminal.info(&FaceMessage::SetupNotCompleted);
             if Terminal.confirm(&FaceMessage::ConfirmRunSetupNow)? {
                 super::setup::run(false)?;
@@ -33,8 +48,6 @@ pub fn run(
             }
         }
     }
-
-    ipc_client::require_root("sudo facelock enroll")?;
 
     // Encryption posture (Plan 04): refuse plaintext enrollment unless opted in;
     // warn prominently when the opt-in is active.

--- a/crates/facelock-cli/src/commands/list.rs
+++ b/crates/facelock-cli/src/commands/list.rs
@@ -7,12 +7,11 @@ use crate::backend::Backend;
 use crate::ipc_client;
 
 pub fn run(config: &Config, user: Option<String>, json: bool) -> anyhow::Result<()> {
-    // DEC-6/N4: `ListModels` is root-only now (was facelock-group). The
-    // direct fallback needs read access to the 0600 root:root database;
-    // checking up front here gives the same interactive escalation prompt on
-    // the D-Bus path too, instead of a bare AccessDenied.
-    ipc_client::require_root("sudo facelock list")?;
-
+    // DEC-6/N4: `ListModels` is root-only now (was facelock-group) — the
+    // direct fallback needs read access to the 0600 root:root database.
+    // Root is established by `main`'s `require_root_for` gate, ahead of the
+    // config parse (C6, issue #191), so escalation — or refusal — has
+    // already happened by the time this runs.
     let user = ipc_client::resolve_user(user.as_deref());
 
     // One selection, one list operation (D1). The seam's direct read opens

--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -13,8 +13,8 @@ use crate::message::{AccessMessage, Terminal};
 pub fn run(config: &Config, json: bool, user: Option<String>) -> anyhow::Result<()> {
     // DEC-6/N13: `PreviewDetectFrame` is root-only now — it was the last
     // unprivileged consumer of a per-frame similarity score (the
-    // hill-climbing oracle N12/N13 close by construction).
-    ipc_client::require_root("sudo facelock preview")?;
+    // hill-climbing oracle N12/N13 close by construction). Root is
+    // established by `main`'s `require_root_for` gate (C6).
 
     // One user-resolution implementation (C5, issue #105). The local
     // getpwuid-only version this replaces resolved `sudo facelock preview`

--- a/crates/facelock-cli/src/commands/remove.rs
+++ b/crates/facelock-cli/src/commands/remove.rs
@@ -5,12 +5,12 @@ use crate::ipc_client;
 use crate::message::{FaceMessage, Terminal};
 
 pub fn run(config: &Config, model_id: u32, user: Option<String>, yes: bool) -> anyhow::Result<()> {
-    // C6: root check must run before the confirmation prompt below — a group
-    // member confirming a destructive action only to then hit AccessDenied
-    // is exactly the bug this ordering fixes. RemoveModel is root-only on the
-    // daemon side too, so this applies regardless of transport.
-    ipc_client::require_root(&format!("sudo facelock remove {model_id}"))?;
-
+    // C6: the root check runs before the confirmation prompt below — a user
+    // confirming a destructive action only to then hit AccessDenied is
+    // exactly the bug this ordering fixes. The check lives in `main`'s
+    // `require_root_for` gate, ahead of the config parse (issue #191);
+    // RemoveModel is root-only on the daemon side too, so it applies
+    // regardless of transport.
     let user = ipc_client::resolve_user(user.as_deref());
 
     // One selection for the whole command (D1), before the unbounded prompt.

--- a/crates/facelock-cli/src/commands/test_cmd.rs
+++ b/crates/facelock-cli/src/commands/test_cmd.rs
@@ -16,9 +16,9 @@ pub fn run(config: &Config, user: Option<String>) -> anyhow::Result<()> {
     // from rate-limit consumption (root already has unrestricted access to
     // the rate-limit table). On the daemon transport that exemption is the
     // root-only `TestAuthenticate` method, asked for explicitly, rather than
-    // something the daemon infers from this process being root. Must run
-    // before any prompt or output (C6).
-    ipc_client::require_root("sudo facelock test")?;
+    // something the daemon infers from this process being root. Root is
+    // established by `main`'s `require_root_for` gate, before any prompt,
+    // output, or the config parse itself (C6).
 
     // Check models exist — offer to run setup if missing
     if !crate::resolved::ModelFiles::probe(config).all_present() {

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -35,7 +35,27 @@ pub enum TpmCommand {
     Reseal,
 }
 
+impl TpmCommand {
+    /// The escalation hint `main`'s root gate (C6) names for each verb —
+    /// the spelling `--help` teaches, one row per subcommand.
+    pub fn sudo_hint(&self) -> &'static str {
+        match self {
+            TpmCommand::Status => "sudo facelock tpm status",
+            TpmCommand::SealKey => "sudo facelock tpm seal-key",
+            TpmCommand::UnsealKey => "sudo facelock tpm unseal-key",
+            TpmCommand::UnsealCheck => "sudo facelock tpm unseal-check",
+            TpmCommand::PcrBaseline => "sudo facelock tpm pcr-baseline",
+            TpmCommand::Encrypt { .. } => "sudo facelock tpm encrypt",
+            TpmCommand::Decrypt => "sudo facelock tpm decrypt",
+            TpmCommand::Reseal => "sudo facelock tpm reseal",
+        }
+    }
+}
+
 pub fn run(config: &Config, command: TpmCommand) -> Result<()> {
+    // Root for every verb is established by `main`'s `require_root_for`
+    // gate, ahead of the config parse (C6, issue #191); `sudo_hint` above
+    // is the spelling that gate escalates with.
     match command {
         TpmCommand::Status => status(config),
         TpmCommand::SealKey => seal_key(config),
@@ -60,8 +80,6 @@ pub fn run(config: &Config, command: TpmCommand) -> Result<()> {
 /// exit) when unseal fails — e.g. after a bound PCR changed. Used by operators to
 /// confirm whether `facelock tpm reseal` is needed, and by the TPM E2E suite.
 fn unseal_check(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm unseal-check")?;
-
     if config.encryption.method != facelock_core::config::EncryptionMethod::Tpm {
         anyhow::bail!(
             "encryption.method is not \"tpm\" (current: {:?}); nothing to unseal.",
@@ -101,8 +119,6 @@ fn unseal_check(config: &Config) -> Result<()> {
 }
 
 fn status(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm status")?;
-
     // Extract device path from TCTI string (e.g., "device:/dev/tpmrm0" -> "/dev/tpmrm0")
     let device_path = config
         .tpm
@@ -169,8 +185,6 @@ fn status(config: &Config) -> Result<()> {
 
 #[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
 fn seal_key(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm seal-key")?;
-
     #[cfg(feature = "tpm")]
     {
         let key_path = Path::new(&config.encryption.key_path);
@@ -253,8 +267,6 @@ fn seal_key(config: &Config) -> Result<()> {
 
 #[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
 fn unseal_key(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm unseal-key")?;
-
     #[cfg(feature = "tpm")]
     {
         let key_path = Path::new(&config.encryption.key_path);
@@ -319,8 +331,6 @@ fn unseal_key(config: &Config) -> Result<()> {
 /// sealed blob when PCRs are still valid, otherwise from the plaintext key backup
 /// at `encryption.key_path` if present.
 pub fn run_reseal(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm reseal")?;
-
     if config.encryption.method != facelock_core::config::EncryptionMethod::Tpm {
         anyhow::bail!(
             "`facelock tpm reseal` only applies when encryption.method = \"tpm\" \
@@ -425,8 +435,6 @@ pub fn run_reseal(config: &Config) -> Result<()> {
 }
 
 fn pcr_baseline(config: &Config) -> Result<()> {
-    crate::ipc_client::require_root("sudo facelock tpm pcr-baseline")?;
-
     println!("PCR Baseline (indices: {:?})", config.tpm.pcr_indices);
     println!("----------");
 

--- a/crates/facelock-cli/src/main.rs
+++ b/crates/facelock-cli/src/main.rs
@@ -23,7 +23,7 @@ use facelock_cli::commands::daemon::DaemonCommand;
 use facelock_cli::commands::hyprlock::HyprlockCommand;
 use facelock_cli::commands::setup::{SetupArgs, resolve_setup_plan};
 use facelock_cli::logging::Program;
-use facelock_cli::{commands, logging, message, notifications, resolved};
+use facelock_cli::{commands, ipc_client, logging, message, notifications, resolved};
 
 use args::{ConfirmArg, JsonArg, PamCli, SetupCli, UserArg};
 
@@ -185,6 +185,59 @@ enum Commands {
     },
 }
 
+/// The DEC-6 root gate for every command dispatched through the shared
+/// config parse in `main` (C6): privilege is decided *before*
+/// `resolved::ConfigLoad::read()`, so a non-root caller is refused — or
+/// offered the sudo re-exec — regardless of config state. A missing or
+/// broken config file must never answer ahead of "Root required"
+/// (issue #191).
+///
+/// Exhaustive on `Commands` with no wildcard, so a new post-config command
+/// does not compile until it is assigned a privilege class here. Two classes
+/// exist (DEC-6), and each arm names its own escalation hint, which is why
+/// this cannot collapse into a single call.
+fn require_root_for(command: &Commands) -> anyhow::Result<()> {
+    match command {
+        // Hard-error class: `audit` is typically invoked scripted or
+        // non-interactively, where a re-exec prompt is a hang, not a
+        // convenience — it refuses without ever prompting.
+        Commands::Audit { .. } => ipc_client::require_root_scripted("sudo facelock audit"),
+
+        // Interactive class: prompt + sudo re-exec on a TTY, hard error off
+        // one. Each hint reproduces the command's own spelling.
+        Commands::Enroll {
+            skip_setup_check, ..
+        } => ipc_client::require_root(commands::enroll::sudo_hint(*skip_setup_check)),
+        Commands::Remove { model_id, .. } => {
+            ipc_client::require_root(&format!("sudo facelock remove {model_id}"))
+        }
+        Commands::Clear { .. } => ipc_client::require_root("sudo facelock clear"),
+        Commands::List { .. } => ipc_client::require_root("sudo facelock list"),
+        Commands::Test { .. } => ipc_client::require_root("sudo facelock test"),
+        Commands::Preview { .. } => ipc_client::require_root("sudo facelock preview"),
+        Commands::Devices { .. } => ipc_client::require_root("sudo facelock devices"),
+        Commands::Bench { .. } => ipc_client::require_root("sudo facelock bench <subcommand>"),
+        Commands::Tpm { command } => ipc_client::require_root(command.sudo_hint()),
+
+        // Dispatched ahead of the shared parse — or, for `status`, returned
+        // before this gate is consulted. Each owns its privilege decision:
+        // `status` checks root before its first line of output, `config
+        // edit` / `daemon` / `setup` / `pam` check inside the command, and
+        // the rest are unprivileged by design (DEC-6). Reaching this arm is
+        // a dispatch bug, same as the `unreachable!` group at the bottom of
+        // `main`.
+        Commands::Setup(..)
+        | Commands::IsEnrolled { .. }
+        | Commands::Capabilities { .. }
+        | Commands::Pam { .. }
+        | Commands::Hyprlock { .. }
+        | Commands::Config { .. }
+        | Commands::Daemon { .. }
+        | Commands::Auth { .. }
+        | Commands::Status { .. } => unreachable!("not dispatched through the root gate"),
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     // Localization first: user-facing text (D10) may render before any
     // subcommand dispatch. Log/tracing output is unaffected by design (D2).
@@ -307,16 +360,28 @@ fn main() -> anyhow::Result<()> {
                 }
 
                 other => {
-                    // The one parse for this process (D7): every remaining
-                    // command consumes this Config and none re-reads the file.
-                    let loaded = resolved::ConfigLoad::read();
-
                     // `status` reports on the config file itself, so a load
-                    // failure is a finding to render, not an exit.
+                    // failure is a finding to render, not an exit. It reads
+                    // ahead of the gate below and runs its own root check
+                    // before its first line of output — the read has no
+                    // user-visible effect ahead of that refusal.
                     if let Commands::Status { json } = &other {
-                        return commands::status::run(loaded, json.json);
+                        return commands::status::run(resolved::ConfigLoad::read(), json.json);
                     }
-                    let config = loaded.require()?;
+
+                    // Root gate (C6): decided before the config file is
+                    // read, so a non-root caller learns "Root required" —
+                    // never the state of a file only root may act on
+                    // (issue #191).
+                    require_root_for(&other)?;
+
+                    // The one parse for this process (D7): every remaining
+                    // command consumes this Config and none re-reads the
+                    // file. This read and `status`'s above are exclusive
+                    // branches of one dispatch — still one read per process;
+                    // both sites are pinned by
+                    // `resolved::canonical_config_reads_are_pinned`.
+                    let config = resolved::ConfigLoad::read().require()?;
 
                     match other {
                         Commands::Enroll {

--- a/crates/facelock-cli/src/resolved.rs
+++ b/crates/facelock-cli/src/resolved.rs
@@ -3,7 +3,12 @@
 //! Two different questions, two types:
 //!
 //! - [`ConfigLoad`] — **what the file says.** `main` performs the one read and
-//!   parse for the process and hands every command a `&Config`. Commands do
+//!   parse for the process and hands every command a `&Config`. For
+//!   root-required commands the read runs *after* `main`'s `require_root_for`
+//!   gate (C6, issue #191), so a non-root caller is refused before the file
+//!   is even read — config state never answers ahead of "Root required";
+//!   `status` reads ahead of its own root check so a load failure renders as
+//!   a finding, and the read alone has no user-visible effect. Commands do
 //!   not re-read the file mid-flow; the deliberate exceptions each carry a
 //!   comment at their load site (`daemon` reloads on mtime change, `auth` is
 //!   its own one-shot process, `setup` bootstraps and edits the file,
@@ -605,18 +610,26 @@ mod tests {
     /// `Config::load()` and `load_from(config_path())` are pinned above, and
     /// neither matches the canonical read — so a command that reaches for
     /// `ConfigLoad::read()` passes both pins silently, which is exactly what
-    /// happened when `pam` grew a config read of its own. Per file, with the
-    /// reason beside it, so the next one is a decision someone makes here.
+    /// happened when `pam` grew a config read of its own. Per file *and per
+    /// count*, with the reason beside it, so the next one is a decision
+    /// someone makes here. The count matters in `main`, where placement is
+    /// load-bearing: both sites sit in one dispatch whose ordering is the C6
+    /// guarantee, and a third site would be a read the root gate does not
+    /// precede.
     #[test]
     fn canonical_config_reads_are_pinned() {
-        let allowed: &[(&str, &str)] = &[
-            // The one read for the process (D7).
-            ("main.rs", "the parse every other command consumes"),
+        let allowed: &[(&str, usize)] = &[
+            // The dispatch owns two sites — exclusive branches of one match,
+            // so still one parse per process (D7): `status` reads ahead of
+            // its own root check so a load failure renders as a finding, and
+            // every other root-required command reaches the second read only
+            // through the `require_root_for` gate (C6, issue #191).
+            ("main.rs", 2),
             // Dispatched ahead of main's parse and must survive a missing or
             // broken file: `[pam] config_dirs` decides where a service name
             // resolves, and the default list is the answer when the read
             // fails. See `commands::pam::PamDirs::system`.
-            ("commands/pam.rs", "the PAM search path, best-effort"),
+            ("commands/pam.rs", 1),
         ];
 
         // Assembled at runtime so this test's own prose does not count.
@@ -628,15 +641,19 @@ mod tests {
                 .last()
                 .unwrap()
                 .to_string();
-            if count_code_occurrences(&content, &needle) == 0 {
-                continue;
-            }
-            assert!(
-                allowed.iter().any(|(p, _)| *p == rel),
-                "{rel}: reads the config through {needle}), which only the \
-                 files listed in this test may do. Commands receive &Config \
-                 from main (see resolved::ConfigLoad); a second read is a D7 \
-                 exception and belongs in that list with its reason."
+            let count = count_code_occurrences(&content, &needle);
+            let expected = allowed
+                .iter()
+                .find(|(p, _)| *p == rel)
+                .map(|(_, n)| *n)
+                .unwrap_or(0);
+            assert_eq!(
+                count, expected,
+                "{rel}: found {count} canonical config read(s) ({needle})), \
+                 expected {expected}. Commands receive &Config from main (see \
+                 resolved::ConfigLoad); a new read site is a D7/C6 decision \
+                 and belongs in this list with its reason — in main, the root \
+                 gate must precede it."
             );
         }
     }

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -127,8 +127,9 @@ fn tpm_decrypt_refuses_before_root_non_root() {
 
 #[test]
 fn tpm_reseal_refuses_before_root_non_root() {
-    // The method check is the first thing `run_reseal` does after the root
-    // check, so its refusal text is the tightest ordering witness available.
+    // The method check is the first thing `run_reseal` does (the root check
+    // runs in main's dispatch gate, before the config parse), so its refusal
+    // text is the tightest ordering witness available.
     assert_refuses_before_output(
         &["tpm", "reseal"],
         &[

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1755,10 +1755,22 @@ runs an interactive question runs its root check **first**, before that
 prompt or any other output or side effect. `remove` and `clear` both ask a
 Y/N confirmation before deleting a face model; historically `remove`'s root
 check ran *after* that confirmation, so a non-root user would confirm a
-destructive action and only then discover it was refused — this is fixed. The same ordering applies to `status`, `devices`,
-`preview`, `test`, `audit`, `bench`, and `config edit`: the root check is
-the first statement in each command's entry point, before `Config::load()`
-or any `println!`.
+destructive action and only then discover it was refused — this is fixed.
+
+The check also precedes the config parse. For the commands dispatched
+through the shared config load (`enroll`, `remove`, `clear`, `list`, `test`,
+`preview`, `devices`, `bench`, `tpm …`, `audit`), `main` runs the root gate
+(`require_root_for`) before `ConfigLoad::read()`, so a non-root caller is
+refused before the config file is read at all — a missing or broken config
+answers ("no config file at …") only to a caller that has already passed
+the root check, never ahead of `Root required` (issue #191). Commands
+dispatched ahead of that load (`config edit`, `daemon run`,
+`daemon restart`, `setup`, `pam add`, `pam remove`) keep the root check as
+the first statement in the command's entry point, before any `println!`.
+`status` is the one exception to gate *placement*, not to ordering: it
+holds the unresolved load so a broken config renders as a finding in its
+report, and its own root check still runs before its first line of output —
+the read alone has no user-visible effect ahead of the refusal.
 
 **AccessDenied hint.** A D-Bus `AccessDenied` reply carries one actionable
 hint (`ipc_client::add_access_denied_hint`): root is required. Since almost


### PR DESCRIPTION
## Summary

- move the root check for the post-config commands (`enroll`, `remove`, `clear`, `list`, `test`, `preview`, `devices`, `bench`, `tpm …`, `audit`) into a `require_root_for` gate in `main`, ahead of `ConfigLoad::read()`
- keep `audit` in the hard-error class (`require_root_scripted`); every other gated command keeps the interactive prompt, with unchanged escalation hints
- keep `status`'s exception: it holds the unresolved load, renders a broken config as a finding, and checks root before its first line of output
- make the gate exhaustive over `Commands` with no wildcard, so a new post-config command does not compile until it is assigned a privilege class
- upgrade `resolved`'s canonical-read pin from per-file to per-count: `main.rs` holds exactly two exclusive read sites, keeping the parse at one per process (D7)
- update the C6 ordering guarantee in `docs/contracts.md` and the changelog

## Why

A non-root caller with a missing or broken config saw "no config file at …" before any privilege check, because the shared `ConfigLoad::read()`/`require()` ran ahead of each command's in-body root check. That contradicts C6, which promises the root check before `Config::load()` or any output, and it reports the state of a file only root may act on. The gate now decides privilege before the file is read.

## Validation

- `just check`
- `cargo test -p facelock-cli --test cli_smoke` as non-root with `FACELOCK_CONFIG=/nonexistent/nope.toml`, so all 18 C6 rows execute unskipped
- pty checks that `list` still offers the sudo re-exec prompt and `audit` still hard-errors without one (the C6 rows close stdin, so they cannot distinguish escalation class)

Fixes #191
