### PR TITLE
test(cli): pin enroll's root gate and stop skipping under root

### DIFF
--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -184,22 +184,113 @@ mod tests {
         config
     }
 
+    /// The uid/gid a root test runner drops the child to, matching
+    /// `tests/cli_smoke.rs`. `setuid`/`setgid` do not consult `/etc/passwd`,
+    /// so the account need not exist inside a CI container.
+    const NOBODY_UID: u32 = 65534;
+    const NOBODY_GID: u32 = 65534;
+
+    /// Set in the re-executed copy of this test binary, to tell it that it is
+    /// the child and should run the assertion rather than spawn again.
+    const BACKSTOP_CHILD_VAR: &str = "FACELOCK_TEST_ENROLL_BACKSTOP_CHILD";
+
+    /// The line the child prints once the refusal has held, with the uid it
+    /// held under. libtest exits 0 when a filter matches nothing, so a
+    /// successful child status is not on its own evidence that anything ran.
+    const BACKSTOP_WITNESS: &str = "enroll backstop refused as uid";
+
     /// Issue #288: the backstop at the top of [`run`] is the whole defense
     /// for callers that bypass `main`'s gate, and `setup` is one — it calls
     /// `run` directly, behind a precheck that is conditional on
     /// `plan.base.is_some()`. Nothing about the gate's exhaustive match
     /// would notice a future standalone plan enrolling unprivileged.
     ///
