### PR TITLE
fix(apt): keep the v0.1.4 main and legacy suites published until 0.3.0

### DIFF
--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -32,7 +32,7 @@ need `podman`; none in the routing table needs a camera.
 | `dist/PKGBUILD*`, `dist/facelock.install`, `dist/facelock-pam-remove.hook` | `just test-arch-pkg` |
 | `.packit.yaml` schema only | `just test-packit-config` — real `packit` in a pinned Fedora container, seconds |
 | `.packit.yaml` semantics, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
-| APT repo generation, `publish-apt` workflow | `just test-apt-repo` — needs `reprepro` and `gpg` |
+| APT repo generation, `publish-apt` workflow, `dist/apt/**` | `just test-apt-repo` — the real publisher, signing, and a clean APT client for every suite, in the pinned trixie container |
 | `systemd/`, `dbus/`, `polkit/`, install paths | both Debian suite recipes or `just test-rpm-pkg` — all validate under booted systemd |
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
 | File layout, installed paths | `just test-arch-layout` |

--- a/.github/workflows/scripts/publish-apt.sh
+++ b/.github/workflows/scripts/publish-apt.sh
@@ -101,9 +101,10 @@ for index in "${!DEBS[@]}"; do
   DEB="${DEBS[index]}"
   echo "Adding ${DEB} to ${SUITE}"
   reprepro -b "${REPO_DIR}" includedeb "$SUITE" "$DEB"
-  if [ "$SUITE" = trixie ]; then
-    # Clients set up from the v0.1.4 README ask for the `main` suite. They keep
-    # receiving the trixie package under that name until 0.3.0 (#310).
+  # Clients set up from the v0.1.4 README ask for the `main` suite. They keep
+  # receiving the trixie package under that name until 0.3.0 (#310). The step
+  # follows its stanza, so retiring the suite is deleting the stanza.
+  if [ "$SUITE" = trixie ] && grep -qx 'Codename: main' "${REPO_DIR}/conf/distributions"; then
     echo "Adding ${DEB} to main (compatibility suite for v0.1.4 source entries)"
     reprepro -b "${REPO_DIR}" includedeb main "$DEB"
   fi
@@ -111,7 +112,9 @@ done
 
 # `legacy` was the non-TPM suite and nothing is built for it any more. Signed
 # empty indexes keep `apt update` succeeding on those clients until 0.3.0.
-reprepro -b "${REPO_DIR}" export legacy
+if grep -qx 'Codename: legacy' "${REPO_DIR}/conf/distributions"; then
+  reprepro -b "${REPO_DIR}" export legacy
+fi
 
 # Export only the signing key (not the entire keyring)
 gpg --export "${KEY_FPR}" > "${REPO_DIR}/tysmith-archive-keyring.gpg"

--- a/.github/workflows/scripts/publish-apt.sh
+++ b/.github/workflows/scripts/publish-apt.sh
@@ -69,11 +69,13 @@ if [ -z "${APT_GPG_PASSPHRASE:-}" ]; then
   exit 1
 fi
 
-# Configure GPG agent for non-interactive signing
-mkdir -p ~/.gnupg
-chmod 700 ~/.gnupg
-echo "allow-preset-passphrase" >> ~/.gnupg/gpg-agent.conf
-echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+# Configure GPG agent for non-interactive signing. GNUPGHOME is honoured so a
+# test can give the publisher its own keyring and agent instead of the user's.
+export GNUPGHOME="${GNUPGHOME:-$HOME/.gnupg}"
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+echo "allow-preset-passphrase" >> "$GNUPGHOME/gpg-agent.conf"
+echo "allow-loopback-pinentry" >> "$GNUPGHOME/gpg-agent.conf"
 gpgconf --kill gpg-agent || true
 gpg-agent --daemon 2>/dev/null || gpgconf --launch gpg-agent
 
@@ -99,7 +101,17 @@ for index in "${!DEBS[@]}"; do
   DEB="${DEBS[index]}"
   echo "Adding ${DEB} to ${SUITE}"
   reprepro -b "${REPO_DIR}" includedeb "$SUITE" "$DEB"
+  if [ "$SUITE" = trixie ]; then
+    # Clients set up from the v0.1.4 README ask for the `main` suite. They keep
+    # receiving the trixie package under that name until 0.3.0 (#310).
+    echo "Adding ${DEB} to main (compatibility suite for v0.1.4 source entries)"
+    reprepro -b "${REPO_DIR}" includedeb main "$DEB"
+  fi
 done
+
+# `legacy` was the non-TPM suite and nothing is built for it any more. Signed
+# empty indexes keep `apt update` succeeding on those clients until 0.3.0.
+reprepro -b "${REPO_DIR}" export legacy
 
 # Export only the signing key (not the entire keyring)
 gpg --export "${KEY_FPR}" > "${REPO_DIR}/tysmith-archive-keyring.gpg"
@@ -108,7 +120,9 @@ echo "Public keyring exported ($(du -h "${REPO_DIR}/tysmith-archive-keyring.gpg"
 echo "=== APT repo structure ==="
 find "${REPO_DIR}" -type f | sort
 echo ""
-echo "=== Release file (trixie) ==="
-cat "${REPO_DIR}/dists/trixie/Release" || true
+for SUITE in $(sed -n 's/^Codename:[[:space:]]*//p' "${REPO_DIR}/conf/distributions"); do
+  echo "=== Release file (${SUITE}) ==="
+  cat "${REPO_DIR}/dists/${SUITE}/Release" || true
+done
 
 echo "=== APT repository built ==="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embedding counts, so remove any model from an enrollment you remember
   failing with `facelock remove <id>`, or `facelock clear` and re-enroll.
 
