### PR TITLE
test(rpm): require a copr lifecycle lane per fedora target

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,6 +18,7 @@ paths:
 | 3c | Arch container E2E (oneshot) | `just test-arch-oneshot` |
 | 3d | Arch package from `dist/PKGBUILD` | `just test-arch-pkg` |
 | 3e | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
+| 3f | Fedora COPR path, rebuilt from source on system ORT | `just test-copr-lanes` |
 | 3a | Arch container E2E, camera-free | `just test-arch-camera-free` |
 | 3b | Arch container E2E (daemon), needs a camera | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot), needs a camera | `just test-arch-oneshot` |
@@ -25,6 +26,14 @@ paths:
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 
 **Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.
+
+Tier 3f is not a duplicate of 3e. 3e builds the direct `.rpm` from host
+binaries with a bundled ONNX Runtime; 3f rebuilds the package from source in a
+mock chroot and runs it against Fedora's system ONNX Runtime, which is the path
+Packit publishes to COPR. The release gate requires both, and a direct-RPM
+record cannot satisfy a COPR target. The COPR lanes never run on a pull request
+-- mock needs a privileged container -- so only the nightly, a
+`workflow_dispatch`, or a local run covers them.
 
 Fedora recipes take a release and default to 44 (`just test-rpm-pkg 43`). Tier 3e
 covers all three declared targets at the depth `dist/release-matrix.json` gives

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -130,7 +130,7 @@ the question is "does a fresh install work", a dev shell when iterating.
 - Name which packaging recipe you ran; if none, say so
 - Report camera-gated tests as not run, never as passed
 - A green pull request only proves packaging if the `packaging.yml` jobs ran rather than reporting skipped
-- `just test-packaging-matrix` is the whole gate in one command (2+ hours, because the three COPR lanes rebuild the workspace inside mock), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic — it writes its `partial` per-lane records, but the marker is withheld
+- `just test-packaging-matrix` is the whole gate in one command (about 1 h 45 min measured on 2026-09-02 — COPR lanes 31, 23 and 20 min — because each rebuilds the workspace inside mock), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic — it writes its `partial` per-lane records, but the marker is withheld
 
 ## Cost
 

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -16,8 +16,11 @@ evidence at HEAD: the `packaging-evidence-*` artifacts a green run uploads, or
 the record a local `just test-packaging-matrix` writes.
 
 Two consequences for you. A green pull request says nothing about packaging
-unless those jobs ran on it, so check rather than assume. COPR and the APT repo
-are still local-only: nothing gates them until a release tag fires `release.yml`.
+unless those jobs ran on it, so check rather than assume. The COPR lanes go
+further: they never run on a pull request at all, because mock needs a
+privileged container. Only the nightly and a `workflow_dispatch` run them. The
+APT repo is still local-only: nothing gates it until a release tag fires
+`release.yml`.
 
 Running the right recipe yourself is still the fast way to find out. All of them
 need `podman`; none in the routing table needs a camera.
@@ -32,7 +35,8 @@ need `podman`; none in the routing table needs a camera.
 | TPM packaging or `facelock-tpm` build features | `just test-deb-trixie-pkg` and `just test-deb-resolute-pkg` |
 | `dist/PKGBUILD*`, `dist/facelock.install`, `dist/facelock-pam-remove.hook` | `just test-arch-pkg` |
 | `.packit.yaml` schema only | `just test-packit-config` — real `packit` in a pinned Fedora container, seconds |
-| `.packit.yaml` semantics, or anything COPR consumes | `just test-copr` — slow, opt-in, Packit SRPM plus a mock from-source rebuild |
+| `.packit.yaml` semantics, or anything COPR consumes | `just test-copr-pkg 44` — the mock from-source rebuild plus the booted lifecycle it produces (`just test-copr` is the build half alone) |
+| `dist/facelock.spec` `%build`/`%check`, or a new runtime dependency | `just test-copr-lanes` — the direct `.rpm` lanes stage host binaries and never compile from the spec |
 | APT repo generation, `publish-apt` workflow, `dist/apt/**` | `just test-apt-repo` — the real publisher, signing, and a clean APT client for every suite, in the pinned trixie container |
 | `systemd/`, `dbus/`, `polkit/`, install paths | both Debian suite recipes or `just test-rpm-pkg` — all validate under booted systemd |
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
@@ -52,6 +56,14 @@ behave differently across releases (dnf/rpm behavior, scriptlets, dependency
 resolution, systemd or SELinux versions). It runs 43 and 44 at full lifecycle
 depth and branched 45 at build plus runtime smoke, which is the depth the matrix
 gives each one.
+
+There are two Fedora channels, not one, and neither proves the other.
+`test-rpm-lanes` builds the direct `.rpm` from host binaries around a bundled
+ONNX Runtime. `just test-copr-lanes` builds what COPR would publish: the Packit
+SRPM rebuilt from source in a mock chroot, installed so the package's own
+`Requires: onnxruntime` resolves against Fedora's system runtime, then booted
+for the same validation. The release gate requires both, and the evidence
+validator refuses a direct-RPM record offered as a COPR target's evidence.
 
 Never add a Rawhide lane. Rawhide is optional and experimental in the matrix and
 cannot substitute for a Fedora 43, 44 or 45 result. Lane images come from the
@@ -122,7 +134,9 @@ the question is "does a fresh install work", a dev shell when iterating.
 
 ## Cost
 
-`test-copr` and `test-arch-pkg` are slow and opt-in: both compile the workspace
-from source inside the container. The Debian and Fedora `-pkg` recipes boot a
+`test-copr`, the `test-copr-*` lanes and `test-arch-pkg` are the slow ones: all
+compile the workspace from source inside the container, and the COPR lanes also
+run the spec's `%check` inside the mock chroot. They share one staging path, so
+never run two COPR lanes at once. The Debian and Fedora `-pkg` recipes boot a
 container under systemd. Run the narrowest recipe the routing table allows
 rather than the whole set.

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -130,7 +130,7 @@ the question is "does a fresh install work", a dev shell when iterating.
 - Name which packaging recipe you ran; if none, say so
 - Report camera-gated tests as not run, never as passed
 - A green pull request only proves packaging if the `packaging.yml` jobs ran rather than reporting skipped
-- `just test-packaging-matrix` is the whole gate in one command (30-60+ minutes), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic — it writes its `partial` per-lane records, but the marker is withheld
+- `just test-packaging-matrix` is the whole gate in one command (2+ hours, because the three COPR lanes rebuild the workspace inside mock), and it writes the lane evidence `just release-preflight` validates; a `FACELOCK_ALLOW_MISSING_MODELS=1` run is a diagnostic — it writes its `partial` per-lane records, but the marker is withheld
 
 ## Cost
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,7 +28,7 @@ and release secrets. Fix every `MISSING` before continuing.
 
 It also needs complete packaging evidence at this commit: the
 `packaging-evidence-*` artifacts of a successful `packaging.yml` run, or a
-local `just test-packaging-matrix` (2+ hours, needs the ONNX models).
+local `just test-packaging-matrix` (about 1 h 45 min measured on 2026-09-02, needs the ONNX models).
 Dispatch the workflow only from the exact commit preflight will validate, with
 nothing uncommitted:
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,7 +28,7 @@ and release secrets. Fix every `MISSING` before continuing.
 
 It also needs complete packaging evidence at this commit: the
 `packaging-evidence-*` artifacts of a successful `packaging.yml` run, or a
-local `just test-packaging-matrix` (30-60+ minutes, needs the ONNX models).
+local `just test-packaging-matrix` (2+ hours, needs the ONNX models).
 Dispatch the workflow only from the exact commit preflight will validate, with
 nothing uncommitted:
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,9 @@ target/
 !target/release/facelock
 !target/release/libpam_facelock.so
 !target/release/facelock-polkit-agent
+# The COPR lifecycle lanes stage the RPM mock built from source here, so
+# test/Containerfile.copr-e2e can install the exact artifact under test.
+!target/copr-lane/facelock.rpm
 
 # Git history not needed in containers
 .git/

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -275,6 +275,7 @@ jobs:
         with:
           name: packaging-evidence-copr-${{ matrix.release }}
           path: .packaging-evidence/
+          include-hidden-files: true
           if-no-files-found: error
           overwrite: true
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,10 +3,11 @@ name: Packaging
 # Every .deb, .rpm and Arch gate used to be local-only, invoked by hand, for a
 # release that ships through four channels (#229). This is where they run.
 #
-# Three schedules, because the full matrix runs for hours and most pull
-# requests touch no packaging:
+# Three schedules, because the full matrix takes about 1 h 45 min (measured
+# 2026-09-02) and most pull requests touch no packaging:
 #
-#   pull request   path-filtered by the `changes` job below
+#   pull request   path-filtered by the `changes` job below, and never the
+#                  copr job -- mock needs a privileged container
 #   nightly        the whole matrix, unfiltered
 #   release        `just release-preflight` refuses to pass without a green
 #                  run of this workflow at the release commit

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,7 +3,7 @@ name: Packaging
 # Every .deb, .rpm and Arch gate used to be local-only, invoked by hand, for a
 # release that ships through four channels (#229). This is where they run.
 #
-# Three schedules, because the full matrix is 30-60+ minutes and most pull
+# Three schedules, because the full matrix runs for hours and most pull
 # requests touch no packaging:
 #
 #   pull request   path-filtered by the `changes` job below

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -213,6 +213,71 @@ jobs:
           # files and if-no-files-found fails the job.
           include-hidden-files: true
 
