### PR TITLE
ci(release): guard staging publication config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,9 @@ jobs:
       - name: Compare live production release channels with checked-in authority
         run: python3 test/check-live-release-channels.py
 
+      - name: Compare the staging release channel with checked-in authority
+        run: python3 test/check-live-release-channels.py --channel staging
+
   catalog-check:
     name: Translation Catalog Freshness
     runs-on: ubuntu-latest

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,18 @@
         "fedora-44-x86_64",
         "fedora-45-x86_64"
       ]
+    },
+    {
+      "job": "copr_build",
+      "trigger": "pull_request",
+      "manual_trigger": true,
+      "owner": "tyvsmith",
+      "project": "facelock-testing",
+      "targets": [
+        "fedora-43-x86_64",
+        "fedora-44-x86_64",
+        "fedora-45-x86_64"
+      ]
     }
   ]
 }

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@
     },
     {
       "job": "copr_build",
-      "trigger": "pull_request",
+      "trigger": "ignore",
       "manual_trigger": true,
       "owner": "tyvsmith",
       "project": "facelock-testing",

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -66,8 +66,15 @@
     "staging": {
       "owner": "tyvsmith",
       "project": "facelock-testing",
+      "api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock-testing",
+      "required_supported_chroots": [
+        "fedora-43-x86_64",
+        "fedora-44-x86_64",
+        "fedora-45-x86_64"
+      ],
       "provisioning_issue": 236,
-      "managed_by_this_change": false
+      "managed_by_this_change": false,
+      "provisioned": false
     }
   },
   "arch": {

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2139,13 +2139,20 @@ acceptance or release evidence. Promotion requires a separately reviewed
 amendment and full Fedora gates.
 
 The staging channel is `tyvsmith/facelock-testing`. `.packit.yaml` declares
-exactly one `copr_build` job for it, pull-request triggered and manually run; a
-release-triggered staging job is rejected, as is a second one. Its chroots equal
-the supported set exactly: staging declares no optional experimental chroot, so
-Rawhide there is drift rather than a permitted experiment.
-`copr_channels.staging.provisioned` stays false until issue #236 creates the
-project, and while it is false `test/check-live-release-channels.py --channel
-staging` reports `not provisioned` and contacts nothing.
+exactly one `copr_build` job for it; a release-triggered staging job is
+rejected, as is a second one. Its chroots equal the supported set exactly:
+staging declares no optional experimental chroot, so Rawhide there is drift
+rather than a permitted experiment.
+
+`copr_channels.staging.provisioned` and the staging job's trigger are one
+contract. While `provisioned` is false the job must carry `trigger: ignore` and
+is dispatched by hand; when it is true the job must carry
+`trigger: pull_request`. Either value alone fails the release matrix contract,
+so the project cannot be declared live without the job that builds into it, and
+the job cannot chase a project that does not exist. `provisioned` stays false
+until issue #236 creates the project, and while it is false
+`test/check-live-release-channels.py --channel staging` reports `not
+provisioned` and contacts nothing.
 
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2149,17 +2149,26 @@ contract. While `provisioned` is false the job must carry `trigger: ignore` and
 is dispatched by hand; when it is true the job must carry
 `trigger: pull_request`. Either value alone fails the release matrix contract,
 so the project cannot be declared live without the job that builds into it, and
-the job cannot chase a project that does not exist. `provisioned` stays false
-until issue #236 creates the project, and while it is false
-`test/check-live-release-channels.py --channel staging` reports `not
-provisioned` and contacts nothing.
+the job cannot chase a project that does not exist. A third assertion holds
+`provisioned` false until issue #236 creates the project, so provisioning is
+three reviewed edits: the switch, the trigger, and retiring that assertion.
+While the switch is false, `test/check-live-release-channels.py --channel
+staging` reports `not provisioned` and contacts nothing.
+
+Only an explicit `provisioned: false` skips a channel. `copr_channels.production`
+declares no such switch and must never grow one, so the production comparison
+always queries its authority.
 
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and
 how fresh each channel's repository metadata was.
 `scripts/release-attestation.py` renders and validates that document. No channel
 in it may carry the production COPR identity, and a channel carrying the staging
-COPR identity must serve exactly the declared staging chroots.
+COPR identity must serve exactly the declared staging chroots. The expectation
+file the validator compares against, `metadata_max_age_seconds` included, is
+reviewed release input produced with the release, not a value the attested
+channels supply; the validator checks that it is a positive integer and does not
+bound how loose a freshness window a reviewer may approve.
 
 Issue #236 owns pre-tag and post-publication proof that optional Rawhide serves
 no alpha or candidate build. This contract does not provision, publish to, or

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2138,6 +2138,22 @@ Rawhide-only failure is not alpha-blocking, and its smoke result is not alpha
 acceptance or release evidence. Promotion requires a separately reviewed
 amendment and full Fedora gates.
 
+The staging channel is `tyvsmith/facelock-testing`. `.packit.yaml` declares
+exactly one `copr_build` job for it, pull-request triggered and manually run; a
+release-triggered staging job is rejected, as is a second one. Its chroots equal
+the supported set exactly: staging declares no optional experimental chroot, so
+Rawhide there is drift rather than a permitted experiment.
+`copr_channels.staging.provisioned` stays false until issue #236 creates the
+project, and while it is false `test/check-live-release-channels.py --channel
+staging` reports `not provisioned` and contacts nothing.
+
+A pre-tag attestation binds the candidate commit to the EVRs each channel
+serves, the artifact and repository digests, the signing key fingerprints, and
+how fresh each channel's repository metadata was.
+`scripts/release-attestation.py` renders and validates that document. No channel
+in it may carry the production COPR identity, and a channel carrying the staging
+COPR identity must serve exactly the declared staging chroots.
+
 Issue #236 owns pre-tag and post-publication proof that optional Rawhide serves
 no alpha or candidate build. This contract does not provision, publish to, or
 otherwise mutate COPR or Packit infrastructure.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -538,18 +538,25 @@ tag at production while staging is unavailable.
 ##### Staging COPR (`tyvsmith/facelock-testing`)
 
 `.packit.yaml` declares a second `copr_build` job, for
-`tyvsmith/facelock-testing`. It is pull-request triggered with
-`manual_trigger: true`, so it builds only when a maintainer asks for it with a
-`/packit build` comment. A tag never publishes into staging.
+`tyvsmith/facelock-testing`. It carries `trigger: ignore`, so nothing runs it
+automatically: a maintainer dispatches it by hand with a `/packit build`
+comment. A tag never publishes into staging.
 
 The project does not exist yet. Issue #236 owns creating it and granting Packit
 builder access; until then `dist/release-matrix.json` keeps
 `copr_channels.staging.provisioned` false and
 `python3 test/check-live-release-channels.py --channel staging` reports `not
-provisioned` and queries nothing. Provisioning is one edit here: create the
-project with exactly the Fedora 43, 44, and 45 chroots, then set `provisioned`
-to true. The same checker then compares the live project with the checked-in
-authority on every pull request and in preflight.
+provisioned` and queries nothing.
+
+The trigger and that switch move together, and `test/check-release-matrix.py`
+enforces the pairing. While `provisioned` is false the staging job must stay on
+`trigger: ignore`; a pull-request trigger would aim every pull request's Packit
+run at a project that answers 404. Provisioning is therefore one edit in two
+places: create the project with exactly the Fedora 43, 44, and 45 chroots, then
+set `provisioned` to true **and** move the staging job to
+`trigger: pull_request`. Changing either alone fails the release matrix
+contract. From then on the same checker compares the live project with the
+checked-in authority on every pull request and in preflight.
 
 Staging tolerates no optional experimental chroot. Production accepts Rawhide's
 presence or absence; in staging any chroot beyond the supported three is drift.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -551,12 +551,22 @@ provisioned` and queries nothing.
 The trigger and that switch move together, and `test/check-release-matrix.py`
 enforces the pairing. While `provisioned` is false the staging job must stay on
 `trigger: ignore`; a pull-request trigger would aim every pull request's Packit
-run at a project that answers 404. Provisioning is therefore one edit in two
-places: create the project with exactly the Fedora 43, 44, and 45 chroots, then
-set `provisioned` to true **and** move the staging job to
-`trigger: pull_request`. Changing either alone fails the release matrix
-contract. From then on the same checker compares the live project with the
-checked-in authority on every pull request and in preflight.
+run at a project that answers 404.
+
+Provisioning is therefore three edits, and the contract rejects any two of them
+without the third. Create the project with exactly the Fedora 43, 44, and 45
+chroots, then:
+
+1. set `copr_channels.staging.provisioned` to true in `dist/release-matrix.json`
+2. move the staging job in `.packit.yaml` to `trigger: pull_request`
+3. delete the `staging COPR provisioning must stay unclaimed until issue #236
+   creates the project` assertion from `test/check-release-matrix.py`
+
+The third edit is the point of review: that assertion exists so provisioning
+cannot be claimed by a config change alone, and retiring it is the moment
+someone confirms the project really exists. From then on the same checker
+compares the live project with the checked-in authority on every pull request
+and in preflight.
 
 Staging tolerates no optional experimental chroot. Production accepts Rawhide's
 presence or absence; in staging any chroot beyond the supported three is drift.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -532,9 +532,46 @@ reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot and
 checks that the payload has no bundle while its dependencies select Fedora ORT.
 
 Only a stable-tagged config with the deliberately restored production release
-trigger can populate production COPR automatically. Prerelease staging project
-provisioning and served-repository validation are separate release-infrastructure
-work; do not point prerelease tags at production while it is unavailable.
+trigger can populate production COPR automatically. Do not point a prerelease
+tag at production while staging is unavailable.
+
+##### Staging COPR (`tyvsmith/facelock-testing`)
+
+`.packit.yaml` declares a second `copr_build` job, for
+`tyvsmith/facelock-testing`. It is pull-request triggered with
+`manual_trigger: true`, so it builds only when a maintainer asks for it with a
+`/packit build` comment. A tag never publishes into staging.
+
+The project does not exist yet. Issue #236 owns creating it and granting Packit
+builder access; until then `dist/release-matrix.json` keeps
+`copr_channels.staging.provisioned` false and
+`python3 test/check-live-release-channels.py --channel staging` reports `not
+provisioned` and queries nothing. Provisioning is one edit here: create the
+project with exactly the Fedora 43, 44, and 45 chroots, then set `provisioned`
+to true. The same checker then compares the live project with the checked-in
+authority on every pull request and in preflight.
+
+Staging tolerates no optional experimental chroot. Production accepts Rawhide's
+presence or absence; in staging any chroot beyond the supported three is drift.
+
+##### Pre-tag attestation
+
+`scripts/release-attestation.py` renders and validates the document that binds a
+candidate to what its channels serve: the candidate commit, the EVR each channel
+serves per target, artifact and repository digests, signing key fingerprints, and
+when each channel last refreshed its repository metadata.
+
+```bash
+python3 scripts/release-attestation.py render --input facts.json --output attestation.json
+python3 scripts/release-attestation.py validate --attestation attestation.json --expect expect.json
+```
+
+`validate` fails closed on a drifted candidate commit, a served EVR or digest
+that disagrees with the recorded expectations, a changed signing fingerprint,
+metadata older than `metadata_max_age_seconds` or stamped in the future, and on
+any channel carrying the production COPR identity. Gathering those facts from
+live staging repositories is issue #236's remaining infrastructure work; the
+script and its contract cases run against fixtures today.
 
 Note: a previously published release will **not** retroactively build — Packit
 reacts only to *new* Release events.

--- a/justfile
+++ b/justfile
@@ -1517,6 +1517,7 @@ release-preflight tag='':
         test/release-version-contract.sh \
         test/check-release-matrix.py \
         test/check-live-release-channels.py \
+        scripts/release-attestation.py \
         .github/workflows/release.yml; do
         if [ -f "$f" ]; then
             echo "OK: $f"
@@ -1536,6 +1537,7 @@ release-preflight tag='':
     bash test/release-version-contract.sh || failed=1
     RELEASE_MATRIX_VERSION="$VERSION" python3 test/check-release-matrix.py || failed=1
     python3 test/check-live-release-channels.py || failed=1
+    python3 test/check-live-release-channels.py --channel staging || failed=1
 
     echo ""
     echo "== GitHub release secret checks =="

--- a/scripts/release-attestation.py
+++ b/scripts/release-attestation.py
@@ -82,6 +82,21 @@ def string_map(value: object, description: str) -> dict[str, str]:
     return dict(value)
 
 
+def chroot_authority(value: object, channel: str) -> set[str]:
+    """A channel's required_supported_chroots, validated before it becomes a
+    set: a non-empty list of non-empty strings with no duplicates. Used for
+    both COPR channels the release matrix declares."""
+    require(
+        isinstance(value, list) and value and all(isinstance(item, str) and item for item in value),
+        f"release matrix {channel} COPR required_supported_chroots must be a non-empty list of non-empty strings: {value!r}",
+    )
+    require(
+        len(value) == len(set(value)),
+        f"release matrix {channel} COPR required_supported_chroots must not contain duplicate chroots: {value!r}",
+    )
+    return set(value)
+
+
 def channel_authority() -> tuple[str, str, set[str]]:
     """The production identity no attestation may claim, plus the staging one
     and the chroots it is allowed to serve."""
@@ -91,9 +106,10 @@ def channel_authority() -> tuple[str, str, set[str]]:
         production = f"{channels['production']['owner']}/{channels['production']['project']}"
         staging = channels["staging"]
         staging_identity = f"{staging['owner']}/{staging['project']}"
-        staging_chroots = set(staging["required_supported_chroots"])
+        staging_required_chroots = staging["required_supported_chroots"]
     except (KeyError, TypeError) as error:
         fail(f"release matrix has no complete COPR channel authority: {error}")
+    staging_chroots = chroot_authority(staging_required_chroots, "staging")
     return production, staging_identity, staging_chroots
 
 

--- a/scripts/release-attestation.py
+++ b/scripts/release-attestation.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Render and validate the pre-tag release attestation (#236).
+
+A green build job proves a package was built. It does not prove that a channel
+serves it, that the bytes it serves are the ones that were validated, or that
+the metadata a client would fetch is current. The attestation is the document
+that binds those together for one candidate commit:
+
+    candidate commit -> per-channel served EVRs
+                     -> artifact and repository digests
+                     -> signing key fingerprints
+                     -> when each channel's metadata was last refreshed
+
+`render` turns the facts a release run gathered into that document, in a
+canonical form so two runs over the same facts produce identical bytes.
+`validate` compares a document with the expectations recorded for the release
+and with the checked-in channel authority in dist/release-matrix.json, and
+fails closed on any disagreement.
+
+Provisioning the staging channels is issue #236's infrastructure phase; this
+script contacts nothing and only reads files it is given. Stdlib only: it runs
+in the same bare containers as the rest of the release gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "dist" / "release-matrix.json"
+SCHEMA = "facelock-release-attestation/1"
+
+COMMIT = re.compile(r"[0-9a-f]{40}")
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+FINGERPRINT = re.compile(r"[0-9A-F]{40}")
+VERSION = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?")
+
+CHANNEL_FIELDS = ("identity", "served_evrs", "repository_digest", "metadata_refreshed_at", "signing_key_fingerprint")
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: object, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def load_json(path: Path, description: str) -> dict:
+    try:
+        content = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read {description}: {error}")
+    require(isinstance(content, dict), f"{description} is not a JSON object")
+    return content
+
+
+def timestamp(value: object, description: str) -> datetime:
+    require(isinstance(value, str) and value.endswith("Z"), f"{description} must be a UTC RFC 3339 timestamp: {value!r}")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        fail(f"{description} is not a parseable timestamp: {error}")
+    return parsed.astimezone(timezone.utc)
+
+
+def string_map(value: object, description: str) -> dict[str, str]:
+    require(
+        isinstance(value, dict)
+        and value
+        and all(isinstance(key, str) and isinstance(item, str) and key and item for key, item in value.items()),
+        f"{description} must be a non-empty map of strings to strings",
+    )
+    return dict(value)
+
+
+def channel_authority() -> tuple[str, str, set[str]]:
+    """The production identity no attestation may claim, plus the staging one
+    and the chroots it is allowed to serve."""
+    matrix = load_json(MATRIX_PATH, "release matrix")
+    try:
+        channels = matrix["copr_channels"]
+        production = f"{channels['production']['owner']}/{channels['production']['project']}"
+        staging = channels["staging"]
+        staging_identity = f"{staging['owner']}/{staging['project']}"
+        staging_chroots = set(staging["required_supported_chroots"])
+    except (KeyError, TypeError) as error:
+        fail(f"release matrix has no complete COPR channel authority: {error}")
+    return production, staging_identity, staging_chroots
+
+
+def normalized_channel(name: str, channel: object) -> dict:
+    where = f"channel {name}"
+    require(isinstance(channel, dict), f"{where} is not an object")
+    for field in CHANNEL_FIELDS:
+        require(field in channel, f"{where} omits {field}")
+    identity = channel["identity"]
+    require(isinstance(identity, str) and identity, f"{where} identity must be a non-empty string")
+    digest = channel["repository_digest"]
+    require(isinstance(digest, str) and DIGEST.fullmatch(digest), f"{where} repository_digest is not a sha256 digest: {digest!r}")
+    fingerprint = channel["signing_key_fingerprint"]
+    require(
+        isinstance(fingerprint, str) and FINGERPRINT.fullmatch(fingerprint),
+        f"{where} signing_key_fingerprint is not a 40-character uppercase hex fingerprint: {fingerprint!r}",
+    )
+    timestamp(channel["metadata_refreshed_at"], f"{where} metadata_refreshed_at")
+    unknown = sorted(set(channel) - set(CHANNEL_FIELDS))
+    require(not unknown, f"{where} carries unknown fields: {unknown}")
+    return {
+        "identity": identity,
+        "metadata_refreshed_at": channel["metadata_refreshed_at"],
+        "repository_digest": digest,
+        "served_evrs": dict(sorted(string_map(channel["served_evrs"], f"{where} served_evrs").items())),
+        "signing_key_fingerprint": fingerprint,
+    }
+
+
+def normalized_artifact(name: str, artifact: object, channels: set[str]) -> dict:
+    where = f"artifact {name}"
+    require(isinstance(artifact, dict), f"{where} is not an object")
+    require(set(artifact) == {"channel", "digest"}, f"{where} must carry exactly a channel and a digest")
+    channel = artifact["channel"]
+    require(channel in channels, f"{where} names an undeclared channel: {channel!r}")
+    digest = artifact["digest"]
+    require(isinstance(digest, str) and DIGEST.fullmatch(digest), f"{where} digest is not a sha256 digest: {digest!r}")
+    return {"channel": channel, "digest": digest}
+
+
+def render(inputs: dict) -> dict:
+    commit = inputs.get("candidate_commit")
+    require(
+        isinstance(commit, str) and COMMIT.fullmatch(commit),
+        f"candidate_commit must be a full lowercase git commit id: {commit!r}",
+    )
+    version = inputs.get("release_version")
+    require(
+        isinstance(version, str) and VERSION.fullmatch(version),
+        f"release_version must be a release identity: {version!r}",
+    )
+    raw_channels = inputs.get("channels")
+    require(isinstance(raw_channels, dict) and raw_channels, "channels must be a non-empty object")
+    channels = {name: normalized_channel(name, channel) for name, channel in sorted(raw_channels.items())}
+    raw_artifacts = inputs.get("artifacts")
+    require(isinstance(raw_artifacts, dict) and raw_artifacts, "artifacts must be a non-empty object")
+    artifacts = {
+        name: normalized_artifact(name, artifact, set(channels))
+        for name, artifact in sorted(raw_artifacts.items())
+    }
+    unknown = sorted(set(inputs) - {"candidate_commit", "release_version", "channels", "artifacts", "schema"})
+    require(not unknown, f"attestation input carries unknown fields: {unknown}")
+    return {
+        "schema": SCHEMA,
+        "candidate_commit": commit,
+        "release_version": version,
+        "channels": channels,
+        "artifacts": artifacts,
+    }
+
+
+def validate(attestation: dict, expect: dict, now: datetime) -> None:
+    require(attestation.get("schema") == SCHEMA, f"attestation schema drifted: {attestation.get('schema')!r}")
+    # Re-render rather than trust the document's shape: a hand-edited
+    # attestation is exactly what this gate is looking for.
+    document = render({key: value for key, value in attestation.items() if key != "schema"})
+
+    require(
+        document["candidate_commit"] == expect.get("candidate_commit"),
+        f"candidate commit drifted: attested {document['candidate_commit']}, expected {expect.get('candidate_commit')!r}",
+    )
+    require(
+        document["release_version"] == expect.get("release_version"),
+        f"release version drifted: attested {document['release_version']}, expected {expect.get('release_version')!r}",
+    )
+    max_age = expect.get("metadata_max_age_seconds")
+    require(
+        isinstance(max_age, int) and not isinstance(max_age, bool) and max_age > 0,
+        f"expectation metadata_max_age_seconds must be a positive integer: {max_age!r}",
+    )
+
+    expected_channels = expect.get("channels")
+    require(isinstance(expected_channels, dict) and expected_channels, "expectation channels must be a non-empty object")
+    require(
+        set(document["channels"]) == set(expected_channels),
+        f"attested channels {sorted(document['channels'])} != expected {sorted(expected_channels)}",
+    )
+
+    production_identity, staging_identity, staging_chroots = channel_authority()
+    for name, channel in document["channels"].items():
+        expected = expected_channels[name]
+        require(isinstance(expected, dict), f"expectation for channel {name} is not an object")
+        require(
+            channel["identity"] != production_identity,
+            f"channel {name} must never attest the production COPR project {production_identity}",
+        )
+        for field in ("identity", "repository_digest", "signing_key_fingerprint"):
+            label = {"identity": "identity", "repository_digest": "repository digest", "signing_key_fingerprint": "signing key fingerprint"}[field]
+            require(
+                channel[field] == expected.get(field),
+                f"channel {name} {label} drifted: attested {channel[field]!r}, expected {expected.get(field)!r}",
+            )
+        expected_evrs = string_map(expected.get("served_evrs"), f"expectation for channel {name} served_evrs")
+        require(
+            set(channel["served_evrs"]) == set(expected_evrs),
+            f"channel {name} served targets {sorted(channel['served_evrs'])} != expected {sorted(expected_evrs)}",
+        )
+        for target, evr in sorted(channel["served_evrs"].items()):
+            require(
+                evr == expected_evrs[target],
+                f"channel {name} served EVR drifted for {target}: attested {evr!r}, expected {expected_evrs[target]!r}",
+            )
+        if channel["identity"] == staging_identity:
+            require(
+                set(channel["served_evrs"]) == staging_chroots,
+                f"channel {name} disagrees with the staging COPR chroot authority: "
+                f"attested {sorted(channel['served_evrs'])}, declared {sorted(staging_chroots)}",
+            )
+        refreshed = timestamp(channel["metadata_refreshed_at"], f"channel {name} metadata_refreshed_at")
+        age = (now - refreshed).total_seconds()
+        require(
+            age >= 0,
+            f"channel {name} metadata timestamp is in the future: refreshed {channel['metadata_refreshed_at']}, checked at {now.isoformat()}",
+        )
+        require(
+            age <= max_age,
+            f"channel {name} metadata is stale: refreshed {channel['metadata_refreshed_at']}, "
+            f"{int(age)}s before the check, limit {max_age}s",
+        )
+
+    expected_artifacts = expect.get("artifacts")
+    require(
+        isinstance(expected_artifacts, dict) and expected_artifacts,
+        "expectation artifacts must be a non-empty object",
+    )
+    require(
+        set(document["artifacts"]) == set(expected_artifacts),
+        f"attested artifacts {sorted(document['artifacts'])} != expected {sorted(expected_artifacts)}",
+    )
+    for name, artifact in sorted(document["artifacts"].items()):
+        expected = expected_artifacts[name]
+        require(isinstance(expected, dict), f"expectation for artifact {name} is not an object")
+        require(
+            artifact["channel"] == expected.get("channel"),
+            f"artifact {name} channel drifted: attested {artifact['channel']!r}, expected {expected.get('channel')!r}",
+        )
+        require(
+            artifact["digest"] == expected.get("digest"),
+            f"artifact {name} digest drifted: attested {artifact['digest']}, expected {expected.get('digest')!r}",
+        )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Render and validate the pre-tag release attestation.")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    renderer = commands.add_parser("render", help="render an attestation document from gathered release facts")
+    renderer.add_argument("--input", type=Path, required=True, help="JSON document of gathered facts")
+    renderer.add_argument("--output", type=Path, help="write the document here instead of stdout")
+
+    validator = commands.add_parser("validate", help="compare an attestation with the release expectations")
+    validator.add_argument("--attestation", type=Path, required=True, help="rendered attestation document")
+    validator.add_argument("--expect", type=Path, required=True, help="expectations recorded for this release")
+    validator.add_argument("--now", help="UTC RFC 3339 instant the check runs at (default: now)")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "render":
+        document = render(load_json(args.input, "attestation input"))
+        rendered = json.dumps(document, indent=2, sort_keys=False) + "\n"
+        if args.output:
+            try:
+                args.output.write_text(rendered)
+            except OSError as error:
+                fail(f"cannot write the attestation document: {error}")
+            print(f"release attestation: rendered {args.output}")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+
+    now = timestamp(args.now, "--now") if args.now else datetime.now(timezone.utc)
+    validate(
+        load_json(args.attestation, "attestation document"),
+        load_json(args.expect, "attestation expectations"),
+        now,
+    )
+    print("release attestation: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -79,13 +79,27 @@ if not required_chroots.isdisjoint(optional_chroots):
     fail(f"release matrix {args.channel} COPR required and optional chroots overlap")
 allowed_chroots = required_chroots | optional_chroots
 
+# The provisioning switch decides whether a channel may be skipped, so it is
+# read strictly. Only an explicit false skips: a missing or malformed switch
+# queries, because a channel that cannot say it is unprovisioned has not said
+# it. Production declares no switch at all and therefore always queries.
+declared_provisioned = channel.get("provisioned")
+if args.channel == "production":
+    if declared_provisioned is not None:
+        fail("release matrix production COPR authority must not declare a provisioning switch")
+elif not isinstance(declared_provisioned, bool):
+    fail(
+        "release matrix staging COPR authority must declare a boolean provisioning switch: "
+        f"{declared_provisioned!r}"
+    )
+
 # A response fixture is the project answering, so it is always compared. Without
 # one, an unprovisioned channel reports that and queries nothing: issue #236
 # owns creating the staging project, and a checker that invented a verdict for a
 # project that does not exist would be the failure this gate exists to prevent.
 if args.response_file:
     response = load_json(args.response_file, f"{args.channel} COPR response fixture")
-elif channel.get("provisioned") is not True:
+elif declared_provisioned is False:
     provisioning_issue = channel.get("provisioning_issue")
     owed_to = f"; issue #{provisioning_issue} owns it" if provisioning_issue else ""
     print(

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -27,7 +27,22 @@ def load_json(path: Path, description: str) -> object:
         fail(f"cannot read {description}: {error}")
 
 
+def chroot_set(value: object, description: str) -> set[str]:
+    if not isinstance(value, list) or not all(isinstance(chroot, str) for chroot in value):
+        fail(f"release matrix {description} are invalid")
+    chroots = set(value)
+    if len(chroots) != len(value):
+        fail(f"release matrix {description} contain duplicates")
+    return chroots
+
+
 parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--channel",
+    choices=("production", "staging"),
+    default="production",
+    help="which COPR channel to compare (default: production)",
+)
 parser.add_argument(
     "--response-file",
     type=Path,
@@ -37,45 +52,57 @@ args = parser.parse_args()
 
 matrix = load_json(MATRIX_PATH, "release matrix")
 try:
-    production = matrix["copr_channels"]["production"]
-    owner = production["owner"]
-    project = production["project"]
-    api_url = production["api_url"]
-    required_chroot_list = production["required_supported_chroots"]
-    optional_chroot_list = production["optional_experimental_chroots"]
+    channel = matrix["copr_channels"][args.channel]
+    owner = channel["owner"]
+    project = channel["project"]
+    api_url = channel["api_url"]
+    required_chroot_list = channel["required_supported_chroots"]
 except (KeyError, TypeError) as error:
-    fail(f"release matrix has no complete production COPR authority: {error}")
+    fail(f"release matrix has no complete {args.channel} COPR authority: {error}")
 
-if not isinstance(required_chroot_list, list) or not all(
-    isinstance(chroot, str) for chroot in required_chroot_list
-):
-    fail("release matrix production COPR required supported chroots are invalid")
-if not isinstance(optional_chroot_list, list) or not all(
-    isinstance(chroot, str) for chroot in optional_chroot_list
-):
-    fail("release matrix production COPR optional experimental chroots are invalid")
-required_chroots = set(required_chroot_list)
-optional_chroots = set(optional_chroot_list)
-if len(required_chroots) != len(required_chroot_list):
-    fail("release matrix production COPR required supported chroots contain duplicates")
-if len(optional_chroots) != len(optional_chroot_list):
-    fail("release matrix production COPR optional experimental chroots contain duplicates")
+required_chroots = chroot_set(required_chroot_list, f"{args.channel} COPR required supported chroots")
+# Production tolerates one optional experimental chroot (Rawhide); staging has
+# no such allowance, so its allowed set is exactly the supported set. Neither
+# side defaults: a production authority that lost its optional list, or a
+# staging authority that grew one, is drift in the file this checker trusts.
+declared_optional = channel.get("optional_experimental_chroots")
+if args.channel == "production":
+    if declared_optional is None:
+        fail("release matrix production COPR authority omits its optional experimental chroots")
+elif declared_optional is not None:
+    fail("release matrix staging COPR authority must declare no optional experimental chroots")
+optional_chroots = chroot_set(
+    declared_optional if declared_optional is not None else [],
+    f"{args.channel} COPR optional experimental chroots",
+)
 if not required_chroots.isdisjoint(optional_chroots):
-    fail("release matrix production COPR required and optional chroots overlap")
+    fail(f"release matrix {args.channel} COPR required and optional chroots overlap")
 allowed_chroots = required_chroots | optional_chroots
 
+# A response fixture is the project answering, so it is always compared. Without
+# one, an unprovisioned channel reports that and queries nothing: issue #236
+# owns creating the staging project, and a checker that invented a verdict for a
+# project that does not exist would be the failure this gate exists to prevent.
 if args.response_file:
-    response = load_json(args.response_file, "COPR response fixture")
+    response = load_json(args.response_file, f"{args.channel} COPR response fixture")
+elif channel.get("provisioned") is not True:
+    provisioning_issue = channel.get("provisioning_issue")
+    owed_to = f"; issue #{provisioning_issue} owns it" if provisioning_issue else ""
+    print(
+        f"live release channel contract: SKIPPED ({args.channel} COPR "
+        f"{owner}/{project} is not provisioned{owed_to})"
+    )
+    raise SystemExit(0)
 else:
     request = urllib.request.Request(api_url, headers={"User-Agent": "facelock-release-matrix/1"})
     try:
         with urllib.request.urlopen(request, timeout=20) as remote:
             response = json.load(remote)
     except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        fail(f"cannot read the public production COPR API: {error}")
+        fail(f"cannot read the public {args.channel} COPR API: {error}")
 
 if not isinstance(response, dict):
-    fail("production COPR API response is not an object")
+    fail(f"{args.channel} COPR API response is not an object")
 expected_full_name = f"{owner}/{project}"
 if (
     response.get("ownername") != owner
@@ -83,27 +110,27 @@ if (
     or response.get("full_name") != expected_full_name
 ):
     fail(
-        "production COPR identity drifted: "
+        f"{args.channel} COPR identity drifted: "
         f"expected {expected_full_name}, "
         f"got owner={response.get('ownername')!r}, name={response.get('name')!r}, "
         f"full_name={response.get('full_name')!r}"
     )
 chroot_repos = response.get("chroot_repos")
 if not isinstance(chroot_repos, dict) or not all(isinstance(chroot, str) for chroot in chroot_repos):
-    fail("production COPR API response has no valid chroot_repos object")
+    fail(f"{args.channel} COPR API response has no valid chroot_repos object")
 
 live_chroots = set(chroot_repos)
 missing = sorted(required_chroots - live_chroots)
 extra = sorted(live_chroots - allowed_chroots)
 if missing or extra:
     fail(
-        f"production COPR {owner}/{project} chroots drifted; "
+        f"{args.channel} COPR {owner}/{project} chroots drifted; "
         f"required={sorted(required_chroots)}, optional={sorted(optional_chroots)}, "
         f"live={sorted(live_chroots)}, "
         f"missing={missing}, extra={extra}"
     )
 
 print(
-    f"live release channel contract: OK (production COPR {owner}/{project}; "
+    f"live release channel contract: OK ({args.channel} COPR {owner}/{project}; "
     f"live={sorted(live_chroots)})"
 )

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -172,14 +172,17 @@ require(
 )
 require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisioning must remain owned by issue #236")
 require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")
-# `provisioned` is the maintainer's switch, and the only thing that lets
-# test/check-live-release-channels.py query the staging project. While it is
-# false that checker reports "not provisioned" and touches no network, which is
-# what keeps the staging fixtures in release-version-contract.sh offline.
+# `provisioned` is the maintainer's switch. It gates two things at once: it is
+# the only thing that lets test/check-live-release-channels.py query the staging
+# project, and it decides which trigger the staging Packit job may carry. While
+# it is false that checker reports "not provisioned" and touches no network,
+# which is what keeps the staging fixtures in release-version-contract.sh
+# offline. The trigger half is checked with the Packit jobs below.
 require(
-    staging_copr.get("provisioned") is False,
-    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
+    isinstance(staging_copr.get("provisioned"), bool),
+    f"staging COPR provisioned must be a boolean: {staging_copr.get('provisioned')!r}",
 )
+staging_provisioned = staging_copr["provisioned"]
 staging_copr_targets = require_string_set(
     matrix.get("fedora", {}).get("staging_copr_targets"),
     expected_copr_targets,
@@ -410,13 +413,24 @@ require(
     staging_job.get("owner") == staging_copr["owner"],
     "Packit staging COPR owner disagrees with the release matrix",
 )
+# The trigger tracks provisioning. Until the project exists, `ignore` keeps the
+# job hand-dispatched (`/packit build`), because a pull-request trigger would
+# aim every pull request's Packit run at a project that answers 404. Once the
+# maintainer creates it they flip `provisioned` and the trigger together, and
+# this pairing is what stops one moving without the other.
+expected_staging_trigger = "pull_request" if staging_provisioned else "ignore"
 require(
-    staging_job.get("trigger") == "pull_request",
-    f"Packit staging COPR trigger must be 'pull_request', got {staging_job.get('trigger')!r}",
+    staging_job.get("trigger") == expected_staging_trigger,
+    f"Packit staging COPR trigger must be {expected_staging_trigger!r} while "
+    f"copr_channels.staging.provisioned is {staging_provisioned}, got {staging_job.get('trigger')!r}",
 )
 require(
     staging_job.get("manual_trigger") is True,
     "Packit staging COPR job must stay manually triggered while the project is unprovisioned",
+)
+require(
+    staging_provisioned is False,
+    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
 )
 production_jobs = [
     job

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -151,6 +151,13 @@ require(
     "production COPR authority must separate required supported and optional experimental chroots",
 )
 require(production_copr.get("prerelease_publication") is False, "production COPR must exclude prereleases")
+# Production has no provisioning switch and must never grow one. The switch is
+# what makes test/check-live-release-channels.py skip a channel, and production
+# is the channel that must always be queried.
+require(
+    "provisioned" not in production_copr,
+    "production COPR must not declare a provisioning switch",
+)
 require(staging_copr.get("owner") == "tyvsmith", "staging COPR owner drifted")
 require(staging_copr.get("project") == "facelock-testing", "staging COPR identity drifted")
 require(

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -433,11 +433,21 @@ require(
 )
 require(
     staging_job.get("manual_trigger") is True,
-    "Packit staging COPR job must stay manually triggered while the project is unprovisioned",
+    "Packit staging COPR job must stay manually triggered",
 )
 require(
     staging_provisioned is False,
     "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
+)
+# Two COPR projects exist and no more. Without a bound, a job aimed at a third
+# project passes every check above simply by choosing allowlisted targets, and
+# the allowlist stops constraining where builds land. Counted after the staging
+# and per-job checks so a malformed job still reports what is wrong with it
+# rather than only that there are too many.
+copr_jobs = [job for job in packit_jobs if isinstance(job, dict) and job.get("job") == "copr_build"]
+require(
+    len(copr_jobs) == 2,
+    f"Packit must define exactly two copr_build jobs, production and staging, found {len(copr_jobs)}",
 )
 production_jobs = [
     job
@@ -709,6 +719,7 @@ staging_doc_claims = {
         "tyvsmith/facelock-testing",
         "copr_channels.staging.provisioned",
         "scripts/release-attestation.py",
+        "metadata_max_age_seconds",
     ),
 }
 for relative_path, claims in staging_doc_claims.items():

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -151,9 +151,35 @@ require(
     "production COPR authority must separate required supported and optional experimental chroots",
 )
 require(production_copr.get("prerelease_publication") is False, "production COPR must exclude prereleases")
+require(staging_copr.get("owner") == "tyvsmith", "staging COPR owner drifted")
 require(staging_copr.get("project") == "facelock-testing", "staging COPR identity drifted")
+require(
+    staging_copr.get("api_url")
+    == "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock-testing",
+    "staging COPR public API drifted",
+)
+require_string_set(
+    staging_copr.get("required_supported_chroots"),
+    expected_copr_targets,
+    "staging COPR required supported chroots",
+)
+# Staging equals the supported set exactly. Production tolerates Rawhide as an
+# optional experimental chroot; staging has no such allowance, so an extra
+# chroot there is drift rather than a permitted experiment.
+require(
+    "optional_experimental_chroots" not in staging_copr,
+    "staging COPR must not declare optional experimental chroots",
+)
 require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisioning must remain owned by issue #236")
 require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")
+# `provisioned` is the maintainer's switch, and the only thing that lets
+# test/check-live-release-channels.py query the staging project. While it is
+# false that checker reports "not provisioned" and touches no network, which is
+# what keeps the staging fixtures in release-version-contract.sh offline.
+require(
+    staging_copr.get("provisioned") is False,
+    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
+)
 staging_copr_targets = require_string_set(
     matrix.get("fedora", {}).get("staging_copr_targets"),
     expected_copr_targets,
@@ -349,6 +375,14 @@ for job_index, job in enumerate(packit_jobs):
     )
     targets = set(target_list)
     require(len(target_list) == len(targets), f"{target_description} must be unique")
+    # Rawhide is experimental everywhere and a release target nowhere. The
+    # allowlist below already excludes it; naming it first is what makes the
+    # diagnostic say so instead of "undeclared target".
+    rawhide_targets = {"fedora-rawhide", "fedora-rawhide-x86_64"} & targets
+    require(
+        not rawhide_targets,
+        f"Packit copr_build job {job_index} targets Rawhide: {sorted(rawhide_targets)}",
+    )
     undeclared_targets = targets - packit_release_targets
     require(
         not undeclared_targets,
@@ -359,6 +393,31 @@ for job_index, job in enumerate(packit_jobs):
             targets == staging_copr_targets,
             f"Packit staging COPR targets drifted: {sorted(targets)}",
         )
+# The staging job is what will build a candidate commit into facelock-testing
+# once #236 provisions it. It must exist now so its shape is reviewed before
+# the project does, and it must stay pull-request/manual: a release trigger
+# would make a tag publish into staging without any of the wave 4 proof.
+staging_jobs = [
+    job
+    for job in packit_jobs
+    if isinstance(job, dict)
+    and job.get("job") == "copr_build"
+    and job.get("project") == staging_copr["project"]
+]
+require(len(staging_jobs) == 1, f"Packit must define exactly one staging COPR job, found {len(staging_jobs)}")
+staging_job = staging_jobs[0]
+require(
+    staging_job.get("owner") == staging_copr["owner"],
+    "Packit staging COPR owner disagrees with the release matrix",
+)
+require(
+    staging_job.get("trigger") == "pull_request",
+    f"Packit staging COPR trigger must be 'pull_request', got {staging_job.get('trigger')!r}",
+)
+require(
+    staging_job.get("manual_trigger") is True,
+    "Packit staging COPR job must stay manually triggered while the project is unprovisioned",
+)
 production_jobs = [
     job
     for job in packit_jobs
@@ -383,7 +442,7 @@ if release_version is not None and "-" not in release_version:
 elif release_version is not None:
     require(
         production_trigger == "ignore",
-        "prerelease-tagged Packit config can select a release-triggered production COPR job",
+        "prerelease-tagged Packit config must not select a release-triggered production COPR job",
     )
 packit_target_list = production_job.get("targets")
 require(
@@ -605,6 +664,36 @@ require(
 live_channel_command = "python3 test/check-live-release-channels.py"
 require(live_channel_command in ci_workflow, "CI does not compare live release channels with the checked-in authority")
 require(live_channel_command in justfile, "release preflight does not compare live release channels with the checked-in authority")
+# Staging is unprovisioned, so this run reports "not provisioned" and stops.
+# It is wired now anyway: the flag is what turns the checked-in staging
+# authority into a gate the day #236 creates the project, and an unwired flag
+# is the failure mode this file exists to catch.
+staging_channel_command = f"{live_channel_command} --channel staging"
+require(staging_channel_command in ci_workflow, "CI does not compare the staging release channel")
+require(staging_channel_command in justfile, "release preflight does not compare the staging release channel")
+require(
+    "scripts/release-attestation.py" in justfile,
+    "release preflight does not require the pre-tag release attestation renderer",
+)
+# The staging channel and the attestation are contracts, not just scripts: a
+# reader has to be able to find out that staging exists, that it is not
+# provisioned yet, and what flipping that switch turns on.
+staging_doc_claims = {
+    "docs/releasing.md": (
+        "tyvsmith/facelock-testing",
+        "--channel staging",
+        "scripts/release-attestation.py",
+    ),
+    "docs/contracts.md": (
+        "tyvsmith/facelock-testing",
+        "copr_channels.staging.provisioned",
+        "scripts/release-attestation.py",
+    ),
+}
+for relative_path, claims in staging_doc_claims.items():
+    content = (ROOT / relative_path).read_text()
+    for claim in claims:
+        require(claim in content, f"{relative_path} omits the staging publication claim: {claim}")
 require("ARCH_SNAPSHOT" not in justfile, "unused ARCH_SNAPSHOT signaling remains")
 
 # Fedora lifecycle lanes take their base image from this matrix rather than

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -978,6 +978,11 @@ assert_matrix_mutation_rejected \
 # checked-in authority it must agree with, and the fact that neither may reach
 # Rawhide or the production project.
 assert_matrix_mutation_rejected \
+    "production COPR granted a provisioning switch" \
+    "dist/release-matrix.json" \
+    's/"prerelease_publication": false/"provisioned": true, "prerelease_publication": false/' \
+    "production COPR must not declare a provisioning switch"
+assert_matrix_mutation_rejected \
     "staging COPR api_url pointed at the production project" \
     "dist/release-matrix.json" \
     's@projectname=facelock-testing@projectname=facelock@' \
@@ -1280,6 +1285,26 @@ live_channel_authority_case() {
     esac
     echo "release channel case: $context rejected"
 }
+
+# Production carries no provisioning switch, so it must query on every run. The
+# authority here points at a closed local port: the checker has to report a
+# failed read rather than skipping, and nothing reaches COPR to prove it.
+live_offline_root="$tmp_root/live-channel-offline"
+mkdir -p "$live_offline_root/dist" "$live_offline_root/test"
+cp "$repo_root/test/check-live-release-channels.py" "$live_offline_root/test/"
+sed 's@"api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock"@"api_url": "http://127.0.0.1:1/"@' \
+    "$repo_root/dist/release-matrix.json" > "$live_offline_root/dist/release-matrix.json"
+if cmp -s "$repo_root/dist/release-matrix.json" "$live_offline_root/dist/release-matrix.json"; then
+    fail "live channel offline fixture did not repoint the production API"
+fi
+if live_offline_output=$(python3 "$live_offline_root/test/check-live-release-channels.py" 2>&1); then
+    fail "live channel checker skipped the production query instead of performing it: $live_offline_output"
+fi
+case "$live_offline_output" in
+    *"cannot read the public production COPR API"*) ;;
+    *) fail "live channel checker did not report a failed production query: $live_offline_output" ;;
+esac
+echo "release channel case: production queries its authority on every run"
 
 live_channel_authority_case \
     "production authority without optional experimental chroots" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -339,7 +339,24 @@ case "$apt_guard_output" in
     *) fail "APT publisher did not consume the mutated central resolute suffix: $apt_guard_output" ;;
 esac
 
-sed -i 's/"trigger": "ignore"/"trigger": "release"/' "$matrix_root/.packit.yaml"
+# Both Packit jobs sit on "trigger": "ignore", so this restores the release
+# trigger on the production job by project rather than by text.
+python3 - "$matrix_root/.packit.yaml" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+config = json.loads(path.read_text())
+restored = 0
+for job in config["jobs"]:
+    if job.get("project") == "facelock":
+        job["trigger"] = "release"
+        restored += 1
+if restored != 1:
+    raise SystemExit(f"expected exactly one production Packit job to restore, found {restored}")
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
 env -u RELEASE_MATRIX_VERSION python3 "$matrix_root/test/check-release-matrix.py"
 if prerelease_packit_output=$(RELEASE_MATRIX_VERSION=0.2.0-alpha.1 python3 "$matrix_root/test/check-release-matrix.py" 2>&1); then
     fail "release matrix checker accepted a production COPR release job for a prerelease identity"
@@ -703,13 +720,13 @@ valid_packit_staging_root="$tmp_root/packit-valid-staging"
 cp -R "$matrix_root" "$valid_packit_staging_root"
 replace_packit_staging_job \
     "$valid_packit_staging_root/.packit.yaml" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
 RELEASE_MATRIX_VERSION=0.2.0 python3 "$valid_packit_staging_root/test/check-release-matrix.py" >/dev/null
 echo "release matrix Packit case: exact facelock-testing staging targets accepted"
 
 assert_extra_packit_job_rejected \
     "second facelock-testing staging job" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 
 assert_extra_packit_job_rejected \
     "canonical Rawhide target outside production and staging" \
@@ -725,14 +742,14 @@ assert_extra_packit_job_rejected \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing Rawhide target" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
     "targets Rawhide"
 assert_extra_packit_job_rejected \
     "Rawhide target outside production and staging" \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing incomplete staging targets" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
     "Packit staging COPR targets drifted"
 assert_extra_packit_job_rejected \
     "duplicate targets outside production and staging" \
@@ -975,31 +992,67 @@ assert_matrix_mutation_rejected \
     "dist/release-matrix.json" \
     's/"provisioned": false/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": false/' \
     "staging COPR must not declare optional experimental chroots"
-assert_matrix_mutation_rejected \
-    "staging COPR claimed as provisioned" \
-    "dist/release-matrix.json" \
-    's/"provisioned": false/"provisioned": true/' \
-    "staging COPR provisioning must stay unclaimed"
-assert_matrix_mutation_rejected \
+assert_staging_packit_job_rejected \
     "Packit staging job deleted" \
-    ".packit.yaml" \
-    's/"project": "facelock-testing"/"project": "facelock-retired"/' \
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-retired","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit must define exactly one staging COPR job"
-assert_matrix_mutation_rejected \
+assert_staging_packit_job_rejected \
     "Packit staging job made release-triggered" \
-    ".packit.yaml" \
-    's/"trigger": "pull_request"/"trigger": "release"/' \
+    '{"job":"copr_build","trigger":"release","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR trigger"
-assert_matrix_mutation_rejected \
+assert_staging_packit_job_rejected \
     "Packit staging job made automatic" \
-    ".packit.yaml" \
-    's/"manual_trigger": true/"manual_trigger": false/' \
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":false,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR job must stay manually triggered"
-assert_matrix_mutation_rejected \
+assert_staging_packit_job_rejected \
     "Packit staging job owner drifted" \
-    ".packit.yaml" \
-    '/"trigger": "pull_request"/,/"targets"/s/"owner": "tyvsmith"/"owner": "packit"/' \
+    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"packit","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR owner"
+
+# The staging trigger and copr_channels.staging.provisioned move together. An
+# unprovisioned project must not be the target of every pull request's Packit
+# run, and a provisioned one that stays hand-dispatched is a gate nobody runs.
+staging_pairing_index=0
+assert_staging_provisioning_pair_rejected() {
+    local context="$1"
+    local matrix_expression="$2"
+    local staging_job_json="$3"
+    local diagnostic="$4"
+    local mutation_root="$tmp_root/staging-pairing-$staging_pairing_index"
+    local checker_output
+    staging_pairing_index=$((staging_pairing_index + 1))
+    cp -R "$matrix_root" "$mutation_root"
+    if [ -n "$matrix_expression" ]; then
+        sed -i "$matrix_expression" "$mutation_root/dist/release-matrix.json"
+    fi
+    if [ -n "$staging_job_json" ]; then
+        replace_packit_staging_job "$mutation_root/.packit.yaml" "$staging_job_json"
+    fi
+    if checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" 2>&1); then
+        fail "release matrix checker accepted drift: $context"
+    fi
+    case "$checker_output" in
+        *"$diagnostic"*) ;;
+        *) fail "release matrix checker rejected $context for another reason: $checker_output" ;;
+    esac
+    echo "release matrix staging pairing case: $context rejected"
+}
+
+assert_staging_provisioning_pair_rejected \
+    "unprovisioned staging job triggered by pull requests" \
+    "" \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    "must be 'ignore' while copr_channels.staging.provisioned is False"
+assert_staging_provisioning_pair_rejected \
+    "provisioned staging left on the manual trigger" \
+    's/"provisioned": false/"provisioned": true/' \
+    "" \
+    "must be 'pull_request' while copr_channels.staging.provisioned is True"
+assert_staging_provisioning_pair_rejected \
+    "staging claimed as provisioned with its pull-request trigger restored" \
+    's/"provisioned": false/"provisioned": true/' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    "staging COPR provisioning must stay unclaimed"
 assert_matrix_mutation_rejected \
     "staging channel comparison dropped from CI" \
     ".github/workflows/ci.yml" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -341,9 +341,13 @@ esac
 
 sed -i 's/"trigger": "ignore"/"trigger": "release"/' "$matrix_root/.packit.yaml"
 env -u RELEASE_MATRIX_VERSION python3 "$matrix_root/test/check-release-matrix.py"
-if RELEASE_MATRIX_VERSION=0.2.0-alpha.1 python3 "$matrix_root/test/check-release-matrix.py" >/dev/null 2>&1; then
+if prerelease_packit_output=$(RELEASE_MATRIX_VERSION=0.2.0-alpha.1 python3 "$matrix_root/test/check-release-matrix.py" 2>&1); then
     fail "release matrix checker accepted a production COPR release job for a prerelease identity"
 fi
+case "$prerelease_packit_output" in
+    *"prerelease-tagged Packit config must not select a release-triggered production COPR job"*) ;;
+    *) fail "release matrix checker rejected the prerelease production job for another reason: $prerelease_packit_output" ;;
+esac
 RELEASE_MATRIX_VERSION=0.2.0 python3 "$matrix_root/test/check-release-matrix.py"
 
 matrix_mutation_index=0
@@ -655,13 +659,57 @@ assert_extra_packit_job_rejected() {
     echo "release matrix Packit case: $context rejected"
 }
 
+# The staging job is declared in .packit.yaml, so a staging case replaces it
+# rather than appending a second one; appending is its own rejection case.
+replace_packit_staging_job() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+config = json.loads(path.read_text())
+jobs = config["jobs"]
+indexes = [index for index, job in enumerate(jobs) if job.get("project") == "facelock-testing"]
+if len(indexes) != 1:
+    raise SystemExit(f"expected exactly one staging Packit job to replace, found {len(indexes)}")
+jobs[indexes[0]] = json.loads(sys.argv[2])
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+}
+
+packit_staging_job_index=0
+assert_staging_packit_job_rejected() {
+    local context="$1"
+    local job_json="$2"
+    local diagnostic="$3"
+    local mutation_root="$tmp_root/packit-staging-job-$packit_staging_job_index"
+    local checker_output
+    packit_staging_job_index=$((packit_staging_job_index + 1))
+    cp -R "$matrix_root" "$mutation_root"
+    replace_packit_staging_job "$mutation_root/.packit.yaml" "$job_json"
+    if checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" 2>&1); then
+        printf '%s\n' "$checker_output"
+        fail "release matrix checker accepted a bad staging Packit job: $context"
+    fi
+    case "$checker_output" in
+        *"$diagnostic"*) ;;
+        *) fail "release matrix checker rejected $context for another reason: $checker_output" ;;
+    esac
+    echo "release matrix Packit case: $context rejected"
+}
+
 valid_packit_staging_root="$tmp_root/packit-valid-staging"
 cp -R "$matrix_root" "$valid_packit_staging_root"
-append_packit_job \
+replace_packit_staging_job \
     "$valid_packit_staging_root/.packit.yaml" \
-    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
 RELEASE_MATRIX_VERSION=0.2.0 python3 "$valid_packit_staging_root/test/check-release-matrix.py" >/dev/null
 echo "release matrix Packit case: exact facelock-testing staging targets accepted"
+
+assert_extra_packit_job_rejected \
+    "second facelock-testing staging job" \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 
 assert_extra_packit_job_rejected \
     "canonical Rawhide target outside production and staging" \
@@ -675,15 +723,17 @@ assert_extra_packit_job_rejected \
 assert_extra_packit_job_rejected \
     "architecture-suffixed mutable alias" \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
-assert_extra_packit_job_rejected \
+assert_staging_packit_job_rejected \
     "facelock-testing Rawhide target" \
-    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}'
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
+    "targets Rawhide"
 assert_extra_packit_job_rejected \
     "Rawhide target outside production and staging" \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