+- **APT source entries from v0.1.4 keep updating** (#310): the `main` and
+  `legacy` suites are published again as compatibility suites until 0.3.0.
+  `main` carries the signed trixie package, `legacy` carries signed empty
+  indexes, and `apt update` succeeds with either entry unchanged. Replace the
+  suite with the host codename (`trixie` or `resolute`) before 0.3.0.
 - **Root refusal now precedes config-state errors** (#191): for the commands
   dispatched through the shared config parse (`enroll`, `remove`, `clear`,
   `list`, `test`, `preview`, `devices`, `bench`, `tpm …`, `audit`), the root

--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ sudo apt update && sudo apt install facelock
 
 Source entries written for v0.1.4 name the `main` or `legacy` suite. They
 keep working until 0.3.0: `main` serves the trixie package and `legacy`
-serves no package. Replace that suite with your host's codename before then.
+serves no package. On Debian 13 or Ubuntu 26.04, replace the suite with
+`trixie` or `resolute`. Bookworm, noble, and Ubuntu 25.x have no suite: 0.1.4
+was the last release for those hosts, so remove
+`/etc/apt/sources.list.d/facelock.list`. At 0.3.0 the old suites disappear
+and `apt update` fails until the entry is removed. Reinstalling or
+downloading 0.1.4 through APT stops working at 0.2.0, because the pool is
+rebuilt at each release.
 
 ### Fedora / RHEL (COPR)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ echo "deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] https://tysm
 sudo apt update && sudo apt install facelock
 ```
 
+Source entries written for v0.1.4 name the `main` or `legacy` suite. They
+keep working until 0.3.0: `main` serves the trixie package and `legacy`
+serves no package. Replace that suite with your host's codename before then.
+
 ### Fedora / RHEL (COPR)
 
 ```bash

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -37,7 +37,13 @@ sudo apt install facelock
 
 Source entries written for v0.1.4 name the `main` or `legacy` suite. They
 keep working until 0.3.0: `main` serves the trixie package and `legacy`
-serves no package. Replace that suite with your host's codename before then.
+serves no package. On Debian 13 or Ubuntu 26.04, replace the suite with
+`trixie` or `resolute`. Bookworm, noble, and Ubuntu 25.x have no suite: 0.1.4
+was the last release for those hosts, so remove
+`/etc/apt/sources.list.d/facelock.list`. At 0.3.0 the old suites disappear
+and `apt update` fails until the entry is removed. Reinstalling or
+downloading 0.1.4 through APT stops working at 0.2.0, because the pool is
+rebuilt at each release.
 
 ### Fedora / RHEL (COPR)
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -35,6 +35,10 @@ sudo apt update
 sudo apt install facelock
 ```
 
+Source entries written for v0.1.4 name the `main` or `legacy` suite. They
+keep working until 0.3.0: `main` serves the trixie package and `legacy`
+serves no package. Replace that suite with your host's codename before then.
+
 ### Fedora / RHEL (COPR)
 
 ```bash

--- a/dist/apt/conf/distributions
+++ b/dist/apt/conf/distributions
@@ -13,3 +13,19 @@ Architectures: amd64
 Components: facelock
 Description: Facelock APT repository - Ubuntu 26.04 resolute
 SignWith: default
+
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: main
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - deprecated v0.1.4 suite name, serves the trixie package until 0.3.0
+SignWith: default
+
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: legacy
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - deprecated v0.1.4 non-TPM suite, empty; use trixie (Debian 13) or resolute (Ubuntu 26.04)
+SignWith: default

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -21,6 +21,16 @@
       "revision_suffix": "~ubuntu26.04.1",
       "image": "docker.io/library/ubuntu:26.04@sha256:6df9e8dd1eac389ebfef692c9648449adeb815d01e16e29cd6f3e50fe64ba9a6",
       "image_amd64_digest": "sha256:889d056d5c6c0bfb55789ff3710681d68e50713cb562d2196dc07110599c7a6f"
+    },
+    "compat": {
+      "main": {
+        "source": "trixie",
+        "retire_at": "0.3.0"
+      },
+      "legacy": {
+        "source": "none",
+        "retire_at": "0.3.0"
+      }
     }
   },
   "fedora": {

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2121,20 +2121,24 @@ paths and payload identities are:
 | `legacy` | `https://tysmith.me/facelock/apt/dists/legacy/Release` | amd64 | none, until 0.3.0 |
 
 The v0.1.4 suite names `main` and `legacy` are compatibility suites, not
-aliases or redirects. `main` carries the exact signed `trixie` package set;
-`legacy`, which served the non-TPM build, carries signed empty indexes so that
-`apt update` still succeeds. Both are published with every stable release
-through 0.2.x and removed at 0.3.0. `dist/release-matrix.json` declares them
-under `apt_suites.compat` with that `retire_at`; `test/check-release-matrix.py`
-requires their stanzas, publisher steps, and documentation before that version
-and refuses all three from it on, prereleases included. Existing source entries
-must replace that suite component with the host operating-system codename
-before 0.3.0 while keeping the `facelock` component.
+aliases or redirects, and neither ships a package of its own. Only `main`
+carries a package: the exact signed `trixie` package set. `legacy`, which
+served the non-TPM build, carries signed empty indexes so that `apt update`
+still succeeds. Both are published with every stable release through 0.2.x
+and both are removed at 0.3.0. `dist/release-matrix.json` declares them under
+`apt_suites.compat` with that `retire_at`. `test/check-release-matrix.py`
+requires their stanzas, the publisher steps, and the migration note while the
+window is open, and refuses the stanzas and the note from that version on,
+prereleases included; the publisher runs each step only when its stanza is
+declared, so retirement is the stanza deletion. Existing source entries must
+replace that suite with the host operating-system codename before 0.3.0 while
+keeping the `facelock` component.
 Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
 LTS (Resolute). Bookworm and Noble artifacts may remain in historical releases,
 but those suites are unsupported and receive no new packages.
 
-Both suites ship one binary package named `facelock` with TPM support enabled.
+Both codenamed suites ship one binary package named `facelock` with TPM
+support enabled.
 There are no legacy/TPM package-name alternatives and the package declares no
 `Provides`, `Conflicts`, or `Replaces` transition identity. Stable publication
 consumes exactly two suite manifests, one matching package per suite, and a

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2117,10 +2117,19 @@ paths and payload identities are:
 |-------|---------------------|--------------|---------|
 | `trixie` | `https://tysmith.me/facelock/apt/dists/trixie/Release` | amd64 | `facelock`, TPM enabled |
 | `resolute` | `https://tysmith.me/facelock/apt/dists/resolute/Release` | amd64 | `facelock`, TPM enabled |
+| `main` | `https://tysmith.me/facelock/apt/dists/main/Release` | amd64 | the `trixie` package, until 0.3.0 |
+| `legacy` | `https://tysmith.me/facelock/apt/dists/legacy/Release` | amd64 | none, until 0.3.0 |
 
-The former `main` and `legacy` suite names are retired; they are not aliases or
-redirects. Existing source entries must replace that suite component with the
-host operating-system codename while keeping the `facelock` component.
+The v0.1.4 suite names `main` and `legacy` are compatibility suites, not
+aliases or redirects. `main` carries the exact signed `trixie` package set;
+`legacy`, which served the non-TPM build, carries signed empty indexes so that
+`apt update` still succeeds. Both are published with every stable release
+through 0.2.x and removed at 0.3.0. `dist/release-matrix.json` declares them
+under `apt_suites.compat` with that `retire_at`; `test/check-release-matrix.py`
+requires their stanzas, publisher steps, and documentation before that version
+and refuses all three from it on, prereleases included. Existing source entries
+must replace that suite component with the host operating-system codename
+before 0.3.0 while keeping the `facelock` component.
 Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
 LTS (Resolute). Bookworm and Noble artifacts may remain in historical releases,
 but those suites are unsupported and receive no new packages.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -91,7 +91,7 @@ The `.github/workflows/release.yml` workflow:
 4. Builds the direct `.rpm` package in the pinned Fedora 44 container and validates contents
 5. Validates Nix flake evaluation
 6. Publishes stable releases to AUR — `facelock`, `facelock-bin`, and `facelock-git` — if `AUR_SSH_KEY` is configured
-7. Publishes stable releases to the signed, codenamed APT suites if the APT signing secrets are configured
+7. Publishes stable releases to the signed, codenamed APT suites, and to the `main` and `legacy` compatibility suites until 0.3.0, if the APT signing secrets are configured
 8. Triggers GitHub Pages rebuild to include updated APT repo
 
 Validated prerelease tags set the GitHub Release `prerelease` output and upload

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -109,7 +109,7 @@ which reacts to the GitHub Release published in step 1. See the COPR section bel
 | `resolute` | Ubuntu 26.04 | native distro `cargo` and `rustc` | Yes | `X.Y.Z-1~ubuntu26.04.1` |
 
 Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
-LTS (Resolute). Both suites ship one binary package named `facelock` with TPM
+LTS (Resolute). Both codenamed suites ship one binary package named `facelock` with TPM
 support enabled. No `rustup` toolchain participates in Debian source builds.
 Bookworm and Noble artifacts may remain in historical releases, but those
 suites are unsupported and receive no new packages.
@@ -536,7 +536,7 @@ clients whose source entry was written for v0.1.4:
 - **`legacy`**: no package; `reprepro export` writes signed empty indexes so
   `apt update` keeps succeeding
 
-Those clients must replace the suite component in their Facelock source entry
+Those clients must replace the suite in their Facelock source entry
 with their operating-system codename before 0.3.0. `dist/release-matrix.json`
 declares the window under `apt_suites.compat`, and `check-release-matrix.py`
 fails the first tree at or past `retire_at` that still carries the stanzas.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -359,7 +359,7 @@ unrun. `just test-packit-config` runs the same gate on its own.
 Preflight also holds the APT compatibility window: `main` and `legacy`
 compatibility suites present until 0.3.0, as `dist/release-matrix.json`
 declares, and absent from the first 0.3.0 tree on. `just test-apt-repo` proves
-the published shape end to end, as a clean APT client.
+the published shape when run, as a clean APT client; no workflow runs it.
 
 ### Package repository setup (one-time)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -356,6 +356,11 @@ reachable without a host `packit` install. It has no skip path: podman is a
 preflight prerequisite, and without it the gate fails rather than passing
 unrun. `just test-packit-config` runs the same gate on its own.
 
+Preflight also holds the APT compatibility window: `main` and `legacy`
+compatibility suites present until 0.3.0, as `dist/release-matrix.json`
+declares, and absent from the first 0.3.0 tree on. `just test-apt-repo` proves
+the published shape end to end, as a clean APT client.
+
 ### Package repository setup (one-time)
 
 #### AUR (Arch Linux)
@@ -523,10 +528,19 @@ codenamed suites are published:
 - **`trixie`**: Debian 13 TPM build using Trixie Backports Rust/Cargo
 - **`resolute`**: Ubuntu 26.04 TPM build using native Rust/Cargo
 
-The former ambiguous `main` and `legacy` suite names are retired. Existing
-clients must replace that suite component in their Facelock source entry with
-their operating-system codename before the first codenamed stable publication.
-Prerelease packages are never inserted into these stable suites.
+Two compatibility suites are published alongside them until 0.3.0, for
+clients whose source entry was written for v0.1.4:
+
+- **`main`**: the `trixie` package, included by `publish-apt.sh` from the same
+  validated artifact
+- **`legacy`**: no package; `reprepro export` writes signed empty indexes so
+  `apt update` keeps succeeding
+
+Those clients must replace the suite component in their Facelock source entry
+with their operating-system codename before 0.3.0. `dist/release-matrix.json`
+declares the window under `apt_suites.compat`, and `check-release-matrix.py`
+fails the first tree at or past `retire_at` that still carries the stanzas.
+Prerelease packages are never inserted into any of these stable suites.
 Stable publication requires exactly one suite-matching package for both
 codenames before signing or repository writes begin.
 

--- a/justfile
+++ b/justfile
@@ -1282,31 +1282,20 @@ test-rpm-release-shell release="44": (_fedora-lane-image release) build-release
     podman run --rm -it $devices $mounts facelock-rpm-pkg-f{{ release }} \
         bash -c "cp /tmp/container-config.toml /etc/facelock/config.toml; exec bash"
 
-# Test APT repo generation locally from both exact manifests (requires reprepro + gpg).
+# Publish both exact manifests, or stand-in packages when none are given,
+# through the real stable publisher in the pinned Debian trixie container, then
+# prove a clean APT client resolves every declared suite from the tree pages.yml
+# serves: the codenamed pair and the v0.1.4 compatibility names (#310).
+# Needs podman; reprepro, gpg, dpkg-deb and apt all run in the container.
 test-apt-repo trixie_manifest='' resolute_manifest='':
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Check tools
-    for cmd in reprepro dpkg-deb; do
-        command -v "$cmd" >/dev/null || { echo "Error: '$cmd' not found. Install it first."; exit 1; }
-    done
-
-    # Verify config exists
+    command -v podman >/dev/null || { echo "Error: 'podman' not found. Install it first."; exit 1; }
     if [ ! -f dist/apt/conf/distributions ]; then
         echo "Error: dist/apt/conf/distributions not found"
         exit 1
     fi
-
-    TMPDIR=$(mktemp -d)
-    trap 'rm -rf "$TMPDIR"' EXIT
-
-    REPO_DIR="${TMPDIR}/repo"
-    mkdir -p "${REPO_DIR}/conf"
-    cp dist/apt/conf/distributions "${REPO_DIR}/conf/distributions"
-
-    # For local testing without GPG, strip SignWith lines
-    sed -i '/^SignWith:/d' "${REPO_DIR}/conf/distributions"
 
     suites=(trixie resolute)
     manifests=(
@@ -1319,67 +1308,59 @@ test-apt-repo trixie_manifest='' resolute_manifest='':
             supplied=$((supplied + 1))
         fi
     done
-
-    if [ "$supplied" -eq 0 ]; then
-        echo "No exact Debian artifact manifest supplied."
-        echo "Validating reprepro config only..."
-        reprepro -b "${REPO_DIR}" check
-        echo ""
-        echo "APT repo config: OK"
-        echo "Pass the trixie and resolute manifests to include their exact .deb payloads."
-        exit 0
-    fi
-    if [ "$supplied" -ne "${#suites[@]}" ]; then
+    if [ "$supplied" -ne 0 ] && [ "$supplied" -ne "${#suites[@]}" ]; then
         echo "Error: test-apt-repo requires either no manifests or exactly one manifest for each stable suite: trixie, resolute" >&2
         exit 1
     fi
 
+    mounts=(-v "$PWD:/src:ro")
+    lane_args=()
     for index in "${!suites[@]}"; do
         suite="${suites[$index]}"
         manifest="${manifests[$index]}"
-        [ -n "$manifest" ] || {
-            echo "Error: missing exact generated manifest for $suite" >&2
+        [ -n "$manifest" ] || continue
+        [ -f "$manifest" ] || {
+            echo "Error: missing exact generated manifest for $suite: $manifest" >&2
             exit 1
         }
-        bash test/deb-package-contract.sh --manifest "$manifest"
         manifest_dir=$(cd "$(dirname "$manifest")" && pwd)
-        mapfile -t packages < <(grep -E '\.deb$' "$manifest")
-        if [ "${#packages[@]}" -ne 1 ]; then
-            echo "Error: $suite manifest must name exactly one .deb payload: $manifest" >&2
-            exit 1
-        fi
-        deb="$manifest_dir/${packages[0]}"
-        version=$(dpkg-deb -f "$deb" Version)
-        case "$suite" in
-            trixie) expected_suffix='~deb13u1' ;;
-            resolute) expected_suffix='~ubuntu26.04.1' ;;
-        esac
-        case "$version" in
-            *"$expected_suffix") ;;
-            *)
-                echo "Error: $deb version '$version' does not match stable APT suite '$suite' ($expected_suffix)" >&2
-                exit 1
-                ;;
-        esac
-        reprepro -b "${REPO_DIR}" includedeb "$suite" "$deb"
+        mounts+=(-v "$manifest_dir:/manifests/$suite:ro,Z")
+        lane_args+=(--manifest "$suite=/manifests/$suite/$(basename "$manifest")")
+    done
+    if [ "$supplied" -eq 0 ]; then
+        echo "No exact Debian artifact manifest supplied; publishing stand-in packages at this tree's version."
+    fi
+
+    # The lane image is the trixie suite image; the compatibility suites and
+    # what each serves come from the matrix, for the suites the config declares.
+    base_image="$(python3 - dist/release-matrix.json <<'PY'
+    import json
+    import sys
+
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle)["apt_suites"]["trixie"]["image"])
+    PY
+    )"
+    mapfile -t compat < <(python3 - dist/release-matrix.json dist/apt/conf/distributions <<'PY'
+    import json
+    import re
+    import sys
+
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        compat = json.load(handle)["apt_suites"].get("compat", {})
+    with open(sys.argv[2], encoding="utf-8") as handle:
+        declared = set(re.findall(r"(?m)^Codename:\s*(\S+)", handle.read()))
+    for suite, details in compat.items():
+        if suite in declared:
+            print(f"{suite}={details['source']}")
+    PY
+    )
+    for entry in "${compat[@]}"; do
+        lane_args+=(--compat "$entry")
     done
 
-    echo ""
-    echo "=== APT repo structure ==="
-    find "${REPO_DIR}" -type f -not -path '*/db/*' -not -path '*/conf/*' | sort
-
-    # Validate expected structure
-    for SUITE in trixie resolute; do
-        [ -f "${REPO_DIR}/dists/${SUITE}/Release" ] || { echo "MISSING: dists/${SUITE}/Release" >&2; exit 1; }
-        echo "OK: dists/${SUITE}/Release"
-        [ -d "${REPO_DIR}/dists/${SUITE}/facelock/binary-amd64" ] || { echo "MISSING: dists/${SUITE}/facelock/binary-amd64/" >&2; exit 1; }
-        echo "OK: dists/${SUITE}/facelock/binary-amd64/"
-    done
-    [ -d "${REPO_DIR}/pool/facelock" ] || { echo "MISSING: pool/facelock/" >&2; exit 1; }
-    echo "OK: pool/facelock/"
-
-    echo ""
-    echo "APT repo generation: OK"
+    podman build --build-arg "BASE_IMAGE=$base_image" -t facelock-apt-client -f test/Containerfile.apt-client test
+    podman run --rm --network=none "${mounts[@]}" facelock-apt-client /src/test/apt-client-lane.sh "${lane_args[@]}"
 
 # Quick preflight before tagging a release
 # Usage:

--- a/test/Containerfile.apt-client
+++ b/test/Containerfile.apt-client
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The stable publisher's own tools (reprepro, signing through gpg-agent) on top
+# of the suite's apt, plus gpgv to verify what apt will be handed. The lane
+# script runs from the repository mount, so a change to it needs no rebuild.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends reprepro gnupg gpgv && \
+    rm -rf /var/lib/apt/lists/*

--- a/test/apt-client-lane.sh
+++ b/test/apt-client-lane.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Runs inside the image test/Containerfile.apt-client builds, as root, with the
+# repository mounted read-only at /src and no network.
+#
+# Publishes one package per codenamed suite through the real stable publisher
+# under an ephemeral signing key, packs and unpacks the result the way
+# release.yml and pages.yml do, then acts as a clean APT client for every suite
+# dist/apt/conf/distributions declares: the codenamed pair and the v0.1.4 names
+# `main` and `legacy` that stay published until 0.3.0 (#310).
+#
+#   apt-client-lane.sh [--manifest <suite>=<path>]... [--compat <suite>=<source>]...
+#
+# A suite without a manifest is published from a stand-in package at this
+# tree's stable version. The lane proves the repository shape and the client
+# path; the package payload belongs to the suite package gates.
+set -euo pipefail
+
+src=/src
+work=/work
+# shellcheck source=/dev/null
+source "$src/scripts/release-versions.sh"
+
+fail() {
+    echo "apt client lane: $*" >&2
+    exit 1
+}
+
+declare -A manifests=()
+declare -A compat_source=()
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --manifest)
+            [ "$#" -ge 2 ] || fail "--manifest needs <suite>=<path>"
+            manifests["${2%%=*}"]="${2#*=}"
+            shift 2
+            ;;
+        --compat)
+            [ "$#" -ge 2 ] || fail "--compat needs <suite>=<source>"
+            compat_source["${2%%=*}"]="${2#*=}"
+            shift 2
+            ;;
+        *) fail "unknown argument: $1" ;;
+    esac
+done
+
+mkdir -p "$work/debs" "$work/download"
+mkdir -m 700 "$work/gpgv-home"
+mapfile -t declared_suites < <(sed -n 's/^Codename:[[:space:]]*//p' "$src/dist/apt/conf/distributions")
+[ "${#declared_suites[@]}" -gt 0 ] || fail "dist/apt/conf/distributions declares no suite"
+for suite in "${!compat_source[@]}"; do
+    case " ${declared_suites[*]} " in
+        *" $suite "*) ;;
+        *) fail "compatibility suite $suite is not declared in dist/apt/conf/distributions" ;;
+    esac
+done
+
+echo "=== Packages ==="
+tree_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$src/Cargo.toml" | head -1)"
+[ -n "$tree_version" ] || fail "Cargo.toml declares no workspace version"
+stable_version="${tree_version%%-*}"
+declare -A package_path=()
+declare -A package_version=()
+for suite in trixie resolute; do
+    if [ -n "${manifests[$suite]:-}" ]; then
+        manifest="${manifests[$suite]}"
+        bash "$src/test/deb-package-contract.sh" --manifest "$manifest"
+        mapfile -t packages < <(grep -E '\.deb$' "$manifest")
+        [ "${#packages[@]}" -eq 1 ] || fail "$suite manifest must name exactly one .deb payload: $manifest"
+        package_path[$suite]="$(dirname "$manifest")/${packages[0]}"
+    else
+        version="$(release_debian_version "$stable_version" 1 "$suite")"
+        stage="$work/stand-in/$suite"
+        mkdir -p "$stage/DEBIAN"
+        printf '%s\n' \
+            'Package: facelock' \
+            "Version: $version" \
+            'Architecture: amd64' \
+            'Section: admin' \
+            'Priority: optional' \
+            'Maintainer: Facelock APT lane <apt-lane@example.invalid>' \
+            "Description: stand-in for the $suite package in the APT client lane" \
+            > "$stage/DEBIAN/control"
+        package_path[$suite]="$work/debs/facelock_${version}_amd64.deb"
+        dpkg-deb --build "$stage" "${package_path[$suite]}" >/dev/null
+    fi
+    package_version[$suite]="$(dpkg-deb --field "${package_path[$suite]}" Version)"
+    echo "$suite: ${package_path[$suite]} (${package_version[$suite]})"
+done
+
+echo "=== Ephemeral signing key ==="
+keygen_home="$work/keygen"
+mkdir -m 700 "$keygen_home"
+passphrase="apt-client-lane"
+GNUPGHOME="$keygen_home" gpg --batch --quiet --pinentry-mode loopback --passphrase "$passphrase" \
+    --quick-generate-key "Facelock APT lane <apt-lane@example.invalid>" ed25519 sign never
+private_key="$(GNUPGHOME="$keygen_home" gpg --batch --quiet --pinentry-mode loopback \
+    --passphrase "$passphrase" --armor --export-secret-keys)"
+GNUPGHOME="$keygen_home" gpgconf --kill gpg-agent
+
+# The real publisher, from the repository root it expects, with the key and
+# passphrase reaching it the way the CI secrets do, and its own GNUPGHOME.
+repo="$work/apt-repo"
+(
+    cd "$src"
+    GNUPGHOME="$work/publisher-gnupg" APT_GPG_PRIVATE_KEY="$private_key" APT_GPG_PASSPHRASE="$passphrase" \
+        bash .github/workflows/scripts/publish-apt.sh "$repo" \
+        "trixie=${package_path[trixie]}" "resolute=${package_path[resolute]}"
+)
+
+echo "=== Release artifact and Pages tree ==="
+# release.yml packs exactly these three; pages.yml unpacks into _site/apt.
+site="$work/_site/apt"
+tar -czf "$work/apt-repo.tar.gz" -C "$repo" --exclude='conf' --exclude='db' \
+    dists pool tysmith-archive-keyring.gpg
+mkdir -p "$site"
+tar -xzf "$work/apt-repo.tar.gz" -C "$site/"
+for suite in "${declared_suites[@]}"; do
+    for index in Release InRelease; do
+        [ -f "$site/dists/$suite/$index" ] || fail "served tree lacks dists/$suite/$index"
+    done
+    if ! verify_output="$(GNUPGHOME="$work/gpgv-home" gpgv --keyring "$site/tysmith-archive-keyring.gpg" "$site/dists/$suite/InRelease" 2>&1)"; then
+        printf '%s\n' "$verify_output"
+        fail "dists/$suite/InRelease does not verify against the published keyring"
+    fi
+    echo "signed: dists/$suite/InRelease"
+done
+for suite in "${!compat_source[@]}"; do
+    index="$site/dists/$suite/facelock/binary-amd64/Packages"
+    [ -f "$index" ] || fail "compatibility suite $suite has no package index"
+    if [ "${compat_source[$suite]}" = none ]; then
+        ! grep -q '^Package:' "$index" || fail "compatibility suite $suite lists a package"
+        echo "empty: dists/$suite"
+    else
+        cmp -s "$index" "$site/dists/${compat_source[$suite]}/facelock/binary-amd64/Packages" \
+            || fail "compatibility suite $suite index differs from ${compat_source[$suite]}"
+        echo "mirrors ${compat_source[$suite]}: dists/$suite"
+    fi
+done
+
+echo "=== APT client ==="
+install -d -m 0755 /etc/apt/keyrings
+install -m 0644 "$site/tysmith-archive-keyring.gpg" /etc/apt/keyrings/tysmith-archive-keyring.gpg
+# Only the Facelock source is under test, and there is no network anyway.
+mkdir -p "$work/image-sources"
+find /etc/apt/sources.list.d -mindepth 1 -maxdepth 1 -exec mv -t "$work/image-sources" {} +
+[ ! -f /etc/apt/sources.list ] || mv /etc/apt/sources.list "$work/image-sources/"
+
+public_base='https://tysmith.me/facelock/apt'
+served_base="file://$site"
+# The suite a client on this entry is served from: itself, a compatibility
+# suite's source, or nothing.
+serving_suite() {
+    local suite="$1"
+    if [ -n "${compat_source[$suite]:-}" ]; then
+        printf '%s\n' "${compat_source[$suite]}"
+    else
+        printf '%s\n' "$suite"
+    fi
+}
+for suite in "${declared_suites[@]}"; do
+    # The README entry, identical in v0.1.4 and now but for the suite; only the
+    # base is rewritten so the served tree stands in for the public host.
+    public_line="deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] $public_base $suite facelock"
+    served_line="${public_line/$public_base/$served_base}"
+    echo "== $suite"
+    echo "entry: $public_line"
+    printf '%s\n' "$served_line" > /etc/apt/sources.list.d/facelock.list
+    rm -rf /var/lib/apt/lists/*
+    if ! update_output="$(apt-get update 2>&1)"; then
+        printf '%s\n' "$update_output"
+        fail "apt update failed with the $suite source entry"
+    fi
+    if grep -Eq '^(W|E):' <<<"$update_output"; then
+        printf '%s\n' "$update_output"
+        fail "apt update warned with the $suite source entry"
+    fi
+    policy="$(apt-cache policy facelock 2>&1)"
+    printf '%s\n' "$policy"
+    source_suite="$(serving_suite "$suite")"
+    if [ "$source_suite" = none ]; then
+        ! grep -q '^  Candidate:' <<<"$policy" || fail "suite $suite offers a facelock candidate; it must serve none"
+        echo "ok: $suite updates and serves no package"
+        continue
+    fi
+    expected="${package_version[$source_suite]}"
+    grep -qx "  Candidate: $expected" <<<"$policy" || fail "suite $suite candidate is not $expected"
+    grep -q " $suite/facelock amd64 Packages" <<<"$policy" || fail "suite $suite candidate does not come from $suite/facelock"
+    rm -f "$work"/download/*.deb
+    (cd "$work/download" && apt-get download facelock >/dev/null 2>&1) \
+        || fail "apt-get download facelock failed from suite $suite"
+    downloaded="$(find "$work/download" -maxdepth 1 -name '*.deb' -print -quit)"
+    [ -n "$downloaded" ] || fail "apt-get download from suite $suite produced no package"
+    cmp -s "$downloaded" "${package_path[$source_suite]}" \
+        || fail "package downloaded from suite $suite differs from the published $source_suite package"
+    echo "ok: $suite serves $expected from $source_suite"
+done
+
+echo ""
+echo "APT client lane: OK"

--- a/test/apt-client-lane.sh
+++ b/test/apt-client-lane.sh
@@ -4,7 +4,8 @@
 #
 # Publishes one package per codenamed suite through the real stable publisher
 # under an ephemeral signing key, packs and unpacks the result the way
-# release.yml and pages.yml do, then acts as a clean APT client for every suite
+# release.yml and pages.yml do, replays a client that last updated from the
+# v0.1.4 tree, then acts as a clean APT client for every suite
 # dist/apt/conf/distributions declares: the codenamed pair and the v0.1.4 names
 # `main` and `legacy` that stay published until 0.3.0 (#310).
 #
@@ -58,6 +59,21 @@ echo "=== Packages ==="
 tree_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$src/Cargo.toml" | head -1)"
 [ -n "$tree_version" ] || fail "Cargo.toml declares no workspace version"
 stable_version="${tree_version%%-*}"
+stand_in_package() {
+    local label="$1" version="$2" output="$3"
+    local stage="$work/stand-in/$label"
+    mkdir -p "$stage/DEBIAN"
+    printf '%s\n' \
+        'Package: facelock' \
+        "Version: $version" \
+        'Architecture: amd64' \
+        'Section: admin' \
+        'Priority: optional' \
+        'Maintainer: Facelock APT lane <apt-lane@example.invalid>' \
+        "Description: stand-in for the $label package in the APT client lane" \
+        > "$stage/DEBIAN/control"
+    dpkg-deb --build "$stage" "$output" >/dev/null
+}
 declare -A package_path=()
 declare -A package_version=()
 for suite in trixie resolute; do
@@ -69,19 +85,8 @@ for suite in trixie resolute; do
         package_path[$suite]="$(dirname "$manifest")/${packages[0]}"
     else
         version="$(release_debian_version "$stable_version" 1 "$suite")"
-        stage="$work/stand-in/$suite"
-        mkdir -p "$stage/DEBIAN"
-        printf '%s\n' \
-            'Package: facelock' \
-            "Version: $version" \
-            'Architecture: amd64' \
-            'Section: admin' \
-            'Priority: optional' \
-            'Maintainer: Facelock APT lane <apt-lane@example.invalid>' \
-            "Description: stand-in for the $suite package in the APT client lane" \
-            > "$stage/DEBIAN/control"
         package_path[$suite]="$work/debs/facelock_${version}_amd64.deb"
-        dpkg-deb --build "$stage" "${package_path[$suite]}" >/dev/null
+        stand_in_package "$suite" "$version" "${package_path[$suite]}"
     fi
     package_version[$suite]="$(dpkg-deb --field "${package_path[$suite]}" Version)"
     echo "$suite: ${package_path[$suite]} (${package_version[$suite]})"
@@ -95,6 +100,36 @@ GNUPGHOME="$keygen_home" gpg --batch --quiet --pinentry-mode loopback --passphra
     --quick-generate-key "Facelock APT lane <apt-lane@example.invalid>" ed25519 sign never
 private_key="$(GNUPGHOME="$keygen_home" gpg --batch --quiet --pinentry-mode loopback \
     --passphrase "$passphrase" --armor --export-secret-keys)"
+
+# A client that last updated from the v0.1.4 tree keeps that tree's Release
+# data in /var/lib/apt/lists, and apt refuses a suite whose Origin, Label, or
+# Codename changed underneath it. That tree is built here, before this
+# release's, because apt also keeps the newer-dated Release of the two. It is
+# signed by the same key from its keygen home, the agent told the passphrase
+# the way the publisher tells its own.
+transition_suites=()
+for suite in main legacy; do
+    case " ${declared_suites[*]} " in
+        *" $suite "*) transition_suites+=("$suite") ;;
+    esac
+done
+old_repo="$work/apt-repo-v0.1.4"
+if [ "${#transition_suites[@]}" -gt 0 ]; then
+    echo "=== v0.1.4 tree (${transition_suites[*]}) ==="
+    mkdir -p "$old_repo/conf"
+    cp "$src/test/fixtures/apt-distributions-v0.1.4" "$old_repo/conf/distributions"
+    old_package="$work/debs/facelock_0.1.4-1_amd64.deb"
+    stand_in_package v0.1.4 0.1.4-1 "$old_package"
+    printf '%s\n' allow-preset-passphrase > "$keygen_home/gpg-agent.conf"
+    GNUPGHOME="$keygen_home" gpgconf --kill gpg-agent
+    GNUPGHOME="$keygen_home" gpgconf --launch gpg-agent
+    keygrip="$(GNUPGHOME="$keygen_home" gpg --list-keys --with-keygrip --with-colons | awk -F: '/^grp/{print $10; exit}')"
+    GNUPGHOME="$keygen_home" /usr/lib/gnupg/gpg-preset-passphrase --preset --passphrase "$passphrase" "$keygrip"
+    for suite in "${transition_suites[@]}"; do
+        GNUPGHOME="$keygen_home" reprepro -b "$old_repo" includedeb "$suite" "$old_package" >/dev/null
+    done
+    GNUPGHOME="$keygen_home" gpg --export > "$old_repo/tysmith-archive-keyring.gpg"
+fi
 GNUPGHOME="$keygen_home" gpgconf --kill gpg-agent
 
 # The real publisher, from the repository root it expects, with the key and
@@ -108,12 +143,18 @@ repo="$work/apt-repo"
 )
 
 echo "=== Release artifact and Pages tree ==="
-# release.yml packs exactly these three; pages.yml unpacks into _site/apt.
+# release.yml packs exactly these three; pages.yml unpacks into _site/apt,
+# replacing whatever the previous release left there.
 site="$work/_site/apt"
-tar -czf "$work/apt-repo.tar.gz" -C "$repo" --exclude='conf' --exclude='db' \
-    dists pool tysmith-archive-keyring.gpg
-mkdir -p "$site"
-tar -xzf "$work/apt-repo.tar.gz" -C "$site/"
+serve_release() {
+    local from="$1"
+    rm -rf "$work/apt-repo.tar.gz" "$site"
+    tar -czf "$work/apt-repo.tar.gz" -C "$from" --exclude='conf' --exclude='db' \
+        dists pool tysmith-archive-keyring.gpg
+    mkdir -p "$site"
+    tar -xzf "$work/apt-repo.tar.gz" -C "$site/"
+}
+serve_release "$repo"
 for suite in "${declared_suites[@]}"; do
     for index in Release InRelease; do
         [ -f "$site/dists/$suite/$index" ] || fail "served tree lacks dists/$suite/$index"
@@ -147,6 +188,47 @@ find /etc/apt/sources.list.d -mindepth 1 -maxdepth 1 -exec mv -t "$work/image-so
 
 public_base='https://tysmith.me/facelock/apt'
 served_base="file://$site"
+source_entry() {
+    # The README entry, identical in v0.1.4 and now but for the suite; only the
+    # base is rewritten so the served tree stands in for the public host.
+    printf 'deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] %s %s facelock\n' "$1" "$2"
+}
+
+# Replay the client that last updated from the v0.1.4 tree: it updates from
+# that tree, then this release replaces the served tree and it updates again
+# with its lists intact.
+if [ "${#transition_suites[@]}" -gt 0 ]; then
+    echo "== client last updated from v0.1.4 (${transition_suites[*]})"
+    : > /etc/apt/sources.list.d/facelock.list
+    for suite in "${transition_suites[@]}"; do
+        source_entry "$served_base" "$suite" >> /etc/apt/sources.list.d/facelock.list
+    done
+    rm -rf /var/lib/apt/lists/*
+    serve_release "$old_repo"
+    if ! update_output="$(apt-get update 2>&1)"; then
+        printf '%s\n' "$update_output"
+        fail "apt update failed against the v0.1.4 tree"
+    fi
+    grep -h '^Date:' "$old_repo/dists/${transition_suites[0]}/Release" "$repo/dists/${transition_suites[0]}/Release" \
+        | sed 's/^/  /'
+    serve_release "$repo"
+    if ! update_output="$(apt-get update 2>&1)"; then
+        printf '%s\n' "$update_output"
+        fail "apt update failed after this release replaced the v0.1.4 tree"
+    fi
+    printf '%s\n' "$update_output"
+    if grep -q '^E:' <<<"$update_output"; then
+        fail "apt update errored after this release replaced the v0.1.4 tree"
+    fi
+    if [ -n "${compat_source[main]:-}" ] && [ "${compat_source[main]}" != none ]; then
+        expected="${package_version[${compat_source[main]}]}"
+        policy="$(apt-cache policy facelock)"
+        printf '%s\n' "$policy"
+        grep -qx "  Candidate: $expected" <<<"$policy" \
+            || fail "the v0.1.4 client does not see $expected from main after the switch"
+    fi
+    echo "ok: v0.1.4 client updates across the switch"
+fi
 # The suite a client on this entry is served from: itself, a compatibility
 # suite's source, or nothing.
 serving_suite() {
@@ -158,13 +240,9 @@ serving_suite() {
     fi
 }
 for suite in "${declared_suites[@]}"; do
-    # The README entry, identical in v0.1.4 and now but for the suite; only the
-    # base is rewritten so the served tree stands in for the public host.
-    public_line="deb [signed-by=/etc/apt/keyrings/tysmith-archive-keyring.gpg] $public_base $suite facelock"
-    served_line="${public_line/$public_base/$served_base}"
     echo "== $suite"
-    echo "entry: $public_line"
-    printf '%s\n' "$served_line" > /etc/apt/sources.list.d/facelock.list
+    echo "entry: $(source_entry "$public_base" "$suite")"
+    source_entry "$served_base" "$suite" > /etc/apt/sources.list.d/facelock.list
     rm -rf /var/lib/apt/lists/*
     if ! update_output="$(apt-get update 2>&1)"; then
         printf '%s\n' "$update_output"
@@ -178,7 +256,8 @@ for suite in "${declared_suites[@]}"; do
     printf '%s\n' "$policy"
     source_suite="$(serving_suite "$suite")"
     if [ "$source_suite" = none ]; then
-        ! grep -q '^  Candidate:' <<<"$policy" || fail "suite $suite offers a facelock candidate; it must serve none"
+        ! grep -q " $suite/facelock amd64 Packages" <<<"$policy" \
+            || fail "suite $suite offers a facelock version; it must serve none"
         echo "ok: $suite updates and serves no package"
         continue
     fi

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -488,13 +488,14 @@ require(
 )
 for suffix in ("~deb13u1", "~ubuntu26.04.1"):
     require(suffix not in apt_publisher, f"APT publisher duplicates the central suite suffix {suffix}")
-for suite, source in expected_compat_suites.items():
-    step = f"includedeb {suite}" if source != "none" else f"export {suite}"
-    publication = re.search(rf'(?m)^\s*reprepro -b "\$\{{REPO_DIR\}}" {re.escape(step)}\b', apt_publisher)
-    if suite in active_compat_suites:
-        require(publication is not None, f"APT publisher does not populate compatibility suite {suite} ({step})")
-    else:
-        require(publication is None, f"APT publisher still publishes compatibility suite {suite} after retire_at {compat_retire_at}")
+# The publisher's compatibility steps run only when their stanza is declared,
+# so retirement is the stanza deletion and the steps may stay.
+for suite in active_compat_suites:
+    step = f"includedeb {suite}" if expected_compat_suites[suite] != "none" else f"export {suite}"
+    require(
+        re.search(rf'(?m)^\s*reprepro -b "\$\{{REPO_DIR\}}" {re.escape(step)}\b', apt_publisher) is not None,
+        f"APT publisher does not populate compatibility suite {suite} ({step})",
+    )
 require(
     "dists pool tysmith-archive-keyring.gpg" in workflow,
     "APT repo artifact must carry the whole dists tree, every published suite included",
@@ -957,7 +958,7 @@ debian_support_phrase = (
 )
 debian_source_phrases = (
     "Trixie package builds use the official Trixie Backports `cargo` and `rustc`",
-    "Both suites ship one binary package named `facelock` with TPM support enabled.",
+    "Both codenamed suites ship one binary package named `facelock` with TPM support enabled.",
     "No `rustup` toolchain participates in Debian source builds.",
     "deterministic Cargo-vendor component",
     "network denied and empty Cargo/Rustup caches",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -178,11 +178,11 @@ for row in matrix.get("platforms", []):
             f"{row['id']} image is not digest-pinned: {image!r}",
         )
 
+release_identity = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?")
 release_version = os.environ.get("RELEASE_MATRIX_VERSION")
 if release_version is not None:
     require(
-        re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?", release_version)
-        is not None,
+        release_identity.fullmatch(release_version) is not None,
         f"invalid RELEASE_MATRIX_VERSION: {release_version!r}",
     )
 
@@ -190,7 +190,9 @@ if release_version is not None:
 def workspace_version() -> str:
     match = re.search(r'(?m)^version = "([^"]+)"', (ROOT / "Cargo.toml").read_text())
     require(match is not None, "Cargo.toml must declare the workspace version")
-    return match.group(1)
+    version = match.group(1)
+    require(release_identity.fullmatch(version) is not None, f"invalid Cargo.toml workspace version: {version!r}")
+    return version
 
 
 def version_triple(version: str) -> tuple[int, int, int]:
@@ -290,7 +292,7 @@ for stanza in re.split(r"\n\s*\n", apt_config.strip()):
     require(fields["Codename"] not in apt_stanzas, f"duplicate APT config stanza {fields['Codename']}")
     apt_stanzas[fields["Codename"]] = fields
 declared_suites = set(apt_stanzas)
-for suite in set(expected_compat_suites) - active_compat_suites:
+for suite in sorted(set(expected_compat_suites) - active_compat_suites):
     require(
         suite not in declared_suites,
         f"compatibility APT suite {suite} reached retire_at {compat_retire_at}; remove its stanza from dist/apt/conf/distributions",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -178,8 +178,33 @@ for row in matrix.get("platforms", []):
             f"{row['id']} image is not digest-pinned: {image!r}",
         )
 
+release_version = os.environ.get("RELEASE_MATRIX_VERSION")
+if release_version is not None:
+    require(
+        re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?", release_version)
+        is not None,
+        f"invalid RELEASE_MATRIX_VERSION: {release_version!r}",
+    )
+
+
+def workspace_version() -> str:
+    match = re.search(r'(?m)^version = "([^"]+)"', (ROOT / "Cargo.toml").read_text())
+    require(match is not None, "Cargo.toml must declare the workspace version")
+    return match.group(1)
+
+
+def version_triple(version: str) -> tuple[int, int, int]:
+    major, minor, patch = version.split("-", 1)[0].split(".")
+    return (int(major), int(minor), int(patch))
+
+
+# The version the tree is judged as: the tag under release, otherwise the
+# version this tree would tag. Time-boxed contracts measure against it.
+gate_version = release_version if release_version is not None else workspace_version()
+
 expected_suites = {"trixie", "resolute"}
-suite_map = matrix.get("apt_suites", {})
+apt_suites = matrix.get("apt_suites", {})
+suite_map = {suite: details for suite, details in apt_suites.items() if suite != "compat"}
 require(set(suite_map) == expected_suites, "canonical APT suite set drifted")
 expected_suite_contracts = {
     "trixie": {
@@ -230,10 +255,61 @@ for suite, expected in expected_suite_contracts.items():
     require(platform_row.get("package") == "facelock", f"APT suite {suite} must map to the facelock package")
     require(platform_row.get("required_capabilities") == ["tpm"], f"APT suite {suite} must require TPM")
 
+# The v0.1.4 suite names stay published as compatibility suites so a source
+# entry written for 0.1.4 keeps updating: `main` carries trixie's exact package
+# set, `legacy` carries signed empty indexes. The window closes at `retire_at`;
+# the first tree at or past that version, prerelease included, ships without
+# them (#310).
+expected_compat_suites = {"main": "trixie", "legacy": "none"}
+compat_map = apt_suites.get("compat", {})
+require(
+    set(compat_map) == set(expected_compat_suites),
+    f"compatibility APT suite set drifted: {sorted(compat_map)}",
+)
+compat_retire_versions = set()
+for suite, source in expected_compat_suites.items():
+    details = compat_map[suite]
+    require(details.get("source") == source, f"compatibility APT suite {suite} source drifted: {details.get('source')!r}")
+    retire_at = details.get("retire_at")
+    require(
+        isinstance(retire_at, str)
+        and re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", retire_at) is not None,
+        f"compatibility APT suite {suite} has no stable retire_at version: {retire_at!r}",
+    )
+    compat_retire_versions.add(retire_at)
+require(len(compat_retire_versions) == 1, "compatibility APT suites must share one retirement version")
+compat_retire_at = compat_retire_versions.pop()
+compat_active = version_triple(gate_version) < version_triple(compat_retire_at)
+active_compat_suites = set(expected_compat_suites) if compat_active else set()
+
 apt_config = (ROOT / "dist/apt/conf/distributions").read_text()
-declared_suites = set(re.findall(r"^Codename:\s*(\S+)\s*$", apt_config, re.MULTILINE))
-require(declared_suites == expected_suites, f"APT config suites {sorted(declared_suites)} != {sorted(expected_suites)}")
-require("Codename: main" not in apt_config and "Codename: legacy" not in apt_config, "ambiguous APT suites remain")
+apt_stanzas: dict[str, dict[str, str]] = {}
+for stanza in re.split(r"\n\s*\n", apt_config.strip()):
+    fields = dict(re.findall(r"(?m)^([A-Za-z]+):[ \t]*(.*?)[ \t]*$", stanza))
+    require("Codename" in fields, f"APT config stanza without a Codename: {stanza!r}")
+    require(fields["Codename"] not in apt_stanzas, f"duplicate APT config stanza {fields['Codename']}")
+    apt_stanzas[fields["Codename"]] = fields
+declared_suites = set(apt_stanzas)
+for suite in set(expected_compat_suites) - active_compat_suites:
+    require(
+        suite not in declared_suites,
+        f"compatibility APT suite {suite} reached retire_at {compat_retire_at}; remove its stanza from dist/apt/conf/distributions",
+    )
+require(
+    declared_suites == expected_suites | active_compat_suites,
+    f"APT config suites {sorted(declared_suites)} != {sorted(expected_suites | active_compat_suites)}",
+)
+for suite, fields in apt_stanzas.items():
+    for field, value in (("Architectures", "amd64"), ("Components", "facelock"), ("SignWith", "default")):
+        require(fields.get(field) == value, f"APT suite {suite} {field} drifted: {fields.get(field)!r}")
+for suite in active_compat_suites:
+    description = apt_stanzas[suite].get("Description", "")
+    source = expected_compat_suites[suite]
+    replacements = {source} if source != "none" else expected_suites
+    require(
+        "deprecated" in description.lower() and all(name in description for name in replacements),
+        f"compatibility APT suite {suite} description must name the deprecation and the codenamed replacement: {description!r}",
+    )
 
 try:
     packit = json.loads((ROOT / ".packit.yaml").read_text())
@@ -280,13 +356,6 @@ require(
     production_trigger in {"ignore", "release"},
     f"Packit production COPR trigger must be 'ignore' or 'release', got {production_trigger!r}",
 )
-release_version = os.environ.get("RELEASE_MATRIX_VERSION")
-if release_version is not None:
-    require(
-        re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?", release_version)
-        is not None,
-        f"invalid RELEASE_MATRIX_VERSION: {release_version!r}",
-    )
 if release_version is not None and "-" not in release_version:
     require(
         production_trigger == "release",
@@ -408,6 +477,17 @@ require(
 )
 for suffix in ("~deb13u1", "~ubuntu26.04.1"):
     require(suffix not in apt_publisher, f"APT publisher duplicates the central suite suffix {suffix}")
+for suite, source in expected_compat_suites.items():
+    step = f"includedeb {suite}" if source != "none" else f"export {suite}"
+    publication = re.search(rf'(?m)^\s*reprepro -b "\$\{{REPO_DIR\}}" {re.escape(step)}\b', apt_publisher)
+    if suite in active_compat_suites:
+        require(publication is not None, f"APT publisher does not populate compatibility suite {suite} ({step})")
+    else:
+        require(publication is None, f"APT publisher still publishes compatibility suite {suite} after retire_at {compat_retire_at}")
+require(
+    "dists pool tysmith-archive-keyring.gpg" in workflow,
+    "APT repo artifact must carry the whole dists tree, every published suite included",
+)
 direct_fedora_image = next(row["image"] for row in matrix["platforms"] if row["id"] == "fedora-44-direct")
 require(f"image: {direct_fedora_image}" in workflow, "direct RPM workflow must pin Fedora 44 by digest")
 require("prerelease: ${{ needs.metadata.outputs.prerelease }}" in workflow, "GitHub Release prerelease output is not wired")
@@ -758,7 +838,6 @@ for phrase in (
     "## Release Channels and APT Paths",
     "https://tysmith.me/facelock/apt/dists/trixie/Release",
     "https://tysmith.me/facelock/apt/dists/resolute/Release",
-    "`main` and `legacy`",
     "stable APT, stable AUR, or production COPR",
     "required supported production COPR chroots are exactly Fedora 43, Fedora 44, and Fedora 45",
     "Rawhide is the only optional allowed experimental production chroot",
@@ -872,6 +951,41 @@ normalized_releasing = re.sub(r"\s+", " ", (ROOT / "docs/releasing.md").read_tex
 for phrase in debian_source_phrases:
     require(phrase in normalized_releasing, f"release documentation omits Debian source policy: {phrase}")
     require(phrase in normalized_contracts, f"system contracts omit Debian source policy: {phrase}")
+
+# The window is a promise to clients that are not reading this repository, so
+# every install document carries it while it is open, and none may keep the
+# present-tense promise once it has closed.
+compat_window_claims = {
+    "docs/contracts.md": (
+        normalized_contracts,
+        ("`main` and `legacy` are compatibility suites", f"removed at {compat_retire_at}"),
+        "`main` and `legacy` are compatibility suites",
+    ),
+    "docs/releasing.md": (
+        normalized_releasing,
+        (f"compatibility suites present until {compat_retire_at}",),
+        f"compatibility suites present until {compat_retire_at}",
+    ),
+    "README.md": (
+        re.sub(r"\s+", " ", readme),
+        ("`main` or `legacy`", f"keep working until {compat_retire_at}"),
+        f"keep working until {compat_retire_at}",
+    ),
+    "book/src/quickstart.md": (
+        re.sub(r"\s+", " ", install_docs["book/src/quickstart.md"]),
+        ("`main` or `legacy`", f"keep working until {compat_retire_at}"),
+        f"keep working until {compat_retire_at}",
+    ),
+}
+for relative_path, (content, claims, promise) in compat_window_claims.items():
+    if compat_active:
+        for claim in claims:
+            require(claim in content, f"{relative_path} omits the APT compatibility window: {claim}")
+    else:
+        require(
+            promise not in content,
+            f"{relative_path} still promises the APT compatibility window past {compat_retire_at}: {promise}",
+        )
 
 compatibility_paths = ("docs/compatibility.md", "book/src/compatibility.md")
 compatibility_support_floor = debian_support_phrase

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -607,6 +607,15 @@ for relative_path in (
         "registry.fedoraproject.org/fedora:" not in fedora_containerfile,
         f"{relative_path} pins a Fedora image outside the release matrix",
     )
+apt_client_containerfile = (ROOT / "test/Containerfile.apt-client").read_text()
+require(
+    re.search(r"(?m)^ARG BASE_IMAGE\s*$\n^FROM \$\{BASE_IMAGE\}\s*$", apt_client_containerfile) is not None,
+    "test/Containerfile.apt-client does not take its base image from the release matrix",
+)
+require(
+    "docker.io/library/debian:" not in apt_client_containerfile,
+    "test/Containerfile.apt-client pins a Debian image outside the release matrix",
+)
 lane_resolver = (ROOT / "test/fedora-lane-image.sh").read_text()
 for phrase in ("RELEASE_MATRIX_TODAY", "_eol_gate", "staging_copr_targets"):
     require(phrase in lane_resolver, f"Fedora lane resolver omits matrix authority: {phrase}")

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -302,7 +302,16 @@ require(
     f"APT config suites {sorted(declared_suites)} != {sorted(expected_suites | active_compat_suites)}",
 )
 for suite, fields in apt_stanzas.items():
-    for field, value in (("Architectures", "amd64"), ("Components", "facelock"), ("SignWith", "default")):
+    # Origin and Label are compared by every installed client: a change is an
+    # apt update failure, not a warning. Suite is not pinned; adding one where
+    # none existed passes apt.
+    for field, value in (
+        ("Origin", "tysmith"),
+        ("Label", "Ty Smith Packages"),
+        ("Architectures", "amd64"),
+        ("Components", "facelock"),
+        ("SignWith", "default"),
+    ):
         require(fields.get(field) == value, f"APT suite {suite} {field} drifted: {fields.get(field)!r}")
 for suite in active_compat_suites:
     description = apt_stanzas[suite].get("Description", "")
@@ -979,12 +988,29 @@ compat_window_claims = {
     ),
     "README.md": (
         re.sub(r"\s+", " ", readme),
-        ("`main` or `legacy`", f"keep working until {compat_retire_at}"),
+        (
+            "`main` or `legacy`",
+            f"keep working until {compat_retire_at}",
+            "`apt update` fails until the entry is removed",
+        ),
         f"keep working until {compat_retire_at}",
     ),
     "book/src/quickstart.md": (
         re.sub(r"\s+", " ", install_docs["book/src/quickstart.md"]),
-        ("`main` or `legacy`", f"keep working until {compat_retire_at}"),
+        (
+            "`main` or `legacy`",
+            f"keep working until {compat_retire_at}",
+            "`apt update` fails until the entry is removed",
+        ),
+        f"keep working until {compat_retire_at}",
+    ),
+    "website/index.html": (
+        re.sub(r"\s+", " ", install_docs["website/index.html"]),
+        (
+            "<code>main</code> or <code>legacy</code>",
+            f"keep working until {compat_retire_at}",
+            "<code>apt update</code> fails until the entry is removed",
+        ),
         f"keep working until {compat_retire_at}",
     ),
 }

--- a/test/fixtures/apt-distributions-v0.1.4
+++ b/test/fixtures/apt-distributions-v0.1.4
@@ -1,0 +1,15 @@
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: main
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - TPM enabled (modern Debian/Ubuntu)
+SignWith: default
+
+Origin: tysmith
+Label: Ty Smith Packages
+Codename: legacy
+Architectures: amd64
+Components: facelock
+Description: Facelock APT repository - non-TPM (older Debian/Ubuntu)
+SignWith: default

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -972,6 +972,8 @@ if git -C "$repo_root" rev-parse -q --verify 'v0.1.4^{commit}' >/dev/null 2>&1; 
         | cmp -s - "$repo_root/test/fixtures/apt-distributions-v0.1.4" \
         || fail "test/fixtures/apt-distributions-v0.1.4 differs from v0.1.4:dist/apt/conf/distributions"
     echo "APT fixture case: v0.1.4 distributions fixture matches the tag"
+else
+    echo "APT fixture case: skipped, v0.1.4 not reachable in this checkout"
 fi
 
 # Run to completion under an ephemeral signing key, the publisher must fill

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -296,6 +296,7 @@ cp "$repo_root/.github/workflows/packaging.yml" "$matrix_root/.github/workflows/
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
 cp "$repo_root/test/packit-config-validate.sh" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.packit" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.apt-client" "$matrix_root/test/"
 cp "$repo_root/test/run-pkg-validate-systemd.sh" "$matrix_root/test/"
 
 apt_publisher_root="$tmp_root/apt-publisher-root"
@@ -1043,10 +1044,13 @@ if [ "$1" = "purge" ]; then
 fi
 SCRIPT
 cp "$repo_root/dist/apt/conf/distributions" "$apt_recipe_root/dist/apt/conf/"
+cp "$repo_root/dist/release-matrix.json" "$apt_recipe_root/dist/"
 cp "$repo_root/scripts/release-versions.sh" "$apt_recipe_root/scripts/"
 cp "$repo_root/test/deb-package-contract.sh" \
     "$repo_root/test/deb-maintscript-contract.sh" \
     "$repo_root/test/publish-directory-atomic.py" \
+    "$repo_root/test/Containerfile.apt-client" \
+    "$repo_root/test/apt-client-lane.sh" \
     "$apt_recipe_root/test/"
 declare -A apt_recipe_suffix=(
     [trixie]='~deb13u1'
@@ -1180,25 +1184,43 @@ case "${3:-}" in
     *) exit 2 ;;
 esac
 SH
-chmod +x "$tmp_root/bin/dpkg-deb" "$tmp_root/bin/reprepro"
+cat > "$tmp_root/bin/podman" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FACELOCK_TEST_PODMAN_LOG:?}"
+SH
+chmod +x "$tmp_root/bin/dpkg-deb" "$tmp_root/bin/reprepro" "$tmp_root/bin/podman"
+apt_recipe_podman_log="$tmp_root/apt-recipe-podman.log"
 if ! (
     cd "$apt_recipe_root"
-    PATH="$tmp_root/bin:$PATH" just test-apt-repo >/dev/null 2>&1
+    FACELOCK_TEST_PODMAN_LOG="$apt_recipe_podman_log" PATH="$tmp_root/bin:$PATH" just test-apt-repo >/dev/null 2>&1
 ); then
     fail "test-apt-repo rejected config-only validation without a manifest"
 fi
+grep -q -- '^build .*-t facelock-apt-client ' "$apt_recipe_podman_log" \
+    || fail "test-apt-repo did not build the APT client lane image"
+grep -q -- '^run .*--network=none .*facelock-apt-client ' "$apt_recipe_podman_log" \
+    || fail "test-apt-repo did not run the APT client lane offline"
+! grep -q -- '/manifests/' "$apt_recipe_podman_log" \
+    || fail "test-apt-repo mounted a manifest it was not given"
+rm -f "$apt_recipe_podman_log"
 if ! (
     cd "$apt_recipe_root"
-    PATH="$tmp_root/bin:$PATH" just test-apt-repo "${apt_recipe_manifests[@]}" >/dev/null 2>&1
+    FACELOCK_TEST_PODMAN_LOG="$apt_recipe_podman_log" PATH="$tmp_root/bin:$PATH" just test-apt-repo "${apt_recipe_manifests[@]}" >/dev/null 2>&1
 ); then
     fail "test-apt-repo rejected the complete set of two exact generated manifests"
 fi
+for suite in trixie resolute; do
+    grep -q -- "^run .*:/manifests/$suite:ro.* --manifest $suite=/manifests/$suite/facelock_0.2.0-1${apt_recipe_suffix[$suite]}_amd64.manifest" "$apt_recipe_podman_log" \
+        || fail "test-apt-repo did not hand the exact $suite manifest to the APT client lane"
+done
+rm -f "$apt_recipe_podman_log"
 if (
     cd "$apt_recipe_root"
-    PATH="$tmp_root/bin:$PATH" just test-apt-repo "${apt_recipe_manifests[0]}" >/dev/null 2>&1
+    FACELOCK_TEST_PODMAN_LOG="$apt_recipe_podman_log" PATH="$tmp_root/bin:$PATH" just test-apt-repo "${apt_recipe_manifests[0]}" >/dev/null 2>&1
 ); then
     fail "test-apt-repo accepted an incomplete generated-manifest set"
 fi
+[ ! -e "$apt_recipe_podman_log" ] || fail "test-apt-repo reached the container with an incomplete manifest set"
 
 cp "$repo_root/justfile" "$repo_root/Cargo.toml" "$repo_root/Cargo.lock" "$release_repo/"
 cp "$repo_root/dist/PKGBUILD" "$repo_root/dist/PKGBUILD-bin" "$repo_root/dist/PKGBUILD-git" "$repo_root/dist/facelock.spec" "$release_repo/dist/"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -721,6 +721,11 @@ assert_matrix_mutation_rejected \
     's/keep working until 0.3.0/keep working/' \
     "README.md omits the APT compatibility window"
 assert_matrix_mutation_rejected \
+    "README install instruction configures the main suite" \
+    "README.md" \
+    's/apt ${APT_SUITE} facelock/apt main facelock/' \
+    "README.md still configures a retired APT suite"
+assert_matrix_mutation_rejected \
     "quickstart migration note dropped" \
     "book/src/quickstart.md" \
     's/keep working until 0.3.0/keep working/' \
@@ -1120,75 +1125,11 @@ for suite in trixie resolute; do
     printf '%s\n' "${artifacts[@]}" > "$manifest"
     apt_recipe_manifests+=("artifacts/$suite/${binary_basename}.manifest")
 done
-cat > "$tmp_root/bin/dpkg-deb" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-case "${1:-}" in
-    --field|-f)
-        case "${3:-}" in
-            Package) printf '%s\n' facelock ;;
-            Depends) printf '%s\n' 'dbus, libpam-runtime, libc6 (>= 2.36), libtss2-esys-3.0.2-0t64, libtss2-mu-4.0.1-0t64, libtss2-tctildr0t64' ;;
-            Provides|Conflicts|Replaces) printf '\n' ;;
-            Version)
-                version="${2##*/}"
-                version="${version#facelock_}"
-                printf '%s\n' "${version%_amd64.deb}"
-                ;;
-            Architecture) printf '%s\n' amd64 ;;
-            *) exit 2 ;;
-        esac
-        ;;
-    --control)
-        mkdir -p "${3:?}"
-        cat >"$3/postinst" <<'SCRIPT'
-#!/bin/sh
-if [ -d /run/systemd/system ] && \
-           systemctl is-active --quiet facelock-daemon.service; then
-            systemctl try-restart facelock-daemon.service 2>/dev/null || true
-fi
-systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create facelock.conf || true
-SCRIPT
-        cat >"$3/prerm" <<'SCRIPT'
-#!/bin/sh
-facelock pam shared-profile-status
-facelock pam remove --all --dry-run
-facelock pam remove --all
-if [ -z "$DPKG_ROOT" ] && [ "$1" = remove ] && [ -d /run/systemd/system ]; then
-    deb-systemd-invoke stop 'facelock-daemon.service' >/dev/null || true
-fi
-SCRIPT
-        sed -e '/^#DEBHELPER#$/r debian/generated-postrm-helper' \
-            -e '/^#DEBHELPER#$/d' debian/postrm >"$3/postrm"
-        printf '%s\n' '/etc/facelock/config.toml' >"$3/conffiles"
-        ;;
-    *) exit 2 ;;
-esac
-SH
-cat > "$tmp_root/bin/reprepro" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-[ "${1:-}" = -b ] || exit 2
-repo_dir="${2:-}"
-case "${3:-}" in
-    check) exit 0 ;;
-    includedeb)
-        suite="${4:-}"
-        package="${5:-}"
-        mkdir -p \
-            "$repo_dir/dists/$suite/facelock/binary-amd64" \
-            "$repo_dir/pool/facelock"
-        : > "$repo_dir/dists/$suite/Release"
-        : > "$repo_dir/dists/$suite/facelock/binary-amd64/Packages"
-        cp -- "$package" "$repo_dir/pool/facelock/"
-        ;;
-    *) exit 2 ;;
-esac
-SH
 cat > "$tmp_root/bin/podman" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${FACELOCK_TEST_PODMAN_LOG:?}"
 SH
