### PR TITLE
fix(pam): map oneshot exit classes to the daemon transport codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,6 +619,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   password), and a failed model-list read (which folded into an empty
   compare set, a guaranteed no-match that charged the rate limit — the
   hazard the daemon handler refuses per C3/#105).
+
+- **PAM oneshot fallback matches the daemon transport class for class**
+  (#141): `pam_facelock.so` now maps `facelock auth` exit 3 (rate limited) to
+  `PAM_AUTH_ERR` and exit 4 (suppressed) to `PAM_AUTHINFO_UNAVAIL`, the same
+  consequences the daemon transport gives those classes, so daemon
+  unavailability no longer softens rate limiting under `required`/`requisite`
+  stacks. Exit 5 (all frames dark), unknown codes, and a signal-killed binary
+  abstain (`PAM_IGNORE`). The module's table and the binary's are pinned
+  against each other by a cross-crate test, and each code is exercised
+  end-to-end through libpam in the container tier.
 - **Debian PAM and daemon package lifecycle is opt-in and state-preserving**
   (#224): direct `pam add`/`setup --pam` now refuses an already-selected exact
   `pam-auth-update` profile before writing, using fixed-root no-follow evidence

--- a/crates/facelock-cli/src/commands/auth.rs
+++ b/crates/facelock-cli/src/commands/auth.rs
@@ -858,6 +858,60 @@ mod tests {
         );
     }
 
+    /// The PAM module's half of the exit-code contract, compiled from its
+    /// actual source. `pam_facelock.so` cannot be linked here (its
+    /// dependency ceiling is libc/toml/serde/zbus, and the crate builds only
+    /// a cdylib), so the module's mapping table is `include!`d — the same
+    /// bytes `pam-facelock` compiles — and pinned against
+    /// [`oneshot_exit_code`]'s emission table below. Without this the two
+    /// halves live in different crates and drift silently.
+    mod pam_oneshot_map {
+        #![allow(dead_code)]
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../pam-facelock/src/oneshot_exit.rs"
+        ));
+    }
+
+    /// Transport parity, class for class (#141): the code the binary emits
+    /// for a rejection class must map, in the module's oneshot table, to the
+    /// PAM code the daemon transport gives the same class (docs/contracts.md,
+    /// "PAM Semantics"). Daemon unavailability must not change what PAM
+    /// concludes about a rate-limited, suppressed, or dark attempt.
+    #[test]
+    fn oneshot_exit_codes_map_to_the_daemon_transports_pam_codes() {
+        use pam_oneshot_map as pam;
+        for kind in ErrorKind::ALL {
+            // The daemon transport's consequence for this class: the module
+            // substring-matches the frozen "rate limited" message to
+            // PAM_AUTH_ERR and maps every other recoverable error message to
+            // PAM_IGNORE (`pam_code_for_daemon_error`).
+            let daemon_code = match kind {
+                ErrorKind::RateLimited => pam::PAM_AUTH_ERR,
+                _ => pam::PAM_IGNORE,
+            };
+            assert_eq!(
+                pam::classify(oneshot_exit_code(*kind)).pam_code,
+                daemon_code,
+                "{kind:?}: the transports disagree"
+            );
+        }
+        // Suppressed: the daemon's `-3` sentinel maps to PAM_AUTHINFO_UNAVAIL.
+        assert_eq!(
+            pam::classify(EXIT_SUPPRESSED).pam_code,
+            pam::PAM_AUTHINFO_UNAVAIL
+        );
+        // Invariant 1: the permanent codes.
+        assert_eq!(pam::classify(0).pam_code, pam::PAM_SUCCESS);
+        assert_eq!(pam::classify(1).pam_code, pam::PAM_AUTH_ERR);
+        assert_eq!(pam::classify(2).pam_code, pam::PAM_IGNORE);
+        // Invariant 3: a code the module does not know abstains, so a newer
+        // binary (or a signal death, read as 2) never hardens the stack.
+        for unknown in [6, 42, 101, 255] {
+            assert_eq!(pam::classify(unknown).pam_code, pam::PAM_IGNORE);
+        }
+    }
+
     /// The suppressed outcome is not an `ErrorKind`, so it has no row in the
     /// coupling table; its exit code is pinned here instead. 4 is frozen
     /// protocol: the module maps it to PAM_AUTHINFO_UNAVAIL, the same

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -12,14 +12,22 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+// The oneshot exit-code -> PAM mapping, in its own dependency-free file so
+// `facelock-cli`'s test suite can `include!` the same source and pin it
+// against the binary's emission table (see the file header).
+mod oneshot_exit;
+
 // ---------------------------------------------------------------------------
 // PAM constants
 // ---------------------------------------------------------------------------
 