-assert_extra_packit_job_rejected \
+assert_staging_packit_job_rejected \
     "facelock-testing incomplete staging targets" \
-    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}'
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
+    "Packit staging COPR targets drifted"
 assert_extra_packit_job_rejected \
     "duplicate targets outside production and staging" \
     '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-43-x86_64"]}'
@@ -906,6 +956,76 @@ assert_matrix_mutation_rejected \
     ".packit.yaml" \
     's/"fedora-45-x86_64"/"fedora-rawhide-x86_64"/'
 
+# Staging COPR publication (#236). The project is not provisioned, so every
+# guard here is config shape: the Packit job that will build into it, the
+# checked-in authority it must agree with, and the fact that neither may reach
+# Rawhide or the production project.
+assert_matrix_mutation_rejected \
+    "staging COPR api_url pointed at the production project" \
+    "dist/release-matrix.json" \
+    's@projectname=facelock-testing@projectname=facelock@' \
+    "staging COPR public API drifted"
+assert_matrix_mutation_rejected \
+    "staging COPR required supported chroot missing" \
+    "dist/release-matrix.json" \
+    '/"project": "facelock-testing"/,/"provisioned"/s/^        "fedora-43-x86_64",$//' \
+    "staging COPR required supported chroots drifted"
+assert_matrix_mutation_rejected \
+    "staging COPR granted an optional experimental chroot" \
+    "dist/release-matrix.json" \
+    's/"provisioned": false/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": false/' \
+    "staging COPR must not declare optional experimental chroots"
+assert_matrix_mutation_rejected \
+    "staging COPR claimed as provisioned" \
+    "dist/release-matrix.json" \
+    's/"provisioned": false/"provisioned": true/' \
+    "staging COPR provisioning must stay unclaimed"
+assert_matrix_mutation_rejected \
+    "Packit staging job deleted" \
+    ".packit.yaml" \
+    's/"project": "facelock-testing"/"project": "facelock-retired"/' \
+    "Packit must define exactly one staging COPR job"
+assert_matrix_mutation_rejected \
+    "Packit staging job made release-triggered" \
+    ".packit.yaml" \
+    's/"trigger": "pull_request"/"trigger": "release"/' \
+    "Packit staging COPR trigger"
+assert_matrix_mutation_rejected \
+    "Packit staging job made automatic" \
+    ".packit.yaml" \
+    's/"manual_trigger": true/"manual_trigger": false/' \
+    "Packit staging COPR job must stay manually triggered"
+assert_matrix_mutation_rejected \
+    "Packit staging job owner drifted" \
+    ".packit.yaml" \
+    '/"trigger": "pull_request"/,/"targets"/s/"owner": "tyvsmith"/"owner": "packit"/' \
+    "Packit staging COPR owner"
+assert_matrix_mutation_rejected \
+    "staging channel comparison dropped from CI" \
+    ".github/workflows/ci.yml" \
+    's/--channel staging/--channel production/' \
+    "CI does not compare the staging release channel"
+assert_matrix_mutation_rejected \
+    "staging channel comparison dropped from release preflight" \
+    "justfile" \
+    's@check-live-release-channels.py --channel staging@check-live-release-channels.py --channel none@' \
+    "release preflight does not compare the staging release channel"
+assert_matrix_mutation_rejected \
+    "pre-tag attestation renderer dropped from release preflight" \
+    "justfile" \
+    's@scripts/release-attestation.py@scripts/release-attestation-disabled.py@' \
+    "release preflight does not require the pre-tag release attestation"
+assert_matrix_mutation_rejected \
+    "release guide stops naming the staging COPR project" \
+    "docs/releasing.md" \
+    's@tyvsmith/facelock-testing@tyvsmith/facelock-staging@g' \
+    "docs/releasing.md omits the staging publication claim"
+assert_matrix_mutation_rejected \
+    "contract stops naming the staging provisioning switch" \
+    "docs/contracts.md" \
+    's/copr_channels.staging.provisioned/copr_channels.staging.enabled/' \
+    "docs/contracts.md omits the staging publication claim"
+
 live_copr_supported_only="$tmp_root/live-copr-supported-only.json"
 live_copr_supported_with_rawhide="$tmp_root/live-copr-supported-with-rawhide.json"
 live_copr_missing_supported="$tmp_root/live-copr-missing-supported.json"
