### PR TITLE
fix(setup): refuse systemd setup under a config override

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -9,7 +9,7 @@ derives-from:
   - dist/facelock.tmpfiles
   - systemd/facelock-daemon.service
   - docs/adr/**
-reviewed: 2026-08-24
+reviewed: 2026-09-01
 ---
 
 # Security Rules

--- a/crates/facelock-cli/src/backend.rs
+++ b/crates/facelock-cli/src/backend.rs
@@ -12,7 +12,7 @@
 //! Now selection is made **once per invocation**, at the top of each
 //! backend-using command, with **at most one** deliberate, non-activating bus
 //! probe. The outcome is a [`BackendKind`], not a boolean, because "direct"
-//! means two different things that deserve different messages and log levels;
+//! means three different things that deserve different messages and log levels;
 //! and every operation that used to fork per call site forks in exactly one
 //! method here.
 //!
@@ -56,13 +56,21 @@ pub enum BackendKind {
     /// `daemon.mode = "daemon"` but the bus name has no owner — degraded.
     /// WARNed once, at selection.
     DirectByFallback,
+    /// `daemon.mode = "daemon"` under a non-default `--config` (#314). The
+    /// packaged unit runs bare `facelock daemon` and reads only the default
+    /// file, so whatever owns the bus is configured by a file this process is
+    /// not reading: its store, camera, models and security policy cannot be
+    /// proven to match. Expected, told once at INFO; the bus is never asked.
+    DirectByOverride,
 }
 
 impl BackendKind {
     pub fn is_direct(self) -> bool {
         match self {
             BackendKind::Daemon => false,
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => true,
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => true,
         }
     }
 }
@@ -74,7 +82,8 @@ impl BackendKind {
 /// report wants and a human does not need at selection time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DaemonReachability {
-    /// `mode = "oneshot"`: the bus is deliberately never asked.
+    /// `mode = "oneshot"`, or a non-default `--config`: the bus is
+    /// deliberately never asked.
     NotProbed,
     Reachable,
     Unreachable,
@@ -114,7 +123,12 @@ impl<'a> Backend<'a> {
     /// each backend-using command; probes the bus at most once (never for
     /// `mode = "oneshot"`), non-activating by construction.
     pub fn select(config: &'a Config) -> Backend<'a> {
-        let (kind, reachability) = classify(&config.daemon.mode, daemon_bus_reachable);
+        let config_override = facelock_core::paths::non_default_config_override();
+        let (kind, reachability) = classify(
+            &config.daemon.mode,
+            config_override.is_some(),
+            daemon_bus_reachable,
+        );
         let (level, notice) = announcement(kind);
         // The one machine-facing record of the selection and the probed
         // reachability fact. `tracing::event!` needs a const level, hence the
@@ -124,12 +138,21 @@ impl<'a> Backend<'a> {
                 target: "facelock::backend",
                 ?kind,
                 ?reachability,
+                ?config_override,
+                "backend selected"
+            ),
+            tracing::Level::INFO => tracing::info!(
+                target: "facelock::backend",
+                ?kind,
+                ?reachability,
+                ?config_override,
                 "backend selected"
             ),
             _ => tracing::debug!(
                 target: "facelock::backend",
                 ?kind,
                 ?reachability,
+                ?config_override,
                 "backend selected"
             ),
         }
@@ -149,7 +172,9 @@ impl<'a> Backend<'a> {
                 graphical_preview: true,
                 device_formats: false,
             },
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => BackendCaps {
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => BackendCaps {
                 graphical_preview: false,
                 device_formats: true,
             },
@@ -160,13 +185,13 @@ impl<'a> Backend<'a> {
     pub fn has_models(&self, user: &str) -> anyhow::Result<bool> {
         match self.kind {
             BackendKind::Daemon => Ok(!self.daemon_list_models(user)?.is_empty()),
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                self.direct_read(false, |store| {
-                    store
-                        .has_models(user)
-                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-                })
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => self.direct_read(false, |store| {
+                store
+                    .has_models(user)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
         }
     }
 
@@ -177,13 +202,13 @@ impl<'a> Backend<'a> {
                 .daemon_list_models(user)?
                 .iter()
                 .any(|model| model.embedder_model == embedder)),
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                self.direct_read(false, |store| {
-                    store
-                        .has_models_for_embedder(user, embedder)
-                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-                })
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => self.direct_read(false, |store| {
+                store
+                    .has_models_for_embedder(user, embedder)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
         }
     }
 
@@ -191,13 +216,13 @@ impl<'a> Backend<'a> {
     pub fn list_models(&self, user: &str) -> anyhow::Result<Vec<FaceModelInfo>> {
         match self.kind {
             BackendKind::Daemon => self.daemon_list_models(user),
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                self.direct_read(Vec::new(), |store| {
-                    store
-                        .list_models(user)
-                        .map_err(|e| anyhow::anyhow!("storage error: {e}"))
-                })
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => self.direct_read(Vec::new(), |store| {
+                store
+                    .list_models(user)
+                    .map_err(|e| anyhow::anyhow!("storage error: {e}"))
+            }),
         }
     }
 
@@ -213,14 +238,14 @@ impl<'a> Backend<'a> {
             // An absent store provably holds nothing to remove: report "not
             // found" without materializing a database (the per-site version
             // used the creating opener here).
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                self.direct_read(Some(false), |store| {
-                    store
-                        .remove_model(user, model_id)
-                        .map(Some)
-                        .map_err(|e| anyhow::anyhow!("{e}"))
-                })
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => self.direct_read(Some(false), |store| {
+                store
+                    .remove_model(user, model_id)
+                    .map(Some)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }),
         }
     }
 
@@ -239,14 +264,14 @@ impl<'a> Backend<'a> {
             // database (C7). This used to error on the grounds that callers
             // check `has_models` first, which made the answer depend on call
             // ordering the type could not express.
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                self.direct_read(Some(0), |store| {
-                    store
-                        .clear_user(user)
-                        .map(|count| Some(count as usize))
-                        .map_err(|e| anyhow::anyhow!("{e}"))
-                })
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => self.direct_read(Some(0), |store| {
+                store
+                    .clear_user(user)
+                    .map(|count| Some(count as usize))
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }),
         }
     }
 
@@ -256,9 +281,9 @@ impl<'a> Backend<'a> {
     pub fn enroll(&self, user: &str, label: &str) -> anyhow::Result<(u32, u32)> {
         match self.kind {
             BackendKind::Daemon => ipc_client::send_enroll(user, label, self.config),
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                direct::enroll(self.config, user, label)
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => direct::enroll(self.config, user, label),
         }
     }
 
@@ -290,9 +315,9 @@ impl<'a> Backend<'a> {
                 AuthOutcome::Error { message, .. } => bail!("daemon error: {message}"),
                 AuthOutcome::Cancelled => bail!("authentication cancelled"),
             },
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                direct::authenticate(self.config, user)
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => direct::authenticate(self.config, user),
         }
     }
 
@@ -312,9 +337,9 @@ impl<'a> Backend<'a> {
                     }
                 })
             }
-            BackendKind::DirectByConfig | BackendKind::DirectByFallback => {
-                direct::list_devices_info()
-            }
+            BackendKind::DirectByConfig
+            | BackendKind::DirectByFallback
+            | BackendKind::DirectByOverride => direct::list_devices_info(),
         }
     }
 
@@ -386,10 +411,23 @@ fn probe_daemon_with(
 }
 
 /// The selection rule, split from the probe so it is testable without a bus.
+///
+/// `config_override` is [`facelock_core::paths::non_default_config_override`]'s
+/// verdict. It outranks the bus in daemon mode: a daemon that answers is
+/// reading the default file, and an answer from it would be an answer about
+/// a configuration this invocation did not select. The bus is not probed on
+/// that path, so no reachability fact is claimed that was never observed.
 fn classify(
     mode: &DaemonMode,
+    config_override: bool,
     probe: impl FnOnce() -> bool,
 ) -> (BackendKind, Fact<DaemonReachability>) {
+    if config_override && matches!(mode, DaemonMode::Daemon) {
+        return (
+            BackendKind::DirectByOverride,
+            Fact::claimed(DaemonReachability::NotProbed),
+        );
+    }
     match mode {
         DaemonMode::Oneshot => (
             BackendKind::DirectByConfig,
@@ -412,8 +450,10 @@ fn classify(
 }
 
 /// What selection says, per kind: the log level for the machine line, and
-/// the user-facing stderr message, if any. Three kinds, three treatments —
-/// an expected configuration is silent, a degraded fallback warns once.
+/// the user-facing stderr message, if any. Four kinds, three treatments —
+/// an expected configuration is silent, a degraded fallback warns once, and
+/// an override is explained once without a warning, because the operator
+/// chose it and the daemon it bypasses is not at fault.
 fn announcement(kind: BackendKind) -> (tracing::Level, Option<AccessMessage>) {
     match kind {
         BackendKind::Daemon => (tracing::Level::DEBUG, None),
@@ -421,6 +461,10 @@ fn announcement(kind: BackendKind) -> (tracing::Level, Option<AccessMessage>) {
         BackendKind::DirectByFallback => (
             tracing::Level::WARN,
             Some(AccessMessage::DaemonUnreachableFallback),
+        ),
+        BackendKind::DirectByOverride => (
+            tracing::Level::INFO,
+            Some(AccessMessage::DirectByConfigOverride),
         ),
     }
 }
@@ -455,7 +499,7 @@ mod tests {
 
     #[test]
     fn oneshot_config_selects_direct_without_probing() {
-        let (kind, fact) = classify(&DaemonMode::Oneshot, || {
+        let (kind, fact) = classify(&DaemonMode::Oneshot, false, || {
             panic!("oneshot must never probe the bus")
         });
         assert_eq!(kind, BackendKind::DirectByConfig);
@@ -464,16 +508,42 @@ mod tests {
 
     #[test]
     fn daemon_mode_with_owner_selects_daemon() {
-        let (kind, fact) = classify(&DaemonMode::Daemon, || true);
+        let (kind, fact) = classify(&DaemonMode::Daemon, false, || true);
         assert_eq!(kind, BackendKind::Daemon);
         assert_eq!(fact, Fact::probed(DaemonReachability::Reachable));
     }
 
     #[test]
     fn daemon_mode_without_owner_is_fallback_not_config() {
-        let (kind, fact) = classify(&DaemonMode::Daemon, || false);
+        let (kind, fact) = classify(&DaemonMode::Daemon, false, || false);
         assert_eq!(kind, BackendKind::DirectByFallback);
         assert_eq!(fact, Fact::probed(DaemonReachability::Unreachable));
+    }
+
+    /// #314: under a non-default `--config` the daemon on the bus reads a
+    /// different file, so daemon mode never selects it, whatever the bus
+    /// says. The bus is not even asked: its answer could not change the
+    /// selection, and a probe would be a fact `status` might then misreport.
+    #[test]
+    fn config_override_selects_direct_without_probing_whoever_owns_the_bus() {
+        let (kind, fact) = classify(&DaemonMode::Daemon, true, || {
+            panic!("a config override must never probe the bus")
+        });
+        assert_eq!(kind, BackendKind::DirectByOverride);
+        assert_eq!(fact, Fact::claimed(DaemonReachability::NotProbed));
+        assert!(kind.is_direct());
+    }
+
+    /// The override changes nothing for oneshot: direct access is already
+    /// the configuration, and there is no daemon whose identity is in doubt,
+    /// so the override note would explain a choice nothing made.
+    #[test]
+    fn config_override_leaves_oneshot_as_direct_by_config() {
+        let (kind, fact) = classify(&DaemonMode::Oneshot, true, || {
+            panic!("oneshot must never probe the bus")
+        });
+        assert_eq!(kind, BackendKind::DirectByConfig);
+        assert_eq!(fact, Fact::claimed(DaemonReachability::NotProbed));
     }
 
     // -----------------------------------------------------------------------
@@ -523,6 +593,12 @@ mod tests {
         let (level, msg) = announcement(BackendKind::DirectByFallback);
         assert_eq!(level, tracing::Level::WARN);
         assert_eq!(msg, Some(AccessMessage::DaemonUnreachableFallback));
+
+        // An override is a choice the operator made, not a degraded state:
+        // told once, at INFO, never with the fallback's warning.
+        let (level, msg) = announcement(BackendKind::DirectByOverride);
+        assert_eq!(level, tracing::Level::INFO);
+        assert_eq!(msg, Some(AccessMessage::DirectByConfigOverride));
     }
 
     #[test]

--- a/crates/facelock-cli/src/commands/preview/mod.rs
+++ b/crates/facelock-cli/src/commands/preview/mod.rs
@@ -49,6 +49,7 @@ pub fn run(config: &Config, json: bool, user: Option<String>) -> anyhow::Result<
 fn graphical_unavailable_message(kind: BackendKind) -> AccessMessage {
     match kind {
         BackendKind::DirectByFallback => AccessMessage::PreviewGraphicalDaemonUnreachable,
+        BackendKind::DirectByOverride => AccessMessage::PreviewGraphicalDaemonConfigOverride,
         _ => AccessMessage::PreviewGraphicalNeedsDaemonOneshot,
     }
 }
@@ -94,6 +95,12 @@ mod tests {
         assert_eq!(
             graphical_unavailable_message(BackendKind::DirectByConfig),
             AccessMessage::PreviewGraphicalNeedsDaemonOneshot
+        );
+        // Likewise a daemon bypassed under `--config` (#314) is neither
+        // stopped nor configured off.
+        assert_eq!(
+            graphical_unavailable_message(BackendKind::DirectByOverride),
+            AccessMessage::PreviewGraphicalDaemonConfigOverride
         );
     }
 

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -344,6 +344,32 @@ pub fn needs_root_precheck(plan: &SetupPlan) -> bool {
     plan.base.is_some()
 }
 
+/// Whether `plan` enables the daemon unit: `--systemd`, in a base flow or on
+/// its own. `--systemd --disable` stops the unit, which reads no config file
+/// and needs no identity check; `Ask` is answered at step 6, where the wizard
+/// asks [`check_unit_reads_this_config`]'s question before it asks the user.
+fn enables_daemon_unit(plan: &SetupPlan) -> bool {
+    matches!(plan.systemd, SystemdPref::Install)
+}
+
+/// The unit setup enables runs bare `facelock daemon` (ADR 009 §4), which
+/// reads only the default config file: `FACELOCK_CONFIG` is ignored by a
+/// privileged process and the unit passes no `--config`. Under any other
+/// file, the daemon this would enable is configured by a file setup never
+/// touched, so its store, camera, models and encryption policy cannot be
+/// proven to match what enrollment writes (#314). Refused, with the two ways
+/// out named. No unit drop-in and no transient daemon: setup's own
+/// `validate_systemd_unit_resolution` rejects drop-ins, and a daemon that
+/// outlives setup must be the packaged one.
+fn check_unit_reads_this_config() -> anyhow::Result<()> {
+    match facelock_core::paths::non_default_config_override() {
+        Some(path) => Err(fail(SystemMessage::SystemdRefusedConfigOverride {
+            path: path.display().to_string(),
+        })),
+        None => Ok(()),
+    }
+}
+
 /// The writer's two independent knobs, named.
 ///
 /// A pair of `bool`s in a tuple is how `install_for_setup(services,
@@ -395,6 +421,14 @@ fn pam_request(action: PamAction, service: &str, knobs: PamKnobs, if_present: bo
 pub fn run_with_plan(plan: SetupPlan) -> anyhow::Result<()> {
     if needs_root_precheck(&plan) {
         crate::ipc_client::require_root("sudo facelock setup")?;
+        // Ahead of the base flow, which writes from its first step: a
+        // `--systemd` answer the unit cannot honour is refused before a
+        // directory is created or a model downloaded (#314). The standalone
+        // form has no base flow and no precheck; `run_systemd` asks the same
+        // question itself, after its own root check.
+        if enables_daemon_unit(&plan) {
+            check_unit_reads_this_config()?;
+        }
     }
 
     // Whether the interactive wizard ran, and therefore already asked about PAM.
@@ -583,14 +617,24 @@ fn run_wizard(plan: &SetupPlan) -> anyhow::Result<()> {
     Terminal.info(&SetupMessage::SetupStepDaemon);
     let systemd_step = systemd_step_for(plan);
     let systemd_enabled = match systemd_step {
-        SystemdStep::Ask => match wizard_systemd_setup(&theme, plan.yes) {
-            Ok(enabled) => enabled,
-            Err(e) => {
-                Terminal.info(&SetupMessage::SystemdStepFailed {
-                    error: e.to_string(),
+        // The unit would not read the file this wizard is configuring, so
+        // the question has one honest answer (#314): given, not asked.
+        SystemdStep::Ask => match facelock_core::paths::non_default_config_override() {
+            Some(path) => {
+                Terminal.info(&SystemMessage::SystemdSkippedConfigOverride {
+                    path: path.display().to_string(),
                 });
                 false
             }
+            None => match wizard_systemd_setup(&theme, plan.yes) {
+                Ok(enabled) => enabled,
+                Err(e) => {
+                    Terminal.info(&SetupMessage::SystemdStepFailed {
+                        error: e.to_string(),
+                    });
+                    false
+                }
+            },
         },
         // Answered on the command line. Applied here rather than after the
         // whole base flow, for the ordering reason above; the error it can
@@ -3881,6 +3925,11 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
         run_cmd("systemctl", &["disable", "--now", "facelock-daemon"])?;
         Terminal.info(&SystemMessage::SystemdUnitsDisabled);
     } else {
+        // Before the legacy-asset migration below removes anything: the
+        // base flows refused earlier, this is the standalone form's turn
+        // and every other caller's backstop (#314).
+        check_unit_reads_this_config()?;
+
         Terminal.info(&SystemMessage::ValidatingSystemAssets);
         let migrated = validate_and_migrate_system_assets(&SystemAssetLayout::production())?;
         for path in migrated {
@@ -6306,6 +6355,105 @@ mod action_tests {
             assert_eq!(plan.systemd, SystemdPref::Install);
             assert_eq!(systemd_step_for(&plan), SystemdStep::Install);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #314: `--systemd` under a non-default `--config`. The packaged unit
+    // runs bare `facelock daemon` and reads only the default file, so the
+    // daemon setup would enable is not the one it is configuring. Refused,
+    // before anything is written.
+    // -----------------------------------------------------------------------
+
+    /// Only `--systemd` enables the unit. `--systemd --disable` stops it,
+    /// which depends on no config file, and `Ask`/`Skip` enable nothing here.
+    #[test]
+    fn only_an_install_answer_enables_the_daemon_unit() {
+        for (pref, expected) in [
+            (SystemdPref::Install, true),
+            (SystemdPref::Disable, false),
+            (SystemdPref::Ask, false),
+            (SystemdPref::Skip, false),
+        ] {
+            let plan = SetupPlan {
+                systemd: pref,
+                ..SetupPlan::default()
+            };
+            assert_eq!(enables_daemon_unit(&plan), expected, "{pref:?}");
+        }
+    }
+
+    /// The identity check itself, through the process override the global
+    /// `--config` installs: another file refuses with the two ways out, the
+    /// default file (however spelled) and no override at all pass.
+    #[test]
+    fn unit_check_refuses_another_file_and_passes_the_default() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let other = dir.path().join("config.toml");
+        facelock_core::paths::set_process_config_override(other.clone());
+        let err = check_unit_reads_this_config().unwrap_err().to_string();
+        assert!(err.contains("--systemd"), "{err}");
+        assert!(err.contains(&other.display().to_string()), "{err}");
+        assert!(
+            err.contains(facelock_core::paths::DEFAULT_CONFIG_PATH),
+            "{err}"
+        );
+        assert!(err.contains("without --config"), "{err}");
+        assert!(err.contains("without --systemd"), "{err}");
+
+        facelock_core::paths::set_process_config_override(PathBuf::from(
+            facelock_core::paths::DEFAULT_CONFIG_PATH,
+        ));
+        check_unit_reads_this_config().unwrap();
+
+        facelock_core::paths::clear_process_config_override();
+        check_unit_reads_this_config().unwrap();
+    }
+
+    /// Where the check sits is the property: ahead of both base flows in
+    /// `run_with_plan`, so a refused `--systemd --enroll` has created no
+    /// directory, downloaded no model and minted no key; and ahead of the
+    /// legacy-asset migration in `run_systemd`, the first thing that path
+    /// removes. Pinned on the source because `run_with_plan` cannot be
+    /// driven past its root gate from a test.
+    #[test]
+    fn unit_check_precedes_every_mutation_it_guards() {
+        let source = include_str!("setup.rs");
+        let body_of = |name: &str| {
+            let start = source
+                .find(&format!("fn {name}("))
+                .unwrap_or_else(|| panic!("{name} exists"));
+            let rest = &source[start..];
+            let end = rest.find("\n}\n").expect("function body ends");
+            &rest[..end]
+        };
+        let position = |body: &str, needle: &str| {
+            body.find(needle)
+                .unwrap_or_else(|| panic!("{needle:?} appears in the body"))
+        };
+
+        let plan = body_of("run_with_plan");
+        let check = position(plan, "check_unit_reads_this_config()");
+        assert!(check < position(plan, "run_non_interactive(&plan)"));
+        assert!(check < position(plan, "run_wizard(&plan)"));
+        assert!(check < position(plan, "run_systemd("));
+
+        let install = body_of("run_systemd");
+        let check = position(install, "check_unit_reads_this_config()");
+        assert!(check > position(install, "check_root()"));
+        assert!(check < position(install, "validate_and_migrate_system_assets("));
+        assert!(check < position(install, "daemon-reload"));
     }
 
     /// A daemon-less install enrolls exactly as it did before the reorder.

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -3921,6 +3921,14 @@ pub fn run_systemd(disable: bool) -> anyhow::Result<()> {
     check_systemd()?;
 
     if disable {
+        // Allowed under a non-default `--config`: stopping reads no config
+        // file. Said out loud, because the unit being stopped is the one
+        // that reads the default file, not the one the operator named.
+        if let Some(path) = facelock_core::paths::non_default_config_override() {
+            Terminal.error(&SystemMessage::SystemdDisableConfigOverride {
+                path: path.display().to_string(),
+            });
+        }
         Terminal.info(&SystemMessage::DisablingSystemdUnits);
         run_cmd("systemctl", &["disable", "--now", "facelock-daemon"])?;
         Terminal.info(&SystemMessage::SystemdUnitsDisabled);
@@ -6419,10 +6427,15 @@ mod action_tests {
 
         // With no process override the effective path is whatever
         // `FACELOCK_CONFIG` says when the test runs unprivileged, so it is
-        // cleared too, as paths.rs's own tests do.
+        // cleared for the check and put back after, under the same lock.
+        let previous = std::env::var_os("FACELOCK_CONFIG");
         unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         facelock_core::paths::clear_process_config_override();
-        check_unit_reads_this_config().unwrap();
+        let verdict = check_unit_reads_this_config();
+        if let Some(value) = previous {
+            unsafe { std::env::set_var("FACELOCK_CONFIG", value) };
+        }
+        verdict.unwrap();
     }
 
     /// Where the check sits is the property: ahead of both base flows in
@@ -6458,6 +6471,12 @@ mod action_tests {
         assert!(check > position(install, "check_root()"));
         assert!(check < position(install, "validate_and_migrate_system_assets("));
         assert!(check < position(install, "daemon-reload"));
+
+        // The disable path is allowed under an override and says so before
+        // it stops anything.
+        let note = position(install, "SystemdDisableConfigOverride");
+        assert!(note > position(install, "check_root()"));
+        assert!(note < position(install, "\"disable\", \"--now\""));
     }
 
     /// A daemon-less install enrolls exactly as it did before the reorder.

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -6417,6 +6417,10 @@ mod action_tests {
         ));
         check_unit_reads_this_config().unwrap();
 
+        // With no process override the effective path is whatever
+        // `FACELOCK_CONFIG` says when the test runs unprivileged, so it is
+        // cleared too, as paths.rs's own tests do.
+        unsafe { std::env::remove_var("FACELOCK_CONFIG") };
         facelock_core::paths::clear_process_config_override();
         check_unit_reads_this_config().unwrap();
     }

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -115,3 +115,24 @@ impl super::Samples for AccessMessage {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two `--config` lines (#314) spell the default path out because it
+    /// is the whole reason; a moved default must move them too.
+    #[test]
+    fn config_override_lines_name_the_default_path() {
+        use AccessMessage::*;
+        let default = facelock_core::paths::DEFAULT_CONFIG_PATH;
+
+        let note = DirectByConfigOverride.localized();
+        assert!(note.contains(default), "{note}");
+        assert!(note.contains("direct camera access"), "{note}");
+
+        let preview = PreviewGraphicalDaemonConfigOverride.localized();
+        assert!(preview.contains(default), "{preview}");
+        assert!(preview.contains("text-only"), "{preview}");
+    }
+}

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -64,8 +64,12 @@ impl Message for AccessMessage {
             // Not a warning: the operator chose the file, and the daemon on
             // the bus is doing nothing wrong by reading the default one. The
             // default path is spelled out because it is the whole reason.
+            // Neither note names `--config`: an unprivileged process reaches
+            // the same selection through `FACELOCK_CONFIG`, and "direct
+            // access" rather than "direct camera access" because the store
+            // reads (`list`, `remove`) select the same way.
             DirectByConfigOverride => translate(
-                "Note: --config names a file other than /etc/facelock/config.toml, the only file the facelock daemon reads.\nUsing direct camera access under the selected configuration.",
+                "Note: a non-default configuration is active; the facelock daemon reads only /etc/facelock/config.toml.\nUsing direct access under the selected configuration.",
             ),
             // The flag is `--json` since #169; `--text-only` is a hidden
             // alias that `preview --help` no longer lists, so naming it here
@@ -79,7 +83,7 @@ impl Message for AccessMessage {
                 "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the facelock-daemon service to use it.\n",
             ),
             PreviewGraphicalDaemonConfigOverride => translate(
-                "Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under --config.\nFalling back to text-only mode.\n",
+                "Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under a non-default configuration.\nFalling back to text-only mode.\n",
             ),
         }
     }
@@ -129,10 +133,12 @@ mod tests {
 
         let note = DirectByConfigOverride.localized();
         assert!(note.contains(default), "{note}");
-        assert!(note.contains("direct camera access"), "{note}");
+        assert!(note.contains("direct access"), "{note}");
+        assert!(!note.contains("--config"), "{note}");
 
         let preview = PreviewGraphicalDaemonConfigOverride.localized();
         assert!(preview.contains(default), "{preview}");
         assert!(preview.contains("text-only"), "{preview}");
+        assert!(!preview.contains("--config"), "{preview}");
     }
 }

--- a/crates/facelock-cli/src/message/access.rs
+++ b/crates/facelock-cli/src/message/access.rs
@@ -26,8 +26,10 @@ pub enum AccessMessage {
 
     // -- backend selection (D1) --
     DaemonUnreachableFallback,
+    DirectByConfigOverride,
     PreviewGraphicalNeedsDaemonOneshot,
     PreviewGraphicalDaemonUnreachable,
+    PreviewGraphicalDaemonConfigOverride,
 }
 
 impl Message for AccessMessage {
@@ -59,6 +61,12 @@ impl Message for AccessMessage {
             DaemonUnreachableFallback => translate(
                 "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\nStart the facelock-daemon service to use it.",
             ),
+            // Not a warning: the operator chose the file, and the daemon on
+            // the bus is doing nothing wrong by reading the default one. The
+            // default path is spelled out because it is the whole reason.
+            DirectByConfigOverride => translate(
+                "Note: --config names a file other than /etc/facelock/config.toml, the only file the facelock daemon reads.\nUsing direct camera access under the selected configuration.",
+            ),
             // The flag is `--json` since #169; `--text-only` is a hidden
             // alias that `preview --help` no longer lists, so naming it here
             // taught a spelling the program had stopped showing. "text-only
@@ -69,6 +77,9 @@ impl Message for AccessMessage {
             ),
             PreviewGraphicalDaemonUnreachable => translate(
                 "Graphical preview requires the daemon, which is configured but not reachable.\nFalling back to text-only mode. Start the facelock-daemon service to use it.\n",
+            ),
+            PreviewGraphicalDaemonConfigOverride => translate(
+                "Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under --config.\nFalling back to text-only mode.\n",
             ),
         }
     }
@@ -82,7 +93,7 @@ impl Message for AccessMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for AccessMessage {
-    const VARIANT_COUNT: usize = 9;
+    const VARIANT_COUNT: usize = 11;
 
     fn samples() -> Vec<Self> {
         use AccessMessage::*;
@@ -97,8 +108,10 @@ impl super::Samples for AccessMessage {
             AccessDeniedRootHint,
             EnrollTimedOutClientSide,
             DaemonUnreachableFallback,
+            DirectByConfigOverride,
             PreviewGraphicalNeedsDaemonOneshot,
             PreviewGraphicalDaemonUnreachable,
+            PreviewGraphicalDaemonConfigOverride,
         ]
     }
 }

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -17,6 +17,10 @@ pub enum SystemMessage {
     SystemdSkippedFlag,
     SystemdFromCommandLine,
 
+    // -- a non-default `--config` (#314): the unit reads only the default --
+    SystemdSkippedConfigOverride { path: String },
+    SystemdRefusedConfigOverride { path: String },
+
     // -- bringing the daemon up --
     DaemonRestarted,
     DaemonRunning,
@@ -52,6 +56,21 @@ impl Message for SystemMessage {
                 "  Skipping daemon configuration (--no-systemd).\n  No unit files are written and systemctl is not invoked.",
             ),
             SystemdFromCommandLine => translate("  Answered on the command line."),
+            // The default path is spelled out in both: it is the whole reason,
+            // and the refusal's two ways out are named so the operator does
+            // not have to work them out from the diagnosis.
+            SystemdSkippedConfigOverride { path } => fill(
+                translate(
+                    "  Skipping daemon configuration: --config {path} is not /etc/facelock/config.toml,\n  the only file the facelock-daemon unit reads.\n  Enrollment and the recognition test use direct camera access under {path}.",
+                ),
+                &[("path", path.clone())],
+            ),
+            SystemdRefusedConfigOverride { path } => fill(
+                translate(
+                    "--systemd is not supported with --config {path}: the facelock-daemon unit runs `facelock daemon`,\n  which reads only /etc/facelock/config.toml, so the daemon it enables would not use this configuration.\n  Either copy {path} to /etc/facelock/config.toml and re-run without --config,\n  or re-run without --systemd to enroll with direct camera access under {path}.",
+                ),
+                &[("path", path.clone())],
+            ),
             DaemonRestarted => translate(
                 "  facelock-daemon was already running; restarted so enrollment uses\n  the new configuration.",
             ),
@@ -101,7 +120,7 @@ impl Message for SystemMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    const VARIANT_COUNT: usize = 18;
+    const VARIANT_COUNT: usize = 20;
 
     fn samples() -> Vec<Self> {
         use SystemMessage::*;
@@ -111,6 +130,8 @@ impl super::Samples for SystemMessage {
             SystemdDeclined,
             SystemdSkippedFlag,
             SystemdFromCommandLine,
+            SystemdSkippedConfigOverride { path: s("/p") },
+            SystemdRefusedConfigOverride { path: s("/p") },
             DaemonRestarted,
             DaemonRunning,
             DaemonNotReady { seconds: 20 },
@@ -186,5 +207,31 @@ mod tests {
             DbusActivationEnabled.localized(),
             "\nfacelock-daemon D-Bus activation is now enabled."
         );
+    }
+
+    /// The two `--config` lines (#314) spell the default path out because it
+    /// is the whole reason; a moved default must move them too.
+    #[test]
+    fn config_override_lines_name_the_default_path() {
+        use SystemMessage::*;
+        let default = facelock_core::paths::DEFAULT_CONFIG_PATH;
+
+        let skipped = SystemdSkippedConfigOverride {
+            path: "/tmp/x.toml".into(),
+        }
+        .localized();
+        assert!(skipped.contains(default), "{skipped}");
+        assert!(skipped.contains("--config /tmp/x.toml"), "{skipped}");
+        assert!(skipped.contains("under /tmp/x.toml"), "{skipped}");
+
+        let refused = SystemdRefusedConfigOverride {
+            path: "/tmp/x.toml".into(),
+        }
+        .localized();
+        assert!(refused.contains(default), "{refused}");
+        assert!(refused.contains("--config /tmp/x.toml"), "{refused}");
+        assert!(refused.contains("copy /tmp/x.toml to"), "{refused}");
+        assert!(refused.contains("without --config"), "{refused}");
+        assert!(refused.contains("without --systemd"), "{refused}");
     }
 }

--- a/crates/facelock-cli/src/message/system.rs
+++ b/crates/facelock-cli/src/message/system.rs
@@ -20,6 +20,7 @@ pub enum SystemMessage {
     // -- a non-default `--config` (#314): the unit reads only the default --
     SystemdSkippedConfigOverride { path: String },
     SystemdRefusedConfigOverride { path: String },
+    SystemdDisableConfigOverride { path: String },
 
     // -- bringing the daemon up --
     DaemonRestarted,
@@ -68,6 +69,14 @@ impl Message for SystemMessage {
             SystemdRefusedConfigOverride { path } => fill(
                 translate(
                     "--systemd is not supported with --config {path}: the facelock-daemon unit runs `facelock daemon`,\n  which reads only /etc/facelock/config.toml, so the daemon it enables would not use this configuration.\n  Either copy {path} to /etc/facelock/config.toml and re-run without --config,\n  or re-run without --systemd to enroll with direct camera access under {path}.",
+                ),
+                &[("path", path.clone())],
+            ),
+            // Disabling reads no config file and goes ahead; the note says
+            // which daemon that is, since the named file is not its.
+            SystemdDisableConfigOverride { path } => fill(
+                translate(
+                    "Note: --config {path} names another file; this stops the unit that reads /etc/facelock/config.toml.",
                 ),
                 &[("path", path.clone())],
             ),
@@ -120,7 +129,7 @@ impl Message for SystemMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SystemMessage {
-    const VARIANT_COUNT: usize = 20;
+    const VARIANT_COUNT: usize = 21;
 
     fn samples() -> Vec<Self> {
         use SystemMessage::*;
@@ -132,6 +141,7 @@ impl super::Samples for SystemMessage {
             SystemdFromCommandLine,
             SystemdSkippedConfigOverride { path: s("/p") },
             SystemdRefusedConfigOverride { path: s("/p") },
+            SystemdDisableConfigOverride { path: s("/p") },
             DaemonRestarted,
             DaemonRunning,
             DaemonNotReady { seconds: 20 },
@@ -233,5 +243,13 @@ mod tests {
         assert!(refused.contains("copy /tmp/x.toml to"), "{refused}");
         assert!(refused.contains("without --config"), "{refused}");
         assert!(refused.contains("without --systemd"), "{refused}");
+
+        let disabling = SystemdDisableConfigOverride {
+            path: "/tmp/x.toml".into(),
+        }
+        .localized();
+        assert!(disabling.contains(default), "{disabling}");
+        assert!(disabling.contains("--config /tmp/x.toml"), "{disabling}");
+        assert!(disabling.contains("stops the unit"), "{disabling}");
     }
 }

--- a/crates/facelock-cli/tests/cli_smoke.rs
+++ b/crates/facelock-cli/tests/cli_smoke.rs
@@ -349,6 +349,31 @@ fn enroll_refuses_before_setup_prompt_non_root() {
     );
 }
 
+#[test]
+fn setup_systemd_under_config_override_refuses_root_first_non_root() {
+    // #314: `--systemd` under a non-default `--config` is refused, because
+    // the packaged unit reads only the default file. That refusal sits
+    // *behind* the root gate, so an unprivileged caller hears "Root
+    // required" and nothing else: the identity diagnosis, the base flow's
+    // first line and the unit narration are all forbidden here. The refusal
+    // itself is witnessed as root by tier 3a (test/run-camera-free-tests.sh)
+    // and by the setup unit tests.
+    assert_refuses_before_output(
+        &[
+            "--config",
+            "/nonexistent/facelock-setup-override-c6.toml",
+            "setup",
+            "--systemd",
+            "--non-interactive",
+        ],
+        &[
+            "--systemd is not supported with --config",
+            "facelock setup: preparing system",
+            "Validating installed facelock-daemon",
+        ],
+    );
+}
+
 /// DEC-6: `enroll` is the **interactive** escalation class — with a terminal
 /// attached it offers `Re-run with sudo? [Y/n]` before it refuses, the
 /// opposite of `daemon run` above.

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/facelock/config.toml";
@@ -85,10 +85,51 @@ pub fn config_path() -> PathBuf {
     )
 }
 
+/// The config path this process reads, when it is not the default file.
+///
+/// `None` when [`config_path`] resolves to [`DEFAULT_CONFIG_PATH`], including
+/// an override that spells the default another way (through a symlink or a
+/// `..` component). `Some` is the answer to a question the packaged daemon
+/// forces: its unit runs bare `facelock daemon`, which reads only the default
+/// file, so a command running under any other file cannot treat that daemon
+/// as configured the way it is (#314).
+pub fn non_default_config_override() -> Option<PathBuf> {
+    non_default_override_of(&config_path())
+}
+
+fn non_default_override_of(effective: &Path) -> Option<PathBuf> {
+    if names_a_different_file(effective, Path::new(DEFAULT_CONFIG_PATH)) {
+        Some(effective.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Whether two spellings name different files, decided on the filesystem
+/// where it can be and on the spelling where it cannot. A missing file is
+/// resolved through its directory, because setup runs before the config file
+/// exists; two spellings that resolve nowhere compare as written, so an
+/// unresolvable spelling fails closed as "different".
+fn names_a_different_file(a: &Path, b: &Path) -> bool {
+    resolved_identity(a) != resolved_identity(b)
+}
+
+fn resolved_identity(path: &Path) -> PathBuf {
+    if let Ok(real) = path.canonicalize() {
+        return real;
+    }
+    if let (Some(parent), Some(name)) = (path.parent(), path.file_name())
+        && let Ok(dir) = parent.canonicalize()
+    {
+        return dir.join(name);
+    }
+    path.to_path_buf()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+
     use std::sync::Mutex;
 
     static TEST_MUTEX: Mutex<()> = Mutex::new(());
@@ -161,5 +202,100 @@ mod tests {
         set_process_config_override(PathBuf::from("/tmp/process-override.toml"));
         assert_eq!(config_path(), PathBuf::from("/tmp/process-override.toml"));
         clear_process_config_override();
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-default override (#314): the identity question setup and backend
+    // selection ask. Two spellings of one file are the same file; a file that
+    // does not exist yet is compared through the directory that will hold it.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn no_override_is_not_a_non_default_override() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var("FACELOCK_CONFIG") };
+        clear_process_config_override();
+        assert_eq!(non_default_config_override(), None);
+    }
+
+    #[test]
+    fn override_naming_the_default_path_is_not_non_default() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_process_config_override();
+        set_process_config_override(PathBuf::from(DEFAULT_CONFIG_PATH));
+        assert_eq!(non_default_config_override(), None);
+        clear_process_config_override();
+    }
+
+    #[test]
+    fn override_naming_another_file_is_reported_as_set() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_process_config_override();
+        let path = PathBuf::from("/tmp/facelock-non-default-override.toml");
+        set_process_config_override(path.clone());
+        assert_eq!(non_default_config_override(), Some(path));
+        clear_process_config_override();
+    }
+
+    /// The same file reached through a symlinked directory is the default,
+    /// not an override: the daemon would read exactly this file.
+    #[test]
+    fn symlinked_spelling_of_the_same_file_is_the_same_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let etc = dir.path().join("etc");
+        std::fs::create_dir(&etc).unwrap();
+        let default = etc.join("config.toml");
+        std::fs::write(&default, "").unwrap();
+        std::os::unix::fs::symlink(&etc, dir.path().join("link")).unwrap();
+
+        let via_link = dir.path().join("link").join("config.toml");
+        assert!(!names_a_different_file(&via_link, &default));
+        assert!(!names_a_different_file(
+            &etc.join("..").join("etc").join("config.toml"),
+            &default
+        ));
+        assert!(names_a_different_file(&etc.join("other.toml"), &default));
+    }
+
+    /// Setup runs before the config file exists. A missing file is compared
+    /// through its directory, so `--config /etc/facelock/../facelock/config.toml`
+    /// on a fresh install is still the default.
+    #[test]
+    fn missing_file_is_compared_through_its_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let etc = dir.path().join("etc");
+        std::fs::create_dir(&etc).unwrap();
+        let default = etc.join("config.toml");
+        assert!(!default.exists());
+
+        let dotted = etc.join("..").join("etc").join("config.toml");
+        assert!(!names_a_different_file(&dotted, &default));
+        assert!(names_a_different_file(&etc.join("other.toml"), &default));
+
+        // Neither directory exists: only the spelling can decide, and a
+        // different spelling fails closed as "different".
+        let ghost = dir.path().join("ghost").join("config.toml");
+        assert!(!names_a_different_file(&ghost, &ghost));
+        assert!(names_a_different_file(
+            &dir.path()
+                .join("ghost")
+                .join("..")
+                .join("ghost")
+                .join("config.toml"),
+            &ghost
+        ));
+    }
+
+    /// An unprivileged process reads `FACELOCK_CONFIG`, so that is an override
+    /// too; a privileged one ignores it, so for root only `--config` counts.
+    #[test]
+    fn env_override_counts_only_where_config_path_honours_it() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_process_config_override();
+        let env = PathBuf::from("/tmp/facelock-env-override.toml");
+        let resolved = resolve_config_path(None, Some("/tmp/facelock-env-override.toml"), false);
+        assert_eq!(non_default_override_of(&resolved), Some(env));
+        let resolved = resolve_config_path(None, Some("/tmp/facelock-env-override.toml"), true);
+        assert_eq!(non_default_override_of(&resolved), None);
     }
 }

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -113,6 +113,30 @@ fn names_a_different_file(a: &Path, b: &Path) -> bool {
     resolved_identity(a) != resolved_identity(b)
 }
 
+/// Passes of [`resolve_once`] before a spelling is taken as it stands. Each
+/// pass past the first is only needed when a `..` folded by the one before
+/// exposed a symlink; a chain longer than this is left unresolved, which
+/// compares as "different", the fail-closed side.
+const RESOLVE_PASSES: usize = 4;
+
+/// [`resolve_once`], repeated until the result stops changing. One pass
+/// folds a trailing `..` lexically, which can land back in existing
+/// territory and re-descend into a component that exists as a symlink
+/// (`/exists/ghost/../real_symlink/config.toml`); the next pass then
+/// resolves that symlink the way the kernel would, since the prefix now
+/// exists as far as it.
+fn resolved_identity(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    for _ in 0..RESOLVE_PASSES {
+        let folded = resolve_once(&current);
+        if folded == current {
+            break;
+        }
+        current = folded;
+    }
+    current
+}
+
 /// The deepest existing ancestor, resolved on the filesystem, with the
 /// remaining components applied lexically. A component that does not exist
 /// cannot be a symlink, so folding its `.` and `..` is exactly what the
@@ -122,7 +146,7 @@ fn names_a_different_file(a: &Path, b: &Path) -> bool {
 /// existing ancestor at all, a relative path whose first component is
 /// missing, is returned as spelled, which compares unequal to anything
 /// resolved: the fail-closed default for what cannot be answered.
-fn resolved_identity(path: &Path) -> PathBuf {
+fn resolve_once(path: &Path) -> PathBuf {
     let components: Vec<Component<'_>> = path.components().collect();
     for split in (1..=components.len()).rev() {
         let prefix: PathBuf = components[..split].iter().collect();
@@ -337,6 +361,42 @@ mod tests {
             .join("etc")
             .join("config.toml");
         assert!(!names_a_different_file(&via_link, &default));
+    }
+
+    /// A trailing `..` can pop back into existing territory and re-descend
+    /// into a component that exists as a symlink: `/exists/ghost/..` is
+    /// `/exists` again, and `real_symlink` under it must then be resolved,
+    /// not joined as spelled. One lexical pass alone would call this
+    /// spelling of the default a different file.
+    #[test]
+    fn a_symlink_exposed_by_dot_dot_is_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let exists = dir.path().join("exists");
+        let target = dir.path().join("target");
+        std::fs::create_dir(&exists).unwrap();
+        std::fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, exists.join("real_symlink")).unwrap();
+        let default = target.join("config.toml");
+
+        let exposed = exists
+            .join("ghost")
+            .join("..")
+            .join("real_symlink")
+            .join("config.toml");
+        assert!(!names_a_different_file(&exposed, &default));
+
+        // Two levels deep, still within the pass bound.
+        std::os::unix::fs::symlink(&exists, dir.path().join("hop")).unwrap();
+        let twice = dir
+            .path()
+            .join("ghost")
+            .join("..")
+            .join("hop")
+            .join("ghost")
+            .join("..")
+            .join("real_symlink")
+            .join("config.toml");
+        assert!(!names_a_different_file(&twice, &default));
     }
 
     /// `..` at the root stays at the root, as the kernel resolves `/..`, so

--- a/crates/facelock-core/src/paths.rs
+++ b/crates/facelock-core/src/paths.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::RwLock;
 
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/facelock/config.toml";
@@ -105,23 +105,42 @@ fn non_default_override_of(effective: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Whether two spellings name different files, decided on the filesystem
-/// where it can be and on the spelling where it cannot. A missing file is
-/// resolved through its directory, because setup runs before the config file
-/// exists; two spellings that resolve nowhere compare as written, so an
-/// unresolvable spelling fails closed as "different".
+/// Whether two spellings name different files, decided on the filesystem as
+/// far as it exists and on the spelling past that. Setup runs before the
+/// config file, and on a from-source install before its directory, exists;
+/// what is still unresolvable after both fails closed as "different".
 fn names_a_different_file(a: &Path, b: &Path) -> bool {
     resolved_identity(a) != resolved_identity(b)
 }
 
+/// The deepest existing ancestor, resolved on the filesystem, with the
+/// remaining components applied lexically. A component that does not exist
+/// cannot be a symlink, so folding its `.` and `..` is exactly what the
+/// kernel will do once it exists; `..` out of the resolved part goes to the
+/// real parent, as it does through a symlinked directory, and `..` at the
+/// root stays at the root, as the kernel resolves it. Only a spelling with no
+/// existing ancestor at all, a relative path whose first component is
+/// missing, is returned as spelled, which compares unequal to anything
+/// resolved: the fail-closed default for what cannot be answered.
 fn resolved_identity(path: &Path) -> PathBuf {
-    if let Ok(real) = path.canonicalize() {
+    let components: Vec<Component<'_>> = path.components().collect();
+    for split in (1..=components.len()).rev() {
+        let prefix: PathBuf = components[..split].iter().collect();
+        let Ok(mut real) = prefix.canonicalize() else {
+            continue;
+        };
+        for component in &components[split..] {
+            match component {
+                Component::Normal(name) => real.push(name),
+                Component::CurDir => {}
+                // `pop` is false only at the root, where `..` stays put.
+                Component::ParentDir => {
+                    real.pop();
+                }
+                Component::RootDir | Component::Prefix(_) => return path.to_path_buf(),
+            }
+        }
         return real;
-    }
-    if let (Some(parent), Some(name)) = (path.parent(), path.file_name())
-        && let Ok(dir) = parent.canonicalize()
-    {
-        return dir.join(name);
     }
     path.to_path_buf()
 }
@@ -272,18 +291,80 @@ mod tests {
         assert!(!names_a_different_file(&dotted, &default));
         assert!(names_a_different_file(&etc.join("other.toml"), &default));
 
-        // Neither directory exists: only the spelling can decide, and a
-        // different spelling fails closed as "different".
         let ghost = dir.path().join("ghost").join("config.toml");
         assert!(!names_a_different_file(&ghost, &ghost));
-        assert!(names_a_different_file(
-            &dir.path()
-                .join("ghost")
-                .join("..")
-                .join("ghost")
-                .join("config.toml"),
-            &ghost
+        assert!(names_a_different_file(&ghost, &default));
+    }
+
+    /// A from-source install runs the identity check before the base flow
+    /// creates the config directory. With no `/etc/facelock` to resolve, the
+    /// `..` spelling of the default must still be the default: the deepest
+    /// existing ancestor is resolved on the filesystem and the rest of the
+    /// spelling is normalized lexically, which is safe because a component
+    /// that does not exist cannot be a symlink.
+    #[test]
+    fn dotted_spelling_is_the_default_even_before_the_config_dir_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let etc = dir.path().join("etc");
+        assert!(!etc.exists());
+        let default = etc.join("config.toml");
+
+        let dotted = etc.join("..").join("etc").join("config.toml");
+        assert!(!names_a_different_file(&dotted, &default));
+        let cur = etc.join(".").join("config.toml");
+        assert!(!names_a_different_file(&cur, &default));
+        // Through a missing sibling: `ghost/../etc` is `etc`, since `ghost`
+        // cannot be a symlink to anywhere.
+        let via_ghost = dir
+            .path()
+            .join("ghost")
+            .join("..")
+            .join("etc")
+            .join("config.toml");
+        assert!(!names_a_different_file(&via_ghost, &default));
+        assert!(names_a_different_file(&etc.join("other.toml"), &default));
+
+        // `..` out of a resolved directory goes to that directory's real
+        // parent, as the kernel would: through a symlinked directory that
+        // exists, `link/../etc` lands beside the link's target.
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, dir.path().join("link")).unwrap();
+        let via_link = dir
+            .path()
+            .join("link")
+            .join("..")
+            .join("etc")
+            .join("config.toml");
+        assert!(!names_a_different_file(&via_link, &default));
+    }
+
+    /// `..` at the root stays at the root, as the kernel resolves `/..`, so
+    /// climbing past a missing top-level directory lands where the kernel
+    /// would once it exists.
+    #[test]
+    fn dot_dot_at_the_root_stays_at_the_root() {
+        let plain = Path::new("/facelock-no-such-root/config.toml");
+        assert!(!names_a_different_file(
+            Path::new("/../facelock-no-such-root/config.toml"),
+            plain
         ));
+        assert!(!names_a_different_file(
+            Path::new("/facelock-no-such-root/../../facelock-no-such-root/config.toml"),
+            plain
+        ));
+    }
+
+    /// What has no existing ancestor to resolve from fails closed: a relative
+    /// spelling whose first component is missing is compared as written, so
+    /// two lexically equal spellings of it still count as different.
+    #[test]
+    fn a_spelling_with_no_existing_ancestor_fails_closed() {
+        let plain = Path::new("facelock-no-such-dir/config.toml");
+        let dotted = Path::new("facelock-no-such-dir/../facelock-no-such-dir/config.toml");
+        assert!(!plain.exists() && !Path::new("facelock-no-such-dir").exists());
+        assert!(names_a_different_file(dotted, plain));
+        assert!(!names_a_different_file(plain, plain));
     }
 
     /// An unprivileged process reads `FACELOCK_CONFIG`, so that is an override

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,13 +79,15 @@ that once.
 `--systemd` is not supported under a non-default `--config`. The unit runs
 bare `facelock daemon`, which reads only `/etc/facelock/config.toml`, so the
 daemon it enables would not use the file setup just configured. `facelock
---config /tmp/x.toml setup --systemd --enroll` exits non-zero before it writes
-anything or calls `systemctl`, and says what to do instead: copy the file to
-`/etc/facelock/config.toml` and re-run without `--config`, or re-run without
-`--systemd` to enroll with direct camera access under `/tmp/x.toml`. The
+--config /etc/facelock/scratch.toml setup --systemd --enroll` exits non-zero
+before it writes anything or calls `systemctl`, and says what to do instead:
+copy the file to `/etc/facelock/config.toml` and re-run without `--config`, or
+re-run without
+`--systemd` to enroll with direct camera access under `/etc/facelock/scratch.toml`. The
 wizard skips the daemon question under such a `--config` and says why.
-`--systemd --disable` is unaffected; a symlink or `..` spelling of the default
-path counts as the default.
+`--systemd --disable` still runs, with a note that the unit it stops reads the
+default file; a symlink or `..` spelling of the default path counts as the
+default.
 
 ```bash
 facelock setup                          # interactive wizard
@@ -297,8 +299,9 @@ Captures 3-10 frames over ~15 seconds. Requires exactly one face per frame. Re-e
 
 Under a non-default `--config`, enrollment uses direct camera access under that
 file and never the running daemon, which reads only `/etc/facelock/config.toml`;
-a note on stderr says so. The same holds for `test`, `list`, `remove`,
-`clear`, `devices` and `preview` (which then has only its text preview).
+when `daemon.mode = "daemon"` a note on stderr says so. The same holds for
+`test`, `list`, `remove`, `clear`, `devices` and `preview` (which then has only
+its text preview).
 
 Without `--skip-setup-check`, an install whose setup-complete marker is missing
 is offered `facelock setup` first and enrolls through it, since setup enrolls a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -297,8 +297,8 @@ Captures 3-10 frames over ~15 seconds. Requires exactly one face per frame. Re-e
 
 Under a non-default `--config`, enrollment uses direct camera access under that
 file and never the running daemon, which reads only `/etc/facelock/config.toml`;
-a note on stderr says so. The same holds for `test`, `list`, `remove` and
-`clear`.
+a note on stderr says so. The same holds for `test`, `list`, `remove`,
+`clear`, `devices` and `preview` (which then has only its text preview).
 
 Without `--skip-setup-check`, an install whose setup-complete marker is missing
 is offered `facelock setup` first and enrolls through it, since setup enrolls a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ The following flags are accepted by every subcommand (declared `global = true`):
 
 | Flag | Description |
 |------|-------------|
-| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. The packaged daemon reads only the default file, so under a non-default path `enroll` and `test` use direct camera access and `setup --systemd` refuses; a symlink or `..` spelling of the default counts as the default (see [facelock setup](#facelock-setup)). |
+| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. The packaged daemon reads only the default file, so under a non-default path `enroll` and `test` use direct camera access and `setup --systemd` refuses, except `--disable`, which stays allowed since stopping the packaged unit reads no config file; a symlink or `..` spelling of the default counts as the default (see [facelock setup](#facelock-setup)). |
 | `-q`, `--quiet` | Suppress stdout: informational text, and on commands whose stdout is the payload, the payload too. Errors (stderr), prompts and exit codes are unaffected. |
 | `-v`, `--verbose` | Raise diagnostic verbosity on stderr, one level per repeat. The CLI starts at `warn`, `daemon run` at `info`. `RUST_LOG` overrides it. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ The following flags are accepted by every subcommand (declared `global = true`):
 
 | Flag | Description |
 |------|-------------|
-| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. |
+| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. The packaged daemon reads only the default file, so under any other path `enroll` and `test` use direct camera access and `setup --systemd` refuses (see [facelock setup](#facelock-setup)). |
 | `-q`, `--quiet` | Suppress stdout: informational text, and on commands whose stdout is the payload, the payload too. Errors (stderr), prompts and exit codes are unaffected. |
 | `-v`, `--verbose` | Raise diagnostic verbosity on stderr, one level per repeat. The CLI starts at `warn`, `daemon run` at `info`. `RUST_LOG` overrides it. |
 
@@ -75,6 +75,17 @@ of `setup` an untouched daemon would hold the answers from before the wizard.
 A restart interrupts any authentication that daemon is mid-way through, so a
 `sudo` prompt waiting on a face in another terminal falls back to a password
 that once.
+
+`--systemd` is not supported under a non-default `--config`. The unit runs
+bare `facelock daemon`, which reads only `/etc/facelock/config.toml`, so the
+daemon it enables would not use the file setup just configured. `facelock
+--config /tmp/x.toml setup --systemd --enroll` exits non-zero before it writes
+anything or calls `systemctl`, and says what to do instead: copy the file to
+`/etc/facelock/config.toml` and re-run without `--config`, or re-run without
+`--systemd` to enroll with direct camera access under `/tmp/x.toml`. The
+wizard skips the daemon question under such a `--config` and says why.
+`--systemd --disable` is unaffected; a symlink or `..` spelling of the default
+path counts as the default.
 
 ```bash
 facelock setup                          # interactive wizard
@@ -283,6 +294,11 @@ facelock enroll --skip-setup-check      # enroll on a tree setup never marked co
 ```
 
 Captures 3-10 frames over ~15 seconds. Requires exactly one face per frame. Re-enrolling with the same label replaces the previous model on success; a cancelled or failed re-enrollment leaves the previous model in place.
+
+Under a non-default `--config`, enrollment uses direct camera access under that
+file and never the running daemon, which reads only `/etc/facelock/config.toml`;
+a note on stderr says so. The same holds for `test`, `list`, `remove` and
+`clear`.
 
 Without `--skip-setup-check`, an install whose setup-complete marker is missing
 is offered `facelock setup` first and enrolls through it, since setup enrolls a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ The following flags are accepted by every subcommand (declared `global = true`):
 
 | Flag | Description |
 |------|-------------|
-| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. The packaged daemon reads only the default file, so under any other path `enroll` and `test` use direct camera access and `setup --systemd` refuses (see [facelock setup](#facelock-setup)). |
+| `-c`, `--config <PATH>` | Override the config file path. Takes precedence over `FACELOCK_CONFIG`. The packaged daemon reads only the default file, so under a non-default path `enroll` and `test` use direct camera access and `setup --systemd` refuses; a symlink or `..` spelling of the default counts as the default (see [facelock setup](#facelock-setup)). |
 | `-q`, `--quiet` | Suppress stdout: informational text, and on commands whose stdout is the payload, the payload too. Errors (stderr), prompts and exit codes are unaffected. |
 | `-v`, `--verbose` | Raise diagnostic verbosity on stderr, one level per repeat. The CLI starts at `warn`, `daemon run` at `info`. `RUST_LOG` overrides it. |
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -54,7 +54,7 @@ follow it.
 | Command | Purpose |
 |---------|---------|
 | `facelock setup` | Interactive setup wizard (camera, models, inference device, encryption, daemon, enrollment, PAM — the daemon before enrollment, so enrollment and the recognition test run on the transport later authentications use); removes a leftover `facelock` group from an older install, best-effort (ADR 010) |
-| `facelock setup --systemd` | Validate installed systemd/D-Bus assets, retire exact known legacy copies, reload, verify resolution, and enable the daemon unit |
+| `facelock setup --systemd` | Validate installed systemd/D-Bus assets, retire exact known legacy copies, reload, verify resolution, and enable the daemon unit. Refused under a non-default `--config`, before anything is written: the unit runs bare `facelock daemon` and reads only `/etc/facelock/config.toml` (see "facelock setup Flag Composition") |
 | `facelock setup --pam` | Alias onto `facelock pam add\|remove` (see "facelock pam" below). Kept, and kept parsing, for every wrapper written against it |
 | `facelock setup --pam --allow-sensitive` | Explicitly authorize an add to a sensitive PAM service. Does not suppress confirmation and conflicts with `--remove` |
 | `facelock pam add` | Add the facelock line to one or more `/etc/pam.d/<service>` files. Root |
@@ -273,6 +273,23 @@ Consequently `setup --systemd --pam` now runs both (it previously dropped
 (it previously dropped `--non-interactive`). Both were silent flag drops.
 `--remove` and `--service` require `--pam`, and `--disable` requires `--systemd`,
 so a dropped flag is now a parse error rather than silence.
+
+**`--systemd` is unsupported under a non-default `--config`**, in a base flow
+and on its own. The unit it enables runs bare `facelock daemon` (ADR 009 §4),
+which reads only `/etc/facelock/config.toml`: `FACELOCK_CONFIG` is ignored by a
+privileged process and the unit passes no `--config`. A daemon enabled from a
+setup run under any other file would authenticate with a store, camera, model
+set and encryption policy that setup never configured. So `facelock --config
+<other> setup --systemd ...` exits non-zero before the base flow creates a
+directory, downloads a model or mints a key, and before any `systemctl` call;
+the message names the two ways out, copying the file to the default path or
+running setup without `--systemd`. The wizard, which would otherwise ask,
+prints why it is skipping the daemon step instead. `--systemd --disable`
+reads no config file and is unaffected. "Non-default" is decided on the
+filesystem: a symlink or `..` spelling of the default file is the default.
+Under such an override, enrollment and the recognition test use direct
+camera access under that file and never the daemon on the bus, whatever
+owns the name (see "Operating Modes").
 
 `--if-present` requires `--pam` and applies to the add side as well as
 `--remove`. "Configure hyprlock if this machine has hyprlock" is the same
@@ -1919,6 +1936,14 @@ auth would — surfacing an existing lockout instead of masking it.
 
 The CLI silently falls back to direct mode when the daemon is not available on D-Bus, regardless of config mode.
 
+Under a non-default `--config`, daemon mode selects direct access without
+asking the bus, and says so once on stderr. The packaged daemon reads only
+`/etc/facelock/config.toml`, so whatever owns the bus name is configured by a
+file the command is not reading; its answers would be about another store,
+camera, model set and security policy. This is a selection the operator made,
+not a degraded state, so it is not the fallback warning. Oneshot mode is
+unchanged: direct access is already its configuration.
+
 ### facelock is-enrolled Exit Codes
 
 The exit code **is** the contract — `is-enrolled` is designed to drop into a
@@ -3013,7 +3038,10 @@ mistake. `FACELOCK_CONFIG` is ignored in a privileged process, so the
 environment cannot redirect where a root `pam add` writes; the global
 `--config` flag is a process override and *is* honoured under `sudo`, which is
 root naming a different file on purpose rather than the environment doing it
-behind root's back. See "facelock pam
+behind root's back. The one process it cannot reach is the packaged daemon,
+whose unit passes no `--config`; that is why `setup --systemd` refuses under a
+non-default value and why `enroll` and `test` go direct there (see "facelock
+setup Flag Composition"). See "facelock pam
 Semantics" above for the resolution rules themselves.
 
 **Encryption defaults (Plan 04).** `encryption.method` defaults to `keyfile`: face

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -287,7 +287,8 @@ directory, downloads a model or mints a key, and before any `systemctl` call;
 the message names the two ways out, copying the file to the default path or
 running setup without `--systemd`. The wizard, which would otherwise ask,
 prints why it is skipping the daemon step instead. `--systemd --disable`
-reads no config file and is unaffected. "Non-default" is decided on the
+reads no config file and still runs, with a note that the unit it stops reads
+the default file. "Non-default" is decided on the
 filesystem: a symlink or `..` spelling of the default file is the default.
 Under such an override, enrollment and the recognition test use direct
 camera access under that file and never the daemon on the bus, whatever
@@ -1938,8 +1939,10 @@ auth would — surfacing an existing lockout instead of masking it.
 
 The CLI silently falls back to direct mode when the daemon is not available on D-Bus, regardless of config mode.
 
-Under a non-default `--config`, daemon mode selects direct access without
-asking the bus, and says so once on stderr. The packaged daemon reads only
+Under a non-default `--config` in daemon mode, backend selection for
+`enroll`, `test` and the other backend-using commands does not ask the bus and
+selects direct access, saying so once on stderr (`status`'s own daemon probe
+still runs). The packaged daemon reads only
 `/etc/facelock/config.toml`, so whatever owns the bus name is configured by a
 file the command is not reading; its answers would be about another store,
 camera, model set and security policy. This is a selection the operator made,

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -148,8 +148,9 @@ The invariants it pins:
   command re-declares them. `facelock daemon -c X` and `facelock -c X daemon`
   are equivalent, as are `facelock is-enrolled --quiet` and
   `facelock --quiet is-enrolled`. A non-default `--config` makes `setup
-  --systemd` refuse and routes every backend-using command direct (see
-  "facelock setup Flag Composition" and "Operating Modes")
+  --systemd` refuse — except `--disable`, which stays allowed since stopping
+  the packaged unit reads no config file — and routes every backend-using
+  command direct (see "facelock setup Flag Composition" and "Operating Modes")
 - `--verbose` counts its repeats, one level per `-v` from the program's own
   starting level (`warn` for the CLI, `info` for `daemon run`). `RUST_LOG`
   outranks it

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -147,7 +147,9 @@ The invariants it pins:
   `global = true`, and are accepted on either side of the subcommand name. No
   command re-declares them. `facelock daemon -c X` and `facelock -c X daemon`
   are equivalent, as are `facelock is-enrolled --quiet` and
-  `facelock --quiet is-enrolled`
+  `facelock --quiet is-enrolled`. A non-default `--config` makes `setup
+  --systemd` refuse and routes every backend-using command direct (see
+  "facelock setup Flag Composition" and "Operating Modes")
 - `--verbose` counts its repeats, one level per `-v` from the program's own
   starting level (`warn` for the CLI, `info` for `daemon run`). `RUST_LOG`
   outranks it

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 22:47-0700\n"
+"POT-Creation-Date: 2026-09-01 22:37-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,38 +17,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/facelock-cli/src/message/access.rs:38
+#: crates/facelock-cli/src/message/access.rs:40
 #, python-brace-format
 msgid "no config file at {path} — run 'sudo facelock setup' to create one"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:42
+#: crates/facelock-cli/src/message/access.rs:44
 #, python-brace-format
 msgid "invalid config at {path}: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:46
+#: crates/facelock-cli/src/message/access.rs:48
 #, python-brace-format
 msgid ""
 "Root required.\n"
 "  Run: {hint}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:52
+#: crates/facelock-cli/src/message/access.rs:54
 msgid "Root required. Re-run with sudo?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:54
+#: crates/facelock-cli/src/message/access.rs:56
 msgid ""
 "Access denied: this operation requires root.\n"
 "  Re-run with sudo, or as root."
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:57
+#: crates/facelock-cli/src/message/access.rs:59
 msgid "enrollment timed out client-side; the daemon may have completed it — run `facelock list` before retrying"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:60
+#: crates/facelock-cli/src/message/access.rs:62
 msgid ""
 "Warning: daemon.mode = \"daemon\" but the facelock daemon is unreachable — falling back to direct camera access.\n"
 "Start the facelock-daemon service to use it."
@@ -56,14 +56,26 @@ msgstr ""
 
 #: crates/facelock-cli/src/message/access.rs:68
 msgid ""
+"Note: --config names a file other than /etc/facelock/config.toml, the only file the facelock daemon reads.\n"
+"Using direct camera access under the selected configuration."
+msgstr ""
+
+#: crates/facelock-cli/src/message/access.rs:76
+msgid ""
 "Graphical preview requires the daemon. In oneshot mode, use --json.\n"
 "Falling back to text-only mode.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:71
+#: crates/facelock-cli/src/message/access.rs:79
 msgid ""
 "Graphical preview requires the daemon, which is configured but not reachable.\n"
 "Falling back to text-only mode. Start the facelock-daemon service to use it.\n"
+msgstr ""
+
+#: crates/facelock-cli/src/message/access.rs:82
+msgid ""
+"Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under --config.\n"
+"Falling back to text-only mode.\n"
 msgstr ""
 
 #: crates/facelock-cli/src/message/device.rs:54
@@ -1191,344 +1203,356 @@ msgstr ""
 msgid "  hyprlock integration applied for {user}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:142
+#: crates/facelock-cli/src/message/status.rs:137
 msgid "facelock system status"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:143
+#: crates/facelock-cli/src/message/status.rs:138
 msgid "Config file"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:144
+#: crates/facelock-cli/src/message/status.rs:139
 msgid "Daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:145
+#: crates/facelock-cli/src/message/status.rs:140
 msgid "Oneshot fallback"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:146
+#: crates/facelock-cli/src/message/status.rs:141
 msgid "Camera device"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:147
+#: crates/facelock-cli/src/message/status.rs:142
 msgid "Model directory"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:148
+#: crates/facelock-cli/src/message/status.rs:143
 msgid "Execution provider"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:149
+#: crates/facelock-cli/src/message/status.rs:144
 msgid "Encryption"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:150
+#: crates/facelock-cli/src/message/status.rs:145
 msgid "Enrolled faces"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:151
+#: crates/facelock-cli/src/message/status.rs:146
 msgid "Security"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:152
+#: crates/facelock-cli/src/message/status.rs:147
 msgid "Notifications"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:153
+#: crates/facelock-cli/src/message/status.rs:148
 msgid "PAM module"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:155
+#: crates/facelock-cli/src/message/status.rs:150
 #, python-brace-format
 msgid "cannot determine: {why}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:158
+#: crates/facelock-cli/src/message/status.rs:153
 msgid "config not available"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:159
+#: crates/facelock-cli/src/message/status.rs:154
 msgid "valid"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:160
+#: crates/facelock-cli/src/message/status.rs:155
 msgid "not found"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:162
+#: crates/facelock-cli/src/message/status.rs:157
 #, python-brace-format
 msgid "invalid: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:164
+#: crates/facelock-cli/src/message/status.rs:159
 msgid "oneshot mode (no daemon)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:165
+#: crates/facelock-cli/src/message/status.rs:160
 msgid "responding"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:167
+#: crates/facelock-cli/src/message/status.rs:162
 #, python-brace-format
 msgid "not responding: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:171
+#: crates/facelock-cli/src/message/status.rs:166
 msgid "prerequisites present (binary, models and database in place for daemon-less auth)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:174
+#: crates/facelock-cli/src/message/status.rs:169
 msgid "prerequisites missing (PAM would fall through to the next auth method if the daemon is unreachable)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:176
+#: crates/facelock-cli/src/message/status.rs:171
 msgid "device exists"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:177
+#: crates/facelock-cli/src/message/status.rs:172
 msgid "device not found"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:178
+#: crates/facelock-cli/src/message/status.rs:173
 msgid "auto-detect enabled"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:179
+#: crates/facelock-cli/src/message/status.rs:174
 msgid "directory not found"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:180
+#: crates/facelock-cli/src/message/status.rs:175
 msgid "all configured models present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:181
+#: crates/facelock-cli/src/message/status.rs:176
 msgid "some models missing (run 'facelock setup')"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:182
+#: crates/facelock-cli/src/message/status.rs:177
 msgid "present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:183
+#: crates/facelock-cli/src/message/status.rs:178
 msgid "MISSING"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:184
+#: crates/facelock-cli/src/message/status.rs:179
 msgid "supported by the installed ONNX Runtime"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:186
+#: crates/facelock-cli/src/message/status.rs:181
 msgid "not built into the installed ONNX Runtime — inference will fall back to CPU"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:193
+#: crates/facelock-cli/src/message/status.rs:188
 msgid "unknown execution provider (valid: cpu, cuda, rocm, openvino)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:196
+#: crates/facelock-cli/src/message/status.rs:191
 #, python-brace-format
 msgid "ONNX Runtime not loadable: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:200
+#: crates/facelock-cli/src/message/status.rs:195
 #, python-brace-format
 msgid "sealed key: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:203
+#: crates/facelock-cli/src/message/status.rs:198
 #, python-brace-format
 msgid "sealed key missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:207
+#: crates/facelock-cli/src/message/status.rs:202
 #, python-brace-format
 msgid "TPM device missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:211
+#: crates/facelock-cli/src/message/status.rs:206
 #, python-brace-format
 msgid "key file: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:214
+#: crates/facelock-cli/src/message/status.rs:209
 #, python-brace-format
 msgid "key file missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:218
+#: crates/facelock-cli/src/message/status.rs:213
 msgid "embeddings stored as plaintext (run 'facelock setup' to enable encryption)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:220
+#: crates/facelock-cli/src/message/status.rs:215
 msgid "no faces enrolled (run 'facelock enroll')"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:222
+#: crates/facelock-cli/src/message/status.rs:217
 #, python-brace-format
 msgid "{count} model(s)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:226
-#, python-brace-format
-msgid "{label}, unbound (re-enroll to bind)"
-msgstr ""
-
-#: crates/facelock-cli/src/message/status.rs:231
+#: crates/facelock-cli/src/message/status.rs:222
 #, python-brace-format
 msgid "out of date (marker says {marker}, database has {store}) — run 'sudo facelock setup' to reconcile"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:236
+#: crates/facelock-cli/src/message/status.rs:227
 #, python-brace-format
 msgid "unreadable: {why}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:238
+#: crates/facelock-cli/src/message/status.rs:229
 msgid "ALL SECURITY CHECKS DISABLED"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:239
+#: crates/facelock-cli/src/message/status.rs:230
 msgid "yes"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:240
+#: crates/facelock-cli/src/message/status.rs:231
 msgid "no"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:241
+#: crates/facelock-cli/src/message/status.rs:232
 msgid "off"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:242
+#: crates/facelock-cli/src/message/status.rs:233
 msgid "terminal"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:243
+#: crates/facelock-cli/src/message/status.rs:234
 msgid "desktop"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:244
+#: crates/facelock-cli/src/message/status.rs:235
 msgid "terminal + desktop"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:245
+#: crates/facelock-cli/src/message/status.rs:236
 msgid "installed"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:247
+#: crates/facelock-cli/src/message/status.rs:238
 #, python-brace-format
 msgid "installed at {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:249
+#: crates/facelock-cli/src/message/status.rs:240
 msgid "not installed"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:251
+#: crates/facelock-cli/src/message/status.rs:242
 #, python-brace-format
 msgid "{services} ({count} configured)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:259
+#: crates/facelock-cli/src/message/status.rs:250
 #, python-brace-format
 msgid "{services} ({count} configured, {overrides} shadowing a vendor file)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:266
+#: crates/facelock-cli/src/message/status.rs:257
 msgid "none configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:267
+#: crates/facelock-cli/src/message/status.rs:258
 msgid "not checked"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:269
+#: crates/facelock-cli/src/message/status.rs:260
 #, python-brace-format
 msgid "{path} ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:44
+#: crates/facelock-cli/src/message/system.rs:48
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:46
+#: crates/facelock-cli/src/message/system.rs:50
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:49
+#: crates/facelock-cli/src/message/system.rs:53
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:52
+#: crates/facelock-cli/src/message/system.rs:56
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:54
+#: crates/facelock-cli/src/message/system.rs:58
 msgid "  Answered on the command line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:56
+#: crates/facelock-cli/src/message/system.rs:64
+#, python-brace-format
+msgid ""
+"  Skipping daemon configuration: --config {path} is not /etc/facelock/config.toml,\n"
+"  the only file the facelock-daemon unit reads.\n"
+"  Enrollment and the recognition test use direct camera access under {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:70
+#, python-brace-format
+msgid ""
+"--systemd is not supported with --config {path}: the facelock-daemon unit runs `facelock daemon`,\n"
+"  which reads only /etc/facelock/config.toml, so the daemon it enables would not use this configuration.\n"
+"  Either copy {path} to /etc/facelock/config.toml and re-run without --config,\n"
+"  or re-run without --systemd to enroll with direct camera access under {path}."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:75
 msgid ""
 "  facelock-daemon was already running; restarted so enrollment uses\n"
 "  the new configuration."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:58
+#: crates/facelock-cli/src/message/system.rs:77
 msgid "  facelock-daemon is running."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:61
+#: crates/facelock-cli/src/message/system.rs:80
 #, python-brace-format
 msgid ""
 "  facelock-daemon did not answer within {seconds}s.\n"
 "  Continuing with direct camera access; check: systemctl status facelock-daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:66
+#: crates/facelock-cli/src/message/system.rs:85
 msgid "  Removed the legacy 'facelock' group; face unlock no longer uses it."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:68
+#: crates/facelock-cli/src/message/system.rs:87
 msgid "Disabling facelock-daemon systemd units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:69
+#: crates/facelock-cli/src/message/system.rs:88
 msgid "facelock-daemon service disabled and stopped."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:71
+#: crates/facelock-cli/src/message/system.rs:90
 msgid "Validating installed facelock-daemon systemd and D-Bus assets..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:74
+#: crates/facelock-cli/src/message/system.rs:93
 #, python-brace-format
 msgid "  Removed exact known legacy {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:79
+#: crates/facelock-cli/src/message/system.rs:98
 #, python-brace-format
 msgid "  Preserved merged local D-Bus policy {path}; review it if Facelock bus authorization is unexpected."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:83
+#: crates/facelock-cli/src/message/system.rs:102
 msgid "  Installed systemd and D-Bus assets validated."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:84
+#: crates/facelock-cli/src/message/system.rs:103
 msgid "  systemctl daemon-reload done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:86
+#: crates/facelock-cli/src/message/system.rs:105
 #, python-brace-format
 msgid "  systemctl enable {unit} done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:90
+#: crates/facelock-cli/src/message/system.rs:109
 msgid ""
 "\n"
 "facelock-daemon D-Bus activation is now enabled."

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 23:29-0700\n"
+"POT-Creation-Date: 2026-09-02 09:51-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,27 +54,27 @@ msgid ""
 "Start the facelock-daemon service to use it."
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:68
+#: crates/facelock-cli/src/message/access.rs:72
 msgid ""
-"Note: --config names a file other than /etc/facelock/config.toml, the only file the facelock daemon reads.\n"
-"Using direct camera access under the selected configuration."
+"Note: a non-default configuration is active; the facelock daemon reads only /etc/facelock/config.toml.\n"
+"Using direct access under the selected configuration."
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:76
+#: crates/facelock-cli/src/message/access.rs:80
 msgid ""
 "Graphical preview requires the daemon. In oneshot mode, use --json.\n"
 "Falling back to text-only mode.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:79
+#: crates/facelock-cli/src/message/access.rs:83
 msgid ""
 "Graphical preview requires the daemon, which is configured but not reachable.\n"
 "Falling back to text-only mode. Start the facelock-daemon service to use it.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/access.rs:82
+#: crates/facelock-cli/src/message/access.rs:86
 msgid ""
-"Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under --config.\n"
+"Graphical preview requires the daemon, which reads only /etc/facelock/config.toml and is not used under a non-default configuration.\n"
 "Falling back to text-only mode.\n"
 msgstr ""
 

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-02 09:51-0700\n"
+"POT-Creation-Date: 2026-09-02 19:50-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1203,254 +1203,259 @@ msgstr ""
 msgid "  hyprlock integration applied for {user}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:137
+#: crates/facelock-cli/src/message/status.rs:142
 msgid "facelock system status"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:138
+#: crates/facelock-cli/src/message/status.rs:143
 msgid "Config file"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:139
+#: crates/facelock-cli/src/message/status.rs:144
 msgid "Daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:140
+#: crates/facelock-cli/src/message/status.rs:145
 msgid "Oneshot fallback"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:141
+#: crates/facelock-cli/src/message/status.rs:146
 msgid "Camera device"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:142
+#: crates/facelock-cli/src/message/status.rs:147
 msgid "Model directory"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:143
+#: crates/facelock-cli/src/message/status.rs:148
 msgid "Execution provider"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:144
+#: crates/facelock-cli/src/message/status.rs:149
 msgid "Encryption"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:145
+#: crates/facelock-cli/src/message/status.rs:150
 msgid "Enrolled faces"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:146
+#: crates/facelock-cli/src/message/status.rs:151
 msgid "Security"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:147
+#: crates/facelock-cli/src/message/status.rs:152
 msgid "Notifications"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:148
+#: crates/facelock-cli/src/message/status.rs:153
 msgid "PAM module"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:150
+#: crates/facelock-cli/src/message/status.rs:155
 #, python-brace-format
 msgid "cannot determine: {why}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:153
+#: crates/facelock-cli/src/message/status.rs:158
 msgid "config not available"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:154
+#: crates/facelock-cli/src/message/status.rs:159
 msgid "valid"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:155
-msgid "not found"
-msgstr ""
-
-#: crates/facelock-cli/src/message/status.rs:157
-#, python-brace-format
-msgid "invalid: {error}"
-msgstr ""
-
-#: crates/facelock-cli/src/message/status.rs:159
-msgid "oneshot mode (no daemon)"
-msgstr ""
-
 #: crates/facelock-cli/src/message/status.rs:160
-msgid "responding"
+msgid "not found"
 msgstr ""
 
 #: crates/facelock-cli/src/message/status.rs:162
 #, python-brace-format
+msgid "invalid: {error}"
+msgstr ""
+
+#: crates/facelock-cli/src/message/status.rs:164
+msgid "oneshot mode (no daemon)"
+msgstr ""
+
+#: crates/facelock-cli/src/message/status.rs:165
+msgid "responding"
+msgstr ""
+
+#: crates/facelock-cli/src/message/status.rs:167
+#, python-brace-format
 msgid "not responding: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:166
+#: crates/facelock-cli/src/message/status.rs:171
 msgid "prerequisites present (binary, models and database in place for daemon-less auth)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:169
+#: crates/facelock-cli/src/message/status.rs:174
 msgid "prerequisites missing (PAM would fall through to the next auth method if the daemon is unreachable)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:171
+#: crates/facelock-cli/src/message/status.rs:176
 msgid "device exists"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:172
+#: crates/facelock-cli/src/message/status.rs:177
 msgid "device not found"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:173
+#: crates/facelock-cli/src/message/status.rs:178
 msgid "auto-detect enabled"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:174
+#: crates/facelock-cli/src/message/status.rs:179
 msgid "directory not found"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:175
+#: crates/facelock-cli/src/message/status.rs:180
 msgid "all configured models present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:176
+#: crates/facelock-cli/src/message/status.rs:181
 msgid "some models missing (run 'facelock setup')"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:177
+#: crates/facelock-cli/src/message/status.rs:182
 msgid "present"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:178
+#: crates/facelock-cli/src/message/status.rs:183
 msgid "MISSING"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:179
+#: crates/facelock-cli/src/message/status.rs:184
 msgid "supported by the installed ONNX Runtime"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:181
+#: crates/facelock-cli/src/message/status.rs:186
 msgid "not built into the installed ONNX Runtime — inference will fall back to CPU"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:188
+#: crates/facelock-cli/src/message/status.rs:193
 msgid "unknown execution provider (valid: cpu, cuda, rocm, openvino)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:191
+#: crates/facelock-cli/src/message/status.rs:196
 #, python-brace-format
 msgid "ONNX Runtime not loadable: {error}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:195
+#: crates/facelock-cli/src/message/status.rs:200
 #, python-brace-format
 msgid "sealed key: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:198
+#: crates/facelock-cli/src/message/status.rs:203
 #, python-brace-format
 msgid "sealed key missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:202
+#: crates/facelock-cli/src/message/status.rs:207
 #, python-brace-format
 msgid "TPM device missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:206
+#: crates/facelock-cli/src/message/status.rs:211
 #, python-brace-format
 msgid "key file: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:209
+#: crates/facelock-cli/src/message/status.rs:214
 #, python-brace-format
 msgid "key file missing: {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:213
+#: crates/facelock-cli/src/message/status.rs:218
 msgid "embeddings stored as plaintext (run 'facelock setup' to enable encryption)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:215
+#: crates/facelock-cli/src/message/status.rs:220
 msgid "no faces enrolled (run 'facelock enroll')"
-msgstr ""
-
-#: crates/facelock-cli/src/message/status.rs:217
-#, python-brace-format
-msgid "{count} model(s)"
 msgstr ""
 
 #: crates/facelock-cli/src/message/status.rs:222
 #, python-brace-format
+msgid "{count} model(s)"
+msgstr ""
+
+#: crates/facelock-cli/src/message/status.rs:226
+#, python-brace-format
+msgid "{label}, unbound (re-enroll to bind)"
+msgstr ""
+
+#: crates/facelock-cli/src/message/status.rs:231
+#, python-brace-format
 msgid "out of date (marker says {marker}, database has {store}) — run 'sudo facelock setup' to reconcile"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:227
+#: crates/facelock-cli/src/message/status.rs:236
 #, python-brace-format
 msgid "unreadable: {why}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:229
+#: crates/facelock-cli/src/message/status.rs:238
 msgid "ALL SECURITY CHECKS DISABLED"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:230
+#: crates/facelock-cli/src/message/status.rs:239
 msgid "yes"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:231
+#: crates/facelock-cli/src/message/status.rs:240
 msgid "no"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:232
+#: crates/facelock-cli/src/message/status.rs:241
 msgid "off"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:233
+#: crates/facelock-cli/src/message/status.rs:242
 msgid "terminal"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:234
+#: crates/facelock-cli/src/message/status.rs:243
 msgid "desktop"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:235
+#: crates/facelock-cli/src/message/status.rs:244
 msgid "terminal + desktop"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:236
+#: crates/facelock-cli/src/message/status.rs:245
 msgid "installed"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:238
+#: crates/facelock-cli/src/message/status.rs:247
 #, python-brace-format
 msgid "installed at {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:240
+#: crates/facelock-cli/src/message/status.rs:249
 msgid "not installed"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:242
+#: crates/facelock-cli/src/message/status.rs:251
 #, python-brace-format
 msgid "{services} ({count} configured)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:250
+#: crates/facelock-cli/src/message/status.rs:259
 #, python-brace-format
 msgid "{services} ({count} configured, {overrides} shadowing a vendor file)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:257
+#: crates/facelock-cli/src/message/status.rs:266
 msgid "none configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:258
+#: crates/facelock-cli/src/message/status.rs:267
 msgid "not checked"
 msgstr ""
 
-#: crates/facelock-cli/src/message/status.rs:260
+#: crates/facelock-cli/src/message/status.rs:269
 #, python-brace-format
 msgid "{path} ({error})"
 msgstr ""

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-01 22:37-0700\n"
+"POT-Creation-Date: 2026-09-01 23:29-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1455,31 +1455,31 @@ msgstr ""
 msgid "{path} ({error})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:48
+#: crates/facelock-cli/src/message/system.rs:49
 msgid "Enable daemon mode with D-Bus activation?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:50
+#: crates/facelock-cli/src/message/system.rs:51
 msgid ""
 "  systemd not detected. Skipping daemon configuration.\n"
 "  Facelock will use oneshot mode for authentication."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:53
+#: crates/facelock-cli/src/message/system.rs:54
 msgid "  Skipping systemd setup. Facelock will use oneshot mode."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:56
+#: crates/facelock-cli/src/message/system.rs:57
 msgid ""
 "  Skipping daemon configuration (--no-systemd).\n"
 "  No unit files are written and systemctl is not invoked."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:58
+#: crates/facelock-cli/src/message/system.rs:59
 msgid "  Answered on the command line."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:64
+#: crates/facelock-cli/src/message/system.rs:65
 #, python-brace-format
 msgid ""
 "  Skipping daemon configuration: --config {path} is not /etc/facelock/config.toml,\n"
@@ -1487,7 +1487,7 @@ msgid ""
 "  Enrollment and the recognition test use direct camera access under {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:70
+#: crates/facelock-cli/src/message/system.rs:71
 #, python-brace-format
 msgid ""
 "--systemd is not supported with --config {path}: the facelock-daemon unit runs `facelock daemon`,\n"
@@ -1496,63 +1496,68 @@ msgid ""
 "  or re-run without --systemd to enroll with direct camera access under {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:75
+#: crates/facelock-cli/src/message/system.rs:79
+#, python-brace-format
+msgid "Note: --config {path} names another file; this stops the unit that reads /etc/facelock/config.toml."
+msgstr ""
+
+#: crates/facelock-cli/src/message/system.rs:84
 msgid ""
 "  facelock-daemon was already running; restarted so enrollment uses\n"
 "  the new configuration."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:77
+#: crates/facelock-cli/src/message/system.rs:86
 msgid "  facelock-daemon is running."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:80
+#: crates/facelock-cli/src/message/system.rs:89
 #, python-brace-format
 msgid ""
 "  facelock-daemon did not answer within {seconds}s.\n"
 "  Continuing with direct camera access; check: systemctl status facelock-daemon"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:85
+#: crates/facelock-cli/src/message/system.rs:94
 msgid "  Removed the legacy 'facelock' group; face unlock no longer uses it."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:87
+#: crates/facelock-cli/src/message/system.rs:96
 msgid "Disabling facelock-daemon systemd units..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:88
+#: crates/facelock-cli/src/message/system.rs:97
 msgid "facelock-daemon service disabled and stopped."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:90
+#: crates/facelock-cli/src/message/system.rs:99
 msgid "Validating installed facelock-daemon systemd and D-Bus assets..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:93
+#: crates/facelock-cli/src/message/system.rs:102
 #, python-brace-format
 msgid "  Removed exact known legacy {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:98
+#: crates/facelock-cli/src/message/system.rs:107
 #, python-brace-format
 msgid "  Preserved merged local D-Bus policy {path}; review it if Facelock bus authorization is unexpected."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:102
+#: crates/facelock-cli/src/message/system.rs:111
 msgid "  Installed systemd and D-Bus assets validated."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:103
+#: crates/facelock-cli/src/message/system.rs:112
 msgid "  systemctl daemon-reload done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:105
+#: crates/facelock-cli/src/message/system.rs:114
 #, python-brace-format
 msgid "  systemctl enable {unit} done."
 msgstr ""
 
-#: crates/facelock-cli/src/message/system.rs:109
+#: crates/facelock-cli/src/message/system.rs:118
 msgid ""
 "\n"
 "facelock-daemon D-Bus activation is now enabled."

--- a/test/run-camera-free-tests.sh
+++ b/test/run-camera-free-tests.sh
@@ -481,7 +481,12 @@ rm -f "$SYSTEMCTL_CALLS"
 if [ -e /usr/bin/systemctl ]; then
     REAL_SYSTEMCTL="/tmp/facelock-systemctl.real"
     mv /usr/bin/systemctl "$REAL_SYSTEMCTL"
+    # Armed the instant the real binary is aside: a failed shim write below
+    # must still put it back from the EXIT trap.
+    SYSTEMCTL_SHIMMED=1
 fi
+# Armed for the write itself too, so a partial shim is removed on exit even
+# where no real binary was displaced.
 SYSTEMCTL_SHIMMED=1
 printf '#!/bin/sh\necho "$*" >> %s\nexit 1\n' "$SYSTEMCTL_CALLS" > /usr/bin/systemctl
 chmod 0755 /usr/bin/systemctl

--- a/test/run-camera-free-tests.sh
+++ b/test/run-camera-free-tests.sh
@@ -161,7 +161,25 @@ mkdir -p /run/dbus
 dbus-uuidgen --ensure=/etc/machine-id >/dev/null 2>&1 || true
 dbus-daemon --system --fork --nopidfile
 
+# The setup block below shadows /usr/bin/systemctl with a recording shim.
+# Restoring it is registered here, in the one EXIT path, so a failure under
+# `set -e` between the swap and the block's own restore cannot leave the
+# container without a real systemctl for whatever runs next. Idempotent:
+# the block calls it too.
+REAL_SYSTEMCTL=""
+SYSTEMCTL_SHIMMED=0
+restore_systemctl() {
+    if [ "$SYSTEMCTL_SHIMMED" -eq 1 ]; then
+        rm -f /usr/bin/systemctl
+        if [ -n "$REAL_SYSTEMCTL" ]; then
+            mv "$REAL_SYSTEMCTL" /usr/bin/systemctl
+        fi
+        SYSTEMCTL_SHIMMED=0
+    fi
+}
+
 cleanup() {
+    restore_systemctl
     if [ -n "${DAEMON_PID:-}" ]; then
         kill "$DAEMON_PID" 2>/dev/null || true
         wait "$DAEMON_PID" 2>/dev/null || true
@@ -429,7 +447,7 @@ EOF
     # what this run would have printed instead.
     cp "$CONFIG" /tmp/facelock-override-enroll.toml
     run_test "Enroll under --config bypasses the running daemon" \
-        "facelock --config /tmp/facelock-override-enroll.toml enroll --user testuser --skip-setup-check < /dev/null > /tmp/enroll-override.out 2>&1; test \$? -ne 0 && grep -q 'Note: --config names a file other than /etc/facelock/config.toml' /tmp/enroll-override.out && ! grep -q 'D-Bus Enroll call failed' /tmp/enroll-override.out && ! grep -q 'enrollment timed out client-side' /tmp/enroll-override.out"
+        "facelock --config /tmp/facelock-override-enroll.toml enroll --user testuser --skip-setup-check < /dev/null > /tmp/enroll-override.out 2>&1; test \$? -ne 0 && grep -q 'Note: a non-default configuration is active; the facelock daemon reads only /etc/facelock/config.toml' /tmp/enroll-override.out && ! grep -q 'D-Bus Enroll call failed' /tmp/enroll-override.out && ! grep -q 'enrollment timed out client-side' /tmp/enroll-override.out"
     rm -f /tmp/facelock-override-enroll.toml
 
     # The daemon is done: the one-shot block below must answer with no daemon
@@ -460,11 +478,11 @@ OVERRIDE_CONFIG="/tmp/facelock-override-setup.toml"
 cp "$CONFIG" "$OVERRIDE_CONFIG"
 SYSTEMCTL_CALLS="/tmp/facelock-systemctl-calls"
 rm -f "$SYSTEMCTL_CALLS"
-REAL_SYSTEMCTL=""
 if [ -e /usr/bin/systemctl ]; then
     REAL_SYSTEMCTL="/tmp/facelock-systemctl.real"
     mv /usr/bin/systemctl "$REAL_SYSTEMCTL"
 fi
+SYSTEMCTL_SHIMMED=1
 printf '#!/bin/sh\necho "$*" >> %s\nexit 1\n' "$SYSTEMCTL_CALLS" > /usr/bin/systemctl
 chmod 0755 /usr/bin/systemctl
 rm -f /etc/facelock/.setup-complete
@@ -500,10 +518,7 @@ run_test "setup --systemd under --config /etc/facelock/../facelock/config.toml i
     "facelock --config /etc/facelock/../facelock/config.toml setup --systemd > /tmp/setup-default-spelling.out 2>&1; ! grep -q -- '--systemd is not supported' /tmp/setup-default-spelling.out && grep -q 'Validating installed' /tmp/setup-default-spelling.out"
 rmdir /run/systemd/system 2>/dev/null || true
 
-rm -f /usr/bin/systemctl
-if [ -n "$REAL_SYSTEMCTL" ]; then
-    mv "$REAL_SYSTEMCTL" /usr/bin/systemctl
-fi
+restore_systemctl
 rm -f "$OVERRIDE_CONFIG" "$SYSTEMCTL_CALLS"
 
 # ============================================================================

--- a/test/run-camera-free-tests.sh
+++ b/test/run-camera-free-tests.sh
@@ -482,6 +482,15 @@ mkdir -p /run/systemd/system
 run_test "setup --systemd (standalone) under --config is refused before systemctl" \
     "facelock --config $OVERRIDE_CONFIG setup --systemd > /tmp/setup-override-standalone.out 2>&1; test \$? -ne 0 && grep -q -- '--systemd is not supported with --config $OVERRIDE_CONFIG' /tmp/setup-override-standalone.out && ! grep -q 'Validating installed' /tmp/setup-override-standalone.out && ! test -e $SYSTEMCTL_CALLS"
 
+# Positive control for the shim: `--systemd --disable` reads no config file
+# and is allowed under an override, so it reaches `systemctl disable --now`,
+# which the shim records (and fails, so the command exits non-zero). Without
+# this row the two `! test -e` assertions above would hold just as well with
+# a shim setup never execs.
+run_test "setup --systemd --disable under --config reaches systemctl (shim positive control)" \
+    "facelock --config $OVERRIDE_CONFIG setup --systemd --disable > /tmp/setup-override-disable.out 2>&1; ! grep -q -- '--systemd is not supported' /tmp/setup-override-disable.out && grep -qx 'disable --now facelock-daemon' $SYSTEMCTL_CALLS"
+rm -f "$SYSTEMCTL_CALLS"
+
 # The default path is not an override, however it is spelled: the same
 # standalone invocation naming the real file through a `..` component gets
 # past the identity check and on to the asset validation, which is where

--- a/test/run-camera-free-tests.sh
+++ b/test/run-camera-free-tests.sh
@@ -421,12 +421,81 @@ EOF
 
     sqlite3 -cmd ".timeout 8000" "$DB" "DELETE FROM face_models WHERE label = 'rate-limit-fixture';" || true
 
+    # #314: with a daemon owning the bus, a command under a non-default
+    # `--config` still never enrolls through it. The daemon reads only the
+    # default file, so the CLI selects direct access and says so, before it
+    # tries the (absent) camera itself. The daemon transport's own failure
+    # shapes are forbidden: had the request reached the bus, one of them is
+    # what this run would have printed instead.
+    cp "$CONFIG" /tmp/facelock-override-enroll.toml
+    run_test "Enroll under --config bypasses the running daemon" \
+        "facelock --config /tmp/facelock-override-enroll.toml enroll --user testuser --skip-setup-check < /dev/null > /tmp/enroll-override.out 2>&1; test \$? -ne 0 && grep -q 'Note: --config names a file other than /etc/facelock/config.toml' /tmp/enroll-override.out && ! grep -q 'D-Bus Enroll call failed' /tmp/enroll-override.out && ! grep -q 'enrollment timed out client-side' /tmp/enroll-override.out"
+    rm -f /tmp/facelock-override-enroll.toml
+
     # The daemon is done: the one-shot block below must answer with no daemon
     # on the bus, exactly as it does on the hardware tier.
     kill "$DAEMON_PID" 2>/dev/null || true
     wait "$DAEMON_PID" 2>/dev/null || true
     DAEMON_PID=""
 fi
+
+# ============================================================================
+# Setup under a config override (#314) — needs neither the models nor a
+# camera, and runs as root, which is what makes the refusal reachable: the
+# root gate answers first for anyone else (cli_smoke.rs pins that ordering).
+#
+# The packaged unit runs bare `facelock daemon` and reads only the default
+# config file, so `--systemd` under any other `--config` would enable a
+# daemon configured by a file setup never touched. Refused before the base
+# flow writes anything and before any `systemctl` verb. `systemctl` is
+# shadowed on the fixed PATH setup execs privileged commands from with a
+# recording shim, so "never invoked" is a file that does not exist rather
+# than a verb that happened to fail.
+# ============================================================================
+
+echo ""
+echo "--- setup: --systemd under --config ---"
+
+OVERRIDE_CONFIG="/tmp/facelock-override-setup.toml"
+cp "$CONFIG" "$OVERRIDE_CONFIG"
+SYSTEMCTL_CALLS="/tmp/facelock-systemctl-calls"
+rm -f "$SYSTEMCTL_CALLS"
+REAL_SYSTEMCTL=""
+if [ -e /usr/bin/systemctl ]; then
+    REAL_SYSTEMCTL="/tmp/facelock-systemctl.real"
+    mv /usr/bin/systemctl "$REAL_SYSTEMCTL"
+fi
+printf '#!/bin/sh\necho "$*" >> %s\nexit 1\n' "$SYSTEMCTL_CALLS" > /usr/bin/systemctl
+chmod 0755 /usr/bin/systemctl
+rm -f /etc/facelock/.setup-complete
+
+# The base flow: refused ahead of its first line ("preparing system"), so
+# no directory, model, key or marker is written.
+run_test "setup --systemd --non-interactive under --config is refused before any mutation" \
+    "facelock --config $OVERRIDE_CONFIG setup --systemd --non-interactive > /tmp/setup-override.out 2>&1; test \$? -ne 0 && grep -q -- '--systemd is not supported with --config $OVERRIDE_CONFIG' /tmp/setup-override.out && grep -q 're-run without --systemd' /tmp/setup-override.out && ! grep -q 'preparing system' /tmp/setup-override.out && ! test -e $SYSTEMCTL_CALLS && ! test -e /etc/facelock/.setup-complete"
+
+# The standalone form has no base flow: `run_systemd` asks the same question
+# itself, after its own root and systemd checks and before the legacy-asset
+# migration. This container has no systemd, so the directory that check
+# looks for is created for the one row and removed again.
+mkdir -p /run/systemd/system
+run_test "setup --systemd (standalone) under --config is refused before systemctl" \
+    "facelock --config $OVERRIDE_CONFIG setup --systemd > /tmp/setup-override-standalone.out 2>&1; test \$? -ne 0 && grep -q -- '--systemd is not supported with --config $OVERRIDE_CONFIG' /tmp/setup-override-standalone.out && ! grep -q 'Validating installed' /tmp/setup-override-standalone.out && ! test -e $SYSTEMCTL_CALLS"
+
+# The default path is not an override, however it is spelled: the same
+# standalone invocation naming the real file through a `..` component gets
+# past the identity check and on to the asset validation, which is where
+# this container (no installed unit, a shim for systemctl) stops it. The
+# row asserts the refusal did not fire and the validation was reached.
+run_test "setup --systemd under --config /etc/facelock/../facelock/config.toml is not refused" \
+    "facelock --config /etc/facelock/../facelock/config.toml setup --systemd > /tmp/setup-default-spelling.out 2>&1; ! grep -q -- '--systemd is not supported' /tmp/setup-default-spelling.out && grep -q 'Validating installed' /tmp/setup-default-spelling.out"
+rmdir /run/systemd/system 2>/dev/null || true
+
+rm -f /usr/bin/systemctl
+if [ -n "$REAL_SYSTEMCTL" ]; then
+    mv "$REAL_SYSTEMCTL" /usr/bin/systemctl
+fi
+rm -f "$OVERRIDE_CONFIG" "$SYSTEMCTL_CALLS"
 
 # ============================================================================
 # One-shot block — needs neither the models nor a camera.


### PR DESCRIPTION
## Summary

- refuse `--systemd` under a non-default `--config`, before the base flow writes anything and before any `systemctl` call, naming the two ways out
- skip the wizard's daemon question under such a `--config` and say why; keep `--systemd --disable` working, with a note that the unit it stops reads the default file
- route `enroll`, `test`, `list`, `remove`, `clear`, `devices` and `preview` to direct access under an override in daemon mode, without probing the bus, announced once on stderr
- decide "non-default" on the filesystem: a symlink or `..` spelling of `/etc/facelock/config.toml` is the default, and a file that does not exist yet is compared through its directory
- add no flag, D-Bus method, unit drop-in or transient daemon

## Why

`setup` honoured the global `--config` and then enabled and started the packaged unit, which runs bare `facelock daemon` and reads only `/etc/facelock/config.toml`. Enrollment then went through a daemon whose store, camera, models and encryption policy came from a file setup never touched. The unit cannot be pointed at another file (`FACELOCK_CONFIG` is ignored by privileged processes and setup rejects unit drop-ins), so the combination is refused and every other backend-using command stops trusting a daemon it cannot prove is reading its file.

## Validation

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check`, `just pot`
- mutation of every new gate: parent-directory fallback, bus-outranking rule, refusal placement in both `run_with_plan` and `run_systemd`, C6 root-first ordering, message pins
- tier 3a (`just test-arch-camera-free`): refusal as root with `systemctl` shadowed by a recording shim, a `--disable` positive control that must reach the shim, the `..` spelling of the default not refused, and `enroll` under an override bypassing a daemon that owns the bus

## Files

| Path | Why it matters |
|---|---|
| `crates/facelock-core/src/paths.rs` | `non_default_config_override`, the identity check *(start here)* |
| `crates/facelock-cli/src/commands/setup.rs` | the refusal and where it sits; the wizard skip; the `--disable` note |
| `crates/facelock-cli/src/backend.rs` | `BackendKind::DirectByOverride` and the selection rule |
| `crates/facelock-cli/src/message/access.rs`, `system.rs` | the three notes and the refusal text |
| `test/run-camera-free-tests.sh` | the tier-3a rows |
| `docs/contracts.md`, `docs/cli.md` | the unsupported combination and the direct routing |

## Reviewer notes

- **Refusal placement.** Base flows check right after the root gate and before `run_non_interactive`/`run_wizard`; the standalone form checks inside `run_systemd` after `check_root`/`check_systemd` and before the legacy-asset migration. A source-order test pins both, because `run_with_plan` cannot be driven past its root gate from a test.
- **Oneshot is untouched.** Direct access is already its configuration, so the override note is not printed there.
- **Left for follow-ups:** `status` still renders the default-config daemon under an override; `daemon restart` starts it under any `--config` without a note.

Closes #314


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Commands using a non-default configuration path now use direct camera access instead of the daemon.
  - Configuration-aware messages explain backend selection and graphical preview limitations.
  - `status` continues checking daemon availability under configuration overrides.

- **Bug Fixes**
  - `setup --systemd` refuses non-default configurations before making changes; disabling remains supported.
  - Interactive systemd setup skips prompting under configuration overrides.
  - Equivalent default paths and symlink chains involving `.`/`..` are resolved consistently and safely.

- **Documentation**
  - Updated CLI, behavioral contracts, and localized messages for configuration-aware setup and access.
  - Documented preservation of the previous model when re-enrollment fails or is cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->