### PR TITLE
test(rpm): add fedora 43 and 45 lanes and pin config(noreplace)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,7 +15,12 @@ paths:
 | 3 | Arch container PAM smoke | `just test-arch-pam` |
 | 3b | Arch container E2E (daemon) | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
+| 3d | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
 | 4 | VM testing | Disposable VM with snapshots |
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 
 **Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.
+
+Fedora recipes take a release and default to 44 (`just test-rpm-pkg 43`). Tier 3d
+covers all three declared targets at the depth `dist/release-matrix.json` gives
+each; Rawhide is experimental and never a lane.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,12 +15,12 @@ paths:
 | 3 | Arch container PAM smoke | `just test-arch-pam` |
 | 3b | Arch container E2E (daemon) | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
-| 3d | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
+| 3e | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
 | 4 | VM testing | Disposable VM with snapshots |
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 
 **Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.
 
-Fedora recipes take a release and default to 44 (`just test-rpm-pkg 43`). Tier 3d
+Fedora recipes take a release and default to 44 (`just test-rpm-pkg 43`). Tier 3e
 covers all three declared targets at the depth `dist/release-matrix.json` gives
 each; Rawhide is experimental and never a lane.

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -32,6 +32,21 @@ All recipes need `podman`. None of the ones in the routing table need a camera.
 remaining quick syntax-level check is `just test-rpm` (Fedora container), which
 is weaker than `test-rpm-pkg` because it does not install and boot.
 
+## Which Fedora
+
+Every Fedora recipe takes a release and defaults to 44 — `just test-rpm-pkg 43`,
+`just test-copr 45`. `dist/release-matrix.json` declares 43, 44 and 45, so one
+Fedora run is not the whole story: use `just test-rpm-lanes` when a change could
+behave differently across releases (dnf/rpm behavior, scriptlets, dependency
+resolution, systemd or SELinux versions). It runs 43 and 44 at full lifecycle
+depth and branched 45 at build plus runtime smoke, which is the depth the matrix
+gives each one.
+
+Never add a Rawhide lane. Rawhide is optional and experimental in the matrix and
+cannot substitute for a Fedora 43, 44 or 45 result. Lane images come from the
+matrix through `test/fedora-lane-image.sh`, which also refuses a release past its
+EOL gate — Fedora 43 stops on 2026-12-02.
+
 ## The `-pkg` recipes are the real ones
 
 `test-deb-trixie-pkg`, `test-deb-resolute-pkg`, and `test-rpm-pkg` build a real package,

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -148,8 +148,8 @@ just uninstall
 Ordinary package removal and `just uninstall` preserve the face database,
 encryption keys, downloaded models, enrollment markers, audit logs, snapshots,
 and setup state. Debian also retains its conffile until `purge`; RPM follows
-`%config(noreplace)` and may retain an administrator-modified config as
-`config.toml.rpmsave`.
+`%config(noreplace)`, removing an unmodified config and retaining an
+administrator-modified one as `config.toml.rpmsave`.
 
 Debian purge removes only provably safe entries inside the three compiled
 Facelock roots. Unsafe or externally configured remnants are retained and

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2284,7 +2284,8 @@ mechanisms:
 |----------------------|--------------------------------------|
 | Debian `remove` | `/etc/facelock/config.toml` is a Debian conffile and remains at its installed path. Biometric and operational state also remains |
 | Debian `purge` | `dpkg` removes the conffile, and the post-removal purge may then remove only safe remnants inside the compiled roots. Unsafe and external remnants are retained and reported |
-| RPM erase | `/etc/facelock/config.toml` is RPM `%config(noreplace)`. RPM removes an unmodified copy and retains an administrator-modified copy according to RPM semantics, commonly as `config.toml.rpmsave`. A `.rpmsave` is retained state, not evidence of a failed erase and not something a Facelock script deletes |
+| RPM erase | `/etc/facelock/config.toml` is RPM `%config(noreplace)`. An unmodified copy is removed outright and leaves nothing behind. An administrator-modified copy leaves `config.toml` and is retained, byte for byte, as `config.toml.rpmsave`. A `.rpmsave` is retained state, not evidence of a failed erase and not something a Facelock script deletes |
+| RPM upgrade | An unmodified `/etc/facelock/config.toml` is replaced in place by the new packaged file, with no `.rpmnew` and no `.rpmsave`. An administrator-modified one is kept byte for byte at its own path and the new packaged file arrives as `config.toml.rpmnew`, which Facelock never activates or deletes. `.rpmnew` is written only when the packaged config actually changed between the two versions |
 | Arch package removal | the `backup` entry follows pacman's native saved-configuration behavior (including `.pacsave` when applicable). Facelock lifecycle code does not bypass it |
 | `just uninstall` | no package manager owns the config, so the source-install uninstall preserves `/etc/facelock` with the biometric and operational state |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,8 +96,8 @@ just uninstall
 Ordinary package removal and `just uninstall` preserve the face database,
 encryption keys, downloaded models, enrollment markers, audit logs, snapshots,
 and setup state. Debian also retains its conffile until `purge`; RPM follows
-`%config(noreplace)` and may retain an administrator-modified config as
-`config.toml.rpmsave`.
+`%config(noreplace)`, removing an unmodified config and retaining an
+administrator-modified one as `config.toml.rpmsave`.
 
 Debian purge removes only provably safe entries inside the three compiled
 Facelock roots. Unsafe or externally configured remnants are retained and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -239,6 +239,15 @@ stops with a message instead of quietly testing an unmaintained release. Set
 `test/check-release-matrix.py` reads. Retiring the lane means retiring its
 matrix rows, and moving the date is a deliberate matrix edit.
 
+Fedora 43 is the only release carrying a gate today. The lookup is generic on
+`fedora.<release>_eol_gate`, so adding a `44_eol_gate` or `45_eol_gate` key
+gates those lanes immediately; until one exists, 44 and 45 run past their own
+end of life without complaint.
+
+`just test-rpm-lanes` runs each release through the recipe its matrix
+`lifecycle_depth` names, and `test/check-release-matrix.py` requires that exact
+pairing, so a full lifecycle lane cannot be quietly downgraded to a smoke lane.
+
 The full lifecycle lane also pins `%config(noreplace)`: an unmodified
 `/etc/facelock/config.toml` is replaced in place on upgrade, a modified one
 survives byte for byte with the new file diverted to `.rpmnew`, and erase

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -198,6 +198,7 @@ just test-deb            # delegate to both exact supported-suite package gates
 just test-deb-trixie-pkg    # Debian 13 — offline source rebuild, install, TPM, lifecycle
 just test-deb-resolute-pkg  # Ubuntu 26.04 — the same complete package gate
 just test-rpm-pkg        # Fedora — build real .rpm, install via dnf, validate