@@ -991,6 +1111,327 @@ if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$li
 fi
 echo "release channel case: wrong-project rejected"
 echo "release channel case: Rawhide-in-Packit-targets rejected"
+
+# Staging (#236). The project does not exist yet, so the unprovisioned run must
+# report that and touch no network; check-release-matrix.py pins
+# copr_channels.staging.provisioned to false, which is what keeps this offline.
+staging_copr_supported_only="$tmp_root/staging-copr-supported-only.json"
+staging_copr_missing_supported="$tmp_root/staging-copr-missing-supported.json"
+staging_copr_rawhide_extra="$tmp_root/staging-copr-rawhide-extra.json"
+staging_copr_wrong_project="$tmp_root/staging-copr-wrong-project.json"
+cat > "$staging_copr_supported_only" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+cat > "$staging_copr_missing_supported" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/"
+  }
+}
+JSON
+cat > "$staging_copr_rawhide_extra" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/",
+    "fedora-rawhide-x86_64": "https://example.invalid/rawhide/"
+  }
+}
+JSON
+cat > "$staging_copr_wrong_project" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+python3 "$repo_root/test/check-live-release-channels.py" --channel production \
+    --response-file "$live_copr_supported_only" >/dev/null
+echo "release channel case: explicit production channel accepted"
+staging_unprovisioned_output=$(python3 "$repo_root/test/check-live-release-channels.py" --channel staging)
+case "$staging_unprovisioned_output" in
+    *"staging COPR tyvsmith/facelock-testing is not provisioned"*) ;;
+    *) fail "live staging checker did not report the unprovisioned project: $staging_unprovisioned_output" ;;
+esac
+echo "release channel case: staging not provisioned reported"
+python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
+    --response-file "$staging_copr_supported_only" >/dev/null
+echo "release channel case: staging supported-only accepted"
+if python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
+    --response-file "$staging_copr_missing_supported" >/dev/null 2>&1; then
+    fail "live staging checker accepted a missing supported staging chroot"
+fi
+echo "release channel case: staging missing-supported rejected"
+if python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
+    --response-file "$staging_copr_rawhide_extra" >/dev/null 2>&1; then
+    fail "live staging checker accepted Rawhide as a staging chroot"
+fi
+echo "release channel case: staging Rawhide-extra rejected"
+if python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
+    --response-file "$staging_copr_wrong_project" >/dev/null 2>&1; then
+    fail "live staging checker accepted the production project identity"
+fi
+echo "release channel case: staging wrong-project rejected"
+if python3 "$repo_root/test/check-live-release-channels.py" --channel nonsense \
+    --response-file "$staging_copr_supported_only" >/dev/null 2>&1; then
+    fail "live channel checker accepted an undeclared channel"
+fi
+echo "release channel case: undeclared channel rejected"
+
+# The checker trusts dist/release-matrix.json, so it fails on an authority that
+# lost the distinction between required and optional chroots rather than
+# quietly defaulting one side to empty.
+live_channel_authority_case() {
+    local context="$1"
+    local expression="$2"
+    local channel="$3"
+    local diagnostic="$4"
+    local case_root="$tmp_root/live-channel-authority-$channel"
+    local output
+    rm -rf "$case_root"
+    mkdir -p "$case_root/dist" "$case_root/test"
+    cp "$repo_root/test/check-live-release-channels.py" "$case_root/test/"
+    sed "$expression" "$repo_root/dist/release-matrix.json" > "$case_root/dist/release-matrix.json"
+    if cmp -s "$repo_root/dist/release-matrix.json" "$case_root/dist/release-matrix.json"; then
+        fail "live channel authority fixture did not change the matrix: $context"
+    fi
+    if output=$(python3 "$case_root/test/check-live-release-channels.py" --channel "$channel" \
+        --response-file "$live_copr_supported_only" 2>&1); then
+        fail "live channel checker accepted $context"
+    fi
+    case "$output" in
+        *"$diagnostic"*) ;;
+        *) fail "live channel checker rejected $context for another reason: $output" ;;
+    esac
+    echo "release channel case: $context rejected"
+}
+
+live_channel_authority_case \
+    "production authority without optional experimental chroots" \
+    's/"optional_experimental_chroots"/"retired_experimental_chroots"/' \
+    production \
+    "omits its optional experimental chroots"
+live_channel_authority_case \
+    "staging authority granted optional experimental chroots" \
+    's/"provisioned": false/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": false/' \
+    staging \
+    "must declare no optional experimental chroots"
+
+# Pre-tag staging attestation (#236, Track M2 task 5). The document binds the
+# candidate commit, the EVRs each channel serves, artifact and repository
+# digests, signing identities, and how fresh the repository metadata was. Every
+# case here is a fixture: nothing contacts COPR or an APT endpoint.
+attestation_root="$tmp_root/attestation"
+attestation_script="$repo_root/scripts/release-attestation.py"
+attestation_commit=3f0a1c2d4e5b6f708192a3b4c5d6e7f809a1b2c3
+mkdir -p "$attestation_root"
+cat > "$attestation_root/inputs.json" <<'JSON'
+{
+  "candidate_commit": "3f0a1c2d4e5b6f708192a3b4c5d6e7f809a1b2c3",
+  "release_version": "0.2.0-alpha.1",
+  "channels": {
+    "staging-copr": {
+      "identity": "tyvsmith/facelock-testing",
+      "served_evrs": {
+        "fedora-45-x86_64": "0:0.2.0-0.1.alpha.1.fc45",
+        "fedora-43-x86_64": "0:0.2.0-0.1.alpha.1.fc43",
+        "fedora-44-x86_64": "0:0.2.0-0.1.alpha.1.fc44"
+      },
+      "repository_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "metadata_refreshed_at": "2026-09-01T11:30:00Z",
+      "signing_key_fingerprint": "AAAABBBBCCCCDDDDEEEEFFFF00001111222233FF"
+    },
+    "staging-apt": {
+      "identity": "https://staging.invalid/facelock/apt/",
+      "served_evrs": {
+        "trixie": "0.2.0~alpha.1-1~deb13u1",
+        "resolute": "0.2.0~alpha.1-1~ubuntu26.04.1"
+      },
+      "repository_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "metadata_refreshed_at": "2026-09-01T11:45:00Z",
+      "signing_key_fingerprint": "99998888777766665555444433332222111100AA"
+    }
+  },
+  "artifacts": {
+    "facelock-0.2.0-0.1.alpha.1.fc43.x86_64.rpm": {
+      "channel": "staging-copr",
+      "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "facelock_0.2.0~alpha.1-1~deb13u1_amd64.deb": {
+      "channel": "staging-apt",
+      "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  }
+}
+JSON
+cat > "$attestation_root/expect.json" <<'JSON'
+{
+  "candidate_commit": "3f0a1c2d4e5b6f708192a3b4c5d6e7f809a1b2c3",
+  "release_version": "0.2.0-alpha.1",
+  "metadata_max_age_seconds": 3600,
+  "channels": {
+    "staging-copr": {
+      "identity": "tyvsmith/facelock-testing",
+      "served_evrs": {
+        "fedora-43-x86_64": "0:0.2.0-0.1.alpha.1.fc43",
+        "fedora-44-x86_64": "0:0.2.0-0.1.alpha.1.fc44",
+        "fedora-45-x86_64": "0:0.2.0-0.1.alpha.1.fc45"
+      },
+      "repository_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "signing_key_fingerprint": "AAAABBBBCCCCDDDDEEEEFFFF00001111222233FF"
+    },
+    "staging-apt": {
+      "identity": "https://staging.invalid/facelock/apt/",
+      "served_evrs": {
+        "trixie": "0.2.0~alpha.1-1~deb13u1",
+        "resolute": "0.2.0~alpha.1-1~ubuntu26.04.1"
+      },
+      "repository_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "signing_key_fingerprint": "99998888777766665555444433332222111100AA"
+    }
+  },
+  "artifacts": {
+    "facelock-0.2.0-0.1.alpha.1.fc43.x86_64.rpm": {
+      "channel": "staging-copr",
+      "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "facelock_0.2.0~alpha.1-1~deb13u1_amd64.deb": {
+      "channel": "staging-apt",
+      "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  }
+}
+JSON
+python3 "$attestation_script" render \
+    --input "$attestation_root/inputs.json" \
+    --output "$attestation_root/attestation.json" >/dev/null
+python3 "$attestation_script" render \
+    --input "$attestation_root/inputs.json" \
+    --output "$attestation_root/attestation-again.json" >/dev/null
+if ! cmp -s "$attestation_root/attestation.json" "$attestation_root/attestation-again.json"; then
+    fail "release attestation render is not deterministic"
+fi
+echo "release attestation case: render is deterministic"
+python3 "$attestation_script" validate \
+    --attestation "$attestation_root/attestation.json" \
+    --expect "$attestation_root/expect.json" \
+    --now 2026-09-01T12:00:00Z >/dev/null
+echo "release attestation case: valid document accepted"
+
+attestation_case_index=0
+assert_attestation_rejected() {
+    local context="$1"
+    local expression="$2"
+    local diagnostic="$3"
+    local case_root="$attestation_root/case-$attestation_case_index"
+    local output
+    attestation_case_index=$((attestation_case_index + 1))
+    mkdir -p "$case_root"
+    sed "$expression" "$attestation_root/attestation.json" > "$case_root/attestation.json"
+    if cmp -s "$attestation_root/attestation.json" "$case_root/attestation.json"; then
+        fail "attestation fixture did not change the document: $context"
+    fi
+    if output=$(python3 "$attestation_script" validate \
+        --attestation "$case_root/attestation.json" \
+        --expect "$attestation_root/expect.json" \
+        --now 2026-09-01T12:00:00Z 2>&1); then
+        fail "release attestation validator accepted $context"
+    fi
+    case "$output" in
+        *"$diagnostic"*) ;;
+        *) fail "release attestation validator rejected $context for another reason: $output" ;;
+    esac
+    echo "release attestation case: $context rejected"
+}
+
+assert_attestation_rejected \
+    "wrong candidate commit" \
+    "s/$attestation_commit/9d8c7b6a5f4e3d2c1b0a99887766554433221100/" \
+    "candidate commit drifted"
+assert_attestation_rejected \
+    "served EVR mismatch" \
+    's/0:0.2.0-0.1.alpha.1.fc43/0:0.2.0-0.2.alpha.1.fc43/' \
+    "served EVR drifted"
+assert_attestation_rejected \
+    "artifact digest mismatch" \
+    's/sha256:3333333333333333333333333333333333333333333333333333333333333333/sha256:5555555555555555555555555555555555555555555555555555555555555555/' \
+    "x86_64.rpm digest drifted"
+assert_attestation_rejected \
+    "repository digest mismatch" \
+    's/sha256:1111111111111111111111111111111111111111111111111111111111111111/sha256:6666666666666666666666666666666666666666666666666666666666666666/' \
+    "repository digest drifted"
+assert_attestation_rejected \
+    "stale repository metadata" \
+    's/2026-09-01T11:30:00Z/2026-09-01T09:00:00Z/' \
+    "metadata is stale"
+assert_attestation_rejected \
+    "metadata refreshed after the attestation was checked" \
+    's/2026-09-01T11:30:00Z/2026-09-01T12:30:00Z/' \
+    "metadata timestamp is in the future"
+assert_attestation_rejected \
+    "signing key fingerprint drifted" \
+    's/AAAABBBBCCCCDDDDEEEEFFFF00001111222233FF/AAAABBBBCCCCDDDDEEEEFFFF000011112222AAAA/' \
+    "signing key fingerprint drifted"
+assert_attestation_rejected \
+    "staging channel repointed at the production COPR project" \
+    's@"tyvsmith/facelock-testing"@"tyvsmith/facelock"@' \
+    "must never attest the production COPR project"
+
+# The staging COPR channel is bound to the checked-in chroot authority, so an
+# attestation that serves a target the matrix does not declare fails even when
+# the expectation file agrees with it.
+attestation_unknown_target="$attestation_root/unknown-target"
+mkdir -p "$attestation_unknown_target"
+sed 's/fedora-45-x86_64/fedora-rawhide-x86_64/g' \
+    "$attestation_root/attestation.json" > "$attestation_unknown_target/attestation.json"
+sed 's/fedora-45-x86_64/fedora-rawhide-x86_64/g' \
+    "$attestation_root/expect.json" > "$attestation_unknown_target/expect.json"
+if attestation_output=$(python3 "$attestation_script" validate \
+    --attestation "$attestation_unknown_target/attestation.json" \
+    --expect "$attestation_unknown_target/expect.json" \
+    --now 2026-09-01T12:00:00Z 2>&1); then
+    fail "release attestation validator accepted an undeclared staging COPR chroot"
+fi
+case "$attestation_output" in
+    *"staging COPR chroot authority"*) ;;
+    *) fail "release attestation validator rejected the undeclared chroot for another reason: $attestation_output" ;;
+esac
+echo "release attestation case: undeclared staging COPR chroot rejected"
+
+# Render fails closed: an input missing a required binding cannot become a
+# document that validate would then have to reject.
+attestation_bad_input="$attestation_root/bad-input.json"
+sed '/"candidate_commit"/d' "$attestation_root/inputs.json" > "$attestation_bad_input"
+if attestation_output=$(python3 "$attestation_script" render --input "$attestation_bad_input" 2>&1); then
+    fail "release attestation render accepted an input without a candidate commit"
+fi
+case "$attestation_output" in
+    *"candidate_commit"*) ;;
+    *) fail "release attestation render rejected the incomplete input for another reason: $attestation_output" ;;
+esac
+echo "release attestation case: incomplete render input rejected"
 
 prerelease_deb="$tmp_root/facelock-prerelease.deb"
 : > "$prerelease_deb"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -729,6 +729,9 @@ assert_extra_packit_job_rejected \
     '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 
 assert_extra_packit_job_rejected \