-    /// The store path is a temp dir that must survive untouched: the refusal
-    /// has to land ahead of every read `run` would otherwise do.
+    /// `run` is called in-process, so unlike the rows in `tests/cli_smoke.rs`
+    /// there is no child to drop privileges on — and a test that returned
+    /// early under a root runner would assert nothing in CI, where both test
+    /// jobs are root in a container (issues #189, #303). So this re-executes
+    /// the test binary at itself and drops *that* child, which puts the
+    /// assertion back under the same rule every spawning row follows.
+    ///
+    /// The re-exec is unconditional. A branch that only spawned under root
+    /// would leave the path CI takes as the one path no developer ever runs,
+    /// which is the shape of the bug being fixed.
     #[test]
     fn run_refuses_a_non_root_caller_on_its_own() {
-        if nix::unistd::Uid::effective().is_root() {
-            eprintln!("skipping: as root the backstop passes, which is its job");
+        if std::env::var_os(BACKSTOP_CHILD_VAR).is_some() {
+            backstop_assertion();
             return;
         }
 
-        let dir = tempfile::tempdir().unwrap();
+        // Derived rather than spelled out, so moving the module does not
+        // silently turn the filter into a no-match. libtest names a test by
+        // its module path with the crate root stripped.
+        let module = module_path!()
+            .split_once("::")
+            .map_or(module_path!(), |(_, rest)| rest);
+        let test_name = format!("{module}::run_refuses_a_non_root_caller_on_its_own");
+
+        let mut command = std::process::Command::new(
+            std::env::current_exe().expect("path to the running test binary"),
+        );
+        command
+            .args([&test_name, "--exact", "--nocapture"])
+            .env(BACKSTOP_CHILD_VAR, "1")
+            .stdin(std::process::Stdio::null());
+
+        let dropped_privileges = nix::unistd::Uid::effective().is_root();
+        if dropped_privileges {
+            use std::os::unix::process::CommandExt;
+            command.uid(NOBODY_UID).gid(NOBODY_GID);
+        }
+
+        let output = command.output().unwrap_or_else(|e| {
+            let hint = if dropped_privileges {
+                format!(
+                    "\nA root test runner re-execs this test as uid {NOBODY_UID}, so the \
+                     test binary and every directory above it must be traversable and \
+                     executable by other users — mode 0755, not 0700."
+                )
+            } else {
+                String::new()
+            };
+            panic!("failed to re-exec the test binary: {e}{hint}");
+        });
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        let uid: u32 = stdout
+            .lines()
+            .find_map(|line| line.trim().strip_prefix(BACKSTOP_WITNESS))
+            .and_then(|rest| rest.trim().parse().ok())
+            .unwrap_or_else(|| {
+                panic!(
+                    "the child never reached the assertion — a renamed test makes \
+                     `--exact {test_name}` match nothing, and libtest reports that as \
+                     a pass:\nstdout: {stdout}\nstderr: {stderr}"
+                )
+            });
+
+        assert!(
+            output.status.success(),
+            "the re-executed backstop assertion failed:\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_ne!(
+            uid, 0,
+            "the assertion ran as root, where the backstop passes by design and \
+             witnesses nothing:\nstdout: {stdout}"
+        );
+    }
+
+    /// The assertion proper, run only in the re-executed child.
+    ///
+    /// The store path is a temp dir that must survive untouched: the refusal
+    /// has to land ahead of every read `run` would otherwise do.
+    fn backstop_assertion() {
+        // `/tmp` is world-writable, so this holds for the dropped child too;
+        // a `TMPDIR` only root can write would defeat it.
+        let dir = tempfile::tempdir().expect("a temp dir the current uid can create");
         let db_path = dir.path().join("facelock.db");
         let config = oneshot_config_with_db(&db_path);
 
@@ -221,6 +312,11 @@ mod tests {
         assert!(
             !db_path.exists(),
             "the refusal must precede every store access"
+        );
+
+        println!(
+            "{BACKSTOP_WITNESS} {}",
+            nix::unistd::Uid::effective().as_raw()
         );
     }
 

--- a/crates/facelock-cli/src/commands/enroll.rs
+++ b/crates/facelock-cli/src/commands/enroll.rs
@@ -6,10 +6,11 @@ use crate::backend::Backend;
 use crate::ipc_client;
 use crate::message::{FaceMessage, Terminal, fail};
 
-/// The escalation hint `main`'s root gate (C6) names for `enroll`. When the
-/// setup marker is absent (and `--skip-setup-check` not given), the remedy
-/// the refusal names is `setup` — the command [`run`] will offer to execute
-/// it — rather than `enroll` itself.
+/// The escalation hint `enroll`'s two root checks name — `main`'s gate (C6)
+/// and [`run`]'s own backstop. When the setup marker is absent (and
+/// `--skip-setup-check` not given), the remedy the refusal names is `setup`
+/// — the command [`run`] will offer to execute it — rather than `enroll`
+/// itself.
 pub fn sudo_hint(skip_setup_check: bool) -> &'static str {
     if !skip_setup_check && !std::path::Path::new(super::setup::SETUP_COMPLETE_MARKER).exists() {
         "sudo facelock setup"
@@ -24,10 +25,23 @@ pub fn run(
     label: Option<String>,
     skip_setup_check: bool,
 ) -> anyhow::Result<()> {
-    // Root is established by `main`'s `require_root_for` gate, ahead of the
-    // config parse (C6, issue #191); `sudo_hint` below picks the spelling
-    // that gate escalates with.
+    // Belt and braces on `main`'s `require_root_for` gate, which establishes
+    // root ahead of the config parse and owns the interactive escalation
+    // (C6, issue #191). This second check is for the callers that never
+    // reach that gate: `setup` invokes `run` directly, from the wizard's
+    // step 7 and from `--enroll`. Those are covered today only by
+    // `run_with_plan`'s precheck, which is conditional on
+    // `plan.base.is_some()` — a future standalone plan that enrolled would
+    // walk straight past it, and the gate would never see the command at
+    // all. Under root, which is every path that exists now, this costs one
+    // `getuid` (issue #288).
     //
+    // Hard-error class deliberately, where the gate's is interactive: the
+    // gate already offered the sudo re-exec for the CLI spelling, and
+    // re-execing `facelock enroll` from inside a half-finished `setup` would
+    // resume the wrong command.
+    ipc_client::require_root_scripted(sudo_hint(skip_setup_check))?;
+
     // Setup gate: prompt user if setup hasn't been run.
     // Setup includes model downloads, encryption, and face enrollment,
     // so if setup runs successfully we're done — no need to enroll again.
@@ -168,6 +182,46 @@ mod tests {
         let mut config = Config::parse("[daemon]\nmode = \"oneshot\"\n").expect("config parses");
         config.storage.db_path = db_path.to_string_lossy().into_owned();
         config
+    }
+
+    /// Issue #288: the backstop at the top of [`run`] is the whole defense
+    /// for callers that bypass `main`'s gate, and `setup` is one — it calls
+    /// `run` directly, behind a precheck that is conditional on
+    /// `plan.base.is_some()`. Nothing about the gate's exhaustive match
+    /// would notice a future standalone plan enrolling unprivileged.
+    ///
+    /// The store path is a temp dir that must survive untouched: the refusal
+    /// has to land ahead of every read `run` would otherwise do.
+    #[test]
+    fn run_refuses_a_non_root_caller_on_its_own() {
+        if nix::unistd::Uid::effective().is_root() {
+            eprintln!("skipping: as root the backstop passes, which is its job");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let config = oneshot_config_with_db(&db_path);
+
+        // `skip_setup_check: true` takes the branch with no prompt in it, so
+        // a regression that dropped the check runs on to a file read rather
+        // than blocking on stdin.
+        let err = run(
+            &config,
+            Some("nonexistent-test-user".to_string()),
+            None,
+            true,
+        )
+        .expect_err("enroll::run must refuse a non-root caller without help from main");
+
+        assert!(
+            err.to_string().contains("Root required"),
+            "expected the root refusal, got: {err}"
+        );
+        assert!(
+            !db_path.exists(),
+            "the refusal must precede every store access"
+        );
     }
 
     /// `Absent` vs everything else at the pre-enrollment reads: a fresh

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -13,6 +13,48 @@ fn facelock_bin() -> Command {
 const NOBODY_UID: u32 = 65534;
 const NOBODY_GID: u32 = 65534;
 
+/// Make `command` run unprivileged whatever the test runner's own uid is:
+/// under a root runner it drops to `nobody` before `exec`. Returns whether
+/// the drop was applied, which only the failure hint needs.
+///
+/// Every row in this file that spawns a process goes through here, including
+/// the two pty rows. Rows used to return early under a root runner instead,
+/// which is how this contract ended up with no CI coverage at all — both CI
+/// test jobs run `cargo test` as root in a container, so a skipping row was a
+/// no-op that reported as a pass (issues #189, #303).
+///
+/// Dropping cannot regress the way skipping did: `setuid(2)` from root
+/// replaces the saved uid as well, and the standard library clears root's
+/// supplementary groups ahead of it, so a row that runs at all ran
+/// unprivileged. No environment variable, workflow step, or runner user
+/// decides that.
+///
+/// A pty survives the drop. Both ends are opened by the parent, before the
+/// fork, so the kernel's permission check on the device is already done and
+/// the child inherits open descriptors rather than reopening them by path.
+/// `openpty` chowning the device to the invoking user therefore does not
+/// keep the dropped child from reading its own queued input.
+fn run_unprivileged(command: &mut Command) -> bool {
+    if nix::unistd::Uid::effective().is_root() {
+        command.uid(NOBODY_UID).gid(NOBODY_GID);
+        return true;
+    }
+    false
+}
+
+/// What to add to a spawn failure when the drop was applied: at uid 65534 the
+/// child must be able to reach and execute the binary it was pointed at.
+fn spawn_hint(dropped_privileges: bool) -> String {
+    if !dropped_privileges {
+        return String::new();
+    }
+    format!(
+        "\nA root test runner runs this row as uid {NOBODY_UID}, so the built \
+         binary and every directory above it must be traversable and executable \
+         by other users — mode 0755, not 0700."
+    )
+}
+
 /// DEC-6/C6 contract: every root-required command must refuse *before*
 /// emitting any prompt text or touching state, when invoked non-root with no
 /// TTY attached. Closing stdin (rather than leaving it inherited) forces
@@ -27,35 +69,18 @@ const NOBODY_GID: u32 = 65534;
 /// split needs a row that allocates a real pty, which is a separate concern.
 ///
 /// The child always runs unprivileged, whatever the test runner's own uid is:
-/// under a root runner it drops to `nobody` before `exec`. The row used to
-/// return early there instead, which is how this contract ended up with no CI
-/// coverage at all — both CI test jobs run `cargo test` as root in a
-/// container, so all 18 rows were no-ops that reported as passes (issue
-/// #189). Dropping cannot regress the way skipping did: `setuid(2)` from root
-/// replaces the saved uid as well, and the standard library clears root's
-/// supplementary groups ahead of it, so a row that runs at all ran
-/// unprivileged. No environment variable, workflow step, or runner user
-/// decides that.
+/// see [`run_unprivileged`], which every spawning row in this file goes
+/// through.
 fn assert_refuses_before_output(args: &[&str], forbidden_substrings: &[&str]) {
     let mut command = facelock_bin();
     command.args(args).stdin(Stdio::null());
-
-    let dropped_privileges = nix::unistd::Uid::effective().is_root();
-    if dropped_privileges {
-        command.uid(NOBODY_UID).gid(NOBODY_GID);
-    }
+    let dropped_privileges = run_unprivileged(&mut command);
 
     let output = command.output().unwrap_or_else(|e| {
-        let hint = if dropped_privileges {
-            format!(
-                "\nA root test runner runs this row as uid {NOBODY_UID}, so the built \
-                 binary and every directory above it must be traversable and executable \
-                 by other users — mode 0755, not 0700."
-            )
-        } else {
-            String::new()
-        };
-        panic!("failed to execute facelock {args:?}: {e}{hint}");
+        panic!(
+            "failed to execute facelock {args:?}: {e}{}",
+            spawn_hint(dropped_privileges)
+        );
     });
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -218,26 +243,37 @@ fn open_pty() -> (std::fs::File, std::fs::File) {
 /// regression to `require_root` here does not fail fast: it blocks forever on
 /// a prompt nobody will answer, which is why the wait is bounded and a
 /// timeout is the assertion.
+///
+/// Like every other row here it drops to `nobody` under a root runner rather
+/// than returning early. As root `daemon run` would start the daemon instead
+/// of refusing, so skipping was the only alternative — and skipping is what
+/// left this row with no CI coverage (issue #303).
 #[test]
 fn daemon_run_never_prompts_with_a_tty_attached() {
     use std::io::Read;
     use std::time::{Duration, Instant};
 
-    if nix::unistd::Uid::effective().is_root() {
-        eprintln!("skipping: as root `daemon run` starts the daemon instead of refusing");
-        return;
-    }
-
     let (mut controller, device) = open_pty();
-    let mut child = facelock_bin()
+    let mut command = facelock_bin();
+    command
         .args(["daemon", "run"])
         .stdin(Stdio::from(device.try_clone().expect("dup pty device")))
         .stdout(Stdio::from(device.try_clone().expect("dup pty device")))
-        // The parent keeps no device fd, so reads on the controller see EOF
-        // once the child exits rather than hanging on an open write end.
-        .stderr(Stdio::from(device))
-        .spawn()
-        .expect("failed to spawn facelock daemon run");
+        .stderr(Stdio::from(device));
+    let dropped_privileges = run_unprivileged(&mut command);
+
+    let spawned = command.spawn();
+    // Drop the parent's copies of the device fds now that the child holds
+    // them. `Command` owns its `Stdio` handles until it is itself dropped, so
+    // a `Command` that outlives the spawn keeps a write end of the device
+    // open here and `read_to_end` on the controller below never sees EOF.
+    drop(command);
+    let mut child = spawned.unwrap_or_else(|e| {
+        panic!(
+            "failed to spawn facelock daemon run: {e}{}",
+            spawn_hint(dropped_privileges)
+        )
+    });
 
     let deadline = Instant::now() + Duration::from_secs(30);
     let status = loop {
@@ -330,6 +366,10 @@ fn enroll_refuses_before_setup_prompt_non_root() {
 /// `--config` points at nothing for the same reason the row above does: the
 /// backstop inside `enroll::run` must not be able to answer for the gate.
 ///
+/// Under a root runner it drops to `nobody` like every other row rather than
+/// returning early: as root `enroll` opens the camera instead of refusing,
+/// and skipping is what left this row with no CI coverage (issue #303).
+///
 /// The child is given an empty `PATH` so this row can never escalate for
 /// real. The answer written to the pty is "n", but if the parser ever read
 /// that as consent, `Command::new("sudo")` fails to spawn instead of
@@ -340,18 +380,14 @@ fn enroll_offers_the_sudo_re_exec_with_a_tty_attached() {
     use std::io::{Read, Write};
     use std::time::{Duration, Instant};
 
-    if nix::unistd::Uid::effective().is_root() {
-        eprintln!("skipping: as root `enroll` opens the camera instead of refusing");
-        return;
-    }
-
     let (mut controller, device) = open_pty();
     // Queued in the tty's input buffer before the child exists, so the prompt
     // cannot race ahead of the answer and read EOF — which
     // `confirm_default_yes` would take as the default *yes*.
     controller.write_all(b"n\n").expect("write answer to pty");
 
-    let mut child = facelock_bin()
+    let mut command = facelock_bin();
+    command
         .args([
             "--config",
             "/nonexistent/facelock-enroll-c6.toml",
@@ -363,9 +399,21 @@ fn enroll_offers_the_sudo_re_exec_with_a_tty_attached() {
         .env("PATH", "")
         .stdin(Stdio::from(device.try_clone().expect("dup pty device")))
         .stdout(Stdio::from(device.try_clone().expect("dup pty device")))
-        .stderr(Stdio::from(device))
-        .spawn()
-        .expect("failed to spawn facelock enroll");
+        .stderr(Stdio::from(device));
+    let dropped_privileges = run_unprivileged(&mut command);
+
+    let spawned = command.spawn();
+    // Drop the parent's copies of the device fds now that the child holds
+    // them. `Command` owns its `Stdio` handles until it is itself dropped, so
+    // a `Command` that outlives the spawn keeps a write end of the device
+    // open here and `read_to_end` on the controller below never sees EOF.
+    drop(command);
+    let mut child = spawned.unwrap_or_else(|e| {
+        panic!(
+            "failed to spawn facelock enroll: {e}{}",
+            spawn_hint(dropped_privileges)
+        )
+    });
 
     let deadline = Instant::now() + Duration::from_secs(30);
     let status = loop {

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -277,6 +277,132 @@ fn daemon_run_never_prompts_with_a_tty_attached() {
 }
 
 #[test]
+fn enroll_refuses_before_setup_prompt_non_root() {
+    // C6: `enroll` was the one gated spelling with no row at all — its
+    // ordering rested entirely on the gate's exhaustive match in `main`, so
+    // nothing failed if the arm went missing (issue #288).
+    //
+    // `--config` at a path that does not exist is what makes this row bite,
+    // and it is the one difference from the rows above. `enroll::run` now
+    // re-checks root itself, as a backstop for the callers inside `setup`
+    // that never reach the gate — so with a readable config on the machine,
+    // a deleted gate arm would still produce "Root required", just one parse
+    // too late. Pointing at nothing means only the gate can answer first:
+    // reaching the parse renders a config error instead (issue #191).
+    //
+    // Which branch `enroll` opens with depends on `/etc/facelock/.setup-complete`,
+    // a property of the machine running the test, so the forbidden list
+    // covers both: the marker-absent branch prints "Setup has not been
+    // completed." and asks to run setup, the marker-present one goes to the
+    // encryption posture check and the model probe.
+    assert_refuses_before_output(
+        &[
+            "--config",
+            "/nonexistent/facelock-enroll-c6.toml",
+            "enroll",
+            "--user",
+            "nonexistent-test-user",
+        ],
+        &[
+            "Setup has not been completed",
+            "Run setup now?",
+            "WARNING: encryption.method",
+            "Face recognition models not found",
+            "Enrolling face for user",
+        ],
+    );
+}
+
+/// DEC-6: `enroll` is the **interactive** escalation class — with a terminal
+/// attached it offers `Re-run with sudo? [Y/n]` before it refuses, the
+/// opposite of `daemon run` above.
+///
+/// The stdin-closed rows cannot witness that. `require_root` and
+/// `require_root_scripted` share the non-interactive branch, so silently
+/// downgrading `enroll`'s arm to the hard-error class passes every one of
+/// them. Only a real pty separates the two (issue #288).
+///
+/// `--skip-setup-check` pins the hint: without it `sudo_hint` names `setup`
+/// or `enroll` depending on whether the setup marker exists on the machine
+/// running the test, and the assertion below would be reading the host
+/// rather than the code.
+///
+/// `--config` points at nothing for the same reason the row above does: the
+/// backstop inside `enroll::run` must not be able to answer for the gate.
+///
+/// The child is given an empty `PATH` so this row can never escalate for
+/// real. The answer written to the pty is "n", but if the parser ever read
+/// that as consent, `Command::new("sudo")` fails to spawn instead of
+/// enrolling a face as root — and the assertions below fail loudly rather
+/// than the row passing by accident.
+#[test]
+fn enroll_offers_the_sudo_re_exec_with_a_tty_attached() {
+    use std::io::{Read, Write};
+    use std::time::{Duration, Instant};
+
+    if nix::unistd::Uid::effective().is_root() {
+        eprintln!("skipping: as root `enroll` opens the camera instead of refusing");
+        return;
+    }
+
+    let (mut controller, device) = open_pty();
+    // Queued in the tty's input buffer before the child exists, so the prompt
+    // cannot race ahead of the answer and read EOF — which
+    // `confirm_default_yes` would take as the default *yes*.
+    controller.write_all(b"n\n").expect("write answer to pty");
+
+    let mut child = facelock_bin()
+        .args([
+            "--config",
+            "/nonexistent/facelock-enroll-c6.toml",
+            "enroll",
+            "--user",
+            "nonexistent-test-user",
+            "--skip-setup-check",
+        ])
+        .env("PATH", "")
+        .stdin(Stdio::from(device.try_clone().expect("dup pty device")))
+        .stdout(Stdio::from(device.try_clone().expect("dup pty device")))
+        .stderr(Stdio::from(device))
+        .spawn()
+        .expect("failed to spawn facelock enroll");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        match child.try_wait().expect("try_wait on facelock enroll") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("`facelock enroll` never exited as a non-root user with a TTY attached");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+
+    let mut raw = Vec::new();
+    let _ = controller.read_to_end(&mut raw);
+    let out = String::from_utf8_lossy(&raw);
+
+    assert!(!status.success(), "should refuse non-root, got: {status}");
+    assert!(
+        out.contains("Re-run with sudo"),
+        "`enroll` must offer the interactive re-exec on a TTY (expected \
+         require_root, not require_root_scripted), got: {out}"
+    );
+    // Asserted without the preceding newline: the pty translates it to CRLF.
+    assert!(out.contains("Run: sudo facelock enroll"), "got: {out}");
+    assert!(
+        !out.contains("failed to execute sudo"),
+        "declining the prompt must refuse, never escalate, got: {out}"
+    );
+    assert!(
+        !out.contains("Enrolling face for user"),
+        "the root check must run before anything else, got: {out}"
+    );
+}
+
+#[test]
 fn list_refuses_before_root_non_root() {
     assert_refuses_before_output(
         &["list", "--user", "nonexistent-test-user"],

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1830,6 +1830,16 @@ with a terminal attached (issue #188), and `enroll` must always print it
 exist, so its own backstop cannot answer in the gate's place and pass a row
 that the gate should have failed.
 
+**Dropping, never skipping.** Every one of those rows drops the process it
+spawns to uid 65534 under a root runner, the pty rows included: a pty is
+opened by the parent before the fork, so the child inherits descriptors the
+kernel has already granted and can still read its own queued input after the
+drop. The backstop test in `commands::enroll` calls `run` in-process, where
+there is no child to drop, so it re-executes the test binary at itself and
+drops that. None of these return early under root. A test that skips on the
+one configuration CI runs is a test that asserts nothing while reporting a
+pass, which is how this contract lost its coverage twice (issues #189, #303).
+
 **AccessDenied hint.** A D-Bus `AccessDenied` reply carries one actionable
 hint (`ipc_client::add_access_denied_hint`): root is required. Since almost
 every D-Bus method is root-only (see IPC Protocol below) and, under ADR 010,

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1823,7 +1823,12 @@ there reported as a pass while asserting nothing (issue #189). They close
 stdin, so what they witness is that the refusal preceded the output, not
 which of DEC-6's two escalation classes produced it; `require_root` and
 `require_root_scripted` share one non-interactive branch and are
-indistinguishable to them.
+indistinguishable to them. Two commands carry a second row that allocates a
+real pty and does pin the class: `daemon run` must never print the prompt
+with a terminal attached (issue #188), and `enroll` must always print it
+(issue #288). `enroll`'s rows also pass `--config` at a path that does not
+exist, so its own backstop cannot answer in the gate's place and pass a row
+that the gate should have failed.
 
 **AccessDenied hint.** A D-Bus `AccessDenied` reply carries one actionable
 hint (`ipc_client::add_access_denied_hint`): root is required. Since almost

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1808,6 +1808,14 @@ holds the unresolved load so a broken config renders as a finding in its
 report, and its own root check still runs before its first line of output —
 the read alone has no user-visible effect ahead of the refusal.
 
+`enroll` carries the check in **both** places. `main`'s gate is what
+enforces the ordering above — root decided before the config parse — and
+`enroll::run` re-checks on entry, as a hard error, because `setup` calls it
+directly and `run_with_plan`'s precheck is conditional on a base flow
+running. The second check is unreachable on every path that exists today; it
+is there so a future setup path that enrolls cannot do so unprivileged by
+omission (issue #288).
+
 The rows in `crates/facelock-cli/tests/cli_smoke.rs` pin this ordering per
 gated command. They run the binary unprivileged even under a root test
 runner: both CI test jobs are root in a container, and a row that skipped


### PR DESCRIPTION
## Summary

- add the C6 ordering row for `enroll`, the one gated spelling that had none
- point that row's `--config` at a path that does not exist, so only the central gate can answer first
- add a pty row pinning `enroll` to the interactive escalation class, the shape #262 used for `daemon run`
- re-check root on entry to `enroll::run`, hard-error class, for the `setup` callers that never reach the gate
- drop the spawned child to uid 65534 in both pty rows instead of returning early under a root runner
- re-execute the test binary at itself for the backstop test, which calls `run` in-process and had no child to drop

## Why

`enroll`'s ordering rested entirely on `require_root_for`'s exhaustive match, so
neutering the arm failed nothing. It also lost its in-command check when the
checks moved into the central gate, and `setup` still calls `enroll::run`
directly, behind a precheck conditional on a base flow running. Nothing reaches
it ungated today, but a future standalone plan that enrolled would, silently.

Every test added here would then have skipped on the one configuration CI runs.
Both CI test jobs are root in a container, and a row that returns early there
asserts nothing while reporting a pass, which is the defect #189 already fixed
once for the stdin-closed rows.

The two halves interact, which is why the rows pin `--config`: with a readable
config on the machine, the backstop answers "Root required" for a gate arm that
is already gone, one parse too late.

## Validation

- `just check`
- the smoke suite and the lib tests as a non-root user, and again as uid 0 in a user namespace where 65534 is mapped, which is what a root CI runner sees
- mutation checks under both uids, against the rows meant to catch them: neutering the gate arm, downgrading it to `require_root_scripted`, dropping the in-command check, and renaming the re-executed test so its filter matches nothing

Fixes #288
Fixes #303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enrollment now consistently requires administrator privileges before accessing configuration or enrollment data.
  - Non-administrator attempts are rejected early, including enrollment paths launched through setup.
  - Interactive terminal sessions can offer sudo re-execution, while declining the prompt safely cancels enrollment.
  - Enrollment refuses to prompt when run non-interactively, such as through the daemon.
  - Improved handling of enrollment commands in automated and terminal-based environments.

- **Documentation**
  - Clarified administrator requirements and privilege-check behavior for enrollment commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->