### PR TITLE
fix(test): install the main arch package, not the debug split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
       - name: Verify Debian source contract
         run: just test-deb-source-contract
 
+      - name: Verify the Arch lane picks the package it means to install
+        run: just test-arch-package-select
+
       - name: Verify release target declarations
         run: python3 test/check-release-matrix.py
 

--- a/justfile
+++ b/justfile
@@ -98,7 +98,7 @@ check-package-names-live:
     python3 test/check-package-names-live.py
 
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
-check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes
+check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,
@@ -107,6 +107,15 @@ check: test lint fmt-check audit check-pam-standalone check-agent-docs test-sour
 # one-line commits in a temporary directory.
 test-classify-changes:
     bash test/classify-changes-test.sh
+
+# Prove the Arch lane installs the package makepkg built for pkgname=facelock
+# and not the debug split it now emits beside it. Getting this wrong installs
+# facelock-debug, and every assertion after it reports facelock as absent --
+# nondeterministically, because the losing selection reads directory order
+# (#212). Runs in `just check`: it is a few file names in a temporary directory,
+# and the lane that would otherwise catch it is a full release build.
+test-arch-package-select:
+    bash test/arch-package-select-test.sh
 
 # Prove every install path ships compiled gettext catalogs. Static checks run
 # everywhere; the compile check needs gettext and skips without it, so that

--- a/test/arch-package-select-test.sh
+++ b/test/arch-package-select-test.sh
@@ -60,24 +60,26 @@ expect_reject() {
     fi
 }
 
-main=facelock-0.1.4-1-x86_64.pkg.tar.zst
-debug=facelock-debug-0.1.4-1-x86_64.pkg.tar.zst
+# Not `main`: select_main_package declares `local -a main`, and a global of the
+# same name would shadow-warn (SC2178) and read as the function's array.
+main_pkg=facelock-0.1.4-1-x86_64.pkg.tar.zst
+debug_pkg=facelock-debug-0.1.4-1-x86_64.pkg.tar.zst
 
 echo "select_main_package -- a debug split beside the package"
-expect_pick "main written first" "$main" \
-    "$(fixture main-first "$main" "$debug")"
-expect_pick "debug written first" "$main" \
-    "$(fixture debug-first "$debug" "$main")"
-expect_pick "no debug split" "$main" \
-    "$(fixture solo "$main")"
+expect_pick "main written first" "$main_pkg" \
+    "$(fixture main-first "$main_pkg" "$debug_pkg")"
+expect_pick "debug written first" "$main_pkg" \
+    "$(fixture debug-first "$debug_pkg" "$main_pkg")"
+expect_pick "no debug split" "$main_pkg" \
+    "$(fixture solo "$main_pkg")"
 
 echo "select_main_package -- nothing to install"
 expect_reject "empty directory" "$(fixture empty)"
-expect_reject "only the debug split" "$(fixture debug-only "$debug")"
+expect_reject "only the debug split" "$(fixture debug-only "$debug_pkg")"
 
 echo "select_main_package -- more than one candidate"
 expect_reject "two versions of the package" \
-    "$(fixture two-mains "$main" facelock-0.1.5-1-x86_64.pkg.tar.zst)"
+    "$(fixture two-mains "$main_pkg" facelock-0.1.5-1-x86_64.pkg.tar.zst)"
 
 if [ "$failures" -ne 0 ]; then
     echo "$failures package selection case(s) failed" >&2