+    "third copr_build job with allowlisted targets" \
+    '{"job":"copr_build","trigger":"ignore","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+assert_extra_packit_job_rejected \
     "canonical Rawhide target outside production and staging" \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide"]}'
 assert_extra_packit_job_rejected \
@@ -1058,6 +1061,37 @@ assert_staging_provisioning_pair_rejected \
     's/"provisioned": false/"provisioned": true/' \
     '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "staging COPR provisioning must stay unclaimed"
+
+# Provisioning is three edits, and docs/releasing.md says so: flip the switch,
+# move the staging job to the pull-request trigger, and retire the pin that
+# keeps the switch unclaimed. The pairing cases above prove no two of them pass
+# alone; this proves the three together do, so the procedure is reachable.
+provisioned_root="$tmp_root/matrix-staging-provisioned"
+cp -R "$matrix_root" "$provisioned_root"
+sed -i 's/"provisioned": false/"provisioned": true/' "$provisioned_root/dist/release-matrix.json"
+replace_packit_staging_job \
+    "$provisioned_root/.packit.yaml" \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+python3 - "$provisioned_root/test/check-release-matrix.py" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+content = path.read_text()
+pin = """require(
+    staging_provisioned is False,
+    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
+)
+"""
+if pin not in content:
+    raise SystemExit("the unclaimed-provisioning pin is not the block the provisioning procedure retires")
+path.write_text(content.replace(pin, "", 1))
+PY
+if provisioned_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$provisioned_root/test/check-release-matrix.py" 2>&1); then
+    echo "release matrix staging pairing case: the three provisioning edits together accepted"
+else
+    fail "release matrix checker rejected the documented provisioning procedure: $provisioned_output"
+fi
 assert_matrix_mutation_rejected \
     "staging channel comparison dropped from CI" \
     ".github/workflows/ci.yml" \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1532,6 +1532,46 @@ case "$attestation_output" in
 esac
 echo "release attestation case: undeclared staging COPR chroot rejected"
 
