### PR TITLE
test(docs): guard package names, pam_facelock.8, and doc pairs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,20 @@ describe the tree: that every `paths:` glob matches something, that referenced
 a workflow still match their source. A rule scoped to a path that no longer
 exists fails silently otherwise -- it simply never loads.
 
+`cargo test` also holds the user-facing documentation to the tree, in
+`crates/facelock-cli/src/conformance/`. `docs.rs` and `man_pam.rs` check that
+the CLI reference and both man pages describe the binary and the PAM module
+that shipped. `packages.rs` checks that every package name a document tells a
+reader to install is declared by `dist/PKGBUILD*`, `debian/control` or
+`dist/facelock.spec`; if you add an install instruction, declare the dependency
+in the packaging manifest that should already have had it. `pairs.rs` checks
+that the six pages carried in both `docs/` and `book/src/` do not contradict
+each other on package names, command names or file paths.
+
+None of these reach the network. `just check-package-names-live` does, and asks
+Arch, the AUR, Debian and Fedora whether the names still exist. Run it when you
+touch a dependency; it is deliberately outside `just check`.
+
 ## Security considerations
 
 Read `docs/security.md` before implementing any auth-related code. Key rules:

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -100,7 +100,23 @@ Face embeddings are **biometric data**. Unlike passwords, they cannot be changed
 
 #### C. Encryption at Rest (Implemented)
 
-For high-security deployments, embeddings can be encrypted with AES-256-GCM using either a plaintext key file (`encryption.method = "keyfile"`) or a TPM-sealed key (`encryption.method = "tpm"`). The TPM method seals the AES key at rest; it is unsealed at daemon startup and held in memory. See [Configuration](configuration.md) for the `[encryption]` and `[tpm]` sections.
+Templates are encrypted at rest by default. The key lives in a plaintext key file (`encryption.method = "keyfile"`, the default) or sealed to the TPM (`encryption.method = "tpm"`), and either way the embeddings themselves are AES-256-GCM. The keyfile is generated at mode `0600` on first use. A TPM-sealed key is unsealed once at daemon startup and held in memory.
+
+Plaintext storage (`encryption.method = "none"`) is an explicit opt-out: enrollment refuses to write unencrypted templates unless `security.allow_plaintext = true`. Auth is never affected by any of this. A decrypt failure falls back to the password, never to a lockout.
+
+`tpm.pcr_binding` is **off by default**, and turning it on is a commitment rather than a hardening tweak. With it on, the sealed key is bound to a PCR selection recorded in the sealed blob, and unsealing replays a real `PolicyPCR` session against the machine's current PCRs. A firmware or kernel change to a bound PCR makes the key refuse to unseal. Face auth then falls through to the password, which is the safe failure, but the templates stay locked until you act.
+
+Recovery is one command:
+
+```bash
+sudo facelock tpm reseal
+```
+
+It re-seals the key under the current PCR state, recovering the key from the existing blob if the PCRs still match and from the plaintext `encryption.key` backup if they do not.
+
+**Keep that `encryption.key` backup.** It is the recommended setup and it is what makes a reseal painless: without it, a PCR change after a firmware update means re-enrolling every face. The honest cost is that while the backup exists, the `tpm` method's protection against anyone who can read the file is the backup's own `0600` root-only permissions, not the TPM. Deleting the backup buys stronger at-rest confidentiality and pays for it in re-enrollment.
+
+See [Configuration](configuration.md) for the `[encryption]` and `[tpm]` sections, and `docs/security.md` for the full finding.
 
 ### 4. D-Bus IPC Security
 

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -165,6 +165,7 @@ Local full CI: `bash test/run-tests.sh`
 | `just test` | Unit tests |
 | `just lint` | Clippy |
 | `just check` | test + lint + fmt |
+| `just check-package-names-live` | Re-check documented package names against live Arch, AUR, Debian and Fedora (network; not part of `just check`) |
 | `just test-arch-pam` | Arch container PAM smoke |
 | `just test-arch-integration` | E2E daemon mode |
 | `just test-arch-oneshot` | E2E oneshot mode |

--- a/crates/facelock-cli/src/conformance/docs.rs
+++ b/crates/facelock-cli/src/conformance/docs.rs
@@ -38,12 +38,10 @@ const MARKDOWN_REFERENCES: &[(&str, &str)] = &[
     ("book/src/cli-reference.md", BOOK_CLI_DOC),
 ];
 
-/// `man(7)` writes a literal hyphen as `\-`, so `system-auth` is on disk as
-/// `system\-auth` and a plain substring search for it fails. Undoing that
-/// one escape is the whole normalization these checks need; nothing here
-/// looks at roff structure.
+/// The man page with its roff hyphen escapes undone. Shared with
+/// [`super::man_pam`], which asks the same question of the other page.
 fn unescaped_man_page() -> String {
-    MAN_PAGE.replace(r"\-", "-")
+    super::unescape_roff(MAN_PAGE)
 }
 
 /// The body of one `##` section, so a check scoped to a section cannot be

