### PR TITLE
fix(auth): give each oneshot rejection class its own exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -601,6 +601,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its hard-error (never-prompt) class, and `status` still renders a broken
   config as a finding, after its own root check.
 
+- **Oneshot exit codes carry the rejection class** (#141): `facelock auth`
+  now exits 3 for a rate-limited rejection, 4 for a suppressed attempt (no
+  enrolled models with `security.suppress_unknown`), and 5 when every
+  captured frame was dark; every other pre-flight rejection keeps exit 2.
+  Previously all of them collapsed to 2, so daemon unavailability silently
+  softened a rate-limited rejection from `PAM_AUTH_ERR` to `PAM_IGNORE`, and
+  a dark scan exited 1 (`PAM_AUTH_ERR`) where the daemon transport abstains.
+  Exit 0, 1 and 2 keep their historical meanings; the new codes come only
+  from the space an older PAM module maps to `PAM_IGNORE`, so a module
+  predating the split degrades to the old collapsed behavior instead of
+  regressing. The full table and its compatibility invariants are frozen in
+  `docs/contracts.md`.
 - **Debian PAM and daemon package lifecycle is opt-in and state-preserving**
   (#224): direct `pam add`/`setup --pam` now refuses an already-selected exact
   `pam-auth-update` profile before writing, using fixed-root no-follow evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,7 +612,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the space an older PAM module maps to `PAM_IGNORE`, so a module
   predating the split degrades to the old collapsed behavior instead of
   regressing. The full table and its compatibility invariants are frozen in
-  `docs/contracts.md`.
+  `docs/contracts.md`. Two failure paths that wrongly produced exit 1
+  (`PAM_AUTH_ERR`) now exit 2 as the storage class, matching the daemon: a
+  failed embeddings load or decrypt (a TPM unseal broken by rotated PCRs
+  failed every attempt, locking out a `required` stack with the correct
+  password), and a failed model-list read (which folded into an empty
+  compare set, a guaranteed no-match that charged the rate limit — the
+  hazard the daemon handler refuses per C3/#105).
 - **Debian PAM and daemon package lifecycle is opt-in and state-preserving**
   (#224): direct `pam add`/`setup --pam` now refuses an already-selected exact
   `pam-auth-update` profile before writing, using fixed-root no-follow evidence

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -1,6 +1,10 @@
 //! One-shot authentication subcommand.
 //!
-//! Exit codes: 0 = matched, 1 = no match/timeout, 2 = error.
+//! Exit codes: 0 = matched, 1 = scanned and not matched, 2 = error / no
+//! opinion, 3 = rate limited, 4 = suppressed, 5 = all frames dark. The full
+//! table and its compatibility invariants are frozen in docs/contracts.md
+//! ("facelock auth Exit Codes"); [`oneshot_exit_code`] and
+//! [`EXIT_SUPPRESSED`] are the implementation.
 
 use std::path::Path;
 
@@ -113,17 +117,15 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
         &caps,
         AuditSource::Oneshot,
     ) {
-        // Every pre-flight rejection exits 2 ("error"), which the PAM module
-        // maps to PAM_IGNORE — the same code the deleted mirror used for each
-        // gate, so a rate-limited or not-enrolled user still falls through to
-        // password rather than registering a failed match (exit 1). The
-        // suppressed / not-enrolled / rate-limited distinction is carried by
-        // the audit record and the tracing output, not the exit code.
-        //
-        // `oneshot_exit_code` is the single table, so the recommendation to
-        // stop collapsing these classes has one place to land. It cannot
-        // change anything today: no pre-flight gate produces the one class
-        // that maps to 1 (the camera is not open yet).
+        // Each pre-flight rejection exits under its class's own code
+        // (#141), so the PAM module can give it the same consequence the
+        // daemon transport does instead of reading every rejection as "no
+        // opinion" (exit 2) — which is what daemon unavailability used to
+        // buy: a rate-limited user's PAM_AUTH_ERR softened to PAM_IGNORE
+        // whenever PAM fell back to this path. A module older than the split
+        // maps the new codes back to PAM_IGNORE, exactly the collapsed
+        // behavior it always had. The table and its invariants are frozen in
+        // docs/contracts.md ("facelock auth Exit Codes").
         debug!(?resp, "pre-check short-circuit");
 
         // The only marker work a *rejected* attempt performs, and the reason
@@ -132,10 +134,7 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
         // side of the rate limiter when a marker *write* is not.
         clear_marker_the_store_contradicts(&config, &store, &user);
 
-        return match resp {
-            AuthOutcome::Error { kind, .. } => oneshot_exit_code(kind),
-            _ => 2,
-        };
+        return preflight_exit_code(&resp);
     }
 
     // The user's model list, read before anything opens the camera. The
@@ -295,8 +294,10 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
             failure_reason,
             ..
         }) => {
-            // Exit code stays 1 (PAM falls through to password); the reason is
-            // diagnostic only.
+            // Exit 1 means exactly this arm: the scan ran and did not match.
+            // The camera-failure class that used to share it (all frames
+            // dark) now exits under its own code, so this is the only place
+            // the binary can say "not you". The reason is diagnostic only.
             info!(
                 user = %user,
                 similarity = format!("{similarity:.4}"),
@@ -307,8 +308,10 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
         }
         AuthOutcome::Cancelled => {
             // Already audited as `cancelled` by the auth loop. Exit 2 is the
-            // existing "no opinion" code, which PAM maps to PAM_IGNORE — the
-            // contract is unchanged, nothing new is added to it.
+            // "no opinion" code, which every module generation maps to
+            // PAM_IGNORE — the same abstention the daemon transport's frozen
+            // "cancelled" message produces. An abandoned attempt gets no code
+            // of its own: it is the absence of an answer, not a class of one.
             info!(user = %user, duration_ms, "cancelled");
             2
         }
@@ -514,6 +517,31 @@ fn register_cancel_signals(cancel: &CancelToken) {
     }
 }
 
+/// Exit code for [`AuthOutcome::Suppressed`] (#141). Not an [`ErrorKind`],
+/// so it cannot have a row in [`oneshot_exit_code`]'s exhaustive match; this
+/// constant is its entry in the same frozen table (docs/contracts.md,
+/// "facelock auth Exit Codes"). A module that knows the code maps it to
+/// PAM_AUTHINFO_UNAVAIL — the consequence the daemon transport's `-3`
+/// sentinel already had — and an older module maps it to PAM_IGNORE, the
+/// collapsed pre-#141 behavior.
+const EXIT_SUPPRESSED: i32 = 4;
+
+/// The process exit code for a pre-flight short-circuit outcome.
+///
+/// Split from its one call site so the non-`Error` arms are pinned by test
+/// the same way [`oneshot_exit_code`]'s table is.
+fn preflight_exit_code(resp: &AuthOutcome) -> i32 {
+    match resp {
+        AuthOutcome::Error { kind, .. } => oneshot_exit_code(*kind),
+        AuthOutcome::Suppressed => EXIT_SUPPRESSED,
+        // Not-enrolled without `suppress_unknown` (the daemon transport's
+        // plain `-1` reply) and anything unforeseen: "no opinion". The camera
+        // never opened on this path, so exit 1's "scanned and not matched" is
+        // not available to it by construction.
+        _ => 2,
+    }
+}
+
 /// The process exit code for a rejection of class `kind`.
 ///
 /// The oneshot binary is spawned by the PAM module, which turns this number
@@ -522,23 +550,36 @@ fn register_cancel_signals(cancel: &CancelToken) {
 ///
 /// Exhaustive on purpose: a new class must be assigned a code here.
 ///
-/// Today only the camera-produced class earns exit 1; every rejection reached
-/// before the camera collapses to 2 (PAM_IGNORE). That collapse is itself a
-/// defect — it softens a rate-limited rejection whenever the daemon is
-/// unavailable and PAM falls back to this path — but fixing it changes PAM
-/// semantics under `required`/`requisite` stacks and belongs in its own
-/// reviewed change. This function is where that fix will land.
+/// The codes are a frozen contract (docs/contracts.md, "facelock auth Exit
+/// Codes") with three invariants: exit 0, 1 and 2 keep their historical
+/// meanings permanently; every newer code is allocated from the space an
+/// older module already maps to PAM_IGNORE (so old module + new binary
+/// degrades to the pre-split collapse and regresses nothing); and the
+/// module's arm for unknown codes stays PAM_IGNORE (so new module + old
+/// binary is unchanged too). Within that frame, each class whose
+/// daemon-transport consequence is not PAM_IGNORE carries its own code, so
+/// daemon unavailability no longer changes what PAM concludes (#141).
+/// [`EXIT_SUPPRESSED`] is the companion code for the suppressed outcome,
+/// which is not an `ErrorKind`.
 fn oneshot_exit_code(kind: ErrorKind) -> i32 {
     match kind {
-        // The camera produced no usable image. Not an error the stack should
-        // ignore, and not a non-match either; exit 1 keeps PAM falling
-        // through to the password.
-        ErrorKind::AllFramesDark => 1,
+        // The one pre-flight class whose daemon consequence is a deliberate
+        // failure (PAM_AUTH_ERR): an exhausted face-auth budget must not
+        // soften to fall-through just because the daemon was unreachable.
+        ErrorKind::RateLimited => 3,
+        // The camera produced no usable image: not a non-match, and under
+        // the daemon transport not a failure either — its rendered message
+        // maps to PAM_IGNORE. Moved off exit 1 (which is frozen as "scanned
+        // and not matched") to a code both module generations read as the
+        // same abstention the daemon produces.
+        ErrorKind::AllFramesDark => 5,
+        // Every remaining class means "face auth cannot answer here": both
+        // transports abstain (PAM_IGNORE), so they share the historical
+        // catch-all code.
         ErrorKind::Disabled
         | ErrorKind::SshSession
         | ErrorKind::LidClosed
         | ErrorKind::Storage
-        | ErrorKind::RateLimited
         | ErrorKind::RateLimitCheckFailed
         | ErrorKind::IrRequired
         | ErrorKind::Y16BitDepthRequired
@@ -548,7 +589,10 @@ fn oneshot_exit_code(kind: ErrorKind) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{StartupAbort, oneshot_exit_code, start_engine_then_camera};
+    use super::{
+        EXIT_SUPPRESSED, StartupAbort, oneshot_exit_code, preflight_exit_code,
+        start_engine_then_camera,
+    };
     use facelock_core::config::Config;
     use facelock_core::types::MatchResult;
     use facelock_daemon::audit::AuditSource;
@@ -677,8 +721,10 @@ mod tests {
             (ErrorKind::LidClosed, "lid closed", "error", 2),
             (ErrorKind::Storage, "storage error: boom", "error", 2),
             // Frozen: PAM reads this one as a deliberate lockout
-            // (PAM_AUTH_ERR, no oneshot retry).
-            (ErrorKind::RateLimited, "rate limited", "rate_limited", 2),
+            // (PAM_AUTH_ERR, no oneshot retry) — on the daemon transport via
+            // the message, on the oneshot transport via exit 3 (#141). An
+            // older module reads 3 as PAM_IGNORE, the pre-#141 collapse.
+            (ErrorKind::RateLimited, "rate limited", "rate_limited", 3),
             (
                 ErrorKind::RateLimitCheckFailed,
                 "rate limit check failed: boom",
@@ -698,7 +744,11 @@ mod tests {
                 "error",
                 2,
             ),
-            (ErrorKind::AllFramesDark, "all frames dark", "error", 1),
+            // Exit 5, not 1: exit 1 is frozen as "scanned and not matched",
+            // and the daemon transport abstains (PAM_IGNORE) on a dark scan,
+            // so the oneshot side now does too — under every module
+            // generation (#141).
+            (ErrorKind::AllFramesDark, "all frames dark", "error", 5),
             (ErrorKind::Internal, "boom", "error", 2),
         ];
 
@@ -734,6 +784,56 @@ mod tests {
                 "{kind:?} has no row in the coupling table"
             );
         }
+    }
+
+    /// Invariants 1 and 2 of the exit-code contract (docs/contracts.md,
+    /// "facelock auth Exit Codes"): exit 0 and 1 belong to the matched /
+    /// scanned-and-not-matched outcomes permanently, so no rejection class
+    /// may claim either — every class code comes from the space (2 and up)
+    /// that a module predating it maps to PAM_IGNORE. This is what makes the
+    /// upgrade window safe: a new binary under an old module can only ever
+    /// degrade a rejection to the historical collapse, never turn one into a
+    /// success or a non-match.
+    #[test]
+    fn rejection_classes_never_claim_the_match_codes() {
+        for kind in ErrorKind::ALL {
+            let code = oneshot_exit_code(*kind);
+            assert!(
+                code >= 2,
+                "{kind:?} exits {code}: 0 and 1 are frozen for matched / no-match"
+            );
+        }
+        // Compile-time: the suppressed code is a constant, so its half of
+        // the invariant needs no runtime assert.
+        const { assert!(EXIT_SUPPRESSED >= 2, "suppressed may not claim 0 or 1") }
+    }
+
+    /// The suppressed outcome is not an `ErrorKind`, so it has no row in the
+    /// coupling table; its exit code is pinned here instead. 4 is frozen
+    /// protocol: the module maps it to PAM_AUTHINFO_UNAVAIL, the same
+    /// consequence the daemon transport's `-3` sentinel produces.
+    #[test]
+    fn the_preflight_short_circuit_pins_its_non_error_codes() {
+        assert_eq!(EXIT_SUPPRESSED, 4, "suppressed exit code is frozen");
+        assert_eq!(preflight_exit_code(&AuthOutcome::Suppressed), 4);
+        // A rejection class keeps its own code through the short-circuit.
+        assert_eq!(
+            preflight_exit_code(&AuthOutcome::error(ErrorKind::RateLimited)),
+            3
+        );
+        // Not-enrolled without suppress_unknown: a plain "no opinion", never
+        // exit 1 — the camera did not open, so nothing was scanned.
+        assert_eq!(
+            preflight_exit_code(&AuthOutcome::AuthResult(MatchResult {
+                matched: false,
+                model_id: None,
+                label: None,
+                similarity: 0.0,
+                face_detected: false,
+                failure_reason: None,
+            })),
+            2
+        );
     }
     use facelock_daemon::rate_limit::RateLimiter;
     use facelock_store::FaceStore;

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -170,7 +170,22 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
     // the camera-lifecycle work moved that line below the camera open — would
     // have handed every one of them a veto.
     converge_enrollment_marker(&config, &user, listed.as_ref().ok().map(|m| m.len() as u32));
-    let models = listed.unwrap_or_default();
+
+    // A storage failure here must surface as an error, never fold into an
+    // empty model list (C3, issue #105) — the same refusal the daemon
+    // handler makes, in the same words: empty `models` means an empty
+    // device-allowed set, a guaranteed "no match" (exit 1, PAM_AUTH_ERR),
+    // and a rate-limit charge for an attempt the user never got to make —
+    // retries then walk straight into a lockout. Exit under the storage
+    // class instead (2, PAM_IGNORE): the daemon maps the identical failure
+    // to its `-2` error reply, which PAM reads the same way.
+    let models = match listed {
+        Ok(m) => m,
+        Err(e) => {
+            error!(user = %user, "failed to list models: {e}");
+            return oneshot_exit_code(ErrorKind::Storage);
+        }
+    };
 
     // Signals, before anything that turns the camera on. `facelock auth` is a
     // one-shot: exit *is* the release, so the job of a signal is to end the
@@ -235,13 +250,20 @@ pub fn run(user: String, config_path: Option<String>, verbose: u8) -> i32 {
 
     // Load embeddings through the decryption-aware path so the oneshot binary
     // handles encrypted templates (encrypt-by-default, Plan 04) — the bare
-    // `auth::authenticate` helper reads plaintext only. Decrypt failure degrades
-    // to no-match (exit 1 via an empty compare set), never a hard error.
+    // `auth::authenticate` helper reads plaintext only.
+    //
+    // A failed load is a storage fault, not evidence about the face: the
+    // first failing row fails the whole load (see facelock-daemon's
+    // embeddings module), so a TPM unseal broken by rotated PCRs lands here
+    // on every attempt. Exit 1 is frozen as "scanned and not matched" and
+    // would fail a `required` stack against the correct password — a
+    // lockout, not a fallback. Exit under the storage class (2, PAM_IGNORE),
+    // matching the daemon handler's `-2` storage reply for the same failure.
     let mut stored = match crate::direct::load_user_embeddings(&store, &config, &user) {
         Ok(v) => v,
         Err(e) => {
             error!(user = %user, "failed to load embeddings: {e}");
-            return 1;
+            return oneshot_exit_code(ErrorKind::Storage);
         }
     };
 
@@ -806,6 +828,34 @@ mod tests {
         // Compile-time: the suppressed code is a constant, so its half of
         // the invariant needs no runtime assert.
         const { assert!(EXIT_SUPPRESSED >= 2, "suppressed may not claim 0 or 1") }
+    }
+
+    /// `run()`'s failure exits, pinned at the source (the function needs a
+    /// camera, so its literals cannot be pinned by calling it). Exit 1 is
+    /// frozen as "scanned and not matched", so the only site allowed to
+    /// produce it is the no-match arm of the auth-response match — a bare
+    /// return of 1 is an ad-hoc failure exit that once turned a broken TPM
+    /// unseal into PAM_AUTH_ERR on every attempt (a lockout under a
+    /// `required` stack). And a failed model-list read must hard-error like
+    /// the daemon handler (C3, #105), never degrade to an empty compare set
+    /// that guarantees exit 1 and charges the rate limit.
+    #[test]
+    fn run_has_no_ad_hoc_failure_exits() {
+        let src = include_str!("auth.rs");
+        // Needles assembled at runtime so this test's own literals cannot
+        // satisfy them (include_str! sees this file, tests included).
+        let ad_hoc_exit_one = ["return ", "1;"].concat();
+        assert!(
+            !src.contains(&ad_hoc_exit_one),
+            "exit 1 must only come from the no-match arm; storage-shaped \
+             failures exit via oneshot_exit_code(ErrorKind::Storage)"
+        );
+        let folded_list_error = ["listed", ".unwrap_or_default()"].concat();
+        assert!(
+            !src.contains(&folded_list_error),
+            "a failed model-list read must hard-error (C3/#105), not degrade \
+             to an empty compare set"
+        );
     }
 
     /// The suppressed outcome is not an `ErrorKind`, so it has no row in the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -505,7 +505,11 @@ facelock auth --user alice              # authenticate
 facelock auth --user alice --config /etc/facelock/config.toml
 ```
 
-Exit codes: 0 = matched, 1 = no match, 2 = error.
+Exit codes: 0 = matched, 1 = scanned and not matched, 2 = error / no
+opinion, 3 = rate limited, 4 = suppressed (no enrolled models with
+`security.suppress_unknown`), 5 = all frames dark. The full table and its
+compatibility invariants are frozen in `docs/contracts.md` ("facelock auth
+Exit Codes").
 
 ## facelock tpm
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1966,11 +1966,49 @@ and never a correct one.
 
 ### facelock auth Exit Codes
 
-| Code | Meaning | PAM Code |
-|------|---------|----------|
-| 0 | Face matched | PAM_SUCCESS |
-| 1 | No match / timeout / dark | PAM_AUTH_ERR |
-| 2 | Error / no enrolled faces | PAM_IGNORE |
+The exit code is the only thing the PAM module learns from the oneshot
+fallback, and the two sides upgrade at different moments: a package update
+replaces `/usr/bin/facelock` on disk while every long-lived PAM host (a screen
+locker, `sshd`) keeps the `pam_facelock.so` it already loaded. There is no
+version handshake — the module maps the number and nothing else — so the table
+is governed by three frozen invariants:
+
+1. **Exit 0, 1 and 2 keep their meanings permanently.** 0 = matched, 1 =
+   scanned and not matched, 2 = error / no opinion. They are never redefined
+   or repurposed; a class that leaves one of them moves to a *new* code, never
+   onto a changed meaning of an old one.
+2. **New codes are allocated only from the space an older module already maps
+   to `PAM_IGNORE`** (any code ≥ 3 it does not know). Old module + new binary
+   therefore degrades to the pre-split collapse: it loses the class
+   distinction, and regresses nothing.
+3. **The module's arm for unknown codes stays `PAM_IGNORE`**, so new module +
+   old binary is unchanged too. The same arm absorbs a binary killed by a
+   signal (no exit code; the module reads it as 2).
+
+| Code | Class | PAM code (module ≥ 0.2.0) | PAM code (older module) |
+|------|-------|---------------------------|-------------------------|
+| 0 | Face matched | `PAM_SUCCESS` | `PAM_SUCCESS` |
+| 1 | Scanned, no match | `PAM_AUTH_ERR` | `PAM_AUTH_ERR` |
+| 2 | Error / no opinion: disabled, SSH, lid closed, storage, rate-limit check failed, IR required, unverified Y16, internal, cancelled, not enrolled | `PAM_IGNORE` | `PAM_IGNORE` |
+| 3 | Rate limited | `PAM_AUTH_ERR` | `PAM_IGNORE` |
+| 4 | Suppressed (no enrolled models + `suppress_unknown`) | `PAM_AUTHINFO_UNAVAIL` | `PAM_IGNORE` |
+| 5 | All frames dark | `PAM_IGNORE` | `PAM_IGNORE` |
+
+Codes 3–5 exist so the oneshot fallback carries the same PAM consequence per
+class as the daemon transport: rate limited → `PAM_AUTH_ERR`, suppressed
+(`-3`) → `PAM_AUTHINFO_UNAVAIL`, dark scan → `PAM_IGNORE`. Before the split
+every pre-flight rejection collapsed to exit 2, so daemon unavailability
+silently softened a rate-limited rejection from `PAM_AUTH_ERR` to
+`PAM_IGNORE`; a dark scan diverged the other way, exiting 1 (`PAM_AUTH_ERR`)
+where the daemon abstains. Benign under the recommended `sufficient`
+stacking; wrong under `required`/`requisite` or an `[authinfo_unavail=...]`
+action.
+
+The binary's half of the table is pinned in
+`crates/facelock-cli/src/commands/auth.rs`
+(`every_rejection_class_pins_its_message_audit_label_and_exit_code`,
+`rejection_classes_never_claim_the_match_codes`,
+`the_preflight_short_circuit_pins_its_non_error_codes`).
 
 ## Release Channels and APT Paths
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1979,14 +1979,23 @@ is governed by three frozen invariants:
    onto a changed meaning of an old one.
 2. **New codes are allocated only from the space an older module already maps
    to `PAM_IGNORE`** (any code ≥ 3 it does not know). Old module + new binary
-   therefore degrades to the pre-split collapse: it loses the class
-   distinction, and regresses nothing.
+   can therefore only move a class's consequence to `PAM_IGNORE` — never to
+   `PAM_SUCCESS` or `PAM_AUTH_ERR`. For rate limited (3) and suppressed (4),
+   which were exit 2 before the split, that is byte-for-byte the pre-split
+   behavior. For all frames dark (5), moved off exit 1, it is a deliberate
+   semantic change the moment the new binary ships: a dark scan stops
+   failing the stack (`PAM_AUTH_ERR`) and abstains — the daemon transport's
+   consequence — under every module generation.
 3. **The module's arm for unknown codes stays `PAM_IGNORE`**, so new module +
    old binary is unchanged too. The same arm absorbs a binary killed by a
    signal (no exit code; the module reads it as 2).
 
-| Code | Class | PAM code (module ≥ 0.2.0) | PAM code (older module) |
-|------|-------|---------------------------|-------------------------|
+The "new module" column below is the module that ships alongside this table
+(the same release as the binary emitting codes 3–5); every earlier module
+maps those codes through its unknown-code arm.
+
+| Code | Class | PAM code (new module) | PAM code (older module) |
+|------|-------|-----------------------|-------------------------|
 | 0 | Face matched | `PAM_SUCCESS` | `PAM_SUCCESS` |
 | 1 | Scanned, no match | `PAM_AUTH_ERR` | `PAM_AUTH_ERR` |
 | 2 | Error / no opinion: disabled, SSH, lid closed, storage, rate-limit check failed, IR required, unverified Y16, internal, cancelled, not enrolled | `PAM_IGNORE` | `PAM_IGNORE` |
@@ -2003,6 +2012,29 @@ silently softened a rate-limited rejection from `PAM_AUTH_ERR` to
 where the daemon abstains. Benign under the recommended `sufficient`
 stacking; wrong under `required`/`requisite` or an `[authinfo_unavail=...]`
 action.
+
+Storage-shaped failures during the attempt — a model list that cannot be
+read, an embedding set that cannot be loaded or decrypted (a TPM unseal
+broken by rotated PCRs lands here on every attempt) — exit 2, the storage
+class, exactly as the daemon's `-2` storage reply does. Neither may fold
+into exit 1: an empty compare set is a guaranteed "no match" that charges
+the rate limit and, under a `required` stack, locks the user out with the
+correct password in hand (the daemon handler refuses the same fold; C3,
+issue #105).
+
+**Residual transport divergence.** With the classes above aligned, one
+divergence remains between a current module's two transports: a non-match
+where **no face was seen** (empty chair, `recognition.no_face_timeout_secs`,
+nothing above the detector threshold). The daemon reply carries that as
+`-1`/no-face and PAM abstains (`PAM_IGNORE`); the oneshot exit code has no
+face-seen channel, so the same attempt exits 1 (`PAM_AUTH_ERR`). Closing it
+needs another additive code under the same three invariants. During the
+upgrade window an older module additionally reads codes 3 and 4 as
+`PAM_IGNORE` (invariant 2) — the daemon transport under that same older
+module already carries both classes in-band, so the two transports keep
+today's divergence until the module updates. Timeouts (`PAM_AUTH_ERR`),
+cancellation (`PAM_IGNORE`), and camera/storage/engine failures
+(`PAM_IGNORE`) agree across transports.
 
 The binary's half of the table is pinned in
 `crates/facelock-cli/src/commands/auth.rs`

--- a/man/facelock.1
+++ b/man/facelock.1
@@ -861,7 +861,17 @@ exits 2 with clap's unrecognized-subcommand error on stderr and nothing on
 stdout, which a caller reads as "no capabilities at all".
 .PP
 .B facelock auth
-exits 0 when the face matched, 1 when it did not, and 2 on error.
+exits 0 when the face matched, 1 when a scan ran and did not match, 2 on an
+error or when face authentication has no opinion (disabled, SSH session, lid
+closed, storage failure, IR required, cancelled, not enrolled), 3 when the
+user is rate limited, 4 when the attempt was suppressed (no enrolled models
+with
+.BR security.suppress_unknown ),
+and 5 when every captured frame was dark. Codes 3\-5 let the PAM module give
+these classes the same consequence in oneshot mode as over D\-Bus; a module
+older than the split reads them as "no opinion" and falls through. The full
+table and its compatibility invariants are in
+.IR docs/contracts.md .
 .SH SECURITY
 The default configuration requires an IR camera
 .RB ( security.require_ir=true ).


### PR DESCRIPTION
## Summary

- allocate class-carrying exit codes in `facelock auth`: 3 = rate limited, 4 = suppressed, 5 = all frames dark; every other pre-flight rejection keeps exit 2
- move `AllFramesDark` off exit 1, so a dark scan abstains (`PAM_IGNORE`) like the daemon transport instead of failing the stack
- exit storage-shaped mid-attempt failures as the storage class (2, `PAM_IGNORE`) instead of 1: a failed embeddings load/decrypt (a TPM unseal broken by rotated PCRs failed every attempt, a lockout under a `required` stack), and a failed model-list read (which folded into an empty compare set, a guaranteed no-match that charged the rate limit; the daemon refuses the same fold per C3/#105)
- freeze the contract in `docs/contracts.md`: 0/1/2 keep their meanings permanently, new codes come only from the space an older module maps to `PAM_IGNORE`, the module's unknown-code arm stays `PAM_IGNORE`; invariant 2 names the dark-scan semantic change rather than claiming no regression, and the residual transport divergence (no-face non-match: daemon abstains, oneshot fails) is listed
- pin the binary's side by test: coupling table updated, no rejection class may claim exit 0 or 1, `Suppressed` and the pre-flight short-circuit get their own pins, and a source-pin test forbids bare exit-1 returns and the empty-list fold
- binary side only: `crates/pam-facelock` is untouched; the module's widened mapping stacks on top of this branch (#273)

## Why

The oneshot binary collapses every pre-flight rejection to exit 2, which PAM reads as `PAM_IGNORE`, while the daemon transport gives the same classes `PAM_AUTH_ERR` (rate limited) and `PAM_AUTHINFO_UNAVAIL` (suppressed). PAM falls back to oneshot whenever the daemon is unavailable, so daemon unavailability silently softened rate limiting under `required`/`requisite` stacks. For existing modules the rate-limited and suppressed behavior is byte-identical to today (new codes map to `PAM_IGNORE`); dark scans and storage-shaped failures deliberately change from `PAM_AUTH_ERR` to the daemon's abstention.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`
- `just check`, `just check-pam-standalone`
- `just pot` regenerated with no catalog change for this half
- arch container smoke, package lifecycle, and layout tiers (run on the stacked tree)
- not run: `just test-arch-oneshot` — needs a live camera; awaits a maintainer hardware sitting

Refs #141
