### PR TITLE
build(deb): gate release archives on error-severity lintian tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
             libv4l-dev \
             libwayland-dev \
             libxkbcommon-dev \
+            lintian \
             pkg-config \
             python3 \
             ripgrep \

--- a/.github/workflows/scripts/validate-deb.sh
+++ b/.github/workflows/scripts/validate-deb.sh
@@ -69,4 +69,26 @@ dpkg-deb --extract "$DEB_FILE" "$EXTRACT_ROOT"
   "$EXTRACT_ROOT/usr/lib/facelock/libonnxruntime.so" \
   "$EXTRACT_ROOT/usr/share/doc/facelock/onnxruntime"
 
+echo ""
+echo "=== lintian ==="
+command -v lintian >/dev/null 2>&1 || {
+  echo "FAIL: lintian is not installed in the validation environment" >&2
+  exit 1
+}
+# Severity floor: the gate fails on error-severity tags only. Errors are
+# Debian policy violations; the warning and lower tags this package carries
+# (no-manual-page and similar) are advisory, and gating on them would leave a
+# first lintian gate on a shipping package permanently red. Lintian still
+# prints them for review.
+#
+# Suppressed error tags, each a deliberate deviation:
+# - aliased-location: the PAM module deliberately ships at
+#   /lib/security/pam_facelock.so (docs/contracts.md, canonical-path table and
+#   module probe order; the required-file CHECKS above pin the same path).
+#   Trixie and Resolute lintian both report the merged-/usr alias as an error,
+#   but moving the module is a packaging-semantics change, not a validation
+#   change. As of lintian 2.122/2.129 this placement is the package's only
+#   error-severity source; anything new fails the gate.
+lintian --fail-on error --suppress-tags aliased-location "$DEB_FILE"
+
 echo "=== .deb validation passed ==="

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2024,6 +2024,11 @@ without selecting it. Exact known legacy-copy migration belongs to
 administrator-owned shadow. Package validation requires the installed TPM
 command surface and the suite-native `libtss2` dependency closure.
 
+Release validation runs lintian on every built binary package and fails on
+error-severity tags. Deliberate deviations are suppressed in
+`.github/workflows/scripts/validate-deb.sh`, each with a recorded reason;
+warning and lower severities are reported without gating.
+
 Compat 13's generated `dh_installtmpfiles` post-install snippet is the sole
 install-time tmpfiles activation and invokes `systemd-tmpfiles` for
 `facelock.conf` only. The source `postinst` never runs a global tmpfiles create,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -136,6 +136,13 @@ with Rust 1.95.0 through the immutable `dtolnay/rust-toolchain` action commit
 `4360b52568e2003a75bf9bc1d59f33a8e3fc893c`, matching the repository's pinned
 1.95 toolchain channel.
 
+Every built `.deb` passes `.github/workflows/scripts/validate-deb.sh` in the
+suite container before staging: package identity, forbidden transition fields,
+generated dependencies, the required file set, the hash-verified ORT bundle,
+and a lintian run that fails on error-severity tags. Deliberate deviations are
+suppressed in that script, each with a recorded reason; warnings are printed
+for review but do not gate.
+
 ### Supported release matrix
 
 `dist/release-matrix.json` is the checked-in authority. The release workflow,

--- a/test/deb-source-contract.sh
+++ b/test/deb-source-contract.sh
@@ -814,6 +814,8 @@ for installed_path in \
     grep -Fq "$installed_path" .github/workflows/scripts/validate-deb.sh ||
         fail "Debian archive validation does not require ORT payload: $installed_path"
 done
+grep -Fq 'lintian --fail-on error' .github/workflows/scripts/validate-deb.sh ||
+    fail "Debian archive validation must gate on error-severity lintian tags"
 grep -Fq 'ORT_LIBRARY_FILE="/usr/lib/facelock/libonnxruntime.so"' test/pkg-validate.sh ||
     fail "installed package validation does not pin the ORT library path"
 grep -Fq 'ORT_DOCUMENT_ROOT="/usr/share/doc/facelock/onnxruntime"' test/pkg-validate.sh ||


### PR DESCRIPTION
## Summary

- run lintian on every built `.deb` from `validate-deb.sh`, failing on error-severity tags; warnings print without gating
- suppress `aliased-location` only: the `/lib/security` PAM placement is contract-pinned in `docs/contracts.md`, with the reason recorded beside the flag
- install lintian in the build-deb suite containers
- pin the gate in `test/deb-source-contract.sh` so it cannot be dropped silently

## Why

#223's acceptance requires lintian verification of the built archives, but the debhelper migration landed without it, so nothing ran lintian at all. On both suite lintian versions (2.122 trixie, 2.129 resolute) the aliased-location trio from the PAM module path is the package's only error-severity source, so any new error fails the gate.

## Validation

- `just check`
- `just test-deb-trixie-pkg`
- edited script against a locally built trixie artifact in both suite containers, with and without the suppression

Refs #223
