### PR TITLE
build(release): validate packit config in a pinned fedora container

### DIFF
--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -21,7 +21,8 @@ All recipes need `podman`. None of the ones in the routing table need a camera.
 | `dist/facelock.spec`, `dist/facelock.install` | `just test-rpm-pkg` |
 | TPM packaging or `facelock-tpm` build features | `just test-deb-trixie-pkg` and `just test-deb-resolute-pkg` |
 | `dist/PKGBUILD*` | `just test-arch-pam`, then a release shell (below) |
-| `.packit.yaml`, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
+| `.packit.yaml` schema only | `just test-packit-config` — real `packit` in a pinned Fedora container, seconds |
+| `.packit.yaml` semantics, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
 | APT repo generation, `publish-apt` workflow | `just test-apt-repo` — needs `reprepro` and `gpg` |
 | `systemd/`, `dbus/`, `polkit/`, install paths | both Debian suite recipes or `just test-rpm-pkg` — all validate under booted systemd |
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -199,6 +199,7 @@ just test-deb-trixie-pkg    # Debian 13 — offline source rebuild, install, TPM
 just test-deb-resolute-pkg  # Ubuntu 26.04 — the same complete package gate
 just test-rpm-pkg        # Fedora — build real .rpm, install via dnf, validate
 just test-rpm-authselect # Fedora — retired-profile upgrade guard lifecycle
+just test-packit-config  # Packit config schema — real `packit` in a pinned Fedora container
 just test-copr           # COPR-equivalent — Packit SRPM + mock from-source rebuild (slow)
 
 # Interactive (requires camera)
@@ -258,9 +259,12 @@ production COPR API and require its enabled chroots to equal the checked-in
 authority: Fedora 43/44/45 are required and Rawhide is the only optional
 experimental chroot. Rawhide may be present or absent; a missing required
 chroot or any unknown extra is release-blocking drift. The checker never
-modifies the project. When the Packit CLI is available,
-preflight runs `packit config validate --offline`; `just test-copr` always runs
-that real schema gate inside its Fedora Packit container.
+modifies the project. Preflight always runs `packit config validate --offline`
+against `.packit.yaml`, in the digest-pinned Fedora container built from
+`test/Containerfile.packit` — the same real schema gate `just test-copr` runs,
+reachable without a host `packit` install. It has no skip path: podman is a
+preflight prerequisite, and without it the gate fails rather than passing
+unrun. `just test-packit-config` runs the same gate on its own.
 
 ### Package repository setup (one-time)
 

--- a/justfile
+++ b/justfile
@@ -995,6 +995,10 @@ test-rpm-pkg: (_require-models "1") build-release
     podman build --build-arg ORT_VERSION={{ _ort-version }} -t facelock-rpm-pkg -f test/Containerfile.rpm-e2e .
     test/run-pkg-validate-systemd.sh facelock-rpm-pkg
 
+# Packit config schema gate — runs the real `packit` in a digest-pinned Fedora container
+test-packit-config:
+    bash test/packit-config-validate.sh
+
 # COPR-equivalent build — Packit SRPM + mock from-source rebuild on a Fedora chroot (slow, opt-in)
 test-copr:
     #!/usr/bin/env bash
@@ -1240,11 +1244,9 @@ release-preflight tag='':
         fi
     done
 
-    if command -v packit >/dev/null 2>&1; then
-        packit config validate --offline -c .packit.yaml || failed=1
-    else
-        echo "SKIP: packit CLI not installed; test-copr runs the required schema gate"
-    fi
+    echo ""
+    echo "== Packit config schema (pinned Fedora container) =="
+    bash test/packit-config-validate.sh || failed=1
 
     echo ""
     echo "== Release identity and target contract =="

--- a/test/Containerfile.packit
+++ b/test/Containerfile.packit
@@ -1,0 +1,14 @@
+# Container for `just test-packit-config` — the Packit configuration schema gate.
+# Pins the Fedora that supplies `packit`, so validation does not depend on the
+# host's Python, RPM bindings, or a host `packit` install.
+#
+# A toolchain image with no CMD: test/packit-config-validate.sh mounts the repo
+# read-only at /repo and passes the validator command on the run line, so the
+# command this gate actually runs is visible in one place. Offline schema
+# validation reads only the checked-in config, so neither git history nor the
+# network is needed — the repo may be a git worktree whose .git pointer is
+# unreachable in here.
+FROM registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+RUN dnf install -y --setopt=install_weak_deps=False packit \
+    && dnf clean all
+WORKDIR /repo

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -652,7 +652,28 @@ require(
     packit_schema_command in copr_build_test,
     "COPR-equivalent gate does not run Packit's real offline schema validator",
 )