-chmod +x "$tmp_root/bin/dpkg-deb" "$tmp_root/bin/reprepro" "$tmp_root/bin/podman"
+chmod +x "$tmp_root/bin/podman"
 apt_recipe_podman_log="$tmp_root/apt-recipe-podman.log"
 if ! (
     cd "$apt_recipe_root"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -774,14 +774,12 @@ done
 RELEASE_MATRIX_VERSION=0.2.9 python3 "$matrix_root/test/check-release-matrix.py" >/dev/null
 echo "release matrix expiry case: compatibility suites accepted at 0.2.9"
 
-# The terminal state is reachable: with the stanzas, the publisher steps and
-# the window claims gone, 0.3.0 passes.
+# The terminal state is reachable: with the stanzas and the window claims
+# gone, and the publisher untouched, 0.3.0 passes.
 retired_root="$tmp_root/matrix-retired"
 cp -R "$matrix_root" "$retired_root"
 awk 'BEGIN { RS = ""; ORS = "\n\n" } !/Codename: (main|legacy)\n/' \
     "$matrix_root/dist/apt/conf/distributions" > "$retired_root/dist/apt/conf/distributions"
-sed -i '/reprepro -b "${REPO_DIR}" includedeb main /d; /reprepro -b "${REPO_DIR}" export legacy/d' \
-    "$retired_root/.github/workflows/scripts/publish-apt.sh"
 sed -i 's/`main` and `legacy` are compatibility suites/`main` and `legacy` were compatibility suites/; s/removed at 0.3.0/removed in 0.3.0/' \
     "$retired_root/docs/contracts.md"
 sed -i 's/compatibility suites present until 0.3.0/compatibility suites removed in 0.3.0/' "$retired_root/docs/releasing.md"
@@ -1058,6 +1056,35 @@ case "$apt_tree_output" in
     *) fail "stable APT publisher did not print the compatibility suite Release files" ;;
 esac
 echo "stable APT publisher case: codenamed and compatibility suites published"