--- a/crates/facelock-cli/src/conformance/man_pam.rs
+++ b/crates/facelock-cli/src/conformance/man_pam.rs
@@ -1,0 +1,605 @@
+//! `man/pam_facelock.8` describes the module that shipped (#211).
+//!
+//! `man/facelock.1` has been pinned since #172. Its sibling never was: nothing
+//! in the tree embedded `pam_facelock.8`, read it, or asserted anything about
+//! it, so it drifted for as long as it has existed. By the time this suite was
+//! written it documented a `[pam]` configuration table the module has never
+//! read, three keys under it that do not exist, a `facelock` group that ADR
+//! 010 retired, and three of the four exit codes the module can return.
+//!
+//! Every check here resolves against something that decides behaviour rather
+//! than against prose:
+//!
+//! - the return codes, the configuration schema, the config path and the
+//!   one-shot binary come from `crates/pam-facelock/src/lib.rs`, which is the
+//!   only reader of any of them;
+//! - the module's install locations come from [`PAM_MODULE_PATHS`], the one
+//!   list `setup` and `health` already share;
+//! - the D-Bus grants come from `dbus/org.facelock.Daemon.conf`, the policy
+//!   the bus actually enforces;
+//! - the shipped file locations come from `dist/PKGBUILD`, which writes them;
+//! - the defaults quoted in prose come from `facelock_core`'s `Config`.
+//!
+//! The PAM module is `crate-type = ["cdylib"]` and forbidden from depending on
+//! `facelock-core`, so this crate cannot `use` its constants: it reads the
+//! source text instead. Every extractor here therefore carries a floor
+//! assertion — an extractor that stops finding anything must fail loudly
+//! rather than approve a page it never read.
+
+use std::collections::BTreeSet;
+
+use clap::Parser;
+
+use facelock_cli::commands::pam::PAM_MODULE_PATHS;
+use facelock_core::config::{RateLimitConfig, SecurityConfig};
+use facelock_core::dbus_interface::BUS_NAME;
+use facelock_core::paths::{DEFAULT_CONFIG_PATH, DEFAULT_DB_PATH};
+
+use super::unescape_roff;
+use crate::Cli;
+
+/// The page under test.
+const MAN_PAGE: &str = include_str!("../../../../man/pam_facelock.8");
+
+/// The module the page describes. Read as text, not linked: the PAM crate is a
+/// `cdylib` with a hard dependency ceiling, so its constants cannot be
+/// imported from here.
+const PAM_SOURCE: &str = include_str!("../../../../crates/pam-facelock/src/lib.rs");
+
+/// The bus policy the daemon ships. What it grants is what the page may claim.
+const DBUS_POLICY: &str = include_str!("../../../../dbus/org.facelock.Daemon.conf");
+
+/// The Arch package recipe, used only as the authority on where a shipped file
+/// lands. Any of the three packaging manifests would do; this is the one that
+/// spells absolute paths rather than macros.
+const PKGBUILD: &str = include_str!("../../../../dist/PKGBUILD");
+
+/// The body of one `.SH` section, ending at the next one.
+fn man_section(heading: &str) -> String {
+    let page = unescape_roff(MAN_PAGE);
+    let start = page
+        .find(heading)
+        .unwrap_or_else(|| panic!("man/pam_facelock.8 has no `{heading}` section"));
+    let body = &page[start + heading.len()..];
+    match body.find("\n.SH ") {
+        Some(end) => body[..end].to_string(),
+        None => body.to_string(),
+    }
+}
+
+/// Every `.I` or `.B` argument in a section, one per line, unwrapped from its
+/// roff macro.
+fn macro_arguments(section: &str, macros: &[&str]) -> Vec<String> {
+    section
+        .lines()
+        .filter_map(|line| {
+            macros
+                .iter()
+                .find_map(|name| line.strip_prefix(&format!("{name} ")))
+                .map(|rest| rest.trim().to_string())
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Return values
+// ---------------------------------------------------------------------------
+
+/// The PAM result codes the module can hand back to libpam.
+///
+/// Two filters, and the second is the point. Every `PAM_*` constant is
+/// declared the same way, but `PAM_TEXT_INFO` is a conversation message style
+/// and `PAM_CONV` is an item type — documenting those under RETURN VALUES
+/// would be wrong. A constant counts as a result code when the source
+/// *returns* it: named in a `return`, or standing alone as a tail expression.
+fn pam_return_codes() -> BTreeSet<String> {
+    let declared: Vec<&str> = PAM_SOURCE
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("const PAM_")?;
+            let name = rest.split(':').next()?;
+            rest.contains("libc::c_int").then_some(name)
+        })
+        .collect();
+
+    assert!(
+        declared.len() >= 4,
+        "found only {} top-level `const PAM_*: libc::c_int` declarations in \
+         crates/pam-facelock/src/lib.rs — the extractor is broken, not the module",
+        declared.len()
+    );
+
+    let returned: BTreeSet<String> = declared
+        .into_iter()
+        .map(|name| format!("PAM_{name}"))
+        .filter(|name| {
+            PAM_SOURCE.contains(&format!("return {name};"))
+                || PAM_SOURCE.lines().any(|line| line.trim() == name.as_str())
+        })
+        .collect();
+
+    for required in ["PAM_SUCCESS", "PAM_AUTH_ERR", "PAM_IGNORE"] {
+        assert!(
+            returned.contains(required),
+            "`{required}` is a result code the module certainly returns; the \
+             return-position filter no longer recognises it"
+        );
+    }
+    returned
+}
+
+/// Every result code the module can return is documented.
+///
+/// `PAM_AUTHINFO_UNAVAIL` was the one that was not. It is what the module
+/// returns when the daemon answered but could not decide — the code that tells
+/// a stack to fall through to the next module — and an administrator writing a
+/// `[success=… default=…]` control field was reading a page that said it could
+/// not happen.
+#[test]
+fn pam_man_documents_every_return_code() {
+    let section = man_section("\n.SH RETURN VALUES\n");
+    for code in pam_return_codes() {
+        assert!(
+            macro_arguments(&section, &[".B", ".BR"]).contains(&code),
+            "`pam_facelock.so` can return `{code}` but the RETURN VALUES \
+             section of man/pam_facelock.8 never names it"
+        );
+    }
+}
+
+/// Nothing is documented as a result code that the module cannot return.
+#[test]
+fn pam_man_invents_no_return_code() {
+    let section = man_section("\n.SH RETURN VALUES\n");
+    let codes = pam_return_codes();
+    for documented in macro_arguments(&section, &[".B", ".BR"]) {
+        if !documented.starts_with("PAM_") {
+            continue;
+        }
+        assert!(
+            codes.contains(&documented),
+            "man/pam_facelock.8 documents `{documented}` as a return value, \
+             but crates/pam-facelock/src/lib.rs never returns it"
+        );
+    }
+}
+
+/// The OPTIONS section matches the module arguments the module parses.
+///
+/// It parses none: `pam_sm_authenticate` binds its argument vector as `_argv`
+/// and never reads it. That is worth saying, because every neighbouring module
+/// in a stack takes arguments — an administrator who writes
+/// `pam_facelock.so timeout=10` gets no error and no effect, and the timeout
+/// they wanted is a configuration key.
+///
+/// Two-way, so the section cannot quietly become wrong in either direction: if
+/// the module starts parsing `argv`, an OPTIONS section that documents nothing
+/// fails.
+#[test]
+fn pam_man_options_match_the_arguments_the_module_parses() {
+    let parses_arguments = PAM_SOURCE.contains("\n    argv:");
+    let documented = macro_arguments(&man_section("\n.SH OPTIONS\n"), &[".B", ".BR"]);
+
+    assert_eq!(
+        parses_arguments,
+        !documented.is_empty(),
+        "crates/pam-facelock/src/lib.rs {} a module argument vector, but the \
+         OPTIONS section of man/pam_facelock.8 documents {documented:?}",
+        if parses_arguments {
+            "parses"
+        } else {
+            "ignores"
+        }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Configuration schema
+// ---------------------------------------------------------------------------
+
+/// Every `(table, key)` the module deserializes, tables dotted.
+///
+/// Walks `PamConfig` the way serde does: a field whose type is another
+/// `Pam…Config` struct is a nested table *and* a key of its parent, and
+/// anything else is a leaf key. `Option<…>` is unwrapped, since an optional
+/// table is still a table.
+fn pam_config_schema() -> BTreeSet<(String, String)> {
+    let mut schema = BTreeSet::new();
+    walk_config_struct("PamConfig", "", &mut schema);
+    assert!(
+        schema.len() >= 10,
+        "extracted only {} configuration keys from PamConfig — the struct \
+         parser is broken, not the module",
+        schema.len()
+    );
+    schema
+}
+
+fn walk_config_struct(type_name: &str, table: &str, out: &mut BTreeSet<(String, String)>) {
+    for (field, field_type) in struct_fields(type_name) {
+        if !table.is_empty() {
+            out.insert((table.to_string(), field.clone()));
+        }
+        let inner = field_type
+            .trim_start_matches("Option<")
+            .trim_end_matches('>')
+            .to_string();
+        let nested = inner.starts_with("Pam") && inner.ends_with("Config");
+        if !nested {
+            continue;
+        }
+        let child = if table.is_empty() {
+            field.clone()
+        } else {
+            format!("{table}.{field}")
+        };
+        walk_config_struct(&inner, &child, out);
+    }
+}
+
+/// `(name, type)` for every field of one struct in the PAM module's source.
+///
+/// Field lines are exactly four spaces of indentation, an identifier, a colon
+/// and a type; attribute, comment and nested-brace lines are not. The struct
+/// ends at the first `}` in column zero.
+fn struct_fields(type_name: &str) -> Vec<(String, String)> {
+    let opening = format!("\nstruct {type_name} {{\n");
+    let start = PAM_SOURCE
+        .find(&opening)
+        .unwrap_or_else(|| panic!("crates/pam-facelock/src/lib.rs has no `struct {type_name}`"))
+        + opening.len();
+    let body = &PAM_SOURCE[start..];
+    let end = body.find("\n}").unwrap_or(body.len());
+
+    body[..end]
+        .lines()
+        .filter_map(|line| {
+            let field = line.strip_prefix("    ")?;
+            if field.starts_with([' ', '#', '/', '}']) {
+                return None;
+            }
+            let (name, rest) = field.split_once(": ")?;
+            if !name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            {
+                return None;
+            }
+            Some((
+                name.to_string(),
+                rest.trim().trim_end_matches(',').to_string(),
+            ))
+        })
+        .collect()
+}
+
+/// The `(table, key)` pairs the CONFIGURATION section documents.
+///
+/// The section's shape is the contract: a `.B [table]` opens a table and the
+/// `.BR key` lines under it are its keys, until the next table. Nothing else
+/// in the section is either, which is why `FACELOCK_CONFIG` — uppercase, and
+/// on a `.B` line of its own — is not mistaken for a key.
+fn documented_config_schema() -> BTreeSet<(String, String)> {
+    let section = man_section("\n.SH CONFIGURATION\n");
+    let mut schema = BTreeSet::new();
+    let mut table: Option<String> = None;
+
+    for argument in macro_arguments(&section, &[".B", ".BR"]) {
+        for token in argument.split(',') {
+            let token = token.trim();
+            if let Some(name) = token.strip_prefix('[').and_then(|t| t.strip_suffix(']')) {
+                table = Some(name.to_string());
+                continue;
+            }
+            let is_key = !token.is_empty()
+                && token
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+            if let (true, Some(current)) = (is_key, table.as_ref()) {
+                schema.insert((current.clone(), token.to_string()));
+            }
+        }
+    }
+    schema
+}
+
+/// The documented configuration schema is the one the module reads — exactly.
+///
+/// Both directions, because both had failed. The page listed a `[pam]` table
+/// with `timeout_secs`, `notification_mode` and `skip_for_ssh` under it: one
+/// table that does not exist and three keys that were never spelled that way,
+/// while the four tables the module does read went unmentioned. An
+/// administrator following the page got a config file the module silently
+/// ignored, which is the worst failure mode a security control has.
+#[test]
+fn pam_man_configuration_matches_what_the_module_reads() {
+    let actual = pam_config_schema();
+    let documented = documented_config_schema();
+
+    for (table, key) in &actual {
+        assert!(
+            documented.contains(&(table.clone(), key.clone())),
+            "`pam_facelock.so` reads `{table}.{key}` but the CONFIGURATION \
+             section of man/pam_facelock.8 never documents it"
+        );
+    }
+    for (table, key) in &documented {
+        assert!(
+            actual.contains(&(table.clone(), key.clone())),
+            "man/pam_facelock.8 documents `{table}.{key}`, but \
+             crates/pam-facelock/src/lib.rs does not read it — a reader who \
+             sets it gets no error and no effect"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Files
+// ---------------------------------------------------------------------------
+
+/// A `&str` constant's value from the PAM module's source.
+fn pam_source_constant(name: &str) -> String {
+    let needle = format!("const {name}: &str = \"");
+    let start = PAM_SOURCE
+        .find(&needle)
+        .unwrap_or_else(|| panic!("crates/pam-facelock/src/lib.rs has no `{name}`"))
+        + needle.len();
+    let rest = &PAM_SOURCE[start..];
+    rest[..rest.find('"').expect("an unterminated string literal")].to_string()
+}
+
+/// Every absolute path the FILES section lists is a path something in this
+/// tree actually places, and every place the module can be installed is
+/// listed.
+///
+/// The page named one module location out of the three the code probes, which
+/// is the one a Fedora reader does not have: RPM installs into
+/// `/usr/lib64/security`, and a page that names only `/usr/lib/security` reads
+/// as "your install is broken".
+#[test]
+fn pam_man_files_are_places_the_tree_writes() {
+    let section = man_section("\n.SH FILES\n");
+    let listed: Vec<String> = macro_arguments(&section, &[".I"]);
+    assert!(
+        listed.len() >= 4,
+        "the FILES section lists only {} paths — the extractor is broken",
+        listed.len()
+    );
+
+    for path in &listed {
+        let justified = path == DEFAULT_CONFIG_PATH
+            || path == DEFAULT_DB_PATH
+            || PAM_MODULE_PATHS.contains(&path.as_str())
+            || PKGBUILD.contains(path.as_str());
+        assert!(
+            justified,
+            "man/pam_facelock.8 lists `{path}` under FILES, but nothing in \
+             this tree writes it: it is not a facelock-core path, not a \
+             PAM_MODULE_PATHS entry, and dist/PKGBUILD never installs it"
+        );
+    }
+
+    for module_path in PAM_MODULE_PATHS {
+        assert!(
+            listed.iter().any(|path| path == module_path),
+            "`{module_path}` is probed by PAM_MODULE_PATHS but the FILES \
+             section of man/pam_facelock.8 never names it"
+        );
+    }
+
+    assert!(
+        listed.iter().any(|path| path == DEFAULT_CONFIG_PATH),
+        "the FILES section must name the configuration file, `{DEFAULT_CONFIG_PATH}`"
+    );
+}
+
+/// The configuration path and one-shot binary the page names are the ones the
+/// module compiles in.
+///
+/// `AUTH_BIN` is deliberately not configurable — a config-selected binary in a
+/// root PAM context is the whole reason it is a constant — so the page naming
+/// a different one would send an administrator looking for a file that is
+/// never executed.
+#[test]
+fn pam_man_names_the_paths_the_module_compiles_in() {
+    let page = unescape_roff(MAN_PAGE);
+
+    let module_config = pam_source_constant("DEFAULT_CONFIG_PATH");
+    assert_eq!(
+        module_config, DEFAULT_CONFIG_PATH,
+        "the PAM module and facelock-core disagree about the config path"
+    );
+    assert!(
+        page.contains(&module_config),
+        "man/pam_facelock.8 must name the config path the module reads, \
+         `{module_config}`"
+    );
+
+    let auth_bin = pam_source_constant("AUTH_BIN");
+    assert!(
+        page.contains(&auth_bin),
+        "man/pam_facelock.8 describes the one-shot fallback but never names \
+         the binary it spawns, `{auth_bin}`"
+    );
+
+    // The module reads `DEFAULT_CONFIG_PATH` and nothing else: it never looks
+    // at `FACELOCK_CONFIG`, and `facelock_core::paths::config_path` ignores it
+    // for privileged processes for the same reason. The page said otherwise,
+    // which is worse than a plain inaccuracy — it advertised an
+    // environment-controlled input to a root PAM context that does not exist.
+    //
+    // Scoped to CONFIGURATION rather than the whole page: that section
+    // enumerates what the module reads, which is where a reader looking to
+    // point it at another file goes. SECURITY may still explain that the
+    // variable is deliberately ignored here.
+    let env_var = "FACELOCK_CONFIG";
+    assert_eq!(
+        PAM_SOURCE.contains(env_var),
+        man_section("\n.SH CONFIGURATION\n").contains(env_var),
+        "the CONFIGURATION section and the module disagree about whether \
+         `{env_var}` selects the config path the module reads"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// D-Bus grants
+// ---------------------------------------------------------------------------
+
+/// Methods the default (non-root) policy context is allowed to send.
+fn user_grantable_methods() -> BTreeSet<String> {
+    DBUS_POLICY
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim().strip_prefix("send_member=\"")?;
+            Some(rest[..rest.find('"')?].to_string())
+        })
+        .collect()
+}
+
+/// The page describes the access the shipped policy actually grants.
+///
+/// It described the policy that was retired: "deny-all default, restricting
+/// access to root and members of the `facelock` group". ADR 010 removed the
+/// group entirely and opened exactly one method to every local user, which is
+/// what lets a screen locker unlock without a group membership. A reader of
+/// the old page would add users to a group that does not exist and conclude
+/// face unlock does not work for them.
+#[test]
+fn pam_man_dbus_section_matches_the_shipped_policy() {
+    let page = unescape_roff(MAN_PAGE);
+    let section = man_section("\n.SH SECURITY\n");
+
+    assert!(
+        page.contains(BUS_NAME),
+        "man/pam_facelock.8 must name the bus the module connects to, `{BUS_NAME}`"
+    );
+
+    let policy_grants_a_group = DBUS_POLICY.contains("<policy group=");
+    assert_eq!(
+        policy_grants_a_group,
+        section.contains("group"),
+        "dbus/org.facelock.Daemon.conf grants nothing to a group (ADR 010 \
+         retired the `facelock` group), so the SECURITY section of \
+         man/pam_facelock.8 must not describe one"
+    );
+
+    let methods = user_grantable_methods();
+    assert!(
+        !methods.is_empty(),
+        "no `send_member` grant parsed out of dbus/org.facelock.Daemon.conf — \
+         the extractor is broken, not the policy"
+    );
+    for method in methods {
+        assert!(
+            section.contains(&method),
+            "the shipped policy lets any local user send `{method}`, but the \
+             SECURITY section of man/pam_facelock.8 never says so"
+        );
+    }
+}
+
+/// The defaults quoted in prose are the defaults that ship.
+///
+/// Numbers in a security section are the part a reader plans around, and they
+/// are also the part nobody revisits when a default moves.
+#[test]
+fn pam_man_quotes_the_defaults_that_ship() {
+    let section = man_section("\n.SH SECURITY\n");
+    let rate_limit = RateLimitConfig::default();
+
+    assert!(
+        section.contains(&rate_limit.max_attempts.to_string()),
+        "the SECURITY section quotes a rate limit but not the shipped default \
+         of {} attempts",
+        rate_limit.max_attempts
+    );
+    assert!(
+        section.contains(&rate_limit.window_secs.to_string()),
+        "the SECURITY section quotes a rate-limit window but not the shipped \
+         default of {} seconds",
+        rate_limit.window_secs
+    );
+
+    let require_ir = SecurityConfig::default().require_ir;
+    assert!(
+        section.contains(&format!("security.require_ir={require_ir}")),
+        "the SECURITY section must state the shipped `security.require_ir` \
+         default, which is `{require_ir}`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Examples
+// ---------------------------------------------------------------------------
+
+/// Every `facelock …` line in a `.nf` block, as argv.
+fn documented_invocations() -> Vec<Vec<String>> {
+    let page = unescape_roff(MAN_PAGE);
+    let mut invocations = Vec::new();
+    let mut in_block = false;
+
+    for line in page.lines() {
+        match line.trim() {
+            ".nf" => in_block = true,
+            ".fi" => in_block = false,
+            command if in_block => {
+                let command = command.strip_prefix("sudo ").unwrap_or(command).trim();
+                if command == "facelock" || command.starts_with("facelock ") {
+                    invocations.push(command.split_whitespace().map(str::to_string).collect());
+                }
+            }
+            _ => {}
+        }
+    }
+    invocations
+}
+
+/// The page's own examples parse, and none of them installs into a service
+/// that would refuse them.
+///
+/// The same promise `docs_cli_examples_all_parse` makes for the markdown
+/// references, made for the page an administrator reaches with `man 8
+/// pam_facelock`. Both halves matter: `docs/cli.md` once documented
+/// `setup --pam --service login`, which parses and then fails at run time on
+/// the sensitive-service gate.
+#[test]
+fn pam_man_examples_parse_and_are_not_gated() {
+    use facelock_cli::commands::pam::SENSITIVE_SERVICES;
+    use facelock_cli::commands::setup::{PamPref, SetupArgs, resolve_setup_plan};
+
+    use crate::Commands;
+
+    let invocations = documented_invocations();
+    assert!(
+        !invocations.is_empty(),
+        "no `facelock` example extracted from man/pam_facelock.8 — the \
+         extractor is broken, not the page"
+    );
+
+    for argv in invocations {
+        let rendered = argv.join(" ");
+        let cli = Cli::try_parse_from(&argv)
+            .unwrap_or_else(|e| panic!("`{rendered}` in man/pam_facelock.8 must parse: {e}"));
+
+        let Commands::Setup(setup) = cli.command else {
+            continue;
+        };
+        let plan = resolve_setup_plan(SetupArgs::from(setup));
+        if plan.allow_sensitive {
+            continue;
+        }
+        let PamPref::Install {
+            service: Some(service),
+            ..
+        } = &plan.pam
+        else {
+            continue;
+        };
+        assert!(
+            !SENSITIVE_SERVICES.contains(&service.as_str()),
+            "`{rendered}` in man/pam_facelock.8 installs into the gated \
+             service `{service}` without --allow-sensitive, so it fails as \
+             written"
+        );
+    }
+}

--- a/crates/facelock-cli/src/conformance/mod.rs
+++ b/crates/facelock-cli/src/conformance/mod.rs
@@ -11,17 +11,34 @@
 //! - [`capabilities`] — every name `facelock capabilities` emits is backed by
 //!   the clap surface it names.
 //! - [`docs`] — the reference docs describe the binary that shipped.
+//! - [`man_pam`] — `man/pam_facelock.8` describes the PAM module that shipped.
+//! - [`packages`] — every package name an instruction hands a reader is one
+//!   the project's own packaging manifests declare.
+//! - [`pairs`] — the six pages that exist in both `docs/` and `book/src/` do
+//!   not contradict each other.
 //!
-//! What is shared is here: the clap-tree navigation helpers all three suites
-//! use, and the derive check every one of them presumes.
+//! What is shared is here: the clap-tree navigation helpers the suites use,
+//! the roff normalization the two man-page suites both need, and the derive
+//! check every one of them presumes.
 
 mod capabilities;
 mod docs;
 mod flags;
+mod man_pam;
+mod packages;
+mod pairs;
 
 use clap::CommandFactory;
 
 use crate::Cli;
+
+/// `man(7)` writes a literal hyphen as `\-`, so `system-auth` is on disk as
+/// `system\-auth` and a plain substring search for it fails. Undoing that one
+/// escape is the whole normalization the man-page checks need; nothing here
+/// looks at roff structure.
+fn unescape_roff(page: &str) -> String {
+    page.replace(r"\-", "-")
+}
 
 #[test]
 fn verify_cli() {

--- a/crates/facelock-cli/src/conformance/packages.rs
+++ b/crates/facelock-cli/src/conformance/packages.rs
@@ -1,0 +1,687 @@
+//! Distro package names (#209, #211): a name a document tells a reader to
+//! install is one the project's own packaging declares.
+//!
+//! `onnxruntime-opt-openvino` reached five user-facing files and a shipped
+//! config template. No Arch repository and no AUR package has ever carried
+//! that name, so the Intel setup path stopped at a failed `pacman -S` — and
+//! the person who found it was a contributor evaluating facelock for Omarchy,
+//! not us. The same class had already shipped twice (#172, #187). Nothing in
+//! the tree validated a package name anywhere.
+//!
+//! **Offline by construction.** `just check` and CI must not need the network,
+//! so nothing here queries a repository. The known-good names are *derived*
+//! instead: `dist/PKGBUILD*`, `debian/control` and `dist/facelock.spec`
+//! already declare every package the project builds, depends on or suggests,
+//! and those manifests are exercised against real repositories by the
+//! packaging jobs on every release. A name a document hands a reader must
+//! appear in the manifest for that document's distro. `onnxruntime-opt-openvino`
+//! never appeared in `dist/PKGBUILD` — it was invented in prose, which is
+//! exactly the shape this catches.
+//!
+//! What the derivation does *not* prove is that a third-party name still
+//! exists upstream: the manifest could be as wrong as the prose was.
+//! `just check-package-names-live` revalidates the derived set against Arch,
+//! the AUR, Debian and Fedora over the network. It is opt-in and deliberately
+//! outside `just check`.
+//!
+//! The corpus is walked at test time rather than `include_str!`d, unlike
+//! [`super::docs`]. That module pins named facts in named documents, where a
+//! deleted file should break the build; this one sweeps every document a
+//! reader could take an instruction from, where a *new* file that nobody
+//! remembered to register is the failure mode. A floor assertion stands in for
+//! the compile-time guarantee: a walk that stops finding files fails loudly
+//! rather than passing vacuously.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The packaging manifest allowed to vouch for a name.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(super) enum Distro {
+    Arch,
+    Debian,
+    Fedora,
+    /// A package manager the project ships no manifest for. Every name
+    /// reached through one of these fails: there is nothing to check it
+    /// against, and an unverifiable instruction is the thing being stopped.
+    Unmanifested,
+}
+
+impl Distro {
+    /// Named in the failure message so the fix is obvious: add the dependency
+    /// where it belongs, or stop telling readers to install it.
+    fn manifest(self) -> &'static str {
+        match self {
+            Distro::Arch => "dist/PKGBUILD, dist/PKGBUILD-bin or dist/PKGBUILD-git",
+            Distro::Debian => "debian/control",
+            Distro::Fedora => "dist/facelock.spec",
+            Distro::Unmanifested => "no packaging manifest in this tree",
+        }
+    }
+}
+
+/// Install verbs that take bare package names, and the manifest that has to
+/// declare what follows them.
+///
+/// The trailing space is load-bearing: without it `pacman -S` also matches
+/// `pacman -Ss` and `pacman -Sy`, and the guard would read a flag as a
+/// package name.
+const INSTALL_VERBS: &[(&str, Distro)] = &[
+    ("pacman -S ", Distro::Arch),
+    ("yay -S ", Distro::Arch),
+    ("paru -S ", Distro::Arch),
+    ("apt-get install ", Distro::Debian),
+    ("apt install ", Distro::Debian),
+    ("dnf install ", Distro::Fedora),
+    ("yum install ", Distro::Fedora),
+    ("zypper install ", Distro::Unmanifested),
+    ("apk add ", Distro::Unmanifested),
+    ("emerge ", Distro::Unmanifested),
+];
+
+/// Names that are real but that no manifest in this tree declares.
+///
+/// Empty, and meant to stay that way. An entry here is an assertion made by a
+/// human against a live repository on the date given, which is exactly the
+/// kind of claim that goes stale — `just check-package-names-live` re-checks
+/// these along with the derived set. Prefer declaring the dependency in the
+/// manifest that should have had it.
+const KNOWN_EXTERNAL: &[(Distro, &str, &str)] = &[
+    // (distro, package, why no manifest declares it + when it was verified)
+];
+
+/// Repository root, from the compile-time manifest directory so the walk does
+/// not depend on the working directory `cargo test` happens to use.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .canonicalize()
+        .expect("the crate sits two levels below the repository root")
+}
+
+/// Every document a reader could take an install instruction from.
+///
+/// `docs/` is walked recursively so `docs/adr/` is covered; `book/src/` is
+/// flat. `config/facelock.toml` is here because it ships to
+/// `/etc/facelock/config.toml` — its comments are instructions a user reads
+/// on their own machine, and they carried the #209 defect in prose form.
+/// `website/index.html` is here because it is where an evaluator lands first.
+fn instruction_corpus() -> Vec<(String, String)> {
+    let root = repo_root();
+    let mut files = vec![
+        root.join("README.md"),
+        root.join("AGENTS.md"),
+        root.join("config/facelock.toml"),
+        root.join("website/index.html"),
+    ];
+    collect_markdown(&root.join("docs"), &mut files);
+    collect_markdown(&root.join("book/src"), &mut files);
+    files.sort();
+
+    let corpus: Vec<(String, String)> = files
+        .iter()
+        .map(|path| {
+            let text = fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+            let relative = path
+                .strip_prefix(&root)
+                .unwrap_or(path)
+                .display()
+                .to_string();
+            let text = if relative.ends_with(".html") {
+                strip_markup(&text)
+            } else {
+                text
+            };
+            (relative, text)
+        })
+        .collect();
+
+    assert!(
+        corpus.len() > 25,
+        "walked only {} documents — the walk is broken, not the tree",
+        corpus.len()
+    );
+    corpus
+}
+
+fn collect_markdown(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("{} must be readable: {e}", dir.display()))
+        .filter_map(Result::ok);
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+}
+
+/// Flatten HTML to the text a reader sees, so a command wrapped in
+/// `<span class="command">` is still one command line.
+///
+/// Deliberately naive — the only job is to stop tags and entities from
+/// splitting or joining tokens. Anything it gets wrong shows up as a package
+/// name that fails to resolve, which is a loud failure and not a silent pass.
+fn strip_markup(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut depth = 0usize;
+    for ch in html.chars() {
+        match ch {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            _ if depth == 0 => out.push(ch),
+            _ => {}
+        }
+    }
+    out.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+}
+
+/// One package name a document hands a reader, with enough context to name
+/// the offender.
+#[derive(Debug)]
+struct Mention {
+    distro: Distro,
+    name: String,
+    source: String,
+}
+
+/// Package names reached through an install verb.
+///
+/// Scanning is per line and per verb, so `yay -S facelock  # or paru -S
+/// facelock` yields both. A ` #` ends the argument list except where the
+/// comment itself carries a second verb, which is why the search runs from
+/// each verb rather than from the start of the line.
+pub(super) fn install_mentions(text: &str) -> Vec<(Distro, String)> {
+    let mut found = Vec::new();
+    for line in text.lines() {
+        for (verb, distro) in INSTALL_VERBS {
+            let mut from = 0usize;
+            while let Some(at) = line[from..].find(verb) {
+                let start = from + at + verb.len();
+                for name in package_tokens(&line[start..]) {
+                    found.push((*distro, name));
+                }
+                from = start;
+            }
+        }
+    }
+    found
+}
+
+/// The bare names in an argument list, stopping where the command does.
+///
+/// Stops at a comment, a shell operator, or anything that cannot be a package
+/// name — a placeholder, a redirect, a quoted string. Flags are skipped rather
+/// than ending the list, since `--needed` and `-y` sit among the names.
+///
+/// Trailing markup (a closing backtick, a sentence's period) is trimmed and
+/// then *ends* the list: a name cited inline in prose is still a name a reader
+/// will type, but the words after the closing backtick are prose, not more
+/// packages.
+fn package_tokens(rest: &str) -> Vec<String> {
+    const CLOSERS: [char; 7] = ['`', '.', ',', ')', '"', '\'', ';'];
+
+    let mut names = Vec::new();
+    for raw in rest.split_whitespace() {
+        if raw.starts_with('#') {
+            break;
+        }
+        if raw.starts_with('-') {
+            continue;
+        }
+        let token = raw.trim_end_matches(CLOSERS);
+        if token.is_empty() || !is_package_name(token) {
+            break;
+        }
+        names.push(token.to_string());
+        if token.len() != raw.len() {
+            break;
+        }
+    }
+    names
+}
+
+/// The shape every distro this project ships to agrees on: lowercase, digits,
+/// and `. _ + -`, opening on an alphanumeric.
+fn is_package_name(token: &str) -> bool {
+    token
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && token
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || "._+-".contains(c))
+}
+
+/// Package names given in a table rather than in a command.
+///
+/// The GPU tables in `README.md` and `book/src/gpu.md` name the package to
+/// install in a column and leave the `pacman -S` to a code block further
+/// down — which is how `onnxruntime-opt-openvino` survived in two files after
+/// the command that installed it was fixed. A cell counts only when it is
+/// *exactly* one backticked token and the column header names a distro, so a
+/// prose cell (`none packaged`) and a mixed cell (`` `facelock`, TPM
+/// enabled ``) are left alone.
+pub(super) fn table_mentions(text: &str) -> Vec<(Distro, String)> {
+    let mut found = Vec::new();
+    let mut header: Option<Vec<String>> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            header = None;
+            continue;
+        }
+        let cells: Vec<String> = trimmed
+            .trim_matches('|')
+            .split('|')
+            .map(|c| c.trim().to_string())
+            .collect();
+
+        // The `|---|---|` rule line neither is a header nor carries data.
+        if cells
+            .iter()
+            .all(|c| !c.is_empty() && c.chars().all(|ch| ch == '-' || ch == ':'))
+        {
+            continue;
+        }
+        let Some(columns) = &header else {
+            header = Some(cells);
+            continue;
+        };
+
+        for (column, cell) in columns.iter().zip(&cells) {
+            if !column.contains("Package") {
+                continue;
+            }
+            // A column headed only "Package" says nothing about which
+            // repository the name lives in, so there is no manifest to check
+            // it against.
+            let distro = if column.contains("Arch") {
+                Distro::Arch
+            } else if column.contains("Debian") || column.contains("Ubuntu") {
+                Distro::Debian
+            } else if column.contains("Fedora") {
+                Distro::Fedora
+            } else {
+                continue;
+            };
+            let Some(name) = cell.strip_prefix('`').and_then(|c| c.strip_suffix('`')) else {
+                continue;
+            };
+            if is_package_name(name) {
+                found.push((distro, name.to_string()));
+            }
+        }
+    }
+    found
+}
+
+/// Every name the packaging manifests declare, by distro.
+fn declared_names() -> BTreeMap<Distro, BTreeSet<String>> {
+    let root = repo_root();
+    let read = |relative: &str| {
+        fs::read_to_string(root.join(relative))
+            .unwrap_or_else(|e| panic!("{relative} must be readable: {e}"))
+    };
+
+    let mut arch = BTreeSet::new();
+    for pkgbuild in ["dist/PKGBUILD", "dist/PKGBUILD-bin", "dist/PKGBUILD-git"] {
+        arch.extend(pkgbuild_names(&read(pkgbuild)));
+    }
+
+    BTreeMap::from([
+        (Distro::Arch, arch),
+        (Distro::Debian, control_names(&read("debian/control"))),
+        (Distro::Fedora, spec_names(&read("dist/facelock.spec"))),
+        (Distro::Unmanifested, BTreeSet::new()),
+    ])
+}
+
+/// `pkgname` plus every dependency array.
+///
+/// `optdepends` entries are `'name: description'`, and every array entry can
+/// carry a version constraint, so both are trimmed off.
+fn pkgbuild_names(pkgbuild: &str) -> BTreeSet<String> {
+    const ARRAYS: &[&str] = &["depends", "makedepends", "optdepends", "checkdepends"];
+
+    let mut names = BTreeSet::new();
+    let mut in_array = false;
+
+    for line in pkgbuild.lines() {
+        let trimmed = line.trim();
+        if let Some(name) = trimmed.strip_prefix("pkgname=") {
+            names.insert(strip_constraint(name.trim_matches(['\'', '"'])));
+            continue;
+        }
+        let opens = ARRAYS.iter().any(|array| {
+            trimmed
+                .strip_prefix(array)
+                .is_some_and(|rest| rest.starts_with("=("))
+        });
+        if opens {
+            in_array = true;
+        }
+        if !in_array {
+            continue;
+        }
+        for entry in quoted_entries(trimmed) {
+            let name = entry.split(':').next().unwrap_or(&entry);
+            names.insert(strip_constraint(name.trim()));
+        }
+        if trimmed.ends_with(')') {
+            in_array = false;
+        }
+    }
+    names.remove("");
+    names
+}
+
+/// The `'…'`-quoted entries on one line of a bash array.
+fn quoted_entries(line: &str) -> Vec<String> {
+    let mut entries = Vec::new();
+    let mut rest = line;
+    while let Some(open) = rest.find(['\'', '"']) {
+        let quote = rest.as_bytes()[open] as char;
+        let after = &rest[open + 1..];
+        let Some(close) = after.find(quote) else {
+            break;
+        };
+        entries.push(after[..close].to_string());
+        rest = &after[close + 1..];
+    }
+    entries
+}
+
+/// `Package:` plus every dependency field.
+///
+/// Alternatives (`a | b`) count as two names; substvars (`${shlibs:Depends}`)
+/// are not names at all.
+fn control_names(control: &str) -> BTreeSet<String> {
+    const FIELDS: &[&str] = &[
+        "Package:",
+        "Depends:",
+        "Pre-Depends:",
+        "Build-Depends:",
+        "Recommends:",
+        "Suggests:",
+    ];
+
+    let mut names = BTreeSet::new();
+    let mut in_field = false;
+
+    for line in control.lines() {
+        let starts_field = FIELDS.iter().any(|field| line.starts_with(field));
+        if starts_field {
+            in_field = true;
+        } else if !line.starts_with([' ', '\t']) {
+            in_field = false;
+        }
+        if !in_field {
+            continue;
+        }
+        let value = line.split_once(':').map_or(line, |(_, rest)| rest);
+        for entry in value.split([',', '|']) {
+            let entry = entry.trim();
+            if entry.is_empty() || entry.starts_with('$') {
+                continue;
+            }
+            let name = entry.split_whitespace().next().unwrap_or(entry);
+            if is_package_name(name) {
+                names.insert(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// `Name:` plus every dependency tag. Macro-valued dependencies
+/// (`%{name}-libs`) are skipped: nothing here expands macros.
+fn spec_names(spec: &str) -> BTreeSet<String> {
+    const TAGS: &[&str] = &[
+        "Name:",
+        "Requires:",
+        "BuildRequires:",
+        "Recommends:",
+        "Suggests:",
+    ];
+
+    let mut names = BTreeSet::new();
+    for line in spec.lines() {
+        if !TAGS.iter().any(|tag| line.starts_with(tag)) {
+            continue;
+        }
+        let Some((_, value)) = line.split_once(':') else {
+            continue;
+        };
+        let Some(name) = value.split_whitespace().next() else {
+            continue;
+        };
+        if is_package_name(name) {
+            names.insert(name.to_string());
+        }
+    }
+    names
+}
+
+/// Trim a version constraint from a dependency entry.
+fn strip_constraint(entry: &str) -> String {
+    let end = entry.find(['>', '<', '=']).unwrap_or(entry.len());
+    entry[..end].trim().to_string()
+}
+
+/// Every package name a document hands a reader, from commands and tables
+/// alike.
+fn documented_packages() -> Vec<Mention> {
+    let mut mentions = Vec::new();
+    for (path, text) in instruction_corpus() {
+        for (distro, name) in install_mentions(&text) {
+            mentions.push(Mention {
+                distro,
+                name,
+                source: path.clone(),
+            });
+        }
+        for (distro, name) in table_mentions(&text) {
+            mentions.push(Mention {
+                distro,
+                name,
+                source: path.clone(),
+            });
+        }
+    }
+    assert!(
+        mentions.len() > 10,
+        "found only {} package mentions — the extractor is broken, not the docs",
+        mentions.len()
+    );
+    mentions
+}
+
+/// Every documented package name is declared by the packaging manifest for
+/// its distro.
+///
+/// This is the whole guard. A name that no manifest declares is either a
+/// dependency the packaging forgot — in which case declare it there, where a
+/// build would have caught it — or a name that does not exist, which is #209.
+#[test]
+fn documented_packages_are_declared_by_packaging() {
+    let declared = declared_names();
+
+    for mention in documented_packages() {
+        if KNOWN_EXTERNAL
+            .iter()
+            .any(|(distro, name, _)| *distro == mention.distro && *name == mention.name)
+        {
+            continue;
+        }
+        let known = declared
+            .get(&mention.distro)
+            .expect("every Distro variant has a declared set");
+        assert!(
+            known.contains(&mention.name),
+            "`{}` tells a reader to install `{}`, but {} never declares it. \
+             Either the package does not exist (#209) or the dependency is \
+             missing from packaging — say it in {}, not only in prose.",
+            mention.source,
+            mention.name,
+            mention.distro.manifest(),
+            mention.distro.manifest()
+        );
+    }
+}
+
+/// The manifests parse to something, so the guard above cannot pass by
+/// finding nothing to compare against.
+///
+/// A parser that silently returns an empty set turns
+/// [`documented_packages_are_declared_by_packaging`] into an assertion that
+/// every documented name is missing — which fails, loudly, and would be
+/// mistaken for a docs bug. Naming the failure here says which half broke.
+#[test]
+fn packaging_manifests_declare_the_names_they_are_read_for() {
+    let declared = declared_names();
+
+    for (distro, floor, must_hold) in [
+        (Distro::Arch, 12usize, "facelock"),
+        (Distro::Debian, 6, "facelock"),
+        (Distro::Fedora, 6, "facelock"),
+    ] {
+        let names = &declared[&distro];
+        assert!(
+            names.len() >= floor,
+            "{} parsed to only {} names ({names:?}) — the manifest parser is \
+             broken, not the manifest",
+            distro.manifest(),
+            names.len()
+        );
+        assert!(
+            names.contains(must_hold),
+            "{} must declare `{must_hold}`",
+            distro.manifest()
+        );
+    }
+
+    let arch = &declared[&Distro::Arch];
+    for gpu in ["onnxruntime-opt-cuda", "onnxruntime-opt-rocm"] {
+        assert!(
+            arch.contains(gpu),
+            "dist/PKGBUILD lists `{gpu}` in optdepends; the optdepends parser \
+             must reach it, or every GPU instruction fails this suite"
+        );
+    }
+}
+
+/// No unmanifested package manager reaches a reader.
+///
+/// Separated from the main guard so the message is the right one: a
+/// `zypper install` instruction is not a wrong package name, it is a name
+/// this tree has no way to check. Adding openSUSE packaging, or an entry in
+/// [`KNOWN_EXTERNAL`], is the fix — not a looser check.
+#[test]
+fn no_documented_install_uses_an_unverifiable_package_manager() {
+    for mention in documented_packages() {
+        assert!(
+            mention.distro != Distro::Unmanifested
+                || KNOWN_EXTERNAL
+                    .iter()
+                    .any(|(distro, name, _)| *distro == mention.distro && *name == mention.name),
+            "`{}` tells a reader to install `{}` with a package manager this \
+             tree ships no manifest for, so nothing can confirm the name exists",
+            mention.source,
+            mention.name
+        );
+    }
+}
+
+#[test]
+fn install_verbs_do_not_match_a_longer_flag() {
+    assert!(install_mentions("pacman -Ss onnxruntime").is_empty());
+    assert!(install_mentions("pacman -Qkk facelock").is_empty());
+}
+
+#[test]
+fn a_comment_can_carry_a_second_verb() {
+    let found = install_mentions("yay -S facelock           # or paru -S facelock");
+    assert_eq!(
+        found,
+        vec![
+            (Distro::Arch, "facelock".to_string()),
+            (Distro::Arch, "facelock".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn flags_are_skipped_and_comments_end_the_list() {
+    let found = install_mentions("sudo pacman -S --needed onnxruntime-opt-cuda  # NVIDIA");
+    assert_eq!(found, vec![(Distro::Arch, "onnxruntime-opt-cuda".into())]);
+}
+
+#[test]
+fn a_chained_update_does_not_swallow_the_install() {
+    let found = install_mentions("sudo apt update && sudo apt install facelock");
+    assert_eq!(found, vec![(Distro::Debian, "facelock".into())]);
+}
+
+#[test]
+fn an_inline_citation_keeps_its_name() {
+    let found = install_mentions("Run `sudo dnf install facelock` to get it.");
+    assert_eq!(found, vec![(Distro::Fedora, "facelock".into())]);
+}
+
+#[test]
+fn table_cells_need_a_distro_column_and_a_bare_backticked_name() {
+    let table = "\
+| GPU Vendor | Package (Arch) | Config value |
+|---|---|---|
+| NVIDIA | `onnxruntime-opt-cuda` | `\"cuda\"` |
+| Intel | none packaged | `\"openvino\"` |
+";
+    assert_eq!(
+        table_mentions(table),
+        vec![(Distro::Arch, "onnxruntime-opt-cuda".into())]
+    );
+
+    let unlabelled = "\
+| Suite | Package |
+|---|---|
+| trixie | `facelock`, TPM enabled |
+";
+    assert!(table_mentions(unlabelled).is_empty());
+}
+
+#[test]
+fn optdepends_descriptions_and_version_constraints_are_trimmed() {
+    let pkgbuild = "\
+pkgname=facelock
+depends=('glibc' 'onnxruntime>=1.16')
+optdepends=(
+'onnxruntime-opt-cuda: NVIDIA GPU acceleration (replaces onnxruntime)'
+)
+";
+    let names = pkgbuild_names(pkgbuild);
+    assert!(names.contains("facelock"));
+    assert!(names.contains("onnxruntime"));
+    assert!(names.contains("onnxruntime-opt-cuda"));
+}
+
+#[test]
+fn control_substvars_are_not_package_names() {
+    let control = "\
+Package: facelock
+Depends: ${shlibs:Depends}, ${misc:Depends}, dbus, libpam-runtime
+";
+    let names = control_names(control);
+    assert!(names.contains("facelock"));
+    assert!(names.contains("libpam-runtime"));
+    assert!(!names.iter().any(|n| n.contains('$')));
+}

--- a/crates/facelock-cli/src/conformance/pairs.rs
+++ b/crates/facelock-cli/src/conformance/pairs.rs
@@ -1,0 +1,409 @@
+//! Six documents exist twice, and the copies drift (#211).
+//!
+//! `docs/` and `book/src/` carry a same-named page for `architecture`,
+//! `compatibility`, `configuration`, `quickstart`, `security` and
+//! `troubleshooting`. `contracts.md` used to be a seventh until #187 made the
+//! book's copy a one-line `{{#include}}`; the other six are still two files
+//! maintained by hand, and nothing compares them.
+//!
+//! **Byte equality would be the wrong check.** They are deliberately different
+//! documents for different readers: `docs/security.md` is the normative
+//! security review and `book/src/security.md` is the chapter someone reads
+//! before installing. The book is allowed to say less, in different words, in a
+//! different order.
+//!
+//! What it is not allowed to do is say something *else*. So the comparison is
+//! scoped to headings both files carry, and within a shared heading to the
+//! tokens that decide what a reader types or looks for:
+//!
+//! - **package names** must match exactly, in both directions. A GPU section
+//!   that names one package in `docs/` and another in `book/` is #209 with an
+//!   extra step, and neither copy is more authoritative than the other here.
+//! - **command names and absolute paths** must be a subset on the book's side.
+//!   The book may omit what `docs/` covers — that is the relationship between
+//!   the two — but a command or a path it names under a shared heading and
+//!   `docs/` does not is either invented or renamed.
+//!
+//! What this does **not** catch is stated plainly because it matters: a fact
+//! that `docs/` gains and the book never does. That is the direction #211
+//! actually found — `docs/security.md` documented TPM PCR binding at length
+//! and the book's security page said nothing about it — and it cannot be
+//! mechanical, because "the book is shallower" is the design. The only pin for
+//! it is [`BOOK_MUST_COVER`], a curated list of facts a reader must not be able
+//! to miss by reading the book instead of the docs.
+//!
+//! Also out of scope: prose, ordering, headings that exist on one side only,
+//! and the `docs/cli.md` ↔ `book/src/cli-reference.md` pair, which is not
+//! same-named and is already held to a stricter standard by [`super::docs`].
+
+use std::collections::BTreeSet;
+
+use clap::{CommandFactory, Parser};
+
+use super::packages::{install_mentions, table_mentions};
+use crate::Cli;
+
+/// The pairs, as `(docs path, docs text, book path, book text)`.
+///
+/// Embedded rather than walked: these are named documents whose disappearance
+/// should break the build, which is the same reasoning [`super::docs`] applies
+/// to `docs/cli.md`. A seventh pair added to the tree and not to this list is
+/// caught by [`every_same_named_page_is_paired`].
+const PAIRS: &[(&str, &str, &str, &str)] = &[
+    (
+        "docs/architecture.md",
+        include_str!("../../../../docs/architecture.md"),
+        "book/src/architecture.md",
+        include_str!("../../../../book/src/architecture.md"),
+    ),
+    (
+        "docs/compatibility.md",
+        include_str!("../../../../docs/compatibility.md"),
+        "book/src/compatibility.md",
+        include_str!("../../../../book/src/compatibility.md"),
+    ),
+    (
+        "docs/configuration.md",
+        include_str!("../../../../docs/configuration.md"),
+        "book/src/configuration.md",
+        include_str!("../../../../book/src/configuration.md"),
+    ),
+    (
+        "docs/quickstart.md",
+        include_str!("../../../../docs/quickstart.md"),
+        "book/src/quickstart.md",
+        include_str!("../../../../book/src/quickstart.md"),
+    ),
+    (
+        "docs/security.md",
+        include_str!("../../../../docs/security.md"),
+        "book/src/security.md",
+        include_str!("../../../../book/src/security.md"),
+    ),
+    (
+        "docs/troubleshooting.md",
+        include_str!("../../../../docs/troubleshooting.md"),
+        "book/src/troubleshooting.md",
+        include_str!("../../../../book/src/troubleshooting.md"),
+    ),
+];
+
+/// Facelock-owned path roots. A path under one of these is a promise about
+/// this machine; anything else in the prose is an example or a third party's
+/// file and is none of this check's business.
+const PATH_ROOTS: &[&str] = &[
+    "/etc/facelock",
+    "/var/lib/facelock",
+    "/var/log/facelock",
+    "/run/facelock",
+    "/lib/security",
+    "/usr/lib/security",
+    "/usr/lib64/security",
+    "/usr/bin/facelock",
+    "/usr/share/dbus-1",
+    "/usr/share/pam-configs",
+    "/usr/lib/systemd",
+    "/etc/dbus-1",
+    "/etc/pam.d",
+    "/usr/lib/pam.d",
+];
+
+/// Facts a reader of the book must not be able to miss.
+///
+/// The one direction the mechanical comparison cannot cover: `docs/` gaining
+/// depth the book never gets. Every entry is a decision a reader makes
+/// differently depending on whether they know it, not merely a detail `docs/`
+/// happens to carry — which is why the list is short and why adding to it is a
+/// judgement rather than a rule.
+///
+/// Every token here is checked to be real by
+/// [`required_coverage_names_things_that_exist`], so this cannot pin the book
+/// to a config key or a command that no longer ships.
+const BOOK_MUST_COVER: &[(&str, &[&str])] = &[(
+    "book/src/security.md",
+    &[
+        // `tpm.pcr_binding` decides whether a firmware or kernel update
+        // silently costs the user their enrolled templates. The book's
+        // security page described TPM sealing and stopped there, so a reader
+        // who chose the `tpm` method from the book alone had no way to know
+        // there was a reseal step, or a backup that makes it painless.
+        "pcr_binding",
+        "facelock tpm reseal",
+        "encryption.key",
+    ],
+)];
+
+/// A `##` or `###` heading and the body under it, ending at the next heading
+/// of either level.
+///
+/// Fenced code blocks are skipped when looking for headings: a `### ` inside a
+/// shell example is a comment, not a section.
+fn sections(doc: &str) -> Vec<(String, String)> {
+    let mut sections: Vec<(String, String)> = Vec::new();
+    let mut heading = String::from("(preamble)");
+    let mut body = String::new();
+    let mut fenced = false;
+
+    for line in doc.lines() {
+        if line.trim_start().starts_with("```") {
+            fenced = !fenced;
+        }
+        let is_heading = !fenced
+            && (line.starts_with("## ") || line.starts_with("### "))
+            && !line.contains('\r');
+        if is_heading {
+            sections.push((heading, std::mem::take(&mut body)));
+            heading = line.trim_end().to_string();
+        } else {
+            body.push_str(line);
+            body.push('\n');
+        }
+    }
+    sections.push((heading, body));
+    sections
+}
+
+/// Package names an install command or a package table hands a reader.
+fn packages(body: &str) -> BTreeSet<String> {
+    install_mentions(body)
+        .into_iter()
+        .chain(table_mentions(body))
+        .map(|(_, name)| name)
+        .collect()
+}
+
+/// `facelock <verb>` mentions, filtered to verbs the binary actually has.
+///
+/// The filter is what makes this usable: without it "facelock is a PAM module"
+/// contributes a command called `is`. With it, a heading can only contribute a
+/// name the clap tree agrees exists — so the check compares documentation of
+/// real commands rather than parts of speech.
+fn commands(body: &str, known: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let mut rest = body;
+    while let Some(at) = rest.find("facelock ") {
+        rest = &rest[at + "facelock ".len()..];
+        let verb: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_lowercase() || *c == '-')
+            .collect();
+        if known.contains(&verb) {
+            found.insert(verb);
+        }
+    }
+    found
+}
+
+/// Absolute paths under a facelock-owned root.
+fn paths(body: &str) -> BTreeSet<String> {
+    const TRAILING: [char; 6] = ['/', '.', ',', ')', '`', ':'];
+
+    let mut found = BTreeSet::new();
+    for token in body.split(|c: char| c.is_whitespace() || c == '`' || c == '(' || c == '"') {
+        let Some(start) = token.find('/') else {
+            continue;
+        };
+        let token = &token[start..];
+        if !PATH_ROOTS.iter().any(|root| token.starts_with(root)) {
+            continue;
+        }
+        let token = token.trim_end_matches(TRAILING);
+        if !token.is_empty() {
+            found.insert(token.to_string());
+        }
+    }
+    found
+}
+
+/// Every top-level and nested verb the binary offers.
+fn known_commands() -> BTreeSet<String> {
+    let root = Cli::command();
+    let mut names = BTreeSet::new();
+    for command in root.get_subcommands() {
+        if command.get_name() == "help" {
+            continue;
+        }
+        names.insert(command.get_name().to_string());
+    }
+    names
+}
+
+/// Under a heading both copies carry, both name the same packages.
+///
+/// Exact, and in both directions: neither copy is the authority on which
+/// package a reader installs, so a disagreement is a defect wherever it sits.
+#[test]
+fn paired_sections_name_the_same_packages() {
+    for (docs_path, docs, book_path, book) in PAIRS {
+        let book_sections = sections(book);
+        for (heading, docs_body) in sections(docs) {
+            let Some((_, book_body)) = book_sections.iter().find(|(h, _)| *h == heading) else {
+                continue;
+            };
+            let in_docs = packages(&docs_body);
+            let in_book = packages(book_body);
+            assert_eq!(
+                in_docs, in_book,
+                "`{heading}` names different packages in {docs_path} ({in_docs:?}) \
+                 and {book_path} ({in_book:?}); a reader following one of them \
+                 installs something the other never mentions"
+            );
+        }
+    }
+}
+
+/// Under a heading both copies carry, the book names no command the docs do
+/// not.
+///
+/// One direction on purpose. The book is the shallower of the two, so a
+/// command it omits is editorial; a command it introduces under a heading its
+/// canonical copy does not mention is a rename that only landed in one place,
+/// or a command that never existed.
+#[test]
+fn paired_sections_introduce_no_command_the_docs_lack() {
+    let known = known_commands();
+
+    for (docs_path, docs, book_path, book) in PAIRS {
+        let book_sections = sections(book);
+        for (heading, docs_body) in sections(docs) {
+            let Some((_, book_body)) = book_sections.iter().find(|(h, _)| *h == heading) else {
+                continue;
+            };
+            let in_docs = commands(&docs_body, &known);
+            for verb in commands(book_body, &known) {
+                assert!(
+                    in_docs.contains(&verb),
+                    "`{heading}` in {book_path} documents `facelock {verb}`, but \
+                     the same section of {docs_path} never mentions it"
+                );
+            }
+        }
+    }
+}
+
+/// Under a heading both copies carry, the book names no facelock path the docs
+/// do not.
+///
+/// A book path that refines a directory the docs name is fine — naming
+/// `/var/lib/facelock/facelock.db` where the docs said `/var/lib/facelock` is
+/// more specific, not different. A path with no such ancestor is a location
+/// only one copy believes in.
+#[test]
+fn paired_sections_introduce_no_path_the_docs_lack() {
+    for (docs_path, docs, book_path, book) in PAIRS {
+        let book_sections = sections(book);
+        for (heading, docs_body) in sections(docs) {
+            let Some((_, book_body)) = book_sections.iter().find(|(h, _)| *h == heading) else {
+                continue;
+            };
+            let in_docs = paths(&docs_body);
+            for path in paths(book_body) {
+                let refines = in_docs
+                    .iter()
+                    .any(|known| *known != path && path.starts_with(known.as_str()));
+                assert!(
+                    in_docs.contains(&path) || refines,
+                    "`{heading}` in {book_path} names `{path}`, which the same \
+                     section of {docs_path} never mentions"
+                );
+            }
+        }
+    }
+}
+
+/// The book carries the facts a reader would otherwise only find in `docs/`.
+#[test]
+fn book_pages_cover_the_facts_that_change_a_decision() {
+    for (path, required) in BOOK_MUST_COVER {
+        let (_, _, _, book) = PAIRS
+            .iter()
+            .find(|(_, _, book_path, _)| book_path == path)
+            .unwrap_or_else(|| panic!("`{path}` is not one of the paired documents"));
+        for fact in *required {
+            assert!(
+                book.contains(fact),
+                "`{path}` never mentions `{fact}`. Its canonical copy in docs/ \
+                 covers it, and a reader who reaches the book instead is missing \
+                 the tradeoff, not just the detail"
+            );
+        }
+    }
+}
+
+/// The required-coverage list names things that exist.
+///
+/// A curated list is the one part of this suite that is asserted rather than
+/// derived, so each entry is held to the tree: a command must parse, and a
+/// config key must be in the shipped template. Without this the list could go
+/// on pinning the book to a key that was renamed two releases ago.
+#[test]
+fn required_coverage_names_things_that_exist() {
+    const CONFIG_TEMPLATE: &str = include_str!("../../../../config/facelock.toml");
+
+    for (_, required) in BOOK_MUST_COVER {
+        for fact in *required {
+            if let Some(command) = fact.strip_prefix("facelock ") {
+                let argv: Vec<&str> = std::iter::once("facelock")
+                    .chain(command.split_whitespace())
+                    .collect();
+                Cli::try_parse_from(&argv).unwrap_or_else(|e| {
+                    panic!("BOOK_MUST_COVER pins `{fact}`, which does not parse: {e}")
+                });
+                continue;
+            }
+            assert!(
+                CONFIG_TEMPLATE.contains(fact),
+                "BOOK_MUST_COVER pins `{fact}`, which config/facelock.toml does \
+                 not mention — either it was renamed or the pin was never real"
+            );
+        }
+    }
+}
+
+/// Every page that exists under both names is in [`PAIRS`].
+///
+/// The list is embedded, so a seventh pair added to the tree would simply not
+/// be checked. This walks the two directories and says so.
+#[test]
+fn every_same_named_page_is_paired() {
+    use std::fs;
+    use std::path::Path;
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let names = |dir: &Path| -> BTreeSet<String> {
+        fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", dir.display()))
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let path = entry.path();
+                (path.extension()? == "md")
+                    .then(|| path.file_name()?.to_str().map(str::to_string))?
+            })
+            .collect()
+    };
+
+    let shared: BTreeSet<String> = names(&root.join("docs"))
+        .intersection(&names(&root.join("book/src")))
+        .cloned()
+        .collect();
+    assert!(
+        shared.len() >= 6,
+        "found only {} same-named pages — the walk is broken, not the tree",
+        shared.len()
+    );
+
+    for name in shared {
+        // `contracts.md` is deduplicated: the book's copy is a one-line
+        // `{{#include}}` of the canonical file (#187), so the two cannot drift
+        // and there is nothing to compare.
+        if name == "contracts.md" {
+            continue;
+        }
+        let book_path = format!("book/src/{name}");
+        assert!(
+            PAIRS.iter().any(|(_, _, path, _)| *path == book_path),
+            "`docs/{name}` and `{book_path}` are a same-named pair that PAIRS \
+             does not list, so nothing compares them"
+        );
+    }
+}

--- a/docs/testing-safety.md
+++ b/docs/testing-safety.md
@@ -165,6 +165,7 @@ Local full CI: `bash test/run-tests.sh`
 | `just test` | Unit tests |
 | `just lint` | Clippy |
 | `just check` | test + lint + fmt |
+| `just check-package-names-live` | Re-check documented package names against live Arch, AUR, Debian and Fedora (network; not part of `just check`) |
 | `just test-arch-pam` | Arch container PAM smoke |
 | `just test-arch-integration` | E2E daemon mode |
 | `just test-arch-oneshot` | E2E oneshot mode |

--- a/justfile
+++ b/justfile
@@ -86,6 +86,17 @@ check-agent-docs base='':
 test-debian-postrm-purge:
     bash test/debian-postrm-purge.sh
 
+# Re-check documented package names against live Arch, AUR, Debian and Fedora.
+#
+# Opt-in, and deliberately outside `just check`: it needs the network, and a
+# repository outage must not turn an unrelated pull request red. The offline
+# half runs under `cargo test` -- `conformance::packages` holds every
+# documented name to the packaging manifest that declares it. This recipe is
+# what proves the manifests themselves are not naming a package that stopped
+# existing.
+check-package-names-live:
+    python3 test/check-package-names-live.py
+
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
 check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets
 

--- a/man/pam_facelock.8
+++ b/man/pam_facelock.8
@@ -1,28 +1,40 @@
-.TH PAM_FACELOCK 8 "2026-03-11" "pam_facelock" "System Administration"
+.TH PAM_FACELOCK 8 "2026-08-23" "pam_facelock" "System Administration"
 .SH NAME
 pam_facelock \- PAM module for face authentication
 .SH SYNOPSIS
 .B pam_facelock.so
 .SH DESCRIPTION
 .B pam_facelock
-is a PAM module that provides face-based authentication for Linux systems.
+is a PAM module that provides face\-based authentication for Linux systems.
 It is a thin client that first attempts to connect to the
 .BR facelock (1)
-daemon via the D-Bus system bus (\fBorg.facelock.Daemon\fR). If the daemon is unavailable, it falls back
+daemon via the D\-Bus system bus (\fBorg.facelock.Daemon\fR). If the daemon is unavailable, it falls back
 to spawning
-.B facelock auth
-as a one-shot process.
+.I /usr/bin/facelock
+.B auth
+as a one\-shot process. That path is not configurable: a config\-selected binary
+would let anyone who can influence the configuration file choose which
+executable a root PAM context runs.
 .PP
 The module is intentionally kept minimal with no heavy dependencies (no ONNX
-runtime, no V4L2, no facelock-core). All inference is delegated to the daemon
+runtime, no V4L2, no facelock\-core). All inference is delegated to the daemon
 or the facelock binary.
 .PP
 All authentication attempts are logged to syslog under the AUTH facility.
 .SH MODULE TYPES PROVIDED
 .TP
 .B auth
-This module performs face-based user authentication. It does not provide
+This module performs face\-based user authentication. It does not provide
 account, session, or password management.
+.SH OPTIONS
+This module parses no module arguments. Everything that varies is read from the
+configuration file described under CONFIGURATION, so a token appended to the
+.I /etc/pam.d
+line \- for example a
+.I timeout
+or
+.I debug
+argument copied from another module \- is silently ignored rather than applied.
 .SH RETURN VALUES
 .TP
 .B PAM_SUCCESS
@@ -30,13 +42,19 @@ The user's face was matched against an enrolled model with sufficient
 confidence.
 .TP
 .B PAM_AUTH_ERR
-Authentication failed. The face did not match any enrolled model, no face
-was detected, or an error occurred during the authentication process.
+Authentication failed. The face did not match any enrolled model, or an error
+occurred during the authentication process.
 .TP
 .B PAM_IGNORE
-The module is configured to be skipped for this authentication context,
-or the user has no enrolled face models. This allows the PAM stack to
-fall through to the next module.
+The module abstained: it is disabled for this authentication context, the user
+has no enrolled face models, no face was seen, or a precondition such as the IR
+camera requirement was not met. The PAM stack falls through to the next module.
+.TP
+.B PAM_AUTHINFO_UNAVAIL
+The user has no enrolled face models and
+.I security.suppress_unknown
+is enabled, so the module declines to reveal whether the user is enrolled and
+hands the decision to the next module in the stack.
 .SH EXAMPLES
 To enable face authentication for
 .BR sudo (8),
@@ -51,7 +69,7 @@ auth    sufficient    pam_facelock.so
 .RE
 .PP
 This allows face authentication to succeed without requiring a password. If
-face authentication fails or returns PAM_IGNORE, the next module in the PAM
+face authentication fails or abstains, the next module in the PAM
 stack (typically
 .BR pam_unix (8))
 will prompt for a password.
@@ -78,63 +96,111 @@ facelock setup --pam --service sudo
 .SS IR Camera Requirement
 By default, facelock requires an infrared (IR) camera for authentication
 .RB ( security.require_ir=true
-in the configuration file). IR cameras are resistant to photo-based spoofing
+in the configuration file). IR cameras are resistant to photo\-based spoofing
 attacks. Do not disable this requirement unless you understand the security
 implications.
-.SS Anti-Spoofing
+.SS Anti\-Spoofing
 Frame variance checks are performed during authentication to detect
 presentation attacks (e.g., holding a photo or video in front of the camera).
 .SS Rate Limiting
 The daemon enforces rate limiting (5 attempts per user per 60 seconds by
-default) to prevent brute-force attacks.
+default) to prevent brute\-force attacks.
 .SS IPC Security
-Communication between the PAM module and daemon uses the D-Bus system bus.
+Communication between the PAM module and the daemon uses the D\-Bus system bus.
 The system bus policy
 .RI ( /usr/share/dbus-1/system.d/org.facelock.Daemon.conf )
-applies a deny-all default, restricting access to root and members of the
-.B facelock
-group. The daemon verifies the caller UID via
+denies the daemon's name and destination by default and then makes exactly one
+exception for unprivileged callers: any local user may send
+.BR Authenticate ,
+which is what lets a screen locker or the polkit agent unlock as the user
+running it. Every other method, and receipt of the daemon's signals, is
+restricted to root. The daemon independently verifies the caller UID via
 .B GetConnectionUnixUser
-before executing any method. Message size limits are enforced by the D-Bus
-daemon.
+before executing any method, and allows a non\-root
+.B Authenticate
+only for the caller's own username. Message size limits are enforced by the
+D\-Bus daemon.
+.SS Fixed Inputs
+Two inputs a PAM module could take from its environment are compiled in
+instead. The configuration file is always
+.IR /etc/facelock/config.toml :
+the module does not honour
+.BR FACELOCK_CONFIG ,
+which the unprivileged
+.BR facelock (1)
+commands do honour, because an environment variable that selects a
+configuration file is an environment variable that selects security policy for
+a root PAM context. The one\-shot fallback binary is likewise the fixed path
+.IR /usr/bin/facelock ,
+and it and its parent directories are checked for root ownership and
+non\-writability before it is spawned.
 .SS Syslog Logging
 All authentication attempts (success, failure, and error) are logged to
 syslog under the AUTH facility with the identifier
 .IR pam_facelock .
 .SH CONFIGURATION
-The module reads its configuration from
-.I /etc/facelock/config.toml
-(or the path specified by the
-.B FACELOCK_CONFIG
-environment variable). Relevant configuration sections:
-.TP
-.B [pam]
-PAM-specific settings including
-.BR timeout_secs ,
-.BR notification_mode ,
-and
-.BR skip_for_ssh .
-.TP
-.B [security]
-Security settings including
-.B require_ir
-(default: true).
+The module parses its own minimal view of the configuration file, independently
+of the daemon. That file is always
+.IR /etc/facelock/config.toml ;
+see Fixed Inputs above for why the path is fixed. Only the tables and keys
+listed here are read by the module; every other key in the file belongs to the
+daemon and has no effect on the PAM stack.
 .TP
 .B [daemon]
-Daemon settings including mode and model directory.
+.BR mode
+.br
+Whether to reach the daemon over D\-Bus ("daemon", the default) or spawn the
+one\-shot binary directly ("oneshot").
+.TP
+.B [security]
+.BR disabled ,
+.BR abort_if_ssh ,
+.BR abort_if_lid_closed ,
+.BR suppress_unknown ,
+.BR pam_policy
+.br
+Whether the module runs at all, the contexts it refuses to run in, and whether
+an unenrolled user is reported as such or hidden behind PAM_AUTHINFO_UNAVAIL.
+.TP
+.B [security.pam_policy]
+.BR allowed_services ,
+.BR denied_services
+.br
+Per\-service allow and deny lists, matched against the PAM service name.
+.TP
+.B [recognition]
+.BR timeout_secs
+.br
+How long the module waits for a decision before abstaining.
+.TP
+.B [notification]
+.BR mode ,
+.BR notify_prompt ,
+.BR notify_on_success
+.br
+What the module writes into the PAM conversation while it waits. Desktop
+delivery is the daemon's job, not the module's.
 .SH FILES
 .TP
 .I /etc/facelock/config.toml
 Main configuration file.
 .TP
+.I /lib/security/pam_facelock.so
+.TP
 .I /usr/lib/security/pam_facelock.so
-The PAM module shared library.
+.TP
+.I /usr/lib64/security/pam_facelock.so
+The PAM module shared library. Which of the three a distribution uses is a
+property of that distribution; facelock probes all three in this order.
+.TP
+.I /usr/bin/facelock
+The binary spawned for one\-shot authentication when the daemon is unavailable.
 .TP
 .I /usr/share/dbus-1/system.d/org.facelock.Daemon.conf
-D-Bus system bus policy file for the facelock daemon.
+D\-Bus system bus policy file for the facelock daemon.
 .TP
 .I /usr/share/dbus-1/system-services/org.facelock.Daemon.service
-D-Bus activation file for the facelock daemon service.
+D\-Bus activation file for the facelock daemon service.
 .TP
 .I /var/lib/facelock/facelock.db
 Face embedding database.

--- a/test/check-package-names-live.py
+++ b/test/check-package-names-live.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Revalidate documented package names against live repositories (#209, #211).
+
+The offline half of this guard lives in
+`crates/facelock-cli/src/conformance/packages.rs`: every package name a
+document tells a reader to install must be declared by the packaging manifest
+for that distro. That derivation is exact and needs no network, which is why it
+can run under `just check` and in CI -- but it proves only that prose and
+packaging agree. If the manifest names a package that does not exist, both are
+wrong together and the offline check still passes.
+
+This script closes that gap by asking the repositories. It is deliberately
+*not* part of `just check`: it needs the network, and a repository outage would
+turn an unrelated pull request red.
+
+    just check-package-names-live
+
+Queries, all read-only JSON endpoints:
+
+  Arch    https://archlinux.org/packages/search/json/
+  AUR     https://aur.archlinux.org/rpc/v5/info
+  Debian  https://sources.debian.org/api/src/
+  Fedora  https://mdapi.fedoraproject.org
+
+Exit status is 0 when every name resolves, 1 when one does not, and 2 when a
+lookup could not be completed (network, rate limit, schema change) -- an
+unreachable repository is not evidence that a package is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TIMEOUT = 20
+USER_AGENT = "facelock-package-name-check (+https://github.com/tyvsmith/facelock)"
+
+# Names the project publishes itself. No third-party repository carries them,
+# so a "not found" here means the release has not been published yet -- which
+# is a release question, not a documentation defect.
+SELF_PUBLISHED = {
+    "facelock",
+    "facelock-bin",
+    "facelock-git",
+}
+
+
+class RepositoryUnavailable(Exception):
+    """A repository could not answer. Never treated as "package missing"."""
+
+
+def fetch_json(url: str) -> object:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RepositoryUnavailable(f"{url}: {exc}") from exc
+
+
+def in_arch_repos(name: str) -> bool:
+    query = urllib.parse.urlencode({"name": name})
+    payload = fetch_json(f"https://archlinux.org/packages/search/json/?{query}")
+    if not isinstance(payload, dict):
+        raise RepositoryUnavailable("archlinux.org returned an unexpected shape")
+    return bool(payload.get("results"))
+
+
+def in_aur(name: str) -> bool:
+    query = urllib.parse.urlencode({"arg[]": name})
+    payload = fetch_json(f"https://aur.archlinux.org/rpc/v5/info?{query}")
+    if not isinstance(payload, dict):
+        raise RepositoryUnavailable("aur.archlinux.org returned an unexpected shape")
+    if payload.get("type") == "error":
+        raise RepositoryUnavailable(f"AUR RPC error: {payload.get('error')}")
+    return bool(payload.get("results"))
+
+
+def in_debian(name: str) -> bool:
+    # sources.debian.org indexes *source* packages. Every Debian name the docs
+    # currently hand a reader is `facelock`, which this project publishes and
+    # which is skipped below, so the distinction has not mattered yet. A future
+    # instruction naming a binary-only package (`libpam-runtime`) needs a
+    # binary-package lookup here, not a looser reading of this one.
+    payload = fetch_json(f"https://sources.debian.org/api/src/{urllib.parse.quote(name)}/")
+    if not isinstance(payload, dict):
+        raise RepositoryUnavailable("sources.debian.org returned an unexpected shape")
+    return "error" not in payload
+
+
+def in_fedora(name: str) -> bool:
+    try:
+        payload = fetch_json(
+            f"https://mdapi.fedoraproject.org/rawhide/pkg/{urllib.parse.quote(name)}"
+        )
+    except RepositoryUnavailable as exc:
+        # mdapi answers 404 for an unknown package, which urllib raises.
+        if "404" in str(exc):
+            return False
+        raise
+    return isinstance(payload, dict) and "basename" in payload
+
+
+RESOLVERS = {
+    # Arch documentation points at both the repositories and the AUR, and the
+    # GPU packages live in the AUR, so either is proof the name exists.
+    "Arch": lambda name: in_arch_repos(name) or in_aur(name),
+    "Debian": in_debian,
+    "Fedora": in_fedora,
+}
+
+
+def documented_names() -> dict[str, set[str]]:
+    """Every package name the documents hand a reader, by distro.
+
+    Deliberately a second implementation of the Rust guard's extractor rather
+    than a shared one: that guard checks prose against the manifests, this one
+    checks names against reality, and the two answer to different owners. If
+    the extractors disagree, the difference surfaces as a name checked in one
+    place and not the other, which is the safe direction to fail.
+    """
+    found: dict[str, set[str]] = {distro: set() for distro in RESOLVERS}
+
+    verbs = {
+        "pacman -S ": "Arch",
+        "yay -S ": "Arch",
+        "paru -S ": "Arch",
+        "apt-get install ": "Debian",
+        "apt install ": "Debian",
+        "dnf install ": "Fedora",
+        "yum install ": "Fedora",
+    }
+
+    corpus = [
+        ROOT / "README.md",
+        ROOT / "AGENTS.md",
+        ROOT / "config" / "facelock.toml",
+        ROOT / "website" / "index.html",
+    ]
+    corpus += sorted((ROOT / "docs").rglob("*.md"))
+    corpus += sorted((ROOT / "book" / "src").glob("*.md"))
+
+    for path in corpus:
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".html":
+            text = re.sub(r"<[^>]*>", "", text).replace("&amp;", "&").replace("&nbsp;", " ")
+        for line in text.splitlines():
+            for verb, distro in verbs.items():
+                start = 0
+                while (at := line.find(verb, start)) != -1:
+                    start = at + len(verb)
+                    for token in line[start:].split():
+                        if token.startswith("#"):
+                            break
+                        if token.startswith("-"):
+                            continue
+                        name = token.rstrip("`.,)\"';")
+                        if not re.fullmatch(r"[a-z0-9][a-z0-9._+-]*", name):
+                            break
+                        found[distro].add(name)
+                        if name != token:
+                            break
+
+    # The GPU tables name the package in a column rather than in a command.
+    for path in (ROOT / "README.md", ROOT / "book" / "src" / "gpu.md"):
+        for row in path.read_text(encoding="utf-8").splitlines():
+            if not row.strip().startswith("|"):
+                continue
+            for cell in row.strip().strip("|").split("|"):
+                cell = cell.strip()
+                if len(cell) > 2 and cell[0] == cell[-1] == "`":
+                    name = cell[1:-1]
+                    if re.fullmatch(r"[a-z0-9][a-z0-9._+-]*", name) and "onnxruntime" in name:
+                        found["Arch"].add(name)
+
+    return found
+
+
+def main() -> int:
+    names = documented_names()
+    total = sum(len(v) for v in names.values())
+    if total == 0:
+        print("no package names extracted -- the extractor is broken", file=sys.stderr)
+        return 2
+
+    missing: list[str] = []
+    unresolved: list[str] = []
+
+    for distro in sorted(names):
+        for name in sorted(names[distro]):
+            if name in SELF_PUBLISHED:
+                print(f"  skip  {distro:7} {name}  (published by this project)")
+                continue
+            try:
+                exists = RESOLVERS[distro](name)
+            except RepositoryUnavailable as exc:
+                unresolved.append(f"{distro} {name}: {exc}")
+                print(f"  ????  {distro:7} {name}")
+                continue
+            print(f"  {'ok  ' if exists else 'GONE'}  {distro:7} {name}")
+            if not exists:
+                missing.append(f"{distro} {name}")
+
+    if missing:
+        print("", file=sys.stderr)
+        print("package names no repository carries:", file=sys.stderr)
+        for entry in missing:
+            print(f"  {entry}", file=sys.stderr)
+        print(
+            "\nremove the instruction, or correct it to a name that exists.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if unresolved:
+        print("", file=sys.stderr)
+        print("lookups that did not complete (not a verdict):", file=sys.stderr)
+        for entry in unresolved:
+            print(f"  {entry}", file=sys.stderr)
+        return 2
+
+    print(f"\n{total} documented package names resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add `conformance::packages`: every package name a document tells a reader to install must be declared by `dist/PKGBUILD*`, `debian/control` or `dist/facelock.spec`
- add `conformance::man_pam`: `man/pam_facelock.8` resolved against the PAM module's source, the shipped bus policy, `PAM_MODULE_PATHS`, `dist/PKGBUILD` and `Config`'s defaults
- add `conformance::pairs`: the six pages carried in both `docs/` and `book/src/`, compared on package names, command names and file paths under headings both copies share
- add `just check-package-names-live`, an opt-in network re-check against Arch, the AUR, Debian and Fedora
- fix four defects the man-page guard found, and bring TPM PCR binding into the book's security page

## Why

Nothing in the tree validated a package name. `onnxruntime-opt-openvino` exists in no Arch repository and no AUR package, and the person who found that out was a contributor evaluating facelock for Omarchy, with a screenshot of the failed `pacman -S` (#209). #172 and #187 were the same class. Instructions that cannot succeed keep shipping, and people outside the project keep finding them first.

## How the package check stays offline

`just check` and CI must not need the network, so a live repository query at test time is the wrong mechanism. The known-good names are derived instead. `dist/PKGBUILD*`, `debian/control` and `dist/facelock.spec` already declare every package the project builds, depends on or suggests, and the packaging jobs exercise those manifests against real repositories on every release. A name a document hands a reader must appear in the manifest for that document's distro; `onnxruntime-opt-openvino` never appeared in `dist/PKGBUILD`, so the derivation reproduces #209 exactly.

Names come from install verbs (`pacman -S`, `apt install`, `dnf install`, and the rest) and from the GPU tables, where a package is named in a column and the `pacman -S` sits further down the page. The corpus is `README.md`, `AGENTS.md`, `docs/**`, `book/src/`, the shipped `config/facelock.toml`, and `website/index.html`.

What the derivation cannot prove is that a third-party name still exists upstream: the manifest could be as wrong as the prose was. `just check-package-names-live` closes that, and stays out of `just check`.

## What the pair guard catches, and what it does not

Catches, under a heading both copies carry:

- package-name disagreement, in either direction
- a `facelock` command the book names and its canonical `docs/` copy does not
- a facelock-owned path the book names and its canonical `docs/` copy does not, allowing the book to be more specific than a directory `docs/` names

Does not catch:

- a fact `docs/` gains and the book never does. That is the direction #211 actually found, and it cannot be mechanical, because "the book is shallower" is the design. The only pin is `BOOK_MUST_COVER`, a short curated list, itself checked against the clap tree and the config template so it cannot pin something that no longer ships.
- prose, ordering, and headings that exist on one side only
- `docs/cli.md` ↔ `book/src/cli-reference.md`, which is not a same-named pair and is already held to a stricter standard by `conformance::docs`
- `docs/testing-safety.md` ↔ `book/src/testing.md`, near-duplicates that are not same-named either

## Man-page defects the guard found

- a `[pam]` configuration table with `timeout_secs`, `notification_mode` and `skip_for_ssh`. The module reads none of those, and reads `[daemon]`, `[security]`, `[security.pam_policy]`, `[recognition]` and `[notification]` instead, so an administrator following the page got a config the module silently ignored
- `PAM_AUTHINFO_UNAVAIL` missing from RETURN VALUES
- D-Bus access described as root plus members of a `facelock` group. ADR 010 retired the group and opened `Authenticate` to every local user
- `FACELOCK_CONFIG` documented as a config-path override. The module reads a compiled-in constant and deliberately never looks at the variable

## Files

| Path | Why it matters |
|---|---|
| `crates/facelock-cli/src/conformance/packages.rs` | the derivation, the extractors, and their unit tests *(start here)* |
| `crates/facelock-cli/src/conformance/man_pam.rs` | `pam_facelock.8` held to the module and the policy |
| `crates/facelock-cli/src/conformance/pairs.rs` | the docs/book comparison and `BOOK_MUST_COVER` |
| `man/pam_facelock.8` | the four defects, and a CONFIGURATION section shaped so both directions are checkable |
| `book/src/security.md` | PCR binding, `facelock tpm reseal`, and the plaintext `encryption.key` backup tradeoff |
| `test/check-package-names-live.py` | the opt-in network re-check |

## Reviewer notes

- **`man/pam_facelock.8`'s CONFIGURATION section is now structured.** `.B [table]` opens a table and the `.BR key` lines under it are its keys. The guard compares that against `PamConfig` in both directions, so a key the module gains and a key the page invents both fail. Rendering is unchanged in shape; `groff -man` output was checked by eye.
- **The PAM module is read as source text, not linked.** It is `crate-type = ["cdylib"]` and forbidden from depending on `facelock-core`, so `facelock-cli` cannot import its constants. Every extractor therefore carries a floor assertion, so one that stops finding anything fails loudly instead of approving a page it never read.
- **`KNOWN_EXTERNAL` is empty and meant to stay that way.** A real package that no manifest declares should usually become a declared dependency, where a build would have caught it, rather than an entry in a list.
- **The corpus is walked, not `include_str!`d.** `conformance::docs` embeds named documents because a deleted file should break the build; the package sweep walks the tree because a *new* file nobody registered is its failure mode. `conformance::pairs` uses both, and `every_same_named_page_is_paired` walks the two directories to catch a seventh pair.

## Validation

- `just check`
- mutation-tested every new guard, one at a time and reverted: a bogus package name in a bash block and in a table, an install verb with no packaging manifest, a dropped return code, an invented module option, a renamed config key, a module path nothing installs, a revived group claim, a stale quoted default, a package disagreement across a pair, a book-only command, a book-only path, a dropped `BOOK_MUST_COVER` fact, a pin on something that does not exist, and an unpaired page
- `just check-package-names-live` against the real repositories, and again with a fake name injected
- `groff -man -Tascii man/pam_facelock.8`

Refs #211