+  # #230: the rpm job above proves the direct .rpm -- host binaries, bundled
+  # ONNX Runtime -- which is not the delivery path dist/release-matrix.json
+  # declares for Fedora. This one rebuilds the package from source in mock, the
+  # way COPR does, and boots what it built against Fedora's system ONNX Runtime.
+  #
+  # Not on pull requests. Each lane compiles the whole workspace inside a mock
+  # chroot, and mock needs a privileged container, which no pull request has
+  # been shown to get on a rootless-podman runner. Making it a required PR check
+  # before that is proven would block every packaging merge on an unproven
+  # capability. The nightly and the dispatch `just release-preflight` reads are
+  # unfiltered, so release evidence still comes from here -- and the residual
+  # risk, a COPR-only break that survives its own pull request, is written down
+  # in docs/releasing.md next to the one the path filter already buys.
+  copr:
+    name: Fedora ${{ matrix.release }} COPR ${{ matrix.depth }}
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.packaging == 'true' && github.event_name != 'pull_request'
+    # Twice the rpm job's budget: mock compiles the workspace and runs the
+    # spec's %check inside the chroot before the lifecycle half starts.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      # One lane per Packit release target, at the lifecycle depth the matrix
+      # declares -- `just test-copr-lanes` is the same set, run sequentially.
+      # test/check-release-matrix.py fails if this list and the matrix ever
+      # disagree.
+      matrix:
+        include:
+          - release: "43"
+            depth: Package Lifecycle
+            recipe: test-copr-pkg 43
+          - release: "44"
+            depth: Package Lifecycle
+            recipe: test-copr-pkg 44
+          - release: "45"
+            depth: Runtime Smoke
+            recipe: test-copr-smoke 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Reclaim runner disk space
+        run: .github/workflows/scripts/reclaim-runner-disk.sh
+
+      - name: Install packaging test dependencies
+        run: .github/workflows/scripts/install-packaging-test-deps.sh
+
+      # No release binaries: the whole point is that mock builds them from the
+      # source the SRPM carries. Models are still needed -- the lifecycle half
+      # starts the daemon under the hardened unit.
+      - name: Fetch required ONNX models
+        uses: ./.github/actions/fetch-models
+
+      - name: Run the Fedora ${{ matrix.release }} COPR gate
+        run: just ${{ matrix.recipe }}
+
+      # See the Debian lane's upload step.
+      - name: Upload packaging evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packaging-evidence-copr-${{ matrix.release }}
+          path: .packaging-evidence/
+          if-no-files-found: error
+          overwrite: true
+
   arch:
     name: Arch Package From dist/PKGBUILD
     runs-on: ubuntu-latest

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2129,8 +2129,9 @@ is any other undeclared target. Rawhide is not a Packit staging or production
 release target; both `fedora-rawhide` and `fedora-rawhide-x86_64` fail
 validation. The prerelease rule is that no alpha may publish to Rawhide.
 Fedora 43 and Fedora 44 are the required full-lifecycle targets; Fedora 45 is a
-required build/runtime-smoke target. Issue #230 owns the actual lifecycle
-evidence. Rawhide cannot supply lifecycle, artifact, upgrade, rollback,
+required build/runtime-smoke target. That evidence is the COPR lane per target
+described under "Packaging matrix evidence"; a direct-RPM result cannot supply
+it. Rawhide cannot supply lifecycle, artifact, upgrade, rollback,
 served-version, or availability evidence; it is limited to best-effort pinned
 Track D smoke only. It is non-release and non-gating: its absence or a
 Rawhide-only failure is not alpha-blocking, and its smoke result is not alpha
@@ -2188,7 +2189,8 @@ every record before its first lane, then folds the records into
 ```json
 {"schema": 1, "commit": "<40-hex sha>", "tree_clean": true,
  "started_at": "<ISO 8601 UTC>", "finished_at": "<ISO 8601 UTC>",
- "required_lanes": ["test-arch-pkg", "test-deb-resolute-pkg", "test-deb-trixie-pkg",
+ "required_lanes": ["test-arch-pkg", "test-copr-pkg-43", "test-copr-pkg-44",
+                    "test-copr-smoke-45", "test-deb-resolute-pkg", "test-deb-trixie-pkg",
                     "test-rpm-pkg-43", "test-rpm-pkg-44", "test-rpm-smoke-45"],
  "lanes": [{"name": "test-deb-trixie-pkg", "target": "debian-trixie", "channel": "apt",
             "build_origin": "container-source-build", "runtime_policy": "bundled-ort",
@@ -2197,11 +2199,12 @@ every record before its first lane, then folds the records into
             "status": "pass"}]}
 ```
 