+
+# With the stanzas deleted and the publisher untouched, the compatibility
+# steps must not run: an undeclared codename would make reprepro fail the
+# release under set -e (#320).
+apt_retired_publisher_root="$tmp_root/apt-retired-publisher"
+apt_retired_tree_root="$tmp_root/apt-retired-tree"
+mkdir -p "$apt_retired_publisher_root/.github/workflows/scripts" "$apt_retired_publisher_root/scripts" "$apt_retired_publisher_root/dist/apt/conf"
+cp "$repo_root/.github/workflows/scripts/publish-apt.sh" "$apt_retired_publisher_root/.github/workflows/scripts/"
+cp "$repo_root/scripts/release-versions.sh" "$apt_retired_publisher_root/scripts/"
+cp "$retired_root/dist/apt/conf/distributions" "$apt_retired_publisher_root/dist/apt/conf/"
+if ! apt_tree_output=$(
+    cd "$apt_retired_publisher_root" && \
+        GNUPGHOME="$apt_publisher_gnupg" APT_GPG_PRIVATE_KEY="$apt_private_key" APT_GPG_PASSPHRASE=contract-passphrase \
+        PATH="$tmp_root/bin:$PATH" \
+        bash .github/workflows/scripts/publish-apt.sh "$apt_retired_tree_root" \
+        "trixie=$apt_tree_debs/trixie.deb" "resolute=$apt_tree_debs/resolute.deb" 2>&1
+); then
+    printf '%s\n' "$apt_tree_output"
+    fail "stable APT publisher failed once the compatibility stanzas were retired"
+fi
+for suite in trixie resolute; do
+    [ -f "$apt_retired_tree_root/dists/$suite/Release" ] || fail "retired-stanza publisher left dists/$suite/Release unpublished"
+done
+for suite in main legacy; do
+    ! grep -q -- " $suite" "$apt_retired_tree_root/reprepro-calls" \
+        || fail "retired-stanza publisher still ran reprepro for $suite"
+    [ ! -e "$apt_retired_tree_root/dists/$suite" ] || fail "retired-stanza publisher still published dists/$suite"
+done
+echo "stable APT publisher case: retired stanzas leave the compatibility steps unrun"
 
 assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0-alpha.1 unused
 # A stable version with an implausible source digest must be refused before any

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -16,6 +16,11 @@ fail() {
 }
 
 cleanup() {
+    for gnupg_home in "${apt_keygen_home:-}" "${apt_publisher_gnupg:-}"; do
+        if [ -d "$gnupg_home" ]; then
+            GNUPGHOME="$gnupg_home" gpgconf --kill gpg-agent 2>/dev/null || true
+        fi
+    done
     rm -f "$packit_fixture"
     rm -f "${packit_complex_fixture:-}" "${packit_commented_fixture:-}"
     rm -f "${github_output_fixture:-}"
@@ -270,7 +275,7 @@ cp "$repo_root/dist/nix/default.nix" "$matrix_root/dist/nix/"
 cp "$repo_root/docs/releasing.md" "$repo_root/docs/contracts.md" "$repo_root/docs/integrating.md" "$repo_root/docs/security.md" "$repo_root/docs/compatibility.md" "$repo_root/docs/quickstart.md" "$matrix_root/docs/"
 cp "$repo_root/docs/adr/009-cli-verb-noun-shape.md" "$matrix_root/docs/adr/"
 cp "$repo_root/docs/testing-roadmap.md" "$matrix_root/docs/"
-cp "$repo_root/README.md" "$repo_root/CONTRIBUTING.md" "$matrix_root/"
+cp "$repo_root/README.md" "$repo_root/CONTRIBUTING.md" "$repo_root/Cargo.toml" "$matrix_root/"
 cp "$repo_root/book/src/quickstart.md" "$repo_root/book/src/contributing.md" "$repo_root/book/src/compatibility.md" "$matrix_root/book/src/"
 cp "$repo_root/.github/ISSUE_TEMPLATE/bug_report.md" "$matrix_root/.github/ISSUE_TEMPLATE/"
 cp "$repo_root/crates/facelock-cli/src/commands/pam.rs" "$matrix_root/crates/facelock-cli/src/commands/"
@@ -336,15 +341,23 @@ assert_matrix_mutation_rejected() {
     local context="$1"
     local relative_file="$2"
     local expression="$3"
+    local diagnostic="${4:-}"
     local mutation_root="$tmp_root/matrix-mutation-$matrix_mutation_index"
+    local checker_output
     matrix_mutation_index=$((matrix_mutation_index + 1))
     cp -R "$matrix_root" "$mutation_root"
     sed -i "$expression" "$mutation_root/$relative_file"
     if cmp -s "$matrix_root/$relative_file" "$mutation_root/$relative_file"; then
         fail "matrix mutation fixture did not change $relative_file: $context"
     fi
-    if RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" >/dev/null 2>&1; then
+    if checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" 2>&1); then
         fail "release matrix checker accepted drift: $context"
+    fi
+    if [ -n "$diagnostic" ]; then
+        case "$checker_output" in
+            *"$diagnostic"*) ;;
+            *) fail "release matrix checker rejected $context for another reason: $checker_output" ;;
+        esac
     fi
     echo "release matrix mutation case: $context rejected"
 }
