### PR TITLE
fix(ci): require a trusted author to start the claude.yml job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
       - name: Verify agent docs still describe the tree
         run: just check-agent-docs "${{ github.event.pull_request.base.sha }}"
 
+      - name: Verify workflow trust policy
+        run: just check-workflow-policy
+
       - name: Verify source-install daemon lifecycle
         run: just test-source-install-daemon-lifecycle
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,9 +24,10 @@ jobs:
     #     collaborators; the action still requires write access. MEMBER is
     #     left out: it never occurs on a user-owned repository and would admit
     #     every organisation member after a transfer.
-    #   - the two review events also refuse fork heads. `issue_comment` cannot:
-    #     its payload has no head repository, so a maintainer's `@claude` on a
-    #     fork PR does run here and checks out the fork head.
+    #   - the two review events also refuse fork heads here. `issue_comment`
+    #     payloads carry no head repository, so a guard step below reads the
+    #     PR with the read-only github.token and fails before the action step
+    #     when the head is a fork.
     #   - the gate decides who starts the job, not what reaches the model: a
     #     stranger's issue body is still the prompt once a maintainer answers.
     # Never switch this workflow to `pull_request_target`.
@@ -65,6 +66,24 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # issue_comment payloads carry no head repository, so the job-level `if:`
+      # above cannot see a fork PR. This step can, with the read-only
+      # github.token; when it fails the action step never runs, so neither the
+      # OAuth token nor the App-token exchange reaches a fork head.
+      # test/check-workflow-policy.py pins this step's position and `if:`.
+      - name: Refuse fork heads on pull request conversation comments
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          head="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name')"
+          if [ -z "$head" ] || [ "$head" != "$REPO" ]; then
+            echo "refusing: pull request head is '${head:-unknown}', not $REPO" >&2
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,12 +12,52 @@ on:
 
 jobs:
   claude:
+    # Trusted authors only. Every event above is raised by whoever writes an
+    # issue, comment or review on a public repository, and this job carries
+    # CLAUDE_CODE_OAUTH_TOKEN plus an OIDC-capable context. The action checks
+    # write access itself, but only after the job has started with the secret
+    # in its environment; this gate keeps the job from being scheduled at all.
+    #   - author gate: the payload field that carries the author's association
+    #     for each event (`issues: assigned` gates on the issue author, not the
+    #     assigner). `contains(array, null)` is false, so a payload without the
+    #     field fails closed. COLLABORATOR includes read-only and triage
+    #     collaborators; the action still requires write access. MEMBER is
+    #     left out: it never occurs on a user-owned repository and would admit
+    #     every organisation member after a transfer.
+    #   - the two review events also refuse fork heads. `issue_comment` cannot:
+    #     its payload has no head repository, so a maintainer's `@claude` on a
+    #     fork PR does run here and checks out the fork head.
+    #   - the gate decides who starts the job, not what reaches the model: a
+    #     stranger's issue body is still the prompt once a maintainer answers.
+    # Never switch this workflow to `pull_request_target`.
+    # test/check-workflow-policy.py pins this condition; change both together.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.comment.author_association) &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.review.author_association) &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issues' &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       contains(fromJSON('["OWNER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    # `permissions:` scopes github.token only, and nothing here writes with it.
+    # The action exchanges this job's OIDC token for a short-lived Claude
+    # GitHub App installation token (src/github/token.ts at v1.0.201) that
+    # requests contents, pull-requests and issues as write plus the
+    # `additional_permissions` below, and hands that token to Claude as
+    # GITHUB_TOKEN. That exchange is why `id-token: write` stays although
+    # claude_code_oauth_token is supplied (it only covers the Claude API), and
+    # it is the scope's cost: anything running in this job can mint OIDC tokens
+    # for any audience, including the one that yields the write-capable App
+    # token. Everything else is `read`; test/check-workflow-policy.py refuses
+    # any other `write`.
     permissions:
       contents: read
       pull-requests: read

--- a/docs/security.md
+++ b/docs/security.md
@@ -1605,7 +1605,10 @@ every `issue_comment` job that runs the action, the same-repo guard and the
 same ceiling on every secret-bearing `pull_request` job, a 40-hex pin on
 `anthropics/claude-code-action` with its bypass inputs
 (`allowed_non_write_users`, `allowed_bots`, `github_token`) refused, and the
-`pull_request_target` ban. It runs in `just check` and in CI.
+`pull_request_target` ban. It also refuses a fork-head guard step that carries
+`continue-on-error` and an action step whose `if:` (`always()`, `failure()`,
+`cancelled()`, a negated `success()`) or whose job's `continue-on-error` would
+run it past a failed guard. It runs in `just check` and in CI.
 
 ## Security Configuration Reference
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1547,6 +1547,62 @@ agent resolves the target username to a uid. If the name does not resolve, the
 agent refuses to respond. It never substitutes UID 0 — the previous
 `unwrap_or(0)` behavior would have authenticated an unresolvable name as root.
 
