### PR TITLE
test(arch): build and install the real dist/PKGBUILD

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,6 +15,7 @@ paths:
 | 3 | Arch container PAM smoke | `just test-arch-pam` |
 | 3b | Arch container E2E (daemon) | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
+| 3d | Arch package from `dist/PKGBUILD` | `just test-arch-pkg` |
 | 4 | VM testing | Disposable VM with snapshots |
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -18,9 +18,9 @@ All recipes need `podman`. None of the ones in the routing table need a camera.
 |---|---|
 | `debian/**`, `dist/facelock.spec` shared install logic | `just test-deb-trixie-pkg`, `just test-deb-resolute-pkg`, and `just test-rpm-pkg` |
 | `debian/**` only | `just test-deb-trixie-pkg` and `just test-deb-resolute-pkg` |
-| `dist/facelock.spec`, `dist/facelock.install` | `just test-rpm-pkg` |
+| `dist/facelock.spec` | `just test-rpm-pkg` |
 | TPM packaging or `facelock-tpm` build features | `just test-deb-trixie-pkg` and `just test-deb-resolute-pkg` |
-| `dist/PKGBUILD*` | `just test-arch-pam`, then a release shell (below) |
+| `dist/PKGBUILD*`, `dist/facelock.install`, `dist/facelock-pam-remove.hook` | `just test-arch-pkg` |
 | `.packit.yaml` schema only | `just test-packit-config` — real `packit` in a pinned Fedora container, seconds |
 | `.packit.yaml` semantics, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
 | APT repo generation, `publish-apt` workflow | `just test-apt-repo` — needs `reprepro` and `gpg` |
@@ -40,6 +40,27 @@ the only path that catches unit-file, D-Bus policy, polkit and post-install
 scriptlet problems. `test-deb` is an alias for both Debian suite gates; prefer
 `test-rpm-pkg` over `test-rpm` whenever the change could affect installed state
 rather than just packaging syntax.