@@ -654,6 +667,108 @@ assert_matrix_mutation_rejected \
     "stable publication suite input resolute to duplicate trixie" \
     ".github/workflows/release.yml" \
     's/"resolute=$(exact_deb_from_manifest resolute)"/"trixie=$(exact_deb_from_manifest resolute)"/'
+# The v0.1.4 suite names stay published until 0.3.0 (#310). Every place that
+# promise lives must agree, and the window must actually close.
+assert_matrix_mutation_rejected \
+    "compatibility suite retire_at removed" \
+    "dist/release-matrix.json" \
+    '0,/"retire_at": "0.3.0"/s//"retired": "0.3.0"/' \
+    "has no stable retire_at version"
+assert_matrix_mutation_rejected \
+    "compatibility suites retire at different versions" \
+    "dist/release-matrix.json" \
+    '0,/"retire_at": "0.3.0"/s//"retire_at": "0.4.0"/' \
+    "must share one retirement version"
+assert_matrix_mutation_rejected \
+    "compatibility suite main sourced from resolute" \
+    "dist/release-matrix.json" \
+    's/"source": "trixie"/"source": "resolute"/' \
+    "compatibility APT suite main source drifted"
+assert_matrix_mutation_rejected \
+    "compatibility suite legacy stanza dropped from the APT config" \
+    "dist/apt/conf/distributions" \
+    's/^Codename: legacy$/Codename: bookworm/' \
+    "APT config suites"
+assert_matrix_mutation_rejected \
+    "compatibility suite main description silent about the deprecation" \
+    "dist/apt/conf/distributions" \
+    's/^\(Description: .*\)deprecated\(.*trixie.*\)$/\1renamed\2/' \
+    "must name the deprecation and the codenamed replacement"
+assert_matrix_mutation_rejected \
+    "compatibility suite legacy left unsigned" \
+    "dist/apt/conf/distributions" \
+    '/^Codename: legacy$/,/^SignWith: default$/s/^SignWith: default$/SignWith: no/' \
+    "APT suite legacy SignWith drifted"
+assert_matrix_mutation_rejected \
+    "APT publisher stops mirroring trixie into main" \
+    ".github/workflows/scripts/publish-apt.sh" \
+    's/includedeb main/includedeb trixie/' \
+    "does not populate compatibility suite main"
+assert_matrix_mutation_rejected \
+    "APT publisher stops exporting legacy" \
+    ".github/workflows/scripts/publish-apt.sh" \
+    's/export legacy/export resolute/' \
+    "does not populate compatibility suite legacy"
+assert_matrix_mutation_rejected \
+    "APT repo artifact drops the dists tree" \
+    ".github/workflows/release.yml" \
+    's/dists pool tysmith-archive-keyring.gpg/pool tysmith-archive-keyring.gpg/' \
+    "must carry the whole dists tree"
+assert_matrix_mutation_rejected \
+    "README migration note dropped" \
+    "README.md" \
+    's/keep working until 0.3.0/keep working/' \
+    "README.md omits the APT compatibility window"
+assert_matrix_mutation_rejected \
+    "quickstart migration note dropped" \
+    "book/src/quickstart.md" \
+    's/keep working until 0.3.0/keep working/' \
+    "book/src/quickstart.md omits the APT compatibility window"
+assert_matrix_mutation_rejected \
+    "release checklist line dropped" \
+    "docs/releasing.md" \
+    's/compatibility suites present until 0.3.0/compatibility suites present/' \
+    "docs/releasing.md omits the APT compatibility window"
+assert_matrix_mutation_rejected \
+    "contract retirement version dropped" \
+    "docs/contracts.md" \
+    's/removed at 0.3.0/removed later/' \
+    "docs/contracts.md omits the APT compatibility window"
+
+for retired_version in 0.3.0 0.3.0-alpha.1 1.0.0; do
+    if checker_output=$(RELEASE_MATRIX_VERSION="$retired_version" python3 "$matrix_root/test/check-release-matrix.py" 2>&1); then
+        fail "release matrix checker kept the APT compatibility suites at $retired_version"
+    fi
+    case "$checker_output" in
+        *"reached retire_at 0.3.0"*) ;;
+        *) fail "release matrix checker rejected $retired_version for another reason: $checker_output" ;;
+    esac
+    echo "release matrix expiry case: compatibility suites rejected at $retired_version"
+done
+RELEASE_MATRIX_VERSION=0.2.9 python3 "$matrix_root/test/check-release-matrix.py" >/dev/null
+echo "release matrix expiry case: compatibility suites accepted at 0.2.9"
+
+# The terminal state is reachable: with the stanzas, the publisher steps and
+# the window claims gone, 0.3.0 passes.
+retired_root="$tmp_root/matrix-retired"
+cp -R "$matrix_root" "$retired_root"
+awk 'BEGIN { RS = ""; ORS = "\n\n" } !/Codename: (main|legacy)\n/' \
+    "$matrix_root/dist/apt/conf/distributions" > "$retired_root/dist/apt/conf/distributions"
+sed -i '/reprepro -b "${REPO_DIR}" includedeb main /d; /reprepro -b "${REPO_DIR}" export legacy/d' \
+    "$retired_root/.github/workflows/scripts/publish-apt.sh"
+sed -i 's/`main` and `legacy` are compatibility suites/`main` and `legacy` were compatibility suites/; s/removed at 0.3.0/removed in 0.3.0/' \
+    "$retired_root/docs/contracts.md"
+sed -i 's/compatibility suites present until 0.3.0/compatibility suites removed in 0.3.0/' "$retired_root/docs/releasing.md"
+sed -i 's/keep working until 0.3.0/stopped working in 0.3.0/' "$retired_root/README.md" "$retired_root/book/src/quickstart.md"
+if ! checker_output=$(RELEASE_MATRIX_VERSION=0.3.0 python3 "$retired_root/test/check-release-matrix.py" 2>&1); then
+    fail "release matrix checker rejected the retired compatibility-suite state at 0.3.0: $checker_output"
+fi
+echo "release matrix expiry case: retired state accepted at 0.3.0"
+if RELEASE_MATRIX_VERSION=0.2.0 python3 "$retired_root/test/check-release-matrix.py" >/dev/null 2>&1; then
+    fail "release matrix checker accepted the retired compatibility-suite state inside the window"
+fi
+echo "release matrix expiry case: retired state rejected at 0.2.0"
+
 assert_matrix_mutation_rejected \
     "production required supported chroot missing" \
     "dist/release-matrix.json" \