+### 8. CI Trust Boundary
+
+The workflows anyone can trigger carry one external credential,
+`CLAUDE_CODE_OAUTH_TOKEN`, in two workflows. `release.yml` holds the
+publishing credentials and runs only on `v*` tag pushes.
+`claude-code-review.yml` runs on `pull_request`, where GitHub withholds secrets
+from fork heads, and skips any PR whose head is not this repository.
+
+`claude.yml` answers `@claude` on issues, comments and reviews. Anyone can
+raise those events on a public repository, so text alone never selects its
+job. The job's `if:` requires, per event, that the author's
+`author_association` is `OWNER` or `COLLABORATOR`, read from the payload field
+that carries it (`comment`, `review` or `issue`); a payload without the field
+fails closed, because `contains(array, null)` is false. `issues: assigned`
+gates on the issue author, not the assigner (assigning needs triage or above).
+`COLLABORATOR` includes read-only and triage outside collaborators; the action
+then requires write access before it does anything. `MEMBER` is not accepted:
+it never occurs on a user-owned repository, and after a transfer to an
+organization it would admit every member.
+
+The gate decides who starts the job, not what reaches the model. A stranger's
+issue body is still the prompt once a maintainer answers it with `@claude`;
+the action strips hidden markdown, but read the raw text first.
+
+The two review events (`pull_request_review`, `pull_request_review_comment`)
+also require the head repository to be this one, defense in depth on the two
+payloads that carry it. `issue_comment` carries no head repository, only the
+issue number, so the same guard cannot be written for it: a trusted `@claude`
+on a fork PR does start the job, and the action fetches `refs/pull/<n>/head`,
+the fork's code, into a job holding the OAuth token and a write-capable App
+token. The action refuses actors without write access on its own, but only
+after the job has started with the secret in its environment; the workflow
+gate keeps the job from being scheduled at all.
+
+The job's `permissions:` scope `github.token` only: `contents`,
+`pull-requests`, `issues` and `actions` as `read`, plus `id-token: write`.
+The action does not write through `github.token`. It exchanges the job's OIDC
+token for a short-lived Claude GitHub App installation token that requests
+`contents`, `pull-requests` and `issues` as `write`, plus whatever the
+workflow adds through `additional_permissions` (here `actions: read`), and
+hands that token to Claude as `GITHUB_TOKEN`; `claude_code_oauth_token`
+covers only the Claude API. `id-token: write` is what makes that exchange
+possible, and it is the scope's cost: anything running in the job can mint
+OIDC tokens for any audience, including the one that yields the App token.
+
+No workflow uses `pull_request_target`. `test/check-workflow-policy.py` pins,
+for every `.yml` and `.yaml` workflow: the per-event author gate and the
+read-only `github.token` ceiling on every job of a workflow that subscribes to
+an actor-authored event, the accepted set, `issues: types` as exactly
+`[opened, assigned]`, the same-repo guard on the two review events, the
+same-repo guard and the same ceiling on every secret-bearing `pull_request`
+job, a 40-hex pin on
+`anthropics/claude-code-action` with its bypass inputs
+(`allowed_non_write_users`, `allowed_bots`, `github_token`) refused, and the
+`pull_request_target` ban. It runs in `just check` and in CI.
+
 ## Security Configuration Reference
 
 ```toml

--- a/docs/security.md
+++ b/docs/security.md
@@ -1574,12 +1574,15 @@ the action strips hidden markdown, but read the raw text first.
 The two review events (`pull_request_review`, `pull_request_review_comment`)
 also require the head repository to be this one, defense in depth on the two
 payloads that carry it. `issue_comment` carries no head repository, only the
-issue number, so the same guard cannot be written for it: a trusted `@claude`
-on a fork PR does start the job, and the action fetches `refs/pull/<n>/head`,
-the fork's code, into a job holding the OAuth token and a write-capable App
-token. The action refuses actors without write access on its own, but only
-after the job has started with the secret in its environment; the workflow
-gate keeps the job from being scheduled at all.
+issue number, so the job-level `if:` cannot see a fork PR there. A guard step
+ahead of the action step closes that: when the comment is on a pull request,
+it reads the PR with the job's read-only `github.token` and exits non-zero
+unless the head repository is this one. The action step, and with it the
+OAuth token and the App-token exchange, never runs for a fork; the job that
+does start holds nothing but `github.token`. The action refuses actors
+without write access on its own, but only after the job has started with the
+secret in its environment; the workflow gate keeps the job from being
+scheduled at all.
 
 The job's `permissions:` scope `github.token` only: `contents`,
 `pull-requests`, `issues` and `actions` as `read`, plus `id-token: write`.
@@ -1597,8 +1600,9 @@ for every `.yml` and `.yaml` workflow: the per-event author gate and the
 read-only `github.token` ceiling on every job of a workflow that subscribes to
 an actor-authored event, the accepted set, `issues: types` as exactly
 `[opened, assigned]`, the same-repo guard on the two review events, the
-same-repo guard and the same ceiling on every secret-bearing `pull_request`
-job, a 40-hex pin on
+fork-head guard step (its position before the action step and its `if:`) in
+every `issue_comment` job that runs the action, the same-repo guard and the
+same ceiling on every secret-bearing `pull_request` job, a 40-hex pin on
 `anthropics/claude-code-action` with its bypass inputs
 (`allowed_non_write_users`, `allowed_bots`, `github_token`) refused, and the
 `pull_request_target` ban. It runs in `just check` and in CI.

--- a/justfile
+++ b/justfile
@@ -82,6 +82,10 @@ check-agent-docs base='':
     bash test/debian-postrm-purge.sh
     bash test/rpm-authselect-contract.sh
 
+# Pin the trust boundary of the comment-triggered Claude workflow (docs/security.md, CI Trust Boundary).
+check-workflow-policy:
+    python3 test/check-workflow-policy.py
+
 # Exercise Debian remove/purge policy below disposable fixed roots only.
 test-debian-postrm-purge:
     bash test/debian-postrm-purge.sh
@@ -98,7 +102,7 @@ check-package-names-live:
     python3 test/check-package-names-live.py
 
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
-check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select
+check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,

--- a/test/check-workflow-policy.py
+++ b/test/check-workflow-policy.py
@@ -91,7 +91,7 @@ GATE_CLAUSE = re.compile(
 SECRET_REF = re.compile(r"\bsecrets\s*[.:\[]|toJSON\s*\(\s*secrets\b", re.IGNORECASE)
 ACTION_USE = re.compile(rf"^\s*(?:- )?uses:\s*{re.escape(ACTION)}@(\S+)")
 STEP_KEY = re.compile(r"^\s+([A-Za-z_][A-Za-z0-9_-]*)\s*:")
-BLOCK_SCALAR = re.compile(r"^(\s*)(?:- )?[^\s#][^:#]*:\s*[|>][-+]?[0-9]*\s*(?:#.*)?$")
+BLOCK_SCALAR = re.compile(r"^(\s*)(- )?[^\s#][^:#]*:\s*[|>][-+]?[0-9]*\s*(?:#.*)?$")
 # `always()`/`failure()`/`cancelled()` override the implicit `success()` an
 # `if:` carries by default; a negated `success()` does the same.
 BYPASS_IF = re.compile(r"\b(?:always|failure|cancelled)\s*\(\s*\)|!\s*success\s*\(\s*\)")
@@ -118,7 +118,14 @@ def content_lines(text: str) -> list[str]:
     """Drop blank lines and full-line comments outside block scalars.
 
     Lines inside a block scalar come back verbatim as `ScalarLine`, so a
-    `#` there is not a comment and a `key:` there is not a key."""
+    `#` there is not a comment and a `key:` there is not a key.
+
+    A block scalar's owning key can be a step's first line (`      - run: |`):
+    the `- ` marker is part of that key's indent, not the scalar's, so the
+    scalar's indent is the marker's end, not the dash. Otherwise a sibling
+    key written at the marker's own indent (`continue-on-error:` at 8 spaces
+    after a `- run: |` at 6) would read as deeper than the scalar and get
+    swallowed as content instead of structure."""
     out: list[str] = []
     scalar_indent: int | None = None
     for line in text.splitlines():
@@ -134,7 +141,7 @@ def content_lines(text: str) -> list[str]:
         out.append(line)
         opened = BLOCK_SCALAR.match(line)
         if opened:
-            scalar_indent = len(opened.group(1))
+            scalar_indent = len(opened.group(1)) + len(opened.group(2) or "")
     return out
 
 
@@ -214,12 +221,18 @@ def block_text(inline: str | None, body: list[str]) -> str:
 
 
 def steps_of(job: list[str]) -> list[list[str]]:
-    """The job's `steps:` items, each as its own list of lines."""
+    """The job's `steps:` items, each as its own list of lines.
+
+    A step's first line keeps its `- ` marker in the raw text, which would
+    leave its inline key (`- run: |`, `- name: ...`) one column shallower
+    than the rest of the step's keys and invisible to `mapping()`. Replacing
+    the marker with two spaces puts that key at the same indent (8) as its
+    siblings."""
     _, body = mapping(job, "steps", 4)
     steps: list[list[str]] = []
     for line in body:
         if not isinstance(line, ScalarLine) and re.match(r"^      - ", line):