-Lane claims use a fixed vocabulary. `channel`: `apt`, `direct-rpm`, `aur`
-(#230 adds `copr`). `build_origin`: `container-source-build` (the Debian
-assembler and `.dsc` rebuild), `host-binaries` (release binaries staged from
-`target/release`), `makepkg-source-build` (#230 adds `mock-source-rebuild`).
-`runtime_policy`: `bundled-ort`, `system-ort`. `depth`: `full`, `smoke`.
+Lane claims use a fixed vocabulary. `channel`: `apt`, `direct-rpm`, `aur`,
+`copr`. `build_origin`: `container-source-build` (the Debian assembler and
+`.dsc` rebuild), `host-binaries` (release binaries staged from
+`target/release`), `makepkg-source-build`, `mock-source-rebuild` (Packit SRPM
+rebuilt from source in a mock chroot). `runtime_policy`: `bundled-ort`,
+`system-ort`. `depth`: `full`, `smoke`.
 `status`: `pass`; `partial` for an exit 0 with an allowed skip or without
 models; `fail` for a non-zero exit, a failed assertion, or a mandatory skip.
 The counters are assertion counts by class, and `skip` equals
@@ -2213,9 +2216,34 @@ withheld.
 
 `required_lanes` derives from `dist/release-matrix.json`: one Debian lane per
 APT suite whose platform row is a non-optional release target, the Arch recipe
-lane, and one direct-RPM lane per `fedora.packit_release_targets` entry at the
-depth its platform rows declare. A row whose `evidence_eligibility.lifecycle`
-is false (Rawhide) contributes nothing.
+lane, and *two* Fedora lanes per `fedora.packit_release_targets` entry, both at
+the depth its platform rows declare. A row whose
+`evidence_eligibility.lifecycle` is false (Rawhide) contributes nothing.
+
+The two Fedora lanes exist because the matrix declares two Fedora delivery
+paths and neither proves the other (#230). The direct-RPM lane
+(`test-rpm-pkg-<release>` / `test-rpm-smoke-<release>`) stages host-built
+binaries and a bundled ONNX Runtime. The COPR lane
+(`test-copr-pkg-<release>` / `test-copr-smoke-<release>`) is what COPR itself
+would publish: a Packit SRPM rebuilt from source in a mock chroot, installed
+with `dnf` so the package's own `Requires: onnxruntime` resolves against
+Fedora's system runtime, then booted for the same validation. A COPR lane is
+required for a target only while some platform row for that release declares
+`system ORT`; the artifact is checked against the COPR channel rules
+(`validate-rpm.sh <rpm> copr`), which fail if a bundled runtime rode along.
+Because the validator compares every lane attribute against what the matrix
+requires, a direct-RPM record offered as a COPR target's evidence is refused on
+`channel`, and a COPR record built from host binaries or run against a bundled
+runtime is refused on `build_origin` or `runtime_policy`.
+
+The COPR lane's `full` depth is the booted package lifecycle
+(`test/pkg-validate.sh` plus the RPM service/PAM lifecycle), not the
+`%config(noreplace)` upgrade halves: those need a second, higher-versioned
+package, and a second mock source rebuild per release is not what that
+assertion is worth. The direct-RPM lane runs them against the same
+`dist/facelock.spec`, so the file flags and scriptlets they pin are covered;
+what is not covered is a COPR-only upgrade difference, which is why this
+sentence exists.
 
 The marker is refused, and the aggregate refuses to write it, unless all of
 the following hold: `schema` is 1; `commit` equals HEAD; `tree_clean` is true;
@@ -2232,15 +2260,17 @@ evidence, and a record from one channel cannot stand in for another's lane.
 The legacy one-line commit marker is refused with a message naming this
 format. Preflight reads evidence from two places, in order: the
 `packaging-evidence-*` artifacts a successful `packaging.yml` run at HEAD
-uploaded (`packaging-evidence-deb-<suite>`, `packaging-evidence-rpm-<release>`
-and `packaging-evidence-arch`, fetched with `gh run download` and aggregated
-the same way), then the local marker. `.packaging-evidence/` is dot-prefixed,
-so every upload step sets `include-hidden-files: true`; without it
-`actions/upload-artifact` finds no files and `if-no-files-found: error` fails
-the job. A run without those artifacts is not
-evidence, whatever its conclusion; neither is a pull-request run, which builds
-the merge commit, nor a run of any other workflow. The marker and the
-artifacts are maintainer-trust records: preflight checks their shape and their
+uploaded (`packaging-evidence-deb-<suite>`, `packaging-evidence-rpm-<release>`,
+`packaging-evidence-copr-<release>` and `packaging-evidence-arch`, fetched with
+`gh run download` and aggregated the same way), then the local marker.
+`.packaging-evidence/` is dot-prefixed, so every upload step sets
+`include-hidden-files: true`; without it `actions/upload-artifact` finds no
+files and `if-no-files-found: error` fails the job. A run without those
+artifacts is not evidence, whatever its conclusion; neither is a pull-request
+run, which builds the merge commit, nor a run of any other workflow. The `copr`
+jobs do not run on pull requests at all, so only an unfiltered run -- the
+nightly or a `workflow_dispatch` -- can carry the full lane set. The marker and
+the artifacts are maintainer-trust records: preflight checks their shape and their
 binding to HEAD and the matrix, not that a real lane produced them. A forged
 record is a deliberate act, not the slip this gate exists to catch.
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2236,14 +2236,23 @@ requires, a direct-RPM record offered as a COPR target's evidence is refused on
 `channel`, and a COPR record built from host binaries or run against a bundled
 runtime is refused on `build_origin` or `runtime_policy`.
 
-The COPR lane's `full` depth is the booted package lifecycle
-(`test/pkg-validate.sh` plus the RPM service/PAM lifecycle), not the
-`%config(noreplace)` upgrade halves: those need a second, higher-versioned
-package, and a second mock source rebuild per release is not what that
-assertion is worth. The direct-RPM lane runs them against the same
-`dist/facelock.spec`, so the file flags and scriptlets they pin are covered;
-what is not covered is a COPR-only upgrade difference, which is why this
-sentence exists.
+`full` depth for an RPM lane is three stages under booted systemd: the RPM
+service/PAM lifecycle, `test/pkg-validate.sh`, and the `%config(noreplace)`
+upgrade lifecycle. Each is optional by the presence of its script in the image,
+so `test/run-pkg-validate-systemd.sh` records `depth: partial` when a stage is
+missing. No lane in the release matrix requires `partial`, so the aggregate
+refuses such a record instead of accepting a short lifecycle as a full one.
+
+The third stage needs a second, higher-versioned package differing only in the
+config file. The COPR lane builds that upgrade candidate by repacking the
+payload mock just produced: binaries taken from the installed package,
+re-versioned to `<mock version>.1`, rebuilt through the same
+`dist/facelock.spec` with its cargo lines no-oped and `bundled_ort` still off,
+and re-checked with `validate-rpm.sh <rpm> copr`. It is the same trick the
+direct lane uses for its `0.0.0` to `0.0.1` pair. **It is a fixture, not a
+second COPR build**, and it is not byte-identical to one: what it pins is
+rpm's `%config(noreplace)` behaviour across an upgrade of a COPR-shaped
+package, not the reproducibility of a mock rebuild.
 
 The marker is refused, and the aggregate refuses to write it, unless all of
 the following hold: `schema` is 1; `commit` equals HEAD; `tree_clean` is true;

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2204,7 +2204,7 @@ Lane claims use a fixed vocabulary. `channel`: `apt`, `direct-rpm`, `aur`,
 `.dsc` rebuild), `host-binaries` (release binaries staged from
 `target/release`), `makepkg-source-build`, `mock-source-rebuild` (Packit SRPM
 rebuilt from source in a mock chroot). `runtime_policy`: `bundled-ort`,
-`system-ort`. `depth`: `full`, `smoke`.
+`system-ort`. `depth`: `full`, `smoke`, `partial`.
 `status`: `pass`; `partial` for an exit 0 with an allowed skip or without
 models; `fail` for a non-zero exit, a failed assertion, or a mandatory skip.
 The counters are assertion counts by class, and `skip` equals
@@ -2228,9 +2228,11 @@ binaries and a bundled ONNX Runtime. The COPR lane
 would publish: a Packit SRPM rebuilt from source in a mock chroot, installed
 with `dnf` so the package's own `Requires: onnxruntime` resolves against
 Fedora's system runtime, then booted for the same validation. A COPR lane is
-required for a target only while some platform row for that release declares
-`system ORT`; the artifact is checked against the COPR channel rules
-(`validate-rpm.sh <rpm> copr`), which fail if a bundled runtime rode along.
+required for every Packit release target: `test/packaging-evidence.py` raises
+`EvidenceError` and refuses the aggregate outright if no platform row for that
+release declares `system ORT`, rather than treating the lane as optional. The
+artifact is checked against the COPR channel rules (`validate-rpm.sh <rpm>
+copr`), which fail if a bundled runtime rode along.
 Because the validator compares every lane attribute against what the matrix
 requires, a direct-RPM record offered as a COPR target's evidence is refused on
 `channel`, and a COPR record built from host binaries or run against a bundled
@@ -2466,9 +2468,10 @@ payload, and reject the inverse missing dependency/payload.
 Track D validates only direct/COPR build success, real ORT runtime
 initialization, and the intended payload and dependency policy. It supplies no
 clean-install, upgrade, erase, rollback, served-repository, availability,
-alpha-acceptance, or release evidence. Issue #230 owns exact-artifact package
-lifecycle proof; issue #236 owns staging and production repository publication
-and served-version proof.
+alpha-acceptance, or release evidence. The two-Fedora-lanes contract under
+"Packaging matrix evidence" above owns exact-artifact package lifecycle proof;
+issue #236 owns staging and production repository publication and
+served-version proof.
 
 Optional experimental Rawhide may attempt only the separately digest-pinned,
 best-effort system-ORT build/session smoke. It is non-release and non-gating,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -295,7 +295,7 @@ gates, every declared Fedora lane, the Arch package built from the real
 checksum-verifies the ONNX models first, through `.github/actions/fetch-models`,
 so the daemon-start assertions execute instead of being counted as skipped.
 
-Three schedules, because the full matrix is 30-60+ minutes and most pull
+Three schedules, because the full matrix runs for hours and most pull
 requests touch no packaging:
 
 | When | Lanes | Filtered |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -295,14 +295,17 @@ gates, every declared Fedora lane, the Arch package built from the real
 checksum-verifies the ONNX models first, through `.github/actions/fetch-models`,
 so the daemon-start assertions execute instead of being counted as skipped.
 
-Three schedules, because the full matrix runs for hours and most pull
-requests touch no packaging:
+Three schedules, because the full matrix takes about 1 h 45 min (measured
+2026-09-02) and most pull requests touch no packaging:
 
 | When | Lanes | Filtered |
 |---|---|---|
-| Pull request | all | yes, only when the diff reaches a package |
+| Pull request | all but `copr` | yes, only when the diff reaches a package |
 | Nightly, 07:00 UTC | all | no |
 | `just release-preflight` | evidence of a green run at HEAD | no |
+
+The `copr` job never runs on a pull request regardless of the filter above --
+mock needs a privileged container.
 
 The pull-request filter is a `changes` job running
 `.github/workflows/scripts/classify-changes.sh`, which classifies the merge-base

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -201,7 +201,9 @@ just test-rpm-pkg        # Fedora — build real .rpm, install via dnf, validate
 just test-rpm-lanes      # every declared Fedora target at its declared depth
 just test-rpm-authselect # Fedora — retired-profile upgrade guard lifecycle
 just test-packit-config  # Packit config schema — real `packit` in a pinned Fedora container
-just test-copr           # COPR-equivalent — Packit SRPM + mock from-source rebuild (slow)
+just test-copr           # COPR-equivalent build only — Packit SRPM + mock from-source rebuild (slow)
+just test-copr-pkg 43    # the same rebuild, then install it and run the booted lifecycle
+just test-copr-lanes     # every Packit/COPR target rebuilt from source at its declared depth
 
 # Interactive (requires camera)
 just test-deb-dev-shell      # Ubuntu .deb with host models — fast iteration
@@ -229,6 +231,23 @@ the lifecycle depth `dist/release-matrix.json` gives it: full lifecycle for
 Fedora 43 and 44, build plus runtime smoke for branched Fedora 45. Rawhide is
 optional and experimental, has no lane, and can never stand in for a Fedora 43,
 44, or 45 result.
+
+Each Fedora target needs two lanes, not one. `test-rpm-lanes` proves the direct
+`.rpm`: host-built binaries, bundled ONNX Runtime. That is not the delivery
+path the matrix declares for Fedora, which is Packit publishing to COPR against
+Fedora's system ONNX Runtime. `just test-copr-lanes` proves that one at the
+same declared depths — `test-copr-pkg 43`, `test-copr-pkg 44`,
+`test-copr-smoke 45`. Each rebuilds the package from source in a mock chroot
+(the `test-copr` half), exports the RPM it built, installs it with `dnf` so the
+package's own `Requires: onnxruntime` resolves, and boots it for the same
+validation the direct lane runs. `just test-packaging-matrix` requires both,
+and `test/packaging-evidence.py` refuses a direct-RPM record offered as a COPR
+target's evidence.
+
+The COPR lanes are slow even by this file's standards: each one compiles the
+whole workspace and runs the spec's `%check` inside the mock chroot, and mock
+needs a privileged container, so they run serially through a single staging
+path (`target/copr-lane/facelock.rpm`). Never run two at once.
 
 `test/fedora-lane-image.sh` resolves each lane's digest-pinned base image from
 the matrix, so no Containerfile carries its own Fedora digest. It refuses a
@@ -306,6 +325,16 @@ release gate below catches it before anything ships. When a change is
 packaging-relevant in a way the filter cannot see, run the lane by hand or add
 the path to `classify-changes.sh`.
 
+**The COPR jobs go further and skip pull requests entirely.** Each one compiles
+the workspace inside a mock chroot, which needs a privileged container, and no
+pull request has been shown to get one on a rootless-podman runner; making that
+a required check before it is proven would block every packaging merge on an
+unproven capability. So a COPR-only break — something that shows up when the
+package is rebuilt from source or run against Fedora's system ONNX Runtime, and
+not otherwise — survives its own pull request even when the filter fires. The
+nightly and the pre-release `workflow_dispatch` are unfiltered and do run them;
+locally, `just test-copr-lanes`.
+
 ### Release preflight (recommended)
 
 Run this before creating/pushing a release tag:
@@ -339,7 +368,9 @@ Every packaging lane writes a record of what it claimed and what it counted,
 and `test/packaging-evidence.py` accepts the set only when every lane the
 release matrix requires is present at this commit with zero skips and the ONNX
 models on hand (the contract is in `docs/contracts.md`, "Packaging matrix
-evidence"). Preflight reads it from the `packaging-evidence-*` artifacts a
+evidence"). That set includes a COPR lane per Packit release target beside the
+direct-RPM lane, so a green Fedora `.rpm` result alone leaves the evidence
+incomplete. Preflight reads it from the `packaging-evidence-*` artifacts a
 successful `packaging.yml` run at that exact commit uploaded, fetched with
 `gh run download`, or from `.packaging-matrix-verified`, which
 `just test-packaging-matrix` writes after running every lane locally. A run's

--- a/justfile
+++ b/justfile
@@ -1252,7 +1252,7 @@ _copr-mock-rpm release: (_fedora-lane-image release)
 # starts the daemon under the hardened unit and reads what it holds.
 
 # COPR lifecycle lane — mock source rebuild, then the booted package lifecycle
-test-copr-pkg release="43": (_require-models "1") (_copr-mock-rpm release)
+test-copr-pkg release="44": (_require-models "1") (_copr-mock-rpm release)
     #!/usr/bin/env bash
     set -euo pipefail
     image="$(bash test/fedora-lane-image.sh '{{ release }}')"
@@ -1618,7 +1618,7 @@ release-preflight tag='':
         echo "MISSING: no complete packaging evidence for $HEAD_SHA (reasons above)"
         echo "  Run the matrix in CI against this commit, then re-run preflight:"
         echo "    gh workflow run packaging.yml --ref $(git rev-parse --abbrev-ref HEAD)"
-        echo "  Or run every lane locally (2+ hours, needs podman and the ONNX models):"
+        echo "  Or run every lane locally (about 1 h 45 min measured on 2026-09-02, needs podman and the ONNX models):"
         echo "    just test-packaging-matrix"
         failed=1
     fi
@@ -1658,12 +1658,12 @@ _packaging-evidence-reset:
     date -u +%Y-%m-%dT%H:%M:%SZ > .packaging-evidence/started-at
 
 # The same lanes `.github/workflows/packaging.yml` runs, in one command, for a
-# maintainer without CI in reach (#229). It needs podman and the ONNX models and
-# takes upwards of two hours: the three COPR lanes measured 31, 23 and 20 minutes
-# on their own, because each rebuilds the workspace from source inside mock.
-# plus the ONNX models; CI is the faster path, and `just release-preflight`
-# accepts a green run of that workflow at HEAD through the evidence artifacts
-# its lanes upload, validated the same way as this record.
+# maintainer without CI in reach (#229). It needs podman and the ONNX models
+# and takes about 1 h 45 min measured on 2026-09-02 (COPR lanes 31, 23 and
+# 20 min), because each rebuilds the workspace from source inside mock. CI is
+# the faster path, and `just release-preflight` accepts a green run of that
+# workflow at HEAD through the evidence artifacts its lanes upload, validated
+# the same way as this record.
 #
 # Clean tree first, for the same reason the camera tiers demand one: a record
 # that names a commit the lanes did not actually build is worse than no record.

--- a/justfile
+++ b/justfile
@@ -1222,6 +1222,58 @@ test-copr release="44": (_fedora-lane-image release)
     podman run --privileged --rm -e COPR_CHROOT=fedora-{{ release }}-x86_64 \
         -v "$PWD:/repo:ro" facelock-copr-test-f{{ release }}
 
+# The COPR lifecycle lanes below are the same source rebuild plus what
+# test-copr never did: install the artifact it produced and boot it. Stage one
+# is `mock` in a privileged container, so it exports the built RPM to
+# target/copr-lane/ (gitignored, and re-included in .dockerignore) rather than
+# validating in place. Stage two installs exactly that file, which is what
+# makes the lane's evidence a claim about the mock-built package and not about
+# a second build that happens to come from the same tree.
+#
+# Serial by construction: the staging path is one file, so two COPR lanes must
+# not run at once.
+_copr-mock-rpm release: (_fedora-lane-image release)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-copr-test-f{{ release }} -f test/Containerfile.copr .
+    rm -rf -- target/copr-lane
+    mkdir -p target/copr-lane
+    podman run --privileged --rm -e COPR_CHROOT=fedora-{{ release }}-x86_64 \
+        -v "$PWD:/repo:ro" -v "$PWD/target/copr-lane:/out:z" \
+        facelock-copr-test-f{{ release }}
+    [ -f target/copr-lane/facelock.rpm ] || {
+        echo "error: the Fedora {{ release }} source rebuild exported no RPM" >&2
+        exit 1
+    }
+
+# Needs models/*.onnx for the same reason test-rpm-pkg does: the validation
+# starts the daemon under the hardened unit and reads what it holds.
+
+# COPR lifecycle lane — mock source rebuild, then the booted package lifecycle
+test-copr-pkg release="43": (_require-models "1") (_copr-mock-rpm release)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-copr-pkg-f{{ release }} -f test/Containerfile.copr-e2e .
+    PACKAGING_LANE='test-copr-pkg-{{ release }} target=fedora-{{ release }} channel=copr build_origin=mock-source-rebuild runtime_policy=system-ort depth=full' \
+        test/run-pkg-validate-systemd.sh facelock-copr-pkg-f{{ release }}
+
+# Branched-release COPR lane — mock source rebuild, then the runtime smoke
+test-copr-smoke release="45": (_copr-mock-rpm release)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    image="$(bash test/fedora-lane-image.sh '{{ release }}')"
+    podman build --build-arg "BASE_IMAGE=$image" \
+        -t facelock-copr-smoke-f{{ release }} -f test/Containerfile.copr-e2e .
+    PACKAGING_LANE='test-copr-smoke-{{ release }} target=fedora-{{ release }} channel=copr build_origin=mock-source-rebuild runtime_policy=system-ort depth=smoke' \
+        bash test/run-rpm-smoke-systemd.sh facelock-copr-smoke-f{{ release }}
+
+# Every Packit/COPR release target rebuilt from source at its declared depth
+test-copr-lanes: (test-copr-pkg "43") (test-copr-pkg "44") (test-copr-smoke "45")
+
 # Dev shell — interactive .deb container with host models for fast iteration (requires camera)
 test-deb-dev-shell:
     #!/usr/bin/env bash
@@ -1620,7 +1672,7 @@ _packaging-evidence-reset:
 # never records.
 
 # Every packaging lane the release gate requires, recorded for release-preflight
-test-packaging-matrix: _require-clean-tree _packaging-evidence-reset test-release-matrix test-arch-pkg test-deb test-rpm-lanes
+test-packaging-matrix: _require-clean-tree _packaging-evidence-reset test-release-matrix test-arch-pkg test-deb test-rpm-lanes test-copr-lanes
     #!/usr/bin/env bash
     set -euo pipefail
     commit="$(git rev-parse HEAD)"

--- a/justfile
+++ b/justfile
@@ -1618,7 +1618,7 @@ release-preflight tag='':
         echo "MISSING: no complete packaging evidence for $HEAD_SHA (reasons above)"
         echo "  Run the matrix in CI against this commit, then re-run preflight:"
         echo "    gh workflow run packaging.yml --ref $(git rev-parse --abbrev-ref HEAD)"
-        echo "  Or run every lane locally (30-60+ minutes, needs podman and the ONNX models):"
+        echo "  Or run every lane locally (2+ hours, needs podman and the ONNX models):"
         echo "    just test-packaging-matrix"
         failed=1
     fi
@@ -1658,7 +1658,9 @@ _packaging-evidence-reset:
     date -u +%Y-%m-%dT%H:%M:%SZ > .packaging-evidence/started-at
 
 # The same lanes `.github/workflows/packaging.yml` runs, in one command, for a
-# maintainer without CI in reach (#229). It is 30-60+ minutes and needs podman
+# maintainer without CI in reach (#229). It needs podman and the ONNX models and
+# takes upwards of two hours: the three COPR lanes measured 31, 23 and 20 minutes
+# on their own, because each rebuilds the workspace from source inside mock.
 # plus the ONNX models; CI is the faster path, and `just release-preflight`
 # accepts a green run of that workflow at HEAD through the evidence artifacts
 # its lanes upload, validated the same way as this record.

--- a/test/Containerfile.copr
+++ b/test/Containerfile.copr
@@ -7,7 +7,12 @@
 # silently pick a release.
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
-RUN dnf install -y --setopt=install_weak_deps=False \
+# The Cisco OpenH264 repo Fedora enables by default is a single unpinned host
+# with no mirrors (ciscobinary.openh264.org). Nothing here needs a codec, and a
+# packaging gate that fails when that one host is unreachable reports a network
+# outage as a packaging regression. Disabled by glob so it stays harmless on a
+# release whose image does not ship the repo.
+RUN dnf install -y --setopt=install_weak_deps=False --disablerepo='*openh264*' \
         packit mock rpm-build git tar python3 \
     && dnf clean all
 COPY test/copr-build.sh /copr-build.sh

--- a/test/Containerfile.copr-e2e
+++ b/test/Containerfile.copr-e2e
@@ -32,7 +32,7 @@ FROM ${BASE_IMAGE}
 # each run their own `dnf` transaction and would still contact the repo for
 # metadata. Disabling it in the repo file itself persists across every later
 # layer in this image; the flag stays as belt-and-braces on this one.
-RUN sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo \
+RUN for repo in /etc/yum.repos.d/*openh264*.repo; do [ -e "$repo" ] && sed -i 's/^enabled=1/enabled=0/' "$repo"; done; true \
     && dnf -y install --disablerepo='*openh264*' \
         pam authselect dbus dbus-daemon rpm systemd binutils gettext \
         glibc libxkbcommon tpm2-tss ca-certificates openssl-libs python3 util-linux strace \

--- a/test/Containerfile.copr-e2e
+++ b/test/Containerfile.copr-e2e
@@ -23,7 +23,13 @@ FROM ${BASE_IMAGE}
 # dbus-daemon for the D-Bus and polkit boundary checks, binutils for the PAM
 # symbol assertions, gettext for the packaged catalogs, strace for the
 # pamtester diagnostics in rpm-service-pam-lifecycle.sh.
-RUN dnf -y install pam authselect dbus dbus-daemon rpm systemd binutils gettext \
+# The Cisco OpenH264 repo Fedora enables by default is a single unpinned host
+# with no mirrors (ciscobinary.openh264.org). Nothing here needs a codec, and a
+# packaging gate that fails when that one host is unreachable reports a network
+# outage as a packaging regression. Disabled by glob so it stays harmless on a
+# release whose image does not ship the repo.
+RUN dnf -y install --disablerepo='*openh264*' \
+        pam authselect dbus dbus-daemon rpm systemd binutils gettext \
         glibc libxkbcommon tpm2-tss ca-certificates openssl-libs python3 util-linux strace \
     && dnf clean all
 

--- a/test/Containerfile.copr-e2e
+++ b/test/Containerfile.copr-e2e
@@ -1,0 +1,63 @@
+# COPR lifecycle image — install the RPM mock built from source and boot it.
+#
+# test/Containerfile.copr builds the package the way COPR does: Packit SRPM,
+# mock rebuild in a clean chroot, no bundled ONNX Runtime. That container is
+# privileged and disposable, so the lane exports the built RPM to
+# target/copr-lane/facelock.rpm and this image installs it for the same booted
+# lifecycle validation the direct-RPM lanes run.
+#
+# The difference from test/Containerfile.rpm-e2e is the whole point of the lane:
+# nothing here is built from host binaries and nothing bundles ONNX Runtime.
+# `dnf install` resolves the package's own `Requires: onnxruntime`, so what the
+# validation exercises is Fedora's system runtime, which is what the release
+# matrix declares for every Packit/COPR target.
+#
+# Base image comes from dist/release-matrix.json via
+# test/fedora-lane-image.sh, which is where the digest pin and the Fedora
+# EOL gate live. No default: a build without --build-arg must fail, not
+# silently pick a release.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# The same runtime and harness dependencies test/Containerfile.rpm-e2e installs:
+# dbus-daemon for the D-Bus and polkit boundary checks, binutils for the PAM
+# symbol assertions, gettext for the packaged catalogs, strace for the
+# pamtester diagnostics in rpm-service-pam-lifecycle.sh.
+RUN dnf -y install pam authselect dbus dbus-daemon rpm systemd binutils gettext \
+        glibc libxkbcommon tpm2-tss ca-certificates openssl-libs python3 util-linux strace \
+    && dnf clean all
+
+# Build pamtester from source (not in Fedora repos)
+COPY test/install-pamtester.sh /tmp/install-pamtester.sh
+RUN dnf -y install gcc gcc-c++ pam-devel make curl && \
+    sh /tmp/install-pamtester.sh && \
+    rm -f /tmp/install-pamtester.sh && \
+    dnf -y remove gcc gcc-c++ pam-devel make && dnf clean all
+
+# Test user for the PAM assertions. The 0400 shadow mode is the same container
+# fixture accommodation test/Containerfile.rpm-e2e documents: pam_unix 1.7+
+# verifies through setuid unix_chkpwd, which cannot read a mode-0000 shadow
+# under rootless podman.
+RUN useradd -m testuser && echo "testuser:test" | chpasswd && chmod 0400 /etc/shadow
+
+COPY .github/workflows/scripts/validate-rpm.sh /validate-rpm.sh
+COPY test/pkg-validate.sh /pkg-validate.sh
+COPY test/polkit-agent-validate.sh /polkit-agent-validate.sh
+COPY test/rpm-service-pam-lifecycle.sh /rpm-service-pam-lifecycle.sh
+COPY test/rpm-runtime-smoke.sh /rpm-runtime-smoke.sh
+COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
+RUN chmod +x /validate-rpm.sh /pkg-validate.sh /polkit-agent-validate.sh \
+    /rpm-service-pam-lifecycle.sh /rpm-runtime-smoke.sh
+
+# The exact artifact under test, mock built from source by the stage before
+# this one. Installing it here rather than mounting it at run time is what lets
+# pkg-validate.sh see an installed package the moment systemd has booted, and
+# what leaves /facelock-test-package.rpm on disk for its reinstall assertions.
+COPY target/copr-lane/facelock.rpm /facelock-test-package.rpm
+RUN /validate-rpm.sh /facelock-test-package.rpm copr \
+    && dnf install -y /facelock-test-package.rpm \
+    && rpm -q facelock onnxruntime \
+    && ! rpm -q onnxruntime-devel \
+    && dnf clean all
+
+CMD ["/pkg-validate.sh"]

--- a/test/Containerfile.copr-e2e
+++ b/test/Containerfile.copr-e2e
@@ -44,10 +44,11 @@ COPY .github/workflows/scripts/validate-rpm.sh /validate-rpm.sh
 COPY test/pkg-validate.sh /pkg-validate.sh
 COPY test/polkit-agent-validate.sh /polkit-agent-validate.sh
 COPY test/rpm-service-pam-lifecycle.sh /rpm-service-pam-lifecycle.sh
+COPY test/rpm-config-lifecycle.sh /rpm-config-lifecycle.sh
 COPY test/rpm-runtime-smoke.sh /rpm-runtime-smoke.sh
 COPY test/pam.d/facelock-test /etc/pam.d/facelock-test
 RUN chmod +x /validate-rpm.sh /pkg-validate.sh /polkit-agent-validate.sh \
-    /rpm-service-pam-lifecycle.sh /rpm-runtime-smoke.sh
+    /rpm-service-pam-lifecycle.sh /rpm-config-lifecycle.sh /rpm-runtime-smoke.sh
 
 # The exact artifact under test, mock built from source by the stage before
 # this one. Installing it here rather than mounting it at run time is what lets
@@ -59,5 +60,46 @@ RUN /validate-rpm.sh /facelock-test-package.rpm copr \
     && rpm -q facelock onnxruntime \
     && ! rpm -q onnxruntime-devel \
     && dnf clean all
+
+# The %config(noreplace) upgrade lifecycle needs a second, higher-versioned
+# package whose only payload difference is the config file. A second mock
+# source rebuild would cost another full workspace compile for an assertion
+# about rpm's file flags, so this is a re-versioned repack of the payload mock
+# just built: the binaries come out of the installed package, the spec is the
+# same dist/facelock.spec (only its cargo lines no-oped, which the direct lane
+# already does for 0.0.0 -> 0.0.1), and the bundled_ort bcond stays off so the
+# artifact keeps the COPR shape. It is a fixture, not a second COPR build, and
+# it is not byte-identical to one.
+WORKDIR /build
+COPY Cargo.toml Cargo.lock LICENSE-MIT LICENSE-APACHE /build/
+COPY config/ /build/config/
+COPY systemd/ /build/systemd/
+COPY dbus/ /build/dbus/
+COPY dist/ /build/dist/
+COPY po/ /build/po/
+COPY scripts/install-locale-catalogs.sh /build/scripts/install-locale-catalogs.sh
+COPY test/build-rpm-prebuilt.sh /build/test/build-rpm-prebuilt.sh
+COPY .github/workflows/scripts/run-networkless.sh /run-networkless.sh
+RUN dnf -y install rpm-build && dnf clean all && \
+    chmod +x /build/test/build-rpm-prebuilt.sh /run-networkless.sh && \
+    mkdir -p /build/target/release && \
+    cp /usr/bin/facelock /build/target/release/facelock && \
+    cp /usr/bin/facelock-polkit-agent /build/target/release/facelock-polkit-agent && \
+    cp "$(rpm -ql facelock | grep security/pam_facelock.so)" \
+        /build/target/release/libpam_facelock.so && \
+    baseline="$(rpm -qp --queryformat '%{VERSION}' /facelock-test-package.rpm)" && \
+    cp /build/config/facelock.toml /tmp/facelock.toml.baseline && \
+    printf '\n# packaged-only-in-facelock-upgrade-rpm\n' >> /build/config/facelock.toml && \
+    /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "${baseline}.1" copr && \
+    RPM_FILE="$(find . -maxdepth 1 -name '*.rpm' -print -quit)" && \
+    cp "$RPM_FILE" /facelock-test-upgrade.rpm && \
+    /validate-rpm.sh /facelock-test-upgrade.rpm copr && \
+    cp /tmp/facelock.toml.baseline /build/config/facelock.toml && \
+    rm -rf ~/rpmbuild ./*.rpm /tmp/facelock.toml.baseline /build/target && \
+    cmp /build/config/facelock.toml /etc/facelock/config.toml
+
+# rpm-config-lifecycle.sh proves the version ordering by outcome: it upgrades
+# to this package and asserts the new packaged bytes landed, which cannot
+# happen unless `<baseline>.1` outranks `<baseline>`.
 
 CMD ["/pkg-validate.sh"]

--- a/test/Containerfile.copr-e2e
+++ b/test/Containerfile.copr-e2e
@@ -26,9 +26,14 @@ FROM ${BASE_IMAGE}
 # The Cisco OpenH264 repo Fedora enables by default is a single unpinned host
 # with no mirrors (ciscobinary.openh264.org). Nothing here needs a codec, and a
 # packaging gate that fails when that one host is unreachable reports a network
-# outage as a packaging regression. Disabled by glob so it stays harmless on a
-# release whose image does not ship the repo.
-RUN dnf -y install --disablerepo='*openh264*' \
+# outage as a packaging regression. --disablerepo only covers this transaction;
+# the pamtester toolchain install, the package install below that resolves
+# `Requires: onnxruntime`, and the rpm-build install for the upgrade fixture
+# each run their own `dnf` transaction and would still contact the repo for
+# metadata. Disabling it in the repo file itself persists across every later
+# layer in this image; the flag stays as belt-and-braces on this one.
+RUN sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo \
+    && dnf -y install --disablerepo='*openh264*' \
         pam authselect dbus dbus-daemon rpm systemd binutils gettext \
         glibc libxkbcommon tpm2-tss ca-certificates openssl-libs python3 util-linux strace \
     && dnf clean all

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -615,6 +615,7 @@ for relative_path in (
     "test/Containerfile.rpm-e2e",
     "test/Containerfile.rpm-authselect",
     "test/Containerfile.copr",
+    "test/Containerfile.copr-e2e",
     "test/Containerfile.fedora",
 ):
     fedora_containerfile = (ROOT / relative_path).read_text()
@@ -643,50 +644,96 @@ require(
     "bash test/fedora-lane-image.sh" in justfile,
     "justfile Fedora lanes do not resolve their image through the matrix",
 )
-lanes_recipe = re.search(r"(?m)^test-rpm-lanes:(?P<dependencies>[^\n]*)$", justfile)
-require(lanes_recipe is not None, "justfile omits the aggregate Fedora lifecycle lane target")
-lane_invocations = re.findall(
-    r'\((test-rpm-[a-z-]+)\s+"([^"]+)"\)', lanes_recipe.group("dependencies")
+def fedora_lane_bindings(aggregate, prefix, declared_targets, authority, recipe_by_depth):
+    """The {release: recipe} a `just <aggregate>` line declares, bound to the matrix.
+
+    The matrix declares how deeply each release is tested, so the gate has to
+    require that exact recipe. Accepting either one lets a full lifecycle lane
+    be downgraded to a smoke lane without anything noticing, which is the
+    regression these lanes exist to prevent.
+    """
+    aggregate_line = re.search(rf"(?m)^{aggregate}:(?P<dependencies>[^\n]*)$", justfile)
+    require(aggregate_line is not None, f"justfile omits the aggregate Fedora lane target {aggregate}")
+    invocations = re.findall(
+        rf'\(({prefix}[a-z-]+)\s+"([^"]+)"\)', aggregate_line.group("dependencies")
+    )
+    by_release = {release: recipe for recipe, release in invocations}
+    require(
+        len(invocations) == len(by_release),
+        f"just {aggregate} invokes a Fedora release more than once",
+    )
+    releases = {target.split("-")[1] for target in declared_targets}
+    require(
+        set(by_release) == releases,
+        f"just {aggregate} covers {sorted(by_release)}, "
+        f"not the declared {authority} {sorted(releases)}",
+    )
+    for fedora_release in sorted(releases):
+        lane_depths = {
+            row["lifecycle_depth"]
+            for row in matrix.get("platforms", [])
+            if row.get("release_target") is True
+            and re.fullmatch(rf"Fedora {fedora_release}(?: .*)?", row.get("platform", ""))
+        }
+        require(lane_depths, f"release matrix declares no Fedora {fedora_release} platform row")
+        require(
+            len(lane_depths) == 1,
+            f"Fedora {fedora_release} platform rows disagree on lifecycle depth: {sorted(lane_depths)}",
+        )
+        lane_depth = lane_depths.pop()
+        require(
+            lane_depth in recipe_by_depth,
+            f"Fedora {fedora_release} lifecycle depth {lane_depth!r} has no mapped {aggregate} recipe",
+        )
+        require(
+            by_release[fedora_release] == recipe_by_depth[lane_depth],
+            f"just {aggregate} runs Fedora {fedora_release} through "
+            f"{by_release[fedora_release]}, but its declared lifecycle depth "
+            f"{lane_depth!r} requires {recipe_by_depth[lane_depth]}",
+        )
+    return by_release
+
+
+lanes_by_release = fedora_lane_bindings(
+    "test-rpm-lanes",
+    "test-rpm-",
+    expected_copr_targets,
+    "release targets",
+    {"full": "test-rpm-pkg", "build/runtime smoke": "test-rpm-smoke"},
 )
-lanes_by_release = {release: recipe for recipe, release in lane_invocations}
+# #230: the direct-RPM lanes above build from host binaries and ship a bundled
+# ONNX Runtime, which is not the delivery path the matrix declares for Fedora.
+# Every Packit/COPR release target gets a second lane that rebuilds the package
+# from source in mock and validates it against Fedora's system ONNX Runtime, at
+# the same declared depth. Binding this set to packit_release_targets, not to
+# the staging chroots, is what stops a declared COPR target from having only
+# direct-RPM evidence behind it.
+copr_lanes_by_release = fedora_lane_bindings(
+    "test-copr-lanes",
+    "test-copr-",
+    packit_release_targets,
+    "Packit release targets",
+    {"full": "test-copr-pkg", "build/runtime smoke": "test-copr-smoke"},
+)
 require(
-    len(lane_invocations) == len(lanes_by_release),
-    "just test-rpm-lanes invokes a Fedora release more than once",
+    set(copr_lanes_by_release) == set(lanes_by_release),
+    f"just test-copr-lanes covers {sorted(copr_lanes_by_release)}, but the direct-RPM "
+    f"lanes cover {sorted(lanes_by_release)}; each Fedora target needs both channels",
 )
-# The matrix declares how deeply each release is tested, so the gate has to
-# require that exact recipe. Accepting either one lets a full lifecycle lane be
-# downgraded to a smoke lane without anything noticing, which is the regression
-# these lanes exist to prevent.
-lane_recipe_by_depth = {"full": "test-rpm-pkg", "build/runtime smoke": "test-rpm-smoke"}
-declared_fedora_releases = {target.split("-")[1] for target in expected_copr_targets}
+for fedora_release in sorted(copr_lanes_by_release):
+    require(
+        any(
+            row.get("runtime") == "system ORT"
+            for row in matrix.get("platforms", [])
+            if row.get("release_target") is True
+            and re.fullmatch(rf"Fedora {fedora_release}(?: .*)?", row.get("platform", ""))
+        ),
+        f"release matrix declares no system-ORT Fedora {fedora_release} row for its COPR lane",
+    )
 require(
-    set(lanes_by_release) == declared_fedora_releases,
-    f"just test-rpm-lanes covers {sorted(lanes_by_release)}, "
-    f"not the declared release targets {sorted(declared_fedora_releases)}",
+    "test-copr-lanes" in re.search(r"(?m)^test-packaging-matrix:[^\n]*$", justfile).group(0),
+    "just test-packaging-matrix does not run the COPR lifecycle lanes",
 )
-for fedora_release in sorted(declared_fedora_releases):
-    lane_depths = {
-        row["lifecycle_depth"]
-        for row in matrix.get("platforms", [])
-        if row.get("release_target") is True
-        and re.fullmatch(rf"Fedora {fedora_release}(?: .*)?", row.get("platform", ""))
-    }
-    require(lane_depths, f"release matrix declares no Fedora {fedora_release} platform row")
-    require(
-        len(lane_depths) == 1,
-        f"Fedora {fedora_release} platform rows disagree on lifecycle depth: {sorted(lane_depths)}",
-    )
-    lane_depth = lane_depths.pop()
-    require(
-        lane_depth in lane_recipe_by_depth,
-        f"Fedora {fedora_release} lifecycle depth {lane_depth!r} has no mapped lane recipe",
-    )
-    require(
-        lanes_by_release[fedora_release] == lane_recipe_by_depth[lane_depth],
-        f"just test-rpm-lanes runs Fedora {fedora_release} through "
-        f"{lanes_by_release[fedora_release]}, but its declared lifecycle depth "
-        f"{lane_depth!r} requires {lane_recipe_by_depth[lane_depth]}",
-    )
 # The packaging workflow runs the same Fedora lanes as `just test-rpm-lanes`,
 # one job each so they run in parallel rather than end to end. That parallelism
 # is the only reason CI restates the list, so it has to restate it exactly --
@@ -703,6 +750,17 @@ require(
     workflow_fedora_lanes == lanes_by_release,
     f"packaging workflow Fedora lanes {workflow_fedora_lanes} differ from "
     f"just test-rpm-lanes {lanes_by_release}",
+)
+workflow_copr_lanes = {
+    release: recipe
+    for recipe, release in re.findall(
+        r"(?m)^\s+recipe: (test-copr-[a-z-]+) (\d+)\s*$", packaging_workflow
+    )
+}
+require(
+    workflow_copr_lanes == copr_lanes_by_release,
+    f"packaging workflow COPR lanes {workflow_copr_lanes} differ from "
+    f"just test-copr-lanes {copr_lanes_by_release}",
 )
 workflow_deb_lanes = set(re.findall(r"(?m)^\s+recipe: test-deb-([a-z]+)-pkg\s*$", packaging_workflow))
 require(
@@ -806,16 +864,21 @@ evidence_uploads = [
     if re.search(r"(?m)^\s+uses: actions/upload-artifact@", step)
     and re.search(r"(?m)^\s+path: \.packaging-evidence/\s*$", step)
 ]
-# One upload step per lane job: deb, rpm, arch. The two matrix jobs run the
-# same step once per entry, so the step count stays three. A new lane job (the
-# copr job #230 adds) brings its own upload step and bumps this count.
-EVIDENCE_UPLOAD_STEPS = 3
+# One upload step per lane job: deb, rpm, copr, arch. The three matrix jobs run
+# the same step once per entry, so the step count stays one per job. A new lane
+# job brings its own upload step and bumps this count.
+EVIDENCE_UPLOAD_STEPS = 4
 require(
     len(evidence_uploads) == EVIDENCE_UPLOAD_STEPS,
     f"packaging workflow must carry exactly {EVIDENCE_UPLOAD_STEPS} evidence upload steps "
     f"(found {len(evidence_uploads)}); a new lane job adds one and bumps the count",
 )
-for artifact in ("deb-${{ matrix.suite }}", "rpm-${{ matrix.release }}", "arch"):
+for artifact in (
+    "deb-${{ matrix.suite }}",
+    "rpm-${{ matrix.release }}",
+    "copr-${{ matrix.release }}",
+    "arch",
+):
     matching = [
         step
         for step in evidence_uploads
@@ -1070,6 +1133,35 @@ require(
 require(
     "staging_copr_targets" in copr_build_test,
     "COPR-equivalent gate does not check its chroot against the declared staging targets",
+)
+# The COPR lifecycle lanes are the mock build plus the booted validation of what
+# it produced. Both halves have to stay in the source rebuild: the copr-mode
+# artifact check is what proves no bundled ONNX Runtime rode along, and the /out
+# export is the only way the built RPM reaches the lifecycle image.
+require(
+    '.github/workflows/scripts/validate-rpm.sh "$BIN_RPM" copr' in copr_build_test,
+    "COPR-equivalent gate does not validate its artifact against the COPR channel rules",
+)
+require(
+    "/out" in copr_build_test,
+    "COPR-equivalent gate does not export its mock-built RPM for the lifecycle lanes",
+)
+copr_lifecycle_image = (ROOT / "test/Containerfile.copr-e2e").read_text()
+require(
+    "COPY target/copr-lane/facelock.rpm" in copr_lifecycle_image,
+    "COPR lifecycle image does not install the mock-built RPM the lane exported",
+)
+require(
+    "/validate-rpm.sh /facelock-test-package.rpm copr" in copr_lifecycle_image,
+    "COPR lifecycle image does not re-check the exported RPM against the COPR channel rules",
+)
+require(
+    "onnxruntime" in copr_lifecycle_image,
+    "COPR lifecycle image does not pin its system ONNX Runtime dependency",
+)
+require(
+    "!target/copr-lane/facelock.rpm" in (ROOT / ".dockerignore").read_text(),
+    ".dockerignore excludes the staged COPR RPM from the lifecycle image build context",
 )
 
 install_docs = {

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -730,8 +730,10 @@ for fedora_release in sorted(copr_lanes_by_release):
         ),
         f"release matrix declares no system-ORT Fedora {fedora_release} row for its COPR lane",
     )
+test_packaging_matrix_recipe = re.search(r"(?m)^test-packaging-matrix:[^\n]*$", justfile)
+require(test_packaging_matrix_recipe is not None, "justfile omits the test-packaging-matrix recipe")
 require(
-    "test-copr-lanes" in re.search(r"(?m)^test-packaging-matrix:[^\n]*$", justfile).group(0),
+    "test-copr-lanes" in test_packaging_matrix_recipe.group(0),
     "just test-packaging-matrix does not run the COPR lifecycle lanes",
 )
 # The packaging workflow runs the same Fedora lanes as `just test-rpm-lanes`,

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1159,6 +1159,24 @@ require(
     "onnxruntime" in copr_lifecycle_image,
     "COPR lifecycle image does not pin its system ONNX Runtime dependency",
 )
+# Full depth for an RPM lane is three stages. The upgrade candidate is a
+# re-versioned repack of the mock payload, not a second COPR build, so the
+# image has to carry both the stage script and the fixture it consumes.
+for stage in ("/rpm-service-pam-lifecycle.sh", "/rpm-config-lifecycle.sh"):
+    require(
+        f"COPY test{stage} {stage}" in copr_lifecycle_image,
+        f"COPR lifecycle image omits the {stage} stage its full depth claims",
+    )
+require(
+    "/facelock-test-upgrade.rpm" in copr_lifecycle_image
+    and "build-rpm-prebuilt.sh" in copr_lifecycle_image,
+    "COPR lifecycle image builds no higher-versioned upgrade candidate for rpm-config-lifecycle.sh",
+)
+require(
+    'lane_spec="${lane_spec/depth=full/depth=partial}"'
+    in (ROOT / "test/run-pkg-validate-systemd.sh").read_text(),
+    "the lifecycle runner records depth=full even when the image cannot run every stage",
+)
 require(
     "!target/copr-lane/facelock.rpm" in (ROOT / ".dockerignore").read_text(),
     ".dockerignore excludes the staged COPR RPM from the lifecycle image build context",

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1159,6 +1159,21 @@ require(
     "onnxruntime" in copr_lifecycle_image,
     "COPR lifecycle image does not pin its system ONNX Runtime dependency",
 )
+# --disablerepo only covers the transaction it is passed to; the image runs
+# three more dnf transactions after this one (pamtester toolchain, the RPM
+# install, rpm-build), so only a persistent disable in the repo file keeps
+# every layer off the Cisco OpenH264 host.
+openh264_disable = "sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo"
+require(
+    openh264_disable in copr_lifecycle_image,
+    "COPR lifecycle image does not persistently disable the Cisco OpenH264 repo",
+)
+require(
+    copr_lifecycle_image.index(openh264_disable)
+    < copr_lifecycle_image.index("dnf -y install --disablerepo"),
+    "COPR lifecycle image disables the Cisco OpenH264 repo after its first dnf "
+    "transaction, so that transaction and later layers still contact it",
+)
 # Full depth for an RPM lane is three stages. The upgrade candidate is a
 # re-versioned repack of the mock payload, not a second COPR build, so the
 # image has to carry both the stage script and the fixture it consumes.

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1165,7 +1165,7 @@ require(
 # three more dnf transactions after this one (pamtester toolchain, the RPM
 # install, rpm-build), so only a persistent disable in the repo file keeps
 # every layer off the Cisco OpenH264 host.
-openh264_disable = "sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo"
+openh264_disable = "for repo in /etc/yum.repos.d/*openh264*.repo; do [ -e \"$repo\" ] && sed -i 's/^enabled=1/enabled=0/' \"$repo\"; done; true"
 require(
     openh264_disable in copr_lifecycle_image,
     "COPR lifecycle image does not persistently disable the Cisco OpenH264 repo",

--- a/test/copr-build.sh
+++ b/test/copr-build.sh
@@ -99,6 +99,20 @@ else
   echo "FAIL: pinned-model real ORT session smoke did not pass"; RESULT=1
 fi
 
+# The lifecycle lanes (`just test-copr-pkg` / `just test-copr-smoke`) mount a
+# writable /out and take the mock-built RPM back to the host, so the exact
+# artifact this chroot produced can be installed in a booted systemd container
+# and put through the same validation the direct-RPM lanes run. `just test-copr`
+# mounts nothing and is unaffected.
+if [ -d /out ]; then
+  section "Export the mock-built RPM"
+  if cp "$BIN_RPM" /out/facelock.rpm && chmod 0644 /out/facelock.rpm; then
+    echo "exported $(basename "$BIN_RPM") to /out/facelock.rpm"
+  else
+    echo "FAIL: could not export the built RPM to /out"; RESULT=1
+  fi
+fi
+
 section "Install test"
 if dnf install -y "$BIN_RPM"; then
   if rpm -q onnxruntime >/dev/null; then echo "onnxruntime pulled by dnf: OK"; else echo "FAIL: onnxruntime not pulled"; RESULT=1; fi

--- a/test/packaging-evidence.py
+++ b/test/packaging-evidence.py
@@ -119,14 +119,37 @@ def lane_depth(row: dict) -> str:
     return DEPTH_BY_LIFECYCLE[depth]
 
 
+def fedora_rows(rows: list[dict], release: str) -> list[dict]:
+    """Every eligible platform row for one Fedora release.
+
+    A release has more than one: Fedora 44 carries a system-ORT row for the
+    COPR path and a bundled-ORT row for the direct .rpm, and both describe the
+    same release at the same depth.
+    """
+    return [row for row in rows if re.fullmatch(rf"Fedora {release}(?: .*)?", row.get("platform", ""))]
+
+
+def fedora_depth(rows: list[dict], release: str) -> str:
+    depths = {lane_depth(row) for row in fedora_rows(rows, release)}
+    if len(depths) != 1:
+        raise EvidenceError(
+            f"Fedora {release} platform rows declare {sorted(depths) or 'no'} lifecycle depth"
+        )
+    return depths.pop()
+
+
 def required_lanes(matrix: dict) -> dict[str, dict[str, str]]:
     """The lanes the release gate requires, and what each must claim.
 
     Derived from the release-target platform rows so a new target cannot be
-    declared without a lane to prove it. The Fedora lanes are one direct-RPM
-    lane per Packit release target at the depth its platform rows declare,
-    which is what `just test-rpm-lanes` runs today; #230 adds a COPR lane per
-    target beside it, with its own channel, build origin and runtime policy.
+    declared without a lane to prove it. Each Packit release target needs two
+    Fedora lanes, because the matrix declares two delivery paths for it and one
+    cannot stand in for the other: the direct .rpm built from host binaries
+    around a bundled ONNX Runtime (`just test-rpm-lanes`), and the package
+    COPR itself would publish -- rebuilt from source in mock, resolving
+    Fedora's system ONNX Runtime (`just test-copr-lanes`, #230). The lane
+    attributes are what keep them apart: a direct-RPM record offered for a COPR
+    target is refused on `channel` before anything else is read.
     """
     lanes: dict[str, dict[str, str]] = {}
     rows = [row for row in matrix.get("platforms", []) if eligible(row)]
@@ -164,22 +187,31 @@ def required_lanes(matrix: dict) -> dict[str, dict[str, str]]:
             raise EvidenceError(f"platform {platform_id} is a release target with no lane to prove it")
     for target in matrix.get("fedora", {}).get("packit_release_targets", []):
         release = target.split("-")[1]
-        depths = {
-            lane_depth(row)
-            for row in rows
-            if re.fullmatch(rf"Fedora {release}(?: .*)?", row.get("platform", ""))
-        }
-        if len(depths) != 1:
-            raise EvidenceError(
-                f"Fedora {release} platform rows declare {sorted(depths) or 'no'} lifecycle depth"
-            )
-        depth = depths.pop()
-        recipe = "test-rpm-pkg" if depth == "full" else "test-rpm-smoke"
-        lanes[f"{recipe}-{release}"] = {
+        depth = fedora_depth(rows, release)
+        direct = "test-rpm-pkg" if depth == "full" else "test-rpm-smoke"
+        lanes[f"{direct}-{release}"] = {
             "target": f"fedora-{release}",
             "channel": "direct-rpm",
             "build_origin": "host-binaries",
             "runtime_policy": "bundled-ort",
+            "depth": depth,
+        }
+        # The COPR lane's runtime policy is read off the matrix rather than
+        # asserted here: if no row for this release declares system ORT, the
+        # release matrix no longer describes a COPR delivery path and the lane
+        # would be proving something nothing asked for.
+        if "system-ort" not in {
+            runtime_policy(row.get("runtime", "")) for row in fedora_rows(rows, release)
+        }:
+            raise EvidenceError(
+                f"Fedora {release} is a Packit release target with no system-ORT platform row"
+            )
+        copr = "test-copr-pkg" if depth == "full" else "test-copr-smoke"
+        lanes[f"{copr}-{release}"] = {
+            "target": f"fedora-{release}",
+            "channel": "copr",
+            "build_origin": "mock-source-rebuild",
+            "runtime_policy": "system-ort",
             "depth": depth,
         }
     return lanes

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -695,7 +695,7 @@ assert_matrix_mutation_rejected \
 assert_matrix_mutation_rejected \
     "COPR lifecycle image not persistently disabling the Cisco OpenH264 repo" \
     "test/Containerfile.copr-e2e" \
-    's/fedora-cisco-openh264\.repo/fedora-cisco-openh264-disabled.repo/'
+    's/\*openh264\*/\*nomatch\*/'
 # The variable is literal fixture text inside the sed expression.
 # shellcheck disable=SC2016
 assert_matrix_mutation_rejected \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -692,6 +692,10 @@ assert_matrix_mutation_rejected \
     "RPM service-scoped PAM lifecycle omitted from package fixture" \
     "test/Containerfile.rpm-e2e" \
     's@COPY test/rpm-service-pam-lifecycle.sh /rpm-service-pam-lifecycle.sh@COPY test/rpm-service-pam-lifecycle.sh /rpm-service-pam-lifecycle-disabled.sh@'
+assert_matrix_mutation_rejected \
+    "COPR lifecycle image not persistently disabling the Cisco OpenH264 repo" \
+    "test/Containerfile.copr-e2e" \
+    's/fedora-cisco-openh264\.repo/fedora-cisco-openh264-disabled.repo/'
 # The variable is literal fixture text inside the sed expression.
 # shellcheck disable=SC2016
 assert_matrix_mutation_rejected \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -290,7 +290,9 @@ cp "$repo_root/test/Containerfile.rpm-e2e" "$matrix_root/test/"
 # assert anything (#229 wired this recipe into CI, which is how that surfaced).
 cp "$repo_root/test/Containerfile.rpm-authselect" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.copr" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.copr-e2e" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.fedora" "$matrix_root/test/"
+cp "$repo_root/.dockerignore" "$matrix_root/"
 cp "$repo_root/test/fedora-lane-image.sh" "$matrix_root/test/"
 cp "$repo_root/.github/workflows/packaging.yml" "$matrix_root/.github/workflows/"
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
@@ -1350,13 +1352,18 @@ case "${1:-}" in
         detached=0
         models=nomodels
         image=""
+        out=""
         while [ $# -gt 0 ]; do
             case "$1" in
                 -d) detached=1; shift ;;
                 -v)
-                    case "$2" in *:/facelock-test-models:*) models=models ;; esac
+                    case "$2" in
+                        *:/facelock-test-models:*) models=models ;;
+                        *:/out:*) out="${2%%:*}" ;;
+                    esac
                     shift 2 ;;