@@ -822,6 +937,89 @@ case "$apt_guard_output" in
     *"does not match stable APT suite"*) ;;
     *) fail "stable APT publisher did not reject the suite/version mismatch before signing setup: $apt_guard_output" ;;
 esac
+
+# Run to completion under an ephemeral signing key, the publisher must fill
+# every suite the config declares: the codenamed pair, `main` with trixie's
+# exact package, and `legacy` exported with signed empty indexes (#310).
+# reprepro is a recording stand-in; gpg is real, in throwaway homes. Both
+# homes differ from $HOME/.gnupg, which is what gives them their own agent
+# socket rather than the user's.
+apt_keygen_home="$tmp_root/apt-keygen"
+apt_publisher_gnupg="$tmp_root/apt-publisher-gnupg"
+apt_tree_root="$tmp_root/apt-tree"
+apt_tree_debs="$tmp_root/apt-tree-debs"
+mkdir -p "$apt_tree_debs"
+mkdir -m 700 "$apt_keygen_home"
+GNUPGHOME="$apt_keygen_home" gpg --batch --quiet --pinentry-mode loopback --passphrase contract-passphrase \
+    --quick-generate-key "Facelock contract test <apt-contract@example.invalid>" ed25519 sign never
+apt_private_key="$(GNUPGHOME="$apt_keygen_home" gpg --batch --quiet --pinentry-mode loopback \
+    --passphrase contract-passphrase --armor --export-secret-keys)"
+for suite in trixie resolute; do
+    : > "$apt_tree_debs/$suite.deb"
+done
+cat > "$tmp_root/bin/dpkg-deb" <<'SH'
+#!/usr/bin/env bash
+case "$2" in
+    */trixie.deb) printf '%s\n' '0.2.0-1~deb13u1' ;;
+    */resolute.deb) printf '%s\n' '0.2.0-1~ubuntu26.04.1' ;;
+    *) exit 1 ;;
+esac
+SH
+cat > "$tmp_root/bin/reprepro" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = -b ] || exit 2
+repo_dir="${2:-}"
+command="${3:-}"
+suite="${4:-}"
+printf '%s\n' "$*" >> "$repo_dir/reprepro-calls"
+index_dir="$repo_dir/dists/$suite/facelock/binary-amd64"
+mkdir -p "$index_dir"
+case "$command" in
+    includedeb)
+        package="${5:-}"
+        mkdir -p "$repo_dir/pool/facelock"
+        cp -- "$package" "$repo_dir/pool/facelock/"
+        printf 'Package: facelock\nFilename: pool/facelock/%s\n\n' "$(basename "$package")" >> "$index_dir/Packages"
+        ;;
+    export) : >> "$index_dir/Packages" ;;
+    *) exit 2 ;;
+esac
+: > "$repo_dir/dists/$suite/Release"
+: > "$repo_dir/dists/$suite/InRelease"
+SH
+chmod +x "$tmp_root/bin/dpkg-deb" "$tmp_root/bin/reprepro"
+if ! apt_tree_output=$(
+    cd "$repo_root" && \
+        GNUPGHOME="$apt_publisher_gnupg" APT_GPG_PRIVATE_KEY="$apt_private_key" APT_GPG_PASSPHRASE=contract-passphrase \
+        PATH="$tmp_root/bin:$PATH" \
+        bash .github/workflows/scripts/publish-apt.sh "$apt_tree_root" \
+        "trixie=$apt_tree_debs/trixie.deb" "resolute=$apt_tree_debs/resolute.deb" 2>&1
+); then
+    printf '%s\n' "$apt_tree_output"
+    fail "stable APT publisher did not build the compatibility tree"
+fi
+for suite in trixie resolute main legacy; do
+    for index in Release InRelease; do
+        [ -f "$apt_tree_root/dists/$suite/$index" ] || fail "stable APT publisher left dists/$suite/$index unpublished"
+    done
+done
+grep -Fqx -- "-b $apt_tree_root includedeb main $apt_tree_debs/trixie.deb" "$apt_tree_root/reprepro-calls" \
+    || fail "stable APT publisher did not place trixie's exact package in main"
+grep -Fqx -- "-b $apt_tree_root export legacy" "$apt_tree_root/reprepro-calls" \
+    || fail "stable APT publisher did not export legacy"
+[ ! -s "$apt_tree_root/dists/legacy/facelock/binary-amd64/Packages" ] \
+    || fail "stable APT publisher listed a package in legacy"
+cmp -s "$apt_tree_root/dists/main/facelock/binary-amd64/Packages" "$apt_tree_root/dists/trixie/facelock/binary-amd64/Packages" \
+    || fail "main index differs from the trixie index"
+! grep -q resolute "$apt_tree_root/dists/main/facelock/binary-amd64/Packages" \
+    || fail "main index carries the resolute package"
+[ -s "$apt_tree_root/tysmith-archive-keyring.gpg" ] || fail "stable APT publisher exported no public keyring"
+case "$apt_tree_output" in
+    *"Release file (main)"*"Release file (legacy)"*) ;;
+    *) fail "stable APT publisher did not print the compatibility suite Release files" ;;
+esac
+echo "stable APT publisher case: codenamed and compatibility suites published"
 
 assert_rejected bash "$repo_root/.github/workflows/scripts/publish-aur.sh" 0.2.0-alpha.1 unused
 # A stable version with an implausible source digest must be refused before any

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -696,6 +696,16 @@ assert_matrix_mutation_rejected \
     's/^\(Description: .*\)deprecated\(.*trixie.*\)$/\1renamed\2/' \
     "must name the deprecation and the codenamed replacement"
 assert_matrix_mutation_rejected \