--- a/test/arch-package-select-test.sh
+++ b/test/arch-package-select-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Exercise select_main_package() from test/build-arch-source-package.sh against
+# a directory of package file names, without makepkg or a container.
+#
+# makepkg's `debug` option emits facelock-debug-<pkgver>-<pkgrel>-<arch>.pkg.tar.zst
+# beside the package the Arch lane installs. The lane used to take the first
+# match `find` returned, which is directory order: on one pull request that was
+# the debug package, `pacman -U` installed it, and every later assertion failed
+# with "package 'facelock' was not found"; on the next the same code picked the
+# real package and passed (#212). Directory order is the variable, so both
+# creation orders are built here -- a selection that reads position instead of
+# name passes one and fails the other.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Sourcing defines select_main_package() and returns before the build.
+# shellcheck source=test/build-arch-source-package.sh
+source "$repo_root/test/build-arch-source-package.sh"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/facelock-arch-select.XXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+failures=0
+
+# A fresh directory holding exactly the named files, created in the order given.
+fixture() {
+    local name="$1"
+    shift
+    local dir="$work/$name" file
+    rm -rf -- "$dir"
+    mkdir -p -- "$dir"
+    for file in "$@"; do
+        : > "$dir/$file"
+    done
+    printf '%s\n' "$dir"
+}
+
+expect_pick() {
+    local name="$1" want="$2" dir="$3"
+    local got
+    # select_main_package fails by exiting, so the subshell keeps a rejection
+    # from taking this test down with it.
+    got="$(select_main_package "$dir" 2>/dev/null)" || got=""
+    if [ "${got##*/}" = "$want" ]; then
+        echo "  ok    $name -> $want"
+    else
+        echo "  FAIL  $name -> ${got##*/}, expected $want"
+        failures=$((failures + 1))
+    fi
+}
+
+expect_reject() {
+    local name="$1" dir="$2"
+    local got
+    if got="$(select_main_package "$dir" 2>/dev/null)"; then
+        echo "  FAIL  $name -> accepted ${got##*/}, expected a failure"
+        failures=$((failures + 1))
+    else
+        echo "  ok    $name -> rejected"
+    fi
+}
+
+main=facelock-0.1.4-1-x86_64.pkg.tar.zst
+debug=facelock-debug-0.1.4-1-x86_64.pkg.tar.zst
+
+echo "select_main_package -- a debug split beside the package"
+expect_pick "main written first" "$main" \
+    "$(fixture main-first "$main" "$debug")"
+expect_pick "debug written first" "$main" \
+    "$(fixture debug-first "$debug" "$main")"
+expect_pick "no debug split" "$main" \
+    "$(fixture solo "$main")"
+
+echo "select_main_package -- nothing to install"
+expect_reject "empty directory" "$(fixture empty)"
+expect_reject "only the debug split" "$(fixture debug-only "$debug")"
+
+echo "select_main_package -- more than one candidate"
+expect_reject "two versions of the package" \
+    "$(fixture two-mains "$main" facelock-0.1.5-1-x86_64.pkg.tar.zst)"
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures package selection case(s) failed" >&2
+    exit 1
+fi
+echo "arch package selection: OK"

--- a/test/build-arch-source-package.sh
+++ b/test/build-arch-source-package.sh
@@ -48,6 +48,46 @@ fail() {
     exit 1
 }
 
+# Print the one package this lane is meant to install, out of everything makepkg
+# left in $1.
+#
+# makepkg's `debug` option splits a second package out of the same build,
+# facelock-debug-<pkgver>-<pkgrel>-<arch>.pkg.tar.zst, into the same directory.
+# Taking the first match `find` returns is directory order, not a choice: on one
+# pull request that was the debug package, `pacman -U` installed it, and every
+# assertion after it failed with "package 'facelock' was not found"; on the next
+# it was the real package and the identical code passed (#212).
+#
+# The main package's name continues with the version, so the character after the
+# pkgname dash is a digit and the debug split's is not. Both halves of that are
+# spelled out rather than relying on one, and the count is asserted, so a third
+# split package makepkg starts emitting fails here instead of being installed by
+# lottery.
+select_main_package() {
+    local dir="$1"
+    local -a main=() present=()
+    local path name
+
+    while IFS= read -r -d '' path; do
+        name="${path##*/}"
+        present+=("$name")
+        case "$name" in
+            facelock-debug-*) ;;
+            facelock-[0-9]*) main+=("$path") ;;
+        esac
+    done < <(find "$dir" -maxdepth 1 -type f -name '*.pkg.tar.zst' -print0 | sort -z)
+
+    [ "${#main[@]}" -eq 1 ] || fail \
+        "expected exactly one facelock package in $dir, found ${#main[@]} (built: ${present[*]:-none})"
+    printf '%s\n' "${main[0]}"
+}
+
+# test/arch-package-select-test.sh sources this file for select_main_package
+# alone; everything below builds a package and must not run under it.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
+fi
+
 [ -d "$STAGED" ] || fail "candidate source tree is not mounted at $STAGED"
 [ -f "$STAGED/Cargo.toml" ] && [ -f "$STAGED/dist/PKGBUILD" ] ||
     fail "$STAGED does not look like a facelock checkout"
@@ -143,8 +183,7 @@ runuser -u "$BUILDER" -- \
     bash -c "cd '$BUILD' && makepkg --syncdeps --noconfirm" ||
     fail "makepkg failed"
 