+# channel_authority() reads copr_channels.staging.required_supported_chroots
+# straight out of dist/release-matrix.json and turns it into a set: a
+# duplicated or non-string entry there must fail closed rather than silently
+# deduplicate into a weaker authority.
+attestation_matrix_case_index=0
+assert_attestation_matrix_rejected() {
+    local context="$1"
+    local expression="$2"
+    local diagnostic="$3"
+    local case_root="$attestation_root/matrix-case-$attestation_matrix_case_index"
+    local output
+    attestation_matrix_case_index=$((attestation_matrix_case_index + 1))
+    mkdir -p "$case_root/scripts" "$case_root/dist"
+    cp "$attestation_script" "$case_root/scripts/"
+    sed "$expression" "$repo_root/dist/release-matrix.json" > "$case_root/dist/release-matrix.json"
+    if cmp -s "$repo_root/dist/release-matrix.json" "$case_root/dist/release-matrix.json"; then
+        fail "attestation matrix fixture did not change the release matrix: $context"
+    fi
+    if output=$(python3 "$case_root/scripts/release-attestation.py" validate \
+        --attestation "$attestation_root/attestation.json" \
+        --expect "$attestation_root/expect.json" \
+        --now 2026-09-01T12:00:00Z 2>&1); then
+        fail "release attestation validator accepted $context"
+    fi
+    case "$output" in
+        *"$diagnostic"*) ;;
+        *) fail "release attestation validator rejected $context for another reason: $output" ;;
+    esac
+    echo "release attestation case: $context rejected"
+}
+
+assert_attestation_matrix_rejected \
+    "staging COPR chroot authority duplicated" \
+    '/"project": "facelock-testing"/,/"provisioned"/{/"fedora-44-x86_64"/p}' \
+    "must not contain duplicate chroots"
+assert_attestation_matrix_rejected \
+    "staging COPR chroot authority holds a non-string entry" \
+    '/"project": "facelock-testing"/,/"provisioned"/s/"fedora-44-x86_64"/44/' \
+    "must be a non-empty list of non-empty strings"
+
 # Render fails closed: an input missing a required binding cannot become a
 # document that validate would then have to reject.
 attestation_bad_input="$attestation_root/bad-input.json"