+just test-rpm-lanes      # every declared Fedora target at its declared depth
 just test-rpm-authselect # Fedora — retired-profile upgrade guard lifecycle
 just test-packit-config  # Packit config schema — real `packit` in a pinned Fedora container
 just test-copr           # COPR-equivalent — Packit SRPM + mock from-source rebuild (slow)
@@ -219,6 +220,30 @@ install path.
 The `*-dev-shell` recipes mount host models for fast interactive camera testing.
 The `*-release-shell` recipes start from a clean package install with nothing from the
 host — run `facelock setup` to download models, then enroll and test.
+
+#### Fedora lanes
+
+Every Fedora recipe takes a release — `just test-rpm-pkg 43`, `just test-copr 45`
+— and defaults to 44. `just test-rpm-lanes` runs each declared release target at
+the lifecycle depth `dist/release-matrix.json` gives it: full lifecycle for
+Fedora 43 and 44, build plus runtime smoke for branched Fedora 45. Rawhide is
+optional and experimental, has no lane, and can never stand in for a Fedora 43,
+44, or 45 result.
+
+`test/fedora-lane-image.sh` resolves each lane's digest-pinned base image from
+the matrix, so no Containerfile carries its own Fedora digest. It refuses a
+release the matrix does not declare and refuses one that has reached its EOL
+gate: Fedora 43 goes EOL on 2026-12-02, and from that date the Fedora 43 lane
+stops with a message instead of quietly testing an unmaintained release. Set
+`RELEASE_MATRIX_TODAY` to rehearse that date, the same override
+`test/check-release-matrix.py` reads. Retiring the lane means retiring its
+matrix rows, and moving the date is a deliberate matrix edit.
+
+The full lifecycle lane also pins `%config(noreplace)`: an unmodified
+`/etc/facelock/config.toml` is replaced in place on upgrade, a modified one
+survives byte for byte with the new file diverted to `.rpmnew`, and erase
+removes an unmodified copy outright while retaining a modified one as
+`.rpmsave`. `docs/contracts.md` carries the same contract.
 
 The RPM embeds a read-only retired-profile upgrade guard in `%pre`. The
 model-free `test-rpm-authselect` gate boots Fedora with systemd and exercises

--- a/justfile
+++ b/justfile
@@ -957,18 +957,31 @@ show-paths:
 [private]
 _ort-version := `for ort in /usr/lib/libonnxruntime.so /usr/lib64/libonnxruntime.so; do if [ -e "$ort" ]; then readlink -f "$ort" | grep -oP '\d+\.\d+\.\d+$'; exit; fi; done; echo "1.20.1"`
 
+# Every Fedora recipe below takes a release and resolves its base image through
+# test/fedora-lane-image.sh, which reads the digest pin out of
+# dist/release-matrix.json and refuses a release that is undeclared, that is not
+# a release target (Rawhide), or that has passed its EOL gate. The default stays
+# 44 so bare invocations keep their old meaning. Image tags carry the release so
+# concurrent lanes cannot overwrite each other's image.
+
 # Test RPM packaging in Fedora container
-test-rpm: build-release
+test-rpm release="44": build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build -t facelock-rpm-test -f test/Containerfile.fedora .
-    podman run --rm facelock-rpm-test
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-rpm-test-f{{ release }} -f test/Containerfile.fedora .
+    podman run --rm facelock-rpm-test-f{{ release }}
 
 # Static and booted, model-free Fedora authselect retirement lifecycle.
-test-rpm-authselect:
+test-rpm-authselect release="44":
+    #!/usr/bin/env bash
+    set -euo pipefail
     bash test/rpm-authselect-contract.sh
-    podman build -t facelock-rpm-authselect-test -f test/Containerfile.rpm-authselect .
-    bash test/run-rpm-authselect-systemd.sh facelock-rpm-authselect-test
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-rpm-authselect-test-f{{ release }} -f test/Containerfile.rpm-authselect .
+    bash test/run-rpm-authselect-systemd.sh facelock-rpm-authselect-test-f{{ release }}
 
 # Run both exact supported-suite Debian package gates.
 test-deb: test-deb-trixie-pkg test-deb-resolute-pkg
@@ -1006,22 +1019,45 @@ test-deb-resolute-pkg: (_require-models "1")
 # Same model requirement (and same opt-out) as the two Debian suite package gates.
 
 # Package test — build real .rpm, install via dnf, validate under booted systemd