-const PAM_SUCCESS: libc::c_int = 0;
-const PAM_AUTH_ERR: libc::c_int = 7;
-const PAM_AUTHINFO_UNAVAIL: libc::c_int = 9;
-const PAM_IGNORE: libc::c_int = 25;
+// Aliased from `oneshot_exit` rather than redeclared: the values live once,
+// and a target where `libc::c_int` is not `i32` would fail to compile here
+// instead of silently forking the two files.
+const PAM_SUCCESS: libc::c_int = oneshot_exit::PAM_SUCCESS;
+const PAM_AUTH_ERR: libc::c_int = oneshot_exit::PAM_AUTH_ERR;
+const PAM_AUTHINFO_UNAVAIL: libc::c_int = oneshot_exit::PAM_AUTHINFO_UNAVAIL;
+const PAM_IGNORE: libc::c_int = oneshot_exit::PAM_IGNORE;
 
 // PAM conversation message styles
 const PAM_TEXT_INFO: libc::c_int = 4;
@@ -896,7 +904,12 @@ fn terminate_oneshot_child<T: Terminable>(
 }
 
 /// Run facelock auth as a subprocess for daemonless authentication.
-/// Exit codes: 0 = matched, 1 = no match, 2+ = error.
+///
+/// The child's exit code carries the rejection class and is mapped by
+/// [`oneshot_exit::classify`], class for class with the daemon transport:
+/// 0 = matched, 1 = no match, 2 = error / no opinion, 3 = rate limited,
+/// 4 = suppressed, 5 = all frames dark, anything else = no opinion. The
+/// table is frozen in docs/contracts.md ("facelock auth Exit Codes").
 fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_int {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
@@ -997,26 +1010,22 @@ fn run_oneshot_auth(service: &str, user: &str, config: &PamConfig) -> libc::c_in
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
+                // A child killed by a signal has no exit code; read it as 2
+                // ("error / no opinion"), the frozen catch-all — an abandoned
+                // attempt is not a decision about this face.
                 let code = status.code().unwrap_or(2);
-                return match code {
-                    0 => {
-                        log_auth(service, "success (oneshot)", user, LOG_INFO);
-                        PAM_SUCCESS
-                    }
-                    1 => {
-                        log_auth(service, "no_match (oneshot)", user, LOG_INFO);
-                        PAM_AUTH_ERR
-                    }
-                    _ => {
-                        log_auth(
-                            service,
-                            &format!("error: oneshot_exit={code}"),
-                            user,
-                            LOG_WARNING,
-                        );
-                        PAM_IGNORE
-                    }
-                };
+                let exit = oneshot_exit::classify(code);
+                let severity = if exit.warn { LOG_WARNING } else { LOG_INFO };
+                match exit.label {
+                    Some(label) => log_auth(service, label, user, severity),
+                    None => log_auth(
+                        service,
+                        &format!("error: oneshot_exit={code}"),
+                        user,
+                        severity,
+                    ),
+                }
+                return exit.pam_code;
             }
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
@@ -1282,6 +1291,54 @@ pub unsafe extern "C" fn pam_sm_setcred(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The oneshot table, row for row (docs/contracts.md, "facelock auth
+    /// Exit Codes"). The cross-crate half — that each code a rejection class
+    /// makes the binary emit lands on the daemon transport's PAM code — is
+    /// pinned in `facelock-cli`'s commands/auth.rs, which `include!`s this
+    /// crate's `oneshot_exit.rs`.
+    #[test]
+    fn oneshot_exit_mapping_is_the_contract_table() {
+        assert_eq!(oneshot_exit::classify(0).pam_code, PAM_SUCCESS);
+        assert_eq!(oneshot_exit::classify(1).pam_code, PAM_AUTH_ERR);
+        assert_eq!(oneshot_exit::classify(2).pam_code, PAM_IGNORE);
+        assert_eq!(oneshot_exit::classify(3).pam_code, PAM_AUTH_ERR);
+        assert_eq!(oneshot_exit::classify(4).pam_code, PAM_AUTHINFO_UNAVAIL);
+        assert_eq!(oneshot_exit::classify(5).pam_code, PAM_IGNORE);
+    }
+
+    /// Invariant 3 of the exit-code contract: a code this build does not
+    /// know abstains, so a binary newer than the module (and a signal death,
+    /// which the caller reads as 2) degrades to fall-through and can never
+    /// harden or soften the stack. The label is `None` so the syslog line
+    /// names the raw code.
+    #[test]
+    fn unknown_oneshot_exit_codes_abstain() {
+        for code in [-1, 6, 7, 9, 25, 42, 101, 255] {
+            let exit = oneshot_exit::classify(code);
+            assert_eq!(exit.pam_code, PAM_IGNORE, "exit {code}");
+            assert!(exit.label.is_none(), "exit {code} must log its raw value");
+        }
+    }
+
+    /// Never PAM_SUCCESS except exit 0: an exit *status* is attacker-visible
+    /// but not attacker-choosable (the binary's trust is verified before the
+    /// spawn); still, the mapping itself must make a wrong success
+    /// impossible.
+    #[test]
+    fn only_exit_zero_authenticates() {
+        for code in -128..=512 {
+            let exit = oneshot_exit::classify(code);
+            if code == 0 {
+                assert_eq!(exit.pam_code, PAM_SUCCESS);
+            } else {
+                assert_ne!(
+                    exit.pam_code, PAM_SUCCESS,
+                    "exit {code} may not authenticate"
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_is_ssh_session_fallback() {

--- a/crates/pam-facelock/src/oneshot_exit.rs
+++ b/crates/pam-facelock/src/oneshot_exit.rs
@@ -1,0 +1,86 @@
+// The oneshot exit-code -> PAM mapping. Dependency-free on purpose: this
+// file is compiled twice — as `pam_facelock`'s `oneshot_exit` module, and
+// `include!`d into `facelock-cli`'s test suite (commands/auth.rs), which
+// pins every rejection class's exit code to the PAM code this table gives
+// it. `pam_facelock.so` cannot link the daemon crates (its dependency
+// ceiling is libc/toml/serde/zbus), so sharing the source is what couples
+// the two halves of the contract; nothing here may `use` anything.
+//
+// The contract is docs/contracts.md ("facelock auth Exit Codes"), with
+// three frozen invariants: exit 0, 1 and 2 keep their meanings permanently;
+// new codes are allocated only from the space this table's fallback arm
+// maps to PAM_IGNORE; and that fallback arm stays PAM_IGNORE forever. A
+// binary newer or older than this module therefore degrades to the
+// collapsed pre-#141 behavior, never to a wrong answer.
+
+/// Linux-PAM return codes, fixed by the PAM ABI. `i32` rather than
+/// `libc::c_int` so this file stays dependency-free; the two are the same
+/// type on every Linux target (`lib.rs` aliases its constants to these, so
+/// a target where they diverged would fail to compile).
+pub(crate) const PAM_SUCCESS: i32 = 0;
+pub(crate) const PAM_AUTH_ERR: i32 = 7;
+pub(crate) const PAM_AUTHINFO_UNAVAIL: i32 = 9;
+pub(crate) const PAM_IGNORE: i32 = 25;
+
+/// The module's reading of one `facelock auth` exit code.
+pub(crate) struct OneshotExit {
+    /// The PAM return code. This column is frozen protocol.
+    pub(crate) pam_code: i32,
+    /// Syslog label for a known code; `None` for a code this build does not
+    /// know (the caller formats a line naming the raw code).
+    pub(crate) label: Option<&'static str>,
+    /// Whether the syslog line is a warning rather than info.
+    pub(crate) warn: bool,
+}
+
+/// Map a `facelock auth` exit code onto its PAM consequence.
+///
+/// Class for class this matches the daemon transport: a rate-limited
+/// rejection fails (the consequence the daemon's frozen "rate limited"
+/// message gets), a suppressed attempt reports missing authentication data
+/// (the daemon's `-3` sentinel consequence), a dark scan abstains, and an
+/// unknown code — a newer binary's future class, or a signal death read as
+/// 2 by the caller — abstains too. Never `PAM_SUCCESS` except for exit 0.
+pub(crate) fn classify(code: i32) -> OneshotExit {
+    match code {
+        0 => OneshotExit {
+            pam_code: PAM_SUCCESS,
+            label: Some("success (oneshot)"),
+            warn: false,
+        },
+        1 => OneshotExit {
+            pam_code: PAM_AUTH_ERR,
+            label: Some("no_match (oneshot)"),
+            warn: false,
+        },
+        // Deliberate failure, not fall-through: the user's face-auth budget
+        // is exhausted; the password modules still run after us. Before
+        // #141 this class collapsed to exit 2, so daemon unavailability
+        // silently softened it to PAM_IGNORE.
+        3 => OneshotExit {
+            pam_code: PAM_AUTH_ERR,
+            label: Some("rate_limited (oneshot)"),
+            warn: true,
+        },
+        // No enrolled models with `suppress_unknown`.
+        4 => OneshotExit {
+            pam_code: PAM_AUTHINFO_UNAVAIL,
+            label: Some("suppressed (oneshot, no enrolled models)"),
+            warn: false,
+        },
+        // The camera produced no usable image: no opinion about this face.
+        5 => OneshotExit {
+            pam_code: PAM_IGNORE,
+            label: Some("all_frames_dark (oneshot)"),
+            warn: true,
+        },
+        // 2 (error / no opinion) and every code this build does not know:
+        // abstain. Frozen — this arm is what makes a binary newer than the
+        // module safe.
+        _ => OneshotExit {
+            pam_code: PAM_IGNORE,
+            label: None,
+            warn: true,
+        },
+    }
+}

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2040,7 +2040,14 @@ The binary's half of the table is pinned in
 `crates/facelock-cli/src/commands/auth.rs`
 (`every_rejection_class_pins_its_message_audit_label_and_exit_code`,
 `rejection_classes_never_claim_the_match_codes`,
-`the_preflight_short_circuit_pins_its_non_error_codes`).
+`the_preflight_short_circuit_pins_its_non_error_codes`). The module's half
+lives in `crates/pam-facelock/src/oneshot_exit.rs`, a dependency-free file
+that `facelock-cli`'s test suite `include!`s to pin the two halves against
+each other class for class
+(`oneshot_exit_codes_map_to_the_daemon_transports_pam_codes`) — the module
+cannot be linked there, so sharing the source is what couples them. The
+live module is exercised per code by the `facelock-map-*` fixtures in
+`test/run-container-tests.sh`.
 
 ## Release Channels and APT Paths
 
@@ -3375,6 +3382,7 @@ the module falls through (oneshot fallback / password), never `PAM_SUCCESS`.
 | IR required / unverified Y16 texture scale / internal daemon error (model_id -2) | `PAM_IGNORE` (25) — no oneshot fallback |
 | Suppressed (model_id -3) | `PAM_AUTHINFO_UNAVAIL` (9) |
 | Daemon unavailable / untrusted (non-root) peer | oneshot fallback, else `PAM_IGNORE` (25) |
+| Oneshot fallback (and `mode = "oneshot"`) | per the `facelock auth` exit-code table above: 0 → `PAM_SUCCESS`, 1/3 → `PAM_AUTH_ERR`, 4 → `PAM_AUTHINFO_UNAVAIL`, 2/5/unknown/signal death → `PAM_IGNORE` |
 | Config missing, unparseable, or untrusted (not root-owned / group- or world-writable, incl. parents) | `PAM_IGNORE` (25) |
 | Timeout (structured zbus timeout or overall deadline) | `PAM_AUTH_ERR` (7) |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -805,6 +805,12 @@ PAM still matches the message because it cannot link the daemon crate, so the
 two strings it matches (`rate limited`, `IR camera required`) are frozen
 protocol — see docs/contracts.md, "Rejection classes".
 
+The oneshot transport carries the same classes in the exit code (3 = rate
+limited, 4 = suppressed, 5 = all frames dark; docs/contracts.md, "facelock
+auth Exit Codes"), and the module maps them to the same PAM consequences it
+gives the daemon's replies. Daemon unavailability therefore no longer softens
+a rate-limited rejection to `PAM_IGNORE` on the fallback path.
+
 A non-match reply also states explicitly whether a face was detected
 (`model_id == -4`). PAM used to infer that from `similarity == 0.0`, which is
 wrong for any non-root caller because the score is redacted to `0.0` for all of

--- a/man/pam_facelock.8
+++ b/man/pam_facelock.8
@@ -42,19 +42,23 @@ The user's face was matched against an enrolled model with sufficient
 confidence.
 .TP
 .B PAM_AUTH_ERR
-Authentication failed. The face did not match any enrolled model, or an error
-occurred during the authentication process.
-.TP
-.B PAM_IGNORE
-The module abstained: it is disabled for this authentication context, the user
-has no enrolled face models, no face was seen, or a precondition such as the IR
-camera requirement was not met. The PAM stack falls through to the next module.
+Authentication failed: a face was scanned and did not match, or the user is
+rate limited (the face-auth budget is exhausted; the remaining modules in the
+stack still run). The two transports differ in one case: the daemon abstains
+when no face was seen, while the oneshot binary cannot carry that distinction
+in an exit code and reports it here. See the exit-code table in
+.I docs/contracts.md .
 .TP
 .B PAM_AUTHINFO_UNAVAIL
-The user has no enrolled face models and
-.I security.suppress_unknown
-is enabled, so the module declines to reveal whether the user is enrolled and
-hands the decision to the next module in the stack.
+The attempt was suppressed: the user has no enrolled face models and
+.B security.suppress_unknown
+is enabled, so the module declines to reveal whether the user is enrolled.
+.TP
+.B PAM_IGNORE
+Face authentication has no opinion for this attempt: the module is disabled
+or skipped for this context, the user has no enrolled face models, the camera
+produced no usable image, the attempt was cancelled, or an error occurred.
+The PAM stack falls through to the next module.
 .SH EXAMPLES
 To enable face authentication for
 .BR sudo (8),

--- a/po/pam_facelock.pot
+++ b/po/pam_facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 14:33-0700\n"
+"POT-Creation-Date: 2026-08-23 13:44-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/pam-facelock/src/lib.rs:1166
+#: crates/pam-facelock/src/lib.rs:1175
 msgid "Identifying face..."
 msgstr ""
 
-#: crates/pam-facelock/src/lib.rs:1176 crates/pam-facelock/src/lib.rs:1190
-#: crates/pam-facelock/src/lib.rs:1232
+#: crates/pam-facelock/src/lib.rs:1185 crates/pam-facelock/src/lib.rs:1199
+#: crates/pam-facelock/src/lib.rs:1241
 msgid "Face recognized."
 msgstr ""

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -62,6 +62,18 @@ COPY test/container-config.toml /etc/facelock/config.toml
 # Facelock-test PAM config for pamtester
 COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
 
+# facelock-map-* fixtures for the oneshot exit-code mapping tests (#141),
+# staged OUTSIDE /etc/pam.d: they name pam_facelock.so, and the Arch package
+# removal hook (exercised by run-arch-package-systemd.sh in this same image)
+# treats any /etc/pam.d reference it does not own as administrator-managed
+# and blocks removal. run-container-tests.sh installs them into /etc/pam.d
+# for the duration of the mapping block only.
+COPY test/pam.d/facelock-map-success \
+     test/pam.d/facelock-map-autherr \
+     test/pam.d/facelock-map-authinfo \
+     test/pam.d/facelock-map-ignore \
+     /facelock-map-pam.d/
+
 # Fake daemon harness for the PAM peer-UID container test (plan 05)
 COPY test/fake-facelock-daemon.py /fake-facelock-daemon.py
 

--- a/test/pam.d/facelock-map-autherr
+++ b/test/pam.d/facelock-map-autherr
@@ -1,0 +1,12 @@
+# Fixture for the oneshot exit-code mapping tests (#141, run-container-tests.sh):
+# the stack succeeds if and only if pam_facelock.so returned auth_err.
+#
+# The jump (=1) skips pam_deny; any other return marks failure (bad) and
+# pam_deny (requisite) ends the stack. The jump acts as "ok", which records a
+# failure-valued return (auth_err, authinfo_unavail) as the stack's status, so
+# the first pam_permit resets that memory and the second supplies the success
+# pamtester reports.
+auth  [auth_err=1 default=bad]  pam_facelock.so
+auth  requisite  pam_deny.so
+auth  [success=reset default=bad]  pam_permit.so
+auth  required  pam_permit.so

--- a/test/pam.d/facelock-map-authinfo
+++ b/test/pam.d/facelock-map-authinfo
@@ -1,0 +1,12 @@
+# Fixture for the oneshot exit-code mapping tests (#141, run-container-tests.sh):
+# the stack succeeds if and only if pam_facelock.so returned authinfo_unavail.
+#
+# The jump (=1) skips pam_deny; any other return marks failure (bad) and
+# pam_deny (requisite) ends the stack. The jump acts as "ok", which records a
+# failure-valued return (auth_err, authinfo_unavail) as the stack's status, so
+# the first pam_permit resets that memory and the second supplies the success
+# pamtester reports.
+auth  [authinfo_unavail=1 default=bad]  pam_facelock.so
+auth  requisite  pam_deny.so
+auth  [success=reset default=bad]  pam_permit.so
+auth  required  pam_permit.so

--- a/test/pam.d/facelock-map-ignore
+++ b/test/pam.d/facelock-map-ignore
@@ -1,0 +1,12 @@
+# Fixture for the oneshot exit-code mapping tests (#141, run-container-tests.sh):
+# the stack succeeds if and only if pam_facelock.so returned ignore.
+#
+# The jump (=1) skips pam_deny; any other return marks failure (bad) and
+# pam_deny (requisite) ends the stack. The jump acts as "ok", which records a
+# failure-valued return (auth_err, authinfo_unavail) as the stack's status, so
+# the first pam_permit resets that memory and the second supplies the success
+# pamtester reports.
+auth  [ignore=1 default=bad]  pam_facelock.so
+auth  requisite  pam_deny.so
+auth  [success=reset default=bad]  pam_permit.so
+auth  required  pam_permit.so

--- a/test/pam.d/facelock-map-success
+++ b/test/pam.d/facelock-map-success
@@ -1,0 +1,12 @@
+# Fixture for the oneshot exit-code mapping tests (#141, run-container-tests.sh):
+# the stack succeeds if and only if pam_facelock.so returned success.
+#
+# The jump (=1) skips pam_deny; any other return marks failure (bad) and
+# pam_deny (requisite) ends the stack. The jump acts as "ok", which records a
+# failure-valued return (auth_err, authinfo_unavail) as the stack's status, so
+# the first pam_permit resets that memory and the second supplies the success
+# pamtester reports.
+auth  [success=1 default=bad]  pam_facelock.so
+auth  requisite  pam_deny.so
+auth  [success=reset default=bad]  pam_permit.so
+auth  required  pam_permit.so

--- a/test/run-container-tests.sh
+++ b/test/run-container-tests.sh
@@ -732,6 +732,66 @@ run_test "env_clear: oneshot child PATH pinned to /usr/bin:/bin" \
     "grep -qx 'PATH=/usr/bin:/bin' /tmp/oneshot-child-env" \
     0
 
+# --- #141: oneshot exit-code -> PAM mapping, per code ---
+#
+# `facelock auth`'s exit code carries the rejection class; the module's
+# oneshot arm must give each class the same PAM consequence the daemon
+# transport does (docs/contracts.md, "facelock auth Exit Codes"). Each
+# facelock-map-* service (test/pam.d/) converts exactly one PAM return into
+# stack success via a jump action, so pamtester's own exit code reports
+# whether the module produced that return. A root-owned stub stands in for
+# /usr/bin/facelock (the same swap as the env_clear fixture above) and reads
+# the exit code to emit from a root-owned file, so every code can be forced
+# without a camera.
+# The service fixtures are staged outside /etc/pam.d (see test/Containerfile:
+# a resident copy would block the Arch package-removal hook) and installed
+# only for this block.
+install -m 644 /facelock-map-pam.d/facelock-map-* /etc/pam.d/
+printf '#!/bin/bash\ncode=$(cat /etc/facelock/test-exit-code)\nif [ "$code" = signal ]; then kill -9 $$; fi\nexit "$code"\n' \
+    > /usr/local/bin/facelock-exit-stub
+chmod 755 /usr/local/bin/facelock-exit-stub
+sed -i '/^\[daemon\]/a mode = "oneshot"' /etc/facelock/config.toml
+mv /usr/bin/facelock /usr/bin/facelock.orig
+install -m 755 /usr/local/bin/facelock-exit-stub /usr/bin/facelock
+
+map_case() {
+    local code="$1" service="$2" verdict="$3"
+    echo "$code" > /etc/facelock/test-exit-code
+    if [ "$verdict" = pass ]; then
+        run_test "oneshot exit $code: module returns the $service code" \
+            "pamtester $service testuser authenticate < /dev/null" 0
+    else
+        run_test "oneshot exit $code: module does not return the $service code" \
+            "! pamtester $service testuser authenticate < /dev/null" 0
+    fi
+}
+
+# Exit 0/1/2 keep their permanent meanings (contract invariant 1).
+map_case 0 facelock-map-success pass
+map_case 1 facelock-map-autherr pass
+map_case 2 facelock-map-ignore pass
+# Exit 3 (rate limited) fails like the daemon transport -- and no longer
+# abstains, which is the #141 hardening.
+map_case 3 facelock-map-autherr pass
+map_case 3 facelock-map-ignore fail
+# Exit 4 (suppressed): the daemon transport's -3 sentinel consequence.
+map_case 4 facelock-map-authinfo pass
+# Exit 5 (all frames dark) abstains, matching the daemon transport.
+map_case 5 facelock-map-ignore pass
+# An unknown code abstains (invariant 3: a newer binary degrades to
+# fall-through under this module, never to a harder or softer answer).
+map_case 42 facelock-map-ignore pass
+# A signal-killed child has no exit code; the module reads it as 2 (abstain).
+map_case signal facelock-map-ignore pass
+# Only exit 0 may authenticate.
+map_case 1 facelock-map-success fail
+
+mv -f /usr/bin/facelock.orig /usr/bin/facelock
+sed -i '/^mode = "oneshot"/d' /etc/facelock/config.toml
+rm -f /etc/facelock/test-exit-code /usr/local/bin/facelock-exit-stub \
+    /etc/pam.d/facelock-map-success /etc/pam.d/facelock-map-autherr \
+    /etc/pam.d/facelock-map-authinfo /etc/pam.d/facelock-map-ignore
+
 # (c) Bus policy (ADR 010): the default context may call Authenticate and
 # nothing else. There is no group policy — signals are root-only. A fake
 # daemon owned by ROOT stands in for the real one — the real daemon needs a


### PR DESCRIPTION
## Summary

- widen the module's oneshot exit-code arm to the daemon transport's consequences, class for class: 3 → `PAM_AUTH_ERR` (rate limited), 4 → `PAM_AUTHINFO_UNAVAIL` (suppressed), 5 and unknown codes → `PAM_IGNORE`
- keep 0/1/2 and the unknown-code fallback exactly as before, so a binary newer or older than the module degrades to the collapsed behavior and never to a wrong answer; a signal-killed binary still reads as 2
- move the mapping into `oneshot_exit.rs`, a dependency-free file the `facelock-cli` test suite `include!`s to pin the module's table against the binary's emission table across the crate boundary
- exercise every code end-to-end through libpam in the container tier: a root-owned stub forces each exit code, and `facelock-map-*` service fixtures convert exactly one PAM return into stack success; fixtures are staged outside `/etc/pam.d` so the Arch package-removal hook does not read them as administrator-managed references
- document the widened mapping in `pam_facelock(8)`, `docs/contracts.md`, and `docs/security.md`
- regenerate `po/pam_facelock.pot` (line references shifted; no string changes)
- correct `pam_facelock(8)`'s parity claim: the transports still diverge on a no-face non-match (daemon abstains, oneshot exit code cannot carry face-seen and fails); the contract's residual-divergence list is the reference

Depends on #265, which allocates the codes on the binary side; merge that first.

## Why

PAM falls back to the oneshot binary whenever D-Bus is unavailable, and the module read every rejection exit as "no opinion", so daemon unavailability silently softened a rate-limited `PAM_AUTH_ERR` to `PAM_IGNORE` under `required`/`requisite` stacks. The two halves of the exit-code contract live in crates that cannot link each other, so without the shared-source pin they drift silently.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`
- `just check`, `just check-pam-standalone`
- arch container PAM smoke incl. the ten new per-code mapping cases, arch package lifecycle, arch layout tier
- not run: `just test-arch-oneshot` — needs a live camera; that tier is what exercises the new codes against the real binary end to end, and it awaits a maintainer hardware sitting

Closes #141
