### PR TITLE
test(deb): stop the harness from hiding declared dependencies

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2040,7 +2040,10 @@ systemd, a C toolchain, and a software TPM, and requires every declared
 dependency to be shipped by the suite base, named by the harness exemption list
 with its reason, or resolved by the runtime transaction itself. Both directions
 of that list are enforced: an unlisted dependency the harness satisfies fails
-the gate, and so does a listed pattern that no longer matches one. Supplying an
+the gate, and so does a listed pattern that no longer matches one. The
+suite-base record that verdict rests on is taken before its stage installs
+anything, held there by a static read of the harness Containerfile, and
+compared at run time against that stage's own package database. Supplying an
 exact package to a harness image that carries no lifecycle script is a failure,
 not a skipped lane.
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2033,6 +2033,17 @@ without selecting it. Exact known legacy-copy migration belongs to
 administrator-owned shadow. Package validation requires the installed TPM
 command surface and the suite-native `libtss2` dependency closure.
 
+Two lanes read the same declared `Depends`. One resolves the exact candidate on
+a pristine suite base and requires every declared dependency to be installed
+there. The other installs it into the booted harness image, which also carries
+systemd, a C toolchain, and a software TPM, and requires every declared
+dependency to be shipped by the suite base, named by the harness exemption list
+with its reason, or resolved by the runtime transaction itself. Both directions
+of that list are enforced: an unlisted dependency the harness satisfies fails
+the gate, and so does a listed pattern that no longer matches one. Supplying an
+exact package to a harness image that carries no lifecycle script is a failure,
+not a skipped lane.
+
 Release validation runs lintian on every built binary package and fails on
 error-severity tags. Deliberate deviations are suppressed in
 `.github/workflows/scripts/validate-deb.sh`, each with a recorded reason;

--- a/test/Containerfile.deb-runtime
+++ b/test/Containerfile.deb-runtime
@@ -3,11 +3,14 @@ FROM ${BASE_IMAGE} AS dependency-closure
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# First instruction in the stage, so this record is exactly what the suite base
-# image ships. The runtime harness carries it in to tell a dependency the suite
-# already provides from one the harness installed, and deb-dependency-closure.sh
-# compares it against its own live dpkg database, which catches any later
-# instruction added here that would make the record a lie.
+# Recorded before the stage's first RUN, COPY, or ADD, so this is exactly what
+# the suite base image ships. The runtime harness carries it in to tell a
+# dependency the suite already provides from one the harness installed.
+#
+# Both halves of that are checked rather than trusted. deb-runtime-image-contract.sh
+# reads this file and fails if anything that can change the package set precedes
+# the record; deb-dependency-closure.sh compares the record against its own live
+# dpkg database and fails if anything after it did.
 RUN dpkg-query -W -f='${Package}\n' | LC_ALL=C sort -u \
         > /facelock-suite-base-packages
 

--- a/test/Containerfile.deb-runtime
+++ b/test/Containerfile.deb-runtime
@@ -3,6 +3,15 @@ FROM ${BASE_IMAGE} AS dependency-closure
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# First instruction in the stage, so this record is exactly what the suite base
+# image ships. The runtime harness carries it in to tell a dependency the suite
+# already provides from one the harness installed, and deb-dependency-closure.sh
+# compares it against its own live dpkg database, which catches any later
+# instruction added here that would make the record a lie.
+RUN dpkg-query -W -f='${Package}\n' | LC_ALL=C sort -u \
+        > /facelock-suite-base-packages
+
+COPY test/deb-declared-depends.sh /deb-declared-depends.sh
 COPY test/deb-dependency-closure.sh /deb-dependency-closure.sh
 RUN chmod +x /deb-dependency-closure.sh
 
@@ -10,11 +19,18 @@ FROM ${BASE_IMAGE} AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Harness tooling only: a booted init, a C toolchain for pamtester, python3 for
+# the lifecycle fixtures, and a software TPM for the PCR gate. None of the
+# candidate's own declared dependencies belong here. deb-package-lifecycle.sh
+# holds this list to that rule and names the exact overlap it tolerates.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        binutils build-essential ca-certificates curl dbus libpam0g-dev \
-        libpam-runtime python3 swtpm swtpm-tools systemd tpm2-tools && \
+        binutils build-essential ca-certificates curl libpam0g-dev \
+        python3 swtpm swtpm-tools systemd tpm2-tools && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=dependency-closure /facelock-suite-base-packages \
+    /facelock-suite-base-packages
 
 COPY test/install-pamtester.sh /tmp/install-pamtester.sh
 RUN sh /tmp/install-pamtester.sh && rm -f /tmp/install-pamtester.sh