-test-rpm-pkg: (_require-models "1") build-release
+test-rpm-pkg release="44": (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
-    test/run-pkg-validate-systemd.sh facelock-rpm-pkg
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
+        -t facelock-rpm-pkg-f{{ release }} -f test/Containerfile.rpm-e2e .
+    test/run-pkg-validate-systemd.sh facelock-rpm-pkg-f{{ release }}
+
+# dist/release-matrix.json gives Fedora 45 a lifecycle depth of build/runtime
+# smoke, so this deliberately stops short of the full lifecycle gate and never
+# substitutes for a Fedora 43 or 44 result.
+
+# Branched-release lane — build the package, then boot it for a runtime smoke
+test-rpm-smoke release="45": build-release
+    #!/usr/bin/env bash
+    set -euo pipefail
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
+        -t facelock-rpm-smoke-f{{ release }} -f test/Containerfile.rpm-e2e .
+    bash test/run-rpm-smoke-systemd.sh facelock-rpm-smoke-f{{ release }}
+
+# Full lifecycle for 43 and 44, build plus runtime smoke for branched 45.
+
+# Every declared Fedora release target at its declared lifecycle depth
+test-rpm-lanes: (test-rpm-pkg "43") (test-rpm-pkg "44") (test-rpm-smoke "45")
 
 # Packit config schema gate — runs the real `packit` in a digest-pinned Fedora container
 test-packit-config:
     bash test/packit-config-validate.sh
 
 # COPR-equivalent build — Packit SRPM + mock from-source rebuild on a Fedora chroot (slow, opt-in)
-test-copr:
+test-copr release="44":
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build -t facelock-copr-test -f test/Containerfile.copr .
-    podman run --privileged --rm -v "$PWD:/repo:ro" facelock-copr-test
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-copr-test-f{{ release }} -f test/Containerfile.copr .
+    podman run --privileged --rm -e COPR_CHROOT=fedora-{{ release }}-x86_64 \
+        -v "$PWD:/repo:ro" facelock-copr-test-f{{ release }}
 
 # Dev shell — interactive .deb container with host models for fast iteration (requires camera)
 test-deb-dev-shell:
@@ -1047,10 +1083,12 @@ test-deb-dev-shell:
         bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; cp /tmp/host-models/* /var/lib/facelock/models/ 2>/dev/null; exec bash"
 
 # Dev shell — interactive .rpm container with host models for fast iteration (requires camera)
-test-rpm-dev-shell: build-release
+test-rpm-dev-shell release="44": build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
+        -t facelock-rpm-pkg-f{{ release }} -f test/Containerfile.rpm-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -1063,7 +1101,7 @@ test-rpm-dev-shell: build-release
     echo "Starting dev shell (Fedora, .rpm installed, host models). Try:"
     echo "  facelock enroll --user root --label myface"
     echo "  facelock test --user root"
-    podman run --rm -it $devices $mounts facelock-rpm-pkg \
+    podman run --rm -it $devices $mounts facelock-rpm-pkg-f{{ release }} \
         bash -c "cp /tmp/container-config.toml /etc/facelock/config.toml; cp /tmp/host-models/* /var/lib/facelock/models/ 2>/dev/null; exec bash"
 
 # Release shell — clean-room .deb container, real user experience (requires camera)
@@ -1087,10 +1125,12 @@ test-deb-release-shell:
         bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
 
 # Release shell — clean-room .rpm container, real user experience (requires camera)
-test-rpm-release-shell: build-release
+test-rpm-release-shell release="44": build-release
     #!/usr/bin/env bash
     set -euo pipefail
-    podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
+        -t facelock-rpm-pkg-f{{ release }} -f test/Containerfile.rpm-e2e .
     devices=""
     for d in /dev/video*; do
         [ -e "$d" ] && devices="$devices --device $d"
@@ -1100,7 +1140,7 @@ test-rpm-release-shell: build-release
     echo "  facelock setup"
     echo "  facelock enroll --user root --label myface"
     echo "  facelock test --user root"
-    podman run --rm -it $devices $mounts facelock-rpm-pkg \
+    podman run --rm -it $devices $mounts facelock-rpm-pkg-f{{ release }} \
         bash -c "cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
 
 # Test APT repo generation locally from both exact manifests (requires reprepro + gpg).

--- a/justfile
+++ b/justfile
@@ -963,9 +963,16 @@ _ort-version := `for ort in /usr/lib/libonnxruntime.so /usr/lib64/libonnxruntime
 # a release target (Rawhide), or that has passed its EOL gate. The default stays
 # 44 so bare invocations keep their old meaning. Image tags carry the release so
 # concurrent lanes cannot overwrite each other's image.
+#
+# Resolution runs as the first dependency so an expired or undeclared release is
+# refused before a host release build, not after one.
+
+[private]
+_fedora-lane-image release:
+    @bash test/fedora-lane-image.sh '{{ release }}' >/dev/null
 
 # Test RPM packaging in Fedora container
-test-rpm release="44": build-release
+test-rpm release="44": (_fedora-lane-image release) build-release
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -973,8 +980,13 @@ test-rpm release="44": build-release
         -t facelock-rpm-test-f{{ release }} -f test/Containerfile.fedora .
     podman run --rm facelock-rpm-test-f{{ release }}
 
-# Static and booted, model-free Fedora authselect retirement lifecycle.
-test-rpm-authselect release="44":
+# The upgrade fixture is the released v0.1.4 fc44 RPM, the only build of the
+# retired-profile package that exists. Releases other than 44 are unproven here:
+# an fc44 artifact can fail to install on an older Fedora over a newer glibc or
+# library requirement, and no lane has run 43 or 45 through this recipe.
+
+# Static and booted, model-free Fedora authselect retirement lifecycle
+test-rpm-authselect release="44": (_fedora-lane-image release)
     #!/usr/bin/env bash
     set -euo pipefail
     bash test/rpm-authselect-contract.sh
@@ -1019,7 +1031,7 @@ test-deb-resolute-pkg: (_require-models "1")
 # Same model requirement (and same opt-out) as the two Debian suite package gates.
 
 # Package test — build real .rpm, install via dnf, validate under booted systemd
-test-rpm-pkg release="44": (_require-models "1") build-release
+test-rpm-pkg release="44": (_fedora-lane-image release) (_require-models "1") build-release
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -1032,7 +1044,7 @@ test-rpm-pkg release="44": (_require-models "1") build-release
 # substitutes for a Fedora 43 or 44 result.
 
 # Branched-release lane — build the package, then boot it for a runtime smoke
-test-rpm-smoke release="45": build-release
+test-rpm-smoke release="45": (_fedora-lane-image release) build-release
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -1050,7 +1062,7 @@ test-packit-config:
     bash test/packit-config-validate.sh
 
 # COPR-equivalent build — Packit SRPM + mock from-source rebuild on a Fedora chroot (slow, opt-in)
-test-copr release="44":
+test-copr release="44": (_fedora-lane-image release)
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -1083,7 +1095,7 @@ test-deb-dev-shell:
         bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; cp /tmp/host-models/* /var/lib/facelock/models/ 2>/dev/null; exec bash"
 
 # Dev shell — interactive .rpm container with host models for fast iteration (requires camera)
-test-rpm-dev-shell release="44": build-release
+test-rpm-dev-shell release="44": (_fedora-lane-image release) build-release
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -1125,7 +1137,7 @@ test-deb-release-shell:
         bash -c "/deb-package-lifecycle.sh install; cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
 
 # Release shell — clean-room .rpm container, real user experience (requires camera)
-test-rpm-release-shell release="44": build-release
+test-rpm-release-shell release="44": (_fedora-lane-image release) build-release
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"

--- a/test/Containerfile.copr
+++ b/test/Containerfile.copr
@@ -1,9 +1,14 @@
 # Container for `just test-copr` — a local COPR-equivalent build.
 # Bakes the Packit + mock toolchain; the build logic lives in test/copr-build.sh.
 # Must be run with --privileged (mock needs it) and the repo mounted at /repo:ro.
-FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+# Base image comes from dist/release-matrix.json via
+# test/fedora-lane-image.sh, which is where the digest pin and the Fedora
+# EOL gate live. No default: a build without --build-arg must fail, not
+# silently pick a release.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 RUN dnf install -y --setopt=install_weak_deps=False \
-        packit mock rpm-build git tar \
+        packit mock rpm-build git tar python3 \
     && dnf clean all
 COPY test/copr-build.sh /copr-build.sh
 RUN chmod +x /copr-build.sh

--- a/test/Containerfile.fedora
+++ b/test/Containerfile.fedora
@@ -1,5 +1,10 @@
 # Single-stage test image — uses host-built release binaries (from `just build-release`)
-FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+# Base image comes from dist/release-matrix.json via
+# test/fedora-lane-image.sh, which is where the digest pin and the Fedora
+# EOL gate live. No default: a build without --build-arg must fail, not
+# silently pick a release.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 RUN dnf -y install pam dbus rpm-build libxkbcommon python3 systemd binutils glibc tpm2-tss && dnf clean all
 

--- a/test/Containerfile.rpm-authselect
+++ b/test/Containerfile.rpm-authselect
@@ -1,4 +1,9 @@
-FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+# Base image comes from dist/release-matrix.json via
+# test/fedora-lane-image.sh, which is where the digest pin and the Fedora
+# EOL gate live. No default: a build without --build-arg must fail, not
+# silently pick a release.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 RUN dnf -y install --setopt=install_weak_deps=False \
         authselect coreutils findutils gettext grep python3 util-linux-core rpm-build rpm \
@@ -6,6 +11,9 @@ RUN dnf -y install --setopt=install_weak_deps=False \
         tpm2-tss onnxruntime libxkbcommon \
     && dnf clean all
 
+# The upgrade fixture is the released v0.1.4 fc44 artifact, the only build of
+# the retired-profile package that exists. That is what the guard has to handle
+# on any Fedora release, so this stays pinned to fc44 regardless of BASE_IMAGE.
 ARG FACELOCK_LEGACY_RPM_URL=https://github.com/tyvsmith/facelock/releases/download/v0.1.4/facelock-0.1.4-1.fc44.x86_64.rpm
 ARG FACELOCK_LEGACY_RPM_SHA256=e8d3858adbf001676cc1d25171702c396e6ed22dd2a8c4f0d064a8c2febb3a0b
 RUN mkdir -p /artifacts \

--- a/test/Containerfile.rpm-e2e
+++ b/test/Containerfile.rpm-e2e
@@ -1,6 +1,11 @@
 # E2E package test — builds a real .rpm and installs via dnf
 # Uses host-built release binaries (from `just build-release`); no Rust compilation in container.
-FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+# Base image comes from dist/release-matrix.json via
+# test/fedora-lane-image.sh, which is where the digest pin and the Fedora
+# EOL gate live. No default: a build without --build-arg must fail, not
+# silently pick a release.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 # dbus-daemon (Fedora ships dbus-broker by default) is needed for the runtime
 # D-Bus tests in pkg-validate.sh, including the polkit agent boundary check.
@@ -44,10 +49,13 @@ COPY .github/workflows/scripts/validate-rpm.sh /validate-rpm.sh
 COPY test/pkg-validate.sh /pkg-validate.sh
 COPY test/polkit-agent-validate.sh /polkit-agent-validate.sh
 COPY test/rpm-service-pam-lifecycle.sh /rpm-service-pam-lifecycle.sh
+COPY test/rpm-config-lifecycle.sh /rpm-config-lifecycle.sh
+COPY test/rpm-runtime-smoke.sh /rpm-runtime-smoke.sh
 COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
 RUN chmod +x /build/test/build-rpm-prebuilt.sh /run-networkless.sh \
     /validate-rpm.sh /pkg-validate.sh /polkit-agent-validate.sh \
-    /rpm-service-pam-lifecycle.sh
+    /rpm-service-pam-lifecycle.sh /rpm-config-lifecycle.sh \
+    /rpm-runtime-smoke.sh
 
 # Fetch and verify the same reviewed CPU-only archive as release.yml. This is a
 # distinct network stage; test/build-rpm-prebuilt.sh performs no downloads.
@@ -86,5 +94,18 @@ RUN /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "0.0.0" && \
     cp "$RPM_FILE" /facelock-test-package.rpm && \
     dnf install -y ./*.rpm && \
     rm -rf ~/rpmbuild ./*.rpm
+
+# A second, higher-versioned package whose only payload difference is the
+# %config(noreplace) file. /rpm-config-lifecycle.sh upgrades 0.0.0 -> 0.0.1 with
+# the config untouched and again with it edited; both outcomes only exist when
+# the packaged config actually changes between the two versions.
+RUN cp /build/config/facelock.toml /tmp/facelock.toml.baseline && \
+    printf '\n# packaged-only-in-facelock-upgrade-rpm\n' >> /build/config/facelock.toml && \
+    /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "0.0.1" && \
+    RPM_FILE="$(find . -maxdepth 1 -name '*.rpm' -print -quit)" && \
+    cp "$RPM_FILE" /facelock-test-upgrade.rpm && \
+    cp /tmp/facelock.toml.baseline /build/config/facelock.toml && \
+    rm -rf ~/rpmbuild ./*.rpm /tmp/facelock.toml.baseline && \
+    cmp /build/config/facelock.toml /etc/facelock/config.toml
 
 CMD ["/pkg-validate.sh"]

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -534,15 +534,49 @@ require(
     "bash test/fedora-lane-image.sh" in justfile,
     "justfile Fedora lanes do not resolve their image through the matrix",
 )
-require(
-    re.search(r"(?m)^test-rpm-lanes:", justfile) is not None,
-    "justfile omits the aggregate Fedora lifecycle lane target",
+lanes_recipe = re.search(r"(?m)^test-rpm-lanes:(?P<dependencies>[^\n]*)$", justfile)
+require(lanes_recipe is not None, "justfile omits the aggregate Fedora lifecycle lane target")
+lane_invocations = re.findall(
+    r'\((test-rpm-[a-z-]+)\s+"([^"]+)"\)', lanes_recipe.group("dependencies")
 )
-for copr_target in sorted(expected_copr_targets):
-    fedora_release = copr_target.split("-")[1]
+lanes_by_release = {release: recipe for recipe, release in lane_invocations}
+require(
+    len(lane_invocations) == len(lanes_by_release),
+    "just test-rpm-lanes invokes a Fedora release more than once",
+)
+# The matrix declares how deeply each release is tested, so the gate has to
+# require that exact recipe. Accepting either one lets a full lifecycle lane be
+# downgraded to a smoke lane without anything noticing, which is the regression
+# these lanes exist to prevent.
+lane_recipe_by_depth = {"full": "test-rpm-pkg", "build/runtime smoke": "test-rpm-smoke"}
+declared_fedora_releases = {target.split("-")[1] for target in expected_copr_targets}
+require(
+    set(lanes_by_release) == declared_fedora_releases,
+    f"just test-rpm-lanes covers {sorted(lanes_by_release)}, "
+    f"not the declared release targets {sorted(declared_fedora_releases)}",
+)
+for fedora_release in sorted(declared_fedora_releases):
+    lane_depths = {
+        row["lifecycle_depth"]
+        for row in matrix.get("platforms", [])
+        if row.get("release_target") is True
+        and re.fullmatch(rf"Fedora {fedora_release}(?: .*)?", row.get("platform", ""))
+    }
+    require(lane_depths, f"release matrix declares no Fedora {fedora_release} platform row")
     require(
-        re.search(rf'\(test-rpm-(?:pkg|smoke) "{fedora_release}"\)', justfile) is not None,
-        f"just test-rpm-lanes omits declared release target Fedora {fedora_release}",
+        len(lane_depths) == 1,
+        f"Fedora {fedora_release} platform rows disagree on lifecycle depth: {sorted(lane_depths)}",
+    )
+    lane_depth = lane_depths.pop()
+    require(
+        lane_depth in lane_recipe_by_depth,
+        f"Fedora {fedora_release} lifecycle depth {lane_depth!r} has no mapped lane recipe",
+    )
+    require(
+        lanes_by_release[fedora_release] == lane_recipe_by_depth[lane_depth],
+        f"just test-rpm-lanes runs Fedora {fedora_release} through "
+        f"{lanes_by_release[fedora_release]}, but its declared lifecycle depth "
+        f"{lane_depth!r} requires {lane_recipe_by_depth[lane_depth]}",
     )
 require(
     platforms_by_id.get("fedora-43", {}).get("eol_gate") == matrix["fedora"]["43_eol_gate"],

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -507,6 +507,48 @@ require(live_channel_command in ci_workflow, "CI does not compare live release c
 require(live_channel_command in justfile, "release preflight does not compare live release channels with the checked-in authority")
 require("ARCH_SNAPSHOT" not in justfile, "unused ARCH_SNAPSHOT signaling remains")
 
+# Fedora lifecycle lanes take their base image from this matrix rather than
+# carrying a digest each. That is what stops a declared release from going
+# unbuilt, stops an undeclared one (Rawhide) from acquiring a lane, and puts
+# every lane behind the same EOL gate.
+for relative_path in (
+    "test/Containerfile.rpm-e2e",
+    "test/Containerfile.rpm-authselect",
+    "test/Containerfile.copr",
+    "test/Containerfile.fedora",
+):
+    fedora_containerfile = (ROOT / relative_path).read_text()
+    require(
+        re.search(r"(?m)^ARG BASE_IMAGE\s*$\n^FROM \$\{BASE_IMAGE\}\s*$", fedora_containerfile)
+        is not None,
+        f"{relative_path} does not take its base image from the release matrix",
+    )
+    require(
+        "registry.fedoraproject.org/fedora:" not in fedora_containerfile,
+        f"{relative_path} pins a Fedora image outside the release matrix",
+    )
+lane_resolver = (ROOT / "test/fedora-lane-image.sh").read_text()
+for phrase in ("RELEASE_MATRIX_TODAY", "_eol_gate", "staging_copr_targets"):
+    require(phrase in lane_resolver, f"Fedora lane resolver omits matrix authority: {phrase}")
+require(
+    "bash test/fedora-lane-image.sh" in justfile,
+    "justfile Fedora lanes do not resolve their image through the matrix",
+)
+require(
+    re.search(r"(?m)^test-rpm-lanes:", justfile) is not None,
+    "justfile omits the aggregate Fedora lifecycle lane target",
+)
+for copr_target in sorted(expected_copr_targets):
+    fedora_release = copr_target.split("-")[1]
+    require(
+        re.search(rf'\(test-rpm-(?:pkg|smoke) "{fedora_release}"\)', justfile) is not None,
+        f"just test-rpm-lanes omits declared release target Fedora {fedora_release}",
+    )
+require(
+    platforms_by_id.get("fedora-43", {}).get("eol_gate") == matrix["fedora"]["43_eol_gate"],
+    "Fedora 43 platform row EOL gate disagrees with the matrix-wide gate",
+)
+
 for pkgbuild_name in ("PKGBUILD", "PKGBUILD-bin"):
     pkgbuild = (ROOT / "dist" / pkgbuild_name).read_text()
     require(re.search(r"^_tag=", pkgbuild, re.MULTILINE) is not None, f"dist/{pkgbuild_name} has no upstream _tag")
@@ -675,6 +717,16 @@ require(
 require(
     "SKIP: packit" not in justfile,
     "release preflight can still skip Packit schema validation",
+)
+copr_chroot_default = re.search(r'(?m)^CHROOT="\$\{COPR_CHROOT:-([^"}]+)\}"', copr_build_test)
+require(copr_chroot_default is not None, "COPR-equivalent gate has no parseable chroot default")
+require(
+    copr_chroot_default.group(1) in expected_copr_targets,
+    f"COPR-equivalent gate defaults to an undeclared chroot: {copr_chroot_default.group(1)}",
+)
+require(
+    "staging_copr_targets" in copr_build_test,
+    "COPR-equivalent gate does not check its chroot against the declared staging targets",
 )
 
 install_docs = {

--- a/test/copr-build.sh
+++ b/test/copr-build.sh
@@ -16,6 +16,25 @@ CHROOT="${COPR_CHROOT:-fedora-44-x86_64}"
 RESULT=0
 section() { echo; echo "==== $* ===="; }
 
+# dist/release-matrix.json is the authority for which chroots are staging
+# targets. Refusing anything outside it keeps a lane from silently building
+# against Rawhide, which the matrix marks optional/experimental and which may
+# never stand in for a Fedora 43, 44, or 45 result.
+if ! python3 - "$CHROOT" <<'PY'
+import json
+import sys
+
+with open("/repo/dist/release-matrix.json", encoding="utf-8") as handle:
+    targets = json.load(handle)["fedora"]["staging_copr_targets"]
+if sys.argv[1] not in targets:
+    print(f"COPR_CHROOT {sys.argv[1]!r} is not a declared staging target: {sorted(targets)}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  echo "FAIL: undeclared COPR chroot"
+  exit 1
+fi
+
 section "Copy repo to writable workdir"
 mkdir -p /work
 tar -C /repo --exclude='./target' -cf - . | tar -C /work -xf -

--- a/test/fedora-lane-image.sh
+++ b/test/fedora-lane-image.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Resolve the digest-pinned base image for one Fedora lifecycle lane.
+#
+# dist/release-matrix.json is the only authority for which Fedora releases are
+# release targets and which image each one is pinned to, so lanes read it here
+# instead of hardcoding a digest per Containerfile. Three things fail closed:
+#
+#   * a release that is not a declared Fedora target (Rawhide included — it is
+#     explicitly optional/experimental and never a lifecycle lane)
+#   * platform rows for the same release that disagree on the image, or an
+#     image that is not digest-pinned
+#   * a release past its checked-in EOL gate
+#
+# The EOL gate reuses the matrix mechanism: `fedora.<release>_eol_gate` plus the
+# RELEASE_MATRIX_TODAY override that test/check-release-matrix.py already reads.
+# Fedora 43 goes EOL on 2026-12-02, and on that date this stops the lane with a
+# message rather than letting it quietly rot against an unmaintained release.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+release="${1:?usage: fedora-lane-image.sh <fedora-release>}"
+[ "$#" -eq 1 ] || {
+    echo "usage: fedora-lane-image.sh <fedora-release>" >&2
+    exit 2
+}
+
+RELEASE_MATRIX_TODAY="${RELEASE_MATRIX_TODAY:-}" \
+python3 - "$repo_root/dist/release-matrix.json" "$release" <<'PY'
+import json
+import os
+import re
+import sys
+from datetime import date
+
+matrix_path, release = sys.argv[1], sys.argv[2]
+
+
+def fail(message):
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+if not re.fullmatch(r"[1-9][0-9]*", release):
+    fail(
+        f"Fedora lane release must be a release number, got {release!r}; "
+        "Rawhide is optional/experimental and cannot be a lifecycle lane"
+    )
+
+with open(matrix_path, encoding="utf-8") as handle:
+    matrix = json.load(handle)
+
+fedora = matrix.get("fedora", {})
+declared = set(fedora.get("staging_copr_targets", []))
+if f"fedora-{release}-x86_64" not in declared:
+    fail(
+        f"Fedora {release} is not a declared release target: {sorted(declared)}"
+    )
+
+rows = [
+    row
+    for row in matrix.get("platforms", [])
+    if row.get("release_target") is True
+    and re.fullmatch(rf"Fedora {release}(?: .*)?", row.get("platform", ""))
+]
+if not rows:
+    fail(f"release matrix declares no Fedora {release} platform row")
+
+images = {row.get("image") for row in rows}
+if len(images) != 1:
+    fail(f"Fedora {release} platform rows disagree on the base image: {sorted(images)}")
+image = images.pop()
+if not isinstance(image, str) or not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image):
+    fail(f"Fedora {release} image is not digest-pinned: {image!r}")
+
+gate = fedora.get(f"{release}_eol_gate")
+if gate is not None:
+    for row in rows:
+        row_gate = row.get("eol_gate")
+        if row_gate is not None and row_gate != gate:
+            fail(
+                f"{row['id']} eol_gate {row_gate!r} disagrees with "
+                f"fedora.{release}_eol_gate {gate!r}"
+            )
+    eol = date.fromisoformat(gate)
+    today = date.fromisoformat(
+        os.environ.get("RELEASE_MATRIX_TODAY") or date.today().isoformat()
+    )
+    if today >= eol:
+        fail(
+            f"Fedora {release} reached its {eol.isoformat()} EOL gate: retire the "
+            f"lane and its release-matrix row, or move the gate deliberately"
+        )
+
+print(image)
+PY

--- a/test/fedora-lane-image.sh
+++ b/test/fedora-lane-image.sh
@@ -15,6 +15,11 @@
 # RELEASE_MATRIX_TODAY override that test/check-release-matrix.py already reads.
 # Fedora 43 goes EOL on 2026-12-02, and on that date this stops the lane with a
 # message rather than letting it quietly rot against an unmaintained release.
+#
+# Known gap: 43 is the only release the matrix gives a gate. The lookup is
+# generic, so a `44_eol_gate` or `45_eol_gate` key gates those lanes the moment
+# it is added, but until someone adds one the 44 and 45 lanes keep running past
+# their own end of life without complaint.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -743,8 +743,16 @@ EOF
     run_test "apt wrapper removes the PAM module" \
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
 elif [ "$PACKAGE_FORMAT" = rpm ]; then
-    # Modify config so RPM treats it as user-edited and preserves it as .rpmsave
+    # Modify config so RPM treats it as user-edited. The observed
+    # %config(noreplace) erase contract, pinned below: a modified config is
+    # removed from its own path and its exact bytes are kept as .rpmsave, while
+    # an unmodified one is removed outright and leaves nothing behind. Record
+    # the administrator bytes now so the .rpmsave assertion compares content and
+    # not merely existence.
     echo "# modified by test" >> /etc/facelock/config.toml
+    sha256sum /etc/facelock/config.toml |
+        sed 's|/etc/facelock/config.toml$|/etc/facelock/config.toml.rpmsave|' \
+        > /tmp/facelock-modified-config.sha
     run_test "rpm removal aborts on an unmanaged PAM reference" \
         "! rpm -e facelock"
     run_test "rpm keeps the package installed after aborted removal" \
@@ -772,9 +780,21 @@ elif [ "$PACKAGE_FORMAT" = rpm ]; then
     run_test "facelock binary removed after rpm -e" "[ ! -f /usr/bin/facelock ]"
     run_test "PAM module removed after rpm -e" \
         "[ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
-    run_test "Config preserved after rpm -e (config(noreplace))" "[ -f /etc/facelock/config.toml ] || [ -f /etc/facelock/config.toml.rpmsave ]"
+    run_test "modified config(noreplace) leaves its own path on rpm -e" \
+        "[ ! -e /etc/facelock/config.toml ] && [ ! -L /etc/facelock/config.toml ]"
+    run_test "modified config(noreplace) is retained as .rpmsave on rpm -e" \
+        "[ -f /etc/facelock/config.toml.rpmsave ]"
+    run_test "retained .rpmsave holds the administrator bytes byte-for-byte" \
+        "sha256sum -c --status /tmp/facelock-modified-config.sha"
+    run_test "rpm -e of a modified config writes no .rpmnew" \
+        "[ ! -e /etc/facelock/config.toml.rpmnew ]"
+    # The unmodified-erase half needs a clean slate: consume the .rpmsave just
+    # asserted so the next erase cannot be scored against a stale one.
+    rm -f /etc/facelock/config.toml.rpmsave /tmp/facelock-modified-config.sha
     run_test "facelock reinstalls before dnf wrapper success" \
         "dnf install -y /facelock-test-package.rpm"
+    run_test "reinstall restores config(noreplace) at its own path" \
+        "[ -f /etc/facelock/config.toml ] && ! [ -e /etc/facelock/config.toml.rpmsave ]"
     cat > "$PACKAGE_OWNED_PAM" <<'EOF'
 #%PAM-1.0
 auth      sufficient pam_facelock.so
@@ -787,6 +807,10 @@ EOF
         "[ -f $PACKAGE_OWNED_PAM ] && ! grep -q pam_facelock.so $PACKAGE_OWNED_PAM"
     run_test "dnf wrapper removes the package and PAM module" \
         "! rpm -q facelock && [ ! -f /lib/security/pam_facelock.so ] && [ ! -f /usr/lib/security/pam_facelock.so ] && [ ! -f /usr/lib64/security/pam_facelock.so ]"
+    # Nothing edited the config between the reinstall above and this removal, so
+    # this is the unmodified half of the erase contract: gone, with no .rpmsave.
+    run_test "unmodified config(noreplace) is removed outright on erase" \
+        "[ ! -e /etc/facelock/config.toml ] && [ ! -e /etc/facelock/config.toml.rpmsave ] && [ ! -e /etc/facelock/config.toml.rpmnew ]"
 else
     skip_test "package removal block (removal, binary/PAM module gone, config preserved)" \
         "facelock was not installed by dpkg or rpm here"

--- a/test/rpm-config-lifecycle.sh
+++ b/test/rpm-config-lifecycle.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Booted Fedora proof of what %config(noreplace) does to /etc/facelock/config.toml
+# across an upgrade.
+#
+# The observed RPM contract, confirmed against rpm on Fedora and pinned here:
+#
+#   unmodified on disk, packaged config changed  -> file replaced with the new
+#                                                   packaged bytes, no .rpmnew,
+#                                                   no .rpmsave
+#   modified on disk, packaged config changed    -> administrator bytes kept
+#                                                   byte-for-byte, new packaged
+#                                                   bytes land in .rpmnew,
+#                                                   no .rpmsave
+#
+# `.rpmsave` belongs to erase, not upgrade; test/pkg-validate.sh pins that half.
+# An assertion that accepts either outcome pins nothing, so every case here
+# names exactly one file layout and exactly one set of bytes.
+#
+# Runs after test/pkg-validate.sh, which leaves the package uninstalled.
+set -euo pipefail
+
+baseline_rpm=/facelock-test-package.rpm
+upgrade_rpm=/facelock-test-upgrade.rpm
+config=/etc/facelock/config.toml
+pass_count=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+pass() {
+    printf 'TEST: %s ... PASS\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+
+# Digest of the config file as the package records it, not as some copy of the
+# tree happens to look. Field 4 of --dump is the file digest.
+packaged_config_digest() {
+    rpm -qp --dump "$1" 2>/dev/null |
+        awk -v path="$config" '$1 == path { print $4; found = 1 } END { exit !found }'
+}
+
+packaged_config_flags() {
+    rpm -qp --queryformat '[%{FILENAMES} %{FILEFLAGS:fflags}\n]' "$1" 2>/dev/null |
+        awk -v path="$config" '$1 == path { print $2; found = 1 } END { exit !found }'
+}
+
+on_disk_digest() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+
+require_absent() {
+    [ ! -e "$1" ] && [ ! -L "$1" ] || fail "$2: $1 exists"
+}
+
+reset_state() {
+    if rpm -q facelock >/dev/null 2>&1; then
+        rpm -e facelock >/dev/null
+    fi
+    rm -f -- "$config" "$config".rpmnew "$config".rpmsave "$config".rpmorig
+}
+
+for required in "$baseline_rpm" "$upgrade_rpm"; do
+    [ -f "$required" ] || fail "missing required package: $required"
+done
+
+baseline_digest="$(packaged_config_digest "$baseline_rpm")" ||
+    fail "$baseline_rpm does not package $config"
+upgrade_digest="$(packaged_config_digest "$upgrade_rpm")" ||
+    fail "$upgrade_rpm does not package $config"
+[ "$baseline_digest" != "$upgrade_digest" ] ||
+    fail "both packages ship identical config bytes, so no upgrade case is observable"
+
+for candidate in "$baseline_rpm" "$upgrade_rpm"; do
+    flags="$(packaged_config_flags "$candidate")" || fail "$candidate does not list $config"
+    case "$flags" in
+        *c*n*|*n*c*) ;;
+        *) fail "$candidate does not declare $config as config(noreplace), flags: $flags" ;;
+    esac
+done
+pass "both packages declare the config file as config(noreplace)"
+
+reset_state
+trap 'reset_state || true' EXIT
+
+dnf install -y "$baseline_rpm" >/dev/null
+[ "$(on_disk_digest "$config")" = "$baseline_digest" ] ||
+    fail "fresh install did not lay down the packaged config bytes"
+pass "fresh install lays down exactly the packaged config bytes"
+
+dnf upgrade -y "$upgrade_rpm" >/dev/null
+[ "$(on_disk_digest "$config")" = "$upgrade_digest" ] ||
+    fail "upgrade left an unmodified config that is not the new packaged file"
+require_absent "$config.rpmnew" "unmodified upgrade diverted the new config"
+require_absent "$config.rpmsave" "unmodified upgrade saved a config nobody edited"
+pass "unmodified config is replaced in place by the new packaged config on upgrade"
+
+reset_state
+dnf install -y "$baseline_rpm" >/dev/null
+printf '\n# administrator edit kept across the upgrade\n' >>"$config"
+admin_digest="$(on_disk_digest "$config")"
+[ "$admin_digest" != "$baseline_digest" ] || fail "the administrator edit did not change the file"
+
+dnf upgrade -y "$upgrade_rpm" >/dev/null
+[ "$(on_disk_digest "$config")" = "$admin_digest" ] ||
+    fail "upgrade overwrote an administrator-modified config"
+grep -qxF '# administrator edit kept across the upgrade' "$config" ||
+    fail "administrator edit is gone from the retained config"
+[ -f "$config.rpmnew" ] || fail "upgrade did not divert the new packaged config to .rpmnew"
+[ "$(on_disk_digest "$config.rpmnew")" = "$upgrade_digest" ] ||
+    fail ".rpmnew does not hold the new packaged config bytes"
+require_absent "$config.rpmsave" "upgrade saved an .rpmsave that belongs to erase"
+pass "modified config survives upgrade byte-for-byte with the new file as .rpmnew"
+
+rpm -q facelock >/dev/null || fail "package is not installed after the upgrade cases"
+pass "the upgraded package stays installed through both config cases"
+
+printf '\n=== RPM config(noreplace) upgrade results: %d passed, 0 failed ===\n' "$pass_count"

--- a/test/rpm-runtime-smoke.sh
+++ b/test/rpm-runtime-smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Runtime smoke for a branched Fedora release.
+#
+# dist/release-matrix.json gives Fedora 45 a lifecycle depth of "build/runtime
+# smoke", not "full": the branched release has to prove the package builds and
+# that what it installs is loadable, without standing in for the full Fedora 43
+# and 44 lifecycle lanes. Build coverage happens when the image is assembled
+# (rpmbuild from the real spec, .github/workflows/scripts/validate-rpm.sh, then
+# dnf install). This is the runtime half, run under a booted systemd.
+set -euo pipefail
+
+pass_count=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+pass() {
+    printf 'TEST: %s ... PASS\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+
+rpm -q facelock >/dev/null || fail "facelock is not installed from the built package"
+pass "the built package is installed"
+
+# rpm -V reports one nine-character attribute field per differing file. Mode and
+# mtime drift is normal in a container image, so this fails only on the classes
+# that mean the installed payload is not what the package shipped: size, digest,
+# owner, group, symlink target, or file capabilities.
+verify_report="$(rpm -V --nomtime facelock || true)"
+if [ -n "$verify_report" ]; then
+    printf '%s\n' "$verify_report"
+fi
+while read -r attributes _; do
+    [ -n "$attributes" ] || continue
+    case "$attributes" in
+        missing) fail "package file is missing from the installed payload" ;;
+        *S*|*5*|*U*|*G*|*L*|*P*)
+            fail "installed payload differs from the package: $attributes" ;;
+    esac
+done <<<"$verify_report"
+pass "installed payload matches the packaged size, digest, ownership, and links"
+
+facelock --version >/dev/null || fail "facelock --version did not run"
+facelock --help >/dev/null || fail "facelock --help did not run"
+pass "the installed binary runs against its packaged ONNX Runtime"
+
+pam_module=""
+for candidate in /usr/lib64/security/pam_facelock.so /usr/lib/security/pam_facelock.so; do
+    [ -f "$candidate" ] && pam_module="$candidate" && break
+done
+[ -n "$pam_module" ] || fail "no PAM module was installed"
+pass "the PAM module is installed"
+
+for owned in \
+    /etc/facelock/config.toml \
+    /usr/lib/systemd/system/facelock-daemon.service \
+    /usr/lib/tmpfiles.d/facelock.conf \
+    /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+    /usr/share/dbus-1/system-services/org.facelock.Daemon.service; do
+    [ -f "$owned" ] || fail "package did not install $owned"
+    rpm -qf "$owned" >/dev/null 2>&1 || fail "$owned is not owned by any package"
+done
+pass "config, unit, tmpfiles, and D-Bus files are installed and package-owned"
+
+systemctl cat facelock-daemon.service >/dev/null ||
+    fail "systemd cannot load the packaged unit"
+[ "$(systemctl is-enabled facelock-daemon.service 2>&1)" != "bad" ] ||
+    fail "packaged unit is in a bad enablement state"
+pass "systemd loads the packaged daemon unit"
+
+# %post runs %tmpfiles_create; the runtime directories have to exist, not just
+# the .conf that declares them.
+for runtime_dir in /var/lib/facelock /var/log/facelock; do
+    [ -d "$runtime_dir" ] || fail "RPM tmpfiles did not create $runtime_dir"
+done
+systemd-tmpfiles --cat-config >/dev/null || fail "systemd rejects the tmpfiles configuration"
+pass "packaged tmpfiles entries applied at install time"
+
+printf '\n=== Fedora runtime smoke results: %d passed, 0 failed ===\n' "$pass_count"

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -133,6 +133,12 @@ fi
 
 podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh
 
+# pkg-validate.sh pins %config(noreplace) on erase and finishes with the package
+# uninstalled, which is the clean slate the upgrade half needs.
+if podman exec "$cid" test -x /rpm-config-lifecycle.sh; then
+    podman exec "$cid" /rpm-config-lifecycle.sh
+fi
+
 if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
     podman exec "$cid" /deb-package-lifecycle.sh purge
 fi

--- a/test/run-rpm-smoke-systemd.sh
+++ b/test/run-rpm-smoke-systemd.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Boot an rpm-e2e image with systemd as PID 1 and run the branched-release
+# runtime smoke inside it.
+#
+# test/run-pkg-validate-systemd.sh is the full lifecycle runner for the Fedora
+# releases the matrix marks "full". This is the shorter path for a branched
+# release whose declared depth is build/runtime smoke, so it needs no models,
+# no exact package argument, and none of the Debian lifecycle stages.
+set -euo pipefail
+
+IMAGE="${1:?usage: run-rpm-smoke-systemd.sh <image>}"
+[ "$#" -eq 1 ] || {
+    echo "usage: run-rpm-smoke-systemd.sh <image>" >&2
+    exit 2
+}
+
+cid=$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
+    "$IMAGE" /lib/systemd/systemd)
+trap 'podman rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+booted=""
+for _ in $(seq 1 120); do
+    state=$(podman exec "$cid" systemctl is-system-running 2>/dev/null || true)
+    case "$state" in
+        running|degraded) booted=1; break ;;
+    esac
+    sleep 1
+done
+if [ -z "$booted" ]; then
+    echo "ERROR: systemd did not reach running/degraded state" >&2
+    podman exec "$cid" systemctl --failed --no-pager 2>&1 || true
+    exit 1
+fi
+
+podman exec "$cid" /rpm-runtime-smoke.sh


### PR DESCRIPTION
## Summary

- resolve every Fedora lane's base image from `dist/release-matrix.json` through `test/fedora-lane-image.sh`, replacing the Fedora 44 digest each containerfile carried
- add `just test-rpm-lanes`: full lifecycle on 43 and 44, build plus runtime smoke on branched 45
- require each release to run through the recipe its matrix `lifecycle_depth` names, so a full lane cannot be downgraded to a smoke lane
- take a release argument on every Fedora recipe, defaulting to 44, and resolve the lane before the host release build so an expired release is refused first
- stop the Fedora 43 lane at its 2026-12-02 matrix EOL gate, reading the same `RELEASE_MATRIX_TODAY` override `test/check-release-matrix.py` uses
- refuse a lane for Rawhide or any release the matrix does not declare, and check `COPR_CHROOT` against the declared staging targets
- replace the `%config(noreplace)` erase assertion with one file layout and one set of bytes per case
- add `test/rpm-config-lifecycle.sh` for the upgrade cases, against a second package whose only payload difference is the config

## Why

`dist/release-matrix.json` declares Fedora 43, 44 and 45 as release targets, but every RPM containerfile pinned Fedora 44, so two of the three were never built or installed anywhere. The erase assertion read `[ -f config.toml ] || [ -f config.toml.rpmsave ]`, which holds in the correct world and in both regressed ones, and nothing covered upgrade. Downgrading the spec from `%config(noreplace)` to `%config` passed the entire old suite.

## Reviewer notes

- **based on #266**, not `main`: the pre-#266 spec is the wrong build recipe to test. The `%files` regex fix this branch needed now lives on #266 as `08b2232`, so #266 stands alone and this branch is rebased onto it
- **Fedora 45 depth** is build plus runtime smoke, matching the matrix `lifecycle_depth`, and never substitutes for a 43 or 44 result
- **known gap**: only Fedora 43 has an `eol_gate` row. The lookup is generic on `fedora.<release>_eol_gate`, so 44 and 45 gate the moment a key is added, and run past their own end of life until then
- **`test-rpm-authselect <release>` is unproven off 44**: the upgrade fixture is the released fc44 v0.1.4 RPM, the only build of the retired-profile package that exists, and it may not install on an older base. Noted at the recipe
- **tier row numbering**: this uses `3e` in `.claude/rules/testing.md` so #281 keeps `3d` for its Arch package lane
- **still blocked**: #230's staging-COPR and SELinux-enforcing lanes wait on the `facelock-testing` project (#236) and a pinned enforcing Fedora VM runner

## Validation

- `just test-rpm-pkg 43`, `just test-rpm-pkg 44`, `just test-rpm-smoke 45`
- `just check`
- mutation runs: `%config(noreplace)` downgraded to `%config` in the spec; each release-matrix assertion inverted one at a time; `test-rpm-lanes` rewritten to run every release as a smoke lane

Refs #230