### PR DESCRIPTION
## Summary

- declare a manually dispatched `copr_build` job for `tyvsmith/facelock-testing`, held on `trigger: ignore` until the project exists
- give `copr_channels.staging` its api url and chroot authority behind a `provisioned` switch that stays false
- teach `test/check-live-release-channels.py` `--channel staging|production`, skipping only on an explicit `provisioned: false`
- add `scripts/release-attestation.py` to render and validate the pre-tag document binding commit, served EVRs, artifact and repository digests, signing fingerprints and metadata age
- pin the staging job shape, Rawhide absence, a two-job Packit bound, and the trigger/switch pairing in `test/check-release-matrix.py`

## Why

The staging COPR project is not provisioned, so nothing constrained where a tag could publish, whether Rawhide could reach staging, or what a release run would have to prove before signing. Declaring the shape while the project is still an issue means the guards are already watching on the day it is created. Everything here reads checked-in config or fixtures; creating the project, naming the staging APT url, and provisioning the signing identity stay with #236.

## Files

| path | why it matters |
|---|---|
| `test/check-release-matrix.py` | *(start here)* staging authority, Packit job bound, trigger/switch pairing |
| `test/check-live-release-channels.py` | per-channel comparison, and which channel may be skipped |
| `scripts/release-attestation.py` | attestation renderer and validator, stdlib only, no network |
| `test/release-version-contract.sh` | fixtures for every rule above |