+    "APT suite Origin changed" \
+    "dist/apt/conf/distributions" \
+    's/^Origin: tysmith$/Origin: facelock/' \
+    "Origin drifted"
+assert_matrix_mutation_rejected \
+    "APT suite Label changed" \
+    "dist/apt/conf/distributions" \
+    's/^Label: Ty Smith Packages$/Label: Facelock Packages/' \
+    "Label drifted"
+assert_matrix_mutation_rejected \
     "compatibility suite legacy left unsigned" \
     "dist/apt/conf/distributions" \
     '/^Codename: legacy$/,/^SignWith: default$/s/^SignWith: default$/SignWith: no/' \
@@ -731,6 +741,16 @@ assert_matrix_mutation_rejected \
     's/keep working until 0.3.0/keep working/' \
     "book/src/quickstart.md omits the APT compatibility window"
 assert_matrix_mutation_rejected \
+    "README 0.3.0 failure mode dropped" \
+    "README.md" \
+    's/fails until the entry is removed/fails/' \
+    "README.md omits the APT compatibility window"
+assert_matrix_mutation_rejected \
+    "website migration note dropped" \
+    "website/index.html" \
+    's/keep working until 0.3.0/keep working/' \
+    "website/index.html omits the APT compatibility window"
+assert_matrix_mutation_rejected \
     "release checklist line dropped" \
     "docs/releasing.md" \
     's/compatibility suites present until 0.3.0/compatibility suites present/' \
@@ -765,7 +785,8 @@ sed -i '/reprepro -b "${REPO_DIR}" includedeb main /d; /reprepro -b "${REPO_DIR}
 sed -i 's/`main` and `legacy` are compatibility suites/`main` and `legacy` were compatibility suites/; s/removed at 0.3.0/removed in 0.3.0/' \
     "$retired_root/docs/contracts.md"
 sed -i 's/compatibility suites present until 0.3.0/compatibility suites removed in 0.3.0/' "$retired_root/docs/releasing.md"
-sed -i 's/keep working until 0.3.0/stopped working in 0.3.0/' "$retired_root/README.md" "$retired_root/book/src/quickstart.md"
+sed -i 's/keep working until 0.3.0/stopped working in 0.3.0/' \
+    "$retired_root/README.md" "$retired_root/book/src/quickstart.md" "$retired_root/website/index.html"
 if ! checker_output=$(RELEASE_MATRIX_VERSION=0.3.0 python3 "$retired_root/test/check-release-matrix.py" 2>&1); then
     fail "release matrix checker rejected the retired compatibility-suite state at 0.3.0: $checker_output"
 fi
@@ -943,6 +964,15 @@ case "$apt_guard_output" in
     *"does not match stable APT suite"*) ;;
     *) fail "stable APT publisher did not reject the suite/version mismatch before signing setup: $apt_guard_output" ;;
 esac
+
+# The APT client lane replays a v0.1.4 client from this fixture; it must stay
+# byte-identical to what v0.1.4 published.
+if git -C "$repo_root" rev-parse -q --verify 'v0.1.4^{commit}' >/dev/null 2>&1; then
+    git -C "$repo_root" show v0.1.4:dist/apt/conf/distributions \
+        | cmp -s - "$repo_root/test/fixtures/apt-distributions-v0.1.4" \
+        || fail "test/fixtures/apt-distributions-v0.1.4 differs from v0.1.4:dist/apt/conf/distributions"
+    echo "APT fixture case: v0.1.4 distributions fixture matches the tag"
+fi
 
 # Run to completion under an ephemeral signing key, the publisher must fill
 # every suite the config declares: the codenamed pair, `main` with trixie's

--- a/website/index.html
+++ b/website/index.html
@@ -385,6 +385,7 @@
               <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
+          <p class="install-note migration">Source entries written for v0.1.4 name the <code>main</code> or <code>legacy</code> suite. They keep working until 0.3.0: <code>main</code> serves the trixie package and <code>legacy</code> serves no package. On Debian 13 or Ubuntu 26.04, replace the suite with <code>trixie</code> or <code>resolute</code>. Bookworm, noble, and Ubuntu 25.x have no suite: 0.1.4 was the last release for those hosts, so remove <code>/etc/apt/sources.list.d/facelock.list</code>. At 0.3.0 the old suites disappear and <code>apt update</code> fails until the entry is removed. Reinstalling or downloading 0.1.4 through APT stops working at 0.2.0, because the pool is rebuilt at each release.</p>
         </div>
 
         <div id="install-fedora" class="install-panel" role="tabpanel" hidden>

--- a/website/style.css
+++ b/website/style.css
@@ -579,6 +579,14 @@ section + section {
   opacity: 0.7;
 }
 
+.install-note.migration {
+  text-align: left;
+  max-width: 72ch;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.6;
+}
+
 /* ── Comparison Table ── */
 .comparison-wrap {
   overflow-x: auto;


### PR DESCRIPTION
## Summary

- add `main` and `legacy` stanzas to `dist/apt/conf/distributions`, same `Origin`, `Label`, `Components: facelock`, `Architectures: amd64`, `SignWith: default` as the codenamed pair
- serve trixie's exact package from `main`: `publish-apt.sh` runs `includedeb main` with the same deb right after `includedeb trixie`
- serve nothing from `legacy`: `reprepro export legacy` writes signed empty indexes so `apt update` keeps succeeding
- declare the window in `dist/release-matrix.json` as `apt_suites.compat` with `retire_at: 0.3.0`
- gate the window in `check-release-matrix.py`: stanzas, publisher steps and the migration note required while the gate version is below `retire_at`, refused from it on, prereleases included; the gate version is `RELEASE_MATRIX_VERSION` at tag time and the `Cargo.toml` version in CI, so the 0.3.0 bump goes red until both suites are removed
- pin `Origin` and `Label` on every stanza; an installed client fails `apt update` with exit 100 when either changes
- pin the Pages tarball command in `release.yml` to `dists pool tysmith-archive-keyring.gpg`, which is what carries all four suites into `_site/apt`
- rebuild `just test-apt-repo` as an apt-client lane in the pinned trixie image: the real publisher under an ephemeral key, the release.yml tar and pages.yml untar, `gpgv` on every `InRelease`, then a clean client per suite with the README entry, and a client replayed from the v0.1.4 tree that updates across the switch with its lists intact
- add the migration note to `README.md`, the book quickstart and the website install page: trixie and 26.04 hosts switch to the codename; bookworm, noble and Ubuntu 25.x have no suite, 0.1.4 was their last release, and they remove `/etc/apt/sources.list.d/facelock.list`; at 0.3.0 `apt update` fails until the entry is gone

## Why

v0.1.4 told every APT user to configure the `main` or `legacy` suite, and the codenamed configuration dropped both paths. Publishing 0.2.0 from it would have left those clients with `apt update` exit 100 until someone edited the source entry, the one regression against v0.1.4 in the release. The suites come back as compatibility suites generated from the same validated package set, for a window that closes at 0.3.0 and is enforced rather than remembered.

## Validation

- `bash test/release-version-contract.sh`: publisher run to completion under a real key, mutation cases for every pinned field, publisher step, doc claim and the `retire_at` expiry, a retired-state fixture accepted at 0.3.0
- `python3 test/check-release-matrix.py` unset and with `RELEASE_MATRIX_VERSION=0.3.0`
- `just test-apt-repo` in the pinned trixie container, including the v0.1.4 replay and an `Origin` mutation as the positive control
- `just check`

| Path | Why it matters |
|---|---|
| `dist/apt/conf/distributions` | the two stanzas an installed client compares field by field *(start here)* |
| `.github/workflows/scripts/publish-apt.sh` | `includedeb main`, `export legacy`; input allowlist unchanged |
| `dist/release-matrix.json` | `apt_suites.compat`, the only place the window is declared |
| `test/check-release-matrix.py` | the window gate, the `Origin`/`Label` pins, the tarball pin |
| `test/apt-client-lane.sh`, `test/Containerfile.apt-client` | the apt-client lane |
| `test/fixtures/apt-distributions-v0.1.4` | byte-identical to `v0.1.4:dist/apt/conf/distributions`; the replayed client's starting tree |
| `test/release-version-contract.sh` | publisher and recipe cases, mutations, the retired-state fixture |
| `docs/contracts.md`, `docs/releasing.md`, `README.md`, `book/src/quickstart.md`, `website/index.html` | the contract and the migration note |

## Reviewer notes

- **the v0.1.4 tree is built before this release's in the lane**: apt keeps the newer-dated `Release`, so the order is load-bearing
- **`Suite` is deliberately not pinned**: adding one where none existed passes apt; only `Origin`, `Label` and `Codename` are refused on change
- **`test-apt-repo` is in no workflow**: `packaging.yml` runs the deb matrix on this PR because `dist/` changed; wiring the lane in waits for the packaging-evidence changes

Closes #310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restored signed APT compatibility suites for version 0.1.4: `main` provides Trixie packages, while `legacy` provides signed empty indexes.
  - Added support for codename-specific APT suites, including `trixie` and `resolute`.
  - APT repository metadata now supports all configured distributions and suites.
  - Enrollment now saves validated models atomically and rejects models with fewer than three embeddings.

- **Documentation**
  - Added migration guidance across installation and release documentation.
  - Debian 13 and Ubuntu 26.04 users should switch to codename-specific suites; unsupported hosts should remove the APT source.
  - Compatibility suites are scheduled for removal in version 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->