@@ -29,6 +45,7 @@ RUN printf '%s\n' \
         > /etc/dpkg/dpkg.cfg.d/zz-facelock-test-docs
 
 COPY test/pkg-validate.sh /pkg-validate.sh
+COPY test/deb-declared-depends.sh /deb-declared-depends.sh
 COPY test/deb-package-lifecycle.sh /deb-package-lifecycle.sh
 COPY test/polkit-agent-validate.sh /polkit-agent-validate.sh
 COPY test/tpm-pcr-e2e.sh /tpm-pcr-e2e.sh

--- a/test/build-deb-package-image.sh
+++ b/test/build-deb-package-image.sh
@@ -15,6 +15,12 @@ case "$suite" in
     *) echo "unsupported Debian package suite: $suite" >&2; exit 2 ;;
 esac
 
+# Read the harness Containerfile before building anything from it. The suite
+# package record the lifecycle gate reasons about can only be trusted if it is
+# taken before that stage installs anything, and no run-time check can prove
+# that about an instruction placed above the record.
+"$repo_root/test/deb-runtime-image-contract.sh"
+
 package_parent="$(dirname "$package_output")"
 [ -d "$package_parent" ] || {
     echo "package output parent does not exist: $package_parent" >&2

--- a/test/deb-declared-depends.sh
+++ b/test/deb-declared-depends.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Shared reading of the exact candidate's declared runtime dependencies.
+#
+# Two Debian gates reason about the same Depends field from opposite ends:
+# deb-dependency-closure.sh proves it resolves on a pristine suite base, and
+# deb-package-lifecycle.sh proves the booted harness image is not quietly
+# satisfying it in advance. One parser keeps them from disagreeing about what
+# the package actually declares.
+#
+# Sourced, never executed. The caller defines fail().
+
+# Emit one line per Depends element. Alternatives stay together on their line,
+# space separated, because any one of them satisfies the element. Version
+# constraints, build profiles, and multiarch qualifiers are stripped.
+declared_dependency_groups() {
+    local package="$1" element
+    dpkg-deb --field "$package" Depends |
+        tr ',' '\n' |
+        sed -e 's/([^)]*)//g' -e 's/\[[^]]*\]//g' -e 's/<[^>]*>//g' |
+        while IFS= read -r element; do
+            printf '%s\n' "$element" |
+                tr '|' '\n' |
+                sed -e 's/[[:space:]]//g' -e 's/:.*$//' -e '/^$/d' |
+                paste -sd' ' -
+        done |
+        sed '/^$/d'
+}
+
+dependency_installed() {
+    dpkg-query -W -f='${db:Status-Status}\n' "$1" 2>/dev/null |
+        grep -qx installed
+}
+
+dependency_group_satisfied() {
+    local name
+    for name in $1; do
+        if dependency_installed "$name"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Fail unless every dependency element read from stdin has an installed
+# alternative. Counting "at least one dependency arrived" cannot tell a full
+# closure from a near-empty one, so each element is checked by name.
+assert_dependency_groups_satisfied() {
+    local label="$1" group resolved=0
+    while IFS= read -r group; do
+        [ -n "$group" ] || continue
+        dependency_group_satisfied "$group" ||
+            fail "$label: declared dependency is unsatisfied: $group"
+        resolved=$((resolved + 1))
+    done
+    [ "$resolved" -gt 0 ] || fail "$label: no declared dependency was checked"
+}

--- a/test/deb-dependency-closure.sh
+++ b/test/deb-dependency-closure.sh
@@ -5,11 +5,15 @@ set -euo pipefail
 
 PACKAGE=/facelock-test-package.deb
 APT_LOG=/tmp/facelock-dependency-closure-apt.log
+SUITE_BASE_PACKAGES=/facelock-suite-base-packages
 
 fail() {
     echo "FAIL [Debian dependency closure]: $*" >&2
     exit 1
 }
+
+# shellcheck source=/dev/null
+. /deb-declared-depends.sh
 
 [ -f "$PACKAGE" ] && [ ! -L "$PACKAGE" ] ||
     fail "candidate package is not a regular file"
@@ -25,6 +29,18 @@ if dpkg-query -W -f='${db:Status-Status}\n' facelock 2>/dev/null |
     grep -qx installed; then
     fail "clean dependency stage already contains Facelock"
 fi
+
+# The booted lifecycle gate decides which of its declared dependencies the test
+# harness pre-satisfied by reading the suite manifest recorded during the image
+# build. That verdict is only as good as the record, so prove it here, on the
+# one stage that is supposed to be nothing but the suite base.
+[ -s "$SUITE_BASE_PACKAGES" ] ||
+    fail "image build recorded no pristine suite package set"
+dpkg-query -W -f='${Package}\n' | LC_ALL=C sort -u >/tmp/facelock-live-packages
+cmp -s "$SUITE_BASE_PACKAGES" /tmp/facelock-live-packages || {
+    diff -u "$SUITE_BASE_PACKAGES" /tmp/facelock-live-packages >&2 || true
+    fail "recorded suite package set does not match this pristine stage"
+}
 
 candidate_hash="$(sha256sum "$PACKAGE" | cut -d' ' -f1)"
 before_packages="$(dpkg-query -W -f='${binary:Package}\n' | wc -l)"
@@ -49,6 +65,8 @@ candidate_version="$(dpkg-deb --field "$PACKAGE" Version)"
 after_packages="$(dpkg-query -W -f='${binary:Package}\n' | wc -l)"
 [ "$after_packages" -gt "$((before_packages + 1))" ] ||
     fail "clean-base transaction did not install any dependency package"
+declared_dependency_groups "$PACKAGE" |
+    assert_dependency_groups_satisfied "pristine suite base"
 [ -z "$(dpkg --audit)" ] || fail "dpkg reports an incomplete transaction"
 apt-get check >>"$APT_LOG" 2>&1 || {
     cat "$APT_LOG" >&2

--- a/test/deb-package-lifecycle.sh
+++ b/test/deb-package-lifecycle.sh
@@ -224,6 +224,10 @@ assert_harness_preinstall_contract() {
             continue
         fi
         exempt=""
+        # Stop at the first installed alternative. A second installed one in the
+        # same element goes unexamined, and can: one exempt alternative already
+        # satisfies the element, so the element is exempt either way and no
+        # declared dependency escapes a bucket.
         for name in $group; do
             dependency_installed "$name" || continue
             match="$(harness_presatisfied_entry "$name")" ||

--- a/test/deb-package-lifecycle.sh
+++ b/test/deb-package-lifecycle.sh
@@ -11,7 +11,27 @@ PAM_RETAINED=/var/lib/facelock/pam-backups/lifecycle-retained-provenance
 EXTERNAL_SENTINEL=/srv/facelock-lifecycle-external
 COMMON_AUTH=/etc/pam.d/common-auth
 APT_LOG=/tmp/facelock-deb-lifecycle-apt.log
+SUITE_BASE_PACKAGES=/facelock-suite-base-packages
 DB_HOLDER_PID=
+
+# Declared dependencies this harness image is allowed to satisfy before the
+# candidate is installed, each with the reason it has to be there first.
+#
+# The booted image is not a clean suite base. It also carries systemd, a C
+# toolchain for pamtester, and the swtpm/tpm2-tools software TPM the PCR gate
+# drives, and that TPM stack pulls the whole TSS runtime in with it. Wherever
+# harness tooling arrives ahead of a declared dependency, this lane cannot
+# prove APT resolves it, so deb-dependency-closure.sh resolves the same
+# candidate on a pristine suite base instead.
+#
+# The entries below are the exact extent of that blind spot, and both
+# directions are checked: a declared dependency that neither the suite base
+# ships nor a pattern here names fails the gate, so a new one cannot ride in on
+# harness tooling, and a pattern that matches nothing fails too, so the list
+# cannot rot into a comment about a dependency that moved on.
+HARNESS_PRESATISFIED=(
+    'libtss2-*|swtpm and tpm2-tools carry the TSS runtime for the TPM/PCR gate'
+)
 
 phase="${1:-}"
 case "$phase" in
@@ -26,6 +46,9 @@ fail() {
     echo "FAIL [Debian $phase lifecycle]: $*" >&2
     exit 1
 }
+
+# shellcheck source=/dev/null
+. /deb-declared-depends.sh
 
 pass() {
     printf 'TEST: Debian %s ... PASS\n' "$1"
@@ -150,6 +173,105 @@ assert_not_installed() {
         grep -qx installed; then
         fail "facelock was installed before the runtime transaction"
     fi
+}
+
+suite_base_ships() {
+    local name
+    for name in $1; do
+        if grep -qxF "$name" "$SUITE_BASE_PACKAGES"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Report which HARNESS_PRESATISFIED entry covers a package name, as
+# "<index> <reason>". The index lets the caller prove the entry is still live.
+harness_presatisfied_entry() {
+    local name="$1" entry pattern index=0
+    for entry in "${HARNESS_PRESATISFIED[@]}"; do
+        pattern="${entry%%|*}"
+        # shellcheck disable=SC2254 # the pattern is a deliberate glob
+        case "$name" in
+            $pattern) printf '%s %s\n' "$index" "${entry#*|}"; return 0 ;;
+        esac
+        index=$((index + 1))
+    done
+    return 1
+}
+
+# Bound what the harness preinstall is allowed to hide, by name.
+#
+# Read against the pristine suite manifest the image build recorded, so a
+# dependency the suite itself ships is never confused with one the harness
+# installed. Every declared dependency lands in exactly one of three buckets:
+# shipped by the suite base, named by HARNESS_PRESATISFIED, or left for the
+# runtime transaction to resolve. Anything else fails, and so does an
+# exemption pattern that no longer matches a declared dependency.
+assert_harness_preinstall_contract() {
+    local group name entry match exempt exempted=0 resolvable=0 index
+    local -a pattern_hits=()
+
+    [ -s "$SUITE_BASE_PACKAGES" ] ||
+        fail "harness image recorded no pristine suite package set"
+    for entry in "${HARNESS_PRESATISFIED[@]}"; do
+        pattern_hits+=(0)
+    done
+
+    while IFS= read -r group; do
+        [ -n "$group" ] || continue
+        if suite_base_ships "$group"; then
+            continue
+        fi
+        exempt=""
+        for name in $group; do
+            dependency_installed "$name" || continue
+            match="$(harness_presatisfied_entry "$name")" ||
+                fail "harness preinstall hides declared dependency '$name': drop it from test/Containerfile.deb-runtime, or add it to HARNESS_PRESATISFIED with the reason it must stay"
+            index="${match%% *}"
+            pattern_hits[index]=1
+            exempt="$name (${match#* })"
+            break
+        done
+        if [ -n "$exempt" ]; then
+            echo "NOTE: harness pre-satisfies declared dependency $exempt"
+            exempted=$((exempted + 1))
+        else
+            resolvable=$((resolvable + 1))
+        fi
+    done < <(declared_dependency_groups "$PACKAGE")
+
+    [ "$resolvable" -gt 0 ] ||
+        fail "the harness satisfies every declared dependency; this lane resolves nothing"
+    index=0
+    for entry in "${HARNESS_PRESATISFIED[@]}"; do
+        [ "${pattern_hits[index]}" -eq 1 ] ||
+            fail "harness dependency exemption '${entry%%|*}' matches no declared dependency"
+        index=$((index + 1))
+    done
+    pass "harness preinstall satisfies only recorded declared dependencies ($exempted exempt, $resolvable left to resolve)"
+}
+
+unsatisfied_declared_dependencies() {
+    local group
+    while IFS= read -r group; do
+        [ -n "$group" ] || continue
+        dependency_group_satisfied "$group" || printf '%s\n' "$group"
+    done < <(declared_dependency_groups "$PACKAGE")
+}
+
+# Debian container images ship a policy-rc.d that refuses service starts, so
+# the bus the candidate depends on stays down after APT unpacks it. Bringing it
+# up here, instead of baking dbus into the image, is what lets this lane
+# resolve its own D-Bus dependency and still reach an active daemon.
+assert_system_bus_available() {
+    [ -d /run/systemd/system ] || return 0
+    systemctl start dbus.socket ||
+        fail "the D-Bus runtime installed with the candidate did not start"
+    systemctl is-active --quiet dbus.socket ||
+        fail "system bus socket is inactive after the candidate install"
+    [ -S /run/dbus/system_bus_socket ] ||
+        fail "system bus socket is missing after the candidate install"
 }
 
 assert_installed_candidate() {
@@ -670,15 +792,20 @@ assert_password_fallback() {
 }
 
 fresh_install() {
-    local common_hash common_metadata before_hash
+    local common_hash common_metadata before_hash unresolved
     assert_exact_artifact_mount
     assert_not_installed
+    assert_harness_preinstall_contract
+    unresolved="$(unsatisfied_declared_dependencies)"
     before_hash="$(artifact_hash)"
     common_hash="$(sha256sum "$COMMON_AUTH" | cut -d' ' -f1)"
     common_metadata="$(stat -c '%a:%u:%g' "$COMMON_AUTH")"
 
     apt_transaction install -y --no-install-recommends "$PACKAGE"
 
+    printf '%s\n' "$unresolved" |
+        assert_dependency_groups_satisfied "runtime transaction"
+    assert_system_bus_available
     assert_installed_candidate
     assert_installed_payload_metadata
     assert_eq "$before_hash" "$(artifact_hash)" "candidate artifact digest after install"

--- a/test/deb-runtime-image-contract.sh
+++ b/test/deb-runtime-image-contract.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Structural contract for the Debian harness image, read from the Containerfile.
+#
+# The booted lifecycle gate sorts each declared dependency into "the suite base
+# ships it", "the harness is allowed to pre-satisfy it", or "the runtime
+# transaction resolves it", using a package manifest recorded while the
+# dependency-closure stage was built. deb-dependency-closure.sh compares that
+# record against its own live dpkg database at run time, which catches anything
+# installed after the record was taken.
+#
+# Nothing at run time can catch an install placed before it. The record would be
+# poisoned at birth, the comparison would confirm the poisoned copy, and the
+# lifecycle gate would file a harness-installed package under "the suite base
+# ships it" — the exact masking these gates exist to remove. Only reading the
+# Containerfile settles it, so that is what this does.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+containerfile="${1:-$script_dir/Containerfile.deb-runtime}"
+RECORD=/facelock-suite-base-packages
+STAGE=dependency-closure
+
+fail() {
+    echo "deb runtime image contract: $*" >&2
+    exit 1
+}
+
+[ -f "$containerfile" ] && [ ! -L "$containerfile" ] ||
+    fail "Containerfile is not a regular file: $containerfile"
+
+# One record per instruction: "<stage>\t<KEYWORD>\t<instruction, continuations
+# joined>". Comments and blank lines are dropped, and a comment never continues
+# an instruction.
+instructions="$(awk '
+    {
+        line = $0
+        if (continuing) {
+            continuing = (line ~ /\\[[:space:]]*$/)
+            sub(/\\[[:space:]]*$/, " ", line)
+            text = text line
+            if (!continuing) { print stage "\t" keyword "\t" text }
+            next
+        }
+        sub(/^[[:space:]]+/, "", line)
+        if (line == "" || line ~ /^#/) next
+        keyword = toupper(substr(line, 1, index(line " ", " ") - 1))
+        if (keyword == "FROM") {
+            stage = ""
+            if (match(line, /[[:space:]][Aa][Ss][[:space:]]+[^[:space:]]+[[:space:]]*$/)) {
+                stage = substr(line, RSTART, RLENGTH)
+                sub(/^[[:space:]]+[Aa][Ss][[:space:]]+/, "", stage)
+                sub(/[[:space:]]+$/, "", stage)
+            }
+        }
+        text = line
+        continuing = (line ~ /\\[[:space:]]*$/)
+        sub(/\\[[:space:]]*$/, " ", text)
+        if (!continuing) { print stage "\t" keyword "\t" text }
+    }
+' "$containerfile")"
+
+stage_count="$(printf '%s\n' "$instructions" |
+    awk -F'\t' -v stage="$STAGE" '$2 == "FROM" && $1 == stage' | wc -l)"
+[ "$stage_count" -eq 1 ] ||
+    fail "expected exactly one $STAGE stage, found $stage_count"
+
+# Only RUN, COPY, and ADD can change a stage's package set. ENV, ARG, and the
+# other inert instructions may precede the record.
+first_mutation="$(printf '%s\n' "$instructions" |
+    awk -F'\t' -v stage="$STAGE" '
+        $1 == stage && ($2 == "RUN" || $2 == "COPY" || $2 == "ADD") { print; exit }
+    ')"
+[ -n "$first_mutation" ] ||
+    fail "$STAGE stage records no suite package set"
+IFS=$'\t' read -r _ first_keyword first_text <<<"$first_mutation"
+[ "$first_keyword" = RUN ] ||
+    fail "the $STAGE stage must record $RECORD before its first $first_keyword: $first_text"
+case "$first_text" in
+    *"$RECORD"*) ;;
+    *) fail "the first RUN in the $STAGE stage must record $RECORD, not: $first_text" ;;
+esac
+
+# The record is only worth taking if the harness image actually carries it.
+printf '%s\n' "$instructions" |
+    awk -F'\t' -v stage="$STAGE" -v record="$RECORD" '
+        $2 == "COPY" && $1 != stage &&
+            index($3, "--from=" stage) && index($3, record) { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' ||
+    fail "no later stage copies $RECORD out of the $STAGE stage"
+
+echo "deb runtime image contract: ok"

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -101,6 +101,14 @@ if [ "${#onnx[@]}" -gt 0 ]; then
     '
 fi
 
+# The presence test below is the deb/rpm switch, so it is also the one place a
+# dropped COPY would turn the whole Debian lifecycle into silence and still let
+# the gate finish green. An exact package means the Debian lanes must run.
+if [ -n "$PACKAGE" ] && ! podman exec "$cid" test -x /deb-package-lifecycle.sh; then
+    echo "ERROR: exact Debian package supplied but the image carries no lifecycle harness" >&2
+    exit 1
+fi
+
 if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
     [ -n "$PACKAGE" ] || {
         echo "ERROR: Debian lifecycle image requires an exact package argument" >&2


### PR DESCRIPTION
## Summary

- drop `dbus` and `libpam-runtime` from the lifecycle image, so the booted lane resolves both through APT and brings the system bus up itself
- record the pristine suite package set in the closure stage, and hold that record from both sides: `deb-runtime-image-contract.sh` reads the Containerfile and rejects anything that can change the package set above the record, `deb-dependency-closure.sh` compares it against that stage's own dpkg database at run time
- fail the lifecycle gate when a declared dependency is already satisfied before the runtime transaction and no `HARNESS_PRESATISFIED` pattern names it, and fail when a pattern stops matching one
- name the one real overlap, `libtss2-*`, with the reason it stays: swtpm and tpm2-tools carry the TSS runtime for the TPM/PCR gate
- require every declared dependency by name on the pristine base, replacing the "at least one dependency arrived" count
- fail rather than skip when an exact package reaches an image carrying no lifecycle script
- share one `Depends` parser between the two lanes in `test/deb-declared-depends.sh`

## Why

The lifecycle image preinstalled `dbus` and `libpam-runtime`, so the booted lane
never resolved two of the package's own dependencies. The rest of the preinstall
has to stay, since that lane needs a booted init, a C toolchain, and a software
TPM, so it can never be a pristine suite base and `deb-dependency-closure.sh`
already resolves the exact candidate on one. What was missing is a bound on what
the harness may hide. swtpm and tpm2-tools install the same TSS runtime facelock
declares, and until now nothing said so or checked it.

## Validation

- `just test-deb-trixie-pkg`, `just test-deb-resolute-pkg`, `just check`, `python3 test/check-release-matrix.py`
- mutation probes on derived images: `dbus` returned to the preinstall, an exemption pattern that matches nothing, an extra exemption entry that matches nothing
- mutation probes on the Containerfile: an `apt-get install` above the record (single-line and continued), a `COPY` above it, a renamed record path, and a dropped `COPY --from`

Refs #229