## Reviewer notes

- **provisioning is three edits, deliberately** — flip `provisioned`, move the staging job to `trigger: pull_request`, and delete the assertion holding the switch unclaimed; the contract rejects any two without the third, and a fixture proves the three together pass
- **the production comparison always queries** — production declares no `provisioned` key and is rejected for declaring one, so the check every pull request runs cannot reach the staging skip path
- **the attestation has no producer yet** — wave 4 of #236 gathers the facts; preflight only checks that the file exists

## Validation

- `bash test/release-version-contract.sh`
- `python3 test/check-release-matrix.py`, plain and with `RELEASE_MATRIX_VERSION=0.2.0-alpha.1`
- `python3 test/check-live-release-channels.py` against the live production API, and `--channel staging`
- `just test-packit-config`
- `just check`

Refs #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staging release-channel validation for Fedora COPR builds, including provisioning and chroot checks.
  * Added release attestation generation and validation for release identity, artifacts, digests, signatures, and metadata.
  * Added upgrade and rollback validation from version 0.1.4 across Debian and Fedora packaging lanes.
  * Expanded packaging evidence checks across RPM, COPR, Arch, and Debian workflows.

* **Bug Fixes**
  * Improved detection of channel, identity, target, trigger, configuration, and packaging mismatches.

* **Documentation**
  * Documented staging workflows, attestations, upgrade testing, rollback guarantees, and release preflight checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->