-package="$(find "$BUILD" -maxdepth 1 -type f -name 'facelock-*.pkg.tar.zst' -print -quit)"
-[ -n "$package" ] || fail "makepkg produced no package"
+package="$(select_main_package "$BUILD")" || exit 1
 
 echo "==> pacman -U $(basename -- "$package")"
 cp -- "$package" /facelock-test-package.pkg.tar.zst

--- a/test/build-arch-test-package.sh
+++ b/test/build-arch-test-package.sh
@@ -14,13 +14,19 @@ runuser -u testuser -- bash -c \
 # beside this one, and taking the first match `find` returns would install
 # whichever the directory happened to list first. This image does not carry that
 # script, so the rule is spelled out again here.
-mapfile -d '' -t packages < <(
-    find "$build_dir" -maxdepth 1 -type f \
-        -name 'facelock-[0-9]*.pkg.tar.zst' ! -name 'facelock-debug-*' -print0 |
-        sort -z
-)
+packages=()
+present=()
+while IFS= read -r -d '' path; do
+    present+=("${path##*/}")
+    case "${path##*/}" in
+        facelock-debug-*) ;;
+        facelock-[0-9]*) packages+=("$path") ;;
+    esac
+done < <(find "$build_dir" -maxdepth 1 -type f -name '*.pkg.tar.zst' -print0 | sort -z)
+
 if [ "${#packages[@]}" -ne 1 ]; then
-    echo "expected exactly one facelock package in $build_dir, found ${#packages[@]}" >&2
+    echo "expected exactly one facelock package in $build_dir," \
+        "found ${#packages[@]} (built: ${present[*]:-none})" >&2
     exit 1
 fi
 pacman -U --noconfirm --overwrite '*' "${packages[0]}"

--- a/test/build-arch-test-package.sh
+++ b/test/build-arch-test-package.sh
@@ -9,6 +9,18 @@ install -m 0644 -o testuser -g testuser /build/dist/facelock.install \
 
 runuser -u testuser -- bash -c \
     'cd /tmp/facelock-arch-package && makepkg --nodeps --noconfirm'
-package=$(find "$build_dir" -maxdepth 1 -type f -name 'facelock-*.pkg.tar.zst' -print -quit)
-test -n "$package"
-pacman -U --noconfirm --overwrite '*' "$package"
+# Same hazard select_main_package() covers in test/build-arch-source-package.sh
+# (#212): makepkg's `debug` option can drop a facelock-debug-<pkgver> package
+# beside this one, and taking the first match `find` returns would install
+# whichever the directory happened to list first. This image does not carry that
+# script, so the rule is spelled out again here.
+mapfile -d '' -t packages < <(
+    find "$build_dir" -maxdepth 1 -type f \
+        -name 'facelock-[0-9]*.pkg.tar.zst' ! -name 'facelock-debug-*' -print0 |
+        sort -z
+)
+if [ "${#packages[@]}" -ne 1 ]; then
+    echo "expected exactly one facelock package in $build_dir, found ${#packages[@]}" >&2
+    exit 1
+fi
+pacman -U --noconfirm --overwrite '*' "${packages[0]}"


### PR DESCRIPTION
- pick the arch package by the version digit that follows `facelock-`, excluding the `-debug` split by name
- fail when the build directory holds anything but exactly one candidate, naming what makepkg left there
- add `test/arch-package-select-test.sh` to `just check`, covering both directory orders and the zero- and two-candidate rejections

## Why

makepkg now emits `facelock-debug-<pkgver>-<pkgrel>-<arch>.pkg.tar.zst` beside the package the Arch e2e lane installs, and the lane took whichever name `find` returned first. On #317 that was the debug package, so `pacman -U` installed it and every assertion after it reported `package 'facelock' was not found`; #318 ran the identical code against the same image and passed. Directory order decided the outcome, which makes the red lane read as a flake rather than as the selection bug it is.

Refs #212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Arch package handling to consistently select the correct main package.
  - Debug packages are excluded from installation, while missing or ambiguous package sets now produce a clear failure instead of selecting an arbitrary file.
  - Package test builds now report discovered packages when selection requirements are not met.

- **Tests**
  - Added automated coverage for package selection, including creation-order independence and invalid package scenarios.
  - CI and standard checks now run the Arch package-selection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->