-                --security-opt|-w) shift 2 ;;
+                # Two-token options, or the value is read as the image name.
+                -e|--security-opt|-w) shift 2 ;;
                 -*) shift ;;
                 *) image="$1"; break ;;
             esac
@@ -1368,6 +1375,10 @@ case "${1:-}" in
         case "$image" in
             facelock-arch-pkg-*)
                 printf 'RESULTS_JSON: {"pass":29,"fail":0,"skip":0,"allowed_skip":0,"mandatory_skip":0,"models_present":true}\n' ;;
+            facelock-copr-test-*)
+                # The mock source rebuild hands its RPM back through /out.
+                [ -n "$out" ] || { echo "copr build with no /out mount" >&2; exit 1; }
+                : >"$out/facelock.rpm" ;;
         esac
         exit 0 ;;
     exec)
@@ -1391,7 +1402,11 @@ case "${1:-}" in
             test)
                 case "${2:-} ${3:-}" in
                     "-x /deb-package-lifecycle.sh") [ "$format" = deb ] ;;
-                    "-x /rpm-service-pam-lifecycle.sh"|"-x /rpm-config-lifecycle.sh") [ "$format" = rpm ] ;;
+                    "-x /rpm-service-pam-lifecycle.sh") [ "$format" = rpm ] ;;
+                    # Only the direct-RPM image carries the config-upgrade
+                    # stage; the COPR image has one mock build, so it has no
+                    # higher-versioned fixture to upgrade to.
+                    "-x /rpm-config-lifecycle.sh") case "$cid" in stub-facelock-rpm-pkg-*) ;; *) exit 1 ;; esac ;;
                     *) exit 1 ;;
                 esac ;;
             /pkg-validate.sh)
