### PR TITLE
fix(enroll): persist an enrollment in one store transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,11 +606,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sealing done first. Previously the model row was created on the first
   accepted frame and embeddings were appended one by one, so a cancellation
   after that frame (a killed CLI, a suspend, a caller that went away) left a
-  template behind that never passed the gates and could authenticate, and a
-  re-enrollment deleted the previous template before capturing a single
-  frame. A cancelled or failed enrollment, too few frames at the deadline
-  included, now leaves the store exactly as it was, previous template and
-  all.
+  template behind that never passed the gates and could authenticate, and an
+  explicit re-enrollment under an existing label (`facelock enroll --label
+  <existing>`; default labels never collide) deleted the previous template
+  before capturing a single frame. A cancelled or failed enrollment, too few
+  frames at the deadline included, now leaves the store exactly as it was,
+  previous template and all. The store now refuses a model with fewer than
+  three embeddings. A partial row an earlier version left behind survives
+  the upgrade and still authenticates: `facelock list` shows models, not
+  embedding counts, so remove any model from an enrollment you remember
+  failing with `facelock remove <id>`, or `facelock clear` and re-enroll.
 
 - **Root refusal now precedes config-state errors** (#191): for the commands
   dispatched through the shared config parse (`enroll`, `remove`, `clear`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Enrollment persists atomically** (#308): the daemon and `facelock enroll`
+  now hold accepted embeddings in memory and write the model in one store
+  transaction after the minimum-capture and angle-diversity gates pass, with
+  sealing done first. Previously the model row was created on the first
+  accepted frame and embeddings were appended one by one, so a cancellation
+  after that frame (a killed CLI, a suspend, a caller that went away) left a
+  template behind that never passed the gates and could authenticate, and a
+  re-enrollment deleted the previous template before capturing a single
+  frame. A cancelled or failed enrollment, too few frames at the deadline
+  included, now leaves the store exactly as it was, previous template and
+  all.
+
 - **Root refusal now precedes config-state errors** (#191): for the commands
   dispatched through the shared config parse (`enroll`, `remove`, `clear`,
   `list`, `test`, `preview`, `devices`, `bench`, `tpm …`, `audit`), the root

--- a/crates/facelock-cli/src/ipc_client.rs
+++ b/crates/facelock-cli/src/ipc_client.rs
@@ -156,9 +156,11 @@ pub fn send_enroll(
     let proxy = Proxy::new_owned(connection, BUS_NAME, OBJECT_PATH, INTERFACE_NAME)
         .map_err(|e| anyhow::anyhow!("D-Bus proxy failed: {e}"))?;
 
-    // A client-side timeout does NOT cancel the daemon's enrollment — it runs
-    // to completion and persists. Say so instead of leaving the user to retry
-    // into a duplicate label.
+    // A client-side timeout ends this process, which drops the bus connection;
+    // the daemon's caller-departure watch then cancels the enrollment and
+    // nothing is stored (#308). The one exception is a commit that landed
+    // before we gave up: the reply is lost but the template is real, which is
+    // why the message sends the user to `facelock list` before retrying.
     let result: (u32, u32) = proxy.call("Enroll", &(user, label)).map_err(|e| {
         if is_timeout_error(&e) {
             anyhow::Error::new(e).context(explain(&AccessMessage::EnrollTimedOutClientSide))

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -30,7 +30,9 @@ pub enum EnrollOutcome {
     Cancelled,
 }
 
-const MIN_CAPTURES: usize = 3;
+/// The store refuses a model with fewer embeddings than this, so the capture
+/// gate and the row invariant are one number (#308).
+const MIN_CAPTURES: usize = facelock_store::MIN_EMBEDDINGS_PER_MODEL;
 const MAX_CAPTURES: usize = 10;
 const INTER_FRAME_DELAY: Duration = Duration::from_millis(200);
 

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use facelock_camera::capture::is_dark_with_config;
 use facelock_core::config::Config;
 use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::FaceEmbedding;
+use facelock_core::types::{FaceEmbedding, Wiped};
 use facelock_store::FaceStore;
 use facelock_tpm::SoftwareSealer;
 use tracing::{debug, info, warn};
@@ -25,8 +25,8 @@ pub enum EnrollOutcome {
     },
     /// The caller went away, the system is suspending, or the process was
     /// signalled. Same rule as [`crate::auth::AuthOutcome::Cancelled`]: the
-    /// enrollment was abandoned, not refused, and the camera closes at once
-    /// (ADR 008 §5).
+    /// enrollment was abandoned, not refused, the camera closes at once
+    /// (ADR 008 §5), and the store is exactly as it was (#308).
     Cancelled,
 }
 
@@ -122,37 +122,26 @@ impl RejectionStats {
     }
 }
 
-/// Delete the model row a failed enrollment already created.
+/// What enrollment asks of a sealer: one embedding in, its ciphertext out.
 ///
-/// The row is written on the *first* accepted frame, so every failure path
-/// after that point leaves a usable template behind unless it is removed —
-/// including the angle-diversity rejection, whose whole point is that the
-/// embeddings are too similar to be trustworthy. A retry picks a fresh label,
-/// so the orphan is never overwritten by the next attempt.
-///
-/// Cleanup failures are logged, never returned: they must not mask the
-/// enrollment error that triggered the cleanup.
-fn discard_partial_model(store: &FaceStore, user: &str, label: &str, model_id: Option<u32>) {
-    let Some(id) = model_id else { return };
-    match store.remove_model(user, id) {
-        Ok(true) => info!(
-            user,
-            label,
-            model_id = id,
-            "removed partial model after failed enrollment"
-        ),
-        Ok(false) => warn!(
-            user,
-            label,
-            model_id = id,
-            "partial model already gone during enrollment cleanup"
-        ),
-        Err(e) => warn!(
-            user,
-            label,
-            model_id = id,
-            "failed to remove partial model after failed enrollment: {e}"
-        ),
+/// [`SoftwareSealer`] is the only implementation outside tests. The seam
+/// exists because AES-GCM under a valid key never fails, and the promise that
+/// a sealing failure writes nothing needs a sealer that can.
+trait EmbeddingSealer {
+    fn seal_embedding_with_aad(
+        &self,
+        embedding: &FaceEmbedding,
+        aad: Option<&[u8]>,
+    ) -> facelock_core::error::Result<Vec<u8>>;
+}
+
+impl EmbeddingSealer for SoftwareSealer {
+    fn seal_embedding_with_aad(
+        &self,
+        embedding: &FaceEmbedding,
+        aad: Option<&[u8]>,
+    ) -> facelock_core::error::Result<Vec<u8>> {
+        SoftwareSealer::seal_embedding_with_aad(self, embedding, aad)
     }
 }
 
@@ -168,18 +157,6 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     device_id: Option<&str>,
     cancel: &CancelToken,
 ) -> EnrollOutcome {
-    // Clear any previous model with the same label (re-enrollment)
-    match store.remove_model_by_label(user, label) {
-        Ok(true) => info!(user, label, "removed existing model for re-enrollment"),
-        Ok(false) => {}
-        Err(e) => {
-            warn!(user, label, "failed to remove existing model: {e}");
-            return EnrollOutcome::Error {
-                message: format!("storage error clearing old model: {e}"),
-            };
-        }
-    }
-
     // Opt-in hard device binding (Plan 04): when enabled, fold this camera's
     // device id into the AES-GCM AAD so the template can only be decrypted under
     // the same camera. `None` when disabled or when no device id is available.
@@ -190,17 +167,23 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     let enroll_secs = config.enroll_timeout_secs();
     let deadline = Instant::now() + Duration::from_secs(enroll_secs);
     debug!(timeout_secs = enroll_secs, "starting enrollment");
-    let mut stored_count: u32 = 0;
-    let mut model_id: Option<u32> = None;
     let mut last_capture = Instant::now() - INTER_FRAME_DELAY; // allow immediate first capture
-    let mut enrolled_embeddings: Vec<FaceEmbedding> = Vec::with_capacity(MAX_CAPTURES);
+    // Accepted embeddings wait here until the whole set has passed the gates;
+    // nothing reaches the store before then (#308). The guard wipes them on
+    // every exit path, unwind included.
+    let mut accepted: Wiped<Vec<FaceEmbedding>, FaceEmbedding> = Wiped::with_capacity(MAX_CAPTURES);
     let mut rejections = RejectionStats::default();
 
-    while Instant::now() < deadline && (stored_count as usize) < MAX_CAPTURES {
+    while Instant::now() < deadline && accepted.len() < MAX_CAPTURES {
         // Checked before the inter-frame sleep and the blocking capture, so
         // an abandoned enrollment ends within one frame (ADR 008 §5).
         if cancel.is_cancelled() {
-            info!(user, label, captures = stored_count, "enrollment cancelled");
+            info!(
+                user,
+                label,
+                captures = accepted.len(),
+                "enrollment cancelled"
+            );
             return EnrollOutcome::Cancelled;
         }
         // Delay between captures for varied angles
@@ -278,104 +261,48 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
             continue;
         }
 
-        // First face: create the model. Subsequent faces: add embeddings.
-        // When a sealer is provided, encrypt each embedding before storage.
-        let store_result = if let Some(sealer) = sealer {
-            match sealer.seal_embedding_with_aad(embedding, device_aad.as_deref()) {
-                Ok(encrypted) => match model_id {
-                    None => store
-                        .add_model_raw_with_device(
-                            user,
-                            label,
-                            &encrypted,
-                            true,
-                            &config.recognition.embedder_model,
-                            device_id,
-                        )
-                        .map(Some),
-                    Some(id) => store.add_embedding_raw(id, &encrypted, true).map(|()| None),
-                },
-                Err(e) => {
-                    warn!("failed to encrypt embedding: {e}");
-                    return EnrollOutcome::Error {
-                        message: format!("encryption error: {e}"),
-                    };
-                }
-            }
-        } else {
-            match model_id {
-                None => store
-                    .add_model_with_device(
-                        user,
-                        label,
-                        embedding,
-                        &config.recognition.embedder_model,
-                        device_id,
-                    )
-                    .map(Some),
-                Some(id) => store.add_embedding(id, embedding).map(|()| None),
-            }
-        };
-
-        match store_result {
-            Ok(Some(id)) => {
-                model_id = Some(id);
-                stored_count += 1;
-                enrolled_embeddings.push(*embedding);
-                info!(
-                    capture_ms,
-                    detect_ms,
-                    model_id = id,
-                    encrypted = sealer.is_some(),
-                    "created model with first embedding"
-                );
-            }
-            Ok(None) => {
-                stored_count += 1;
-                enrolled_embeddings.push(*embedding);
-                debug!(
-                    capture_ms,
-                    detect_ms,
-                    count = stored_count,
-                    encrypted = sealer.is_some(),
-                    "stored embedding"
-                );
-            }
-            Err(e) => {
-                if model_id.is_none() {
-                    warn!("failed to create model: {e}");
-                    return EnrollOutcome::Error {
-                        message: format!("storage error: {e}"),
-                    };
-                } else {
-                    warn!("failed to store embedding: {e}");
-                }
-            }
-        }
+        accepted.push(*embedding);
+        debug!(
+            capture_ms,
+            detect_ms,
+            count = accepted.len(),
+            "accepted enrollment frame"
+        );
 
         last_capture = Instant::now();
     }
 
+    // A cancellation that landed on the last frame is still a cancellation:
+    // the caller is gone, and a template it will never hear about is not
+    // stored on its behalf.
+    if cancel.is_cancelled() {
+        info!(
+            user,
+            label,
+            captures = accepted.len(),
+            "enrollment cancelled before commit"
+        );
+        return EnrollOutcome::Cancelled;
+    }
+
     // Check angle diversity: reject if all embeddings are too similar
-    if stored_count >= MIN_CAPTURES as u32 && !quality::check_angle_diversity(&enrolled_embeddings)
-    {
+    if accepted.len() >= MIN_CAPTURES && !quality::check_angle_diversity(&accepted) {
         warn!(
             user,
             label,
-            captured = stored_count,
+            captured = accepted.len(),
             "insufficient angle diversity during enrollment"
         );
-        discard_partial_model(store, user, label, model_id);
         return EnrollOutcome::Error {
             message: "insufficient angle diversity: please move your head to different angles during enrollment".into(),
         };
     }
 
-    if stored_count < MIN_CAPTURES as u32 {
+    if accepted.len() < MIN_CAPTURES {
         warn!(
             user,
             label,
-            captured = stored_count,
+            captured = accepted.len(),
             required = MIN_CAPTURES,
             dark = rejections.dark,
             no_face = rejections.no_face,
@@ -385,26 +312,99 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
             engine_errors = rejections.engine_errors,
             "insufficient face captures during enrollment"
         );
-        discard_partial_model(store, user, label, model_id);
         return EnrollOutcome::Error {
             message: format!(
-                "only captured {stored_count} frames, need at least {MIN_CAPTURES}{}",
+                "only captured {} frames, need at least {MIN_CAPTURES}{}",
+                accepted.len(),
                 rejections.summary()
             ),
         };
     }
 
-    info!(
+    persist_enrollment(
+        store,
+        &config.recognition.embedder_model,
         user,
         label,
-        model_id = model_id.unwrap_or(0),
-        embedding_count = stored_count,
-        "enrollment complete"
-    );
+        sealer,
+        device_id,
+        device_aad.as_deref(),
+        &accepted,
+    )
+}
 
-    EnrollOutcome::Enrolled {
-        model_id: model_id.unwrap_or(0),
-        embedding_count: stored_count,
+/// Enrollment's one write: seal every accepted embedding, then replace the
+/// user's same-label model in a single store transaction.
+///
+/// Runs only after the capture gates passed, so a template a later
+/// authentication can load is always a complete one; and because nothing was
+/// written before this point, a failure here — sealing or storage — leaves
+/// the store exactly as it was, previous same-label model included (#308).
+#[allow(clippy::too_many_arguments)]
+fn persist_enrollment<S: EmbeddingSealer>(
+    store: &FaceStore,
+    embedder_model: &str,
+    user: &str,
+    label: &str,
+    sealer: Option<&S>,
+    device_id: Option<&str>,
+    device_aad: Option<&[u8]>,
+    accepted: &[FaceEmbedding],
+) -> EnrollOutcome {
+    let mut sealed: Vec<Vec<u8>> = Vec::new();
+    if let Some(sealer) = sealer {
+        sealed.reserve_exact(accepted.len());
+        for embedding in accepted {
+            match sealer.seal_embedding_with_aad(embedding, device_aad) {
+                Ok(blob) => sealed.push(blob),
+                Err(e) => {
+                    warn!(user, label, "failed to encrypt embedding: {e}");
+                    return EnrollOutcome::Error {
+                        message: format!("encryption error: {e}"),
+                    };
+                }
+            }
+        }
+    }
+    // Plaintext rows borrow straight from the guarded buffer: no unguarded
+    // copy of a template exists at any point.
+    let blobs: Vec<&[u8]> = if sealer.is_some() {
+        sealed.iter().map(Vec::as_slice).collect()
+    } else {
+        accepted
+            .iter()
+            .map(|embedding| bytemuck::cast_slice(embedding.as_slice()))
+            .collect()
+    };
+
+    match store.replace_model_with_embeddings(
+        user,
+        label,
+        &blobs,
+        sealer.is_some(),
+        embedder_model,
+        device_id,
+    ) {
+        Ok(model_id) => {
+            info!(
+                user,
+                label,
+                model_id,
+                embedding_count = accepted.len(),
+                encrypted = sealer.is_some(),
+                "enrollment complete"
+            );
+            EnrollOutcome::Enrolled {
+                model_id,
+                embedding_count: accepted.len() as u32,
+            }
+        }
+        Err(e) => {
+            warn!(user, label, "failed to store enrollment: {e}");
+            EnrollOutcome::Error {
+                message: format!("storage error: {e}"),
+            }
+        }
     }
 }
 
@@ -578,5 +578,318 @@ mod tests {
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_file(format!("{}-shm", db_path.display()));
         let _ = std::fs::remove_file(format!("{}-wal", db_path.display()));
+    }
+
+    // ---- persistence atomicity (#308) --------------------------------------
+
+    use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
+
+    /// Four embeddings far enough apart that every frame is accepted and the
+    /// angle-diversity gate passes.
+    fn diverse_engine() -> MockFaceEngine {
+        MockFaceEngine::cycling(vec![
+            fixtures::known_embedding(0),
+            fixtures::known_embedding(40),
+            fixtures::known_embedding(80),
+            fixtures::known_embedding(120),
+        ])
+    }
+
+    /// A camera whose `nth` capture cancels `cancel` — the frame it serves is
+    /// still accepted, so the cancellation lands after that frame.
+    fn camera_cancelling_on(nth: usize, cancel: &CancelToken) -> MockCamera {
+        let token = cancel.clone();
+        MockCamera::bright(640, 480, 4).with_capture_hook(move |n| {
+            if n == nth {
+                token.cancel();
+            }
+        })
+    }
+
+    fn enroll_alice(
+        camera: &mut MockCamera,
+        engine: &mut MockFaceEngine,
+        store: &FaceStore,
+        sealer: Option<&SoftwareSealer>,
+        label: &str,
+        cancel: &CancelToken,
+    ) -> EnrollOutcome {
+        let config = Config::parse("[recognition]\ntimeout_secs = 2\n").unwrap();
+        enroll(
+            camera, engine, store, &config, "alice", label, sealer, None, cancel,
+        )
+    }
+
+    /// No model row and no embedding row of any kind, sealed or plain.
+    fn assert_store_untouched(store: &FaceStore) {
+        assert!(
+            store.list_models("alice").unwrap().is_empty(),
+            "no model may remain: {:?}",
+            store.list_models("alice").unwrap()
+        );
+        assert_eq!(
+            store.count_sealed().unwrap(),
+            (0, 0),
+            "no embedding row may remain (sealed, unsealed)"
+        );
+    }
+
+    #[test]
+    fn cancellation_before_the_first_accepted_frame_leaves_no_model() {
+        let store = FaceStore::open_memory().unwrap();
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let mut camera = MockCamera::bright(640, 480, 4);
+
+        let outcome = enroll_alice(
+            &mut camera,
+            &mut diverse_engine(),
+            &store,
+            None,
+            "front",
+            &cancel,
+        );
+
+        assert!(
+            matches!(outcome, EnrollOutcome::Cancelled),
+            "got: {outcome:?}"
+        );
+        assert_eq!(camera.captures(), 0, "a cancelled request captures nothing");
+        assert_store_untouched(&store);
+    }
+
+    #[test]
+    fn cancellation_after_the_first_accepted_frame_leaves_no_model_or_embeddings() {
+        let store = FaceStore::open_memory().unwrap();
+        let cancel = CancelToken::new();
+        let mut camera = camera_cancelling_on(1, &cancel);
+
+        let outcome = enroll_alice(
+            &mut camera,
+            &mut diverse_engine(),
+            &store,
+            Some(&SoftwareSealer::from_key([7u8; 32])),
+            "front",
+            &cancel,
+        );
+
+        assert!(
+            matches!(outcome, EnrollOutcome::Cancelled),
+            "got: {outcome:?}"
+        );
+        assert_eq!(camera.captures(), 1, "the loop ends within one frame");
+        assert_store_untouched(&store);
+    }
+
+    #[test]
+    fn cancellation_at_finalization_persists_nothing() {
+        // The cancellation lands on the capture that completes the set, so
+        // the loop ends by MAX_CAPTURES with the token set: finalization
+        // must honour it rather than commit a template the caller abandoned.
+        let store = FaceStore::open_memory().unwrap();
+        let cancel = CancelToken::new();
+        let mut camera = camera_cancelling_on(MAX_CAPTURES, &cancel);
+
+        let outcome = enroll_alice(
+            &mut camera,
+            &mut diverse_engine(),
+            &store,
+            Some(&SoftwareSealer::from_key([7u8; 32])),
+            "front",
+            &cancel,
+        );
+
+        assert!(
+            matches!(outcome, EnrollOutcome::Cancelled),
+            "got: {outcome:?}"
+        );
+        assert_eq!(camera.captures(), MAX_CAPTURES);
+        assert_store_untouched(&store);
+    }
+
+    /// Fails on its `fail_at`-th call and counts every call: the failure a
+    /// real AES-GCM sealer never produces.
+    struct FailingSealer {
+        fail_at: usize,
+        calls: std::cell::Cell<usize>,
+    }
+
+    impl EmbeddingSealer for FailingSealer {
+        fn seal_embedding_with_aad(
+            &self,
+            _embedding: &FaceEmbedding,
+            _aad: Option<&[u8]>,
+        ) -> facelock_core::error::Result<Vec<u8>> {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if call == self.fail_at {
+                Err(facelock_core::error::FacelockError::Encryption(
+                    "injected seal failure".into(),
+                ))
+            } else {
+                Ok(vec![0xAB; 16])
+            }
+        }
+    }
+
+    #[test]
+    fn seal_failure_on_the_nth_embedding_writes_nothing() {
+        let store = FaceStore::open_memory().unwrap();
+        let previous = store
+            .add_model("alice", "front", &fixtures::known_embedding(9), "")
+            .unwrap();
+        let accepted: Vec<FaceEmbedding> = [0, 40, 80]
+            .into_iter()
+            .map(fixtures::known_embedding)
+            .collect();
+        let sealer = FailingSealer {
+            fail_at: 2,
+            calls: std::cell::Cell::new(0),
+        };
+
+        let outcome = persist_enrollment(
+            &store,
+            "",
+            "alice",
+            "front",
+            Some(&sealer),
+            None,
+            None,
+            &accepted,
+        );
+
+        match outcome {
+            EnrollOutcome::Error { message } => assert!(
+                message.contains("encryption error") && message.contains("injected seal failure"),
+                "got: {message}"
+            ),
+            other => panic!("expected an encryption error, got: {other:?}"),
+        }
+        assert_eq!(sealer.calls.get(), 2, "sealing stops at the failure");
+
+        // The previous same-label model is untouched and nothing from this
+        // attempt exists: not the model, not the one blob that did seal.
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1, "got: {models:?}");
+        assert_eq!(models[0].id, previous);
+        assert_eq!(store.count_sealed().unwrap(), (0, 1));
+    }
+
+    #[test]
+    fn successful_sealed_enrollment_persists_every_accepted_embedding() {
+        let store = FaceStore::open_memory().unwrap();
+        let sealer = SoftwareSealer::from_key([7u8; 32]);
+        let mut camera = MockCamera::bright(640, 480, 4);
+
+        let outcome = enroll_alice(
+            &mut camera,
+            &mut diverse_engine(),
+            &store,
+            Some(&sealer),
+            "front",
+            &CancelToken::new(),
+        );
+
+        let (model_id, embedding_count) = match outcome {
+            EnrollOutcome::Enrolled {
+                model_id,
+                embedding_count,
+            } => (model_id, embedding_count),
+            other => panic!("expected success, got: {other:?}"),
+        };
+        assert_eq!(embedding_count as usize, MAX_CAPTURES);
+
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, model_id);
+        assert_eq!(models[0].label, "front");
+
+        let rows = store.get_user_embeddings_raw("alice").unwrap();
+        assert_eq!(rows.len(), MAX_CAPTURES, "one row per accepted frame");
+        let known: Vec<FaceEmbedding> = [0, 40, 80, 120]
+            .into_iter()
+            .map(fixtures::known_embedding)
+            .collect();
+        for (id, blob, sealed) in &rows {
+            assert_eq!(*id, model_id);
+            assert!(sealed, "every row is sealed under the sealer's key");
+            let plain = sealer.unseal_embedding_with_aad(blob, None).unwrap();
+            assert!(
+                known.contains(&plain),
+                "each row unseals to one of the accepted embeddings"
+            );
+        }
+    }
+
+    #[test]
+    fn successful_plaintext_enrollment_persists_every_accepted_embedding() {
+        let store = FaceStore::open_memory().unwrap();
+        let mut camera = MockCamera::bright(640, 480, 4);
+
+        let outcome = enroll_alice(
+            &mut camera,
+            &mut diverse_engine(),
+            &store,
+            None,
+            "front",
+            &CancelToken::new(),
+        );
+
+        assert!(
+            matches!(outcome, EnrollOutcome::Enrolled { embedding_count, .. } if embedding_count as usize == MAX_CAPTURES),
+            "got: {outcome:?}"
+        );
+        let rows = store.get_user_embeddings("alice").unwrap();
+        assert_eq!(rows.len(), MAX_CAPTURES);
+        assert_eq!(rows[0].1, fixtures::known_embedding(0));
+        assert_eq!(rows[1].1, fixtures::known_embedding(40));
+        assert_eq!(store.count_sealed().unwrap(), (0, MAX_CAPTURES as u32));
+    }
+
+    #[test]
+    fn cancelled_re_enrollment_keeps_the_previous_model() {
+        let store = FaceStore::open_memory().unwrap();
+        let sealer = SoftwareSealer::from_key([7u8; 32]);
+
+        let first = enroll_alice(
+            &mut MockCamera::bright(640, 480, 4),
+            &mut diverse_engine(),
+            &store,
+            Some(&sealer),
+            "front",
+            &CancelToken::new(),
+        );
+        let previous_id = match first {
+            EnrollOutcome::Enrolled { model_id, .. } => model_id,
+            other => panic!("first enrollment must succeed, got: {other:?}"),
+        };
+        let previous_rows = store.get_user_embeddings_raw("alice").unwrap();
+        assert_eq!(previous_rows.len(), MAX_CAPTURES);
+
+        // Re-enroll under the same label, abandoned after two accepted frames.
+        let cancel = CancelToken::new();
+        let outcome = enroll_alice(
+            &mut camera_cancelling_on(2, &cancel),
+            &mut diverse_engine(),
+            &store,
+            Some(&sealer),
+            "front",
+            &cancel,
+        );
+        assert!(
+            matches!(outcome, EnrollOutcome::Cancelled),
+            "got: {outcome:?}"
+        );
+
+        // The template that was there before is there still, row for row:
+        // what authenticated before the attempt authenticates after it.
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1, "got: {models:?}");
+        assert_eq!(models[0].id, previous_id, "the previous model row survived");
+        assert_eq!(
+            store.get_user_embeddings_raw("alice").unwrap(),
+            previous_rows,
+            "the previous model's embeddings are untouched"
+        );
     }
 }

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use facelock_camera::capture::is_dark_with_config;
 use facelock_core::config::Config;
 use facelock_core::traits::{CameraSource, FaceProcessor};
-use facelock_core::types::{FaceEmbedding, Wiped};
+use facelock_core::types::FaceEmbedding;
 use facelock_store::FaceStore;
 use facelock_tpm::SoftwareSealer;
 use tracing::{debug, info, warn};
@@ -25,8 +25,8 @@ pub enum EnrollOutcome {
     },
     /// The caller went away, the system is suspending, or the process was
     /// signalled. Same rule as [`crate::auth::AuthOutcome::Cancelled`]: the
-    /// enrollment was abandoned, not refused, the camera closes at once
-    /// (ADR 008 §5), and the store is exactly as it was (#308).
+    /// enrollment was abandoned, not refused, and the camera closes at once
+    /// (ADR 008 §5).
     Cancelled,
 }
 
@@ -122,29 +122,6 @@ impl RejectionStats {
     }
 }
 
-/// What enrollment asks of a sealer: one embedding in, its ciphertext out.
-///
-/// [`SoftwareSealer`] is the only implementation outside tests. The seam
-/// exists because AES-GCM under a valid key never fails, and the promise that
-/// a sealing failure writes nothing needs a sealer that can.
-trait EmbeddingSealer {
-    fn seal_embedding_with_aad(
-        &self,
-        embedding: &FaceEmbedding,
-        aad: Option<&[u8]>,
-    ) -> facelock_core::error::Result<Vec<u8>>;
-}
-
-impl EmbeddingSealer for SoftwareSealer {
-    fn seal_embedding_with_aad(
-        &self,
-        embedding: &FaceEmbedding,
-        aad: Option<&[u8]>,
-    ) -> facelock_core::error::Result<Vec<u8>> {
-        SoftwareSealer::seal_embedding_with_aad(self, embedding, aad)
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn enroll<C: CameraSource, E: FaceProcessor>(
     camera: &mut C,
@@ -171,7 +148,8 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     // Accepted embeddings wait here until the whole set has passed the gates;
     // nothing reaches the store before then (#308). The guard wipes them on
     // every exit path, unwind included.
-    let mut accepted: Wiped<Vec<FaceEmbedding>, FaceEmbedding> = Wiped::with_capacity(MAX_CAPTURES);
+    let mut accepted: facelock_core::types::Wiped<Vec<FaceEmbedding>, FaceEmbedding> =
+        facelock_core::types::Wiped::with_capacity(MAX_CAPTURES);
     let mut rejections = RejectionStats::default();
 
     while Instant::now() < deadline && accepted.len() < MAX_CAPTURES {
@@ -333,6 +311,29 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     )
 }
 
+/// What enrollment asks of a sealer: one embedding in, its ciphertext out.
+///
+/// [`SoftwareSealer`] is the only implementation outside tests. The seam
+/// exists because AES-GCM under a valid key never fails, and the promise that
+/// a sealing failure writes nothing needs a sealer that can.
+trait EmbeddingSealer {
+    fn seal_embedding_with_aad(
+        &self,
+        embedding: &FaceEmbedding,
+        aad: Option<&[u8]>,
+    ) -> facelock_core::error::Result<Vec<u8>>;
+}
+
+impl EmbeddingSealer for SoftwareSealer {
+    fn seal_embedding_with_aad(
+        &self,
+        embedding: &FaceEmbedding,
+        aad: Option<&[u8]>,
+    ) -> facelock_core::error::Result<Vec<u8>> {
+        SoftwareSealer::seal_embedding_with_aad(self, embedding, aad)
+    }
+}
+
 /// Enrollment's one write: seal every accepted embedding, then replace the
 /// user's same-label model in a single store transaction.
 ///
@@ -411,6 +412,7 @@ fn persist_enrollment<S: EmbeddingSealer>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
 
     #[test]
     fn summary_empty_when_no_rejections() {
@@ -530,7 +532,6 @@ mod tests {
 
     #[test]
     fn angle_diversity_failure_leaves_no_model_behind() {
-        use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
         use std::time::{SystemTime, UNIX_EPOCH};
 
         let unique = SystemTime::now()
@@ -581,8 +582,6 @@ mod tests {
     }
 
     // ---- persistence atomicity (#308) --------------------------------------
-
-    use facelock_test_support::{MockCamera, MockFaceEngine, fixtures};
 
     /// Four embeddings far enough apart that every frame is accepted and the
     /// angle-diversity gate passes.

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -310,6 +310,7 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
         device_id,
         device_aad.as_deref(),
         &accepted,
+        cancel,
     )
 }
 
@@ -343,6 +344,8 @@ impl EmbeddingSealer for SoftwareSealer {
 /// authentication can load is always a complete one; and because nothing was
 /// written before this point, a failure here — sealing or storage — leaves
 /// the store exactly as it was, previous same-label model included (#308).
+/// `cancel` is re-checked right before the write, so a caller that departs
+/// during sealing gets `Cancelled` and the same unchanged store.
 #[allow(clippy::too_many_arguments)]
 fn persist_enrollment<S: EmbeddingSealer>(
     store: &FaceStore,
@@ -353,6 +356,7 @@ fn persist_enrollment<S: EmbeddingSealer>(
     device_id: Option<&str>,
     device_aad: Option<&[u8]>,
     accepted: &[FaceEmbedding],
+    cancel: &CancelToken,
 ) -> EnrollOutcome {
     let mut sealed: Vec<Vec<u8>> = Vec::new();
     if let Some(sealer) = sealer {
@@ -379,6 +383,19 @@ fn persist_enrollment<S: EmbeddingSealer>(
             .map(|embedding| bytemuck::cast_slice(embedding.as_slice()))
             .collect()
     };
+
+    // Last look at the token before the only write: the caller-departure
+    // watch can fire while the set is being sealed, after the loop's final
+    // check. Past this point the commit itself is the residual window.
+    if cancel.is_cancelled() {
+        info!(
+            user,
+            label,
+            captures = accepted.len(),
+            "enrollment cancelled before commit"
+        );
+        return EnrollOutcome::Cancelled;
+    }
 
     match store.replace_model_with_embeddings(
         user,
@@ -757,6 +774,7 @@ mod tests {
             None,
             None,
             &accepted,
+            &CancelToken::new(),
         );
 
         match outcome {
@@ -774,6 +792,76 @@ mod tests {
         assert_eq!(models.len(), 1, "got: {models:?}");
         assert_eq!(models[0].id, previous);
         assert_eq!(store.count_sealed().unwrap(), (0, 1));
+    }
+
+    /// Seals normally but cancels `token` on its first call: the caller
+    /// departs while finalization is sealing, after the loop's last check.
+    struct CancellingSealer {
+        token: CancelToken,
+        calls: std::cell::Cell<usize>,
+    }
+
+    impl EmbeddingSealer for CancellingSealer {
+        fn seal_embedding_with_aad(
+            &self,
+            _embedding: &FaceEmbedding,
+            _aad: Option<&[u8]>,
+        ) -> facelock_core::error::Result<Vec<u8>> {
+            self.calls.set(self.calls.get() + 1);
+            self.token.cancel();
+            Ok(vec![0xCD; 16])
+        }
+    }
+
+    #[test]
+    fn cancellation_during_sealing_persists_nothing() {
+        let store = FaceStore::open_memory().unwrap();
+        let previous = store
+            .add_model("alice", "front", &fixtures::known_embedding(9), "")
+            .unwrap();
+        let previous_rows = store.get_user_embeddings_raw("alice").unwrap();
+        let accepted: Vec<FaceEmbedding> = [0, 40, 80]
+            .into_iter()
+            .map(fixtures::known_embedding)
+            .collect();
+        let cancel = CancelToken::new();
+        let sealer = CancellingSealer {
+            token: cancel.clone(),
+            calls: std::cell::Cell::new(0),
+        };
+
+        let outcome = persist_enrollment(
+            &store,
+            "",
+            "alice",
+            "front",
+            Some(&sealer),
+            None,
+            None,
+            &accepted,
+            &cancel,
+        );
+
+        assert!(
+            matches!(outcome, EnrollOutcome::Cancelled),
+            "got: {outcome:?}"
+        );
+        assert_eq!(
+            sealer.calls.get(),
+            accepted.len(),
+            "sealing itself is not interrupted"
+        );
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1, "got: {models:?}");
+        assert_eq!(
+            models[0].id, previous,
+            "the previous same-label model survived"
+        );
+        assert_eq!(
+            store.get_user_embeddings_raw("alice").unwrap(),
+            previous_rows,
+            "its rows are untouched and nothing sealed here was written"
+        );
     }
 
     #[test]

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -91,6 +91,27 @@ fn mock_camera_wraps_around() {
     assert_eq!(frame.width, 64);
 }
 
+#[test]
+fn mock_camera_capture_hook_sees_each_capture_in_order() {
+    use facelock_core::traits::CameraSource;
+    use std::sync::{Arc, Mutex};
+
+    // The hook is what lets a test act mid-loop (cancel a request on the
+    // Nth frame): it must run once per capture, before the frame is served,
+    // with the capture's 1-based ordinal.
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&seen);
+    let mut cam =
+        MockCamera::bright(64, 64, 2).with_capture_hook(move |n| sink.lock().unwrap().push(n));
+
+    let _ = cam.capture().unwrap();
+    let _ = cam.capture_rgb_only().unwrap();
+    let _ = cam.capture().unwrap();
+
+    assert_eq!(*seen.lock().unwrap(), vec![1, 2, 3]);
+    assert_eq!(cam.captures(), 3);
+}
+
 /// D8 compile-time pin: `CameraSource` is object-safe. The old trait carried
 /// `fn is_dark(..) where Self: Sized`, which made `dyn CameraSource`
 /// unusable; darkness is a free function now and capabilities live on the
@@ -682,6 +703,198 @@ fn keyfile_sealer_init_failure_fails_enroll_closed_no_plaintext() {
     assert_eq!(sealed, 0, "no embedding should have been stored at all");
 
     cleanup_db(&blocker);
+}
+
+/// A handler on an in-memory store with keyfile encryption on, as in
+/// production, so every row an enrollment writes is sealed. The camera
+/// factory hands out bright frames and runs `on_open` with the 1-based open
+/// count, so a test can shape one particular open (a camera that cancels a
+/// token mid-loop, say). Warmup is zero, so capture ordinals are the
+/// request's own.
+fn enroll_handler(
+    key_path: &Path,
+    on_open: impl Fn(usize, MockCamera) -> MockCamera + Send + Sync + 'static,
+) -> facelock_daemon::handler::Handler<MockCamera, MockFaceEngine> {
+    use facelock_core::config::EncryptionMethod;
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let mut config = test_config();
+    config.encryption.method = EncryptionMethod::Keyfile;
+    config.encryption.key_path = key_path.to_string_lossy().into_owned();
+
+    let opens = AtomicUsize::new(0);
+    let factory: MockCameraFactory = Box::new(move |_cfg| {
+        let open = opens.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(on_open(open, MockCamera::bright(640, 480, 40)))
+    });
+    let engine = MockFaceEngine::cycling(vec![
+        fixtures::known_embedding(0),
+        fixtures::known_embedding(40),
+        fixtures::known_embedding(80),
+        fixtures::known_embedding(120),
+    ]);
+    let rate_limiter = RateLimiter::new(
+        config.security.rate_limit.max_attempts,
+        config.security.rate_limit.window_secs,
+    );
+    Handler::new(
+        config,
+        engine,
+        FaceStore::open_memory().unwrap(),
+        rate_limiter,
+        CameraCaps::default(),
+        Some(factory),
+        Some(0),
+    )
+    .expect("handler builds with a generated keyfile")
+}
+
+/// #308: a cancelled enrollment must be invisible afterwards — nothing to
+/// list, nothing to authenticate against — even when the cancellation lands
+/// after a frame was accepted, which used to leave a one-embedding template
+/// behind.
+#[test]
+fn a_cancelled_enroll_is_invisible_to_listing_and_authentication() {
+    let key_path = temp_db_path("cancelled-enroll-key");
+    let cancel = CancelToken::new();
+    let token = cancel.clone();
+    // The first capture is accepted; the second cancels the request.
+    let mut handler = enroll_handler(&key_path, move |_open, camera| {
+        let token = token.clone();
+        camera.with_capture_hook(move |n| {
+            if n == 2 {
+                token.cancel();
+            }
+        })
+    });
+
+    let resp = handler.handle_with_cancel(
+        DaemonRequest::Enroll {
+            user: "u".into(),
+            label: "front".into(),
+        },
+        &cancel,
+    );
+    match resp {
+        DaemonResponse::Error { ref message } => assert_eq!(message, "cancelled"),
+        other => panic!("expected a cancellation, got {other:?}"),
+    }
+
+    // Nothing to list, and no embedding row of any kind.
+    match handler.handle(DaemonRequest::ListModels { user: "u".into() }) {
+        DaemonResponse::Models(models) => assert!(models.is_empty(), "got: {models:?}"),
+        other => panic!("expected a model list, got {other:?}"),
+    }
+    assert_eq!(handler.store.count_sealed().unwrap(), (0, 0));
+
+    // Nothing to authenticate against: the not-enrolled gate answers before
+    // any camera opens, so no face can have been seen.
+    let resp =
+        handler.handle_authenticate("u".into(), AuthIntent::Authenticate, &CancelToken::new());
+    match resp {
+        DaemonResponse::AuthResult(MatchResult {
+            matched,
+            face_detected,
+            model_id,
+            ..
+        }) => {
+            assert!(!matched, "a cancelled attempt must not authenticate");
+            assert!(!face_detected, "no camera opened, no face seen");
+            assert_eq!(model_id, None);
+        }
+        other => panic!("expected a no-match, got {other:?}"),
+    }
+
+    let _ = std::fs::remove_file(&key_path);
+}
+
+/// #308: re-enrolling under an existing label and abandoning the attempt
+/// keeps the previous template, row for row, and it still authenticates.
+/// The old preamble deleted the previous model before the first frame.
+#[test]
+fn a_cancelled_re_enrollment_keeps_the_previous_template_authenticating() {
+    let key_path = temp_db_path("re-enroll-key");
+    let cancel = CancelToken::new();
+    let token = cancel.clone();
+    // Open 1 enrolls cleanly. Open 2 is the re-enrollment, cancelled after
+    // two accepted frames. Open 3 authenticates.
+    let mut handler = enroll_handler(&key_path, move |open, camera| {
+        if open != 2 {
+            return camera;
+        }
+        let token = token.clone();
+        camera.with_capture_hook(move |n| {
+            if n == 3 {
+                token.cancel();
+            }
+        })
+    });
+
+    let enrolled_id = match handler.handle(DaemonRequest::Enroll {
+        user: "u".into(),
+        label: "front".into(),
+    }) {
+        DaemonResponse::Enrolled {
+            model_id,
+            embedding_count,
+        } => {
+            assert_eq!(embedding_count, 10, "a full set was stored");
+            model_id
+        }
+        other => panic!("the first enrollment must succeed, got {other:?}"),
+    };
+    let before = handler.store.get_user_embeddings_raw("u").unwrap();
+    assert_eq!(before.len(), 10);
+
+    let resp = handler.handle_with_cancel(
+        DaemonRequest::Enroll {
+            user: "u".into(),
+            label: "front".into(),
+        },
+        &cancel,
+    );
+    match resp {
+        DaemonResponse::Error { ref message } => assert_eq!(message, "cancelled"),
+        other => panic!("expected a cancellation, got {other:?}"),
+    }
+
+    match handler.handle(DaemonRequest::ListModels { user: "u".into() }) {
+        DaemonResponse::Models(models) => {
+            assert_eq!(models.len(), 1, "got: {models:?}");
+            assert_eq!(models[0].id, enrolled_id, "the previous model survived");
+        }
+        other => panic!("expected a model list, got {other:?}"),
+    }
+    assert_eq!(
+        handler.store.get_user_embeddings_raw("u").unwrap(),
+        before,
+        "the previous template is untouched, row for row"
+    );
+
+    // And it still authenticates: the engine keeps presenting the enrolled
+    // faces, with enough frame-to-frame variance for the liveness gate.
+    let resp =
+        handler.handle_authenticate("u".into(), AuthIntent::Authenticate, &CancelToken::new());
+    match resp {
+        DaemonResponse::AuthResult(MatchResult {
+            matched,
+            model_id,
+            similarity,
+            failure_reason,
+            ..
+        }) => {
+            assert!(
+                matched,
+                "the previous template must still authenticate, got similarity {similarity} reason {failure_reason:?}"
+            );
+            assert_eq!(model_id, Some(enrolled_id));
+        }
+        other => panic!("expected a match, got {other:?}"),
+    }
+
+    let _ = std::fs::remove_file(&key_path);
 }
 
 #[test]

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -187,19 +187,17 @@ impl FaceStore {
         self.add_model_with_device(user, label, embedding, embedder_model, None)
     }
 
-    /// Add a face model with its embedding and the enrolling camera's canonical
-    /// device fingerprint (`Some("vid:pid:serial")`), or `None` when the camera
-    /// exposes no readable USB identity. Returns the new model ID.
-    pub fn add_model_with_device(
+    /// Insert the `face_models` row for a new model inside `tx` and return
+    /// its ID. Every model-creating write goes through here, so the row shape
+    /// and its timestamp are defined once.
+    fn insert_model_row(
         &self,
+        tx: &rusqlite::Transaction<'_>,
         user: &str,
         label: &str,
-        embedding: &FaceEmbedding,
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
-
         // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
         // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
         // because SQLite INTEGER is signed 64-bit).
@@ -214,7 +212,23 @@ impl FaceStore {
         )
         .map_err(|e| self.err(e))?;
 
-        let model_id = tx.last_insert_rowid() as u32;
+        Ok(tx.last_insert_rowid() as u32)
+    }
+
+    /// Add a face model with its embedding and the enrolling camera's canonical
+    /// device fingerprint (`Some("vid:pid:serial")`), or `None` when the camera
+    /// exposes no readable USB identity. Returns the new model ID.
+    pub fn add_model_with_device(
+        &self,
+        user: &str,
+        label: &str,
+        embedding: &FaceEmbedding,
+        embedder_model: &str,
+        device_id: Option<&str>,
+    ) -> Result<u32> {
+        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
+
+        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
 
         let bytes: &[u8] = bytemuck::cast_slice(embedding.as_slice());
         tx.execute(
@@ -489,21 +503,7 @@ impl FaceStore {
     ) -> Result<u32> {
         let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
 
-        // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
-        // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
-        // because SQLite INTEGER is signed 64-bit).
-        let created_at: i64 = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-
-        tx.execute(
-            "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![user, label, created_at, embedder_model, device_id],
-        )
-        .map_err(|e| self.err(e))?;
-
-        let model_id = tx.last_insert_rowid() as u32;
+        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
 
         tx.execute(
@@ -530,7 +530,6 @@ impl FaceStore {
     /// `sealed` applies to every blob: an enrollment is encrypted or plain,
     /// never mixed. An empty `embeddings` is refused — a model with nothing to
     /// compare against must never exist, whatever the caller's gates said.
-    #[allow(clippy::too_many_arguments)] // mirrors add_model_raw_with_device plus the blob set
     pub fn replace_model_with_embeddings(
         &self,
         user: &str,
@@ -557,21 +556,7 @@ impl FaceStore {
         )
         .map_err(|e| self.err(e))?;
 
-        // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
-        // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
-        // because SQLite INTEGER is signed 64-bit).
-        let created_at: i64 = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-
-        tx.execute(
-            "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![user, label, created_at, embedder_model, device_id],
-        )
-        .map_err(|e| self.err(e))?;
-
-        let model_id = tx.last_insert_rowid() as u32;
+        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
 
         for data in embeddings {

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -10,6 +10,15 @@ use facelock_core::types::{FaceEmbedding, FaceModelInfo, Wiped};
 use crate::error::{Result, StoreError};
 use crate::migrations::run_migrations;
 
+/// The fewest embeddings a stored model may hold.
+///
+/// Owned by the store because it is a row invariant, not a capture policy:
+/// [`FaceStore::replace_model_with_embeddings`] refuses a shorter set, so a
+/// model that exists always has enough embeddings to be compared against
+/// from more than one angle (#308). The daemon's enrollment loop derives its
+/// minimum-capture count from this constant, so the two cannot drift.
+pub const MIN_EMBEDDINGS_PER_MODEL: usize = 3;
+
 #[derive(Debug)]
 pub struct FaceStore {
     conn: rusqlite::Connection,
@@ -528,8 +537,9 @@ impl FaceStore {
     /// fails keeps the template it was replacing.
     ///
     /// `sealed` applies to every blob: an enrollment is encrypted or plain,
-    /// never mixed. An empty `embeddings` is refused — a model with nothing to
-    /// compare against must never exist, whatever the caller's gates said.
+    /// never mixed. Fewer than [`MIN_EMBEDDINGS_PER_MODEL`] blobs is refused
+    /// with [`StoreError::Query`] before the transaction opens, whatever the
+    /// caller's own gates said: a model that exists is a complete template.
     pub fn replace_model_with_embeddings(
         &self,
         user: &str,
@@ -539,10 +549,13 @@ impl FaceStore {
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        if embeddings.is_empty() {
+        if embeddings.len() < MIN_EMBEDDINGS_PER_MODEL {
             return Err(StoreError::Query {
                 path: self.path.clone(),
-                detail: format!("refusing to store a model for {user}/{label} with no embeddings"),
+                detail: format!(
+                    "refusing to store a model for {user}/{label} with {} embeddings (minimum {MIN_EMBEDDINGS_PER_MODEL})",
+                    embeddings.len()
+                ),
             });
         }
 
@@ -1310,7 +1323,7 @@ mod tests {
         let alice_side = store.add_model("alice", "side", &emb, "").unwrap();
         let bob_front = store.add_model("bob", "front", &emb, "").unwrap();
 
-        let blobs = blobs(2);
+        let blobs = blobs(3);
         let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
         let new_front = store
             .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
@@ -1341,7 +1354,7 @@ mod tests {
             .into_iter()
             .filter(|r| r.0 == new_front)
             .collect();
-        assert_eq!(front_rows.len(), 2);
+        assert_eq!(front_rows.len(), 3);
         let orphaned: u32 = store
             .conn
             .query_row(
@@ -1389,6 +1402,32 @@ mod tests {
         assert_eq!(rows.len(), 1, "the old model keeps its embedding");
         assert_eq!(rows[0].0, old_id);
         assert_eq!(rows[0].1[0], emb[0]);
+    }
+
+    #[test]
+    fn replace_model_refuses_fewer_than_the_minimum_embeddings() {
+        let store = FaceStore::open_memory().unwrap();
+        let emb = test_embedding();
+        let old_id = store.add_model("alice", "front", &emb, "").unwrap();
+
+        // Two embeddings: enough to exist, not enough to be a template. The
+        // store enforces the floor itself so no caller's gate can drift.
+        let blobs = blobs(2);
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+        let err = store
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .unwrap_err();
+        assert!(
+            matches!(err, StoreError::Query { .. }) && err.to_string().contains("2 embeddings"),
+            "a short set is refused with the count it got, got: {err:?}"
+        );
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].id, old_id,
+            "a refused replacement changes nothing"
+        );
+        assert_eq!(store.get_user_embeddings("alice").unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -516,6 +516,76 @@ impl FaceStore {
         Ok(model_id)
     }
 
+    /// Replace whatever model `user` has under `label` with a new one holding
+    /// every blob in `embeddings`, as one transaction. Returns the new model
+    /// ID.
+    ///
+    /// This is enrollment's only write (#308): the template a later
+    /// authentication can load either has all of its embeddings or does not
+    /// exist. `UNIQUE(user, label)` is why the old model is deleted inside the
+    /// same transaction rather than beforehand — a failure anywhere after the
+    /// delete rolls the old model back into place, so a re-enrollment that
+    /// fails keeps the template it was replacing.
+    ///
+    /// `sealed` applies to every blob: an enrollment is encrypted or plain,
+    /// never mixed. An empty `embeddings` is refused — a model with nothing to
+    /// compare against must never exist, whatever the caller's gates said.
+    #[allow(clippy::too_many_arguments)] // mirrors add_model_raw_with_device plus the blob set
+    pub fn replace_model_with_embeddings(
+        &self,
+        user: &str,
+        label: &str,
+        embeddings: &[&[u8]],
+        sealed: bool,
+        embedder_model: &str,
+        device_id: Option<&str>,
+    ) -> Result<u32> {
+        if embeddings.is_empty() {
+            return Err(StoreError::Query {
+                path: self.path.clone(),
+                detail: format!("refusing to store a model for {user}/{label} with no embeddings"),
+            });
+        }
+
+        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
+
+        // Cascades to the old model's embeddings (`ON DELETE CASCADE`, with
+        // foreign keys on for every connection this crate opens).
+        tx.execute(
+            "DELETE FROM face_models WHERE user = ?1 AND label = ?2",
+            params![user, label],
+        )
+        .map_err(|e| self.err(e))?;
+
+        // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
+        // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
+        // because SQLite INTEGER is signed 64-bit).
+        let created_at: i64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        tx.execute(
+            "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![user, label, created_at, embedder_model, device_id],
+        )
+        .map_err(|e| self.err(e))?;
+
+        let model_id = tx.last_insert_rowid() as u32;
+        let sealed_int: i64 = if sealed { 1 } else { 0 };
+
+        for data in embeddings {
+            tx.execute(
+                "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (?1, ?2, ?3)",
+                params![model_id, data, sealed_int],
+            )
+            .map_err(|e| self.err(e))?;
+        }
+
+        tx.commit().map_err(|e| self.err(e))?;
+        Ok(model_id)
+    }
+
     /// Update an existing embedding's data and sealed flag in-place.
     pub fn update_embedding_sealed(
         &self,
@@ -1206,6 +1276,155 @@ mod tests {
             .unwrap();
         let models = store.list_models("bob").unwrap();
         assert_eq!(models[0].device_id.as_deref(), Some("1234:5678:"));
+    }
+
+    /// Distinct raw blobs standing in for one enrollment's embeddings.
+    fn blobs(count: u8) -> Vec<Vec<u8>> {
+        (0..count).map(|i| vec![i; 8]).collect()
+    }
+
+    #[test]
+    fn replace_model_stores_every_embedding_under_one_model() {
+        let store = FaceStore::open_memory().unwrap();
+        let blobs = blobs(3);
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+
+        let id = store
+            .replace_model_with_embeddings(
+                "alice",
+                "front",
+                &refs,
+                true,
+                "w600k",
+                Some("046d:085e:S"),
+            )
+            .unwrap();
+
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, id);
+        assert_eq!(models[0].label, "front");
+        assert_eq!(models[0].embedder_model, "w600k");
+        assert_eq!(models[0].device_id.as_deref(), Some("046d:085e:S"));
+
+        let mut rows = store.get_user_embeddings_raw("alice").unwrap();
+        rows.sort_by(|a, b| a.1.cmp(&b.1));
+        assert_eq!(rows.len(), 3, "every blob lands under the one model");
+        for (row, blob) in rows.iter().zip(&blobs) {
+            assert_eq!(row.0, id);
+            assert_eq!(&row.1, blob);
+            assert!(row.2, "sealed flag applies to every row");
+        }
+    }
+
+    #[test]
+    fn replace_model_replaces_only_the_same_user_and_label() {
+        let store = FaceStore::open_memory().unwrap();
+        let emb = test_embedding();
+        let old_front = store.add_model("alice", "front", &emb, "").unwrap();
+        let alice_side = store.add_model("alice", "side", &emb, "").unwrap();
+        let bob_front = store.add_model("bob", "front", &emb, "").unwrap();
+
+        let blobs = blobs(2);
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+        let new_front = store
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .unwrap();
+
+        assert_ne!(new_front, old_front, "the replacement is a new row");
+        let mut alice: Vec<(u32, String)> = store
+            .list_models("alice")
+            .unwrap()
+            .into_iter()
+            .map(|m| (m.id, m.label))
+            .collect();
+        alice.sort();
+        assert_eq!(
+            alice,
+            vec![
+                (alice_side, "side".to_string()),
+                (new_front, "front".to_string())
+            ]
+        );
+        assert_eq!(store.list_models("bob").unwrap()[0].id, bob_front);
+
+        // The old model's embedding went with it; only the new blobs remain
+        // under "front".
+        let front_rows: Vec<_> = store
+            .get_user_embeddings_raw("alice")
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.0 == new_front)
+            .collect();
+        assert_eq!(front_rows.len(), 2);
+        let orphaned: u32 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM face_embeddings WHERE model_id = ?1",
+                params![old_front],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphaned, 0, "cascade removed the old model's embeddings");
+    }
+
+    #[test]
+    fn replace_model_rolls_back_to_the_old_model_when_an_insert_fails() {
+        let store = FaceStore::open_memory().unwrap();
+        let emb = test_embedding();
+        let old_id = store.add_model("alice", "front", &emb, "").unwrap();
+
+        // Fault: the second embedding row of any model refuses to insert. The
+        // delete and the model insert have already run inside the transaction
+        // by the time this fires, so a non-transactional implementation would
+        // leave the old model gone and a one-embedding replacement behind.
+        store
+            .conn
+            .execute_batch(
+                "CREATE TRIGGER fail_second_embedding BEFORE INSERT ON face_embeddings
+                 WHEN (SELECT COUNT(*) FROM face_embeddings WHERE model_id = NEW.model_id) >= 1
+                 BEGIN SELECT RAISE(ABORT, 'injected insert failure'); END;",
+            )
+            .unwrap();
+
+        let blobs = blobs(3);
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+        let err = store
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("injected insert failure"),
+            "the injected failure must surface, got: {err}"
+        );
+
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1, "exactly the old model remains: {models:?}");
+        assert_eq!(models[0].id, old_id, "the old model row survived untouched");
+        let rows = store.get_user_embeddings("alice").unwrap();
+        assert_eq!(rows.len(), 1, "the old model keeps its embedding");
+        assert_eq!(rows[0].0, old_id);
+        assert_eq!(rows[0].1[0], emb[0]);
+    }
+
+    #[test]
+    fn replace_model_refuses_an_empty_embedding_set() {
+        let store = FaceStore::open_memory().unwrap();
+        let emb = test_embedding();
+        let old_id = store.add_model("alice", "front", &emb, "").unwrap();
+
+        let err = store
+            .replace_model_with_embeddings("alice", "front", &[], false, "", None)
+            .unwrap_err();
+        assert!(
+            matches!(err, StoreError::Query { .. }),
+            "an empty set is a caller bug reported as a query error, got: {err:?}"
+        );
+        let models = store.list_models("alice").unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].id, old_id,
+            "a refused replacement changes nothing"
+        );
     }
 
     #[test]

--- a/crates/facelock-store/src/lib.rs
+++ b/crates/facelock-store/src/lib.rs
@@ -2,5 +2,5 @@ pub mod db;
 pub mod error;
 pub mod migrations;
 
-pub use db::FaceStore;
+pub use db::{FaceStore, MIN_EMBEDDINGS_PER_MODEL};
 pub use error::{Result, StoreError};

--- a/crates/facelock-test-support/src/mock_camera.rs
+++ b/crates/facelock-test-support/src/mock_camera.rs
@@ -24,6 +24,10 @@ pub type MockCameraFactory = Box<
     dyn Fn(&facelock_core::config::Config) -> std::result::Result<MockCamera, String> + Send + Sync,
 >;
 
+/// Runs before each capture with that capture's 1-based ordinal. `Send` so a
+/// camera carrying one still satisfies the daemon's handler bounds.
+type CaptureHook = Box<dyn FnMut(usize) + Send>;
+
 /// A mock camera that replays pre-built frames.
 pub struct MockCamera {
     frames: Vec<Frame>,
@@ -31,6 +35,9 @@ pub struct MockCamera {
     #[allow(dead_code)]
     dark_threshold: f32,
     caps: CameraCaps,
+    capture_hook: Option<CaptureHook>,
+    /// Total captures served, across wrap-arounds.
+    served: usize,
 }
 
 impl MockCamera {
@@ -44,6 +51,8 @@ impl MockCamera {
             index: 0,
             dark_threshold: 0.4,
             caps: CameraCaps::default(),
+            capture_hook: None,
+            served: 0,
         }
     }
 
@@ -57,6 +66,8 @@ impl MockCamera {
             index: 0,
             dark_threshold: 0.4,
             caps: CameraCaps::default(),
+            capture_hook: None,
+            served: 0,
         }
     }
 
@@ -67,6 +78,8 @@ impl MockCamera {
             index: 0,
             dark_threshold: 0.4,
             caps: CameraCaps::default(),
+            capture_hook: None,
+            served: 0,
         }
     }
 
@@ -77,9 +90,17 @@ impl MockCamera {
         self
     }
 
+    /// Run `hook` before each capture with that capture's 1-based ordinal, so
+    /// a test can act in the middle of a capture loop — cancel the request
+    /// on the Nth frame, say — without a second camera type.
+    pub fn with_capture_hook(mut self, hook: impl FnMut(usize) + Send + 'static) -> Self {
+        self.capture_hook = Some(Box::new(hook));
+        self
+    }
+
     /// How many frames have been captured.
     pub fn captures(&self) -> usize {
-        self.index
+        self.served
     }
 
     /// Mock darkness check (fixed thresholds), kept as an inherent method now
@@ -100,6 +121,10 @@ impl CameraSource for MockCamera {
     }
 
     fn capture(&mut self) -> Result<Frame> {
+        self.served += 1;
+        if let Some(hook) = self.capture_hook.as_mut() {
+            hook(self.served);
+        }
         if self.index >= self.frames.len() {
             // Wrap around to allow repeated captures
             self.index = 0;

--- a/crates/facelock-test-support/src/mock_camera.rs
+++ b/crates/facelock-test-support/src/mock_camera.rs
@@ -140,3 +140,43 @@ impl CameraSource for MockCamera {
         Ok(frame)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn capture_hook_runs_before_each_capture_with_its_ordinal() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let mut cam =
+            MockCamera::bright(8, 8, 2).with_capture_hook(move |n| sink.lock().unwrap().push(n));
+
+        cam.capture().unwrap();
+        cam.capture_rgb_only().unwrap();
+        cam.capture().unwrap();
+
+        // 1-based, one per capture, the RGB-only path included.
+        assert_eq!(*seen.lock().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn captures_counts_across_wrap_arounds() {
+        let mut cam = MockCamera::bright(8, 8, 2);
+        for _ in 0..5 {
+            cam.capture().unwrap();
+        }
+        // Five frames served from a two-frame replay: the count is the
+        // number served, not the replay index (which has wrapped to 1).
+        assert_eq!(cam.captures(), 5);
+    }
+
+    #[test]
+    fn a_camera_without_a_hook_still_counts() {
+        let mut cam = MockCamera::bright(8, 8, 1);
+        assert_eq!(cam.captures(), 0);
+        cam.capture().unwrap();
+        assert_eq!(cam.captures(), 1);
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -282,7 +282,7 @@ facelock enroll --label "office"        # specific label
 facelock enroll --skip-setup-check      # enroll on a tree setup never marked complete
 ```
 
-Captures 3-10 frames over ~15 seconds. Requires exactly one face per frame. Re-enrolling with the same label replaces the previous model.
+Captures 3-10 frames over ~15 seconds. Requires exactly one face per frame. Re-enrolling with the same label replaces the previous model on success; a cancelled or failed re-enrollment leaves the previous model in place.
 
 Without `--skip-setup-check`, an install whose setup-complete marker is missing
 is offered `facelock setup` first and enrolls through it, since setup enrolls a

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3013,21 +3013,22 @@ never a lockout.
 end: after every accepted embedding has passed the minimum-capture and angle-diversity
 gates and, with encryption on, been sealed, one transaction removes the previous model
 under the same user and label and inserts the new model with all of its embeddings. Until
-that commit the accepted embeddings exist only in memory, inside the wiping guard. Every
-other exit (a cancellation, including one that lands on the final frame; the deadline
-passing with too few frames; a rejected set; a sealing error; a storage error; a daemon
-crash) leaves the store exactly as it was: no model, no embeddings, and a previous
-same-label template still in place and still authenticating. A model row written by this
-version or later is therefore a complete template, and `facelock list` and `Authenticate`
-can never observe an attempt that did not finish; the store itself refuses to commit a
-model with fewer than `MIN_EMBEDDINGS_PER_MODEL` (3) embeddings, the same floor the
-capture loop enforces. The cancel token is checked once more immediately before the
-store write, after sealing, so a caller that departs during finalization still gets
-`Cancelled` and an unchanged store; the residual window is the commit itself. The
-guarantee is therefore one-sided: a caller that cancelled is never surprised by a
-template, but a caller whose reply is lost after the commit (the daemon killed, the bus
-connection dropped, a client timeout between commit and reply) may find a valid template
-it reported as failed. No migration inspects rows written by earlier
+that commit the accepted embeddings exist only in memory, inside the wiping guard, and
+every exit observed before the store write (a cancellation, including one that lands on
+the final frame; the deadline passing with too few frames; a rejected set; a sealing
+error; a storage error; a daemon crash) leaves the store exactly as it was: no model, no
+embeddings, and a previous same-label template still in place and still authenticating.
+A model row written by this version or later is therefore a complete template, and
+`facelock list` and `Authenticate` can never observe an attempt that did not finish; the
+store itself refuses to commit a model with fewer than `MIN_EMBEDDINGS_PER_MODEL` (3)
+embeddings, the same floor the capture loop enforces. Both are pre-commit guarantees.
+The cancel token is checked once more immediately before the store write, after sealing,
+so a caller that departs during finalization still gets `Cancelled` and an unchanged
+store; the commit is the one residual window. A cancellation or crash observed during or
+after the commit can leave the new model stored while the reply is lost (the daemon
+killed, the bus connection dropped, a client timeout between commit and reply), so a
+caller may find a valid template it reported as failed, whereas a caller that cancelled
+before the write is never surprised by one. No migration inspects rows written by earlier
 versions: a partial model the old flow left behind stays until `facelock remove` or
 `facelock clear` deletes it.
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3019,10 +3019,14 @@ passing with too few frames; a rejected set; a sealing error; a storage error; a
 crash) leaves the store exactly as it was: no model, no embeddings, and a previous
 same-label template still in place and still authenticating. A model row written by this
 version or later is therefore a complete template, and `facelock list` and `Authenticate`
-can never observe an attempt that did not finish; the store also refuses to commit a model
-with no embeddings at all. No migration inspects rows written by earlier versions: a
-partial model the old flow left behind stays until `facelock remove` or `facelock clear`
-deletes it.
+can never observe an attempt that did not finish; the store itself refuses to commit a
+model with fewer than `MIN_EMBEDDINGS_PER_MODEL` (3) embeddings, the same floor the
+capture loop enforces. The guarantee is one-sided: a caller that cancelled is never
+surprised by a template, but a caller whose reply is lost after the commit (the daemon
+killed, the bus connection dropped, a client timeout between commit and reply) may find a
+valid template it reported as failed. No migration inspects rows written by earlier
+versions: a partial model the old flow left behind stays until `facelock remove` or
+`facelock clear` deletes it.
 
 **Camera hold semantics (ADR 008).** `device.camera_release_secs` (default **3**) is the
 number of seconds the **daemon** keeps the camera streaming **after a failed

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3009,6 +3009,19 @@ on first use if absent. `method = "none"` (plaintext) is **refused at enrollment
 `security.allow_plaintext = true`. Auth always degrades to password on a decrypt failure —
 never a lockout.
 
+**Enrollment atomicity (#308).** An enrollment writes to the store exactly once, at the
+end: after every accepted embedding has passed the minimum-capture and angle-diversity
+gates and, with encryption on, been sealed, one transaction removes the previous model
+under the same user and label and inserts the new model with all of its embeddings. Until
+that commit the accepted embeddings exist only in memory, inside the wiping guard. Every
+other exit (a cancellation, including one that lands on the final frame; the deadline
+passing with too few frames; a rejected set; a sealing error; a storage error; a daemon
+crash) leaves the store exactly as it was: no model, no embeddings, and a previous
+same-label template still in place and still authenticating. A model row that exists is
+therefore a complete template; `facelock list` and `Authenticate` can never observe an
+attempt that did not finish, and the store refuses to commit a model with no embeddings
+at all.
+
 **Camera hold semantics (ADR 008).** `device.camera_release_secs` (default **3**) is the
 number of seconds the **daemon** keeps the camera streaming **after a failed
 authentication** — the one ending a retry plausibly follows — so that retry skips the

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3017,10 +3017,12 @@ that commit the accepted embeddings exist only in memory, inside the wiping guar
 other exit (a cancellation, including one that lands on the final frame; the deadline
 passing with too few frames; a rejected set; a sealing error; a storage error; a daemon
 crash) leaves the store exactly as it was: no model, no embeddings, and a previous
-same-label template still in place and still authenticating. A model row that exists is
-therefore a complete template; `facelock list` and `Authenticate` can never observe an
-attempt that did not finish, and the store refuses to commit a model with no embeddings
-at all.
+same-label template still in place and still authenticating. A model row written by this
+version or later is therefore a complete template, and `facelock list` and `Authenticate`
+can never observe an attempt that did not finish; the store also refuses to commit a model
+with no embeddings at all. No migration inspects rows written by earlier versions: a
+partial model the old flow left behind stays until `facelock remove` or `facelock clear`
+deletes it.
 
 **Camera hold semantics (ADR 008).** `device.camera_release_secs` (default **3**) is the
 number of seconds the **daemon** keeps the camera streaming **after a failed

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3021,10 +3021,13 @@ same-label template still in place and still authenticating. A model row written
 version or later is therefore a complete template, and `facelock list` and `Authenticate`
 can never observe an attempt that did not finish; the store itself refuses to commit a
 model with fewer than `MIN_EMBEDDINGS_PER_MODEL` (3) embeddings, the same floor the
-capture loop enforces. The guarantee is one-sided: a caller that cancelled is never
-surprised by a template, but a caller whose reply is lost after the commit (the daemon
-killed, the bus connection dropped, a client timeout between commit and reply) may find a
-valid template it reported as failed. No migration inspects rows written by earlier
+capture loop enforces. The cancel token is checked once more immediately before the
+store write, after sealing, so a caller that departs during finalization still gets
+`Cancelled` and an unchanged store; the residual window is the commit itself. The
+guarantee is therefore one-sided: a caller that cancelled is never surprised by a
+template, but a caller whose reply is lost after the commit (the daemon killed, the bus
+connection dropped, a client timeout between commit and reply) may find a valid template
+it reported as failed. No migration inspects rows written by earlier
 versions: a partial model the old flow left behind stays until `facelock remove` or
 `facelock clear` deletes it.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -554,6 +554,12 @@ plaintext biometric templates unless `security.allow_plaintext = true`, and warn
 when it does. This never affects auth — a decrypt failure degrades to the password fallback,
 never a lockout.
 
+Enrollment persists a template only once every accepted embedding has passed the capture
+gates and been sealed, in one store transaction that also replaces the previous same-label
+model (#308); a cancelled or failed enrollment leaves the store untouched, so a partial
+template can never authenticate and a failed re-enrollment keeps the template it was
+replacing (`docs/contracts.md`, "Enrollment atomicity").
+
 **In memory**, the long-lived compare sets are held in a drop guard (`Wiped` in
 `facelock-core`) that zeroizes them on every exit path, unwind included: the authentication
 loop's caller buffer and device-filtered compare set, the daemon's preview compare set

--- a/docs/security.md
+++ b/docs/security.md
@@ -557,8 +557,9 @@ never a lockout.
 Enrollment persists a template only once every accepted embedding has passed the capture
 gates and been sealed, in one store transaction that also replaces the previous same-label
 model (#308); a cancelled or failed enrollment leaves the store untouched, so a partial
-template can never authenticate and a failed re-enrollment keeps the template it was
-replacing (`docs/contracts.md`, "Enrollment atomicity").
+template written by this version can never authenticate and a failed re-enrollment keeps
+the template it was replacing. Templates the old flow left behind are covered in
+`docs/contracts.md`, "Enrollment atomicity".
 
 **In memory**, the long-lived compare sets are held in a drop guard (`Wiped` in
 `facelock-core`) that zeroizes them on every exit path, unwind included: the authentication


### PR DESCRIPTION
## Summary

- buffer accepted embeddings in the `Wiped` guard and write the store once, after the minimum-capture and angle-diversity gates pass and sealing is done
- add `FaceStore::replace_model_with_embeddings`: one transaction deletes the previous same-label model and inserts the new model with every embedding; a failure after the delete rolls the old model back
- remove the delete-before-capture in the enrollment preamble and the `discard_partial_model` cleanup it required
- refuse a model with fewer than `MIN_EMBEDDINGS_PER_MODEL` (3) embeddings in the store; the daemon's `MIN_CAPTURES` derives from that constant
- honour a cancellation that lands on the final frame before the commit, so `Cancelled` always means the store is unchanged
- document that partial rows an earlier version left behind are not migrated, and how to remove them
- add `MockCamera::with_capture_hook` so a test can cancel a request on the Nth frame

## Why

Enrollment created the model row on the first accepted frame and appended embeddings one at a time, and a re-enrollment under an existing label deleted the previous model before capturing anything. A cancellation, a sealing or storage error, or a daemon crash after that first write left a template behind that never passed the capture gates, and authentication loaded it like any other. Every exit other than success now leaves the store exactly as it was, previous template included.

## Files

| Path | Why it matters |
|---|---|
| `crates/facelock-daemon/src/enroll.rs` | loop buffers, `persist_enrollment` is the single write *(start here)* |
| `crates/facelock-store/src/db.rs` | `replace_model_with_embeddings`, `MIN_EMBEDDINGS_PER_MODEL`, shared `insert_model_row` |
| `crates/facelock-daemon/tests/daemon_integration.rs` | handler-level proofs: a cancelled enroll is invisible to `ListModels` and `Authenticate`; a cancelled re-enrollment still authenticates |
| `crates/facelock-test-support/src/mock_camera.rs` | capture hook; `captures()` counts across wrap-arounds |
| `docs/contracts.md`, `docs/security.md`, `docs/cli.md`, `CHANGELOG.md` | the guarantee, its one-sided edge, the legacy-row caveat |

## Validation

- `cargo test -p facelock-daemon -p facelock-store`, including a trigger that aborts the second embedding insert to exercise the rollback
- handler-level tests run against the pre-change loop as well
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check`

## Reviewer notes

- **one-sided guarantee**: a cancelled caller never finds a surprise template; a caller whose reply is lost after the commit (daemon kill, bus drop, client timeout) may find a valid template it reported as failed. `docs/contracts.md` says so
- **legacy rows**: a one-embedding row from the old flow survives the upgrade and still authenticates; no migration touches it and `facelock list` shows no embedding counts
- **`EmbeddingSealer` seam**: a private one-method trait so a test can make sealing fail, which AES-GCM under a valid key never does

Closes #308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrollment now saves accepted biometric data in a single atomic operation after all quality and capture requirements pass.
  * At least three embeddings are required to create or replace a model.
  * Cancelled or failed re-enrollment preserves the existing model and authentication behavior.
  * Timeout messages explain cancellation behavior and advise checking enrollment status before retrying.

* **Documentation**
  * Updated CLI, contract, security, and changelog documentation to describe enrollment persistence and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->