### PR TITLE
fix(security): wipe remaining decrypted embedding paths

### DIFF
--- a/crates/facelock-bench/src/main.rs
+++ b/crates/facelock-bench/src/main.rs
@@ -424,7 +424,11 @@ fn cmd_calibrate() -> Result<()> {
     let num_test_frames = 10u32;
     println!("Capturing {} test frames from camera...", num_test_frames);
 
-    let mut live_embeddings: Vec<FaceEmbedding> = Vec::new();
+    // Live-capture probe embeddings are biometric data like the stored set
+    // above: accumulated inside the guard, zeroized when it drops — bails,
+    // panics and buffer growth included (#269).
+    let mut live_embeddings: Wiped<Vec<FaceEmbedding>, FaceEmbedding> =
+        Wiped::with_capacity(num_test_frames as usize);
     for _ in 0..num_test_frames {
         let frame = camera.capture().context("Failed to capture frame")?;
         let faces = engine.process(&frame)?;
@@ -445,7 +449,7 @@ fn cmd_calibrate() -> Result<()> {
 
     // Compute all similarities between live and enrolled embeddings
     let mut similarities: Vec<f32> = Vec::new();
-    for live_emb in &live_embeddings {
+    for live_emb in live_embeddings.iter() {
         for (_, enrolled_emb) in enrolled.iter() {
             similarities.push(cosine_similarity(live_emb, enrolled_emb));
         }

--- a/crates/facelock-cli/src/commands/bench.rs
+++ b/crates/facelock-cli/src/commands/bench.rs
@@ -381,7 +381,11 @@ fn cmd_calibrate(config: &Config) -> Result<()> {
     let num_test_frames = 10u32;
     println!("Capturing {} test frames from camera...", num_test_frames);
 
-    let mut live_embeddings: Vec<FaceEmbedding> = Vec::new();
+    // Live-capture probe embeddings are biometric data like the stored set
+    // above: accumulated inside the guard, zeroized when it drops — bails,
+    // panics and buffer growth included (#269).
+    let mut live_embeddings: Wiped<Vec<FaceEmbedding>, FaceEmbedding> =
+        Wiped::with_capacity(num_test_frames as usize);
     for _ in 0..num_test_frames {
         let frame = camera.capture().context("Failed to capture frame")?;
         let faces = engine.process(&frame)?;
@@ -402,7 +406,7 @@ fn cmd_calibrate(config: &Config) -> Result<()> {
 
     // Compute all similarities between live and enrolled embeddings
     let mut similarities: Vec<f32> = Vec::new();
-    for live_emb in &live_embeddings {
+    for live_emb in live_embeddings.iter() {
         for (_, enrolled_emb) in enrolled.iter() {
             similarities.push(cosine_similarity(live_emb, enrolled_emb));
         }

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -184,9 +184,14 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
         );
 
         for (id, _user, blob, _sealed) in &sw_encrypted {
-            let raw = sealer
-                .unseal_bytes(blob)
-                .with_context(|| format!("failed to decrypt software-encrypted embedding {id}"))?;
+            // Unsealed plaintext template bytes, zeroized when `raw` drops —
+            // the store-update error path included (#293). `Zeroizing`, not
+            // `Wiped`: that guard is typed for embedding sets, and raw byte
+            // buffers already implement `Zeroize`.
+            let raw =
+                zeroize::Zeroizing::new(sealer.unseal_bytes(blob).with_context(|| {
+                    format!("failed to decrypt software-encrypted embedding {id}")
+                })?);
 
             store
                 .update_embedding_sealed(*id, &raw, false)
@@ -206,9 +211,11 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
                 .context("failed to initialize TPM for unsealing")?;
 
             for (id, _user, blob, _sealed) in &tpm_sealed {
-                let raw = tpm
-                    .unseal_bytes(blob)
-                    .with_context(|| format!("failed to unseal TPM embedding {id}"))?;
+                // Same wipe-on-drop as the software branch above (#293).
+                let raw = zeroize::Zeroizing::new(
+                    tpm.unseal_bytes(blob)
+                        .with_context(|| format!("failed to unseal TPM embedding {id}"))?,
+                );
 
                 store
                     .update_embedding_sealed(*id, &raw, false)

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -189,10 +189,15 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
     let models = store
         .list_models(user)
         .context("storage error listing face models")?;
-    // Load embeddings with encryption support, matching the daemon handler
-    // path — and matching its ordering: the plaintext load comes LAST, after
-    // every other fallible call, so no `?` between here and the wiping callee
-    // below can drop the decrypted set unwiped (#293).
+    // Load embeddings with encryption support (the daemon handler's own
+    // decrypt path), and load them LAST, after every other fallible call, so
+    // no `?` between here and the wiping callee below can drop the decrypted
+    // set unwiped (#293). The daemon deliberately orders this the other way:
+    // it loads *before* opening the camera so every LED-on millisecond goes
+    // to analyzed frames (ADR 008 §1), and pays for that with a hand-wipe on
+    // its camera-acquire error path (`handle_authenticate_prechecked`). This
+    // path already holds the camera, so it takes the ordering that needs no
+    // hand-wipe — do not "align" it with the daemon without adding one.
     let mut stored = load_user_embeddings(&store, config, user)?;
 
     // Shared with daemon mode (crates/facelock-daemon/src/auth.rs). A local copy

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -183,14 +183,17 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
     let mut camera = open_resolved_camera(config, resolved, CameraPurpose::Authentication)?;
     let mut engine = load_engine(config)?;
 
-    // Load embeddings with encryption support, matching the daemon handler path.
-    let mut stored = load_user_embeddings(&store, config, user)?;
     // Same shape as the daemon's `handle_authenticate` (C3): a storage failure
     // is an error, not an empty model list that guarantees "no match". No
     // rate-limit charge exists on this path, but the falsehood is the same.
     let models = store
         .list_models(user)
         .context("storage error listing face models")?;
+    // Load embeddings with encryption support, matching the daemon handler
+    // path — and matching its ordering: the plaintext load comes LAST, after
+    // every other fallible call, so no `?` between here and the wiping callee
+    // below can drop the decrypted set unwiped (#293).
+    let mut stored = load_user_embeddings(&store, config, user)?;
 
     // Shared with daemon mode (crates/facelock-daemon/src/auth.rs). A local copy
     // of this loop previously lived here and silently drifted — do not re-fork it.

--- a/crates/facelock-core/src/types.rs
+++ b/crates/facelock-core/src/types.rs
@@ -60,50 +60,132 @@ pub fn zeroize_stored_embeddings(stored: &mut [(u32, FaceEmbedding)]) {
     }
 }
 
+/// Slice elements the [`Wiped`] guard knows how to zeroize in place.
+///
+/// Exists because `zeroize::Zeroize` cannot cover `(u32, FaceEmbedding)` — a
+/// foreign tuple whose id half is not secret. Implement it only for embedding
+/// shapes; a buffer whose element type already implements `Zeroize` (raw
+/// template bytes, say) belongs in `zeroize::Zeroizing`, not here.
+pub trait WipeElement {
+    /// Zeroize the sensitive part of this element in place.
+    fn wipe(&mut self);
+}
+
+/// A stored-template entry: the model id stays readable, the embedding wipes.
+impl WipeElement for (u32, FaceEmbedding) {
+    fn wipe(&mut self) {
+        self.1.zeroize();
+    }
+}
+
+/// A bare embedding — live-capture probe sets hold these (#269).
+impl WipeElement for FaceEmbedding {
+    fn wipe(&mut self) {
+        self.zeroize();
+    }
+}
+
 /// Plaintext embeddings wiped when the guard leaves scope — on every return
 /// path *and* on an unwind, which hand-written per-return-site wipes cannot
 /// cover (D11).
 ///
 /// Generic over how the plaintext is held so the one guard covers every
 /// holder in the workspace: a caller's buffer (`&mut [_]`, borrowed) and an
-/// owned set (`Vec<_>`). `zeroize`'s own `Zeroizing` cannot: it needs
-/// `T: Zeroize`, which `(u32, FaceEmbedding)` is not.
+/// owned set (`Vec<_>`) — and over the element ([`WipeElement`]) so stored
+/// `(u32, FaceEmbedding)` sets (the default) and bare live-capture
+/// `FaceEmbedding` sets share the one guard. `zeroize`'s own `Zeroizing`
+/// cannot: it needs `T: Zeroize`, which `(u32, FaceEmbedding)` is not.
 ///
 /// The plaintext is reachable only through `Deref` to a shared slice: a
 /// holder can compare against the embeddings but cannot move them back out
-/// from under the wipe.
-pub struct Wiped<T>(T)
+/// from under the wipe. The only mutation is [`Wiped::push`], which adds —
+/// never exposes or extracts — and wipes the outgrown allocation when the
+/// buffer must grow.
+pub struct Wiped<T, E = (u32, FaceEmbedding)>(T, std::marker::PhantomData<E>)
 where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>;
+    T: AsRef<[E]> + AsMut<[E]>,
+    E: WipeElement;
 
-impl<T> Wiped<T>
+impl<T, E> Wiped<T, E>
 where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+    T: AsRef<[E]> + AsMut<[E]>,
+    E: WipeElement,
 {
     /// Take ownership of `inner`; every embedding in it is zeroized when the
     /// guard drops.
     pub fn new(inner: T) -> Self {
-        Self(inner)
+        Self(inner, std::marker::PhantomData)
     }
 }
 
-impl<T> std::ops::Deref for Wiped<T>
+/// Wipe-aware append shared by the owned and borrowed `push` impls: when the
+/// buffer is full, growth is done by hand — copy into a larger allocation,
+/// zeroize the outgrown one in place, then let it free — because `Vec`'s own
+/// reallocation frees the plaintext-bearing buffer unwiped (#293).
+fn push_wiping<E: WipeElement + Clone>(buf: &mut Vec<E>, element: E) {
+    if buf.len() == buf.capacity() {
+        let mut grown = Vec::with_capacity((buf.capacity() * 2).max(4));
+        grown.extend_from_slice(buf);
+        for old in buf.iter_mut() {
+            old.wipe();
+        }
+        *buf = grown;
+    }
+    buf.push(element);
+}
+
+impl<E> Wiped<Vec<E>, E>
 where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+    E: WipeElement + Clone,
 {
-    type Target = [(u32, FaceEmbedding)];
+    /// An empty guard whose buffer holds `capacity` elements before growing.
+    /// Size it to the exact count (or a cheap upper bound) so [`Self::push`]
+    /// never has to grow.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::new(Vec::with_capacity(capacity))
+    }
+
+    /// Append an element. The plaintext enters the guard directly — there is
+    /// never an unguarded buffer to wrap afterwards — and growth wipes the
+    /// outgrown allocation instead of freeing it live.
+    pub fn push(&mut self, element: E) {
+        push_wiping(&mut self.0, element);
+    }
+}
+
+impl<E> Wiped<&mut Vec<E>, E>
+where
+    E: WipeElement + Clone,
+{
+    /// [`Wiped::push`] for a guard over a caller's buffer — the accumulation
+    /// form a fallible producer uses so a mid-loop failure wipes everything
+    /// already produced into the caller's allocation.
+    pub fn push(&mut self, element: E) {
+        push_wiping(self.0, element);
+    }
+}
+
+impl<T, E> std::ops::Deref for Wiped<T, E>
+where
+    T: AsRef<[E]> + AsMut<[E]>,
+    E: WipeElement,
+{
+    type Target = [E];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
     }
 }
 
-impl<T> Drop for Wiped<T>
+impl<T, E> Drop for Wiped<T, E>
 where
-    T: AsRef<[(u32, FaceEmbedding)]> + AsMut<[(u32, FaceEmbedding)]>,
+    T: AsRef<[E]> + AsMut<[E]>,
+    E: WipeElement,
 {
     fn drop(&mut self) {
-        zeroize_stored_embeddings(self.0.as_mut());
+        for element in self.0.as_mut() {
+            element.wipe();
+        }
     }
 }
 
@@ -876,6 +958,91 @@ mod tests {
                 "embedding for model {id} must be zeroized on the unwind path"
             );
         }
+    }
+
+    /// The bare-embedding element (#269): a `Vec<FaceEmbedding>` of
+    /// live-capture probes is guarded by the same `Wiped`, not a second
+    /// implementation.
+    #[test]
+    fn wiped_covers_bare_embedding_sets() {
+        let mut live: Vec<FaceEmbedding> = vec![[1.0; 512], [2.0; 512]];
+
+        {
+            let guard = Wiped::new(live.as_mut_slice());
+            assert_eq!(guard.len(), 2);
+            assert_eq!(guard[0][0], 1.0, "guard must deref to the plaintext");
+        }
+
+        assert!(
+            live.iter().all(|e| e.iter().all(|&v| v == 0.0)),
+            "bare embeddings must be zeroized after the guard drops"
+        );
+    }
+
+    /// The borrowed push form: a fallible producer accumulates into a
+    /// caller's buffer through the guard, and dropping the guard (the
+    /// producer's error path) leaves the caller's rows zeroized in place.
+    #[test]
+    fn wiped_borrowed_push_wipes_the_callers_buffer_on_drop() {
+        let mut out: Vec<(u32, FaceEmbedding)> = Vec::new();
+
+        {
+            let mut guard = Wiped::new(&mut out);
+            guard.push((1, [1.0; 512]));
+            guard.push((2, [2.0; 512]));
+            assert_eq!(guard.len(), 2);
+        }
+
+        assert_eq!(out.len(), 2);
+        assert!(
+            out.iter().all(|(_, e)| e.iter().all(|&v| v == 0.0)),
+            "rows pushed through the borrowed guard must be wiped on drop"
+        );
+    }
+
+    /// Counts wipes instead of holding an embedding, so the growth tests can
+    /// observe the wipe of the outgrown allocation — which no real-element
+    /// test can see after the free.
+    #[derive(Clone)]
+    struct CountedElem(std::rc::Rc<std::cell::Cell<usize>>);
+
+    impl WipeElement for CountedElem {
+        fn wipe(&mut self) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    #[test]
+    fn wiped_push_within_capacity_never_wipes_early() {
+        let wipes = std::rc::Rc::new(std::cell::Cell::new(0));
+
+        {
+            let mut guard = Wiped::with_capacity(2);
+            guard.push(CountedElem(wipes.clone()));
+            guard.push(CountedElem(wipes.clone()));
+            assert_eq!(wipes.get(), 0, "no growth, so nothing wipes before drop");
+            assert_eq!(guard.len(), 2);
+        }
+
+        assert_eq!(wipes.get(), 2, "drop wipes every element exactly once");
+    }
+
+    /// The reason `push` exists at all: `Vec`'s own reallocation frees the
+    /// old plaintext-bearing buffer unwiped (#293's compare-set gap), so
+    /// growth through the guard must wipe the outgrown allocation first.
+    #[test]
+    fn wiped_push_growth_wipes_the_outgrown_allocation() {
+        let wipes = std::rc::Rc::new(std::cell::Cell::new(0));
+
+        let mut guard = Wiped::with_capacity(1);
+        guard.push(CountedElem(wipes.clone()));
+        // Second push exceeds capacity: the copy into the grown buffer must
+        // be followed by a wipe of the outgrown allocation before it frees.
+        guard.push(CountedElem(wipes.clone()));
+        assert_eq!(wipes.get(), 1, "growth must wipe the outgrown allocation");
+
+        drop(guard);
+        assert_eq!(wipes.get(), 3, "both live elements wiped on drop as well");
     }
 
     #[test]

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -551,13 +551,15 @@ pub fn authenticate_with_embeddings<C: CameraSource, E: FaceProcessor>(
     // a lockout. Fail SOFT by construction.
     let policy = config.security.device_binding_policy();
     let allowed = device_allowed_model_ids(models, &live_fingerprint, &policy);
-    let compare_set = Wiped::new(
-        stored
-            .iter()
-            .filter(|(id, _)| allowed.contains(id))
-            .cloned()
-            .collect::<Vec<(u32, FaceEmbedding)>>(),
-    );
+    // Built through the guard at exact capacity: `collect()` on a filtered
+    // iterator has a zero lower size-hint, so it grew by reallocation and
+    // freed intermediate buffers of decrypted embeddings unwiped (#293).
+    // `stored.len()` is a hard upper bound, so `push` never grows — and if it
+    // ever had to, the guard wipes the outgrown allocation instead.
+    let mut compare_set = Wiped::with_capacity(stored.len());
+    for entry in stored.iter().filter(|(id, _)| allowed.contains(id)) {
+        compare_set.push(*entry);
+    }
     if policy.enabled && compare_set.len() != stored.len() {
         let skipped = stored.len() - compare_set.len();
         warn!(

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -20,7 +20,7 @@
 //! machine-facing (they cross D-Bus and land in logs) and must not localize.
 
 use facelock_core::config::Config;
-use facelock_core::types::FaceEmbedding;
+use facelock_core::types::{FaceEmbedding, Wiped};
 
 /// How the decrypt loop reaches a TPM sealer when a TPM-sealed row appears.
 ///
@@ -83,9 +83,28 @@ pub fn decrypt_user_embeddings(
     raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
     config: &Config,
     software_sealer: Option<&facelock_tpm::SoftwareSealer>,
-    mut tpm: TpmAccess<'_>,
+    tpm: TpmAccess<'_>,
 ) -> Result<Vec<(u32, FaceEmbedding)>, String> {
     let mut results = Vec::with_capacity(raw_rows.len());
+    decrypt_rows_into(raw_rows, config, software_sealer, tpm, &mut results)?;
+    Ok(results)
+}
+
+/// The decrypt loop, accumulating into `out` through [`Wiped`]'s borrowed
+/// form. On any exit before the last row — a failing row (AAD mismatch, TPM
+/// unseal failure) or an unwind — every embedding already decrypted is
+/// zeroized in place, so a mid-loop failure never strands rows 1..N
+/// plaintext in freed heap (#293). On success the rows are handed back live:
+/// from there the caller owns the plaintext, and every caller either wraps
+/// it or passes it to the wiping auth loop (D11).
+fn decrypt_rows_into(
+    raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
+    config: &Config,
+    software_sealer: Option<&facelock_tpm::SoftwareSealer>,
+    mut tpm: TpmAccess<'_>,
+    out: &mut Vec<(u32, FaceEmbedding)>,
+) -> Result<(), String> {
+    let mut guarded = Wiped::new(&mut *out);
     for (id, blob, sealed, device_id) in raw_rows {
         let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
             // Software-encrypted (version byte 0x02)
@@ -115,9 +134,12 @@ pub fn decrypt_user_embeddings(
             emb.copy_from_slice(floats);
             emb
         };
-        results.push((*id, embedding));
+        guarded.push((*id, embedding));
     }
-    Ok(results)
+    // Every row decrypted: the caller takes the plaintext over. Forgetting
+    // the guard skips its wipe without leaking — it owns only the borrow.
+    std::mem::forget(guarded);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -212,6 +234,86 @@ mod tests {
         .unwrap_err();
         assert!(err.contains("TPM unseal failed for embedding 6"), "{err}");
         assert!(err.contains("without TPM support"), "{err}");
+    }
+
+    /// The #293 auth-path case: a row failing mid-loop must not strand the
+    /// rows already decrypted before it. The borrowed accumulation makes the
+    /// wipe observable — without the guard, `out` holds rows 1-2 plaintext.
+    #[test]
+    fn mid_loop_failure_wipes_rows_already_decrypted() {
+        let config = Config::parse("").unwrap();
+        let mut rows = vec![plaintext_row(1, 0.25), plaintext_row(2, 0.75)];
+        // Row 3 fails: software-encrypted with no key configured.
+        let mut blob = vec![0x02u8];
+        blob.extend_from_slice(&[0u8; 64]);
+        rows.push((3u32, blob, true, None));
+
+        let mut out = Vec::new();
+        let err =
+            decrypt_rows_into(&rows, &config, None, TpmAccess::Held(None), &mut out).unwrap_err();
+        assert!(err.contains("software-encrypted"), "{err}");
+
+        assert_eq!(out.len(), 2, "rows 1-2 were decrypted before row 3 failed");
+        for (id, emb) in &out {
+            assert!(
+                emb.iter().all(|&v| v == 0.0),
+                "row {id} must be zeroized when a later row fails the load"
+            );
+        }
+    }
+
+    /// The reproduction shape from #293: encrypted store with
+    /// `bind_device_aad` and a replaced camera. Row 3's stored device id no
+    /// longer matches the AAD it was sealed under, so its GCM check fails
+    /// after rows 1-2 are already decrypted — and they must not sit
+    /// plaintext in freed daemon heap.
+    #[test]
+    fn aad_mismatch_mid_loop_wipes_the_partial_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let sealer = facelock_tpm::SoftwareSealer::from_key_file(&key_path).unwrap();
+
+        let config = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
+        let enrolled = "046d:085e:REAL";
+        let aad = config.security.device_aad(Some(enrolled));
+
+        let row = |id: u32, value: f32, device_id: &str| {
+            let emb: FaceEmbedding = [value; 512];
+            let blob = sealer
+                .seal_embedding_with_aad(&emb, aad.as_deref())
+                .unwrap();
+            (id, blob, true, Some(device_id.to_string()))
+        };
+        // Rows 1-2 decrypt fine; row 3's recorded device id derives a
+        // different AAD than it was sealed under.
+        let rows = vec![
+            row(1, 0.25, enrolled),
+            row(2, 0.75, enrolled),
+            row(3, 0.5, "ffff:ffff:OTHER"),
+        ];
+
+        let mut out = Vec::new();
+        let err = decrypt_rows_into(
+            &rows,
+            &config,
+            Some(&sealer),
+            TpmAccess::Held(None),
+            &mut out,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("software decryption failed for embedding 3"),
+            "{err}"
+        );
+
+        assert_eq!(out.len(), 2);
+        for (id, emb) in &out {
+            assert!(
+                emb.iter().all(|&v| v == 0.0),
+                "row {id} must be zeroized on the AAD-mismatch path"
+            );
+        }
     }
 
     /// `needs_raw_rows` forces the slow path whenever sealed rows may exist,

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rusqlite::params;
 
 use facelock_core::fs_security::ensure_mode;
-use facelock_core::types::{FaceEmbedding, FaceModelInfo};
+use facelock_core::types::{FaceEmbedding, FaceModelInfo, Wiped};
 
 use crate::error::{Result, StoreError};
 use crate::migrations::run_migrations;
@@ -286,7 +286,13 @@ impl FaceStore {
             })
             .map_err(|e| self.err(e))?;
 
+        // Accumulated through [`Wiped`]'s borrowed form, the shape the
+        // decrypt path uses (#293): a corrupt row mid-loop zeroizes the
+        // embeddings already collected, and growth wipes the outgrown
+        // allocation instead of letting `Vec`'s reallocation free the
+        // plaintext live.
         let mut results = Vec::new();
+        let mut guarded = Wiped::new(&mut results);
         for row in rows {
             let (id, blob) = row.map_err(|e| self.err(e))?;
             if blob.len() != 512 * 4 {
@@ -304,8 +310,12 @@ impl FaceStore {
             let floats: &[f32] = bytemuck::cast_slice(&blob);
             let mut embedding = [0f32; 512];
             embedding.copy_from_slice(floats);
-            results.push((id, embedding));
+            guarded.push((id, embedding));
         }
+        // Every row collected: the caller takes the plaintext over.
+        // Forgetting the guard skips its wipe without leaking — it owns only
+        // the borrow.
+        std::mem::forget(guarded);
         Ok(results)
     }
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -556,12 +556,14 @@ loop's caller buffer and device-filtered compare set, the daemon's preview compa
 the store changes through the daemon, or the user changes), and the sets held by the
 `facelock bench` and `facelock-bench` benchmark paths, and the live-capture probe sets both
 `calibrate` implementations accumulate from the camera. The transient copies in the load and
-decrypt paths are guarded too (#293): the decrypt loop accumulates inside the guard, so a row
-failing mid-load (AAD mismatch, TPM unseal failure) zeroizes the rows already decrypted; the
-compare set is built through the guard at exact capacity, so no reallocation frees live
-embeddings; and `facelock tpm decrypt` holds each row's unsealed bytes in `zeroize::Zeroizing`.
-Still unguarded: the per-frame embeddings inference returns before they are consumed, and the
-raw-row snapshot `facelock tpm encrypt` reads from a plaintext store before sealing it.
+decrypt paths are guarded too (#293): the decrypt loop and the store's plaintext fast load
+accumulate inside the guard, so a row failing mid-load (AAD mismatch, TPM unseal failure,
+corrupt row) zeroizes the rows already collected, and buffer growth wipes the outgrown
+allocation; the compare set is built through the guard at exact capacity; and `facelock tpm
+decrypt` holds each row's unsealed bytes in `zeroize::Zeroizing`. Still unguarded: the
+per-frame embeddings inference returns before they are consumed, the per-row blob buffers
+SQLite hands back while a plaintext store loads, and the raw-row snapshot `facelock tpm
+encrypt` reads before sealing one.
 
 **Hard device binding (opt-in, `security.bind_device_aad`).** When enabled, the enrolling
 camera's `device_id` is folded into the AES-GCM Additional Authenticated Data, so a template

--- a/docs/security.md
+++ b/docs/security.md
@@ -554,9 +554,14 @@ never a lockout.
 loop's caller buffer and device-filtered compare set, the daemon's preview compare set
 (loaded once per preview session — not once per frame — and wiped when the camera closes,
 the store changes through the daemon, or the user changes), and the sets held by the
-`facelock bench` and `facelock-bench` benchmark paths. This covers the sets that persist
-across frames; transient copies elsewhere in the load and decrypt paths are not all
-guarded yet.
+`facelock bench` and `facelock-bench` benchmark paths, and the live-capture probe sets both
+`calibrate` implementations accumulate from the camera. The transient copies in the load and
+decrypt paths are guarded too (#293): the decrypt loop accumulates inside the guard, so a row
+failing mid-load (AAD mismatch, TPM unseal failure) zeroizes the rows already decrypted; the
+compare set is built through the guard at exact capacity, so no reallocation frees live
+embeddings; and `facelock tpm decrypt` holds each row's unsealed bytes in `zeroize::Zeroizing`.
+Still unguarded: the per-frame embeddings inference returns before they are consumed, and the
+raw-row snapshot `facelock tpm encrypt` reads from a plaintext store before sealing it.
 
 **Hard device binding (opt-in, `security.bind_device_aad`).** When enabled, the enrolling
 camera's `device_id` is folded into the AES-GCM Additional Authenticated Data, so a template


### PR DESCRIPTION
## Summary

- generalize `Wiped` over its element (`WipeElement`: stored tuples, bare embeddings) and add `push`, which zeroizes the outgrown allocation instead of letting `Vec` free it live
- accumulate the decrypt loop inside the guard's borrowed form, so a row failing mid-load (AAD mismatch, TPM unseal) wipes the rows already decrypted
- build the auth compare set through the guard at exact capacity: `collect()` on the filtered iterator has a zero lower size-hint, so it grew by reallocation and freed live embeddings
- load the direct auth path's plaintext last, after `list_models`, matching the daemon's ordering
- hold `facelock tpm decrypt`'s per-row unsealed bytes in `zeroize::Zeroizing`; raw byte buffers already implement `Zeroize`, so `Wiped` gains no `u8` element
- guard both `calibrate` live-capture probe sets
- accumulate the store's plaintext fast load (`get_user_embeddings`) through the guard: it had the same zero-initial-capacity reallocation, plus an unwiped drop when a corrupt row fails the load mid-loop
- rescope the `docs/security.md` claim to the load and decrypt transients now covered, naming per-frame inference outputs, SQLite's per-row blob buffers, and `facelock tpm encrypt`'s raw-row snapshot as still unguarded

## Why

The guard covered the compare sets its callers wrapped; four error paths released plaintext before the wrap or outside its type, and one is the shared load path under authentication. With `bind_device_aad` and a replaced camera, a row failing its AAD check left every earlier row decrypted in freed daemon heap. The live-capture probes in `calibrate` were never wiped at all.

## Reviewer notes

- **`decrypt_rows_into` forgets its borrowed guard on success.** the guard owns only the borrow, so `mem::forget` skips the wipe without leaking; error and unwind exits still wipe the caller's buffer, which is what makes the new mid-loop tests observable
- **the guard's restrictions are unchanged.** still no `DerefMut`, `into_inner`, or `Clone`; `push` only adds

## Validation

- `just check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just check-pam-standalone` and `cargo tree -p pam-facelock`
- reran the two mid-loop wipe tests with the guard removed to confirm they fail

Fixes #293
Fixes #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Biometric embeddings and decrypted plaintext are now automatically zeroized after use, including during errors, panics, partial failures, and buffer growth.
  * Improved protection across calibration, authentication, comparison, database loading, and software- or TPM-backed decryption workflows.
  * Added safeguards for intermediate biometric data during collection and failed operations.

* **Documentation**
  * Expanded security documentation covering in-memory biometric data protection, cleanup scenarios, and remaining limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->