### PR TITLE
test: split the camera-free assertions out of the two E2E tiers

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -9,7 +9,7 @@ derives-from:
   - dist/facelock.tmpfiles
   - systemd/facelock-daemon.service
   - docs/adr/**
-reviewed: 2026-08-22
+reviewed: 2026-08-24
 ---
 
 # Security Rules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -16,6 +16,9 @@ paths:
 | 3b | Arch container E2E (daemon) | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
 | 3e | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
+| 3a | Arch container E2E, camera-free | `just test-arch-camera-free` |
+| 3b | Arch container E2E (daemon), needs a camera | `just test-arch-integration` |
+| 3c | Arch container E2E (oneshot), needs a camera | `just test-arch-oneshot` |
 | 4 | VM testing | Disposable VM with snapshots |
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 
@@ -24,3 +27,19 @@ paths:
 Fedora recipes take a release and default to 44 (`just test-rpm-pkg 43`). Tier 3e
 covers all three declared targets at the depth `dist/release-matrix.json` gives
 each; Rawhide is experimental and never a lane.
+
+## Which E2E tier a new assertion belongs in
+
+Tier 3a is everything in the two E2E suites that reaches its subject before any
+capture: bus policy, D-Bus authorization, pre-flight rejections and their exit
+codes, schema migrations, the shape of the status document. CI runs it on every
+pull request. Tiers 3b and 3c keep only what a real sensor produces: a frame, a
+match, a device fingerprint, a warm-hold timing.
+
+Put a new assertion in 3a unless it needs a frame. An assertion parked in 3b or
+3c that did not need one is unwatched: those tiers run on one machine, and three
+of their assertions rotted there undetected (#139).
+
+Tiers 3b and 3c are gated at release time, not at review time.
+`just test-arch-camera-required` runs both and records the commit they passed
+at; `just release-preflight` fails until that record names HEAD.

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -5,10 +5,11 @@ description: Pick and run the right facelock packaging or container test for a c
 
 # Packaging and container tests
 
-CI runs exactly one container job — `container-pam-test` in `ci.yml`. Every
-`.deb`, `.rpm`, COPR and APT-repo path is **local only**. If you changed
-packaging and did not run one of these yourself, it is untested until a release
-tag fires `release.yml`, which is the worst place to find out.
+CI runs exactly one container job, `container-pam-test` in `ci.yml`. It runs
+the PAM smoke tier and the camera-free E2E tier. Every `.deb`, `.rpm`, COPR and
+APT-repo path is **local only**. If you changed packaging and did not run one of
+these yourself, it is untested until a release tag fires `release.yml`, which is
+the worst place to find out.
 
 All recipes need `podman`. None of the ones in the routing table need a camera.
 
@@ -27,6 +28,7 @@ All recipes need `podman`. None of the ones in the routing table need a camera.
 | `systemd/`, `dbus/`, `polkit/`, install paths | both Debian suite recipes or `just test-rpm-pkg` — all validate under booted systemd |
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
 | File layout, installed paths | `just test-arch-layout` |
+| D-Bus policy, daemon authorization, pre-flight exit codes, schema migrations | `just test-arch-camera-free` |
 
 `just test-deb` delegates to both exact supported-suite package gates. The
 remaining quick syntax-level check is `just test-rpm` (Fedora container), which
@@ -63,11 +65,17 @@ run them:
 
 - `just test-arch-integration` — daemon-mode end to end
 - `just test-arch-oneshot` — daemonless end to end
+- `just test-arch-camera-required` — both of the above, recorded against HEAD for `just release-preflight`
 - `just test-arch-dev-shell`, `test-arch-release-shell`, `test-deb-dev-shell`, `test-rpm-dev-shell`, `test-deb-release-shell`, `test-rpm-release-shell`
 
 **Do not attempt these.** When a change needs one, say so plainly and name the
 recipe so a human can run it. Never report a change as validated on the strength
 of tests that were skipped.
+
+`just test-arch-camera-free` is the half of the first two that never opens a
+camera, and an agent can and should run it. It needs `podman` and the ONNX
+models baked into the image (`just link-models` once per checkout); the daemon
+half of it refuses to run without them rather than skipping quietly.
 
 Dev shells mount host models for fast iteration; release shells are clean-room
 and reproduce the real first-run user experience. Reach for a release shell when

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,30 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
 
+      # test/Containerfile bakes in models/*.onnx, which are gitignored, so CI
+      # has always built the image without them -- and `facelock daemon`
+      # verifies them at startup and refuses to run when they are absent. That
+      # is what kept the camera-free assertions below out of CI even though
+      # none of them opens a camera (#139). Fetched from the same `assets`
+      # release `facelock setup` uses and verified against the checked-in
+      # manifest, before the image is built.
+      - name: Fetch required ONNX models
+        run: |
+          python3 - <<'PY' > /tmp/required-models.txt
+          import tomllib
+
+          with open("models/manifest.toml", "rb") as fh:
+              manifest = tomllib.load(fh)
+          for model in manifest["models"]:
+              if not model.get("optional"):
+                  print(model["filename"], model["sha256"], model["url"])
+          PY
+          mkdir -p models
+          while read -r name sha url; do
+            curl -fsSL --retry 3 -o "models/$name" "$url"
+            echo "$sha  models/$name" | sha256sum -c -
+          done < /tmp/required-models.txt
+
       - name: Build test container
         run: |
           if [ ! -f test/Containerfile ]; then
@@ -321,6 +345,14 @@ jobs:
           else
             echo "No Containerfile, skipping"
           fi
+
+      # The camera-free half of the two end-to-end tiers (#139). Everything
+      # here reaches its subject before any capture -- bus policy, ADR 010
+      # authorization, pre-flight exit codes, schema migrations -- so it is
+      # gated on every pull request instead of only when someone remembers to
+      # sit in front of a camera. `just test-arch-camera-free` is the same run.
+      - name: Run camera-free E2E tests
+        run: podman run --rm facelock-pam-test /run-camera-free-tests.sh
 
       - name: Verify source-install lifecycle under systemd
         run: test/run-source-install-daemon-lifecycle-systemd.sh facelock-pam-test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dev/*.db
 /.internal/
 .claude/worktrees/
 docs/superpowers/
+/.hardware-tiers-verified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clears on its own. Enablement
   is never changed, and acquisition fails closed without systemd, without the
   lock, or without a confirmed-stopped daemon.
+- **Camera-free end-to-end test tier** (#139): the assertions in the two
+  camera-required E2E suites that never open a camera now live in
+  `just test-arch-camera-free`, which CI runs on every pull request. That
+  covers D-Bus authorization, the `AuthAttempted` broadcast's audience and
+  payload, the rate-limit reply encoding and its no-fallback guarantee, schema
+  migrations, and the one-shot pre-flight exit codes. The two hardware tiers
+  keep what needs a live frame and are now gated at release time:
+  `just test-arch-camera-required` runs both and records the commit they
+  passed at, and `just release-preflight` fails until that record names HEAD.
 - **Explicit authorization for sensitive `setup --pam` writes** (#207):
   `--yes` and its `--no-confirm` alias now suppress only the ordinary per-file
   confirmation. Adding Facelock to a shared or login PAM stack requires the

--- a/docs/adr/008-camera-lifecycle.md
+++ b/docs/adr/008-camera-lifecycle.md
@@ -190,6 +190,14 @@ Invariant (tested): **every exit from `Active` either sets a deadline or drops t
 
 **Bench**: `facelock bench camera-reopen` — N × (drop → open → warmup → first frame), open/`STREAMON`/warmup split. Decides 3 s vs 2 s and replaces the "~600 ms cold" doc line.
 
+**Gating** — the two container tiers above run on a machine with a camera and
+nothing schedules them, which is how three of their assertions rotted
+undetected (#139). Their camera-free assertions now live in
+`just test-arch-camera-free`, which CI runs on every pull request; what remains
+in `test-arch-integration` and `test-arch-oneshot` is gated at release time by
+`just test-arch-camera-required`, which records the commit they passed at and
+without which `just release-preflight` fails.
+
 **Acceptance**: (1) LED off ≤ one frame + 250 ms after Success/Cancel; (2) off at `release_secs ± 250 ms` after Failure; (3) warm retry: no `open()`/`STREAMON`, first analyzed frame is fresh; (4) no `facelock auth` outlives its PAM host by > 500 ms; (5) `release_secs = 0` never holds; (6) invariant in §8.
 
 ## 10. Delivery

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -273,17 +273,33 @@ retire the old authselect payload first.
 Run this before creating/pushing a release tag:
 
 ```bash
+just test-arch-camera-required      # camera + a person in frame; records the commit
 just release-preflight              # stable release checks
 just release-preflight v0.2.0-rc.1 # prerelease checks; no stable secret access
 just test-release-matrix            # converters, matrix drift, native ordering
 just check
 just test-arch-pam
+just test-arch-camera-free
 just test-rpm
 just test-deb
 just test-deb-trixie-pkg
 just test-deb-resolute-pkg
 just test-rpm-pkg
 ```
+
+`just test-arch-camera-required` comes first because it is the only step a
+human has to perform. It runs `test-arch-integration` and `test-arch-oneshot`,
+the two tiers that need `/dev/video*` and a live face, and writes the commit
+they passed at to `.hardware-tiers-verified`. Preflight fails while that record
+is absent or names an older commit, so run it after the last commit that will
+ship, not before.
+
+Those two tiers are the only automated evidence that face authentication works
+end to end: real D-Bus activation, the real PAM stack, real capture, and the
+one-shot path PAM falls back to. Nothing else ran them, and three of their
+assertions rotted undetected as a result (#139). If they were already run by
+hand at this exact commit, acknowledge that by naming it:
+`FACELOCK_HARDWARE_TIERS_ACK=<sha> just release-preflight`.
 
 `just release-preflight` checks local tools, required packaging files (including
 `.packit.yaml`), and whether `AUR_SSH_KEY`, `APT_GPG_PRIVATE_KEY`, and
@@ -567,7 +583,10 @@ Since facelock is a PAM module, broken releases can lock users out. Every releas
 
 1. Pass `just check` (tests + clippy + fmt)
 2. Pass `just test-arch-pam` (Arch container PAM smoke tests)
-3. Pass `just test-rpm` and `just test-deb` (multi-distro package validation)
-4. Not change PAM auth semantics without explicit changelog entry
+3. Pass `just test-arch-camera-free` (camera-free daemon and one-shot E2E)
+4. Pass `just test-arch-camera-required` against the final release commit, with
+   a camera and a person in frame; `just release-preflight` fails until it has
+5. Pass `just test-rpm` and `just test-deb` (multi-distro package validation)
+6. Not change PAM auth semantics without explicit changelog entry
 5. Preserve `/etc/pam.d/sudo` backup on install (`/var/lib/facelock/pam-backups/sudo.<timestamp>`)
 6. Default to `PAM_IGNORE` on internal errors (fall through to password)

--- a/justfile
+++ b/justfile
@@ -157,6 +157,29 @@ test-arch-pam: _build-test-container
 test-arch-layout: _build-test-container
     podman run --rm facelock-pam-test /run-layout-tests.sh
 
+# The half of `test-arch-integration` and `test-arch-oneshot` that never opens
+# a camera (#139): D-Bus authorization, the AuthAttempted broadcast's audience
+# and payload, the rate-limit reply encoding, schema migrations, pre-flight
+# exit codes, and the shape of the status document. CI runs this on every pull
+# request, which is what the two camera-required tiers below cannot be.
+#
+# The ONNX models are still needed and are not a camera dependency: `facelock
+# daemon` verifies them at startup and refuses to run without them, and half
+# of what moved here is daemon-side authorization. The package tiers' opt-out
+# is honoured — FACELOCK_ALLOW_MISSING_MODELS=1 downgrades the daemon block to
+# a loud skip and runs only the one-shot half.
+#
+
+# Automated camera-free E2E tests (Arch container, no camera needed)
+test-arch-camera-free: (_require-models "1") _build-test-container
+    #!/usr/bin/env bash
+    set -euo pipefail
+    env_args=()
+    if [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
+        env_args+=(-e "FACELOCK_ALLOW_MISSING_MODELS=1")
+    fi
+    podman run --rm "${env_args[@]}" facelock-pam-test /run-camera-free-tests.sh
+
 # models/*.onnx is gitignored and never tracked, so a fresh clone — and every
 # `git worktree add`, which is how this repo is normally worked in — starts
 # with an empty models/, while the camera and package test tiers all need the
@@ -471,6 +494,42 @@ test-arch-oneshot: _require-models _build-test-container
         echo "live steps time out after $FACELOCK_LIVE_TIMEOUT (default 90s)"
     fi
     podman run --rm $devices "${env_args[@]}" facelock-pam-test /run-oneshot-tests.sh
+
+# Refuse to record a hardware run against a tree that is not what will ship.
+_require-clean-tree:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "error: the working tree is dirty, so a recorded run would name a commit" >&2
+        echo "       that is not what was tested. Commit first, then re-run." >&2
+        git status --short >&2
+        exit 1
+    fi
+
+# `just release-preflight` refuses to pass without that record (#139). These
+# two tiers are the only automated evidence that face authentication works end
+# to end — real D-Bus activation, the real PAM stack, real capture, the
+# one-shot fallback — and nothing else runs them, which is how three of their
+# assertions rotted undetected. They need a camera and someone sitting in
+# front of it, so this is the one gate a human has to perform.
+#
+# FACELOCK_LIVE_TIMEOUT is forwarded by each tier; relax it here too when the
+# stock 90s per live step is not enough time to get into frame.
+#
+
+# Both camera-required E2E tiers, recorded for release-preflight (requires camera)
+test-arch-camera-required: _require-clean-tree test-arch-integration test-arch-oneshot
+    #!/usr/bin/env bash
+    set -euo pipefail
+    commit="$(git rev-parse HEAD)"
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "error: the tree changed while the tiers ran; not recording." >&2
+        exit 1
+    fi
+    printf '%s\n' "$commit" > .hardware-tiers-verified
+    echo ""
+    echo "Recorded: camera-required tiers passed at $commit"
+    echo "'just release-preflight' accepts this until HEAD moves."
 
 # Dev shell — interactive Arch container with host models for fast iteration (requires camera)
 test-arch-dev-shell: _build-test-container
@@ -1370,13 +1429,46 @@ release-preflight tag='':
     fi
 
     echo ""
+    echo "== Camera-required tier evidence =="
+    # #139: `just test-arch-integration` and `just test-arch-oneshot` are the
+    # only automated evidence that face authentication works end to end, and
+    # they need a camera and a person in frame — so preflight cannot run them.
+    # It can refuse to pass while nobody has. `just test-arch-camera-required`
+    # runs both and records the commit they passed at; the omission used to be
+    # invisible, which is how three of their assertions rotted.
+    HEAD_SHA="$(git rev-parse HEAD)"
+    RECORDED=""
+    if [ -f .hardware-tiers-verified ]; then
+        RECORDED="$(head -1 .hardware-tiers-verified)"
+    fi
+    ACK="${FACELOCK_HARDWARE_TIERS_ACK:-}"
+    if [ "$RECORDED" = "$HEAD_SHA" ]; then
+        echo "OK: camera-required tiers recorded green at $HEAD_SHA"
+    elif [ "${#ACK}" -ge 7 ] && [ "${HEAD_SHA#"$ACK"}" != "$HEAD_SHA" ]; then
+        # The acknowledgement has to name this commit, so it cannot be a habit
+        # the way a bare =1 would become.
+        echo "OK: camera-required tiers acknowledged by hand at $HEAD_SHA"
+    else
+        if [ -z "$RECORDED" ]; then
+            echo "MISSING: no camera-required tier run recorded for any commit"
+        else
+            echo "STALE: camera-required tiers recorded at $RECORDED, HEAD is $HEAD_SHA"
+        fi
+        echo "  Run both tiers against this commit, with someone in front of the camera:"
+        echo "    just test-arch-camera-required"
+        echo "  If they were already run by hand at this exact commit, say so:"
+        echo "    FACELOCK_HARDWARE_TIERS_ACK=$HEAD_SHA just release-preflight"
+        failed=1
+    fi
+
+    echo ""
     if [ "$failed" -ne 0 ]; then
         echo "Release preflight: FAILED"
         exit 1
     fi
 
     echo "Release preflight: OK"
-    echo "Next: run 'just check', 'just test-release-matrix', 'just test-arch-pam', 'just test-rpm', and 'just test-deb' before tagging."
+    echo "Next: run 'just check', 'just test-release-matrix', 'just test-arch-pam', 'just test-arch-camera-free', 'just test-rpm', and 'just test-deb' before tagging."
 
 # Fast release contract tests that do not require distro package tools.
 test-release-contract:

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -120,9 +120,11 @@ RUN chmod +x /build/test/build-arch-test-package.sh && \
 COPY test/run-container-tests.sh /run-tests.sh
 COPY test/run-integration-tests.sh /run-integration-tests.sh
 COPY test/run-oneshot-tests.sh /run-oneshot-tests.sh
+COPY test/run-camera-free-tests.sh /run-camera-free-tests.sh
 COPY test/run-layout-tests.sh /run-layout-tests.sh
 COPY test/arch-package-validate.sh /arch-package-validate.sh
 RUN chmod +x /run-tests.sh /run-integration-tests.sh /run-oneshot-tests.sh \
+    /run-camera-free-tests.sh \
     /run-layout-tests.sh /arch-package-validate.sh \
     /source-install-lifecycle/test/source-install-daemon-lifecycle-systemd.sh \
     /source-install-lifecycle/test/source-install-daemon-stub.sh \

--- a/test/run-camera-free-tests.sh
+++ b/test/run-camera-free-tests.sh
@@ -1,0 +1,507 @@
+#!/bin/bash
+# Camera-free half of the two end-to-end tiers (#139).
+#
+# `run-integration-tests.sh` and `run-oneshot-tests.sh` need /dev/video* and a
+# person in frame, so they run on one machine and nothing gates them. Every
+# assertion in those two scripts that never opens a camera lives HERE instead,
+# where CI runs it on every pull request. The three rotted tests that #139
+# describes were all of that kind: two D-Bus authorization checks and a
+# classification rule, none of which needed a capture to be wrong.
+#
+# The boundary rule, applied conservatively:
+#
+#   moves    the assertion's subject is reached before any capture — a bus
+#            policy decision, a pre-flight rejection, a schema migration, a
+#            report rendered from machine state
+#   stays    the assertion reads something only a real sensor produces — a
+#            frame, a match, a device fingerprint, a warm-hold timing
+#
+# An assertion that merely *happens* to be cheap does not move; an assertion
+# whose subject is camera-bound stays even when a headless stand-in could be
+# rigged to make it pass. A test that passes without exercising what it names
+# is worse than one that does not run.
+#
+# What this tier still needs, and why it is not "no dependencies":
+#
+#   * the ONNX models. `facelock daemon` refuses to start when they are
+#     missing (crates/facelock-cli/src/commands/daemon.rs), and half of what
+#     moved here is daemon-side authorization. CI fetches them before building
+#     the image; FACELOCK_ALLOW_MISSING_MODELS=1 downgrades the daemon block
+#     to a loud skip for a local run that only wants the one-shot half.
+#   * a pinned device.path. Auto-detection is a HARD failure with no
+#     /dev/video* (it is the one camera dependency that is not about capture),
+#     while a pinned path that does not resolve is tolerated by design: the
+#     daemon starts with unqueryable caps and auth falls through to password.
+#     Pinning is therefore how this tier reaches the code the hardware tiers
+#     reach, not a way of faking a camera.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIPPED=0
+
+# A device node that cannot exist. Chosen over a made-up /dev/videoN so a real
+# camera appearing on the host can never silently take part in this tier.
+ABSENT_DEVICE="/dev/video-camera-free-none"
+
+CONFIG="/etc/facelock/config.toml"
+# The compiled default. Left unpinned on purpose: the daemon refuses to manage
+# a shared system directory, so a db_path directly under /tmp aborts startup
+# ("refusing to manage shared system directory /tmp"). The one-shot block below
+# pins its own paths, which that rule does not reach.
+DB="/var/lib/facelock/facelock.db"
+DAEMON_LOG="/tmp/facelock-camera-free-daemon.log"
+
+run_test() {
+    local name="$1"
+    local cmd="$2"
+    local expected_result="${3:-0}"
+
+    echo -n "TEST: $name ... "
+    set +o pipefail
+    if eval "$cmd" > /tmp/test-output 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+    set -o pipefail
+
+    if [ "$expected_result" = "any" ] || [ "$result" -eq "$expected_result" ]; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+        return 0
+    fi
+
+    echo "FAIL (exit=$result, expected=$expected_result)"
+    cat /tmp/test-output
+    FAIL=$((FAIL + 1))
+    return 1
+}
+
+run_test_contains() {
+    local name="$1"
+    local cmd="$2"
+    local pattern="$3"
+
+    echo -n "TEST: $name ... "
+    set +o pipefail
+    if eval "$cmd" > /tmp/test-output 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+    set -o pipefail
+
+    if [ "$result" -eq 0 ] && grep -q -- "$pattern" /tmp/test-output; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+        return 0
+    fi
+
+    echo "FAIL (exit=$result, pattern=$pattern)"
+    cat /tmp/test-output
+    FAIL=$((FAIL + 1))
+    return 1
+}
+
+# Announce a block that could not run, and count it. A skip is not a pass and
+# must not read like one in a log someone skims.
+skip_block() {
+    echo "SKIP: $1"
+    SKIPPED=$((SKIPPED + 1))
+}
+
+# Force db_path in a config file (uncomment/replace, or append [storage] if
+# absent). Lifted from run-oneshot-tests.sh, which owns the pre-V6 migration
+# assertion that moved here with it.
+set_db_path() {
+    local cfg="$1" path="$2"
+    if grep -qE '^[[:space:]]*#?[[:space:]]*db_path' "$cfg"; then
+        sed -i -E "s|^[[:space:]]*#?[[:space:]]*db_path.*|db_path = \"$path\"|" "$cfg"
+    elif grep -qE '^\[storage\]' "$cfg"; then
+        sed -i "/^\[storage\]/a db_path = \"$path\"" "$cfg"
+    else
+        printf '\n[storage]\ndb_path = "%s"\n' "$path" >> "$cfg"
+    fi
+}
+
+# Pin device.path under the [device] header. Inserted rather than
+# sed-replacing `path` lines: `path` is not a unique key name ([audit] has one
+# too), so a blind substitution rewrites the wrong line.
+pin_device_path() {
+    local cfg="$1" node="$2"
+    if grep -qE '^\[device\]' "$cfg"; then
+        sed -i "/^\[device\]/a path = \"$node\"" "$cfg"
+    else
+        printf '\n[device]\npath = "%s"\n' "$node" >> "$cfg"
+    fi
+}
+
+echo "=== Camera-free E2E Tests (no /dev/video*, no live face) ==="
+echo ""
+
+if [ -e /dev/video0 ]; then
+    echo "note: /dev/video0 exists in this container; device.path is pinned to"
+    echo "      $ABSENT_DEVICE regardless, so nothing here can capture."
+fi
+
+pin_device_path "$CONFIG" "$ABSENT_DEVICE"
+
+# This container starts a standalone dbus-daemon, not systemd-logind, so it has
+# no authoritative login sessions for the daemon's ProcessFD gate. Disabled for
+# the same reason run-integration-tests.sh disables it; unit and service tests
+# cover the gate's fail-closed and local/remote behavior.
+sed -i '/^\[security\]/a abort_if_ssh = false' "$CONFIG"
+
+# ADR 010: sigwatcher is an unenrolled plain local user, a member of nothing
+# facelock knows about.
+useradd -m sigwatcher 2>/dev/null || true
+
+mkdir -p /run/dbus
+dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true
+dbus-daemon --system --fork --nopidfile
+
+cleanup() {
+    if [ -n "${DAEMON_PID:-}" ]; then
+        kill "$DAEMON_PID" 2>/dev/null || true
+        wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+    if [ "$FAIL" -gt 0 ] && [ -s "$DAEMON_LOG" ]; then
+        echo ""
+        echo "--- daemon log (last 200 lines) ---"
+        tail -n 200 "$DAEMON_LOG" || true
+    fi
+    pkill dbus-daemon 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# The daemon is up when `status --json` reports the bus round trip completed.
+# Parsed, not grepped: `    [ok] responding` is one line of a report written
+# for a person (docs/contracts.md, "facelock status Semantics"). stdout and
+# stderr are captured apart because merging them is what makes a JSON document
+# unparseable the moment RUST_LOG has something to say.
+wait_for_daemon() {
+    local deadline=$((SECONDS + 30))
+    local document=""
+    local errors="/tmp/facelock-status-stderr"
+
+    : > "$errors"
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        document="$(facelock status --json 2>"$errors" || true)"
+        if printf '%s' "$document" \
+            | jq -e '.daemon.reachability == "responding"' > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    printf '%s\n' "$document"
+    cat "$errors" >&2 || true
+    return 1
+}
+
+# ============================================================================
+# Daemon block — needs the ONNX models, never a camera.
+# ============================================================================
+
+MODEL_DIR="/var/lib/facelock/models"
+DAEMON_BLOCK=1
+for m in scrfd_2.5g_bnkps.onnx w600k_r50.onnx; do
+    [ -f "$MODEL_DIR/$m" ] || DAEMON_BLOCK=0
+done
+
+if [ "$DAEMON_BLOCK" -eq 0 ] && [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" != "1" ]; then
+    echo "error: $MODEL_DIR is missing the required ONNX models, so the daemon" >&2
+    echo "       half of this tier cannot run. The models are not a camera" >&2
+    echo "       dependency: 'facelock daemon' verifies them at startup." >&2
+    echo "" >&2
+    echo "       Build the image from a checkout with models/ populated:" >&2
+    echo "         just link-models" >&2
+    echo "       CI fetches them from the 'assets' release before building." >&2
+    echo "" >&2
+    echo "       To run only the one-shot half, with the daemon assertions" >&2
+    echo "       reported as skipped: FACELOCK_ALLOW_MISSING_MODELS=1" >&2
+    exit 1
+fi
+
+if [ "$DAEMON_BLOCK" -eq 0 ]; then
+    skip_block "daemon assertions (no ONNX models, FACELOCK_ALLOW_MISSING_MODELS=1)"
+else
+    : > "$DAEMON_LOG"
+    RUST_LOG="${RUST_LOG:-facelock=info,facelock_daemon=debug}" facelock daemon \
+        > "$DAEMON_LOG" 2>&1 &
+    DAEMON_PID=$!
+    sleep 2
+
+    run_test "Daemon responds to ping" \
+        "wait_for_daemon" || exit 1
+
+    # The report a person reads still says it, in the words it has always
+    # used. `wait_for_daemon` parses the document, so without this row nothing
+    # exercises the human renderer at all.
+    run_test_contains "Status report still names a responding daemon" \
+        "facelock status" \
+        "\[ok\] responding"
+
+    # Every section answers with one of the three verdict words. The filters
+    # live in files rather than inline so the quoting survives `run_test`'s
+    # `eval`. The camera section reports `problem` here and `ok` on the
+    # hardware tier; the assertion is that a verdict exists, not which one.
+    cat > /tmp/status-sections.jq <<'EOF'
+[.config, .daemon, .oneshot_fallback, .camera, .models, .execution_provider,
+ .encryption, .enrollment, .security, .notifications, .pam]
+| length == 11
+  and (map(.state) | all(. == "ok" or . == "problem" or . == "unknown"))
+EOF
+    run_test "Status --json carries a verdict for every section" \
+        "facelock status --json | jq -e -f /tmp/status-sections.jq > /dev/null"
+
+    # The payoff a setup script wants: the PAM scan as data, with "could not
+    # look" distinguishable from "nothing configured" without reading prose.
+    cat > /tmp/status-pam.jq <<'EOF'
+.pam.services
+| (.state == "ok" or .state == "unknown")
+  and (.configured | type) == "array"
+  and (.not_checked | type) == "array"
+EOF
+    run_test "Status --json enumerates the PAM scan as data" \
+        "facelock status --json | jq -e -f /tmp/status-pam.jq > /dev/null"
+
+    # The daemon runs migrations at startup, before any request. On the
+    # hardware tier this row sits after the live enroll and reads the same
+    # fact; nothing about it needed the enroll.
+    SCHEMA_VER="$(sqlite3 "$DB" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
+    run_test "V6 schema migration applied on daemon startup (db=$DB)" \
+        "[ \"$SCHEMA_VER\" -ge 6 ]" 0
+
+    # --- ADR 010 authorization (security plan 06) ---
+    #
+    # ADR 010 left no groups: every local user may call Authenticate for its
+    # own username and nothing else. sigwatcher is not enrolled, so its own
+    # Authenticate is answered by the enrollment pre-check (model_id -1, or -3
+    # under suppress_unknown) WITHOUT opening the camera — which is what makes
+    # this whole block camera-free rather than merely camera-tolerant.
+    run_test_contains "A plain local user's Authenticate for its own user reaches the daemon (no model)" \
+        "runuser -u sigwatcher -- dbus-send --system --print-reply --reply-timeout=30000 --dest=org.facelock.Daemon /org/facelock/Daemon org.facelock.Daemon.Authenticate string:sigwatcher" \
+        "int32 -[13]"
+
+    check_denied_as() {
+        # $1 = user, $2 = method, $3.. = dbus-send args
+        local user="$1" method="$2"
+        shift 2
+        local out rc
+        set +e
+        out=$(runuser -u "$user" -- dbus-send --system --print-reply --reply-timeout=30000 \
+            --dest=org.facelock.Daemon /org/facelock/Daemon "org.facelock.Daemon.$method" "$@" 2>&1)
+        rc=$?
+        set -e
+        echo "$out"
+        [ "$rc" -ne 0 ] || { echo "$method unexpectedly succeeded for $user"; return 1; }
+        echo "$out" | grep -qi "AccessDenied" || return 1
+        return 0
+    }
+    run_test "A plain local user's Authenticate for another user is denied by the daemon" \
+        "check_denied_as sigwatcher Authenticate string:testuser"
+    run_test "A plain local user's Ping is denied by the bus" \
+        "check_denied_as sigwatcher Ping"
+
+    # Policy: the default context explicitly denies owning the daemon name —
+    # only root may own org.facelock.Daemon.
+    check_own_denied() {
+        local out rc
+        set +e
+        out=$(runuser -u sigwatcher -- dbus-send --system --print-reply \
+            --dest=org.freedesktop.DBus /org/freedesktop/DBus \
+            org.freedesktop.DBus.RequestName string:org.facelock.Daemon uint32:0 2>&1)
+        rc=$?
+        set -e
+        echo "$out"
+        [ "$rc" -ne 0 ] || { echo "RequestName unexpectedly succeeded"; return 1; }
+        echo "$out" | grep -qiE "not allowed to own|AccessDenied" || return 1
+        return 0
+    }
+    run_test "Unprivileged user cannot own org.facelock.Daemon" \
+        "check_own_denied"
+
+    # PreviewDetectFrame authz parity — the intent has always been that a
+    # non-root caller obtains no imagery. Under N13 the method became
+    # root-only, so a non-root caller is denied outright, BEFORE the method
+    # reaches the camera. That "before" is why the check belongs here: this is
+    # one of the two assertions #139 records as having rotted undetected, and
+    # neither of them ever needed a frame to be right or wrong. Asserts the
+    # denial AND that the error reply carries no frame bytes (dbus-send
+    # renders non-empty byte arrays as hex; a JPEG starts with ff d8).
+    check_preview_detect_frame_denied() {
+        local out rc
+        set +e
+        out=$(runuser -u testuser -- dbus-send --system --print-reply \
+            --reply-timeout=60000 \
+            --dest=org.facelock.Daemon /org/facelock/Daemon \
+            org.facelock.Daemon.PreviewDetectFrame string:testuser 2>&1)
+        rc=$?
+        set -e
+        echo "$out"
+        [ "$rc" -ne 0 ] || {
+            echo "PreviewDetectFrame unexpectedly succeeded for a non-root caller"
+            return 1
+        }
+        echo "$out" | grep -qi "AccessDenied" || return 1
+        if echo "$out" | grep -qi "ff d8"; then
+            echo "denial reply contains JPEG frame bytes (ff d8)"
+            return 1
+        fi
+        return 0
+    }
+    run_test "PreviewDetectFrame denies non-root caller (no raw frame)" \
+        "check_preview_detect_frame_denied"
+
+    # --- AuthAttempted signal hardening (security plan 06) ---
+    #
+    # Provoked with an Authenticate for an unenrolled testuser: the daemon
+    # answers -1 from the pre-check and emits the signal on the way out
+    # (crates/facelock-daemon/src/server.rs), so the broadcast happens without
+    # a capture. The hardware tier provokes it with a real `facelock test`;
+    # what is asserted — who receives it, and that the payload carries no
+    # similarity score — is the same either way.
+    runuser -u sigwatcher -- dbus-monitor --system \
+        "type='signal',interface='org.facelock.Daemon'" > /tmp/sig-unpriv.log 2>&1 &
+    UNPRIV_MON_PID=$!
+    dbus-monitor --system \
+        "type='signal',interface='org.facelock.Daemon'" > /tmp/sig-root.log 2>&1 &
+    ROOT_MON_PID=$!
+    sleep 2
+    dbus-send --system --print-reply --reply-timeout=30000 \
+        --dest=org.facelock.Daemon /org/facelock/Daemon \
+        org.facelock.Daemon.Authenticate string:testuser > /dev/null 2>&1 || true
+    sleep 2
+    kill "$UNPRIV_MON_PID" "$ROOT_MON_PID" 2>/dev/null || true
+    wait "$UNPRIV_MON_PID" "$ROOT_MON_PID" 2>/dev/null || true
+
+    run_test "AuthAttempted signal visible to root monitor" \
+        "grep -q 'member=AuthAttempted' /tmp/sig-root.log"
+
+    run_test "AuthAttempted payload carries no similarity score" \
+        "! grep -A3 'member=AuthAttempted' /tmp/sig-root.log | grep -q 'double'"
+
+    run_test "Unprivileged user receives no AuthAttempted signal" \
+        "! grep -q 'member=AuthAttempted' /tmp/sig-unpriv.log"
+
+    # --- Plan 05: rate-limited daemon state must never escalate to a fresh
+    # one-shot ---
+    #
+    # Rate limiting is checked AFTER the has-models pre-check and BEFORE the
+    # camera is acquired (crates/facelock-daemon/src/auth.rs, pre_check), so
+    # the only thing standing between this tier and the assertion is a row in
+    # face_models. Seeded directly rather than enrolled: the subject is the
+    # rate limiter's reply encoding, not the template, and a synthetic row
+    # reaches the same gate a real one does. Nothing below ever gets far
+    # enough to read the embedding.
+    # `.timeout` rather than a busy_timeout PRAGMA: the PRAGMA returns a row,
+    # so sqlite3 prints 8000 into the middle of the test output.
+    sqlite3 -cmd ".timeout 8000" "$DB" "INSERT INTO face_models (user, label, created_at, embedder_model) VALUES ('testuser', 'rate-limit-fixture', strftime('%s','now'), 'w600k_r50.onnx');"
+
+    run_test "Rate limit: seed failed attempts" \
+        "sqlite3 $DB \"INSERT INTO rate_limit (user, attempt_time) SELECT 'testuser', strftime('%s','now') FROM (VALUES (1),(2),(3),(4),(5),(6));\""
+
+    run_test_contains "Rate limit: daemon encodes recoverable error in-band (model_id=-2)" \
+        "dbus-send --system --print-reply --dest=org.facelock.Daemon /org/facelock/Daemon org.facelock.Daemon.Authenticate string:testuser" \
+        "int32 -2"
+
+    # With the in-band encoding the PAM module classifies the error itself
+    # (rate limited -> PAM_AUTH_ERR) instead of retrying as a root one-shot.
+    # Swapping a marker stub in at /usr/bin/facelock proves no one-shot child
+    # is ever spawned (the module spawns that fixed path; an auth_bin config
+    # redirect would be ignored and make this test vacuous). The daemon keeps
+    # answering from its already-exec'd binary while the file is swapped.
+    run_test "Rate limit: PAM fails without oneshot escalation" \
+        "printf '#!/bin/bash\ntouch /tmp/oneshot-invoked\nexit 2\n' > /usr/local/bin/oneshot-marker && chmod 755 /usr/local/bin/oneshot-marker && rm -f /tmp/oneshot-invoked && mv /usr/bin/facelock /usr/bin/facelock.orig && install -m 755 /usr/local/bin/oneshot-marker /usr/bin/facelock; timeout 30 pamtester facelock-test testuser authenticate < /dev/null; rc=\$?; mv -f /usr/bin/facelock.orig /usr/bin/facelock; test \$rc -ne 0 && test ! -f /tmp/oneshot-invoked"
+
+    run_test "Rate limit: clear seeded attempts" \
+        "sqlite3 $DB \"DELETE FROM rate_limit WHERE user = 'testuser';\""
+
+    sqlite3 -cmd ".timeout 8000" "$DB" "DELETE FROM face_models WHERE label = 'rate-limit-fixture';" || true
+
+    # The daemon is done: the one-shot block below must answer with no daemon
+    # on the bus, exactly as it does on the hardware tier.
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+    DAEMON_PID=""
+fi
+
+# ============================================================================
+# One-shot block — needs neither the models nor a camera.
+#
+# `facelock auth` opens the store (running migrations) and runs the daemon's
+# pre-flight gates before it loads the ONNX engine or touches the camera
+# (crates/facelock-cli/src/commands/auth.rs), so every rejection that a gate
+# produces is reachable here.
+# ============================================================================
+
+echo ""
+echo "--- one-shot (daemonless) ---"
+
+sed -i '/^\[daemon\]/a mode = "oneshot"' "$CONFIG"
+
+# facelock auth rejects unknown user. Exit 2 is "no opinion": the camera never
+# opened, so exit 1's "scanned and not matched" is not available to this path
+# by construction (docs/contracts.md, "facelock auth Exit Codes").
+run_test "facelock auth rejects unknown user" \
+    "facelock auth --user nobody --config $CONFIG" \
+    2
+
+# Exit 2 carries more classes than it used to: the storage class moved onto it
+# when a failed embeddings load and a failed model-list read stopped exiting 1
+# (#141). A broken database would now answer this row with the same number the
+# enrollment gate does. So pin the code to the gate that produced it, the way
+# run-oneshot-tests.sh pins the require_ir refusal, and the row cannot start
+# passing for a different reason than it was written for. `AuthResult` is the
+# not-enrolled short-circuit; every error class renders as `Error {`.
+run_test "the exit 2 above is the enrollment gate, not a storage fault" \
+    "RUST_LOG=debug facelock auth --user nobody --config $CONFIG 2>&1 | grep 'pre-check short-circuit' | grep -q 'AuthResult(MatchResult'"
+
+# A fresh database migrates on first open by the one-shot binary, not only by
+# the daemon. Given its own db_path so the daemon's already-migrated file
+# cannot make this vacuous.
+FRESH="/tmp/facelock-oneshot-fresh.db"
+rm -f "$FRESH" "$FRESH-wal" "$FRESH-shm"
+cp "$CONFIG" /tmp/facelock-fresh.toml
+set_db_path /tmp/facelock-fresh.toml "$FRESH"
+facelock auth --user nobody --config /tmp/facelock-fresh.toml >/dev/null 2>&1 || true
+FRESH_VER="$(sqlite3 "$FRESH" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
+FRESH_COL="$(sqlite3 "$FRESH" "SELECT COUNT(*) FROM pragma_table_info('face_models') WHERE name='device_id'" 2>/dev/null || echo 0)"
+run_test "V6 schema migration applied (oneshot; fresh db v=$FRESH_VER col=$FRESH_COL)" \
+    "[ \"$FRESH_VER\" -ge 6 ] && [ \"$FRESH_COL\" = 1 ]" 0
+rm -f "$FRESH" "$FRESH-wal" "$FRESH-shm" /tmp/facelock-fresh.toml
+
+# A pre-V6 database migrates cleanly on open: seed schema V5, open it via a
+# store-opening command, then confirm the column was added, the version bumped
+# to >=6, and the legacy row survived with a NULL device_id.
+PREV6="/tmp/facelock-prev6.db"
+rm -f "$PREV6" "$PREV6-wal" "$PREV6-shm"
+sqlite3 "$PREV6" "
+CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+CREATE TABLE face_models (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT NOT NULL, label TEXT NOT NULL, created_at INTEGER NOT NULL, embedder_model TEXT NOT NULL DEFAULT '', UNIQUE(user,label));
+CREATE TABLE face_embeddings (id INTEGER PRIMARY KEY AUTOINCREMENT, model_id INTEGER NOT NULL REFERENCES face_models(id) ON DELETE CASCADE, embedding BLOB NOT NULL, sealed INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE rate_limit (user TEXT NOT NULL, attempt_time INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (5);
+INSERT INTO face_models (user,label,created_at,embedder_model) VALUES ('legacyuser','legacy-face',1700000000,'w600k_r50.onnx');
+" || true
+cp "$CONFIG" /tmp/facelock-prev6.toml
+set_db_path /tmp/facelock-prev6.toml "$PREV6"
+# Opening the store (via any command) runs migrations; auth on a user with no
+# embeddings exits non-zero after migrating — we only care about the migration.
+timeout --foreground 20s facelock auth --user legacyuser --config /tmp/facelock-prev6.toml >/dev/null 2>&1 || true
+PREV6_VER="$(sqlite3 "$PREV6" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
+PREV6_COL="$(sqlite3 "$PREV6" "SELECT COUNT(*) FROM pragma_table_info('face_models') WHERE name='device_id'" 2>/dev/null || echo 0)"
+PREV6_ROW="$(sqlite3 "$PREV6" "SELECT label FROM face_models WHERE user='legacyuser'" 2>/dev/null || echo '')"
+PREV6_DID="$(sqlite3 "$PREV6" "SELECT COALESCE(device_id,'NULL') FROM face_models WHERE user='legacyuser'" 2>/dev/null || echo '?')"
+run_test "pre-V6 DB migrates cleanly, preserves row, device_id NULL (v=$PREV6_VER col=$PREV6_COL row=$PREV6_ROW did=$PREV6_DID)" \
+    "[ \"$PREV6_VER\" -ge 6 ] && [ \"$PREV6_COL\" = 1 ] && [ \"$PREV6_ROW\" = legacy-face ] && [ \"$PREV6_DID\" = NULL ]" 0
+rm -f "$PREV6" "$PREV6-wal" "$PREV6-shm" /tmp/facelock-prev6.toml
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIPPED block(s) skipped ==="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/test/run-integration-tests.sh
+++ b/test/run-integration-tests.sh
@@ -128,6 +128,13 @@ wait_for_daemon() {
 
 echo "=== Integration Tests (with camera) ==="
 echo ""
+# Camera-bound half of the daemon E2E suite. Everything that reached its
+# subject before any capture — the status document's shape, the schema
+# migration, ADR 010 authorization, the AuthAttempted broadcast, the
+# rate-limit reply encoding — moved to test/run-camera-free-tests.sh (#139),
+# which CI runs on every pull request. Add a row here only when it needs a
+# real frame; anything else belongs in the camera-free tier where it will
+# actually be gated.
 
 # Use the installed config (written by Containerfile), override db path
 # to a writable location since default may not be writable in containers
@@ -176,34 +183,9 @@ sleep 2
 run_test "Daemon responds to ping" \
     "wait_for_daemon" || exit 1
 
-# The report a person reads still says it, in the words it has always used.
-# `wait_for_daemon` parses the document now, so without this row nothing here
-# would exercise the human renderer at all.
-run_test_contains "Status report still names a responding daemon" \
-    "facelock status" \
-    "\[ok\] responding"
-
-# Every section answers with one of the three verdict words. The filters live in
-# files rather than inline so the quoting survives `run_test`'s `eval`.
-cat > /tmp/status-sections.jq <<'EOF'
-[.config, .daemon, .oneshot_fallback, .camera, .models, .execution_provider,
- .encryption, .enrollment, .security, .notifications, .pam]
-| length == 11
-  and (map(.state) | all(. == "ok" or . == "problem" or . == "unknown"))
-EOF
-run_test "Status --json carries a verdict for every section" \
-    "facelock status --json | jq -e -f /tmp/status-sections.jq > /dev/null"
-
-# The payoff a setup script wants: the PAM scan as data, with "could not look"
-# distinguishable from "nothing configured" without reading prose.
-cat > /tmp/status-pam.jq <<'EOF'
-.pam.services
-| (.state == "ok" or .state == "unknown")
-  and (.configured | type) == "array"
-  and (.not_checked | type) == "array"
-EOF
-run_test "Status --json enumerates the PAM scan as data" \
-    "facelock status --json | jq -e -f /tmp/status-pam.jq > /dev/null"
+# The status document's shape and the human renderer's "[ok] responding" line
+# are asserted in run-camera-free-tests.sh: neither reads anything a camera
+# produces.
 
 # Test device listing
 run_test_contains "Device listing works" \
@@ -242,9 +224,8 @@ run_test "Authenticate enrolled face (PAM)" \
 DB="$({ grep -E '^[[:space:]]*db_path[[:space:]]*=' /etc/facelock/config.toml 2>/dev/null || true; } | tail -1 | sed -E 's/^[^=]*=[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
 [ -n "$DB" ] || DB="/var/lib/facelock/facelock.db"
 
-SCHEMA_VER="$(sqlite3 "$DB" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
-run_test "V6 schema migration applied on daemon startup (db=$DB)" \
-    "[ \"$SCHEMA_VER\" -ge 6 ]" 0
+# The V6 migration itself runs at daemon startup, before any request, and is
+# asserted in run-camera-free-tests.sh.
 
 # --- Encryption at rest (Plan 04, finding #8) ---
 # Encryption defaults to keyfile, so the daemon enroll above must have stored
@@ -283,143 +264,13 @@ run_test_contains "facelock test matches again on legacy NULL device_id (daemon)
     "timeout --foreground $LIVE_TIMEOUT facelock test --user testuser" \
     "Matched"
 
-# --- Plan 05: rate-limited daemon state must never escalate to a fresh oneshot ---
-
-# Resolve the database the daemon actually uses (config db_path or default).
-FACELOCK_DB="$(sed -n 's/^[[:space:]]*db_path[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' /etc/facelock/config.toml | head -1)"
-FACELOCK_DB="${FACELOCK_DB:-/var/lib/facelock/facelock.db}"
-
-# Force a rate-limited state by inserting failed attempts directly into the
-# shared SQLite window (default: 5 attempts / 60s). Requires enrolled models
-# (rate limiting is checked after the has-models pre-check).
-run_test "Rate limit: seed failed attempts" \
-    "sqlite3 $FACELOCK_DB \"INSERT INTO rate_limit (user, attempt_time) SELECT 'testuser', strftime('%s','now') FROM (VALUES (1),(2),(3),(4),(5),(6));\""
-
-run_test_contains "Rate limit: daemon encodes recoverable error in-band (model_id=-2)" \
-    "dbus-send --system --print-reply --dest=org.facelock.Daemon /org/facelock/Daemon org.facelock.Daemon.Authenticate string:testuser" \
-    "int32 -2"
-
-# With the in-band encoding the PAM module classifies the error itself
-# (rate limited -> PAM_AUTH_ERR) instead of retrying as a root oneshot.
-# Swapping a marker stub in at /usr/bin/facelock proves no oneshot child is
-# ever spawned (the module spawns that fixed path; an auth_bin config
-# redirect would be ignored and make this test vacuous). The daemon keeps
-# answering from its already-exec'd binary while the file is swapped.
-run_test "Rate limit: PAM fails without oneshot escalation" \
-    "printf '#!/bin/bash\ntouch /tmp/oneshot-invoked\nexit 2\n' > /usr/local/bin/oneshot-marker && chmod 755 /usr/local/bin/oneshot-marker && rm -f /tmp/oneshot-invoked && mv /usr/bin/facelock /usr/bin/facelock.orig && install -m 755 /usr/local/bin/oneshot-marker /usr/bin/facelock; timeout 30 pamtester facelock-test testuser authenticate < /dev/null; rc=\$?; mv -f /usr/bin/facelock.orig /usr/bin/facelock; test \$rc -ne 0 && test ! -f /tmp/oneshot-invoked"
-
-run_test "Rate limit: clear seeded attempts" \
-    "sqlite3 $FACELOCK_DB \"DELETE FROM rate_limit WHERE user = 'testuser';\""
-
-# --- D-Bus hardening assertions (security plan 06) ---
-
-# ADR 010 left no groups: testuser is just an enrolled local user and
-# sigwatcher an unenrolled one, and neither is a member of anything facelock
-# knows about. Both may call Authenticate for themselves and nothing else;
-# only root receives AuthAttempted.
-useradd -m sigwatcher 2>/dev/null || true
-
-# (a) Signal hardening — needs the daemon up plus one auth attempt to emit
-# the signal. Unprivileged users must not receive AuthAttempted, and the
-# payload must carry no similarity score (no 'double' argument).
-runuser -u sigwatcher -- dbus-monitor --system \
-    "type='signal',interface='org.facelock.Daemon'" > /tmp/sig-unpriv.log 2>&1 &
-UNPRIV_MON_PID=$!
-dbus-monitor --system \
-    "type='signal',interface='org.facelock.Daemon'" > /tmp/sig-root.log 2>&1 &
-ROOT_MON_PID=$!
-sleep 2
-timeout --foreground "$LIVE_TIMEOUT" facelock test --user testuser > /dev/null 2>&1 || true
-sleep 2
-kill "$UNPRIV_MON_PID" "$ROOT_MON_PID" 2>/dev/null || true
-wait "$UNPRIV_MON_PID" "$ROOT_MON_PID" 2>/dev/null || true
-
-run_test "AuthAttempted signal visible to root monitor" \
-    "grep -q 'member=AuthAttempted' /tmp/sig-root.log"
-
-run_test "AuthAttempted payload carries no similarity score" \
-    "! grep -A3 'member=AuthAttempted' /tmp/sig-root.log | grep -q 'double'"
-
-run_test "Unprivileged user receives no AuthAttempted signal" \
-    "! grep -q 'member=AuthAttempted' /tmp/sig-unpriv.log"
-
-# (a2) ADR 010: Authenticate is open to every local user for its own username
-# and nothing else is. sigwatcher is not enrolled, so its own Authenticate is
-# answered by the enrollment pre-check (model_id -1, or -3 under
-# suppress_unknown) without opening the camera; naming another user is refused
-# by the daemon; Ping is refused by the bus.
-run_test_contains "A plain local user's Authenticate for its own user reaches the daemon (no model)" \
-    "runuser -u sigwatcher -- dbus-send --system --print-reply --reply-timeout=30000 --dest=org.facelock.Daemon /org/facelock/Daemon org.facelock.Daemon.Authenticate string:sigwatcher" \
-    "int32 -[13]"
-
-check_denied_as() {
-    # $1 = user, $2 = method, $3.. = dbus-send args
-    local user="$1" method="$2"
-    shift 2
-    local out rc
-    set +e
-    out=$(runuser -u "$user" -- dbus-send --system --print-reply --reply-timeout=30000 \
-        --dest=org.facelock.Daemon /org/facelock/Daemon "org.facelock.Daemon.$method" "$@" 2>&1)
-    rc=$?
-    set -e
-    echo "$out"
-    [ "$rc" -ne 0 ] || { echo "$method unexpectedly succeeded for $user"; return 1; }
-    echo "$out" | grep -qi "AccessDenied" || return 1
-    return 0
-}
-run_test "A plain local user's Authenticate for another user is denied by the daemon" \
-    "check_denied_as sigwatcher Authenticate string:testuser"
-run_test "A plain local user's Ping is denied by the bus" \
-    "check_denied_as sigwatcher Ping"
-
-# Policy: the default context explicitly denies owning the daemon name —
-# only root may own org.facelock.Daemon.
-check_own_denied() {
-    local out rc
-    set +e
-    out=$(runuser -u sigwatcher -- dbus-send --system --print-reply \
-        --dest=org.freedesktop.DBus /org/freedesktop/DBus \
-        org.freedesktop.DBus.RequestName string:org.facelock.Daemon uint32:0 2>&1)
-    rc=$?
-    set -e
-    echo "$out"
-    [ "$rc" -ne 0 ] || { echo "RequestName unexpectedly succeeded"; return 1; }
-    echo "$out" | grep -qiE "not allowed to own|AccessDenied" || return 1
-    return 0
-}
-run_test "Unprivileged user cannot own org.facelock.Daemon" \
-    "check_own_denied"
-
-# (b) PreviewDetectFrame authz parity — the intent here has always been that a
-# non-root caller obtains no imagery. Under N13 the method became root-only, so
-# the way that holds changed: a non-root caller is now denied outright, before
-# the method reaches the camera, rather than receiving a reply with jpeg_data
-# stripped. This asserts the denial AND that the error reply carries no frame
-# bytes (dbus-send renders non-empty byte arrays as hex; a JPEG starts with
-# ff d8).
-check_preview_detect_frame_denied() {
-    local out rc
-    set +e
-    out=$(runuser -u testuser -- dbus-send --system --print-reply \
-        --reply-timeout=60000 \
-        --dest=org.facelock.Daemon /org/facelock/Daemon \
-        org.facelock.Daemon.PreviewDetectFrame string:testuser 2>&1)
-    rc=$?
-    set -e
-    echo "$out"
-    [ "$rc" -ne 0 ] || {
-        echo "PreviewDetectFrame unexpectedly succeeded for a non-root caller"
-        return 1
-    }
-    echo "$out" | grep -qi "AccessDenied" || return 1
-    if echo "$out" | grep -qi "ff d8"; then
-        echo "denial reply contains JPEG frame bytes (ff d8)"
-        return 1
-    fi
-    return 0
-}
-run_test "PreviewDetectFrame denies non-root caller (no raw frame)" \
-    "check_preview_detect_frame_denied"
+# Everything the daemon answers before it acquires the camera moved to
+# run-camera-free-tests.sh (#139): the rate-limit reply encoding and its
+# no-oneshot-escalation guarantee, the AuthAttempted broadcast's audience
+# and payload, ADR 010's per-user Authenticate authorization, the bus's own
+# deny rules, and PreviewDetectFrame's root-only refusal. Two of those are
+# the checks #139 records as having rotted here undetected; none of them
+# ever needed a frame.
 
 # Release the preview camera session before the concurrency test
 dbus-send --system --print-reply --dest=org.facelock.Daemon /org/facelock/Daemon \

--- a/test/run-oneshot-tests.sh
+++ b/test/run-oneshot-tests.sh
@@ -99,6 +99,11 @@ run_test_or_skip() {
 
 echo "=== Oneshot Mode Tests (fully daemonless, with camera) ==="
 echo ""
+# Camera-bound half of the daemonless E2E suite. `facelock auth` opens the
+# store and runs every pre-flight gate before it loads the ONNX engine or
+# touches the camera, so the schema migrations and the pre-flight exit codes
+# moved to test/run-camera-free-tests.sh (#139), which CI runs on every pull
+# request. Add a row here only when it needs a real frame.
 
 # Use installed config, set oneshot mode and writable paths
 sed -i 's|db_path.*|db_path = "/tmp/facelock-test.db"|' /etc/facelock/config.toml 2>/dev/null || true
@@ -177,9 +182,10 @@ run_test_contains "facelock test (oneshot)" \
 
 # --- Device coupling (Plan 02, oneshot/direct path) ---
 # The template enrolled above records the live camera's fingerprint in
-# face_models.device_id (schema V6). These assertions prove: the migration
-# applied, enroll records a device_id, a forged/mismatched id falls through to
-# no-match (never a success), and a legacy NULL id still authenticates.
+# face_models.device_id (schema V6). These assertions prove: enroll records a
+# device_id, a forged/mismatched id falls through to no-match (never a
+# success), and a legacy NULL id still authenticates. The V6 migration that
+# makes the column exist is asserted in run-camera-free-tests.sh.
 # Resolve the DB path facelock actually uses (config db_path if uncommented,
 # else the compiled default). container-config.toml sets no db_path, so this
 # yields /var/lib/facelock/facelock.db — the path enroll above wrote to.
@@ -187,17 +193,6 @@ db_path_from_config() {
     local p
     p="$(grep -E '^[[:space:]]*db_path[[:space:]]*=' "$1" 2>/dev/null | tail -1 | sed -E 's/^[^=]*=[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
     [ -n "$p" ] && echo "$p" || echo "/var/lib/facelock/facelock.db"
-}
-# Force db_path in a config file (uncomment/replace, or append [storage] if absent).
-set_db_path() {
-    local cfg="$1" path="$2"
-    if grep -qE '^[[:space:]]*#?[[:space:]]*db_path' "$cfg"; then
-        sed -i -E "s|^[[:space:]]*#?[[:space:]]*db_path.*|db_path = \"$path\"|" "$cfg"
-    elif grep -qE '^\[storage\]' "$cfg"; then
-        sed -i "/^\[storage\]/a db_path = \"$path\"" "$cfg"
-    else
-        printf '\n[storage]\ndb_path = "%s"\n' "$path" >> "$cfg"
-    fi
 }
 
 DB="$(db_path_from_config /etc/facelock/config.toml)"
@@ -220,10 +215,9 @@ KEYMODE="$(stat -c '%a' "$KEYF" 2>/dev/null || echo '?')"
 run_test "encryption key auto-generated at 0600 ($KEYF mode=$KEYMODE)" \
     "[ -f \"$KEYF\" ] && [ \"$KEYMODE\" = 600 ]" 0
 
-# Migration applied on first store open (enroll).
-SCHEMA_VER="$(sqlite3 "$DB" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
-run_test "V6 schema migration applied (oneshot; db=$DB)" \
-    "[ \"$SCHEMA_VER\" -ge 6 ]" 0
+# The V6 migration itself runs on first store open, before the camera is
+# touched, and is asserted against a fresh database in
+# run-camera-free-tests.sh.
 
 # (a) After enroll, the model row carries a device_id. Whether it is NON-NULL
 #     depends on the live camera exposing a USB identity via sysfs in-container;
@@ -251,31 +245,8 @@ run_test "facelock auth succeeds on legacy NULL device_id (allow-with-warn)" \
     "timeout --foreground $LIVE_TIMEOUT facelock auth --user testuser --config /etc/facelock/config.toml" \
     0
 
-# (d) A pre-V6 database migrates cleanly on open: seed schema V5, open it via a
-#     store-opening command, then confirm the column was added, the version
-#     bumped to >=6, and the legacy row survived with a NULL device_id.
-PREV6="/tmp/facelock-prev6.db"
-rm -f "$PREV6" "$PREV6-wal" "$PREV6-shm"
-sqlite3 "$PREV6" "
-CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
-CREATE TABLE face_models (id INTEGER PRIMARY KEY AUTOINCREMENT, user TEXT NOT NULL, label TEXT NOT NULL, created_at INTEGER NOT NULL, embedder_model TEXT NOT NULL DEFAULT '', UNIQUE(user,label));
-CREATE TABLE face_embeddings (id INTEGER PRIMARY KEY AUTOINCREMENT, model_id INTEGER NOT NULL REFERENCES face_models(id) ON DELETE CASCADE, embedding BLOB NOT NULL, sealed INTEGER NOT NULL DEFAULT 0);
-CREATE TABLE rate_limit (user TEXT NOT NULL, attempt_time INTEGER NOT NULL);
-INSERT INTO schema_version (version) VALUES (5);
-INSERT INTO face_models (user,label,created_at,embedder_model) VALUES ('legacyuser','legacy-face',1700000000,'w600k_r50.onnx');
-" || true
-cp /etc/facelock/config.toml /tmp/facelock-prev6.toml
-set_db_path /tmp/facelock-prev6.toml "$PREV6"
-# Opening the store (via any command) runs migrations; auth on a user with no
-# embeddings exits non-zero after migrating — we only care about the migration.
-timeout --foreground 20s facelock auth --user legacyuser --config /tmp/facelock-prev6.toml >/dev/null 2>&1 || true
-PREV6_VER="$(sqlite3 "$PREV6" 'SELECT MAX(version) FROM schema_version' 2>/dev/null || echo 0)"
-PREV6_COL="$(sqlite3 "$PREV6" "SELECT COUNT(*) FROM pragma_table_info('face_models') WHERE name='device_id'" 2>/dev/null || echo 0)"
-PREV6_ROW="$(sqlite3 "$PREV6" "SELECT label FROM face_models WHERE user='legacyuser'" 2>/dev/null || echo '')"
-PREV6_DID="$(sqlite3 "$PREV6" "SELECT COALESCE(device_id,'NULL') FROM face_models WHERE user='legacyuser'" 2>/dev/null || echo '?')"
-run_test "pre-V6 DB migrates cleanly, preserves row, device_id NULL (v=$PREV6_VER col=$PREV6_COL row=$PREV6_ROW did=$PREV6_DID)" \
-    "[ \"$PREV6_VER\" -ge 6 ] && [ \"$PREV6_COL\" = 1 ] && [ \"$PREV6_ROW\" = legacy-face ] && [ \"$PREV6_DID\" = NULL ]" 0
-rm -f "$PREV6" "$PREV6-wal" "$PREV6-shm" /tmp/facelock-prev6.toml
+# (d) Pre-V6 migration on open needs no camera and is asserted in
+#     run-camera-free-tests.sh, alongside the fresh-database case.
 
 # facelock auth binary (used by PAM module)
 run_test "facelock auth authenticates (oneshot)" \
@@ -637,10 +608,9 @@ sqlite3 "$DB" "UPDATE face_models SET device_id=$ADR008_DEVID WHERE user='testus
 
 # --- End ADR 008 one-shot lifecycle ---
 
-# facelock auth rejects unknown user
-run_test "facelock auth rejects unknown user" \
-    "facelock auth --user nobody --config /etc/facelock/config.toml" \
-    2
+# The unknown-user pre-flight rejection (exit 2) short-circuits before the
+# engine loads and before the camera opens, so it is asserted in
+# run-camera-free-tests.sh.
 
 # Clear models (direct DB access)
 run_test "facelock clear (oneshot)" \


### PR DESCRIPTION
## Summary

- move every assertion in the two E2E suites that never opens a camera into `test/run-camera-free-tests.sh`, run by CI on each pull request
- cover bus policy, ADR 010 per-user `Authenticate` authorization, `PreviewDetectFrame`'s root-only refusal, the `AuthAttempted` broadcast's audience and payload, the rate-limit reply encoding and its no-oneshot-escalation guarantee, schema migrations, and the one-shot pre-flight exit codes
- keep in the hardware tiers everything a real sensor produces: capture, matching, device fingerprints, the `require_ir` format evidence, all ADR 008 lifecycle timings
- fetch the two required ONNX models in `container-pam-test` and verify them against `models/manifest.toml`; the daemon verifies them at startup, so without them half the tier cannot run
- gate the hardware tiers at release time: `just test-arch-camera-required` runs both and records the commit they passed at, and `just release-preflight` fails while that record is missing or names an older commit

## Why

`just test-arch-integration` and `just test-arch-oneshot` need `/dev/video*` and a person in frame, so they run on one machine and no gate reached them. Three of their assertions had rotted by the time they were next run, two of which never needed a frame to be right or wrong. ADR 008 §9 also names those two recipes as the entire evidence base for its acceptance criteria.

## Reviewer notes

- **the boundary is the review question.** An assertion moved only when its subject is reached before any capture. A pinned nonexistent `device.path` is what lets the camera-free tier reach that code (auto-detection is a hard failure headless, and a pinned path that does not resolve is tolerated by design); it is not a stand-in camera. The one assertion left behind on purpose is `encryption key auto-generated at 0600`, whose subject is the one-shot enroll path's key creation, not the daemon's.
- **the rate-limit rows need an enrolled row, not an enrolled face.** Rate limiting is checked after the has-models pre-check and before the camera is acquired, so the tier seeds a synthetic `face_models` row and deletes it again. Nothing downstream reads the embedding.
- **models in CI change the image the existing PAM tier runs on.** That image already carries them locally, where `just test-arch-pam` and `just test-arch-layout` are run, so this removes a CI-only divergence rather than creating one.
- **no new action reference.** The fetch and the run are plain `run:` steps in the existing job, per #260.
- **exit 2 now carries the storage class**, so the migrated unknown-user row could start passing for a storage fault instead of the enrollment gate. A second row pins the rejection to its gate by reading the pre-check short-circuit class, the same shape as the `require_ir` pin in `run-oneshot-tests.sh`.

## Validation

- `just check`
- camera-free tier end to end in the container, plus its missing-models hard failure and the `FACELOCK_ALLOW_MISSING_MODELS=1` skip path
- `just test-arch-pam` and `just test-arch-layout` against an image built with models present
- mutation: reverted the `PreviewDetectFrame` row to the pre-N13 expectation (non-root caller allowed) and confirmed the CI-path invocation goes red
- forced a storage fault at the unknown-user row to confirm the bare exit-2 assertion accepts it and the new gate pin rejects it
- `just release-preflight` against a missing record, a stale record, a matching acknowledgement, and a wrong one

Depends on #273; branched off `fix/pam-oneshot-exit-mapping` so its ten per-code mapping cases are not re-split.

Refs #139