-require(packit_schema_command in justfile, "release preflight does not run Packit's schema validator when available")
+packit_gate = (ROOT / "test/packit-config-validate.sh").read_text()
+packit_gate_image = (ROOT / "test/Containerfile.packit").read_text()
+require(
+    packit_schema_command in packit_gate,
+    "Packit config gate does not run Packit's real offline schema validator",
+)
+require(
+    re.search(r"(?m)^FROM \S*/fedora:\S*@sha256:[0-9a-f]{64}\s*$", packit_gate_image) is not None,
+    "Packit config gate image is not a digest-pinned Fedora",
+)
+require(
+    "test/packit-config-validate.sh" in justfile,
+    "release preflight does not run the containerized Packit schema gate",
+)
+require(
+    packit_schema_command not in justfile,
+    "release preflight still runs Packit from the host instead of the pinned container",
+)
+require(
+    "SKIP: packit" not in justfile,
+    "release preflight can still skip Packit schema validation",
+)
 
 install_docs = {
     "README.md": (ROOT / "README.md").read_text(),

--- a/test/packit-config-validate.sh
+++ b/test/packit-config-validate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Packit configuration schema gate.
+#
+# Runs `packit config validate --offline -c .packit.yaml` inside the
+# digest-pinned Fedora image built from test/Containerfile.packit. The host
+# needs podman and nothing else: no `packit`, no Python RPM bindings, no pipx
+# venv that happens to see the system `rpm` module.
+#
+# Called by `just test-packit-config` and by `just release-preflight`.
+#
+# There is no skip path. This is a release gate, and a release gate that passes
+# when it did not run is the failure this repository has been removing. Preflight
+# already requires podman (`check_cmd podman`), so a host without podman is
+# already a failing preflight; this reports the same answer with a reason.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE=facelock-packit-validate
+
+if ! command -v podman >/dev/null 2>&1; then
+    echo "FAIL: podman not found; the Packit config gate runs only in its pinned Fedora container" >&2
+    echo "      install podman, or run the check on a host that has it — it is not skippable" >&2
+    exit 1
+fi
+
+# Preflight prints a terse summary, so the image build is quiet unless it fails.
+build_log="$(mktemp)"
+trap 'rm -f -- "$build_log"' EXIT
+if ! podman build -t "$IMAGE" -f "$REPO_ROOT/test/Containerfile.packit" "$REPO_ROOT" >"$build_log" 2>&1; then
+    cat "$build_log" >&2
+    echo "FAIL: could not build the pinned Packit image" >&2
+    exit 1
+fi
+
+podman run --rm -v "$REPO_ROOT:/repo:ro" "$IMAGE" \
+    packit config validate --offline -c .packit.yaml
+echo "Packit config schema: OK"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -280,6 +280,8 @@ cp "$repo_root/test/check-release-matrix.py" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.rpm-e2e" "$matrix_root/test/"
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
+cp "$repo_root/test/packit-config-validate.sh" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.packit" "$matrix_root/test/"
 cp "$repo_root/test/run-pkg-validate-systemd.sh" "$matrix_root/test/"
 
 apt_publisher_root="$tmp_root/apt-publisher-root"
@@ -354,6 +356,22 @@ assert_matrix_mutation_rejected \
     "Debian source-contract mutation recipe command" \
     "justfile" \
     's@    python3 test/deb-source-contract-test.py@    python3 test/deb-source-contract-test-disabled.py@'
+assert_matrix_mutation_rejected \
+    "Packit schema gate skipped in preflight" \
+    "justfile" \
+    's@    bash test/packit-config-validate.sh || failed=1@    echo "SKIP: packit CLI not installed"@'
+assert_matrix_mutation_rejected \
+    "Packit schema gate run from the host instead of the pinned container" \
+    "justfile" \
+    's@    bash test/packit-config-validate.sh || failed=1@    packit config validate --offline -c .packit.yaml || failed=1@'
+assert_matrix_mutation_rejected \
+    "Packit schema gate validator command" \
+    "test/packit-config-validate.sh" \
+    's@packit config validate --offline -c .packit.yaml@packit config validate -c .packit.yaml@'
+assert_matrix_mutation_rejected \
+    "Packit schema gate image digest pin" \
+    "test/Containerfile.packit" \
+    's|@sha256:[0-9a-f]*||'
 
 assert_matrix_payload_mutation_rejected_with_diagnostic() {
     local context="$1"


### PR DESCRIPTION
## Summary

- add `test/Containerfile.packit`, a digest-pinned Fedora 44 image carrying the real `packit`
- run `packit config validate --offline -c .packit.yaml` from `test/packit-config-validate.sh`, repo mounted read-only at `/repo`
- replace preflight's host `packit` invocation with that gate and delete its skip branch
- expose the same gate as `just test-packit-config`
- require in `test/check-release-matrix.py`: containerized gate wired into preflight, digest-pinned image, no host invocation, no skip path
- cover each of those four assertions with a mutation case in `test/release-version-contract.sh`

## Why

Preflight called `packit` on the host. That binary is optional, and a pipx-installed `packitos` on Python 3.14 cannot import the system RPM bindings, so the command errored while the surrounding `command -v packit` test kept the skip branch out of reach. Preflight therefore could not pass on the maintainer's machine, which blocks tagging `v0.2.0-alpha.1`. #236 separately asks for Packit config validation in a pinned Fedora environment.

## Reviewer notes

- **no skip path is the point.** podman is already a preflight prerequisite (`check_cmd podman`), so a host without it already fails preflight; the gate reports the same answer with a reason rather than passing unrun.
- **`.packit.yaml` is untouched.** its production COPR job stays `"trigger": "ignore"`, which `test/check-release-matrix.py` enforces.
- image tag is `facelock-packit-validate`, distinct from every other recipe's tag.

## Validation

- `just release-preflight v0.2.0-alpha.1` and bare `just release-preflight`
- `just check`
- mutation: an invalid `job` value in `.packit.yaml`, then reverted
- the missing-podman path, with `podman` absent from `PATH`

Refs #236