@@ -1437,7 +1452,7 @@ run_packaging_matrix >"$tmp_root/evidence-complete.log" 2>&1 ||
 validate_output=$(evidence_validate "$evidence_root/.packaging-matrix-verified" 2>&1) ||
     fail "release preflight refused the marker a complete matrix run wrote: $validate_output"
 case "$validate_output" in
-    *"6 lanes"*) ;;
+    *"9 lanes"*) ;;
     *) fail "validate accepted the marker without summarising it: $validate_output" ;;
 esac
 python3 - "$evidence_root/.packaging-matrix-verified" "$evidence_head" <<'PY'
@@ -1452,6 +1467,9 @@ assert marker["tree_clean"] is True
 assert marker["started_at"] and marker["finished_at"] and marker["started_at"] <= marker["finished_at"]
 expected = [
     "test-arch-pkg",
+    "test-copr-pkg-43",
+    "test-copr-pkg-44",
+    "test-copr-smoke-45",
     "test-deb-resolute-pkg",
     "test-deb-trixie-pkg",
     "test-rpm-pkg-43",
@@ -1474,6 +1492,19 @@ assert lanes["test-rpm-pkg-43"]["runtime_policy"] == "bundled-ort"
 assert lanes["test-rpm-smoke-45"]["depth"] == "smoke"
 assert lanes["test-arch-pkg"]["channel"] == "aur"
 assert lanes["test-arch-pkg"]["runtime_policy"] == "system-ort"
+# #230: every declared Packit/COPR target carries its own record, built from
+# source in mock and run against Fedora's system ONNX Runtime. Same target as
+# the direct-RPM lane beside it, different channel, origin and runtime.
+for release in ("43", "44"):
+    copr = lanes[f"test-copr-pkg-{release}"]
+    assert copr["target"] == f"fedora-{release}", copr
+    assert copr["channel"] == "copr", copr
+    assert copr["build_origin"] == "mock-source-rebuild", copr
+    assert copr["runtime_policy"] == "system-ort", copr
+    assert copr["depth"] == "full", copr
+    assert lanes[f"test-rpm-pkg-{release}"]["target"] == copr["target"], release
+assert lanes["test-copr-smoke-45"]["channel"] == "copr"
+assert lanes["test-copr-smoke-45"]["depth"] == "smoke"
 PY
 cp "$evidence_root/.packaging-matrix-verified" "$tmp_root/evidence-good.json"
 cp -R "$evidence_root/.packaging-evidence" "$tmp_root/evidence-good-records"
@@ -1585,6 +1616,19 @@ assert_evidence_refused "lane record from another commit" \
     'lanes["test-rpm-smoke-45"]["commit"] = "0" * 40' "commit"
 assert_evidence_refused "direct RPM record claiming another channel" \
     'lanes["test-rpm-pkg-43"]["channel"] = "copr"' "channel"
+# #230's core refusal: the direct-RPM lanes prove a bundled-runtime package
+# built from host binaries, so their success can never stand in for the COPR
+# delivery path the release matrix declares for the same Fedora target.
+assert_evidence_refused "direct RPM record offered as the COPR lane" \
+    'marker["lanes"] = [lane for lane in marker["lanes"] if lane["name"] != "test-copr-pkg-44"] + [{**lanes["test-rpm-pkg-44"], "name": "test-copr-pkg-44"}]' \
+    "channel"
+assert_evidence_refused "COPR record built from host binaries" \
+    'lanes["test-copr-pkg-43"]["build_origin"] = "host-binaries"' "build_origin"
+assert_evidence_refused "COPR record run against a bundled runtime" \
+    'lanes["test-copr-pkg-43"]["runtime_policy"] = "bundled-ort"' "runtime_policy"
+assert_evidence_refused "missing COPR lane record" \
+    'marker["lanes"] = [lane for lane in marker["lanes"] if lane["name"] != "test-copr-smoke-45"]' \
+    "test-copr-smoke-45"
 assert_evidence_refused "lane depth downgraded" \
     'lanes["test-rpm-pkg-44"]["depth"] = "smoke"' "depth"
 assert_evidence_refused "duplicate lane records" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1403,10 +1403,15 @@ case "${1:-}" in
                 case "${2:-} ${3:-}" in
                     "-x /deb-package-lifecycle.sh") [ "$format" = deb ] ;;
                     "-x /rpm-service-pam-lifecycle.sh") [ "$format" = rpm ] ;;