-            steps.append([line])
+            steps.append([re.sub(r"^      - ", "        ", line, count=1)])
         elif steps:
             steps[-1].append(line)
     return steps

--- a/test/check-workflow-policy.py
+++ b/test/check-workflow-policy.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Static trust-boundary gate for the GitHub Actions workflows.
+
+`.github/workflows/claude.yml` starts a job holding CLAUDE_CODE_OAUTH_TOKEN on
+events anyone can raise against a public repository: opening an issue, leaving
+a comment, submitting a review. Text alone must never select that job, and no
+sibling job may ride the same trigger ungated. In every workflow (`.yml` or
+`.yaml`) that subscribes to one of those actor-authored events, every job must
+satisfy, for each of the workflow's `on:` events:
+
+  1. a clause `github.event_name == '<event>'` joined by `&&` to
+     `contains(fromJSON('[...]'), github.event.<actor>.author_association)`,
+     where `<actor>` is the payload field that carries the association for
+     that event; a payload without the field fails closed, because
+     `contains(array, null)` is false;
+  2. the accepted set inside `fromJSON` is exactly OWNER and COLLABORATOR
+     (MEMBER never occurs on a user-owned repository and would admit every
+     organisation member after a transfer);
+  3. the pull-request-shaped events also require the head repository to be
+     this repository;
+  4. `issues:` subscribes to exactly `[opened, assigned]`, so relabelling or
+     reopening an old `@claude` issue cannot re-fire it;
+  5. the job's `permissions:` (the scope of `github.token`) grant nothing but
+     `read`, except `id-token: write`, which the action needs to mint its
+     GitHub App token.
+
+A workflow on `pull_request` only, where GitHub already withholds secrets from
+fork heads, must still guard every secret-bearing job with the same-repo
+conjunct and the same permission ceiling.
+
+Every step using `anthropics/claude-code-action` must pin a 40-hex commit and
+may not pass `allowed_non_write_users`, `allowed_bots` or `github_token`, the
+inputs that bypass the action's own write-access check. A job that names the
+action but whose `steps:` cannot be read in the supported shape (items at
+six-space `- `, block-form `with:`) fails closed.
+
+No workflow may use `pull_request_target`.
+
+The YAML is read by indentation, not a YAML library: this runs in a bare
+archlinux container with the standard library only. The supported shape is the
+one this repository writes: `on:` and `jobs:` as mappings, both at two-space
+indentation. A workflow whose text names one of the actor events but yields no
+events or no jobs under that reading fails closed as unparseable. A
+workflow-level `env:` that references `secrets` (dotted, indexed or through
+`toJSON(secrets)`, in any letter case) makes every job in the workflow
+secret-bearing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = ROOT / ".github/workflows"
+WORKFLOWS = sorted([*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")])
+PINNED = ".github/workflows/claude.yml"
+
+ACCEPTED = {"OWNER", "COLLABORATOR"}
+ASSOCIATION_FIELD = {
+    "issue_comment": "github.event.comment.author_association",
+    "pull_request_review_comment": "github.event.comment.author_association",
+    "pull_request_review": "github.event.review.author_association",
+    "issues": "github.event.issue.author_association",
+}
+PR_SHAPED = {"pull_request_review", "pull_request_review_comment"}
+EVENT_TYPES = {"issues": {"opened", "assigned"}}
+SAME_REPO = "github.event.pull_request.head.repo.full_name == github.repository"
+
+ACTION = "anthropics/claude-code-action"
+BYPASS_INPUTS = ("allowed_non_write_users", "allowed_bots", "github_token")
+
+EVENT_CLAUSE = re.compile(r"^github\.event_name == '([a-z_]+)'$")
+GATE_CLAUSE = re.compile(
+    r"^contains\(fromJSON\('(\[[^']*\])'\),(github\.event\.[a-z_.]+\.author_association)\)$"
+)
+# The runner matches context and function names case-insensitively.
+SECRET_REF = re.compile(r"\bsecrets\s*[.:\[]|toJSON\s*\(\s*secrets\b", re.IGNORECASE)
+ACTION_USE = re.compile(rf"^\s*(?:- )?uses:\s*{re.escape(ACTION)}@(\S+)")
+STEP_KEY = re.compile(r"^\s+([A-Za-z_][A-Za-z0-9_-]*)\s*:")
+
+failures: list[str] = []
+
+
+def fail(context: str, detail: str) -> None:
+    failures.append(f"{context}: {detail}")
+
+
+# ------------------------------------------------------------------ YAML text
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def content_lines(text: str) -> list[str]:
+    """Drop blank lines and full-line comments; keep everything else verbatim."""
+    return [line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+
+def mapping(lines: list[str], key: str, indent: int) -> tuple[str | None, list[str]]:
+    """The inline value and the deeper-indented body of `key:` at `indent`.
+
+    Returns (None, []) when the key is absent."""
+    head = re.compile(rf"^{' ' * indent}{re.escape(key)}:(.*)$")
+    for i, line in enumerate(lines):
+        m = head.match(line)
+        if not m:
+            continue
+        body: list[str] = []
+        for later in lines[i + 1 :]:
+            if indent_of(later) <= indent:
+                break
+            body.append(later)
+        return m.group(1).strip() or None, body
+    return None, []
+
+
+def keys_at(lines: list[str], indent: int) -> list[str]:
+    pattern = re.compile(rf"^{' ' * indent}([A-Za-z_][A-Za-z0-9_-]*):")
+    return [m.group(1) for line in lines if (m := pattern.match(line))]
+
+
+def scalar(value: str) -> str:
+    """An inline value with its trailing comment and quotes removed."""
+    value = value.strip()
+    if value.startswith("#"):
+        return ""
+    return value.split(" #", 1)[0].strip().strip("'\"")
+
+
+def inline_list(value: str) -> set[str]:
+    return {scalar(item) for item in scalar(value).strip("[]").split(",") if item.strip()}
+
+
+def events_of(lines: list[str]) -> set[str]:
+    """Events under `on:`: a block mapping, an inline `[a, b]` list or one scalar.
+
+    A flow mapping (`on: { ... }`) is not read; the empty set makes the caller
+    fail closed."""
+    inline, body = mapping(lines, "on", 0)
+    inline = scalar(inline or "")
+    if inline.startswith("{"):
+        return set()
+    if inline.startswith("["):
+        return inline_list(inline)
+    if inline:
+        return {inline}
+    return set(keys_at(body, 2))
+
+
+def event_types(lines: list[str], event: str) -> set[str]:
+    """The `types:` list under `on: <event>:`, inline or block form."""
+    _, on_body = mapping(lines, "on", 0)
+    _, event_body = mapping(on_body, event, 2)
+    inline, body = mapping(event_body, "types", 4)
+    if inline:
+        return inline_list(inline)
+    return {m.group(1) for line in body if (m := re.match(r"^\s+- ([a-z_]+)", line))}
+
+
+def block_text(inline: str | None, body: list[str]) -> str:
+    """Flatten a scalar that may be inline, `|`, `>` or `${{ }}`-wrapped."""
+    if inline is not None and inline not in ("|", ">", "|-", ">-"):
+        text = inline
+    else:
+        text = " ".join(line.strip() for line in body)
+    text = re.sub(r"^\$\{\{(.*)\}\}$", r"\1", text.strip())
+    return text
+
+
+def steps_of(job: list[str]) -> list[list[str]]:
+    """The job's `steps:` items, each as its own list of lines."""
+    _, body = mapping(job, "steps", 4)
+    steps: list[list[str]] = []
+    for line in body:
+        if re.match(r"^      - ", line):
+            steps.append([line])
+        elif steps:
+            steps[-1].append(line)
+    return steps
+
+
+# --------------------------------------------------------------- expressions
+
+
+def split_top(expr: str, op: str) -> list[str]:
+    """Split on `op` at parenthesis depth zero, outside string literals."""
+    parts: list[str] = []
+    depth = 0
+    quote: str | None = None
+    start = i = 0
+    while i < len(expr):
+        c = expr[i]
+        if quote:
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        elif depth == 0 and expr.startswith(op, i):
+            parts.append(expr[start:i])
+            i += len(op)
+            start = i
+            continue
+        i += 1
+    parts.append(expr[start:])
+    return [p.strip() for p in parts]
+
+
+def encloses(expr: str) -> bool:
+    """True when the first '(' of `expr` closes at its last character."""
+    depth = 0
+    quote: str | None = None
+    for i, c in enumerate(expr):
+        if quote:
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i == len(expr) - 1
+    return False
+
+
+def unwrap(expr: str) -> str:
+    expr = expr.strip()
+    while expr.startswith("(") and expr.endswith(")") and encloses(expr):
+        expr = expr[1:-1].strip()
+    return expr
+
+
+def normalize(expr: str) -> str:
+    expr = re.sub(r"\s+", " ", expr.strip())
+    return re.sub(r"\s*([(),])\s*", r"\1", expr)
+
+
+def conjuncts(clause: str) -> list[str]:
+    return [unwrap(c) for c in split_top(unwrap(clause), "&&")]
+
+
+def job_condition(context: str, job: list[str], purpose: str) -> str | None:
+    inline, body = mapping(job, "if", 4)
+    if inline is None and not body:
+        fail(context, f"job has no `if:` {purpose}")
+        return None
+    return normalize(block_text(inline, body))
+
+
+# --------------------------------------------------------------------- checks
+
+
+def check_clause(context: str, clause: str, events: set[str]) -> str | None:
+    """Validate one top-level `||` alternative; return the event it gates."""
+    parts = conjuncts(clause)
+    named = [m.group(1) for part in parts if (m := EVENT_CLAUSE.match(part))]
+    if any("github.event_name" in part and not EVENT_CLAUSE.match(part) for part in parts):
+        fail(context, f"event_name must be tested as a top-level `== '<event>'` conjunct: {clause}")
+        return None
+    if len(named) != 1:
+        fail(context, f"each `||` alternative must name exactly one event as a top-level conjunct: {clause}")
+        return None
+    event = named[0]
+    if event not in events:
+        fail(context, f"alternative gates {event!r}, which the workflow does not subscribe to")
+        return None
+    if event not in ASSOCIATION_FIELD:
+        fail(context, f"no known author_association field for event {event!r}; extend ASSOCIATION_FIELD deliberately")
+        return None
+
+    gates = [m for part in parts if (m := GATE_CLAUSE.match(part))]
+    for part in parts:
+        if "author_association" in part and not GATE_CLAUSE.match(part):
+            fail(context, f"author_association may only appear inside the accepted-set gate: {part}")
+    matched = False
+    for m in gates:
+        try:
+            accepted = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            fail(context, f"accepted set is not JSON: {m.group(1)}")
+            continue
+        if not isinstance(accepted, list) or set(accepted) != ACCEPTED or len(accepted) != len(ACCEPTED):
+            fail(context, f"accepted set must be exactly {sorted(ACCEPTED)}, got {accepted}")
+            continue
+        if m.group(2) == ASSOCIATION_FIELD[event]:
+            matched = True
+        else:
+            fail(context, f"{event}: gate reads {m.group(2)}, expected {ASSOCIATION_FIELD[event]}")
+    if not matched:
+        fail(context, f"{event}: no top-level `&&` conjunct `contains(fromJSON('[...]'), {ASSOCIATION_FIELD[event]})`")
+    if event in PR_SHAPED and normalize(SAME_REPO) not in parts:
+        fail(context, f"{event}: missing top-level `&&` conjunct `{SAME_REPO}`")
+    return event
+
+
+def check_permissions(context: str, job: list[str]) -> None:
+    """`permissions:` scopes github.token: read only, `id-token: write` excepted."""
+    inline, body = mapping(job, "permissions", 4)
+    if inline is None and not body:
+        fail(context, "job declares no `permissions:` block")
+        return
+    if inline is not None:
+        if scalar(inline) == "{}":
+            return  # no scopes at all: the most restrictive form
+        fail(context, f"permissions must be in block form, not {inline!r}")
+        return
+    for line in body:
+        if indent_of(line) != 6 or ":" not in line:
+            continue
+        scope, _, value = line.strip().partition(":")
+        value = scalar(value)
+        if scope == "id-token":
+            if value != "write":
+                fail(context, f"id-token must be `write` (the action mints its app token from the OIDC token), got {value!r}")
+        elif value != "read":
+            fail(context, f"permission {scope}: {value!r}; a job on these triggers grants only `read` (id-token excepted)")
+
+
+def check_action_steps(context: str, job: list[str]) -> None:
+    """Every claude-code-action step: 40-hex pin, none of the bypass inputs.
+
+    A job that names the action outside a readable step fails closed."""
+    matched = 0
+    for step in steps_of(job):
+        use = next((m for line in step if (m := ACTION_USE.match(line))), None)
+        if use is None:
+            continue
+        matched += 1
+        ref = use.group(1)
+        if not re.fullmatch(r"[0-9a-f]{40}", ref):
+            fail(context, f"{ACTION} must be pinned to a 40-hex commit, not {ref!r}")
+        for line in step:
+            key = STEP_KEY.match(line)
+            if not key:
+                continue
+            if key.group(1) in BYPASS_INPUTS:
+                fail(context, f"input {key.group(1)!r} bypasses the action's own write-access check")
+            if key.group(1) == "with" and "{" in line:
+                fail(context, "`with:` must be in block form; a flow mapping hides its inputs from this check")
+    if not matched and ACTION in "\n".join(job):
+        fail(context, f"steps shape not readable: {ACTION} occurs in the job but no step at six-space `- ` uses it")
+
+
+def check_actor_job(context: str, job: list[str], events: set[str]) -> None:
+    """A job on an actor-authored trigger: per-event author gate plus the ceiling."""
+    expression = job_condition(context, job, "gate on an actor-authored trigger")
+    if expression is None:
+        return
+    gated: set[str] = set()
+    for clause in split_top(expression, "||"):
+        event = check_clause(context, clause, events)
+        if event:
+            gated.add(event)
+    for event in sorted(events - gated):
+        fail(context, f"event {event!r} has no gated `||` alternative")
+    check_permissions(context, job)
+
+
+def check_pull_request_job(context: str, job: list[str]) -> None:
+    """A secret-bearing job on `pull_request`: same-repo guard plus the ceiling."""
+    expression = job_condition(context, job, "guard while carrying a secret on pull_request")
+    if expression is None:
+        return
+    for clause in split_top(expression, "||"):
+        if normalize(SAME_REPO) not in conjuncts(clause):
+            fail(context, f"every `||` alternative needs the top-level `&&` conjunct `{SAME_REPO}`: {clause}")
+    check_permissions(context, job)
+
+
+def check_workflow(path: Path) -> int:
+    """Return the number of jobs held to a gate in this workflow."""
+    relative = path.relative_to(ROOT).as_posix()
+    lines = content_lines(path.read_text(encoding="utf-8"))
+    text = "\n".join(lines)
+
+    if re.search(r"\bpull_request_target\b", text):
+        fail(relative, "`pull_request_target` runs untrusted heads with this repository's secrets")
+
+    events = events_of(lines)
+    _, jobs = mapping(lines, "jobs", 0)
+    names = keys_at(jobs, 2)
+    mentioned = sorted(event for event in ASSOCIATION_FIELD if re.search(rf"\b{event}\b", text))
+    malformed = sorted(event for event in events if not re.fullmatch(r"[a-z_]+", event))
+    if mentioned and (not events or malformed or not names):
+        fail(
+            relative,
+            f"unparseable shape: names {mentioned} but reads as events={sorted(events)} jobs={names}; "
+            "only `on:` and `jobs:` mappings at two-space indentation are supported",
+        )
+        return 0
+
+    actor = bool(events & ASSOCIATION_FIELD.keys())
+    if actor:
+        for event, wanted in EVENT_TYPES.items():
+            if event in events and event_types(lines, event) != wanted:
+                fail(relative, f"`{event}:` must subscribe to exactly types {sorted(wanted)}, got {sorted(event_types(lines, event))}")
+
+    env_inline, env_body = mapping(lines, "env", 0)
+    workflow_secret = bool(SECRET_REF.search("\n".join([env_inline or "", *env_body])))
+    checked = 0
+    for name in names:
+        _, job = mapping(jobs, name, 2)
+        context = f"{relative} job {name!r}"
+        check_action_steps(context, job)
+        secret = workflow_secret or bool(SECRET_REF.search("\n".join(job)))
+        if actor:
+            check_actor_job(context, job, events)
+            checked += 1
+        elif "pull_request" in events and secret:
+            check_pull_request_job(context, job)
+            checked += 1
+    return checked
+
+
+def main() -> int:
+    checked: dict[str, int] = {}
+    for path in WORKFLOWS:
+        checked[path.relative_to(ROOT).as_posix()] = check_workflow(path)
+
+    if not checked.get(PINNED):
+        fail(PINNED, "expected at least one job to pin; the workflow moved or lost its trigger")
+
+    if failures:
+        for line in failures:
+            print(f"FAIL  {line}")
+        print(f"\nworkflow policy: {len(failures)} failure(s)")
+        return 1
+    print(
+        f"workflow policy: OK ({sum(checked.values())} gated job(s) in "
+        f"{sum(1 for n in checked.values() if n)} workflow(s); {len(checked)} scanned)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/check-workflow-policy.py
+++ b/test/check-workflow-policy.py
@@ -17,7 +17,10 @@ satisfy, for each of the workflow's `on:` events:
      (MEMBER never occurs on a user-owned repository and would admit every
      organisation member after a transfer);
   3. the pull-request-shaped events also require the head repository to be
-     this repository;
+     this repository; `issue_comment` payloads carry no head repository, so
+     a job on that event that runs the action must first run a guard step
+     (pinned `if:`, placed before the action step) that reads the PR with
+     `github.token` and exits non-zero unless the head is this repository;
   4. `issues:` subscribes to exactly `[opened, assigned]`, so relabelling or
      reopening an old `@claude` issue cannot re-fire it;
   5. the job's `permissions:` (the scope of `github.token`) grant nothing but
@@ -37,9 +40,10 @@ six-space `- `, block-form `with:`) fails closed.
 No workflow may use `pull_request_target`.
 
 The YAML is read by indentation, not a YAML library: this runs in a bare
-archlinux container with the standard library only. The supported shape is the
-one this repository writes: `on:` and `jobs:` as mappings, both at two-space
-indentation. A workflow whose text names one of the actor events but yields no
+archlinux container with the standard library only. A `|` or `>` value pins a
+block scalar whose body (deeper-indented lines) is content: never a comment
+to strip, never a key to scan. The supported shape is the one this repository
+writes: `on:` and `jobs:` as mappings, both at two-space indentation. A workflow whose text names one of the actor events but yields no
 events or no jobs under that reading fails closed as unparseable. A
 workflow-level `env:` that references `secrets` (dotted, indexed or through
 `toJSON(secrets)`, in any letter case) makes every job in the workflow
@@ -71,6 +75,8 @@ SAME_REPO = "github.event.pull_request.head.repo.full_name == github.repository"
 
 ACTION = "anthropics/claude-code-action"
 BYPASS_INPUTS = ("allowed_non_write_users", "allowed_bots", "github_token")
+FORK_GUARD_IF = "github.event_name == 'issue_comment' && github.event.issue.pull_request"
+FORK_GUARD_RUN = ("gh api", "/pulls/", ".head.repo.full_name", "exit 1")
 
 EVENT_CLAUSE = re.compile(r"^github\.event_name == '([a-z_]+)'$")
 GATE_CLAUSE = re.compile(
@@ -80,6 +86,7 @@ GATE_CLAUSE = re.compile(
 SECRET_REF = re.compile(r"\bsecrets\s*[.:\[]|toJSON\s*\(\s*secrets\b", re.IGNORECASE)
 ACTION_USE = re.compile(rf"^\s*(?:- )?uses:\s*{re.escape(ACTION)}@(\S+)")
 STEP_KEY = re.compile(r"^\s+([A-Za-z_][A-Za-z0-9_-]*)\s*:")
+BLOCK_SCALAR = re.compile(r"^(\s*)(?:- )?[^\s#][^:#]*:\s*[|>][-+]?[0-9]*\s*(?:#.*)?$")
 
 failures: list[str] = []
 
@@ -95,9 +102,36 @@ def indent_of(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
 
 
+class ScalarLine(str):
+    """A line inside a `|` or `>` block scalar: content, never structure."""
+
+
 def content_lines(text: str) -> list[str]:
-    """Drop blank lines and full-line comments; keep everything else verbatim."""
-    return [line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+    """Drop blank lines and full-line comments outside block scalars.
+
+    Lines inside a block scalar come back verbatim as `ScalarLine`, so a
+    `#` there is not a comment and a `key:` there is not a key."""
+    out: list[str] = []
+    scalar_indent: int | None = None
+    for line in text.splitlines():
+        if scalar_indent is not None:
+            if not line.strip():
+                continue
+            if indent_of(line) > scalar_indent:
+                out.append(ScalarLine(line))
+                continue
+            scalar_indent = None
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        out.append(line)
+        opened = BLOCK_SCALAR.match(line)
+        if opened:
+            scalar_indent = len(opened.group(1))
+    return out
+
+
+def structural(lines: list[str]) -> list[str]:
+    return [line for line in lines if not isinstance(line, ScalarLine)]
 
 
 def mapping(lines: list[str], key: str, indent: int) -> tuple[str | None, list[str]]:
@@ -106,7 +140,7 @@ def mapping(lines: list[str], key: str, indent: int) -> tuple[str | None, list[s
     Returns (None, []) when the key is absent."""
     head = re.compile(rf"^{' ' * indent}{re.escape(key)}:(.*)$")
     for i, line in enumerate(lines):
-        m = head.match(line)
+        m = None if isinstance(line, ScalarLine) else head.match(line)
         if not m:
             continue
         body: list[str] = []
@@ -120,7 +154,7 @@ def mapping(lines: list[str], key: str, indent: int) -> tuple[str | None, list[s
 
 def keys_at(lines: list[str], indent: int) -> list[str]:
     pattern = re.compile(rf"^{' ' * indent}([A-Za-z_][A-Za-z0-9_-]*):")
-    return [m.group(1) for line in lines if (m := pattern.match(line))]
+    return [m.group(1) for line in structural(lines) if (m := pattern.match(line))]
 
 
 def scalar(value: str) -> str:
@@ -176,7 +210,7 @@ def steps_of(job: list[str]) -> list[list[str]]:
     _, body = mapping(job, "steps", 4)
     steps: list[list[str]] = []
     for line in body:
-        if re.match(r"^      - ", line):
+        if not isinstance(line, ScalarLine) and re.match(r"^      - ", line):
             steps.append([line])
         elif steps:
             steps[-1].append(line)
@@ -313,7 +347,7 @@ def check_permissions(context: str, job: list[str]) -> None:
             return  # no scopes at all: the most restrictive form
         fail(context, f"permissions must be in block form, not {inline!r}")
         return
-    for line in body:
+    for line in structural(body):
         if indent_of(line) != 6 or ":" not in line:
             continue
         scope, _, value = line.strip().partition(":")
@@ -331,14 +365,13 @@ def check_action_steps(context: str, job: list[str]) -> None:
     A job that names the action outside a readable step fails closed."""
     matched = 0
     for step in steps_of(job):
-        use = next((m for line in step if (m := ACTION_USE.match(line))), None)
-        if use is None:
+        if not uses_action(step):
             continue
         matched += 1
-        ref = use.group(1)
+        ref = uses_action(step)
         if not re.fullmatch(r"[0-9a-f]{40}", ref):
             fail(context, f"{ACTION} must be pinned to a 40-hex commit, not {ref!r}")
-        for line in step:
+        for line in structural(step):
             key = STEP_KEY.match(line)
             if not key:
                 continue
@@ -346,8 +379,36 @@ def check_action_steps(context: str, job: list[str]) -> None:
                 fail(context, f"input {key.group(1)!r} bypasses the action's own write-access check")
             if key.group(1) == "with" and "{" in line:
                 fail(context, "`with:` must be in block form; a flow mapping hides its inputs from this check")
-    if not matched and ACTION in "\n".join(job):
+    if not matched and ACTION in "\n".join(structural(job)):
         fail(context, f"steps shape not readable: {ACTION} occurs in the job but no step at six-space `- ` uses it")
+
+
+def uses_action(step: list[str]) -> str | None:
+    """The ref this step pins `ACTION` to, or None when it is another step."""
+    return next((m.group(1) for line in structural(step) if (m := ACTION_USE.match(line))), None)
+
+
+def is_fork_guard(step: list[str]) -> bool:
+    inline, body = mapping(step, "if", 8)
+    if (inline is None and not body) or normalize(block_text(inline, body)) != normalize(FORK_GUARD_IF):
+        return False
+    run_inline, run_body = mapping(step, "run", 8)
+    run = block_text(run_inline, run_body)
+    return all(needle in run for needle in FORK_GUARD_RUN)
+
+
+def check_fork_guard(context: str, job: list[str]) -> None:
+    """On `issue_comment` the payload has no head repository: a job that runs the
+    action must first refuse fork heads through the API, before the action step."""
+    steps = steps_of(job)
+    action_at = next((i for i, step in enumerate(steps) if uses_action(step)), None)
+    if action_at is None:
+        return
+    guard_at = next((i for i, step in enumerate(steps) if is_fork_guard(step)), None)
+    if guard_at is None:
+        fail(context, f"issue_comment job runs {ACTION} without a fork-head guard step (`if: {FORK_GUARD_IF}`, `gh api .../pulls/<n> --jq .head.repo.full_name`, `exit 1` on a fork)")
+    elif guard_at > action_at:
+        fail(context, "the fork-head guard step must run before the action step")
 
 
 def check_actor_job(context: str, job: list[str], events: set[str]) -> None:
@@ -414,6 +475,8 @@ def check_workflow(path: Path) -> int:
         secret = workflow_secret or bool(SECRET_REF.search("\n".join(job)))
         if actor:
             check_actor_job(context, job, events)
+            if "issue_comment" in events:
+                check_fork_guard(context, job)
             checked += 1
         elif "pull_request" in events and secret:
             check_pull_request_job(context, job)

--- a/test/check-workflow-policy.py
+++ b/test/check-workflow-policy.py
@@ -21,6 +21,9 @@ satisfy, for each of the workflow's `on:` events:
      a job on that event that runs the action must first run a guard step
      (pinned `if:`, placed before the action step) that reads the PR with
      `github.token` and exits non-zero unless the head is this repository;
+     the API call, the comparison and the `exit 1` must be shell statements,
+     not comments, and the step must bind `GH_TOKEN`, the repository and the
+     PR number from the `github` context;
   4. `issues:` subscribes to exactly `[opened, assigned]`, so relabelling or
      reopening an old `@claude` issue cannot re-fire it;
   5. the job's `permissions:` (the scope of `github.token`) grant nothing but
@@ -76,7 +79,9 @@ SAME_REPO = "github.event.pull_request.head.repo.full_name == github.repository"
 ACTION = "anthropics/claude-code-action"
 BYPASS_INPUTS = ("allowed_non_write_users", "allowed_bots", "github_token")
 FORK_GUARD_IF = "github.event_name == 'issue_comment' && github.event.issue.pull_request"
-FORK_GUARD_RUN = ("gh api", "/pulls/", ".head.repo.full_name", "exit 1")
+FORK_GUARD_TOKEN = ("GH_TOKEN", "${{ github.token }}")
+FORK_GUARD_REPO = "${{ github.repository }}"
+FORK_GUARD_PR = "${{ github.event.issue.number }}"
 
 EVENT_CLAUSE = re.compile(r"^github\.event_name == '([a-z_]+)'$")
 GATE_CLAUSE = re.compile(
@@ -388,13 +393,70 @@ def uses_action(step: list[str]) -> str | None:
     return next((m.group(1) for line in structural(step) if (m := ACTION_USE.match(line))), None)
 
 
-def is_fork_guard(step: list[str]) -> bool:
+def has_fork_guard_if(step: list[str]) -> bool:
     inline, body = mapping(step, "if", 8)
-    if (inline is None and not body) or normalize(block_text(inline, body)) != normalize(FORK_GUARD_IF):
-        return False
-    run_inline, run_body = mapping(step, "run", 8)
-    run = block_text(run_inline, run_body)
-    return all(needle in run for needle in FORK_GUARD_RUN)
+    return bool(inline is not None or body) and normalize(block_text(inline, body)) == normalize(FORK_GUARD_IF)
+
+
+def step_env(step: list[str]) -> dict[str, str]:
+    _, body = mapping(step, "env", 8)
+    env: dict[str, str] = {}
+    for line in structural(body):
+        key, _, value = line.strip().partition(":")
+        env[key.strip()] = value.strip()
+    return env
+
+
+def shell_statements(step: list[str]) -> list[str]:
+    """The `run:` block as statements with shell comments removed, quotes respected."""
+    inline, body = mapping(step, "run", 8)
+    lines = body if inline in (None, "|", ">", "|-", ">-") else [inline]
+    statements: list[str] = []
+    for line in lines:
+        kept: list[str] = []
+        quote: str | None = None
+        for i, c in enumerate(line):
+            if quote:
+                if c == quote:
+                    quote = None
+            elif c in "'\"":
+                quote = c
+            elif c == "#" and (i == 0 or line[i - 1] in " \t;("):
+                break
+            kept.append(c)
+        statement = "".join(kept).strip()
+        if statement:
+            statements.append(statement)
+    return statements
+
+
+def shell_var(name: str) -> str:
+    return rf"\$(?:\{{{re.escape(name)}\}}|{re.escape(name)})"
+
+
+def fork_guard_defects(step: list[str]) -> list[str]:
+    """What a step with the guard's `if:` still lacks to be the guard."""
+    defects: list[str] = []
+    env = step_env(step)
+    if env.get(FORK_GUARD_TOKEN[0]) != FORK_GUARD_TOKEN[1]:
+        defects.append(f"env `{FORK_GUARD_TOKEN[0]}: {FORK_GUARD_TOKEN[1]}`")
+    repo = next((k for k, v in env.items() if v == FORK_GUARD_REPO), None)
+    pr = next((k for k, v in env.items() if v == FORK_GUARD_PR), None)
+    if repo is None:
+        defects.append(f"an env binding of `{FORK_GUARD_REPO}`")
+    if pr is None:
+        defects.append(f"an env binding of `{FORK_GUARD_PR}`")
+    statements = shell_statements(step)
+    if repo is not None and pr is not None:
+        api = re.compile(rf"gh api \"?repos/{shell_var(repo)}/pulls/{shell_var(pr)}\"?\s.*--jq\s+'?\.head\.repo\.full_name'?")
+        if not any(api.search(s) for s in statements):
+            defects.append(f"a statement `gh api \"repos/${repo}/pulls/${pr}\" --jq '.head.repo.full_name'` outside comments")
+        compare = re.compile(rf"!=\s*\"?{shell_var(repo)}\"?")
+        if not any(compare.search(s) for s in statements):
+            defects.append(f"a comparison `!= \"${repo}\"` outside comments")
+    if not any(re.search(r"(^|[;&|(]\s*)exit 1\b", s) for s in statements):
+        defects.append("an `exit 1` statement outside comments")
+    return defects
 
 
 def check_fork_guard(context: str, job: list[str]) -> None:
@@ -404,10 +466,13 @@ def check_fork_guard(context: str, job: list[str]) -> None:
     action_at = next((i for i, step in enumerate(steps) if uses_action(step)), None)
     if action_at is None:
         return
-    guard_at = next((i for i, step in enumerate(steps) if is_fork_guard(step)), None)
+    guard_at = next((i for i, step in enumerate(steps) if has_fork_guard_if(step)), None)
     if guard_at is None:
-        fail(context, f"issue_comment job runs {ACTION} without a fork-head guard step (`if: {FORK_GUARD_IF}`, `gh api .../pulls/<n> --jq .head.repo.full_name`, `exit 1` on a fork)")
-    elif guard_at > action_at:
+        fail(context, f"issue_comment job runs {ACTION} without a fork-head guard step (`if: {FORK_GUARD_IF}`)")
+        return
+    for defect in fork_guard_defects(steps[guard_at]):
+        fail(context, f"fork-head guard step lacks {defect}")
+    if guard_at > action_at:
         fail(context, "the fork-head guard step must run before the action step")
 
 

--- a/test/check-workflow-policy.py
+++ b/test/check-workflow-policy.py
@@ -92,6 +92,9 @@ SECRET_REF = re.compile(r"\bsecrets\s*[.:\[]|toJSON\s*\(\s*secrets\b", re.IGNORE
 ACTION_USE = re.compile(rf"^\s*(?:- )?uses:\s*{re.escape(ACTION)}@(\S+)")
 STEP_KEY = re.compile(r"^\s+([A-Za-z_][A-Za-z0-9_-]*)\s*:")
 BLOCK_SCALAR = re.compile(r"^(\s*)(?:- )?[^\s#][^:#]*:\s*[|>][-+]?[0-9]*\s*(?:#.*)?$")
+# `always()`/`failure()`/`cancelled()` override the implicit `success()` an
+# `if:` carries by default; a negated `success()` does the same.
+BYPASS_IF = re.compile(r"\b(?:always|failure|cancelled)\s*\(\s*\)|!\s*success\s*\(\s*\)")
 
 failures: list[str] = []
 
@@ -365,7 +368,8 @@ def check_permissions(context: str, job: list[str]) -> None:
 
 
 def check_action_steps(context: str, job: list[str]) -> None:
-    """Every claude-code-action step: 40-hex pin, none of the bypass inputs.
+    """Every claude-code-action step: 40-hex pin, none of the bypass inputs, and
+    no `if:`/`continue-on-error:` shape that can run it past a failed fork guard.
 
     A job that names the action outside a readable step fails closed."""
     matched = 0
@@ -384,6 +388,13 @@ def check_action_steps(context: str, job: list[str]) -> None:
                 fail(context, f"input {key.group(1)!r} bypasses the action's own write-access check")
             if key.group(1) == "with" and "{" in line:
                 fail(context, "`with:` must be in block form; a flow mapping hides its inputs from this check")
+        condition = block_text(*mapping(step, "if", 8))
+        if condition and BYPASS_IF.search(condition):
+            fail(context, f"the action step's `if: {condition}` can run it after a failed fork guard")
+    if matched:
+        coe = continue_on_error(job, 4)
+        if coe is not None:
+            fail(context, f"job carries `continue-on-error: {coe}`, which can run {ACTION} after a failed step")
     if not matched and ACTION in "\n".join(structural(job)):
         fail(context, f"steps shape not readable: {ACTION} occurs in the job but no step at six-space `- ` uses it")
 
@@ -434,6 +445,12 @@ def shell_var(name: str) -> str:
     return rf"\$(?:\{{{re.escape(name)}\}}|{re.escape(name)})"
 
 
+def continue_on_error(lines: list[str], indent: int) -> str | None:
+    """The `continue-on-error` value at `indent`, or None when absent or `false`."""
+    value = scalar(block_text(*mapping(lines, "continue-on-error", indent)))
+    return value if value and value != "false" else None
+
+
 def fork_guard_defects(step: list[str]) -> list[str]:
     """What a step with the guard's `if:` still lacks to be the guard."""
     defects: list[str] = []
@@ -472,6 +489,9 @@ def check_fork_guard(context: str, job: list[str]) -> None:
         return
     for defect in fork_guard_defects(steps[guard_at]):
         fail(context, f"fork-head guard step lacks {defect}")
+    coe = continue_on_error(steps[guard_at], 8)
+    if coe is not None:
+        fail(context, f"fork-head guard step carries `continue-on-error: {coe}`, which makes its `exit 1` non-fatal")
     if guard_at > action_at:
         fail(context, "the fork-head guard step must run before the action step")
 


### PR DESCRIPTION
## Summary

- gate the `claude.yml` job, per event, on the author's `author_association` being `OWNER` or `COLLABORATOR`, read from the field each payload carries (`comment`, `review`, `issue`)
- fail closed on a payload without that field: `contains(array, null)` is false
- require the head repository to be this one on `pull_request_review` and `pull_request_review_comment`
- leave `issue_comment` without that guard: its payload carries no head repository, so a maintainer's `@claude` on a fork PR still runs, and the action fetches the fork head into a job holding the OAuth token and the write-capable App installation token
- pin `issues:` to `types: [opened, assigned]`
- keep `id-token: write`: the action exchanges the job's OIDC token for its GitHub App installation token, and `claude_code_oauth_token` only authenticates the action to its own API, not to GitHub
- add `test/check-workflow-policy.py` (stdlib only) to `just check` and the `agent-docs` CI job; describe the boundary in `docs/security.md` §8

## Why

`claude.yml` selected its job from `@claude` in public text alone, then handed it `CLAUDE_CODE_OAUTH_TOKEN` and an OIDC-capable context. `anthropics/claude-code-action` refuses actors without write access, but only after the job has started with the secret in its environment. The workflow-level gate keeps such a job from being scheduled at all, and the static test keeps the gate from drifting. Release-audit finding `7c4b3e9efb3a-f001`.

| Path | Why it matters |
|---|---|
| `.github/workflows/claude.yml` | the gate, the accepted set, the `id-token` rationale *(start here)* |
| `test/check-workflow-policy.py` | the pin |
| `docs/security.md` | §8, CI Trust Boundary |
| `justfile`, `.github/workflows/ci.yml` | `check-workflow-policy` recipe and its CI step |

## What the policy test pins

- every job of a `.yml` or `.yaml` workflow subscribing to `issue_comment`, `issues`, `pull_request_review` or `pull_request_review_comment`: the per-event author gate, the accepted set, and a read-only `github.token` ceiling (`id-token: write` excepted)
- every secret-bearing job on `pull_request`: the same-repo conjunct and the same ceiling
- secrets recognised as `secrets.X`, `secrets['X']`, `toJSON(secrets)` and a workflow-level `env:`, in any letter case
- every `anthropics/claude-code-action` step: a 40-hex commit, and none of `allowed_non_write_users`, `allowed_bots`, `github_token`
- `pull_request_target` nowhere
- fail closed on shapes it cannot read: flow-mapping or list-form `on:`, `jobs:` not at two-space indentation, step items not at six-space `- `, flow-mapping `with:`

## Reviewer notes

- **takes effect after merge**: GitHub reads the workflow for these events from the default branch, so this PR's CI proves the static pin, not the rendered condition
- **`MEMBER` dropped**: it never occurs on a user-owned repository, and after a transfer to an organization it would admit every member; add it deliberately then
- **`claude-code-review.yml` unchanged but now held**: its same-repo `if:` and read-only permissions are pinned too

## Validation

- `python3 test/check-workflow-policy.py`
- mutation suite of 54 cases on scratch copies: each edit to the gate, set, guard, permissions, action pin, inputs, secret spelling or workflow shape
- `actionlint` on `claude.yml` and `claude-code-review.yml`
- `just check`, `just check-agent-docs origin/main`, `test/check-release-matrix.py`, `test/release-version-contract.sh`

Closes #311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added safeguards blocking privileged automation for issue comments on fork pull requests.
  * Strengthened controls for workflow permissions, credential exposure, trusted actions, and event authorization.

* **Validation**
  * Added automated checks for workflow trust boundaries, fork protections, permissions, and action configuration.
  * Added Arch package-selection validation to standard project checks.

* **Documentation**
  * Updated security guidance covering fork pull request protections and credential handling.
  * Documented enrollment persistence behavior, including protection of existing data when enrollment fails or is cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->