### PR TITLE
fix(release): reject model-skipped packaging evidence

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -44,7 +44,7 @@ schedules:
 |---|---|---|
 | Pull request | every lane | only when the diff reaches a package |
 | Nightly (07:00 UTC) | every lane | none |
-| `just release-preflight` | evidence of a green run at HEAD | none |
+| `just release-preflight` | lane evidence uploaded by a green run at HEAD | none |
 
 The pull-request filter is a `changes` job running
 `.github/workflows/scripts/classify-changes.sh`, plain bash over a merge-base
@@ -55,8 +55,9 @@ to review. Add a path there when a new file can reach a built package.
 So a green pull request is **not** packaging-verified unless the packaging jobs
 actually ran on it. A Rust-only change that breaks the packaged runtime is caught
 by the nightly matrix within a day, and by the release gate before it ships.
-`just test-packaging-matrix` runs every lane locally and records the commit, for
-a maintainer without CI in reach.
+`just test-packaging-matrix` runs every lane locally and records each lane's
+evidence, for a maintainer without CI in reach; a run that skipped anything is
+refused, not recorded.
 
 ## Which E2E tier a new assertion belongs in
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -44,7 +44,7 @@ schedules:
 |---|---|---|
 | Pull request | every lane | only when the diff reaches a package |
 | Nightly (07:00 UTC) | every lane | none |
-| `just release-preflight` | lane evidence uploaded by a green run at HEAD | none |
+| `just release-preflight` | lane evidence uploaded by a green run at HEAD, or the marker a local `just test-packaging-matrix` wrote at HEAD | none |
 
 The pull-request filter is a `changes` job running
 `.github/workflows/scripts/classify-changes.sh`, plain bash over a merge-base

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -118,7 +118,7 @@ the question is "does a fresh install work", a dev shell when iterating.
 - Name which packaging recipe you ran; if none, say so
 - Report camera-gated tests as not run, never as passed
 - A green pull request only proves packaging if the `packaging.yml` jobs ran rather than reporting skipped
-- `just test-packaging-matrix` is the whole gate in one command (30-60+ minutes), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is refused, never recorded
+- `just test-packaging-matrix` is the whole gate in one command (30-60+ minutes), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic — it writes its `partial` per-lane records, but the marker is withheld
 
 ## Cost
 

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -11,8 +11,9 @@ suite gates, every declared Fedora lane, the Arch package built from the real
 run **only when the diff reaches a package**. A `changes` job classifies the
 merge-base diff, and every lane sits behind
 `if: needs.changes.outputs.packaging == 'true'`. Unfiltered runs happen nightly
-and at `just release-preflight`, which refuses to pass without a green matrix at
-HEAD.
+and at `just release-preflight`, which refuses to pass without complete lane
+evidence at HEAD: the `packaging-evidence-*` artifacts a green run uploads, or
+the record a local `just test-packaging-matrix` writes.
 
 Two consequences for you. A green pull request says nothing about packaging
 unless those jobs ran on it, so check rather than assume. COPR and the APT repo
@@ -117,7 +118,7 @@ the question is "does a fresh install work", a dev shell when iterating.
 - Name which packaging recipe you ran; if none, say so
 - Report camera-gated tests as not run, never as passed
 - A green pull request only proves packaging if the `packaging.yml` jobs ran rather than reporting skipped
-- `just test-packaging-matrix` is the whole gate in one command (30-60+ minutes), and it records the commit for `just release-preflight`
+- `just test-packaging-matrix` is the whole gate in one command (30-60+ minutes), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is refused, never recorded
 
 ## Cost
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -27,11 +27,21 @@ It checks local tools (`git`, `cargo`, `just`, `podman`), the packaging files,
 and release secrets. Fix every `MISSING` before continuing.
 
 It also needs complete packaging evidence at this commit: the
-`packaging-evidence-*` artifacts of a successful `packaging.yml` run
-(`gh workflow run packaging.yml --ref main`, then wait for it), or a local
-`just test-packaging-matrix` (30-60+ minutes, needs the ONNX models). A
-`FACELOCK_ALLOW_MISSING_MODELS=1` run never counts, and a run whose lanes were
-path-filtered away has no artifacts and is refused.
+`packaging-evidence-*` artifacts of a successful `packaging.yml` run, or a
+local `just test-packaging-matrix` (30-60+ minutes, needs the ONNX models).
+Dispatch the workflow only from the exact commit preflight will validate, with
+nothing uncommitted:
+
+```bash
+[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] && [ -z "$(git status --porcelain)" ] \
+  && gh workflow run packaging.yml --ref main
+```
+
+`--ref main` builds whatever `main` is when the run starts, and preflight
+refuses artifacts from any other commit, so a `main` that moved after the
+dispatch means a fresh dispatch. A `FACELOCK_ALLOW_MISSING_MODELS=1` run never
+counts, and a run whose lanes were path-filtered away has no artifacts and is
+refused.
 
 For Debian-family artifacts, the active release set is exactly Trixie and
 Resolute. Run both `just test-deb-trixie-pkg` and

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -26,6 +26,13 @@ does not. A bare invocation derives the version from `Cargo.toml` and classifies
 It checks local tools (`git`, `cargo`, `just`, `podman`), the packaging files,
 and release secrets. Fix every `MISSING` before continuing.
 
+It also needs complete packaging evidence at this commit: the
+`packaging-evidence-*` artifacts of a successful `packaging.yml` run
+(`gh workflow run packaging.yml --ref main`, then wait for it), or a local
+`just test-packaging-matrix` (30-60+ minutes, needs the ONNX models). A
+`FACELOCK_ALLOW_MISSING_MODELS=1` run never counts, and a run whose lanes were
+path-filtered away has no artifacts and is refused.
+
 For Debian-family artifacts, the active release set is exactly Trixie and
 Resolute. Run both `just test-deb-trixie-pkg` and
 `just test-deb-resolute-pkg`; each proves the TPM-enabled package, exact source

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -99,6 +99,9 @@ jobs:
           path: .packaging-evidence/
           if-no-files-found: error
           overwrite: true
+          # The directory is dot-prefixed; without this the action finds no
+          # files and if-no-files-found fails the job.
+          include-hidden-files: true
 
   # The Fedora lanes stage host-built binaries into the image rather than
   # compiling in it, and `just build-release` cannot run on the runner: its TPM
@@ -206,6 +209,9 @@ jobs:
           path: .packaging-evidence/
           if-no-files-found: error
           overwrite: true
+          # The directory is dot-prefixed; without this the action finds no
+          # files and if-no-files-found fails the job.
+          include-hidden-files: true
 
   arch:
     name: Arch Package From dist/PKGBUILD
@@ -238,6 +244,9 @@ jobs:
           path: .packaging-evidence/
           if-no-files-found: error
           overwrite: true
+          # The directory is dot-prefixed; without this the action finds no
+          # files and if-no-files-found fails the job.
+          include-hidden-files: true
 
   release-matrix:
     name: Release Version Ordering Matrix

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -98,6 +98,7 @@ jobs:
           name: packaging-evidence-deb-${{ matrix.suite }}
           path: .packaging-evidence/
           if-no-files-found: error
+          overwrite: true
 
   # The Fedora lanes stage host-built binaries into the image rather than
   # compiling in it, and `just build-release` cannot run on the runner: its TPM
@@ -197,17 +198,14 @@ jobs:
       - name: Run the Fedora ${{ matrix.release }} gate
         run: just ${{ matrix.recipe }}
 
-      # The lane's evidence record, .packaging-evidence/<lane>.json, is what
-      # `just release-preflight` accepts from this run (#313): a green
-      # conclusion alone is not evidence, since a path-filtered run skips
-      # every lane and still concludes "success". Missing means the lane
-      # never recorded, which fails the job rather than passing silently.
+      # See the Debian lane's upload step.
       - name: Upload packaging evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: packaging-evidence-rpm-${{ matrix.release }}
           path: .packaging-evidence/
           if-no-files-found: error
+          overwrite: true
 
   arch:
     name: Arch Package From dist/PKGBUILD
@@ -232,17 +230,14 @@ jobs:
       - name: Run the Arch package gate
         run: just test-arch-pkg
 
-      # The lane's evidence record, .packaging-evidence/<lane>.json, is what
-      # `just release-preflight` accepts from this run (#313): a green
-      # conclusion alone is not evidence, since a path-filtered run skips
-      # every lane and still concludes "success". Missing means the lane
-      # never recorded, which fails the job rather than passing silently.
+      # See the Debian lane's upload step.
       - name: Upload packaging evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: packaging-evidence-arch
           path: .packaging-evidence/
           if-no-files-found: error
+          overwrite: true
 
   release-matrix:
     name: Release Version Ordering Matrix

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -87,6 +87,18 @@ jobs:
       - name: Run the ${{ matrix.suite }} package gate
         run: just ${{ matrix.recipe }}
 
+      # The lane's evidence record, .packaging-evidence/<lane>.json, is what
+      # `just release-preflight` accepts from this run (#313): a green
+      # conclusion alone is not evidence, since a path-filtered run skips
+      # every lane and still concludes "success". Missing means the lane
+      # never recorded, which fails the job rather than passing silently.
+      - name: Upload packaging evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packaging-evidence-deb-${{ matrix.suite }}
+          path: .packaging-evidence/
+          if-no-files-found: error
+
   # The Fedora lanes stage host-built binaries into the image rather than
   # compiling in it, and `just build-release` cannot run on the runner: its TPM
   # build needs tss2 4.1.3+, and Ubuntu 24.04 ships 4.0.1. Build them once in
@@ -185,6 +197,18 @@ jobs:
       - name: Run the Fedora ${{ matrix.release }} gate
         run: just ${{ matrix.recipe }}
 
+      # The lane's evidence record, .packaging-evidence/<lane>.json, is what
+      # `just release-preflight` accepts from this run (#313): a green
+      # conclusion alone is not evidence, since a path-filtered run skips
+      # every lane and still concludes "success". Missing means the lane
+      # never recorded, which fails the job rather than passing silently.
+      - name: Upload packaging evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packaging-evidence-rpm-${{ matrix.release }}
+          path: .packaging-evidence/
+          if-no-files-found: error
+
   arch:
     name: Arch Package From dist/PKGBUILD
     runs-on: ubuntu-latest
@@ -207,6 +231,18 @@ jobs:
       # workspace twice inside the container, which is why it is the slow one.
       - name: Run the Arch package gate
         run: just test-arch-pkg