+
+`test-arch-pkg` is the Arch equivalent and the only recipe that executes
+`dist/PKGBUILD` itself: `source=`, `depends`, `makedepends`, `prepare()`,
+`build()` and `check()`. `makepkg` runs as a non-root builder, `pacman -U`
+installs the result, and the validation covers the installed inventory, the
+`facelock.install` scriptlet, the first documented commands, and the libalpm
+hook that cleans PAM up on removal. It also resolves every dependency name all
+three PKGBUILDs declare, including `PKGBUILD-git`, which is what Omarchy's
+`omarchy-pkg-aur-add facelock-git` pulls.
+
+Three things it does not do. It does not boot systemd, so unit runtime
+behaviour stays with the deb and rpm gates. It checks no source digest:
+`sha256sums` is `SKIP` (#283), the staged tarball is a repack of the working
+tree, and the `source=` URL is never fetched, so a wrong URL passes. And it
+compiles the workspace twice, release for `build()` and debug for `check()`, so
+it is the slowest recipe here. Reach for `test-arch-pam` while iterating and run
+this before pushing a packaging change.
+
+When #283 replaces `SKIP` with a real digest, this lane breaks: a staged tarball
+cannot match a published sum. Move the staged build to `--skipchecksums` and
+assert the real digest separately.
 
 ## Camera-gated tests
 
@@ -66,6 +87,7 @@ the question is "does a fresh install work", a dev shell when iterating.
 
 ## Cost
 
-`test-copr` is self-described as slow and opt-in. The `-pkg` recipes boot a
+`test-copr` and `test-arch-pkg` are slow and opt-in: both compile the workspace
+from source inside the container. The Debian and Fedora `-pkg` recipes boot a
 container under systemd. Run the narrowest recipe the routing table allows
 rather than the whole set.

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -178,7 +178,7 @@ production-ready in the justfile install recipe.
 | Raw binaries | `release.yml` | Released. Triggered on `v*` tags. Uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, SHA256SUMS to GitHub Releases. |
 | `.deb` | `release.yml` (build-deb job) | Released. Two suite-specific `.deb` artifacts for trixie and resolute are built in CI and uploaded to GitHub Release. Stable releases publish the matching signed APT suites at `tysmith.me/facelock/apt`. |
 | `.rpm` | `release.yml` (build-rpm job) | Released. Built in CI for the GitHub Release asset. COPR builds from source via Packit (`tyvsmith/facelock`) per `releasing.md`. |
-| PKGBUILD (Arch) | `dist/PKGBUILD` | Released. Automated via tag CI; published to AUR (`facelock`, `facelock-git`). References `facelock.install` file. |
+| PKGBUILD (Arch) | `dist/PKGBUILD` | Released. Automated via tag CI; published to AUR (`facelock`, `facelock-git`). References `facelock.install` file. `just test-arch-pkg` builds and installs it. |
 | Nix flake | `dist/nix/flake.nix` | Exists with NixOS module (`module.nix`), derivation (`default.nix`), and dev shell. Not in nixpkgs. `doCheck = false` (needs camera). |
 | openrc | `dist/openrc/facelock-daemon` | Init script exists. |
 | runit | `dist/runit/run`, `dist/runit/log/run` | Service scripts exist. |
@@ -199,6 +199,56 @@ translation landed.
 - Models are downloaded at runtime via `facelock setup`, not bundled in packages
 - 4 models total: scrfd_2.5g (3MB), arcface_r50 (166MB), scrfd_10g (17MB, optional), arcface_r100 (249MB, optional)
 - SHA256 verified at download time and at model load time
+
+### Arch package coverage
+
+`just test-arch-pkg` is the only path that executes `dist/PKGBUILD` rather than
+reading it. `makepkg` runs as a non-root builder against the real recipe, so
+`source=`, `depends`, `makedepends`, `prepare()`, `build()`, `check()` and
+`package()` all run; `pacman -U` then installs the result and the installed
+package is validated against what `package()` declared, what the
+`facelock.install` scriptlet did on `post_install`, the first commands
+`quickstart.md` tells a user to type, and the libalpm hook that clears PAM
+references before removal.
+
+The recipe fetches a GitHub archive tarball for the released tag. Downloading it
+would test the last release rather than the candidate, so the working tree is
+staged and repacked inside the container under exactly the file name the recipe
+declares, in the directory shape a GitHub archive unpacks to. Source retrieval
+then runs under the same fail-closed network sandbox the Debian lane uses, which
+is what makes "it did not download" enforced rather than asserted.
+
+Only `dist/PKGBUILD` is built. `PKGBUILD-git` differs from it in `source=` and
+`pkgver()` alone, and `PKGBUILD-bin` installs binaries that exist only after a
+release is published. Neither can be built against a working tree without
+substituting away the part that differs. What all three do share is a list of
+package names, which is where #209 went wrong, so every name all three declare
+is resolved against the pinned repository snapshot before the build starts.
+
+Nothing in this tier starts the daemon or runs inference, so unlike the Debian
+and Fedora package gates it needs no ONNX models and no booted systemd, and can
+run unattended. It is also the slowest recipe in the tree: the recipe compiles
+the workspace twice, release for `build()` and debug for `check()`.
+
+What this tier does not cover is integrity. `dist/PKGBUILD` carries
+`sha256sums=('SKIP')` (#283), so `makepkg --verifysource` checks no digest at
+all: it proves only that the declared file name resolved without touching the
+network. The staged tarball is this working tree, so what the sum would cover is
+a repack the lane produced itself. The declared `source=` URL is never fetched
+either, which means a wrong or dead URL still passes here.
+
+That also makes #283 a forward conflict. The moment a real digest replaces
+`SKIP`, the staged tarball cannot match it and this lane fails on every run. The
+intended path is `makepkg --skipchecksums` for the staged build, with the real
+sum checked by a separate assertion that reads `sha256sums` directly rather than
+by handing makepkg a tarball it was never going to accept.
+
+Historical note: the first run of this lane caught a genuine shipping bug.
+`check()` runs `cargo test --workspace`, and the `*_non_root` cases in
+`crates/facelock-cli/tests/cli_smoke.rs` failed on any machine with no
+`/etc/facelock/config.toml`, which is every first AUR install. CI runs the suite
+as root, where those cases skip themselves, and a developer machine already has
+the file, so nothing else was positioned to see it. #264 fixed the ordering.
 
 ### Debian source-build coverage
 

--- a/justfile
+++ b/justfile
@@ -508,6 +508,25 @@ test-arch-release-shell: _build-test-container
     echo "  pamtester facelock-test testuser authenticate"
     podman run --rm -it $devices facelock-pam-test /bin/bash
 
+# Needs no models: nothing in this tier starts the daemon or runs inference, so
+# it is the one packaging gate that runs unattended in CI as it stands. It is
+# also the slow one — the recipe compiles the workspace twice, release for
+# build() and debug for check().
+
+# Package test — build the real dist/PKGBUILD with makepkg, install it with pacman, validate
+test-arch-pkg:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    staging="$(mktemp -d "${TMPDIR:-/tmp}/facelock-arch-pkg.XXXXXX")"
+    # A fixed image tag makes two concurrent runs clobber each other, and the
+    # loser fails in ways that read as a code defect. Take the uniqueness
+    # mktemp already produced. Layer caching is keyed by content, not by tag,
+    # so a fresh tag costs nothing but the final commit.
+    image="facelock-arch-pkg-$(basename "$staging" | cut -d. -f2 | tr '[:upper:]' '[:lower:]')"
+    trap 'rm -rf -- "$staging"; podman rmi -f "$image" >/dev/null 2>&1 || true' EXIT
+    test/build-arch-package-image.sh "$image" "$staging"
+    podman run --rm -v "$staging/source:/staged-source:ro,Z" "$image"
+
 # Build release and install to system
 
 # Run as: just install (builds as you, installs as root)

--- a/test/Containerfile.arch-e2e
+++ b/test/Containerfile.arch-e2e
@@ -1,0 +1,54 @@
+# End-to-end Arch package test — `makepkg` builds dist/PKGBUILD as a non-root
+# user, `pacman -U` installs the result, and the installed package is validated.
+#
+# Unlike test/Containerfile, nothing here is host-built. The recipe compiles the
+# tree itself, so this is the only image that executes dist/PKGBUILD's source=,
+# sha256sums, depends, makedepends, prepare(), build() and check().
+#
+# The image carries the recipe and the test scripts and nothing else. The tree
+# the recipe builds is mounted at /staged-source when the container runs, so a
+# source change does not invalidate the image.
+FROM docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
+
+# Same pinned archive snapshot as test/Containerfile, so the dependency names
+# the recipe declares resolve against a fixed repository state rather than
+# whatever Arch shipped this morning.
+RUN printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+
+# base-devel already supplies sudo (makepkg --syncdeps calls pacman through it),
+# gettext (msgfmt, for the recipe's locale stanza) and fakeroot. git is not in
+# base-devel and cargo wants it for any git-sourced crate; util-linux supplies
+# enosys and python backs the probe, both used by run-networkless.sh.
+RUN pacman -Syu --noconfirm --needed git python util-linux && \
+    rm -rf /var/cache/pacman/pkg/*
+
+# systemd-tmpfiles, which the facelock.install scriptlet runs, wants a machine
+# identity even unbooted.
+RUN rm -f /etc/machine-id && \
+    printf '%s\n' 0123456789abcdef0123456789abcdef > /etc/machine-id && \
+    chmod 0444 /etc/machine-id
+
+# makepkg refuses to run as root. It escalates through sudo to install the
+# depends and makedepends the recipe declares, which is the step that catches a
+# renamed or misspelled package (#209).
+RUN useradd -m builder && \
+    printf '%s\n' 'builder ALL=(ALL) NOPASSWD: /usr/bin/pacman' > /etc/sudoers.d/builder && \
+    chmod 0440 /etc/sudoers.d/builder
+
+# Every PKGBUILD, plus the scriptlet and hook they reference. makepkg validates
+# that install= names an existing file, so the whole directory travels together.
+COPY dist/PKGBUILD dist/PKGBUILD-bin dist/PKGBUILD-git dist/facelock.install /recipe/
+
+COPY .github/workflows/scripts/run-networkless.sh /run-networkless.sh
+COPY test/arch-pkgbuild-dependency-contract.sh /arch-pkgbuild-dependency-contract.sh
+COPY test/build-arch-source-package.sh /build-arch-source-package.sh
+COPY test/arch-package-e2e-validate.sh /arch-package-e2e-validate.sh
+COPY test/arch-package-validate.sh /arch-package-validate.sh
+RUN chmod +x /run-networkless.sh /arch-pkgbuild-dependency-contract.sh \
+    /build-arch-source-package.sh /arch-package-e2e-validate.sh \
+    /arch-package-validate.sh
+
+# Dependency names first: a typo there is the cheap failure and must not wait
+# behind a full release build. The e2e validator ends by handing off to
+# arch-package-validate.sh, which removes the package.
+CMD ["/bin/bash", "-c", "/arch-pkgbuild-dependency-contract.sh && /build-arch-source-package.sh && exec /arch-package-e2e-validate.sh"]

--- a/test/arch-package-e2e-validate.sh
+++ b/test/arch-package-e2e-validate.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Validate the facelock package that build-arch-source-package.sh built from
+# dist/PKGBUILD and installed with pacman.
+#
+# Scope is what only a real package can show: what package() actually put on
+# disk, what pacman thinks it owns, what the facelock.install scriptlet did on
+# post_install, whether depends alone is enough to run the binaries, and what a
+# user meets when they type the first documented commands on a clean machine.
+#
+# The run ends by handing off to arch-package-validate.sh, which removes the
+# package and covers the libalpm hook and PAM cleanup. That half is destructive,
+# so nothing may follow it.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+run_test() {
+    local name="$1"
+    local cmd="$2"
+    echo -n "TEST: $name ... "
+    if bash -c "$cmd" >/tmp/arch-e2e-output 2>&1; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL"
+        cat /tmp/arch-e2e-output
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# A first command on a clean install may legitimately fail — no camera, no
+# models, nothing enrolled. It may not panic, and it may not say nothing.
+runs_cleanly() {
+    local output
+    output="$(timeout 60 "$@" 2>&1)"
+    grep -qiE 'panicked at|RUST_BACKTRACE|core dumped' <<<"$output" && return 1
+    [ -n "$output" ]
+}
+export -f runs_cleanly
+
+owned_by_facelock() {
+    [ "$(pacman -Qoq -- "$1" 2>/dev/null)" = facelock ]
+}
+export -f owned_by_facelock
+
+mode_is() {
+    [ "$(stat -c '%a %U %G' -- "$1" 2>/dev/null)" = "$2" ]
+}
+export -f mode_is
+
+echo "=== Arch package validation (built from dist/PKGBUILD) ==="
+echo ""
+
+# --- what pacman thinks it installed ------------------------------------------
+
+run_test "pacman reports the package installed" "pacman -Q facelock"
+run_test "package metadata carries a description, url and licences" \
+    "pacman -Qi facelock | grep -q '^Description *: .' &&
+     pacman -Qi facelock | grep -q '^URL *: http' &&
+     pacman -Qi facelock | grep -q '^Licenses *: .'"
+run_test "no installed file drifted from what package() staged" "pacman -Qkk facelock"
+
+# --- every path package() installs --------------------------------------------
+
+for path in \
+    /usr/bin/facelock \
+    /usr/bin/facelock-polkit-agent \
+    /usr/lib/security/pam_facelock.so \
+    /etc/facelock/config.toml \
+    /usr/lib/systemd/system/facelock-daemon.service \
+    /usr/share/dbus-1/system.d/org.facelock.Daemon.conf \
+    /usr/share/dbus-1/system-services/org.facelock.Daemon.service \
+    /usr/lib/tmpfiles.d/facelock.conf \
+    /usr/share/libalpm/hooks/facelock-pam-remove.hook \
+    /usr/share/licenses/facelock/LICENSE-MIT \
+    /usr/share/licenses/facelock/LICENSE-APACHE
+do
+    run_test "package owns $path" \
+        "[ -f '$path' ] && owned_by_facelock '$path'"
+done
+run_test "package owns the quirks database" \
+    "find /usr/share/facelock/quirks.d -maxdepth 1 -type f -name '*.toml' -print -quit | grep -q . &&
+     pacman -Ql facelock | grep -q '/usr/share/facelock/quirks.d/'"
+run_test "config.toml is registered as a backup file" \
+    "pacman -Qii facelock | grep -qE '/etc/facelock/config.toml \[(un)?modified\]'"
+
+# po/ holds only .pot templates, so the recipe's locale stanza must install
+# nothing and must not leave the package owning an empty /usr/share/locale.
+run_test "package owns no locale root while po/ holds only templates" \
+    "! pacman -Ql facelock | grep -q '/usr/share/locale'"
+
+# --- the binaries the package shipped -----------------------------------------
+
+run_test "facelock binary is executable" "[ -x /usr/bin/facelock ]"
+run_test "PAM module exports pam_sm_authenticate" \
+    "nm -D /usr/lib/security/pam_facelock.so | grep -q pam_sm_authenticate"
+run_test "PAM module exports pam_sm_setcred" \
+    "nm -D /usr/lib/security/pam_facelock.so | grep -q pam_sm_setcred"
+run_test "PAM module avoids heavy dependencies" \
+    "! ldd /usr/lib/security/pam_facelock.so | grep -Eqi '(onnxruntime|libort|libv4l|opencv|gstreamer|openvino|cuda|rocm)'"
+
+# --- what the facelock.install scriptlet did on post_install ------------------
+
+run_test "post_install created the state root at 0711 root:root" \
+    "mode_is /var/lib/facelock '711 root root'"
+run_test "post_install created the model directory at 0755 root:root" \
+    "mode_is /var/lib/facelock/models '755 root root'"
+run_test "post_install created the enrollment marker directory at 0711 root:root" \
+    "mode_is /var/lib/facelock/enrolled '711 root root'"
+run_test "post_install created the PAM backup directory at 0700 root:root" \
+    "mode_is /var/lib/facelock/pam-backups '700 root root'"
+run_test "post_install created the log directory at 0700 root:root" \
+    "mode_is /var/log/facelock '700 root root'"
+run_test "post_install created the snapshot directory at 0700 root:root" \
+    "mode_is /var/log/facelock/snapshots '700 root root'"
+run_test "post_install creates no facelock group (ADR 010 retired it)" \
+    "! getent group facelock"
+run_test "post_install left no database or audit log behind" \
+    "[ ! -e /var/lib/facelock/facelock.db ] && [ ! -e /var/log/facelock/audit.jsonl ]"
+
+# --- depends alone must be enough ---------------------------------------------
+#
+# makepkg --syncdeps installed makedepends too, so up to here a runtime library
+# that only makedepends supplies would look fine. Drop everything nothing
+# depends on any more and the remaining closure is exactly what `depends`
+# bought. #209 was a name error in this list; an omission is the other half of
+# the same failure and reaches users the same way.
+
+echo ""
+echo "==> removing makedepends and every other orphan"
+while mapfile -t orphans < <(pacman -Qdtq 2>/dev/null) && [ "${#orphans[@]}" -gt 0 ]; do
+    pacman -Rns --noconfirm -- "${orphans[@]}" >/dev/null 2>&1 || break
+done
+echo ""
+
+# The ldd checks below are only meaningful if the removal actually happened. A
+# failed `pacman -Rns` leaves makedepends installed, and then every library the
+# recipe forgot to declare is still on disk and every check passes for the wrong
+# reason. rust and clang are build-only under any reading of this recipe, so
+# their survival is the signal that the removal did not take.
+run_test "makedepends are gone, so the checks below are not vacuous" \
+    "! pacman -Q rust && ! pacman -Q clang && [ -z \"\$(pacman -Qdtq 2>/dev/null)\" ]"
+run_test "facelock survives makedepends removal" "pacman -Q facelock"
+for binary in /usr/bin/facelock /usr/bin/facelock-polkit-agent /usr/lib/security/pam_facelock.so; do
+    run_test "runtime depends resolve every library $binary needs" \
+        "! ldd '$binary' 2>&1 | grep -q 'not found'"
+done
+
+# --- the first commands a user types ------------------------------------------
+
+run_test "facelock --version reports the packaged version" \
+    "/usr/bin/facelock --version | grep -q \"\$(pacman -Q facelock | cut -d' ' -f2 | cut -d- -f1)\""
+run_test "facelock --help exits successfully" "/usr/bin/facelock --help >/dev/null"
+run_test "facelock setup --help exits successfully" "/usr/bin/facelock setup --help >/dev/null"
+run_test "facelock tpm --help exits successfully" "/usr/bin/facelock tpm --help >/dev/null"
+run_test "facelock status runs without panicking" "runs_cleanly /usr/bin/facelock status"
+run_test "facelock devices runs without panicking with no camera" \
+    "runs_cleanly /usr/bin/facelock devices"
+run_test "facelock list runs without panicking with nothing enrolled" \
+    "runs_cleanly /usr/bin/facelock list"
+run_test "facelock capabilities runs without panicking" \
+    "runs_cleanly /usr/bin/facelock capabilities"
+run_test "facelock is-enrolled reports root not enrolled" \
+    "/usr/bin/facelock is-enrolled --user root; [ \$? -eq 1 ]"
+run_test "facelock pam status --all runs without panicking" \
+    "runs_cleanly /usr/bin/facelock pam status --all"
+run_test "the packaged config is valid TOML" \
+    "python3 -c 'import tomllib; tomllib.load(open(\"/etc/facelock/config.toml\", \"rb\"))'"
+run_test "D-Bus policy XML is valid" \
+    "python3 -c 'import xml.etree.ElementTree as E; E.parse(\"/usr/share/dbus-1/system.d/org.facelock.Daemon.conf\")'"
+run_test "the packaged unit file parses" \
+    "command -v systemd-analyze >/dev/null &&
+     ! systemd-analyze verify /usr/lib/systemd/system/facelock-daemon.service 2>&1 |
+       grep -q 'Failed to parse'"
+run_test "the packaged tmpfiles config is accepted" \
+    "systemd-tmpfiles --create --dry-run /usr/lib/tmpfiles.d/facelock.conf"
+
+echo ""
+echo "=== Arch package results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1
+
+# The removal half. It edits /etc/pam.d and uninstalls the package, so it runs
+# last and nothing may be added after it.
+echo ""
+echo "=== libalpm hook and PAM cleanup on removal ==="
+exec /arch-package-validate.sh

--- a/test/arch-pkgbuild-dependency-contract.sh
+++ b/test/arch-pkgbuild-dependency-contract.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Every package name all three PKGBUILDs declare must resolve in the pinned
+# Arch repositories.
+#
+# #209 was exactly this: a package named something Arch does not ship. It
+# surfaces on a user's machine, at install time, on the platform most facelock
+# users are on. The names are checked here rather than only inside the full
+# build because a typo has to fail in seconds, and because only dist/PKGBUILD
+# gets built end to end — dist/PKGBUILD-git is what Omarchy's installer pulls
+# through `omarchy-pkg-aur-add facelock-git`, and its depends list is not the
+# same one.
+#
+# Resolution goes through pacman, not a repository listing, so `provides` counts:
+# `onnxruntime` and `cargo` are both virtual today, satisfied by
+# `onnxruntime-cpu` and `rust`. A listing-based check would reject both.
+set -euo pipefail
+
+RECIPE=${FACELOCK_RECIPE_DIR:-/recipe}
+BUILDER=builder
+
+fail() {
+    echo "arch dependency contract: $*" >&2
+    exit 1
+}
+
+[ -d "$RECIPE" ] || fail "no recipe directory at $RECIPE"
+
+# makepkg treats the recipe directory as BUILDDIR, refuses to read one it
+# cannot write, and refuses to run as root at all. Work from a copy the
+# unprivileged builder owns.
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-arch-srcinfo.XXXXXX")"
+trap 'rm -rf -- "$workdir"' EXIT
+cp -- "$RECIPE"/* "$workdir/"
+chown -R "$BUILDER:$BUILDER" "$workdir"
+
+pacman -Sy --noconfirm >/dev/null
+
+failures=0
+checked=0
+
+for recipe in PKGBUILD PKGBUILD-bin PKGBUILD-git; do
+    [ -f "$workdir/$recipe" ] || fail "missing recipe: $RECIPE/$recipe"
+
+    # Ask the recipe what it declares instead of parsing the arrays here: this
+    # expands the same variables makepkg would and drops architecture-specific
+    # and version-constrained forms into one flat list.
+    srcinfo="$(runuser -u "$BUILDER" -- \
+        bash -c "cd '$workdir' && makepkg -p '$recipe' --printsrcinfo")" ||
+        fail "$recipe does not parse"
+
+    mapfile -t names < <(
+        printf '%s\n' "$srcinfo" |
+            sed -n -E 's/^[[:space:]]*(depends|makedepends|checkdepends|optdepends) = //p' |
+            # optdepends carry a ": reason" suffix; every kind may carry a
+            # >=/<=/= version constraint. Keep the bare package name.
+            sed -E 's/:.*$//; s/[<>=].*$//' |
+            sed -E 's/[[:space:]]+$//' |
+            grep -v '^$' |
+            LC_ALL=C sort -u
+    )
+    [ "${#names[@]}" -gt 0 ] || fail "$recipe declares no dependencies at all"
+
+    for name in "${names[@]}"; do
+        checked=$((checked + 1))
+        if pacman -Sp --print-format '%n' -- "$name" >/dev/null 2>&1; then
+            printf '  ok    %-14s %s\n' "$recipe" "$name"
+        else
+            printf '  FAIL  %-14s %s  --  no repository package provides it\n' \
+                "$recipe" "$name"
+            failures=$((failures + 1))
+        fi
+    done
+done
+
+echo ""
+if [ "$failures" -ne 0 ]; then
+    echo "=== Arch dependency contract: $failures of $checked declared names do not resolve ==="
+    exit 1
+fi
+echo "=== Arch dependency contract: all $checked declared names resolve ==="

--- a/test/build-arch-package-image.sh
+++ b/test/build-arch-package-image.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build the Arch end-to-end package image and stage this working tree as the
+# source the recipe will build.
+#
+# The image carries only the recipe and the test scripts. The candidate tree is
+# staged into a directory the caller then mounts at /staged-source, so editing
+# a source file does not rebuild the image, and the tarball the recipe consumes
+# is assembled inside the container from the file name the recipe declares.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image="${1:?usage: build-arch-package-image.sh <image> <staging-dir>}"
+staging="${2:?usage: build-arch-package-image.sh <image> <staging-dir>}"
+[ "$#" -eq 2 ] || {
+    echo "usage: build-arch-package-image.sh <image> <staging-dir>" >&2
+    exit 2
+}
+
+if [ ! -d "$staging" ] || [ -n "$(find "$staging" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    echo "staging directory must exist and be empty: $staging" >&2
+    exit 1
+fi
+staging="$(cd "$staging" && pwd)"
+source_root="$staging/source"
+mkdir -- "$source_root"
+
+# The candidate's tracked and intentionally untracked files, as
+# prepare-deb-test-context.sh selects them: this tests the tree about to be
+# pushed, not the last commit, while leaving build outputs and the downloaded
+# models out — a release tarball has neither.
+git -C "$repo_root" ls-files --cached --others --exclude-standard -z |
+    while IFS= read -r -d '' path; do
+        [ -e "$repo_root/$path" ] && printf '%s\0' "$path"
+    done |
+    tar -C "$repo_root" --null -T - -cf - |
+    tar -C "$source_root" -xf -
+
+# build() and check() are --frozen, so a missing or stale lock file fails deep
+# inside a long container run rather than here.
+[ -f "$source_root/dist/PKGBUILD" ] && [ -f "$source_root/Cargo.lock" ] || {
+    echo "staged tree is missing the recipe or the lock file: $source_root" >&2
+    exit 1
+}
+# package() calls this by relative path, so the mode has to survive staging.
+[ -x "$source_root/scripts/install-locale-catalogs.sh" ] || {
+    echo "staged tree lost the executable bit on scripts/install-locale-catalogs.sh" >&2
+    exit 1
+}
+
+podman build -t "$image" -f "$repo_root/test/Containerfile.arch-e2e" "$repo_root"

--- a/test/build-arch-source-package.sh
+++ b/test/build-arch-source-package.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Build dist/PKGBUILD end to end inside the Arch package container, then
+# install the result with pacman.
+#
+# ## How the recipe's source= is exercised without downloading
+#
+# dist/PKGBUILD fetches a GitHub archive tarball for the released tag. Letting
+# it download would test the last release instead of the candidate, and would
+# make every run depend on the network. Stubbing source= out would test a
+# recipe nobody ships.
+#
+# So the candidate tree is mounted at /staged-source and repacked here under
+# exactly the file name the recipe's own source= array declares, in the
+# directory shape a GitHub archive unpacks to. makepkg then finds it in SRCDEST
+# and does everything else for real: it parses source=, checks sha256sums,
+# extracts, and runs prepare(), build(), check() and package(). If the recipe's
+# rename target and the directory its functions cd into ever disagree, the
+# build fails here.
+#
+# Source retrieval runs under the same fail-closed network sandbox the Debian
+# lane uses, so "it did not download" is enforced rather than asserted.
+#
+# ## What this does NOT verify
+#
+# Integrity. sha256sums is ('SKIP') today (#283), so --verifysource checks no
+# digest: it proves the declared file name resolved offline and nothing more.
+# The declared URL is never fetched either, so a wrong or dead source URL passes
+# here.
+#
+# When #283 replaces SKIP with a real digest this breaks, because a tarball
+# repacked from the working tree cannot match a published sum. The fix is to add
+# --skipchecksums to the staged build below and assert the real digest
+# separately, reading sha256sums directly rather than asking makepkg to validate
+# a tarball it was never going to accept.
+set -euo pipefail
+
+STAGED=${FACELOCK_STAGED_SOURCE:-/staged-source}
+RECIPE=${FACELOCK_RECIPE_DIR:-/recipe}
+BUILD=/tmp/facelock-arch-build
+BUILDER=builder
+
+fail() {
+    echo "arch package build: $*" >&2
+    exit 1
+}
+
+[ -d "$STAGED" ] || fail "candidate source tree is not mounted at $STAGED"
+[ -f "$STAGED/Cargo.toml" ] && [ -f "$STAGED/dist/PKGBUILD" ] ||
+    fail "$STAGED does not look like a facelock checkout"
+[ -f "$RECIPE/PKGBUILD" ] || fail "missing recipe: $RECIPE/PKGBUILD"
+
+# The recipe that gets built is the one in the candidate tree. Copying it out
+# of $STAGED rather than out of the image keeps a single source of truth even
+# though the image also carries a copy for the dependency contract.
+install -d -m 0755 -o "$BUILDER" -g "$BUILDER" "$BUILD"
+install -m 0644 -o "$BUILDER" -g "$BUILDER" "$STAGED/dist/PKGBUILD" "$BUILD/PKGBUILD"
+install -m 0644 -o "$BUILDER" -g "$BUILDER" "$STAGED/dist/facelock.install" \
+    "$BUILD/facelock.install"
+
+srcinfo="$(runuser -u "$BUILDER" -- bash -c "cd '$BUILD' && makepkg --printsrcinfo")" ||
+    fail "dist/PKGBUILD does not parse"
+
+mapfile -t sources < <(printf '%s\n' "$srcinfo" | sed -n -E 's/^[[:space:]]*source = //p')
+[ "${#sources[@]}" -eq 1 ] ||
+    fail "expected dist/PKGBUILD to declare exactly one source, got ${#sources[@]}"
+entry="${sources[0]}"
+case "$entry" in
+    *::*) ;;
+    *) fail "source entry does not rename the fetched tarball: $entry" ;;
+esac
+tarball="${entry%%::*}"
+url="${entry#*::}"
+case "$tarball" in
+    */*|"") fail "source rename target is not a plain file name: $tarball" ;;
+    *.tar.gz) ;;
+    *) fail "source rename target is not a .tar.gz: $tarball" ;;
+esac
+case "$url" in
+    https://*) ;;
+    *) fail "source is not fetched over https: $url" ;;
+esac
+
+# A GitHub archive of v<tag> unpacks to <pkgname>-<tag>/, which is what every
+# recipe function cds into. Deriving it from the rename target rather than
+# restating _tag keeps this honest if the recipe's naming changes.
+topdir="${tarball%.tar.gz}"
+
+echo "==> staging the candidate tree as $tarball"
+echo "    recipe declares: $url"
+cp -a -- "$STAGED" "$BUILD/$topdir"
+chown -R "$BUILDER:$BUILDER" "$BUILD/$topdir"
+runuser -u "$BUILDER" -- tar -C "$BUILD" -czf "$BUILD/$tarball" "$topdir"
+rm -rf -- "$BUILD/${topdir:?}"
+
+# Refresh the sync database once as root. makepkg --syncdeps below resolves the
+# recipe's own depends and makedepends through pacman against this snapshot.
+pacman -Sy --noconfirm >/dev/null
+
+echo "==> verifying sources with networking denied"
+runuser -u "$BUILDER" -- /run-networkless.sh \
+    bash -c "cd '$BUILD' && makepkg --verifysource --nodeps --noconfirm" ||
+    fail "source verification reached for the network or rejected the staged tarball"
+
+# prepare() runs `cargo fetch --locked`, so this half is deliberately online;
+# build() and check() are --frozen and therefore offline regardless.
+echo "==> makepkg: syncdeps, prepare, build, check, package"
+runuser -u "$BUILDER" -- \
+    bash -c "cd '$BUILD' && makepkg --syncdeps --noconfirm" ||
+    fail "makepkg failed"
+
+package="$(find "$BUILD" -maxdepth 1 -type f -name 'facelock-*.pkg.tar.zst' -print -quit)"
+[ -n "$package" ] || fail "makepkg produced no package"
+
+echo "==> pacman -U $(basename -- "$package")"
+cp -- "$package" /facelock-test-package.pkg.tar.zst
+pacman -U --noconfirm -- "$package"
+rm -rf -- "$BUILD"


