### PR TITLE
fix(arch): declare onnxruntime in facelock-git and pin the source digest

### DIFF
--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -67,17 +67,18 @@ hook that cleans PAM up on removal. It also resolves every dependency name all
 three PKGBUILDs declare, including `PKGBUILD-git`, which is what Omarchy's
 `omarchy-pkg-aur-add facelock-git` pulls.
 
-Three things it does not do. It does not boot systemd, so unit runtime
-behaviour stays with the deb and rpm gates. It checks no source digest:
-`sha256sums` is `SKIP` (#283), the staged tarball is a repack of the working
-tree, and the `source=` URL is never fetched, so a wrong URL passes. And it
-compiles the workspace twice, release for `build()` and debug for `check()`, so
-it is the slowest recipe here. Reach for `test-arch-pam` while iterating and run
-this before pushing a packaging change.
+It also exercises integrity the way the shipped recipe gets it: `dist/PKGBUILD`
+carries a fail-closed `__SRC_SHA256__` placeholder that `publish-aur.sh`
+finalizes at release time (#283), so the lane refuses a recipe declaring
+`SKIP`, proves a wrong digest is rejected, then substitutes the staged
+tarball's real digest and lets `makepkg` verify it.
 
-When #283 replaces `SKIP` with a real digest, this lane breaks: a staged tarball
-cannot match a published sum. Move the staged build to `--skipchecksums` and
-assert the real digest separately.
+Two things it does not do. It does not boot systemd, so unit runtime
+behaviour stays with the deb and rpm gates. And it compiles the workspace
+twice, release for `build()` and debug for `check()`, so it is the slowest
+recipe here. Reach for `test-arch-pam` while iterating and run this before
+pushing a packaging change. The `source=` URL is still never fetched, so a
+wrong URL passes.
 
 ## Camera-gated tests
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -50,7 +50,7 @@ It rewrites **six** files with `sed -i`:
 | File | Note |
 |---|---|
 | `Cargo.toml` | workspace version, inherited by all crates |
-| `dist/PKGBUILD` | |
+| `dist/PKGBUILD` | the source sha256 placeholder is filled in by CI at publish, not here |
 | `dist/PKGBUILD-bin` | per-binary sha256sums are filled in by CI, not here |
 | `dist/PKGBUILD-git` | the runtime `pkgver()` computes the real version; this is the fallback |
 | `dist/facelock.spec` | |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,8 @@ jobs:
       - name: Compute source tarball checksum
         id: checksum
         run: |
-          CHECKSUM=$(curl -sL "https://github.com/${{ github.repository }}/archive/${{ github.ref_name }}.tar.gz" | sha256sum | cut -d' ' -f1)
+          set -o pipefail
+          CHECKSUM=$(curl -fsSL "https://github.com/${{ github.repository }}/archive/${{ github.ref_name }}.tar.gz" | sha256sum | cut -d' ' -f1)
           echo "SHA256=${CHECKSUM}" >> "$GITHUB_OUTPUT"
 
       - name: Publish to AUR

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -11,6 +11,14 @@ if release_is_prerelease "$VERSION"; then
   echo "refusing to publish prerelease $VERSION to stable AUR packages" >&2
   exit 1
 fi
+# The checksum pins the source tarball for every AUR consumer. A malformed
+# value, or the digest of empty input (what `curl -sL | sha256sum` yields when
+# the download silently fails), must never reach a published recipe.
+EMPTY_SHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+if ! [[ "$CHECKSUM" =~ ^[0-9a-f]{64}$ ]] || [ "$CHECKSUM" = "$EMPTY_SHA256" ]; then
+  echo "refusing to publish: CHECKSUM is not a plausible source tarball digest: $CHECKSUM" >&2
+  exit 1
+fi
 ARCH_VERSION="$(release_arch_pkgver "$VERSION")"
 
 echo "=== Publishing to AUR ==="
@@ -112,7 +120,14 @@ publish_facelock() {
   cp dist/PKGBUILD "$dir/PKGBUILD"
   cp dist/facelock.install "$dir/facelock.install"
   sed -i "s/^_tag=.*/_tag=${VERSION}/; s/^pkgver=.*/pkgver=${ARCH_VERSION}/" "$dir/PKGBUILD"
-  sed -i "s/sha256sums=('SKIP')/sha256sums=('${CHECKSUM}')/" "$dir/PKGBUILD"
+  # dist/PKGBUILD carries a fail-closed placeholder, never SKIP (#283). If the
+  # placeholder is missing the recipe has drifted; stop rather than publish a
+  # recipe whose integrity line was never finalized.
+  if ! grep -Fq "sha256sums=('__SRC_SHA256__')" "$dir/PKGBUILD"; then
+    echo "ERROR: dist/PKGBUILD does not carry the __SRC_SHA256__ placeholder" >&2
+    exit 1
+  fi
+  sed -i "s/__SRC_SHA256__/${CHECKSUM}/" "$dir/PKGBUILD"
   generate_srcinfo "$dir"
   commit_and_push "$dir" "Update to v${VERSION}"
 }

--- a/dist/PKGBUILD
+++ b/dist/PKGBUILD
@@ -17,7 +17,10 @@ backup=('etc/facelock/config.toml')
 install=facelock.install
 options=(!lto)
 source=("$pkgname-$_tag.tar.gz::$url/archive/v$_tag.tar.gz")
-sha256sums=('SKIP')
+# Filled in by publish-aur.sh at release time, like PKGBUILD-bin's sums: the
+# tagged tree cannot carry its own tarball's digest. The placeholder fails
+# closed — makepkg refuses to build until a real digest replaces it.
+sha256sums=('__SRC_SHA256__')
 
 prepare() {
     cd "$pkgname-$_tag"

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -6,8 +6,12 @@ pkgdesc="Face authentication PAM module for Linux (development build)"
 arch=('x86_64')
 url="https://github.com/tyvsmith/facelock"
 license=('MIT OR Apache-2.0')
-depends=('glibc' 'dbus' 'pam' 'gcc-libs' 'tpm2-tss' 'libxkbcommon')
+depends=('glibc' 'dbus' 'pam' 'gcc-libs' 'tpm2-tss' 'libxkbcommon' 'onnxruntime')
 makedepends=('rust' 'cargo' 'clang' 'gettext' 'wayland' 'libxkbcommon' 'git')
+optdepends=(
+    'onnxruntime-opt-cuda: NVIDIA GPU acceleration (replaces onnxruntime)'
+    'onnxruntime-opt-rocm: AMD GPU acceleration (replaces onnxruntime)'
+)
 provides=('facelock')
 conflicts=('facelock')
 backup=('etc/facelock/config.toml')

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -338,10 +338,14 @@ Automated after setup. The release workflow publishes to AUR when `AUR_SSH_KEY` 
    cp "$REPO_ROOT/dist/PKGBUILD" .
    cp "$REPO_ROOT/dist/facelock.install" .
    # dist/PKGBUILD ships a __SRC_SHA256__ placeholder; substitute the real
-   # tarball digest before pushing or the recipe refuses to build:
+   # tarball digest before pushing or the recipe refuses to build. Download
+   # first, hash the file after: piping curl into sha256sum hashes empty
+   # input when the download fails, and that digest must never be published.
    TAG="$(sed -n 's/^_tag=//p' PKGBUILD)"
-   SUM="$(curl -fsSL "https://github.com/tyvsmith/facelock/archive/v${TAG}.tar.gz" | sha256sum | cut -d' ' -f1)"
-   sed -i "s/__SRC_SHA256__/${SUM}/" PKGBUILD
+   curl -fSsL -o "/tmp/facelock-v${TAG}.tar.gz" \
+     "https://github.com/tyvsmith/facelock/archive/v${TAG}.tar.gz" &&
+     SUM="$(sha256sum "/tmp/facelock-v${TAG}.tar.gz" | cut -d' ' -f1)" &&
+     sed -i "s/__SRC_SHA256__/${SUM}/" PKGBUILD
    makepkg --printsrcinfo > .SRCINFO
    git add PKGBUILD facelock.install .SRCINFO
    git commit -m "Initial commit"
@@ -494,9 +498,13 @@ The APT repo is hosted at `https://tysmith.me/facelock/apt/` alongside the docs 
 
 If CI is not configured or fails:
 
-1. Download the release tarball and compute the checksum:
+1. Download the release tarball, then compute the checksum from the file.
+   Piping curl into sha256sum prints the digest of empty input when the
+   download fails; downloading first prints no digest at all:
    ```bash
-   curl -sL https://github.com/tyvsmith/facelock/archive/v$VERSION.tar.gz | sha256sum
+   curl -fSsL -o "facelock-v$VERSION.tar.gz" \
+     "https://github.com/tyvsmith/facelock/archive/v$VERSION.tar.gz" &&
+     sha256sum "facelock-v$VERSION.tar.gz"
    ```
 2. Clone the AUR repo (first time only):
    ```bash

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -337,6 +337,11 @@ Automated after setup. The release workflow publishes to AUR when `AUR_SSH_KEY` 
    cd aur-facelock
    cp "$REPO_ROOT/dist/PKGBUILD" .
    cp "$REPO_ROOT/dist/facelock.install" .
+   # dist/PKGBUILD ships a __SRC_SHA256__ placeholder; substitute the real
+   # tarball digest before pushing or the recipe refuses to build:
+   TAG="$(sed -n 's/^_tag=//p' PKGBUILD)"
+   SUM="$(curl -fsSL "https://github.com/tyvsmith/facelock/archive/v${TAG}.tar.gz" | sha256sum | cut -d' ' -f1)"
+   sed -i "s/__SRC_SHA256__/${SUM}/" PKGBUILD
    makepkg --printsrcinfo > .SRCINFO
    git add PKGBUILD facelock.install .SRCINFO
    git commit -m "Initial commit"
@@ -498,7 +503,7 @@ If CI is not configured or fails:
    git clone ssh://aur@aur.archlinux.org/facelock.git aur-facelock
    ```
 3. Copy `dist/PKGBUILD` and `dist/facelock.install` into the AUR repo
-4. Update `sha256sums` in the PKGBUILD with the real checksum from step 1
+4. Replace the `__SRC_SHA256__` placeholder in the PKGBUILD with the real checksum from step 1
 5. Generate `.SRCINFO`:
    ```bash
    cd aur-facelock

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -230,18 +230,16 @@ and Fedora package gates it needs no ONNX models and no booted systemd, and can
 run unattended. It is also the slowest recipe in the tree: the recipe compiles
 the workspace twice, release for `build()` and debug for `check()`.
 
-What this tier does not cover is integrity. `dist/PKGBUILD` carries
-`sha256sums=('SKIP')` (#283), so `makepkg --verifysource` checks no digest at
-all: it proves only that the declared file name resolved without touching the
-network. The staged tarball is this working tree, so what the sum would cover is
-a repack the lane produced itself. The declared `source=` URL is never fetched
-either, which means a wrong or dead URL still passes here.
-
-That also makes #283 a forward conflict. The moment a real digest replaces
-`SKIP`, the staged tarball cannot match it and this lane fails on every run. The
-intended path is `makepkg --skipchecksums` for the staged build, with the real
-sum checked by a separate assertion that reads `sha256sums` directly rather than
-by handing makepkg a tarball it was never going to accept.
+Integrity is exercised the way the shipped recipe gets it. `dist/PKGBUILD`
+declares a fail-closed `__SRC_SHA256__` placeholder that `publish-aur.sh`
+replaces with the release tarball's digest at publish time (#283); a tarball
+repacked from the working tree can never match a published sum, so the lane
+applies the same transformation to the staged tarball — it refuses a recipe
+that declares `SKIP`, proves `makepkg --verifysource` rejects a wrong digest,
+then writes the staged file's real digest and requires verification to pass.
+What remains uncovered: the declared `source=` URL is never fetched, so a wrong
+or dead URL still passes here, and the published tarball's true digest is
+computed by CI at publish time rather than asserted in this lane.
 
 Historical note: the first run of this lane caught a genuine shipping bug.
 `check()` runs `cargo test --workspace`, and the `*_non_root` cases in

--- a/test/build-arch-source-package.sh
+++ b/test/build-arch-source-package.sh
@@ -20,18 +20,22 @@
 # Source retrieval runs under the same fail-closed network sandbox the Debian
 # lane uses, so "it did not download" is enforced rather than asserted.
 #
+# ## Integrity
+#
+# dist/PKGBUILD declares a fail-closed placeholder that publish-aur.sh replaces
+# with the release tarball's digest at publish time (#283). A tarball repacked
+# from the working tree can never match a published sum, so this lane applies
+# the same transformation to the staged tarball: it computes the staged file's
+# digest, writes it into the build copy of the recipe, and lets makepkg verify
+# it for real. Before that it proves the check can fail at all, by offering a
+# wrong digest and requiring rejection, and it refuses a recipe that declares
+# SKIP, which is the hole #283 closed.
+#
 # ## What this does NOT verify
 #
-# Integrity. sha256sums is ('SKIP') today (#283), so --verifysource checks no
-# digest: it proves the declared file name resolved offline and nothing more.
-# The declared URL is never fetched either, so a wrong or dead source URL passes
-# here.
-#
-# When #283 replaces SKIP with a real digest this breaks, because a tarball
-# repacked from the working tree cannot match a published sum. The fix is to add
-# --skipchecksums to the staged build below and assert the real digest
-# separately, reading sha256sums directly rather than asking makepkg to validate
-# a tarball it was never going to accept.
+# The declared source URL is never fetched, so a wrong or dead URL passes here.
+# The digest of the published release tarball is computed and substituted by CI
+# at publish time, not asserted here.
 set -euo pipefail
 
 STAGED=${FACELOCK_STAGED_SOURCE:-/staged-source}
@@ -80,6 +84,15 @@ case "$url" in
     *) fail "source is not fetched over https: $url" ;;
 esac
 
+# The recipe must pin its one source: SKIP is the fail-open state #283 removed.
+# The __SRC_SHA256__ placeholder and a real digest are both acceptable here,
+# because either one is replaced with the staged tarball's digest below.
+mapfile -t declared_sums < <(printf '%s\n' "$srcinfo" | sed -n -E 's/^[[:space:]]*sha256sums = //p')
+[ "${#declared_sums[@]}" -eq 1 ] ||
+    fail "expected dist/PKGBUILD to declare exactly one sha256sum, got ${#declared_sums[@]}"
+[ "${declared_sums[0]}" != "SKIP" ] ||
+    fail "dist/PKGBUILD declares sha256sums=('SKIP'); a fixed release tarball must be pinned (#283)"
+
 # A GitHub archive of v<tag> unpacks to <pkgname>-<tag>/, which is what every
 # recipe function cds into. Deriving it from the rename target rather than
 # restating _tag keeps this honest if the recipe's naming changes.
@@ -91,6 +104,28 @@ cp -a -- "$STAGED" "$BUILD/$topdir"
 chown -R "$BUILDER:$BUILDER" "$BUILD/$topdir"
 runuser -u "$BUILDER" -- tar -C "$BUILD" -czf "$BUILD/$tarball" "$topdir"
 rm -rf -- "$BUILD/${topdir:?}"
+
+staged_sum="$(sha256sum "$BUILD/$tarball" | cut -d' ' -f1)"
+
+# Prove the integrity gate bites before relying on it: a digest that cannot
+# match the staged tarball must make --verifysource fail. Flipping the first
+# nibble keeps the value well-formed while guaranteeing a mismatch.
+case "$staged_sum" in
+    0*) wrong_sum="f${staged_sum:1}" ;;
+    *) wrong_sum="0${staged_sum:1}" ;;
+esac
+echo "==> verifying a wrong digest is rejected"
+sed -i "s/^sha256sums=.*/sha256sums=('${wrong_sum}')/" "$BUILD/PKGBUILD"
+chown "$BUILDER:$BUILDER" "$BUILD/PKGBUILD"
+if runuser -u "$BUILDER" -- /run-networkless.sh \
+    bash -c "cd '$BUILD' && makepkg --verifysource --nodeps --noconfirm" >/dev/null 2>&1; then
+    fail "makepkg accepted a tarball whose digest does not match sha256sums"
+fi
+
+# Finalize the staged digest exactly as publish-aur.sh finalizes the shipped
+# recipe, so the verification below checks the sum for real.
+sed -i "s/^sha256sums=.*/sha256sums=('${staged_sum}')/" "$BUILD/PKGBUILD"
+chown "$BUILDER:$BUILDER" "$BUILD/PKGBUILD"
 
 # Refresh the sync database once as root. makepkg --syncdeps below resolves the
 # recipe's own depends and makedepends through pacman against this snapshot.

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -588,6 +588,26 @@ for pkgbuild_name in ("PKGBUILD", "PKGBUILD-bin"):
     require(re.search(r"^_tag=", pkgbuild, re.MULTILINE) is not None, f"dist/{pkgbuild_name} has no upstream _tag")
     require("v$_tag" in pkgbuild, f"dist/{pkgbuild_name} does not fetch the upstream _tag")
 
+# Every Arch recipe installs a binary that dlopens libonnxruntime at runtime
+# (ort's load-dynamic feature), and nothing else in the declared dependency
+# closure provides it, so each must name it in depends (#284).
+for pkgbuild_name in ("PKGBUILD", "PKGBUILD-bin", "PKGBUILD-git"):
+    pkgbuild = (ROOT / "dist" / pkgbuild_name).read_text()
+    depends = re.search(r"^depends=\(([^)]*)\)", pkgbuild, re.MULTILINE)
+    require(depends is not None, f"dist/{pkgbuild_name} has no depends array")
+    require(
+        "'onnxruntime'" in depends.group(1),
+        f"dist/{pkgbuild_name} does not declare the onnxruntime runtime dependency",
+    )
+
+# dist/PKGBUILD fetches a fixed release tarball, so its digest line must be
+# the publish-time placeholder or a pinned digest — never fail-open SKIP (#283).
+pkgbuild_source = (ROOT / "dist" / "PKGBUILD").read_text()
+require(
+    re.search(r"^sha256sums=\('(?:__SRC_SHA256__|[0-9a-f]{64})'\)$", pkgbuild_source, re.MULTILINE) is not None,
+    "dist/PKGBUILD does not pin its source tarball digest",
+)
+
 package_assemblers = (
     "dist/PKGBUILD",
     "dist/PKGBUILD-bin",

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -279,6 +279,10 @@ cp "$repo_root/website/index.html" "$matrix_root/website/"
 cp "$repo_root/test/check-release-matrix.py" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.rpm-e2e" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.rpm-authselect" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.copr" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.fedora" "$matrix_root/test/"
+cp "$repo_root/test/fedora-lane-image.sh" "$matrix_root/test/"
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
 cp "$repo_root/test/packit-config-validate.sh" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.packit" "$matrix_root/test/"
@@ -372,6 +376,14 @@ assert_matrix_mutation_rejected \
     "Packit schema gate image digest pin" \
     "test/Containerfile.packit" \
     's|@sha256:[0-9a-f]*||'
+assert_matrix_mutation_rejected \
+    "PKGBUILD-git dropping the onnxruntime runtime dependency" \
+    "dist/PKGBUILD-git" \
+    "s/ 'onnxruntime'//"
+assert_matrix_mutation_rejected \
+    "PKGBUILD source digest skipped" \
+    "dist/PKGBUILD" \
+    "s/^sha256sums=.*/sha256sums=('SKIP')/"
 
 assert_matrix_payload_mutation_rejected_with_diagnostic() {
     local context="$1"
@@ -807,6 +819,12 @@ case "$apt_guard_output" in
 esac
 
 assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0-alpha.1 unused
+# A stable version with an implausible source digest must be refused before any
+# publish step: a malformed value or the sha256 of empty input is what a silent
+# download failure produces, and neither may become the published pin (#283).
+assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0 not-a-digest
+assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0 \
+    e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 apt_recipe_root="$tmp_root/apt-recipe-root"
 mkdir -p \
@@ -1000,6 +1018,9 @@ assert_file_line "$release_repo/Cargo.toml" 'version = "0.2.0-alpha.1"'
 assert_file_line "$release_repo/dist/PKGBUILD" '_tag=0.2.0-alpha.1'
 assert_file_line "$release_repo/dist/PKGBUILD" 'pkgver=0.2.0alpha1'
 assert_file_line "$release_repo/dist/PKGBUILD" 'pkgrel=1'
+# The release bump must leave the source digest placeholder for publish-aur.sh
+# to finalize — never SKIP, never a stale digest for the old tag (#283).
+assert_file_line "$release_repo/dist/PKGBUILD" "sha256sums=('__SRC_SHA256__')"
 assert_file_line "$release_repo/dist/PKGBUILD-bin" '_tag=0.2.0-alpha.1'
 assert_file_line "$release_repo/dist/PKGBUILD-bin" 'pkgver=0.2.0alpha1'
 assert_file_line "$release_repo/dist/facelock.spec" 'Version:        0.2.0'


### PR DESCRIPTION
## Summary

- add `onnxruntime` to `dist/PKGBUILD-git` depends and optdepends, matching the other two recipes
- replace `sha256sums=('SKIP')` in `dist/PKGBUILD` with a fail-closed `__SRC_SHA256__` placeholder, finalized by `publish-aur.sh` at publish
- refuse a malformed or empty-input checksum in the publisher; fetch the release tarball with `curl -f`
- teach the Arch e2e lane to reject `SKIP`, prove a wrong digest fails `--verifysource`, then verify the staged tarball's real digest
- guard both contracts in the matrix checker, with contract-test mutations proving the gates bite
- copy the four files the matrix checker reads since 6e00813 into the contract fixture; their absence failed `test/release-version-contract.sh` on main

## Why

`ort` builds with `load-dynamic`, so libonnxruntime is dlopened at first authentication rather than linked at build time: `facelock-git`, the recipe Omarchy's installer pulls, installed cleanly on a machine with no ONNX Runtime and failed at first login. `dist/PKGBUILD` was the one fetched artifact in the project trusted without a digest, and the tagged tree cannot carry its own tarball's sum, so the pin follows the `PKGBUILD-bin` convention: placeholder in-repo, real digest substituted at publish.

## Validation

- `just check`
- `just test-arch-pkg`
- `bash test/release-version-contract.sh`
- `python3 test/check-release-matrix.py`
- `makepkg --verifysource` against a corrupted tarball, with the old `SKIP` recipe and with a pinned digest

Fixes #283
Fixes #284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened Arch and AUR package integrity checks with required, validated SHA-256 checksums.
  - Release publishing now fails clearly when downloads fail or checksum data is invalid.
  - Arch package variants consistently include the required runtime dependency.

- **Documentation**
  - Updated packaging, release, and testing guidance for checksum verification and publish-time substitution.
  - Clarified remaining package-testing limitations, including source URL and system startup coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->