-                    # Only the direct-RPM image carries the config-upgrade
-                    # stage; the COPR image has one mock build, so it has no
-                    # higher-versioned fixture to upgrade to.
-                    "-x /rpm-config-lifecycle.sh") case "$cid" in stub-facelock-rpm-pkg-*) ;; *) exit 1 ;; esac ;;
+                    # Both RPM images carry the config-upgrade stage. The
+                    # override drops it from the COPR image so the runner's
+                    # depth downgrade can be exercised.
+                    "-x /rpm-config-lifecycle.sh")
+                        case "$cid" in
+                            stub-facelock-copr-*)
+                                [ "${STUB_COPR_WITHOUT_CONFIG_LIFECYCLE:-0}" != 1 ] ;;
+                            *) [ "$format" = rpm ] ;;
+                        esac ;;
                     *) exit 1 ;;
                 esac ;;
             /pkg-validate.sh)
@@ -1563,6 +1568,28 @@ with open(sys.argv[1], encoding="utf-8") as handle:
     lane = json.load(handle)
 assert lane["status"] == "fail", lane
 PY
+
+# A lane whose image cannot run every stage its declared depth names records
+# what it actually ran. `partial` is a depth the release matrix requires of
+# nothing, so the aggregate refuses it rather than accepting a short lifecycle
+# as a full one (#230).
+if run_packaging_matrix STUB_COPR_WITHOUT_CONFIG_LIFECYCLE=1 >"$tmp_root/evidence-short-depth.log" 2>&1; then
+    fail "test-packaging-matrix recorded a COPR lane that skipped the config lifecycle"
+fi
+[ ! -e "$evidence_root/.packaging-matrix-verified" ] ||
+    fail "the short-depth run left a marker behind"
+grep -q 'rpm-config-lifecycle.sh' "$tmp_root/evidence-short-depth.log" ||
+    fail "the short-depth run did not name the stage it could not run: $(cat "$tmp_root/evidence-short-depth.log")"
+grep -q "depth is 'partial'" "$tmp_root/evidence-short-depth.log" ||
+    fail "the short-depth refusal did not name the depth: $(cat "$tmp_root/evidence-short-depth.log")"
+python3 - "$evidence_root/.packaging-evidence/test-copr-pkg-43.json" <<'DEPTH'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    lane = json.load(handle)
+assert lane["depth"] == "partial", lane
+DEPTH
 
 evidence_case_index=0
 assert_evidence_refused() {

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -145,9 +145,7 @@ fi
 # stages downgrade the recorded depth to `partial`, which the release matrix
 # requires of nothing and the aggregate therefore refuses.
 missing_stages=()
-if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
-    :
-else
+if ! podman exec "$cid" test -x /deb-package-lifecycle.sh; then
     for stage in /rpm-service-pam-lifecycle.sh /rpm-config-lifecycle.sh; do
         podman exec "$cid" test -x "$stage" || missing_stages+=("$stage")
     done

--- a/test/run-pkg-validate-systemd.sh
+++ b/test/run-pkg-validate-systemd.sh
@@ -137,6 +137,22 @@ if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
     podman exec "$cid" install -m 0644 /facelock-test.pam /etc/pam.d/facelock-test
 fi
 
+# An RPM image is one with no Debian lifecycle harness, and its full depth is
+# three stages: the service/PAM lifecycle, pkg-validate.sh, and the
+# %config(noreplace) upgrade lifecycle. A lane that runs fewer must not record
+# `depth=full`: the stages are optional-by-presence, which is exactly how a
+# lane could otherwise claim a complete lifecycle it never ran (#230). Missing
+# stages downgrade the recorded depth to `partial`, which the release matrix
+# requires of nothing and the aggregate therefore refuses.
+missing_stages=()
+if podman exec "$cid" test -x /deb-package-lifecycle.sh; then
+    :
+else
+    for stage in /rpm-service-pam-lifecycle.sh /rpm-config-lifecycle.sh; do
+        podman exec "$cid" test -x "$stage" || missing_stages+=("$stage")
+    done
+fi
+
 if podman exec "$cid" test -x /rpm-service-pam-lifecycle.sh; then
     podman exec "$cid" /rpm-service-pam-lifecycle.sh
 fi
@@ -160,7 +176,13 @@ fi
 
 # Recorded last, so the record's status covers every stage above it.
 if [ -n "${PACKAGING_LANE:-}" ]; then
-    python3 "$(dirname "$0")/packaging-evidence.py" record --lane "$PACKAGING_LANE" \
+    lane_spec="$PACKAGING_LANE"
+    if [ "${#missing_stages[@]}" -gt 0 ]; then
+        echo "WARNING: image carries no ${missing_stages[*]}; recording depth=partial," >&2
+        echo "         which no release-matrix lane accepts, instead of the declared depth." >&2
+        lane_spec="${lane_spec/depth=full/depth=partial}"
+    fi
+    python3 "$(dirname "$0")/packaging-evidence.py" record --lane "$lane_spec" \
         --results-log "$validate_log" --exit-status "$lane_status" "${runner_skips[@]}"
 fi
 exit "$lane_status"


### PR DESCRIPTION
## Summary

- stacked on #321
- add `test-copr-pkg`/`test-copr-smoke`/`test-copr-lanes`, a mock source rebuild feeding the same booted lifecycle validation the direct-rpm lanes run
- repack the mock payload at a higher version for the `%config(noreplace)` upgrade stage instead of running a second mock build
- refuse `depth: partial` evidence for a target the matrix declares `full`
- record `channel: copr`, `build_origin: mock-source-rebuild`, `runtime_policy: system-ort` per lane
- bind the release matrix checker's required copr lanes to `fedora.packit_release_targets`
- run the copr job nightly and on dispatch only, never on pull requests, since mock needs a privileged container
- disable the cisco openh264 repo persistently in every copr image layer, not just the first transaction
- replace the old 30-60 minute estimate with the measured full-matrix timing, about 1 h 45 min on 2026-09-02

## Why

The release matrix declares two Fedora delivery paths, direct RPM and COPR, but only the direct lane had lifecycle coverage. A COPR target could pass release with a package COPR itself never validated end to end. The COPR lane rebuilds the package the way Packit does: SRPM, mock chroot, Fedora's system ONNX Runtime, then runs it through the same booted service and config lifecycle the direct lane runs.

## Validation

- `python3 test/check-release-matrix.py`
- `bash test/release-version-contract.sh`
- `python3 test/check-agent-docs.py`
- `just check`

Closes #230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Fedora COPR packaging lanes for Fedora 43–45, including mock source rebuilds and system ONNX Runtime validation.
  - Added COPR lifecycle and smoke testing to packaging-matrix release checks.
  - Release evidence now requires both direct-RPM and COPR validation for supported Fedora targets.

- **CI & Release**
  - COPR checks run nightly, manually, or during pre-release workflows—not on pull requests.
  - Packaging evidence now includes uploaded COPR artifacts and detailed lane metadata.

- **Documentation**
  - Updated testing, packaging, release, and contract documentation with COPR workflows, requirements, and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->