### PR DESCRIPTION
## Summary

- add `just test-arch-pkg`: `makepkg` as a non-root builder against the real `dist/PKGBUILD`, then `pacman -U`, then validation
- stage the working tree as the recipe's declared source tarball rather than downloading the released one, and run source retrieval under the fail-closed network sandbox the Debian lane uses
- assert the inventory `package()` declares, what the `facelock.install` scriptlet did on `post_install`, the first commands `quickstart.md` documents, and the libalpm hook that clears PAM references on removal
- drop every orphan after install so the remaining closure is what `depends` alone bought, with a sentinel proving the removal took
- resolve every dependency name all three PKGBUILDs declare through pacman before the build starts
- give each run its own image tag, so two concurrent runs cannot clobber each other
- correct a routing row: `dist/facelock.install` is the pacman scriptlet, not an rpm input

## Why

`dist/PKGBUILD` had never been executed. The Arch container suite installs host-built binaries, and `test/arch-package/PKGBUILD` is a fixture with no `source=`, `build()` or `check()`, so the real recipe's dependency lists and build functions ran nowhere. Arch is the platform most facelock users are on, and Omarchy's installer reaches it through `omarchy-pkg-aur-add facelock-git`. A wrong package name like #209 gets there first.

## What it does not cover

`sha256sums` is `SKIP` (#283), so `makepkg --verifysource` checks no digest: it proves only that the declared file name resolved without touching the network. The staged tarball is a repack of this working tree, and the `source=` URL is never fetched, so a wrong or dead URL still passes.

That makes #283 a forward conflict. A real digest cannot match a tarball repacked from the working tree, so this lane fails on every run the moment `SKIP` is replaced. The intended path is `--skipchecksums` for the staged build with the real sum asserted separately; `test/build-arch-source-package.sh`, the roadmap and the packaging-test skill all say so, so whoever fixes #283 is not blindsided.

It also does not boot systemd; unit runtime behaviour stays with the deb and rpm gates.

## Scope

- builds `dist/PKGBUILD` only: `PKGBUILD-git` and `PKGBUILD-bin` differ from it in exactly the part a working-tree build has to substitute away, so building them would test the substitution
- the dependency-name gate covers all three, since that is the list they do share
- needs no ONNX models and no booted systemd, so it can run unattended; no CI job added, matching every other packaging lane
- slowest recipe in the tree: the recipe compiles the workspace twice, release for `build()` and debug for `check()`

## Validation

- `just check`
- `just test-arch-pkg` end to end, with `check()` running the full workspace suite inside the package build
- mutation: a misspelled `depends` entry, checked against both the name gate and `makepkg --syncdeps`
- negative case for the source substitution: source retrieval with the staged tarball absent

An earlier revision of this branch was red here, and worth recording: `check()` runs `cargo test --workspace`, and the `*_non_root` cases in `cli_smoke.rs` failed on any machine with no `/etc/facelock/config.toml`, which is every first AUR install. CI runs that suite as root, where those cases skip themselves, and a developer machine already has the file, so nothing else was positioned to see it. #264 fixed the ordering and the lane is green on the rebase.

Depends on #266. Expect a tier-row conflict with #279, which numbers a row `3d` in `.claude/rules/testing.md` as well; whichever lands second renumbers.

Closes #212
