### PR TITLE
test(cli): run the C6 rows unprivileged under a root test runner

### DIFF
--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -1,10 +1,17 @@
 //! Smoke tests for the facelock CLI binary.
 
+use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 
 fn facelock_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_facelock"))
 }
+
+/// The uid/gid a root test runner drops the child to. `setuid`/`setgid` do
+/// not consult `/etc/passwd`, so the account need not exist inside a CI
+/// container; 65534 is `nobody` on the distributions where it does.
+const NOBODY_UID: u32 = 65534;
+const NOBODY_GID: u32 = 65534;
 
 /// DEC-6/C6 contract: every root-required command must refuse *before*
 /// emitting any prompt text or touching state, when invoked non-root with no
@@ -13,20 +20,43 @@ fn facelock_bin() -> Command {
 /// pipe, so it hard-errors instead of offering to re-exec with sudo — which
 /// would otherwise hang waiting for input that never arrives.
 ///
-/// Skips (rather than failing) under an actual root test runner: these
-/// commands may proceed past the root check and then fail for unrelated
-/// reasons, and this contract has nothing to assert in that case.
+/// Closing stdin is also the limit of what these rows witness: they prove a
+/// refusal preceded the output, not *which* escalation class produced it.
+/// `require_root` and `require_root_scripted` take that same non-interactive
+/// branch and are indistinguishable here. Pinning the prompt-versus-hard-error
+/// split needs a row that allocates a real pty, which is a separate concern.
+///
+/// The child always runs unprivileged, whatever the test runner's own uid is:
+/// under a root runner it drops to `nobody` before `exec`. The row used to
+/// return early there instead, which is how this contract ended up with no CI
+/// coverage at all — both CI test jobs run `cargo test` as root in a
+/// container, so all 18 rows were no-ops that reported as passes (issue
+/// #189). Dropping cannot regress the way skipping did: `setuid(2)` from root
+/// replaces the saved uid as well, and the standard library clears root's
+/// supplementary groups ahead of it, so a row that runs at all ran
+/// unprivileged. No environment variable, workflow step, or runner user
+/// decides that.
 fn assert_refuses_before_output(args: &[&str], forbidden_substrings: &[&str]) {
-    if nix::unistd::Uid::effective().is_root() {
-        eprintln!("skipping {args:?}: non-root refusal cannot be tested as root");
-        return;
+    let mut command = facelock_bin();
+    command.args(args).stdin(Stdio::null());
+
+    let dropped_privileges = nix::unistd::Uid::effective().is_root();
+    if dropped_privileges {
+        command.uid(NOBODY_UID).gid(NOBODY_GID);
     }
 
-    let output = facelock_bin()
-        .args(args)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap_or_else(|e| panic!("failed to execute facelock {args:?}: {e}"));
+    let output = command.output().unwrap_or_else(|e| {
+        let hint = if dropped_privileges {
+            format!(
+                "\nA root test runner runs this row as uid {NOBODY_UID}, so the built \
+                 binary and every directory above it must be traversable and executable \
+                 by other users — mode 0755, not 0700."
+            )
+        } else {
+            String::new()
+        };
+        panic!("failed to execute facelock {args:?}: {e}{hint}");
+    });
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1769,6 +1769,15 @@ holds the unresolved load so a broken config renders as a finding in its
 report, and its own root check still runs before its first line of output —
 the read alone has no user-visible effect ahead of the refusal.
 
+The rows in `crates/facelock-cli/tests/cli_smoke.rs` pin this ordering per
+gated command. They run the binary unprivileged even under a root test
+runner: both CI test jobs are root in a container, and a row that skipped
+there reported as a pass while asserting nothing (issue #189). They close
+stdin, so what they witness is that the refusal preceded the output, not
+which of DEC-6's two escalation classes produced it; `require_root` and
+`require_root_scripted` share one non-interactive branch and are
+indistinguishable to them.
+
 **AccessDenied hint.** A D-Bus `AccessDenied` reply carries one actionable
 hint (`ipc_client::add_access_denied_hint`): root is required. Since almost
 every D-Bus method is root-only (see IPC Protocol below) and, under ADR 010,


### PR DESCRIPTION
## Summary

- drop the C6 rows' child to `nobody` before exec instead of returning early under a root test runner
- leave `ci.yml` untouched: a `su` step or a second job restores the coverage but leaves it hostage to the runner user, which is what lost it in the first place
- cover `build-and-test` and `tpm-tests` alike, since neither job's user decides anything any more
- record under C6 in `docs/contracts.md` what the rows witness and what they do not

## Why

The 18 rows skipped themselves whenever the runner was root, which is both CI test jobs, so they reported as passes while asserting nothing. Moving the root gate back behind `ConfigLoad::read()` leaves the whole suite green.

## Scope

- the rows close stdin, so `require_root` takes its non-interactive branch: they witness that a refusal preceded the output, not which escalation class produced it
- no config fixture, which #189 also asked for: #264 puts the root gate ahead of `ConfigLoad::read()`, so no row reaches the config load

## Validation

- `just check`
- `cargo test -p facelock-cli --test cli_smoke` as uid 1000, with `FACELOCK_CONFIG` unset and pointed at a nonexistent path
- the test binary run as root in the pinned `archlinux:base-devel` container with no `/etc/facelock/config.toml`, with and without `--features tpm`
- mutation check in that container: `require_root_for` moved back behind `ConfigLoad::read().require()`, run against the old helper and the new one

depends on #264

Fixes #189