+
+      # The lane's evidence record, .packaging-evidence/<lane>.json, is what
+      # `just release-preflight` accepts from this run (#313): a green
+      # conclusion alone is not evidence, since a path-filtered run skips
+      # every lane and still concludes "success". Missing means the lane
+      # never recorded, which fails the job rather than passing silently.
+      - name: Upload packaging evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packaging-evidence-arch
+          path: .packaging-evidence/
+          if-no-files-found: error
 
   release-matrix:
     name: Release Version Ordering Matrix

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/superpowers/
 /.hardware-tiers-verified
 /.packaging-matrix-verified
 /.packaging-evidence/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dev/*.db
 docs/superpowers/
 /.hardware-tiers-verified
 /.packaging-matrix-verified
+/.packaging-evidence/

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2171,8 +2171,9 @@ Lane claims use a fixed vocabulary. `channel`: `apt`, `direct-rpm`, `aur`
 assembler and `.dsc` rebuild), `host-binaries` (release binaries staged from
 `target/release`), `makepkg-source-build` (#230 adds `mock-source-rebuild`).
 `runtime_policy`: `bundled-ort`, `system-ort`. `depth`: `full`, `smoke`.
-`status`: `pass`; `partial` for an exit 0 with a skip or without models;
-`fail`. The counters are assertion counts by class, and `skip` equals
+`status`: `pass`; `partial` for an exit 0 with an allowed skip or without
+models; `fail` for a non-zero exit, a failed assertion, or a mandatory skip.
+The counters are assertion counts by class, and `skip` equals
 `allowed_skip` (the `FACELOCK_ALLOW_MISSING_MODELS=1` opt-out) plus
 `mandatory_skip`. `models_present` says whether the ONNX models were on hand
 for every assertion that needs them; a lane with no such assertion
@@ -2187,8 +2188,9 @@ is false (Rawhide) contributes nothing.
 
 The marker is refused, and the aggregate refuses to write it, unless all of
 the following hold: `schema` is 1; `commit` equals HEAD; `tree_clean` is true;
-`started_at` and `finished_at` are present; `required_lanes` equals the
-derived set; every required lane has exactly one record; and every record
+`started_at` and `finished_at` are ISO 8601 timestamps with an offset, in
+order; `required_lanes` equals the derived set; every required lane has
+exactly one record and no record names a lane outside that set; and every record
 names HEAD, has `models_present` true, has `fail`, `skip`, `allowed_skip` and
 `mandatory_skip` all 0, has `pass` of at least 1, has `status` `pass`, and
 carries the target, channel, build origin, runtime policy and depth the matrix
@@ -2201,7 +2203,11 @@ format. Preflight reads evidence from two places, in order: the
 uploaded (`packaging-evidence-deb-<suite>`, `packaging-evidence-rpm-<release>`
 and `packaging-evidence-arch`, fetched with `gh run download` and aggregated
 the same way), then the local marker. A run without those artifacts is not
-evidence, whatever its conclusion.
+evidence, whatever its conclusion; neither is a pull-request run, which builds
+the merge commit, nor a run of any other workflow. The marker and the
+artifacts are maintainer-trust records: preflight checks their shape and their
+binding to HEAD and the matrix, not that a real lane produced them. A forged
+record is a deliberate act, not the slip this gate exists to catch.
 
 ### Debian source and binary package contract
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2189,9 +2189,10 @@ is false (Rawhide) contributes nothing.
 The marker is refused, and the aggregate refuses to write it, unless all of
 the following hold: `schema` is 1; `commit` equals HEAD; `tree_clean` is true;
 `started_at` and `finished_at` are ISO 8601 timestamps with an offset, in
-order; `required_lanes` equals the derived set; every required lane has
-exactly one record and no record names a lane outside that set; and every record
-names HEAD, has `models_present` true, has `fail`, `skip`, `allowed_skip` and
+order; `required_lanes` equals the derived list exactly (sorted, no
+duplicates); every required lane has exactly one record and no record names a
+lane outside that set; and every record carries `schema` 1, names HEAD, has
+`models_present` true, has `fail`, `skip`, `allowed_skip` and
 `mandatory_skip` all 0, has `pass` of at least 1, has `status` `pass`, and
 carries the target, channel, build origin, runtime policy and depth the matrix
 requires of that lane. A partial run therefore never produces release

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2145,6 +2145,64 @@ consumes exactly two suite manifests, one matching package per suite, and a
 prerelease or cross-suite version is rejected before signing or repository
 writes.
 
+### Packaging matrix evidence
+
+`just release-preflight` accepts packaging evidence only in the form
+`test/packaging-evidence.py` validates (#313). Each packaging lane writes one
+record, `.packaging-evidence/<lane>.json`, from the `RESULTS_JSON:` line its
+validator prints. `just test-packaging-matrix` deletes the previous marker and
+every record before its first lane, then folds the records into
+`.packaging-matrix-verified`:
+
+```json
+{"schema": 1, "commit": "<40-hex sha>", "tree_clean": true,
+ "started_at": "<ISO 8601 UTC>", "finished_at": "<ISO 8601 UTC>",
+ "required_lanes": ["test-arch-pkg", "test-deb-resolute-pkg", "test-deb-trixie-pkg",
+                    "test-rpm-pkg-43", "test-rpm-pkg-44", "test-rpm-smoke-45"],
+ "lanes": [{"name": "test-deb-trixie-pkg", "target": "debian-trixie", "channel": "apt",
+            "build_origin": "container-source-build", "runtime_policy": "bundled-ort",
+            "depth": "full", "commit": "<sha>", "models_present": true,
+            "pass": 40, "fail": 0, "skip": 0, "allowed_skip": 0, "mandatory_skip": 0,
+            "status": "pass"}]}
+```
+
+Lane claims use a fixed vocabulary. `channel`: `apt`, `direct-rpm`, `aur`
+(#230 adds `copr`). `build_origin`: `container-source-build` (the Debian
+assembler and `.dsc` rebuild), `host-binaries` (release binaries staged from
+`target/release`), `makepkg-source-build` (#230 adds `mock-source-rebuild`).
+`runtime_policy`: `bundled-ort`, `system-ort`. `depth`: `full`, `smoke`.
+`status`: `pass`; `partial` for an exit 0 with a skip or without models;
+`fail`. The counters are assertion counts by class, and `skip` equals
+`allowed_skip` (the `FACELOCK_ALLOW_MISSING_MODELS=1` opt-out) plus
+`mandatory_skip`. `models_present` says whether the ONNX models were on hand
+for every assertion that needs them; a lane with no such assertion
+(`test-rpm-smoke-45`, `test-arch-pkg`) reports `true` because nothing was
+withheld.
+
+`required_lanes` derives from `dist/release-matrix.json`: one Debian lane per
+APT suite whose platform row is a non-optional release target, the Arch recipe
+lane, and one direct-RPM lane per `fedora.packit_release_targets` entry at the
+depth its platform rows declare. A row whose `evidence_eligibility.lifecycle`
+is false (Rawhide) contributes nothing.
+
+The marker is refused, and the aggregate refuses to write it, unless all of
+the following hold: `schema` is 1; `commit` equals HEAD; `tree_clean` is true;
+`started_at` and `finished_at` are present; `required_lanes` equals the
+derived set; every required lane has exactly one record; and every record
+names HEAD, has `models_present` true, has `fail`, `skip`, `allowed_skip` and
+`mandatory_skip` all 0, has `pass` of at least 1, has `status` `pass`, and
+carries the target, channel, build origin, runtime policy and depth the matrix
+requires of that lane. A partial run therefore never produces release
+evidence, and a record from one channel cannot stand in for another's lane.
+
+The legacy one-line commit marker is refused with a message naming this
+format. Preflight reads evidence from two places, in order: the
+`packaging-evidence-*` artifacts a successful `packaging.yml` run at HEAD
+uploaded (`packaging-evidence-deb-<suite>`, `packaging-evidence-rpm-<release>`
+and `packaging-evidence-arch`, fetched with `gh run download` and aggregated
+the same way), then the local marker. A run without those artifacts is not
+evidence, whatever its conclusion.
+
 ### Debian source and binary package contract
 
 Trixie package builds use the official Trixie Backports `cargo` and `rustc`;

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2203,7 +2203,10 @@ format. Preflight reads evidence from two places, in order: the
 `packaging-evidence-*` artifacts a successful `packaging.yml` run at HEAD
 uploaded (`packaging-evidence-deb-<suite>`, `packaging-evidence-rpm-<release>`
 and `packaging-evidence-arch`, fetched with `gh run download` and aggregated
-the same way), then the local marker. A run without those artifacts is not
+the same way), then the local marker. `.packaging-evidence/` is dot-prefixed,
+so every upload step sets `include-hidden-files: true`; without it
+`actions/upload-artifact` finds no files and `if-no-files-found: error` fails
+the job. A run without those artifacts is not
 evidence, whatever its conclusion; neither is a pull-request run, which builds
 the merge commit, nor a run of any other workflow. The marker and the
 artifacts are maintainer-trust records: preflight checks their shape and their

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -346,8 +346,8 @@ successful `packaging.yml` run at that exact commit uploaded, fetched with
 green conclusion alone is not evidence: a path-filtered pull-request run skips
 every lane and still concludes "success". A pull-request run cannot satisfy it
 either: it builds the merge commit, not the commit being released. A
-`FACELOCK_ALLOW_MISSING_MODELS=1`
-run is a diagnostic and never records. The one-line commit marker from before
+`FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic: it writes its `partial`
+lane records, and the marker is withheld. The one-line commit marker from before
 0.2.0 is refused with a message naming the new format. A nightly run does not
 satisfy it either: nightly builds whatever `main` was at 07:00 UTC, and a
 release commit is a version bump nobody has built a package from yet.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -334,11 +334,20 @@ assertions rotted undetected as a result (#139). If they were already run by
 hand at this exact commit, acknowledge that by naming it:
 `FACELOCK_HARDWARE_TIERS_ACK=<sha> just release-preflight`.
 
-Preflight also refuses to pass without a packaging matrix result for HEAD. It
-accepts a successful `packaging.yml` run at that exact commit (looked up with
-`gh`), or the record `just test-packaging-matrix` writes to
-`.packaging-matrix-verified` after running every lane locally. A nightly run
-does not satisfy it: nightly builds whatever `main` was at 07:00 UTC, and a
+Preflight also refuses to pass without complete packaging evidence for HEAD.
+Every packaging lane writes a record of what it claimed and what it counted,
+and `test/packaging-evidence.py` accepts the set only when every lane the
+release matrix requires is present at this commit with zero skips and the ONNX
+models on hand (the contract is in `docs/contracts.md`, "Packaging matrix
+evidence"). Preflight reads it from the `packaging-evidence-*` artifacts a
+successful `packaging.yml` run at that exact commit uploaded, fetched with
+`gh run download`, or from `.packaging-matrix-verified`, which
+`just test-packaging-matrix` writes after running every lane locally. A run's
+green conclusion alone is not evidence: a path-filtered pull-request run skips
+every lane and still concludes "success". A `FACELOCK_ALLOW_MISSING_MODELS=1`
+run is a diagnostic and never records. The one-line commit marker from before
+0.2.0 is refused with a message naming the new format. A nightly run does not
+satisfy it either: nightly builds whatever `main` was at 07:00 UTC, and a
 release commit is a version bump nobody has built a package from yet.
 
 `just release-preflight` checks local tools, required packaging files (including

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -344,7 +344,9 @@ successful `packaging.yml` run at that exact commit uploaded, fetched with
 `gh run download`, or from `.packaging-matrix-verified`, which
 `just test-packaging-matrix` writes after running every lane locally. A run's
 green conclusion alone is not evidence: a path-filtered pull-request run skips
-every lane and still concludes "success". A `FACELOCK_ALLOW_MISSING_MODELS=1`
+every lane and still concludes "success". A pull-request run cannot satisfy it
+either: it builds the merge commit, not the commit being released. A
+`FACELOCK_ALLOW_MISSING_MODELS=1`
 run is a diagnostic and never records. The one-line commit marker from before
 0.2.0 is refused with a message naming the new format. A nightly run does not
 satisfy it either: nightly builds whatever `main` was at 07:00 UTC, and a

--- a/justfile
+++ b/justfile
@@ -452,7 +452,9 @@ _require-models allow_opt_out="0": (_link-models "auto")
     if [ "{{ allow_opt_out }}" = "1" ] && [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = "1" ]; then
         echo "warning: missing ONNX models, continuing (FACELOCK_ALLOW_MISSING_MODELS=1):" >&2
         for m in "${missing[@]}"; do echo "           $m" >&2; done
-        echo "         The daemon-start assertions will be reported as SKIPPED, not passed." >&2
+        echo "         The daemon-start assertions will be reported as SKIPPED, not passed," >&2
+        echo "         and the run cannot produce release evidence: its lane record is" >&2
+        echo "         refused by 'just test-packaging-matrix' and 'just release-preflight'." >&2
         exit 0
     fi
     echo "error: missing required ONNX models — this test tier needs them baked into the image:" >&2
@@ -465,7 +467,8 @@ _require-models allow_opt_out="0": (_link-models "auto")
     echo "       be committed by accident.)" >&2
     if [ "{{ allow_opt_out }}" = "1" ]; then
         echo "       To validate packaging only, with the daemon-start assertions counted" >&2
-        echo "       as skipped: FACELOCK_ALLOW_MISSING_MODELS=1 just <recipe>" >&2
+        echo "       as skipped (a diagnostic run, never release evidence):" >&2
+        echo "         FACELOCK_ALLOW_MISSING_MODELS=1 just <recipe>" >&2
     fi
     exit 1
 
@@ -605,7 +608,14 @@ test-arch-pkg:
     image="facelock-arch-pkg-$(basename "$staging" | cut -d. -f2 | tr '[:upper:]' '[:lower:]')"
     trap 'rm -rf -- "$staging"; podman rmi -f "$image" >/dev/null 2>&1 || true' EXIT
     test/build-arch-package-image.sh "$image" "$staging"
-    podman run --rm -v "$staging/source:/staged-source:ro,Z" "$image"
+    lane_status=0
+    podman run --rm -v "$staging/source:/staged-source:ro,Z" "$image" | tee "$staging/lane.log" || lane_status=$?
+    # The lane's packaging-evidence record, from the validator's RESULTS_JSON
+    # line; see the Debian suite gates for what the claims mean.
+    python3 test/packaging-evidence.py record \
+        --lane 'test-arch-pkg target=arch channel=aur build_origin=makepkg-source-build runtime_policy=system-ort depth=full' \
+        --results-log "$staging/lane.log" --exit-status "$lane_status"
+    exit "$lane_status"
 
 # Build release and install to system
 
@@ -1132,6 +1142,12 @@ test-deb: test-deb-trixie-pkg test-deb-resolute-pkg
 # Needs models/*.onnx: the validation starts the daemon under the hardened unit
 # and checks what it holds at runtime. FACELOCK_ALLOW_MISSING_MODELS=1 runs the
 # packaging half only, with the rest counted as skipped.
+#
+# PACKAGING_LANE names the lane and what it claims -- target, channel, how the
+# package was built, whose ONNX Runtime it ships, and its lifecycle depth -- and
+# the runner writes .packaging-evidence/<lane>.json from the validator's counts.
+# test/packaging-evidence.py derives what each lane must claim from
+# dist/release-matrix.json, so a claim that drifts from the matrix is refused.
 
 # Debian 13 Trixie package — exact source build, TPM/PCR, and booted lifecycle.
 test-deb-trixie-pkg: (_require-models "1")
@@ -1144,7 +1160,8 @@ test-deb-trixie-pkg: (_require-models "1")
     podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
         facelock-deb-trixie-pkg \
         /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
-    test/run-pkg-validate-systemd.sh facelock-deb-trixie-pkg "$package"
+    PACKAGING_LANE='test-deb-trixie-pkg target=debian-trixie channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=full' \
+        test/run-pkg-validate-systemd.sh facelock-deb-trixie-pkg "$package"
 
 # Ubuntu 26.04 Resolute package — exact source build, TPM/PCR, and booted lifecycle.
 test-deb-resolute-pkg: (_require-models "1")
@@ -1157,7 +1174,8 @@ test-deb-resolute-pkg: (_require-models "1")
     podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
         facelock-deb-resolute-pkg \
         /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
-    test/run-pkg-validate-systemd.sh facelock-deb-resolute-pkg "$package"
+    PACKAGING_LANE='test-deb-resolute-pkg target=ubuntu-resolute channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=full' \
+        test/run-pkg-validate-systemd.sh facelock-deb-resolute-pkg "$package"
 
 # Same model requirement (and same opt-out) as the two Debian suite package gates.
 
@@ -1168,7 +1186,8 @@ test-rpm-pkg release="44": (_fedora-lane-image release) (_require-models "1") _r
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
     podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
         -t facelock-rpm-pkg-f{{ release }} -f test/Containerfile.rpm-e2e .
-    test/run-pkg-validate-systemd.sh facelock-rpm-pkg-f{{ release }}
+    PACKAGING_LANE='test-rpm-pkg-{{ release }} target=fedora-{{ release }} channel=direct-rpm build_origin=host-binaries runtime_policy=bundled-ort depth=full' \
+        test/run-pkg-validate-systemd.sh facelock-rpm-pkg-f{{ release }}
 
 # dist/release-matrix.json gives Fedora 45 a lifecycle depth of build/runtime
 # smoke, so this deliberately stops short of the full lifecycle gate and never
@@ -1181,7 +1200,8 @@ test-rpm-smoke release="45": (_fedora-lane-image release) _require-release-binar
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
     podman build --build-arg "BASE_IMAGE=$image" --build-arg ORT_VERSION={{ _ort-version }} \
         -t facelock-rpm-smoke-f{{ release }} -f test/Containerfile.rpm-e2e .
-    bash test/run-rpm-smoke-systemd.sh facelock-rpm-smoke-f{{ release }}
+    PACKAGING_LANE='test-rpm-smoke-{{ release }} target=fedora-{{ release }} channel=direct-rpm build_origin=host-binaries runtime_policy=bundled-ort depth=smoke' \
+        bash test/run-rpm-smoke-systemd.sh facelock-rpm-smoke-f{{ release }}
 
 # Full lifecycle for 43 and 44, build plus runtime smoke for branched 45.
 
@@ -1521,28 +1541,32 @@ release-preflight tag='':
     # package built from it. The nightly matrix does not close that either: it
     # runs against whatever main was at 07:00 UTC, not against this commit.
     # A tag ships to four channels; this is the last place to find out.
-    PACKAGING_RUN=""
+    #
+    # #313: a run's green conclusion is not the evidence; the lane records its
+    # jobs upload are. A path-filtered run skips every lane and still concludes
+    # "success", and a local FACELOCK_ALLOW_MISSING_MODELS=1 run used to write
+    # the same one-line marker as a complete one. test/packaging-evidence.py
+    # aggregates the workflow artifacts, or reads .packaging-matrix-verified,
+    # and refuses anything short of every required lane at HEAD with zero skips.
+    PACKAGING_EVIDENCE=""
     if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-        PACKAGING_RUN="$(gh run list --workflow packaging.yml --commit "$HEAD_SHA" \
-            --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+        for run_id in $(gh run list --workflow packaging.yml --commit "$HEAD_SHA" \
+                --status success --limit 5 --json databaseId --jq '.[].databaseId' 2>/dev/null || true); do
+            if python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"; then
+                PACKAGING_EVIDENCE="workflow run $run_id"
+                break
+            fi
+        done
     fi
-    PACKAGING_RECORDED=""
-    if [ -f .packaging-matrix-verified ]; then
-        PACKAGING_RECORDED="$(head -1 .packaging-matrix-verified)"
-    fi
-    if [ -n "$PACKAGING_RUN" ]; then
-        echo "OK: packaging workflow run $PACKAGING_RUN succeeded at $HEAD_SHA"
-    elif [ "$PACKAGING_RECORDED" = "$HEAD_SHA" ]; then
-        echo "OK: packaging matrix recorded green at $HEAD_SHA"
+    if [ -n "$PACKAGING_EVIDENCE" ]; then
+        echo "OK: packaging $PACKAGING_EVIDENCE carries complete lane evidence at $HEAD_SHA"
+    elif python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified; then
+        echo "OK: packaging matrix evidence recorded at $HEAD_SHA"
     else
-        if [ -z "$PACKAGING_RECORDED" ]; then
-            echo "MISSING: no packaging matrix result for $HEAD_SHA"
-        else
-            echo "STALE: packaging matrix recorded at $PACKAGING_RECORDED, HEAD is $HEAD_SHA"
-        fi
+        echo "MISSING: no complete packaging evidence for $HEAD_SHA (reasons above)"
         echo "  Run the matrix in CI against this commit, then re-run preflight:"
         echo "    gh workflow run packaging.yml --ref $(git rev-parse --abbrev-ref HEAD)"
-        echo "  Or run every lane locally (30-60+ minutes, needs podman):"
+        echo "  Or run every lane locally (30-60+ minutes, needs podman and the ONNX models):"
         echo "    just test-packaging-matrix"
         failed=1
     fi
@@ -1571,16 +1595,32 @@ test-release-native-ordering:
 # Complete Track V version/matrix gate.
 test-release-matrix: test-release-contract test-release-native-ordering
 
+# A marker that outlives the run that wrote it is the failure this guards
+# against: the previous marker and every lane record go before the first lane
+# starts, so an interrupted or failed run leaves nothing preflight accepts.
+_packaging-evidence-reset:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -rf -- .packaging-matrix-verified .packaging-evidence
+    mkdir -p .packaging-evidence
+    date -u +%Y-%m-%dT%H:%M:%SZ > .packaging-evidence/started-at
+
 # The same lanes `.github/workflows/packaging.yml` runs, in one command, for a
 # maintainer without CI in reach (#229). It is 30-60+ minutes and needs podman
 # plus the ONNX models; CI is the faster path, and `just release-preflight`
-# accepts a green run of that workflow at HEAD instead of this record.
+# accepts a green run of that workflow at HEAD through the evidence artifacts
+# its lanes upload, validated the same way as this record.
 #
 # Clean tree first, for the same reason the camera tiers demand one: a record
 # that names a commit the lanes did not actually build is worse than no record.
+# Each lane writes .packaging-evidence/<lane>.json; the marker is those records
+# folded together by test/packaging-evidence.py, which refuses to write one
+# when any lane skipped anything, ran without the ONNX models, names another
+# commit, or is missing (#313). A FACELOCK_ALLOW_MISSING_MODELS=1 run therefore
+# never records.
 
 # Every packaging lane the release gate requires, recorded for release-preflight
-test-packaging-matrix: _require-clean-tree test-release-matrix test-arch-pkg test-deb test-rpm-lanes
+test-packaging-matrix: _require-clean-tree _packaging-evidence-reset test-release-matrix test-arch-pkg test-deb test-rpm-lanes
     #!/usr/bin/env bash
     set -euo pipefail
     commit="$(git rev-parse HEAD)"
@@ -1588,7 +1628,9 @@ test-packaging-matrix: _require-clean-tree test-release-matrix test-arch-pkg tes
         echo "error: the tree changed while the lanes ran; not recording." >&2
         exit 1
     fi
-    printf '%s\n' "$commit" > .packaging-matrix-verified
+    python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean \
+        --started-at "$(cat .packaging-evidence/started-at)" \
+        --evidence-dir .packaging-evidence --output .packaging-matrix-verified
     echo ""
-    echo "Recorded: packaging matrix passed at $commit"
+    echo "Recorded: packaging matrix evidence at $commit"
     echo "'just release-preflight' accepts this until HEAD moves."

--- a/test/arch-package-e2e-validate.sh
+++ b/test/arch-package-e2e-validate.sh
@@ -184,4 +184,4 @@ echo "=== Arch package results: $PASS passed, $FAIL failed ==="
 # last and nothing may be added after it.
 echo ""
 echo "=== libalpm hook and PAM cleanup on removal ==="
-exec /arch-package-validate.sh
+ARCH_E2E_PASS=$PASS exec /arch-package-validate.sh

--- a/test/arch-package-validate.sh
+++ b/test/arch-package-validate.sh
@@ -66,4 +66,9 @@ rm -f "$owned" /tmp/facelock-package-owned.sha \
 
 echo ""
 echo "=== Arch package results: $PASS passed, $FAIL failed ==="
+# For test/packaging-evidence.py: both halves in one line. The e2e half hands
+# its count over in ARCH_E2E_PASS before exec'ing this one, and neither needs
+# the ONNX models, so none was withheld for lack of them.
+printf 'RESULTS_JSON: {"pass":%d,"fail":%d,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n' \
+    "$((PASS + ${ARCH_E2E_PASS:-0}))" "$FAIL"
 test "$FAIL" -eq 0

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -702,6 +702,30 @@ require(
     f"packaging workflow Debian lanes {sorted(workflow_deb_lanes)} are not the "
     f"declared APT suites {sorted(expected_suites)}",
 )
+# #313: a green packaging.yml conclusion is not release evidence; the lane
+# records its jobs upload are. Every lane job uploads them and fails when its
+# lane recorded nothing, or `just release-preflight` has nothing to validate
+# and quietly falls back to the local marker.
+for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch"):
+    require(
+        f"name: packaging-evidence-{artifact}" in packaging_workflow,
+        f"packaging workflow does not upload the packaging-evidence-{artifact} artifact",
+    )
+require(
+    packaging_workflow.count("path: .packaging-evidence/") == 3
+    and packaging_workflow.count("if-no-files-found: error") == 3,
+    "packaging workflow evidence uploads must fail the job when a lane recorded nothing",
+)
+require(
+    'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in justfile
+    and 'python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified' in justfile,
+    "release-preflight does not validate packaging evidence through test/packaging-evidence.py",
+)
+require(
+    'python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean' in justfile
+    and re.search(r"(?m)^\s+printf '%s\\n' \"\$commit\" > \.packaging-matrix-verified", justfile) is None,
+    "test-packaging-matrix must aggregate lane evidence, never write the commit alone",
+)
 require(
     "rawhide" not in packaging_workflow.lower(),
     "packaging workflow declares a Rawhide lane; Rawhide is experimental and never a gate",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -719,12 +719,15 @@ for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch")
         f"name: packaging-evidence-{artifact}" in packaging_workflow,
         f"packaging workflow does not upload the packaging-evidence-{artifact} artifact",
     )
+# One upload step per lane job: deb, rpm, arch. The two matrix jobs run the
+# same step once per entry, so the step count stays three. A new lane job (the
+# copr job #230 adds) brings its own upload step and bumps this count.
+EVIDENCE_UPLOAD_STEPS = 3
 require(
-    # One upload step per lane job: deb, rpm, arch. The two matrix jobs run the
-    # same step once per entry, so the step count stays three.
-    packaging_workflow.count("path: .packaging-evidence/") == 3
-    and packaging_workflow.count("if-no-files-found: error") == 3,
-    "packaging workflow evidence uploads must fail the job when a lane recorded nothing",
+    packaging_workflow.count("path: .packaging-evidence/") == EVIDENCE_UPLOAD_STEPS
+    and packaging_workflow.count("if-no-files-found: error") == EVIDENCE_UPLOAD_STEPS,
+    f"packaging workflow must carry exactly {EVIDENCE_UPLOAD_STEPS} evidence upload steps, each failing "
+    "the job when its lane recorded nothing; a new lane job adds one and bumps the count",
 )
 require(
     'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in justfile

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -777,6 +777,12 @@ for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch")
         re.search(r"(?m)^\s+if-no-files-found: error\s*$", matching[0]) is not None,
         f"the packaging-evidence-{artifact} upload must fail the job when its lane recorded nothing",
     )
+    # .packaging-evidence/ is dot-prefixed; upload-artifact skips hidden paths
+    # unless told otherwise, and then "no files" fails the job.
+    require(
+        re.search(r"(?m)^\s+include-hidden-files: true\s*$", matching[0]) is not None,
+        f"the packaging-evidence-{artifact} upload must set include-hidden-files: true for the dot-prefixed directory",
+    )
 preflight_body = just_recipe_body(justfile, "release-preflight")
 require(
     'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in preflight_body

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -778,16 +778,26 @@ def recipe_commands(body: str) -> list[str]:
 
 
 def recipe_runs(commands: list[str], command: str) -> bool:
-    """Whether a recipe line starts with `command` as the thing it executes."""
-    return any(
-        line == command or line.startswith(command + " ") or line.startswith(command + ";")
-        for line in commands
-    )
+    """Whether a recipe line executes `command` and nothing else: only a
+    trailing line-continuation backslash, an inline `; then` closing an `if`
+    or `elif`, or trailing whitespace may follow it. A shell operator after
+    the command (`||`, `&&`, `|`, or `;` before anything but `then`) does not
+    count as running it."""
+    for line in commands:
+        if not line.startswith(command):
+            continue
+        rest = line[len(command) :]
+        if re.fullmatch(r"\s*\\?", rest) or re.fullmatch(r";\s+then\s*", rest):
+            return True
+    return False
 
 
 # A write into the marker by anything but the evidence script: `> file`,
-# `>> file`, or `tee file`.
-MARKER_WRITE = re.compile(r"""(?:>{1,2}\s*|\btee\s+(?:-[a-z]+\s+)*)["']?(?:\./)?\.packaging-matrix-verified\b""")
+# `>> file`, or `tee file` (short options like `-a` or long ones like
+# `--append`, optionally `=value`-bearing, ahead of the path).
+MARKER_WRITE = re.compile(
+    r"""(?:>{1,2}\s*|\btee\s+(?:(?:-[a-z]+|--[a-z][a-z-]*(?:=\S+)?)\s+)*)["']?(?:\./)?\.packaging-matrix-verified\b"""
+)
 
 
 evidence_uploads = [

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -714,8 +714,9 @@ require(
 # records its jobs upload are. Every lane job uploads them and fails when its
 # lane recorded nothing, or `just release-preflight` has nothing to validate
 # and quietly falls back to the local marker. The checks read the upload steps
-# themselves and the recipe bodies, comments dropped, so text that survives
-# only in a comment or an unrelated step satisfies nothing.
+# themselves and the executable lines of the recipe bodies, full-line and
+# trailing comments dropped, so text that survives only in a comment or an
+# unrelated step satisfies nothing.
 
 
 def workflow_steps(workflow: str) -> list[str]:
@@ -740,12 +741,53 @@ def workflow_steps(workflow: str) -> list[str]:
 
 
 def just_recipe_body(source: str, name: str) -> str:
-    """The indented body of one justfile recipe, comment lines removed."""
+    """The indented body of one justfile recipe."""
     match = re.search(
         rf"(?m)^{re.escape(name)}(?=[\s:])[^\n]*:[^\n]*\n(?P<body>(?:[ \t]+[^\n]*\n|\n)*)", source
     )
     require(match is not None, f"justfile omits recipe {name}")
-    return "\n".join(line for line in match.group("body").splitlines() if not line.lstrip().startswith("#"))
+    return match.group("body")
+
+
+def shell_command_text(line: str) -> str:
+    """One recipe line with its trailing `#` comment removed, quotes respected."""
+    quote = None
+    for index, char in enumerate(line):
+        if quote:
+            if char == quote:
+                quote = None
+        elif char in ("'", '"'):
+            quote = char
+        elif char == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
+
+
+def recipe_commands(body: str) -> list[str]:
+    """The executable lines of a recipe body, each stripped of leading
+    whitespace, a `@`/`-` recipe prefix, and a leading shell keyword."""
+    commands: list[str] = []
+    for line in body.splitlines():
+        executable = shell_command_text(line).strip()
+        if not executable:
+            continue
+        executable = re.sub(r"^[@-]\s*", "", executable)
+        executable = re.sub(r"^(?:if|elif|while|until)\s+", "", executable)
+        commands.append(executable)
+    return commands
+
+
+def recipe_runs(commands: list[str], command: str) -> bool:
+    """Whether a recipe line starts with `command` as the thing it executes."""
+    return any(
+        line == command or line.startswith(command + " ") or line.startswith(command + ";")
+        for line in commands
+    )
+
+
+# A write into the marker by anything but the evidence script: `> file`,
+# `>> file`, or `tee file`.
+MARKER_WRITE = re.compile(r"""(?:>{1,2}\s*|\btee\s+(?:-[a-z]+\s+)*)["']?(?:\./)?\.packaging-matrix-verified\b""")
 
 
 evidence_uploads = [
@@ -783,19 +825,25 @@ for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch")
         re.search(r"(?m)^\s+include-hidden-files: true\s*$", matching[0]) is not None,
         f"the packaging-evidence-{artifact} upload must set include-hidden-files: true for the dot-prefixed directory",
     )
-preflight_body = just_recipe_body(justfile, "release-preflight")
+preflight_commands = recipe_commands(just_recipe_body(justfile, "release-preflight"))
 require(
-    'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in preflight_body
-    and 'python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified'
-    in preflight_body,
-    "release-preflight does not validate packaging evidence through test/packaging-evidence.py",
+    recipe_runs(preflight_commands, 'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"')
+    and recipe_runs(
+        preflight_commands,
+        'python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified',
+    ),
+    "release-preflight does not run test/packaging-evidence.py ci-run and validate as its own commands",
 )
-matrix_body = just_recipe_body(justfile, "test-packaging-matrix")
+matrix_commands = recipe_commands(just_recipe_body(justfile, "test-packaging-matrix"))
 require(
-    'python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean' in matrix_body
-    and re.search(r"(?m)^\s+printf '%s\\n' \"\$commit\" > \.packaging-matrix-verified", matrix_body) is None,
-    "test-packaging-matrix must aggregate lane evidence, never write the commit alone",
+    recipe_runs(matrix_commands, 'python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean'),
+    "test-packaging-matrix does not run test/packaging-evidence.py aggregate as its own command",
 )
+for command in matrix_commands + preflight_commands:
+    require(
+        "test/packaging-evidence.py" in command or MARKER_WRITE.search(command) is None,
+        f"only test/packaging-evidence.py may write .packaging-matrix-verified: {command!r}",
+    )
 require(
     "rawhide" not in packaging_workflow.lower(),
     "packaging workflow declares a Rawhide lane; Rawhide is experimental and never a gate",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -244,6 +244,14 @@ require(
     rawhide.get("promotion_requires") == "separately reviewed amendment and full Fedora gates",
     "Rawhide promotion contract drifted",
 )
+# Only Rawhide may carry evidence_eligibility: test/packaging-evidence.py drops
+# a row whose lifecycle eligibility is false from the required lane set, so the
+# key on any other row would quietly shrink the release gate.
+for row in matrix.get("platforms", []):
+    require(
+        row.get("id") == "fedora-rawhide" or "evidence_eligibility" not in row,
+        f"{row.get('id')} declares evidence_eligibility; only the Rawhide row may",
+    )
 for suite, expected in expected_suite_contracts.items():
     details = suite_map[suite]
     for field, value in expected.items():
@@ -712,6 +720,8 @@ for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch")
         f"packaging workflow does not upload the packaging-evidence-{artifact} artifact",
     )
 require(
+    # One upload step per lane job: deb, rpm, arch. The two matrix jobs run the
+    # same step once per entry, so the step count stays three.
     packaging_workflow.count("path: .packaging-evidence/") == 3
     and packaging_workflow.count("if-no-files-found: error") == 3,
     "packaging workflow evidence uploads must fail the job when a lane recorded nothing",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -713,30 +713,81 @@ require(
 # #313: a green packaging.yml conclusion is not release evidence; the lane
 # records its jobs upload are. Every lane job uploads them and fails when its
 # lane recorded nothing, or `just release-preflight` has nothing to validate
-# and quietly falls back to the local marker.
-for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch"):
-    require(
-        f"name: packaging-evidence-{artifact}" in packaging_workflow,
-        f"packaging workflow does not upload the packaging-evidence-{artifact} artifact",
+# and quietly falls back to the local marker. The checks read the upload steps
+# themselves and the recipe bodies, comments dropped, so text that survives
+# only in a comment or an unrelated step satisfies nothing.
+
+
+def workflow_steps(workflow: str) -> list[str]:
+    """Each `- name:`/`- uses:` step of a workflow, comment lines removed."""
+    steps: list[list[str]] = []
+    current: list[str] | None = None
+    step_indent = 0
+    for line in workflow.splitlines():
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(stripped)
+        if re.match(r"- (?:name|uses): ", stripped):
+            current = [line]
+            step_indent = indent
+            steps.append(current)
+        elif current is not None and indent > step_indent:
+            current.append(line)
+        else:
+            current = None
+    return ["\n".join(step) for step in steps]
+
+
+def just_recipe_body(source: str, name: str) -> str:
+    """The indented body of one justfile recipe, comment lines removed."""
+    match = re.search(
+        rf"(?m)^{re.escape(name)}(?=[\s:])[^\n]*:[^\n]*\n(?P<body>(?:[ \t]+[^\n]*\n|\n)*)", source
     )
+    require(match is not None, f"justfile omits recipe {name}")
+    return "\n".join(line for line in match.group("body").splitlines() if not line.lstrip().startswith("#"))
+
+
+evidence_uploads = [
+    step
+    for step in workflow_steps(packaging_workflow)
+    if re.search(r"(?m)^\s+uses: actions/upload-artifact@", step)
+    and re.search(r"(?m)^\s+path: \.packaging-evidence/\s*$", step)
+]
 # One upload step per lane job: deb, rpm, arch. The two matrix jobs run the
 # same step once per entry, so the step count stays three. A new lane job (the
 # copr job #230 adds) brings its own upload step and bumps this count.
 EVIDENCE_UPLOAD_STEPS = 3
 require(
-    packaging_workflow.count("path: .packaging-evidence/") == EVIDENCE_UPLOAD_STEPS
-    and packaging_workflow.count("if-no-files-found: error") == EVIDENCE_UPLOAD_STEPS,
-    f"packaging workflow must carry exactly {EVIDENCE_UPLOAD_STEPS} evidence upload steps, each failing "
-    "the job when its lane recorded nothing; a new lane job adds one and bumps the count",
+    len(evidence_uploads) == EVIDENCE_UPLOAD_STEPS,
+    f"packaging workflow must carry exactly {EVIDENCE_UPLOAD_STEPS} evidence upload steps "
+    f"(found {len(evidence_uploads)}); a new lane job adds one and bumps the count",
 )
+for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch"):
+    matching = [
+        step
+        for step in evidence_uploads
+        if re.search(rf"(?m)^\s+name: packaging-evidence-{re.escape(artifact)}\s*$", step)
+    ]
+    require(
+        len(matching) == 1,
+        f"packaging workflow must upload the packaging-evidence-{artifact} artifact from exactly one step",
+    )
+    require(
+        re.search(r"(?m)^\s+if-no-files-found: error\s*$", matching[0]) is not None,
+        f"the packaging-evidence-{artifact} upload must fail the job when its lane recorded nothing",
+    )
+preflight_body = just_recipe_body(justfile, "release-preflight")
 require(
-    'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in justfile
-    and 'python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified' in justfile,
+    'python3 test/packaging-evidence.py ci-run --commit "$HEAD_SHA" --run "$run_id"' in preflight_body
+    and 'python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified'
+    in preflight_body,
     "release-preflight does not validate packaging evidence through test/packaging-evidence.py",
 )
+matrix_body = just_recipe_body(justfile, "test-packaging-matrix")
 require(
-    'python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean' in justfile
-    and re.search(r"(?m)^\s+printf '%s\\n' \"\$commit\" > \.packaging-matrix-verified", justfile) is None,
+    'python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean' in matrix_body
+    and re.search(r"(?m)^\s+printf '%s\\n' \"\$commit\" > \.packaging-matrix-verified", matrix_body) is None,
     "test-packaging-matrix must aggregate lane evidence, never write the commit alone",
 )
 require(

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -266,8 +266,9 @@ def check_record(record: dict, head: str, expected: dict[str, str] | None) -> li
     def problem(message: str) -> None:
         problems.append(f"lane {name}: {message}")
 
-    if record.get("schema") != SCHEMA:
-        problem(f"schema is {record.get('schema')!r}, not {SCHEMA}")
+    schema = record.get("schema")
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != SCHEMA:
+        problem(f"schema is {schema!r}, not {SCHEMA}")
     for field in ("name", "commit", "status", *LANE_FIELDS):
         if not isinstance(record.get(field), str) or not record[field]:
             problem(f"{field} is missing")
@@ -307,8 +308,9 @@ def check_marker(marker: object, head: str, matrix: dict) -> list[str]:
     if not isinstance(marker, dict):
         return ["the marker is not a JSON object"]
     problems: list[str] = []
-    if marker.get("schema") != SCHEMA:
-        problems.append(f"schema is {marker.get('schema')!r}, not {SCHEMA}")
+    schema = marker.get("schema")
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != SCHEMA:
+        problems.append(f"schema is {schema!r}, not {SCHEMA}")
     if marker.get("commit") != head:
         problems.append(f"commit {marker.get('commit')!r} is not HEAD {head}")
     if marker.get("tree_clean") is not True:

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Packaging matrix evidence: record a lane, aggregate the marker, validate it.
+
+`just release-preflight` used to accept `.packaging-matrix-verified` when its
+one line equalled HEAD. A `FACELOCK_ALLOW_MISSING_MODELS=1` run wrote that same
+line after skipping every daemon-start assertion, so the marker could not tell
+a diagnostic partial run from the release gate (#313). The marker is now a JSON
+document that names the commit, every lane the release matrix requires, and
+each lane's assertion counts by class, and it is refused unless every required
+lane is present with zero skips of either class and its models on hand.
+
+Three producers, one consumer:
+
+  record     a lane runner turns the validator's RESULTS_JSON line into
+             .packaging-evidence/<lane>.json, tagged with what the lane claims
+  aggregate  `just test-packaging-matrix` folds the records into the marker,
+             refusing to write one that would not validate
+  ci-run     `just release-preflight` downloads the evidence artifacts a
+             packaging.yml run uploaded and aggregates them the same way
+  validate   `just release-preflight` checks a marker against HEAD
+
+Standard library only: preflight runs wherever `python3` does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "dist" / "release-matrix.json"
+EVIDENCE_DIR = ROOT / ".packaging-evidence"
+MARKER_PATH = ROOT / ".packaging-matrix-verified"
+
+SCHEMA = 1
+LANE_FIELDS = ("target", "channel", "build_origin", "runtime_policy", "depth")
+COUNTERS = ("pass", "fail", "skip", "allowed_skip", "mandatory_skip")
+LANE_NAME = re.compile(r"[a-z][a-z0-9-]*")
+COMMIT_SHA = re.compile(r"[0-9a-f]{40}")
+RESULTS_PREFIX = "RESULTS_JSON: "
+# The matrix spells lifecycle depth out; records carry one token per lane.
+DEPTH_BY_LIFECYCLE = {"full": "full", "build/runtime smoke": "smoke"}
+
+
+class EvidenceError(Exception):
+    """A refusal, with the reasons the caller should print."""
+
+    def __init__(self, *problems: str) -> None:
+        super().__init__("; ".join(problems))
+        self.problems = list(problems)
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def head_commit() -> str:
+    return subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def load_matrix() -> dict:
+    try:
+        return json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise EvidenceError(f"cannot read the release matrix {MATRIX_PATH}: {error}") from error
+
+
+# --------------------------------------------------------------- required lanes
+
+
+def eligible(row: dict) -> bool:
+    """A platform row that can supply release evidence at all.
+
+    Rawhide is the row this excludes: optional, not a release target, and its
+    evidence_eligibility says lifecycle evidence is never accepted from it.
+    """
+    if row.get("release_target") is not True or row.get("optional") is True:
+        return False
+    return row.get("evidence_eligibility", {}).get("lifecycle", True) is not False
+
+
+def runtime_policy(runtime: str) -> str:
+    if runtime.startswith("bundled ORT"):
+        return "bundled-ort"
+    if runtime == "system ORT":
+        return "system-ort"
+    raise EvidenceError(f"release matrix runtime {runtime!r} maps to no runtime policy")
+
+
+def lane_depth(row: dict) -> str:
+    depth = row.get("lifecycle_depth")
+    if depth not in DEPTH_BY_LIFECYCLE:
+        raise EvidenceError(f"release matrix lifecycle depth {depth!r} maps to no lane depth")
+    return DEPTH_BY_LIFECYCLE[depth]
+
+
+def required_lanes(matrix: dict) -> dict[str, dict[str, str]]:
+    """The lanes the release gate requires, and what each must claim.
+
+    Derived from the release-target platform rows so a new target cannot be
+    declared without a lane to prove it. The Fedora lanes are one direct-RPM
+    lane per Packit release target at the depth its platform rows declare,
+    which is what `just test-rpm-lanes` runs today; #230 adds a COPR lane per
+    target beside it, with its own channel, build origin and runtime policy.
+    """
+    lanes: dict[str, dict[str, str]] = {}
+    rows = [row for row in matrix.get("platforms", []) if eligible(row)]
+    suite_by_platform = {
+        suite["platform_id"]: name for name, suite in matrix.get("apt_suites", {}).items()
+    }
+    for row in rows:
+        platform_id = row.get("id", "")
+        if row.get("channel") == "staged APT/direct deb":
+            suite = suite_by_platform.get(platform_id)
+            if suite is None:
+                raise EvidenceError(f"platform {platform_id} has no APT suite in the release matrix")
+            family = platform_id.split("-")[0]
+            lanes[f"test-deb-{suite}-pkg"] = {
+                "target": f"{family}-{suite}",
+                "channel": "apt",
+                "build_origin": "container-source-build",
+                "runtime_policy": runtime_policy(row.get("runtime", "")),
+                "depth": lane_depth(row),
+            }
+        elif row.get("variant") == "PKGBUILD and binary recipe":
+            lanes["test-arch-pkg"] = {
+                "target": "arch",
+                "channel": "aur",
+                "build_origin": "makepkg-source-build",
+                "runtime_policy": runtime_policy(row.get("runtime", "")),
+                "depth": lane_depth(row),
+            }
+        elif not row.get("platform", "").startswith("Fedora "):
+            raise EvidenceError(f"platform {platform_id} is a release target with no lane to prove it")
+    for target in matrix.get("fedora", {}).get("packit_release_targets", []):
+        release = target.split("-")[1]
+        depths = {
+            lane_depth(row)
+            for row in rows
+            if re.fullmatch(rf"Fedora {release}(?: .*)?", row.get("platform", ""))
+        }
+        if len(depths) != 1:
+            raise EvidenceError(
+                f"Fedora {release} platform rows declare {sorted(depths) or 'no'} lifecycle depth"
+            )
+        depth = depths.pop()
+        recipe = "test-rpm-pkg" if depth == "full" else "test-rpm-smoke"
+        lanes[f"{recipe}-{release}"] = {
+            "target": f"fedora-{release}",
+            "channel": "direct-rpm",
+            "build_origin": "host-binaries",
+            "runtime_policy": "bundled-ort",
+            "depth": depth,
+        }
+    return lanes
+
+
+# --------------------------------------------------------------------- records
+
+
+def parse_lane_spec(spec: str) -> tuple[str, dict[str, str]]:
+    """`<name> target=… channel=… build_origin=… runtime_policy=… depth=…`."""
+    parts = spec.split()
+    if not parts or not LANE_NAME.fullmatch(parts[0]):
+        raise EvidenceError(f"lane spec must start with a lane name: {spec!r}")
+    attrs: dict[str, str] = {}
+    for part in parts[1:]:
+        key, sep, value = part.partition("=")
+        if not sep or key not in LANE_FIELDS or not value:
+            raise EvidenceError(f"lane spec field {part!r} is not one of {', '.join(LANE_FIELDS)}")
+        attrs[key] = value
+    missing = [field for field in LANE_FIELDS if field not in attrs]
+    if missing:
+        raise EvidenceError(f"lane spec {parts[0]} omits {', '.join(missing)}")
+    return parts[0], attrs
+
+
+def parse_results(log: Path) -> dict:
+    """The last RESULTS_JSON line a lane validator printed."""
+    try:
+        lines = log.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as error:
+        raise EvidenceError(f"cannot read the lane log {log}: {error}") from error
+    results_lines = [line[len(RESULTS_PREFIX):] for line in lines if line.startswith(RESULTS_PREFIX)]
+    if not results_lines:
+        raise EvidenceError(f"the lane printed no {RESULTS_PREFIX.strip()} line; nothing to record")
+    try:
+        results = json.loads(results_lines[-1])
+    except json.JSONDecodeError as error:
+        raise EvidenceError(f"the lane's RESULTS_JSON line is not JSON: {error}") from error
+    if not isinstance(results, dict):
+        raise EvidenceError("the lane's RESULTS_JSON line is not an object")
+    for counter in COUNTERS:
+        value = results.get(counter)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise EvidenceError(f"RESULTS_JSON {counter} is not a non-negative integer: {value!r}")
+    if not isinstance(results.get("models_present"), bool):
+        raise EvidenceError("RESULTS_JSON models_present is not a boolean")
+    return results
+
+
+def lane_status(record: dict, exit_status: int) -> str:
+    if exit_status != 0 or record["fail"] > 0 or record["mandatory_skip"] > 0:
+        return "fail"
+    if record["skip"] > 0 or not record["models_present"]:
+        return "partial"
+    return "pass"
+
+
+def record(args: argparse.Namespace) -> int:
+    name, attrs = parse_lane_spec(args.lane)
+    results = parse_results(Path(args.results_log))
+    lane = {"schema": SCHEMA, "name": name, **attrs}
+    lane["commit"] = head_commit()
+    lane["recorded_at"] = now_utc()
+    lane["models_present"] = results["models_present"]
+    for counter in COUNTERS:
+        lane[counter] = results[counter]
+    for extra in args.extra_skip:
+        lane["skip"] += 1
+        lane[f"{extra}_skip"] += 1
+    lane["status"] = lane_status(lane, args.exit_status)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{name}.json"
+    path.write_text(json.dumps(lane, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        f"packaging evidence: {name} {lane['status']} "
+        f"({lane['pass']} passed, {lane['fail']} failed, {lane['skip']} skipped) -> {path}"
+    )
+    return 0
+
+
+# ------------------------------------------------------------------ validation
+
+
+def check_record(record: dict, head: str, expected: dict[str, str] | None) -> list[str]:
+    name = record.get("name", "<unnamed>")
+    problems: list[str] = []
+
+    def problem(message: str) -> None:
+        problems.append(f"lane {name}: {message}")
+
+    for field in ("name", "commit", "status", *LANE_FIELDS):
+        if not isinstance(record.get(field), str) or not record[field]:
+            problem(f"{field} is missing")
+    for counter in COUNTERS:
+        value = record.get(counter)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            problem(f"{counter} is not a non-negative integer")
+    if not isinstance(record.get("models_present"), bool):
+        problem("models_present is not a boolean")
+    if problems:
+        return problems
+    if record["commit"] != head:
+        problem(f"commit {record['commit']} is not HEAD {head}")
+    if record["models_present"] is not True:
+        problem("models_present is false: the model-dependent assertions did not run")
+    if record["skip"] != record["allowed_skip"] + record["mandatory_skip"]:
+        problem(
+            f"skip {record['skip']} is not allowed_skip {record['allowed_skip']} "
+            f"plus mandatory_skip {record['mandatory_skip']}"
+        )
+    for counter in ("fail", "skip", "allowed_skip", "mandatory_skip"):
+        if record[counter] != 0:
+            problem(f"{counter} is {record[counter]}, not 0")
+    if record["pass"] < 1:
+        problem("no assertion passed; an empty lane is not evidence")
+    if record["status"] != "pass":
+        problem(f"status is {record['status']!r}, not 'pass'")
+    if expected is not None:
+        for field in LANE_FIELDS:
+            if record[field] != expected[field]:
+                problem(f"{field} is {record[field]!r}; the release matrix requires {expected[field]!r}")
+    return problems
+
+
+def check_marker(marker: object, head: str, matrix: dict) -> list[str]:
+    """Every reason this marker is not release evidence for `head`; [] accepts."""
+    if not isinstance(marker, dict):
+        return ["the marker is not a JSON object"]
+    problems: list[str] = []
+    if marker.get("schema") != SCHEMA:
+        problems.append(f"schema is {marker.get('schema')!r}, not {SCHEMA}")
+    if marker.get("commit") != head:
+        problems.append(f"commit {marker.get('commit')!r} is not HEAD {head}")
+    if marker.get("tree_clean") is not True:
+        problems.append("tree_clean is not true: the lanes did not run on a committed tree")
+    for stamp in ("started_at", "finished_at"):
+        if not isinstance(marker.get(stamp), str) or not marker[stamp]:
+            problems.append(f"{stamp} is missing" + (": the run did not finish" if stamp == "finished_at" else ""))
+    required = required_lanes(matrix)
+    declared = marker.get("required_lanes")
+    if not isinstance(declared, list) or not all(isinstance(name, str) for name in declared):
+        problems.append("required_lanes is not a list of lane names")
+    elif set(declared) != set(required):
+        problems.append(
+            f"required lane set {sorted(declared)} differs from the release matrix's {sorted(required)}"
+        )
+    lanes = marker.get("lanes")
+    if not isinstance(lanes, list) or not all(isinstance(lane, dict) for lane in lanes):
+        problems.append("lanes is not a list of lane records")
+        return problems
+    seen: dict[str, int] = {}
+    for lane in lanes:
+        name = lane.get("name")
+        if isinstance(name, str):
+            seen[name] = seen.get(name, 0) + 1
+        problems.extend(check_record(lane, head, required.get(name) if isinstance(name, str) else None))
+    for name, count in sorted(seen.items()):
+        if count > 1:
+            problems.append(f"lane {name} is recorded more than once")
+    for name in sorted(required):
+        if name not in seen:
+            problems.append(f"required lane {name} has no record")
+    return problems
+
+
+def read_marker(path: Path) -> object:
+    """The marker's JSON, or the reason it is not one."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise EvidenceError(f"no packaging evidence at {path}") from None
+    except OSError as error:
+        raise EvidenceError(f"cannot read {path}: {error}") from error
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as error:
+        if COMMIT_SHA.fullmatch(text.strip()):
+            raise EvidenceError(
+                f"{path} is a legacy one-line commit marker ({text.strip()[:12]}); release evidence "
+                f"is now the schema {SCHEMA} JSON document `just test-packaging-matrix` writes, "
+                "so re-run the matrix at this commit"
+            ) from None
+        raise EvidenceError(f"{path} is not JSON: {error}") from error
+
+
+def refuse(what: str, problems: list[str]) -> int:
+    print(f"packaging evidence: REFUSED {what}", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    return 1
+
+
+def validate(args: argparse.Namespace) -> int:
+    head = args.commit or head_commit()
+    path = Path(args.marker)
+    marker = read_marker(path)
+    problems = check_marker(marker, head, load_matrix())
+    if problems:
+        return refuse(str(path), problems)
+    return 0
+
+
+# ----------------------------------------------------------------- aggregation
+
+
+def load_records(evidence_dir: Path) -> list[dict]:
+    records: list[dict] = []
+    for path in sorted(evidence_dir.rglob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise EvidenceError(f"lane record {path} is not JSON: {error}") from error
+        if not isinstance(record, dict):
+            raise EvidenceError(f"lane record {path} is not a JSON object")
+        records.append(record)
+    return records
+
+
+def build_marker(
+    head: str,
+    evidence_dir: Path,
+    started_at: str,
+    finished_at: str,
+    tree_clean: bool,
+    matrix: dict,
+) -> tuple[dict, list[str]]:
+    marker = {
+        "schema": SCHEMA,
+        "commit": head,
+        "tree_clean": tree_clean,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "required_lanes": sorted(required_lanes(matrix)),
+        "lanes": load_records(evidence_dir),
+    }
+    return marker, check_marker(marker, head, matrix)
+
+
+def aggregate(args: argparse.Namespace) -> int:
+    head = args.commit or head_commit()
+    marker, problems = build_marker(
+        head,
+        Path(args.evidence_dir),
+        args.started_at,
+        args.finished_at or now_utc(),
+        args.tree_clean,
+        load_matrix(),
+    )
+    if problems:
+        return refuse(f"the lane records in {args.evidence_dir}", problems)
+    output = Path(args.output)
+    output.write_text(json.dumps(marker, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    passed = sum(lane["pass"] for lane in marker["lanes"])
+    print(
+        f"packaging evidence: {len(marker['lanes'])} lanes, {passed} assertions passed, "
+        f"no skips, at {head} -> {output}"
+    )
+    return 0
+
+
+def gh(*args: str) -> str:
+    completed = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise EvidenceError(f"gh {' '.join(args[:2])} failed: {completed.stderr.strip() or completed.stdout.strip()}")
+    return completed.stdout
+
+
+def ci_run(args: argparse.Namespace) -> int:
+    """A packaging.yml run is evidence only through the artifacts its lanes uploaded."""
+    head = args.commit or head_commit()
+    what = f"packaging workflow run {args.run}"
+    try:
+        view = json.loads(gh("run", "view", args.run, "--json", "conclusion,headSha,createdAt,updatedAt"))
+    except json.JSONDecodeError as error:
+        raise EvidenceError(f"gh run view returned no JSON: {error}") from error
+    problems: list[str] = []
+    if view.get("conclusion") != "success":
+        problems.append(f"conclusion is {view.get('conclusion')!r}, not 'success'")
+    if view.get("headSha") != head:
+        problems.append(f"head {view.get('headSha')!r} is not HEAD {head}")
+    if problems:
+        return refuse(what, problems)
+    with tempfile.TemporaryDirectory(prefix="facelock-packaging-evidence.") as download_dir:
+        completed = subprocess.run(
+            ["gh", "run", "download", args.run, "--pattern", "packaging-evidence-*", "--dir", download_dir],
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            return refuse(
+                what,
+                [
+                    "the run uploaded no packaging evidence artifact; a path-filtered or "
+                    "pre-evidence run is not evidence: " + (completed.stderr.strip() or completed.stdout.strip())
+                ],
+            )
+        # A workflow run checks out the commit it names, so there is no dirty
+        # tree to record; the lane records still have to name that commit.
+        marker, problems = build_marker(
+            head,
+            Path(download_dir),
+            str(view.get("createdAt") or ""),
+            str(view.get("updatedAt") or ""),
+            True,
+            load_matrix(),
+        )
+    if problems:
+        return refuse(what, problems)
+    passed = sum(lane["pass"] for lane in marker["lanes"])
+    print(f"packaging evidence: {what} carries {len(marker['lanes'])} lanes, {passed} assertions passed, no skips")
+    return 0
+
+
+# ------------------------------------------------------------------------- CLI
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    record_parser = commands.add_parser("record", help="write one lane record from a validator's RESULTS_JSON line")
+    record_parser.add_argument("--lane", required=True, help="'<name> target=… channel=… build_origin=… runtime_policy=… depth=…'")
+    record_parser.add_argument("--results-log", required=True, help="captured stdout of the lane validator")
+    record_parser.add_argument("--exit-status", type=int, required=True, help="the lane's overall exit status")
+    record_parser.add_argument(
+        "--extra-skip",
+        action="append",
+        choices=("allowed", "mandatory"),
+        default=[],
+        help="a skip the runner took outside the validator, by class",
+    )
+    record_parser.add_argument("--output-dir", default=str(EVIDENCE_DIR))
+    record_parser.set_defaults(func=record)
+
+    aggregate_parser = commands.add_parser("aggregate", help="fold lane records into the marker, or refuse")
+    aggregate_parser.add_argument("--commit", help="the commit the lanes ran at (default: HEAD)")
+    aggregate_parser.add_argument("--evidence-dir", default=str(EVIDENCE_DIR))
+    aggregate_parser.add_argument("--started-at", required=True)
+    aggregate_parser.add_argument("--finished-at", help="default: now")
+    aggregate_parser.add_argument("--tree-clean", action="store_true", help="the caller verified a clean tree")
+    aggregate_parser.add_argument("--output", default=str(MARKER_PATH))
+    aggregate_parser.set_defaults(func=aggregate)
+
+    validate_parser = commands.add_parser("validate", help="accept or refuse a marker for a commit")
+    validate_parser.add_argument("--commit", help="the commit being released (default: HEAD)")
+    validate_parser.add_argument("marker", nargs="?", default=str(MARKER_PATH))
+    validate_parser.set_defaults(func=validate)
+
+    ci_parser = commands.add_parser("ci-run", help="accept or refuse a packaging.yml run through its evidence artifacts")
+    ci_parser.add_argument("--commit", help="the commit being released (default: HEAD)")
+    ci_parser.add_argument("--run", required=True, help="the workflow run id")
+    ci_parser.set_defaults(func=ci_run)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except EvidenceError as error:
+        return refuse(args.command, error.problems)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -266,6 +266,8 @@ def check_record(record: dict, head: str, expected: dict[str, str] | None) -> li
     def problem(message: str) -> None:
         problems.append(f"lane {name}: {message}")
 
+    if record.get("schema") != SCHEMA:
+        problem(f"schema is {record.get('schema')!r}, not {SCHEMA}")
     for field in ("name", "commit", "status", *LANE_FIELDS):
         if not isinstance(record.get(field), str) or not record[field]:
             problem(f"{field} is missing")
@@ -328,10 +330,8 @@ def check_marker(marker: object, head: str, matrix: dict) -> list[str]:
     declared = marker.get("required_lanes")
     if not isinstance(declared, list) or not all(isinstance(name, str) for name in declared):
         problems.append("required_lanes is not a list of lane names")
-    elif set(declared) != set(required):
-        problems.append(
-            f"required lane set {sorted(declared)} differs from the release matrix's {sorted(required)}"
-        )
+    elif declared != sorted(required):
+        problems.append(f"required lane set {declared} differs from the release matrix's {sorted(required)}")
     lanes = marker.get("lanes")
     if not isinstance(lanes, list) or not all(isinstance(lane, dict) for lane in lanes):
         problems.append("lanes is not a list of lane records")

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -61,12 +61,26 @@ def now_utc() -> str:
 
 
 def head_commit() -> str:
-    return subprocess.run(
-        ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = (getattr(error, "stderr", "") or str(error)).strip()
+        raise EvidenceError(f"cannot resolve HEAD in {ROOT}: {detail}") from error
+    return completed.stdout.strip()
+
+
+def parse_timestamp(value: str) -> datetime | None:
+    """An ISO 8601 timestamp that carries its UTC offset; None for anything else."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
 
 
 def load_matrix() -> dict:
@@ -297,9 +311,19 @@ def check_marker(marker: object, head: str, matrix: dict) -> list[str]:
         problems.append(f"commit {marker.get('commit')!r} is not HEAD {head}")
     if marker.get("tree_clean") is not True:
         problems.append("tree_clean is not true: the lanes did not run on a committed tree")
+    stamps: dict[str, datetime] = {}
     for stamp in ("started_at", "finished_at"):
-        if not isinstance(marker.get(stamp), str) or not marker[stamp]:
+        value = marker.get(stamp)
+        if not isinstance(value, str) or not value:
             problems.append(f"{stamp} is missing" + (": the run did not finish" if stamp == "finished_at" else ""))
+            continue
+        parsed = parse_timestamp(value)
+        if parsed is None:
+            problems.append(f"{stamp} {value!r} is not an ISO 8601 timestamp with a UTC offset")
+        else:
+            stamps[stamp] = parsed
+    if len(stamps) == 2 and stamps["finished_at"] < stamps["started_at"]:
+        problems.append(f"finished_at {marker['finished_at']} is before started_at {marker['started_at']}")
     required = required_lanes(matrix)
     declared = marker.get("required_lanes")
     if not isinstance(declared, list) or not all(isinstance(name, str) for name in declared):
@@ -317,6 +341,8 @@ def check_marker(marker: object, head: str, matrix: dict) -> list[str]:
         name = lane.get("name")
         if isinstance(name, str):
             seen[name] = seen.get(name, 0) + 1
+            if name not in required:
+                problems.append(f"lane {name} is not a lane the release matrix requires")
         problems.extend(check_record(lane, head, required.get(name) if isinstance(name, str) else None))
     for name, count in sorted(seen.items()):
         if count > 1:
@@ -347,6 +373,14 @@ def read_marker(path: Path) -> object:
         raise EvidenceError(f"{path} is not JSON: {error}") from error
 
 
+def summary(marker: dict, what: str) -> str:
+    passed = sum(lane["pass"] for lane in marker["lanes"])
+    return (
+        f"packaging evidence: {what} carries {len(marker['lanes'])} lanes, "
+        f"{passed} assertions passed, no skips, at {marker['commit']}"
+    )
+
+
 def refuse(what: str, problems: list[str]) -> int:
     print(f"packaging evidence: REFUSED {what}", file=sys.stderr)
     for problem in problems:
@@ -361,6 +395,7 @@ def validate(args: argparse.Namespace) -> int:
     problems = check_marker(marker, head, load_matrix())
     if problems:
         return refuse(str(path), problems)
+    print(summary(marker, str(path)))
     return 0
 
 
@@ -414,11 +449,7 @@ def aggregate(args: argparse.Namespace) -> int:
         return refuse(f"the lane records in {args.evidence_dir}", problems)
     output = Path(args.output)
     output.write_text(json.dumps(marker, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    passed = sum(lane["pass"] for lane in marker["lanes"])
-    print(
-        f"packaging evidence: {len(marker['lanes'])} lanes, {passed} assertions passed, "
-        f"no skips, at {head} -> {output}"
-    )
+    print(summary(marker, str(output)))
     return 0
 
 
@@ -429,15 +460,41 @@ def gh(*args: str) -> str:
     return completed.stdout
 
 
+NO_ARTIFACTS = ("no artifacts match", "no valid artifacts")
+
+
+def packaging_workflow_name() -> str:
+    """The `name:` of .github/workflows/packaging.yml, which gh reports as workflowName."""
+    path = ROOT / ".github" / "workflows" / "packaging.yml"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise EvidenceError(f"cannot read {path}: {error}") from error
+    match = re.search(r"(?m)^name:\s*(\S.*?)\s*$", text)
+    if match is None:
+        raise EvidenceError(f"{path} declares no workflow name")
+    return match.group(1)
+
+
 def ci_run(args: argparse.Namespace) -> int:
     """A packaging.yml run is evidence only through the artifacts its lanes uploaded."""
     head = args.commit or head_commit()
     what = f"packaging workflow run {args.run}"
     try:
-        view = json.loads(gh("run", "view", args.run, "--json", "conclusion,headSha,createdAt,updatedAt"))
+        view = json.loads(
+            gh("run", "view", args.run, "--json", "conclusion,event,headSha,workflowName,createdAt,updatedAt")
+        )
     except json.JSONDecodeError as error:
         raise EvidenceError(f"gh run view returned no JSON: {error}") from error
     problems: list[str] = []
+    workflow = packaging_workflow_name()
+    if view.get("workflowName") != workflow:
+        problems.append(f"workflow is {view.get('workflowName')!r}, not {workflow!r}")
+    if view.get("event") == "pull_request":
+        problems.append(
+            "pull-request runs build the merge commit, not this one; use a workflow_dispatch "
+            "or scheduled run on this commit"
+        )
     if view.get("conclusion") != "success":
         problems.append(f"conclusion is {view.get('conclusion')!r}, not 'success'")
     if view.get("headSha") != head:
@@ -451,13 +508,16 @@ def ci_run(args: argparse.Namespace) -> int:
             text=True,
         )
         if completed.returncode != 0:
-            return refuse(
-                what,
-                [
-                    "the run uploaded no packaging evidence artifact; a path-filtered or "
-                    "pre-evidence run is not evidence: " + (completed.stderr.strip() or completed.stdout.strip())
-                ],
-            )
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            if any(phrase in detail.lower() for phrase in NO_ARTIFACTS):
+                return refuse(
+                    what,
+                    [
+                        "the run uploaded no packaging evidence artifact; a path-filtered or "
+                        f"pre-evidence run is not evidence: {detail}"
+                    ],
+                )
+            return refuse(what, [f"gh run download failed, so the run's evidence could not be read: {detail}"])
         # A workflow run checks out the commit it names, so there is no dirty
         # tree to record; the lane records still have to name that commit.
         marker, problems = build_marker(
@@ -470,8 +530,7 @@ def ci_run(args: argparse.Namespace) -> int:
         )
     if problems:
         return refuse(what, problems)
-    passed = sum(lane["pass"] for lane in marker["lanes"])
-    print(f"packaging evidence: {what} carries {len(marker['lanes'])} lanes, {passed} assertions passed, no skips")
+    print(summary(marker, what))
     return 0
 
 

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -130,9 +130,14 @@ def required_lanes(matrix: dict) -> dict[str, dict[str, str]]:
     """
     lanes: dict[str, dict[str, str]] = {}
     rows = [row for row in matrix.get("platforms", []) if eligible(row)]
-    suite_by_platform = {
-        suite["platform_id"]: name for name, suite in matrix.get("apt_suites", {}).items()
-    }
+    suite_by_platform: dict[str, str] = {}
+    for name, suite in matrix.get("apt_suites", {}).items():
+        if name == "compat":
+            continue
+        platform_id = suite.get("platform_id")
+        if platform_id is None:
+            raise EvidenceError(f"APT suite {name} has no platform_id in the release matrix")
+        suite_by_platform[platform_id] = name
     for row in rows:
         platform_id = row.get("id", "")
         if row.get("channel") == "staged APT/direct deb":

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -42,6 +42,17 @@ run_test() {
         result=$?
     fi
 
+    # Exit 77 is a validator saying it could not reach its subject
+    # (test/polkit-agent-validate.sh). That is a skip, never a pass, and it is
+    # mandatory: nothing in this lane opted out of it.
+    if [ "$result" -eq 77 ]; then
+        local reason
+        reason="$(sed -n 's/^SKIP: //p' /tmp/test-output | head -n 1)"
+        echo "SKIP"
+        skip_test "$name" "${reason:-exit 77}"
+        return
+    fi
+
     if [ "$expected_result" = "any" ] || [ "$result" -eq "$expected_result" ]; then
         echo "PASS"
         PASS=$((PASS + 1))

--- a/test/pkg-validate.sh
+++ b/test/pkg-validate.sh
@@ -5,6 +5,9 @@ PASS=0
 FAIL=0
 SKIP=0
 ALLOWED_SKIP=0
+# Whether the daemon-start block found its ONNX models. Reported in the
+# RESULTS_JSON line so a partial run can never be recorded as a complete one.
+MODELS_PRESENT=false
 
 # Record an assertion (or a whole block of them) that did not run.
 #
@@ -577,6 +580,7 @@ if [ -d /run/systemd/system ] && systemctl show facelock-daemon >/dev/null 2>&1;
     # container: an explicit device.path skips auto-detection, and a probe
     # failure on that path is non-fatal (the camera is only opened on auth).
     if ls /var/lib/facelock/models/*.onnx >/dev/null 2>&1; then
+        MODELS_PRESENT=true
         if ! grep -q '^path\s*=' /etc/facelock/config.toml; then
             sed -i '/^\[device\]/a path = "/dev/video0"' /etc/facelock/config.toml
         fi
@@ -821,6 +825,7 @@ rm -f "$PACKAGE_OWNED_PAM" "$PACKAGE_BLOCKER_PAM" \
     /tmp/facelock-common-auth.before
 
 UNEXPECTED_SKIP=$((SKIP - ALLOWED_SKIP))
+ASSERTION_FAILURES=$FAIL
 if [ "$UNEXPECTED_SKIP" -gt 0 ]; then
     echo "FAIL: $UNEXPECTED_SKIP unexpected skip(s) make package validation incomplete"
     FAIL=$((FAIL + UNEXPECTED_SKIP))
@@ -836,6 +841,13 @@ if [ "$SKIP" -gt 0 ]; then
         echo "      FACELOCK_ALLOW_MISSING_MODELS=1 partial-run opt-out."
     fi
 fi
+
+# One machine-readable line for test/run-pkg-validate-systemd.sh to turn into
+# the lane's packaging-evidence record (test/packaging-evidence.py). These are
+# assertion counts by class; the mandatory-skip penalty folded into FAIL above
+# is a verdict, so it is reported as mandatory_skip rather than as failures.
+printf 'RESULTS_JSON: {"pass":%d,"fail":%d,"skip":%d,"allowed_skip":%d,"mandatory_skip":%d,"models_present":%s}\n' \
+    "$PASS" "$ASSERTION_FAILURES" "$SKIP" "$ALLOWED_SKIP" "$UNEXPECTED_SKIP" "$MODELS_PRESENT"
 
 if [ "$FAIL" -gt 0 ]; then
     exit 1

--- a/test/polkit-agent-validate.sh
+++ b/test/polkit-agent-validate.sh
@@ -13,6 +13,9 @@
 #
 # Env overrides (for running outside the package container):
 #   FACELOCK_POLKIT_AGENT_BIN  path to the agent binary
+#
+# Exit 77 means the check could not reach its subject. pkg-validate.sh counts
+# that as a mandatory skip, never a pass (#313).
 set -uo pipefail
 
 AGENT_BIN="${FACELOCK_POLKIT_AGENT_BIN:-}"
@@ -24,15 +27,15 @@ fi
 
 if [ -z "$AGENT_BIN" ] || [ ! -x "$AGENT_BIN" ]; then
     echo "SKIP: facelock-polkit-agent binary not found"
-    exit 0
+    exit 77
 fi
 if ! command -v dbus-daemon >/dev/null 2>&1; then
     echo "SKIP: dbus-daemon not available"
-    exit 0
+    exit 77
 fi
 if ! command -v busctl >/dev/null 2>&1; then
     echo "SKIP: busctl not available"
-    exit 0
+    exit 77
 fi
 
 echo "=== Polkit Agent D-Bus Boundary Validation ==="
@@ -79,7 +82,7 @@ if [ "$OWNED" -ne 1 ]; then
     echo "SKIP: agent did not claim its session-bus name (no session/system bus?)"
     echo "--- agent log ---"
     cat /tmp/polkit-agent.log 2>/dev/null || true
-    exit 0
+    exit 77
 fi
 
 call_begin() {

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -412,6 +412,10 @@ assert_matrix_mutation_rejected \
     "justfile" \
     's@packaging-evidence.py ci-run --commit@packaging-evidence.py ci-run-disabled --commit@'
 assert_matrix_mutation_rejected \
+    "release preflight swallowing the evidence command's own failure" \
+    "justfile" \
+    's@ci-run --commit "\$HEAD_SHA" --run "\$run_id"; then@ci-run --commit "$HEAD_SHA" --run "$run_id" || true; then@'
+assert_matrix_mutation_rejected \
     "packaging workflow keeping the evidence artifact name only in a comment" \
     ".github/workflows/packaging.yml" \
     's/^          name: packaging-evidence-arch$/          # name: packaging-evidence-arch\n          name: packaging-evidence-arch-moved/'
@@ -444,6 +448,10 @@ assert_matrix_mutation_rejected \
     "packaging matrix echoing the commit into the marker beside the aggregate" \
     "justfile" \
     's@^        --evidence-dir .packaging-evidence --output .packaging-matrix-verified$@&\n    echo "$commit" > .packaging-matrix-verified@'
+assert_matrix_mutation_rejected \
+    "packaging matrix teeing the commit into the marker beside the aggregate" \
+    "justfile" \
+    's@^        --evidence-dir .packaging-evidence --output .packaging-matrix-verified$@&\n    echo "$commit" | tee --append .packaging-matrix-verified@'
 # A marker write that exists only in a trailing comment is not a marker write:
 # the guard reads executable text, not the whole line.
 harmless_comment_root="$tmp_root/matrix-harmless-comment"
@@ -1591,6 +1599,14 @@ assert_evidence_refused "record without a schema" \
     'del lanes["test-arch-pkg"]["schema"]' "schema"
 assert_evidence_refused "record with another schema" \
     'lanes["test-arch-pkg"]["schema"] = 2' "schema"
+assert_evidence_refused "record with schema true" \
+    'lanes["test-arch-pkg"]["schema"] = True' "schema"
+assert_evidence_refused "record with schema 1.0" \
+    'lanes["test-arch-pkg"]["schema"] = 1.0' "schema"
+assert_evidence_refused "marker with schema true" \
+    'marker["schema"] = True' "schema"
+assert_evidence_refused "marker with schema 1.0" \
+    'marker["schema"] = 1.0' "schema"
 assert_evidence_refused "required lane listed twice" \
     'marker["required_lanes"].append("test-arch-pkg")' "required lane set"
 assert_evidence_refused "record for a lane the matrix does not require" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1633,6 +1633,32 @@ case "$output" in
     *) fail "packaging evidence did not say HEAD is unresolvable: $output" ;;
 esac
 
+# A real APT suite missing platform_id (not the compat block, which carries
+# none) is refused with a diagnostic, not a KeyError (#320 added `compat`
+# alongside the real suites).
+platform_id_root="$tmp_root/platform-id-root"
+mkdir -p "$platform_id_root/test" "$platform_id_root/dist"
+cp "$repo_root/test/packaging-evidence.py" "$platform_id_root/test/"
+python3 - "$repo_root/dist/release-matrix.json" "$platform_id_root/dist/release-matrix.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    matrix = json.load(handle)
+del matrix["apt_suites"]["trixie"]["platform_id"]
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(matrix, handle)
+PY
+if output=$(python3 "$platform_id_root/test/packaging-evidence.py" validate --commit "$evidence_head" "$tmp_root/evidence-good.json" 2>&1); then
+    fail "packaging evidence accepted a release matrix APT suite missing platform_id"
+fi
+case "$output" in
+    *Traceback*) fail "packaging evidence crashed on an APT suite missing platform_id: $output" ;;
+    *"trixie has no platform_id"*) ;;
+    *) fail "packaging evidence did not name the APT suite missing platform_id: $output" ;;
+esac
+echo "packaging evidence case: APT suite missing platform_id refused"
+
 if output=$(evidence_validate "$tmp_root/evidence-missing.json" 2>&1); then
     fail "packaging evidence accepted a missing marker"
 fi

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -412,6 +412,10 @@ assert_matrix_mutation_rejected \
     "justfile" \
     's@packaging-evidence.py ci-run --commit@packaging-evidence.py ci-run-disabled --commit@'
 assert_matrix_mutation_rejected \
+    "release matrix granting evidence eligibility outside Rawhide" \
+    "dist/release-matrix.json" \
+    's/"id": "debian-13",/"id": "debian-13", "evidence_eligibility": {"lifecycle": false},/'
+assert_matrix_mutation_rejected \
     "packaging matrix recording without aggregating lane evidence" \
     "justfile" \
     's@packaging-evidence.py aggregate --commit@packaging-evidence.py aggregate-disabled --commit@'

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1222,6 +1222,390 @@ if (
 fi
 [ ! -e "$apt_recipe_podman_log" ] || fail "test-apt-repo reached the container with an incomplete manifest set"
 
+# Packaging matrix evidence (#313). The recipes and runners run for real; only
+# the containers are answered for by a stub podman, and the stages that build
+# images or run this very contract are stubbed to succeed. The stub keys the
+# model-dependent branch off what the runner mounted, as the real images do.
+evidence_root="$tmp_root/evidence-root"
+mkdir -p "$evidence_root/dist" "$evidence_root/test" "$evidence_root/models" "$evidence_root/target/release"
+cp "$repo_root/justfile" "$evidence_root/"
+cp "$repo_root/dist/release-matrix.json" "$evidence_root/dist/"
+cp "$repo_root/test/packaging-evidence.py" \
+    "$repo_root/test/run-pkg-validate-systemd.sh" \
+    "$repo_root/test/run-rpm-smoke-systemd.sh" \
+    "$evidence_root/test/"
+cat >"$evidence_root/test/build-deb-package-image.sh" <<'SH'
+#!/usr/bin/env bash
+install -m 0444 /dev/null "${3:?}"
+SH
+cat >"$evidence_root/test/build-arch-package-image.sh" <<'SH'
+#!/usr/bin/env bash
+mkdir -p "${2:?}/source"
+SH
+cat >"$evidence_root/test/fedora-lane-image.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'stub-fedora:%s\n' "${1:?}"
+SH
+printf '#!/usr/bin/env bash\nexit 0\n' >"$evidence_root/test/release-version-contract.sh"
+printf 'raise SystemExit(0)\n' >"$evidence_root/test/check-release-matrix.py"
+chmod +x "$evidence_root"/test/*.sh
+# A required model no candidate source holds keeps `_link-models auto` from
+# quietly refilling models/ from a host install during the opt-out case.
+cat >"$evidence_root/models/manifest.toml" <<'TOML'
+[[models]]
+filename = "fixture-only.onnx"
+sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+TOML
+printf '%s\n' '/target' '*.onnx' '/.packaging-matrix-verified' '/.packaging-evidence/' >"$evidence_root/.gitignore"
+touch "$evidence_root/target/release/facelock" "$evidence_root/target/release/facelock-polkit-agent" "$evidence_root/target/release/libpam_facelock.so"
+touch "$evidence_root/models/scrfd_2.5g_bnkps.onnx" "$evidence_root/models/w600k_r50.onnx"
+git -C "$evidence_root" init -q
+git -C "$evidence_root" config user.name evidence-test
+git -C "$evidence_root" config user.email evidence-test@example.invalid
+git -C "$evidence_root" add .
+git -C "$evidence_root" -c commit.gpgsign=false commit -qm baseline
+evidence_head="$(git -C "$evidence_root" rev-parse HEAD)"
+cat >"$tmp_root/bin/podman" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+    build|rmi|rm) exit 0 ;;
+    run)
+        shift
+        detached=0
+        models=nomodels
+        image=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -d) detached=1; shift ;;
+                -v)
+                    case "$2" in *:/facelock-test-models:*) models=models ;; esac
+                    shift 2 ;;
+                --security-opt|-w) shift 2 ;;
+                -*) shift ;;
+                *) image="$1"; break ;;
+            esac
+        done
+        if [ "$detached" = 1 ]; then
+            printf 'stub-%s-%s\n' "$image" "$models"
+            exit 0
+        fi
+        case "$image" in
+            facelock-arch-pkg-*)
+                printf 'RESULTS_JSON: {"pass":29,"fail":0,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n' ;;
+        esac
+        exit 0 ;;
+    exec)
+        shift
+        opt_out=0
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -e)
+                    case "$2" in FACELOCK_ALLOW_MISSING_MODELS=1) opt_out=1 ;; esac
+                    shift 2 ;;
+                -*) shift ;;
+                *) break ;;
+            esac
+        done
+        cid="$1"
+        shift
+        case "$cid" in stub-facelock-deb-*) format=deb ;; *) format=rpm ;; esac
+        case "$cid" in *-models) models=1 ;; *) models=0 ;; esac
+        case "${1:-}" in
+            systemctl) echo running ;;
+            test)
+                case "${2:-} ${3:-}" in
+                    "-x /deb-package-lifecycle.sh") [ "$format" = deb ] ;;
+                    "-x /rpm-service-pam-lifecycle.sh"|"-x /rpm-config-lifecycle.sh") [ "$format" = rpm ] ;;
+                    *) exit 1 ;;
+                esac ;;
+            /pkg-validate.sh)
+                if [ "${STUB_PKG_VALIDATE_MANDATORY_SKIP:-0}" = 1 ]; then
+                    printf 'RESULTS_JSON: {"pass":39,"fail":0,"skip":1,"allowed_skip":0,"mandatory_skip":1,"models_present":true}\n'
+                elif [ "$models" = 1 ]; then
+                    printf 'RESULTS_JSON: {"pass":40,"fail":0,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n'
+                elif [ "$opt_out" = 1 ]; then
+                    printf 'RESULTS_JSON: {"pass":37,"fail":0,"skip":3,"allowed_skip":3,"mandatory_skip":0,"models_present":false}\n'
+                else
+                    printf 'RESULTS_JSON: {"pass":37,"fail":1,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":false}\n'
+                    exit 1
+                fi ;;
+            /rpm-runtime-smoke.sh)
+                printf 'RESULTS_JSON: {"pass":8,"fail":0,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n' ;;
+            /rpm-config-lifecycle.sh)
+                if [ "${STUB_RPM_CONFIG_LIFECYCLE_FAIL:-0}" = 1 ]; then exit 1; fi ;;
+        esac
+        exit 0 ;;
+    *) exit 2 ;;
+esac
+SH
+chmod +x "$tmp_root/bin/podman"
+run_packaging_matrix() {
+    (
+        cd "$evidence_root"
+        PATH="$tmp_root/bin:$PATH" env FACELOCK_RELEASE_BINARIES_PREBUILT=1 "$@" just test-packaging-matrix
+    )
+}
+evidence_validate() {
+    python3 "$evidence_root/test/packaging-evidence.py" validate --commit "$evidence_head" "$@"
+}
+
+# A complete run replaces whatever marker and lane records were there before
+# it started, and writes evidence preflight accepts.
+printf '%s\n' "$evidence_head" >"$evidence_root/.packaging-matrix-verified"
+mkdir -p "$evidence_root/.packaging-evidence"
+printf '%s\n' '{"stale": true}' >"$evidence_root/.packaging-evidence/stale-lane.json"
+run_packaging_matrix >"$tmp_root/evidence-complete.log" 2>&1 ||
+    fail "test-packaging-matrix refused a complete run: $(cat "$tmp_root/evidence-complete.log")"
+[ ! -e "$evidence_root/.packaging-evidence/stale-lane.json" ] ||
+    fail "test-packaging-matrix kept a lane record from before the run"
+evidence_validate "$evidence_root/.packaging-matrix-verified" ||
+    fail "release preflight refused the marker a complete matrix run wrote"
+python3 - "$evidence_root/.packaging-matrix-verified" "$evidence_head" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    marker = json.load(handle)
+assert marker["schema"] == 1, marker
+assert marker["commit"] == sys.argv[2], marker["commit"]
+assert marker["tree_clean"] is True
+assert marker["started_at"] and marker["finished_at"] and marker["started_at"] <= marker["finished_at"]
+expected = [
+    "test-arch-pkg",
+    "test-deb-resolute-pkg",
+    "test-deb-trixie-pkg",
+    "test-rpm-pkg-43",
+    "test-rpm-pkg-44",
+    "test-rpm-smoke-45",
+]
+assert sorted(marker["required_lanes"]) == expected, marker["required_lanes"]
+lanes = {lane["name"]: lane for lane in marker["lanes"]}
+assert sorted(lanes) == expected, sorted(lanes)
+for lane in lanes.values():
+    assert lane["status"] == "pass" and lane["models_present"] is True, lane
+    assert lane["fail"] == lane["skip"] == lane["allowed_skip"] == lane["mandatory_skip"] == 0, lane
+    assert lane["pass"] > 0 and lane["commit"] == sys.argv[2], lane
+assert lanes["test-deb-trixie-pkg"]["target"] == "debian-trixie"
+assert lanes["test-deb-trixie-pkg"]["channel"] == "apt"
+assert lanes["test-deb-resolute-pkg"]["target"] == "ubuntu-resolute"
+assert lanes["test-rpm-pkg-43"]["channel"] == "direct-rpm"
+assert lanes["test-rpm-pkg-43"]["build_origin"] == "host-binaries"
+assert lanes["test-rpm-pkg-43"]["runtime_policy"] == "bundled-ort"
+assert lanes["test-rpm-smoke-45"]["depth"] == "smoke"
+assert lanes["test-arch-pkg"]["channel"] == "aur"
+assert lanes["test-arch-pkg"]["runtime_policy"] == "system-ort"
+PY
+cp "$evidence_root/.packaging-matrix-verified" "$tmp_root/evidence-good.json"
+cp -R "$evidence_root/.packaging-evidence" "$tmp_root/evidence-good-records"
+rm -f "$tmp_root/evidence-good-records/started-at"
+
+# The model opt-out still runs, for local diagnostics, but the partial records
+# it leaves are refused and no marker is written.
+rm "$evidence_root"/models/*.onnx
+if run_packaging_matrix FACELOCK_ALLOW_MISSING_MODELS=1 >"$tmp_root/evidence-optout.log" 2>&1; then
+    fail "test-packaging-matrix recorded a FACELOCK_ALLOW_MISSING_MODELS=1 run"
+fi
+[ ! -e "$evidence_root/.packaging-matrix-verified" ] ||
+    fail "the opt-out run left a marker behind"
+grep -q 'test-deb-trixie-pkg' "$tmp_root/evidence-optout.log" ||
+    fail "the opt-out refusal did not name the partial lane: $(cat "$tmp_root/evidence-optout.log")"
+grep -q 'models_present' "$tmp_root/evidence-optout.log" ||
+    fail "the opt-out refusal did not name the missing models: $(cat "$tmp_root/evidence-optout.log")"
+python3 - "$evidence_root/.packaging-evidence" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+records = {path.stem: json.loads(path.read_text()) for path in Path(sys.argv[1]).glob("*.json")}
+trixie = records["test-deb-trixie-pkg"]
+# Three pkg-validate.sh skips plus the runner's own active-upgrade skip.
+assert trixie["models_present"] is False and trixie["status"] == "partial", trixie
+assert trixie["skip"] == trixie["allowed_skip"] == 4, trixie
+fedora = records["test-rpm-pkg-43"]
+assert fedora["models_present"] is False and fedora["skip"] == fedora["allowed_skip"] == 3, fedora
+assert records["test-arch-pkg"]["status"] == "pass"
+PY
+touch "$evidence_root/models/scrfd_2.5g_bnkps.onnx" "$evidence_root/models/w600k_r50.onnx"
+
+# A lane that exits 0 while reporting a mandatory skip is refused by the
+# aggregate itself, not only by its own exit status.
+if run_packaging_matrix STUB_PKG_VALIDATE_MANDATORY_SKIP=1 >"$tmp_root/evidence-mandatory.log" 2>&1; then
+    fail "test-packaging-matrix recorded a run with a mandatory skip"
+fi
+[ ! -e "$evidence_root/.packaging-matrix-verified" ] ||
+    fail "the mandatory-skip run left a marker behind"
+grep -q 'mandatory_skip' "$tmp_root/evidence-mandatory.log" ||
+    fail "the mandatory-skip refusal did not name the skip class: $(cat "$tmp_root/evidence-mandatory.log")"
+
+# A stage after pkg-validate.sh that fails fails the lane, and its record says
+# so: the record is written last, so it covers the whole runner.
+if run_packaging_matrix STUB_RPM_CONFIG_LIFECYCLE_FAIL=1 >"$tmp_root/evidence-late-stage.log" 2>&1; then
+    fail "test-packaging-matrix recorded a run whose config lifecycle stage failed"
+fi
+[ ! -e "$evidence_root/.packaging-matrix-verified" ] ||
+    fail "the failed config-lifecycle run left a marker behind"
+python3 - "$evidence_root/.packaging-evidence/test-rpm-pkg-43.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    lane = json.load(handle)
+assert lane["status"] == "fail", lane
+PY
+
+evidence_case_index=0
+assert_evidence_refused() {
+    local context="$1"
+    local mutation="$2"
+    local expected="$3"
+    local marker="$tmp_root/evidence-case-$evidence_case_index.json"
+    local output
+    evidence_case_index=$((evidence_case_index + 1))
+    python3 - "$tmp_root/evidence-good.json" "$marker" "$mutation" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    marker = json.load(handle)
+lanes = {lane["name"]: lane for lane in marker["lanes"]}
+exec(sys.argv[3])
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(marker, handle)
+PY
+    if output=$(evidence_validate "$marker" 2>&1); then
+        fail "packaging evidence accepted: $context"
+    fi
+    case "$output" in
+        *"$expected"*) ;;
+        *) fail "packaging evidence refusal for '$context' did not say '$expected': $output" ;;
+    esac
+    echo "packaging evidence case: $context refused"
+}
+assert_evidence_refused "stale commit" \
+    'marker["commit"] = "0" * 40' "commit"
+assert_evidence_refused "interrupted run without finished_at" \
+    'del marker["finished_at"]' "finished_at"
+assert_evidence_refused "missing required lane record" \
+    'marker["lanes"] = [lane for lane in marker["lanes"] if lane["name"] != "test-rpm-pkg-44"]' "test-rpm-pkg-44"
+assert_evidence_refused "required lane set narrowed" \
+    'marker["required_lanes"].remove("test-rpm-pkg-44")' "required lane set"
+assert_evidence_refused "allowed skip" \
+    'lanes["test-deb-trixie-pkg"].update(skip=1, allowed_skip=1)' "skip"
+assert_evidence_refused "mandatory skip" \
+    'lanes["test-rpm-pkg-43"].update(skip=1, mandatory_skip=1)' "mandatory_skip"
+assert_evidence_refused "models absent" \
+    'lanes["test-deb-resolute-pkg"]["models_present"] = False' "models_present"
+assert_evidence_refused "partial status" \
+    'lanes["test-deb-resolute-pkg"]["status"] = "partial"' "status"
+assert_evidence_refused "failed assertion" \
+    'lanes["test-arch-pkg"]["fail"] = 1' "fail"
+assert_evidence_refused "lane that asserted nothing" \
+    'lanes["test-arch-pkg"]["pass"] = 0' "no assertion"
+assert_evidence_refused "lane record from another commit" \
+    'lanes["test-rpm-smoke-45"]["commit"] = "0" * 40' "commit"
+assert_evidence_refused "direct RPM record claiming another channel" \
+    'lanes["test-rpm-pkg-43"]["channel"] = "copr"' "channel"
+assert_evidence_refused "lane depth downgraded" \
+    'lanes["test-rpm-pkg-44"]["depth"] = "smoke"' "depth"
+assert_evidence_refused "duplicate lane records" \
+    'marker["lanes"].append(dict(lanes["test-arch-pkg"]))' "more than once"
+assert_evidence_refused "dirty tree" \
+    'marker["tree_clean"] = False' "tree_clean"
+assert_evidence_refused "unknown schema" \
+    'marker["schema"] = 2' "schema"
+assert_evidence_refused "skip count that does not add up" \
+    'lanes["test-deb-trixie-pkg"]["skip"] = 2' "skip"
+
+if output=$(evidence_validate "$tmp_root/evidence-missing.json" 2>&1); then
+    fail "packaging evidence accepted a missing marker"
+fi
+case "$output" in
+    *"no packaging evidence"*) ;;
+    *) fail "missing marker refusal did not say so: $output" ;;
+esac
+printf '%s\n' '{"schema": 1, "commit": ' >"$tmp_root/evidence-malformed.json"
+if output=$(evidence_validate "$tmp_root/evidence-malformed.json" 2>&1); then
+    fail "packaging evidence accepted malformed JSON"
+fi
+case "$output" in
+    *"not JSON"*) ;;
+    *) fail "malformed marker refusal did not say so: $output" ;;
+esac
+printf '%s\n' "$evidence_head" >"$tmp_root/evidence-legacy.json"
+if output=$(evidence_validate "$tmp_root/evidence-legacy.json" 2>&1); then
+    fail "packaging evidence accepted the legacy one-line marker"
+fi
+case "$output" in
+    *"legacy"*"schema 1"*|*"schema 1"*"legacy"*) ;;
+    *) fail "legacy marker refusal did not name the new format: $output" ;;
+esac
+
+# Aggregation from lane records alone, as the CI path does: a record short is a
+# missing lane, never a smaller lane set.
+partial_records="$tmp_root/evidence-partial-records"
+cp -R "$tmp_root/evidence-good-records" "$partial_records"
+rm "$partial_records/test-deb-resolute-pkg.json"
+if output=$(python3 "$evidence_root/test/packaging-evidence.py" aggregate \
+        --commit "$evidence_head" --evidence-dir "$partial_records" --tree-clean \
+        --started-at 2026-09-01T00:00:00Z --output "$tmp_root/evidence-partial.json" 2>&1); then
+    fail "packaging evidence aggregated a lane set with a record missing"
+fi
+[ ! -e "$tmp_root/evidence-partial.json" ] || fail "a refused aggregate still wrote a marker"
+case "$output" in
+    *"test-deb-resolute-pkg"*) ;;
+    *) fail "aggregate refusal did not name the missing lane: $output" ;;
+esac
+
+# The CI path: a successful packaging.yml run is evidence only when its
+# evidence artifacts aggregate into an accepted marker for this commit.
+cat >"$tmp_root/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+    "run view")
+        printf '%s\n' "${STUB_GH_RUN_VIEW:?}" ;;
+    "run download")
+        [ -n "${STUB_GH_ARTIFACTS:-}" ] || { echo "no artifacts match any of the names or patterns provided" >&2; exit 1; }
+        dir=""
+        while [ $# -gt 0 ]; do
+            case "$1" in --dir) dir="$2"; shift 2 ;; *) shift ;; esac
+        done
+        for record in "$STUB_GH_ARTIFACTS"/*.json; do
+            name="$(basename "$record" .json)"
+            mkdir -p "$dir/packaging-evidence-$name"
+            cp "$record" "$dir/packaging-evidence-$name/"
+        done ;;
+    *) exit 2 ;;
+esac
+SH
+chmod +x "$tmp_root/bin/gh"
+ci_run_view="{\"conclusion\":\"success\",\"headSha\":\"$evidence_head\",\"createdAt\":\"2026-09-01T07:00:00Z\",\"updatedAt\":\"2026-09-01T08:00:00Z\"}"
+PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="$ci_run_view" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
+    python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 ||
+    fail "release preflight refused a packaging.yml run carrying complete evidence"
+if output=$(PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="$ci_run_view" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 2>&1); then
+    fail "release preflight accepted a packaging.yml run without evidence artifacts"
+fi
+case "$output" in
+    *"no packaging evidence artifact"*) ;;
+    *) fail "artifact-less run refusal did not say so: $output" ;;
+esac
+if PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="$ci_run_view" STUB_GH_ARTIFACTS="$partial_records" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 >/dev/null 2>&1; then
+    fail "release preflight accepted a packaging.yml run missing a lane artifact"
+fi
+if PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="${ci_run_view/success/failure}" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 >/dev/null 2>&1; then
+    fail "release preflight accepted a failed packaging.yml run"
+fi
+if PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="${ci_run_view/$evidence_head/$(printf '0%.0s' $(seq 40))}" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 >/dev/null 2>&1; then
+    fail "release preflight accepted a packaging.yml run at another commit"
+fi
+echo "packaging evidence: recipe, marker, and workflow-run cases OK"
+
 cp "$repo_root/justfile" "$repo_root/Cargo.toml" "$repo_root/Cargo.lock" "$release_repo/"
 cp "$repo_root/dist/PKGBUILD" "$repo_root/dist/PKGBUILD-bin" "$repo_root/dist/PKGBUILD-git" "$repo_root/dist/facelock.spec" "$release_repo/dist/"
 cp "$repo_root/debian/changelog" "$release_repo/debian/"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -433,6 +433,10 @@ assert_matrix_mutation_rejected \
     '/^          name: packaging-evidence-arch$/,/^          overwrite: true$/{/^          overwrite: true$/a\      - name: Upload extra evidence\n        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a\n        with:\n          name: packaging-evidence-extra\n          path: .packaging-evidence/\n          if-no-files-found: error\n          overwrite: true
 }'
 assert_matrix_mutation_rejected \
+    "packaging workflow uploading the hidden evidence directory without opting in" \
+    ".github/workflows/packaging.yml" \
+    's/^          include-hidden-files: true$//'
+assert_matrix_mutation_rejected \
     "release matrix granting evidence eligibility outside Rawhide" \
     "dist/release-matrix.json" \
     's/"id": "debian-13",/"id": "debian-13", "evidence_eligibility": {"lifecycle": false},/'

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -396,6 +396,26 @@ assert_matrix_mutation_rejected \
     "test/Containerfile.packit" \
     's|@sha256:[0-9a-f]*||'
 assert_matrix_mutation_rejected \
+    "packaging workflow Fedora lanes uploading no evidence artifact" \
+    ".github/workflows/packaging.yml" \
+    's/name: packaging-evidence-rpm-/name: packaging-evidence-fedora-/'
+assert_matrix_mutation_rejected \
+    "packaging workflow tolerating a lane that recorded nothing" \
+    ".github/workflows/packaging.yml" \
+    's/if-no-files-found: error/if-no-files-found: warn/'
+assert_matrix_mutation_rejected \
+    "release preflight validating something other than the packaging marker" \
+    "justfile" \
+    's@validate --commit "\$HEAD_SHA" .packaging-matrix-verified@validate --commit "$HEAD_SHA" .hardware-tiers-verified@'
+assert_matrix_mutation_rejected \
+    "release preflight skipping the workflow-run evidence download" \
+    "justfile" \
+    's@packaging-evidence.py ci-run --commit@packaging-evidence.py ci-run-disabled --commit@'
+assert_matrix_mutation_rejected \
+    "packaging matrix recording without aggregating lane evidence" \
+    "justfile" \
+    's@packaging-evidence.py aggregate --commit@packaging-evidence.py aggregate-disabled --commit@'
+assert_matrix_mutation_rejected \
     "PKGBUILD-git dropping the onnxruntime runtime dependency" \
     "dist/PKGBUILD-git" \
     "s/ 'onnxruntime'//"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1545,6 +1545,12 @@ assert_evidence_refused "unknown schema" \
     'marker["schema"] = 2' "schema"
 assert_evidence_refused "skip count that does not add up" \
     'lanes["test-deb-trixie-pkg"]["skip"] = 2' "skip"
+assert_evidence_refused "record without a schema" \
+    'del lanes["test-arch-pkg"]["schema"]' "schema"
+assert_evidence_refused "record with another schema" \
+    'lanes["test-arch-pkg"]["schema"] = 2' "schema"
+assert_evidence_refused "required lane listed twice" \
+    'marker["required_lanes"].append("test-arch-pkg")' "required lane set"
 assert_evidence_refused "record for a lane the matrix does not require" \
     'marker["lanes"].append({**lanes["test-arch-pkg"], "name": "test-extra-lane"})' "not a lane the release matrix requires"
 assert_evidence_refused "finished before it started" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1247,8 +1247,9 @@ fi
 # images or run this very contract are stubbed to succeed. The stub keys the
 # model-dependent branch off what the runner mounted, as the real images do.
 evidence_root="$tmp_root/evidence-root"
-mkdir -p "$evidence_root/dist" "$evidence_root/test" "$evidence_root/models" "$evidence_root/target/release"
+mkdir -p "$evidence_root/dist" "$evidence_root/test" "$evidence_root/models" "$evidence_root/target/release" "$evidence_root/.github/workflows"
 cp "$repo_root/justfile" "$evidence_root/"
+cp "$repo_root/.github/workflows/packaging.yml" "$evidence_root/.github/workflows/"
 cp "$repo_root/dist/release-matrix.json" "$evidence_root/dist/"
 cp "$repo_root/test/packaging-evidence.py" \
     "$repo_root/test/run-pkg-validate-systemd.sh" \
@@ -1379,8 +1380,12 @@ run_packaging_matrix >"$tmp_root/evidence-complete.log" 2>&1 ||
     fail "test-packaging-matrix refused a complete run: $(cat "$tmp_root/evidence-complete.log")"
 [ ! -e "$evidence_root/.packaging-evidence/stale-lane.json" ] ||
     fail "test-packaging-matrix kept a lane record from before the run"
-evidence_validate "$evidence_root/.packaging-matrix-verified" ||
-    fail "release preflight refused the marker a complete matrix run wrote"
+validate_output=$(evidence_validate "$evidence_root/.packaging-matrix-verified" 2>&1) ||
+    fail "release preflight refused the marker a complete matrix run wrote: $validate_output"
+case "$validate_output" in
+    *"6 lanes"*) ;;
+    *) fail "validate accepted the marker without summarising it: $validate_output" ;;
+esac
 python3 - "$evidence_root/.packaging-matrix-verified" "$evidence_head" <<'PY'
 import json
 import sys
@@ -1536,6 +1541,29 @@ assert_evidence_refused "unknown schema" \
     'marker["schema"] = 2' "schema"
 assert_evidence_refused "skip count that does not add up" \
     'lanes["test-deb-trixie-pkg"]["skip"] = 2' "skip"
+assert_evidence_refused "record for a lane the matrix does not require" \
+    'marker["lanes"].append({**lanes["test-arch-pkg"], "name": "test-extra-lane"})' "not a lane the release matrix requires"
+assert_evidence_refused "finished before it started" \
+    'marker["finished_at"] = "2020-01-01T00:00:00Z"' "before started_at"
+assert_evidence_refused "timestamp that is not ISO 8601" \
+    'marker["started_at"] = "yesterday"' "ISO 8601"
+assert_evidence_refused "timestamp without an offset" \
+    'marker["started_at"] = marker["started_at"].rstrip("Z")' "UTC offset"
+
+# Outside a git checkout, HEAD cannot be resolved; that is a refusal, not a
+# traceback.
+nogit_root="$tmp_root/nogit"
+mkdir -p "$nogit_root/test" "$nogit_root/dist"
+cp "$repo_root/test/packaging-evidence.py" "$nogit_root/test/"
+cp "$repo_root/dist/release-matrix.json" "$nogit_root/dist/"
+if output=$(cd / && python3 "$nogit_root/test/packaging-evidence.py" validate "$tmp_root/evidence-good.json" 2>&1); then
+    fail "packaging evidence resolved HEAD outside a git checkout"
+fi
+case "$output" in
+    *Traceback*) fail "packaging evidence crashed outside a git checkout: $output" ;;
+    *"cannot resolve HEAD"*) ;;
+    *) fail "packaging evidence did not say HEAD is unresolvable: $output" ;;
+esac
 
 if output=$(evidence_validate "$tmp_root/evidence-missing.json" 2>&1); then
     fail "packaging evidence accepted a missing marker"
@@ -1586,6 +1614,7 @@ case "$1 $2" in
     "run view")
         printf '%s\n' "${STUB_GH_RUN_VIEW:?}" ;;
     "run download")
+        [ "${STUB_GH_DOWNLOAD_FAIL:-0}" != 1 ] || { echo "HTTP 401: Bad credentials (https://api.github.com/repos/x/y/actions/runs/1/artifacts)" >&2; exit 1; }
         [ -n "${STUB_GH_ARTIFACTS:-}" ] || { echo "no artifacts match any of the names or patterns provided" >&2; exit 1; }
         dir=""
         while [ $# -gt 0 ]; do
@@ -1600,7 +1629,7 @@ case "$1 $2" in
 esac
 SH
 chmod +x "$tmp_root/bin/gh"
-ci_run_view="{\"conclusion\":\"success\",\"headSha\":\"$evidence_head\",\"createdAt\":\"2026-09-01T07:00:00Z\",\"updatedAt\":\"2026-09-01T08:00:00Z\"}"
+ci_run_view="{\"conclusion\":\"success\",\"event\":\"workflow_dispatch\",\"workflowName\":\"Packaging\",\"headSha\":\"$evidence_head\",\"createdAt\":\"2026-09-01T07:00:00Z\",\"updatedAt\":\"2026-09-01T08:00:00Z\"}"
 PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="$ci_run_view" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
     python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 ||
     fail "release preflight refused a packaging.yml run carrying complete evidence"
@@ -1624,6 +1653,30 @@ if PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="${ci_run_view/$evidence_head/$(p
         python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 >/dev/null 2>&1; then
     fail "release preflight accepted a packaging.yml run at another commit"
 fi
+if output=$(PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="${ci_run_view/workflow_dispatch/pull_request}" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 2>&1); then
+    fail "release preflight accepted a pull-request packaging.yml run"
+fi
+case "$output" in
+    *"pull-request runs build the merge commit"*) ;;
+    *) fail "pull-request run refusal did not explain the merge commit: $output" ;;
+esac
+if output=$(PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="${ci_run_view/Packaging/CI}" STUB_GH_ARTIFACTS="$tmp_root/evidence-good-records" \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 2>&1); then
+    fail "release preflight accepted a run of another workflow as packaging evidence"
+fi
+case "$output" in
+    *"workflow is 'CI'"*) ;;
+    *) fail "other-workflow refusal did not name the workflow: $output" ;;
+esac
+if output=$(PATH="$tmp_root/bin:$PATH" STUB_GH_RUN_VIEW="$ci_run_view" STUB_GH_DOWNLOAD_FAIL=1 \
+        python3 "$evidence_root/test/packaging-evidence.py" ci-run --commit "$evidence_head" --run 12345 2>&1); then
+    fail "release preflight accepted a run whose artifacts could not be downloaded"
+fi
+case "$output" in
+    *"gh run download failed"*"Bad credentials"*) ;;
+    *) fail "download failure was not distinguished from a missing artifact: $output" ;;
+esac
 echo "packaging evidence: recipe, marker, and workflow-run cases OK"
 
 cp "$repo_root/justfile" "$repo_root/Cargo.toml" "$repo_root/Cargo.lock" "$release_repo/"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -437,6 +437,23 @@ assert_matrix_mutation_rejected \
     ".github/workflows/packaging.yml" \
     's/^          include-hidden-files: true$//'
 assert_matrix_mutation_rejected \
+    "release preflight keeping the validate call in a trailing comment" \
+    "justfile" \
+    's@^    elif python3 test/packaging-evidence.py validate --commit "\$HEAD_SHA" .packaging-matrix-verified; then$@    elif true; then # python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified@'
+assert_matrix_mutation_rejected \
+    "packaging matrix echoing the commit into the marker beside the aggregate" \
+    "justfile" \
+    's@^        --evidence-dir .packaging-evidence --output .packaging-matrix-verified$@&\n    echo "$commit" > .packaging-matrix-verified@'
+# A marker write that exists only in a trailing comment is not a marker write:
+# the guard reads executable text, not the whole line.
+harmless_comment_root="$tmp_root/matrix-harmless-comment"
+cp -R "$matrix_root" "$harmless_comment_root"
+sed -i 's@^    echo "Recorded: packaging matrix evidence at $commit"$@&  # never: echo "$commit" > .packaging-matrix-verified@' "$harmless_comment_root/justfile"
+grep -q 'never: echo' "$harmless_comment_root/justfile" || fail "harmless-comment fixture did not change the justfile"
+RELEASE_MATRIX_VERSION=0.2.0 python3 "$harmless_comment_root/test/check-release-matrix.py" >/dev/null 2>&1 ||
+    fail "release matrix checker rejected a marker write that exists only in a trailing comment"
+echo "release matrix case: marker write in a trailing comment tolerated"
+assert_matrix_mutation_rejected \
     "release matrix granting evidence eligibility outside Rawhide" \
     "dist/release-matrix.json" \
     's/"id": "debian-13",/"id": "debian-13", "evidence_eligibility": {"lifecycle": false},/'

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -412,6 +412,27 @@ assert_matrix_mutation_rejected \
     "justfile" \
     's@packaging-evidence.py ci-run --commit@packaging-evidence.py ci-run-disabled --commit@'
 assert_matrix_mutation_rejected \
+    "packaging workflow keeping the evidence artifact name only in a comment" \
+    ".github/workflows/packaging.yml" \
+    's/^          name: packaging-evidence-arch$/          # name: packaging-evidence-arch\n          name: packaging-evidence-arch-moved/'
+assert_matrix_mutation_rejected \
+    "release preflight keeping the validate call only in a comment" \
+    "justfile" \
+    's@^    elif python3 test/packaging-evidence.py validate --commit "\$HEAD_SHA" .packaging-matrix-verified; then$@    # python3 test/packaging-evidence.py validate --commit "$HEAD_SHA" .packaging-matrix-verified\n    elif true; then@'
+assert_matrix_mutation_rejected \
+    "packaging matrix keeping the aggregate call only in a comment" \
+    "justfile" \
+    's@^    python3 test/packaging-evidence.py aggregate --commit "\$commit" --tree-clean \\$@    # python3 test/packaging-evidence.py aggregate --commit "$commit" --tree-clean\n    true \\@'
+assert_matrix_mutation_rejected \
+    "packaging workflow with every evidence upload step commented out" \
+    ".github/workflows/packaging.yml" \
+    '/^      - name: Upload packaging evidence$/,/^          overwrite: true$/s/^\( *\)/\1# /'
+assert_matrix_mutation_rejected \
+    "packaging workflow adding a lane upload without bumping the step count" \
+    ".github/workflows/packaging.yml" \
+    '/^          name: packaging-evidence-arch$/,/^          overwrite: true$/{/^          overwrite: true$/a\      - name: Upload extra evidence\n        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a\n        with:\n          name: packaging-evidence-extra\n          path: .packaging-evidence/\n          if-no-files-found: error\n          overwrite: true
+}'
+assert_matrix_mutation_rejected \
     "release matrix granting evidence eligibility outside Rawhide" \
     "dist/release-matrix.json" \
     's/"id": "debian-13",/"id": "debian-13", "evidence_eligibility": {"lifecycle": false},/'

--- a/test/rpm-runtime-smoke.sh
+++ b/test/rpm-runtime-smoke.sh
@@ -79,3 +79,6 @@ systemd-tmpfiles --cat-config >/dev/null || fail "systemd rejects the tmpfiles c
 pass "packaged tmpfiles entries applied at install time"
 
 printf '\n=== Fedora runtime smoke results: %d passed, 0 failed ===\n' "$pass_count"
+# For test/packaging-evidence.py. No assertion here needs the ONNX models, so
+# none was withheld for lack of them; a failure above exits before this line.
+printf 'RESULTS_JSON: {"pass":%d,"fail":0,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n' "$pass_count"

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -62,6 +62,15 @@ if [ -n "${FACELOCK_ALLOW_MISSING_MODELS:-}" ]; then
     exec_env=(-e "FACELOCK_ALLOW_MISSING_MODELS=$FACELOCK_ALLOW_MISSING_MODELS")
 fi
 
+# When a lane recipe names itself in PACKAGING_LANE, the run ends by writing
+# .packaging-evidence/<lane>.json through test/packaging-evidence.py: the
+# counts from pkg-validate.sh's RESULTS_JSON line, plus any skip this runner
+# took on its own, so `just test-packaging-matrix` can refuse a partial run
+# instead of recording it as the release gate.
+runner_skips=()
+validate_log="$(mktemp "${TMPDIR:-/tmp}/facelock-pkg-validate.XXXXXX")"
+trap 'rm -f -- "$validate_log"' EXIT
+
 # --systemd=always: podman sets up /run, /tmp, cgroups and SIGRTMIN+3 for a
 #   systemd payload.
 # --security-opt unmask=ALL: leave /proc unmasked so systemd can set up
@@ -69,7 +78,7 @@ fi
 #   kernel refuses when parts of /proc are overmounted).
 cid=$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
     "${mounts[@]}" "${package_mount[@]}" "$IMAGE" /lib/systemd/systemd)
-trap 'podman rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+trap 'podman rm -f "$cid" >/dev/null 2>&1 || true; rm -f -- "$validate_log"' EXIT
 
 # Wait for systemd to finish booting (degraded is fine — minimal containers
 # routinely have a failed getty/timesyncd; the validation doesn't need them).
@@ -120,6 +129,7 @@ if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
         podman exec "$cid" /deb-package-lifecycle.sh versioned-upgrade-active
     elif [ "${FACELOCK_ALLOW_MISSING_MODELS:-0}" = 1 ]; then
         echo "SKIP: Debian active-service versioned upgrades (no ONNX models, FACELOCK_ALLOW_MISSING_MODELS=1)" >&2
+        runner_skips+=(--extra-skip allowed)
     else
         echo "ERROR: Debian active-service versioned upgrades require the reviewed ONNX models" >&2
         exit 1
@@ -131,14 +141,26 @@ if podman exec "$cid" test -x /rpm-service-pam-lifecycle.sh; then
     podman exec "$cid" /rpm-service-pam-lifecycle.sh
 fi
 
-podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh
+lane_status=0
+podman exec "${exec_env[@]}" "$cid" /pkg-validate.sh | tee "$validate_log" || lane_status=$?
 
 # pkg-validate.sh pins %config(noreplace) on erase and finishes with the package
 # uninstalled, which is the clean slate the upgrade half needs.
-if podman exec "$cid" test -x /rpm-config-lifecycle.sh; then
-    podman exec "$cid" /rpm-config-lifecycle.sh
+after_validate() {
+    if podman exec "$cid" test -x /rpm-config-lifecycle.sh; then
+        podman exec "$cid" /rpm-config-lifecycle.sh || return
+    fi
+    if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
+        podman exec "$cid" /deb-package-lifecycle.sh purge || return
+    fi
+}
+if [ "$lane_status" -eq 0 ]; then
+    after_validate || lane_status=$?
 fi
 
-if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
-    podman exec "$cid" /deb-package-lifecycle.sh purge
+# Recorded last, so the record's status covers every stage above it.
+if [ -n "${PACKAGING_LANE:-}" ]; then
+    python3 "$(dirname "$0")/packaging-evidence.py" record --lane "$PACKAGING_LANE" \
+        --results-log "$validate_log" --exit-status "$lane_status" "${runner_skips[@]}"
 fi
+exit "$lane_status"

--- a/test/run-rpm-smoke-systemd.sh
+++ b/test/run-rpm-smoke-systemd.sh
@@ -14,9 +14,11 @@ IMAGE="${1:?usage: run-rpm-smoke-systemd.sh <image>}"
     exit 2
 }
 
+smoke_log="$(mktemp "${TMPDIR:-/tmp}/facelock-rpm-smoke.XXXXXX")"
+trap 'rm -f -- "$smoke_log"' EXIT
 cid=$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
     "$IMAGE" /lib/systemd/systemd)
-trap 'podman rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+trap 'podman rm -f "$cid" >/dev/null 2>&1 || true; rm -f -- "$smoke_log"' EXIT
 
 booted=""
 for _ in $(seq 1 120); do
@@ -32,4 +34,13 @@ if [ -z "$booted" ]; then
     exit 1
 fi
 
-podman exec "$cid" /rpm-runtime-smoke.sh
+lane_status=0
+podman exec "$cid" /rpm-runtime-smoke.sh | tee "$smoke_log" || lane_status=$?
+
+# The lane's packaging-evidence record, when the recipe named itself in
+# PACKAGING_LANE (see test/run-pkg-validate-systemd.sh).
+if [ -n "${PACKAGING_LANE:-}" ]; then
+    python3 "$(dirname "$0")/packaging-evidence.py" record --lane "$PACKAGING_LANE" \
+        --results-log "$smoke_log" --exit-status "$lane_status"
+fi
+exit "$lane_status"


### PR DESCRIPTION
## Summary

- replace the one-line commit marker with a schema 1 JSON document: commit, tree state, timestamps, the required lane set, and one record per lane
- record each lane from its validator's `RESULTS_JSON` line: target, channel, build origin, runtime policy, depth, `models_present`, and pass/fail/skip counts with skips split into allowed and mandatory
- derive the required lane set from `dist/release-matrix.json`; refuse a record whose claims differ from what the matrix requires of that lane, or that names a lane the matrix does not require
- make `just test-packaging-matrix` delete the previous marker and every record before its first lane, then aggregate; refuse to write a marker on any skip of either class, `models_present: false`, a record from another commit, or a missing lane
- keep the `FACELOCK_ALLOW_MISSING_MODELS=1` opt-out for local diagnostics; its records are `partial` and never aggregate
- validate the marker in `just release-preflight` with the same rules; refuse the legacy one-line marker with a message naming the new format
- upload `.packaging-evidence/` from every `packaging.yml` lane job; preflight fetches the `packaging-evidence-*` artifacts with `gh run download` and aggregates them the same way, so a run's green conclusion alone is not evidence
- refuse pull-request runs, which build the merge commit rather than the commit being released, and runs of any other workflow
- exit 77 from `polkit-agent-validate.sh` when it cannot reach its subject; `pkg-validate.sh` counts that as a mandatory skip, not a pass
- forbid `evidence_eligibility` on any platform row but Rawhide, so the key cannot shrink the required lane set quietly
- pin the upload steps and the preflight invocations in `check-release-matrix.py`

## Why

`FACELOCK_ALLOW_MISSING_MODELS=1` skips the daemon-start, D-Bus, runtime capability and active-upgrade assertions, and the run still wrote the same commit hash a complete run wrote, so preflight could not tell a diagnostic partial run from the release gate. The CI path had the same hole: a path-filtered pull-request run skips every lane, concludes "success", and matched `gh run list --commit`. The marker stays a maintainer-trust record: preflight checks its shape and its binding to HEAD and the matrix, not that a real lane produced it.

## Validation

- `bash test/release-version-contract.sh`: stub-lane runs of `just test-packaging-matrix` (complete, opt-out, mandatory skip, late-stage failure), hand-built markers for every refusal, `ci-run` against a stub `gh`, matrix drift mutations
- mutation of every validator rule, the reset dependency, the runner's own skip, and the checker guards
- `python3 test/check-release-matrix.py`, `just check`
- `just test-packaging-matrix` at the head commit, then `just release-preflight` against the marker it wrote and against a hand-written legacy marker
- `just test-rpm-pkg 44` with the polkit validator forced to exit 77

## Reviewer notes

- **claims are stated by the recipe, required by the matrix**: each lane recipe passes `PACKAGING_LANE='<name> target=… channel=…'`; `required_lanes()` derives the expectation; the validator joins them
- **fedora lanes are one direct-RPM record per Packit release target**, mirroring the existing `test-rpm-lanes` binding; #230 adds a `copr` record per target beside it, and the channel check already refuses a direct record standing in for it
- **`models_present` is true on `test-rpm-smoke-45` and `test-arch-pkg`**: neither has a model-dependent assertion, so nothing was withheld; the deb and rpm-pkg records carry the real signal
- **debian lanes claim `container-source-build`**, not host binaries: `build-deb-package-image.sh` builds inside the assembler container and rebuilds the `.dsc`

| file | why it matters |
|---|---|
| `test/packaging-evidence.py` *(start here)* | record, aggregate, validate, ci-run; one `check_marker()` for every path |
| `justfile` | lane claims, `_packaging-evidence-reset`, the aggregate, preflight's evidence block |
| `test/run-pkg-validate-systemd.sh`, `test/run-rpm-smoke-systemd.sh` | capture the validator's counts and record last, so the status covers every stage |
| `test/pkg-validate.sh`, `test/rpm-runtime-smoke.sh`, `test/arch-package-validate.sh` | print `RESULTS_JSON`; map exit 77 to a mandatory skip |
| `test/polkit-agent-validate.sh` | exit 77 instead of 0 when the check cannot run |
| `.github/workflows/packaging.yml` | evidence artifact uploads, failing the job when a lane recorded nothing |
| `test/check-release-matrix.py` | upload, preflight, and eligibility guards |
| `test/release-version-contract.sh` | the evidence fixture and its cases |
| `docs/contracts.md`, `docs/releasing.md`, the release and packaging-test skills, the testing rule | the contract and the procedure |

Closes #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Validation**
  - Release preflight now requires complete, zero-skip packaging evidence for the exact release commit, including available ONNX models.
  - Incomplete, stale, mismatched, path-filtered, legacy, merge-commit, nightly, or diagnostic evidence is rejected.

- **Packaging CI**
  - Debian, Fedora, and Arch jobs upload structured lane evidence artifacts.
  - Packaging checks report passes, failures, skips, and model availability.

- **Compatibility**
  - APT releases support temporary `main` and `legacy` compatibility suites through the documented retirement window.

- **Tests**
  - Expanded validation covers evidence collection, artifact handling, release eligibility, repository publishing, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->