### PR TITLE
ci(release): publish the release exactly once after validation

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -126,11 +126,12 @@ build-deb · build-rpm · build-nix
 publish-apt · publish · publish-aur · trigger-pages
 ```
 
-`build` creates the release as a **draft**. `publish` is the only job that
-writes to the release: it verifies the tag, holds every asset to the canonical
-allowlist and to its builder's digest, writes `MANIFEST.json`, and flips the
-draft to published exactly once. Until it runs, nothing is public and Packit has
-seen nothing.
+Every builder produces workflow artifacts and nothing else. `publish` is the
+only job that touches the release: it verifies the tag, stages exactly the
+canonical assets out of those artifacts, holds each one to the digest its
+builder attested, creates the release as a **draft**, writes `MANIFEST.json`,
+and flips the draft to published exactly once. Until it runs, no release exists
+and Packit has seen nothing.
 
 ```bash
 gh run watch
@@ -138,7 +139,8 @@ gh release view v<X.Y.Z> --json assets --jq '.assets[].name'
 ```
 
 A release that stays a draft failed validation: read the `publish` job, fix the
-cause, and re-run the workflow. Never publish the draft by hand.
+cause, and re-run the workflow. Re-running is safe; publishing the draft by hand
+is not, and `publish` refuses a tag that is already published.
 
 `publish-aur` and `publish-apt` push to external package repositories. A failure
 after those succeed is only partially recoverable — check them first when

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -118,18 +118,27 @@ Only after explicit confirmation. No AI attribution in the commit or tag message
 
 ## Step 6: Watch the publish
 
-The `v*` tag triggers `.github/workflows/release.yml`, which has 10 jobs:
+The `v*` tag triggers `.github/workflows/release.yml`, which has 11 jobs:
 
 ```
 metadata · build · download-ort · prepare-cargo-vendor
 build-deb · build-rpm · build-nix
-publish-aur · publish-apt · trigger-pages
+publish-apt · publish · publish-aur · trigger-pages
 ```
+
+`build` creates the release as a **draft**. `publish` is the only job that
+writes to the release: it verifies the tag, holds every asset to the canonical
+allowlist and to its builder's digest, writes `MANIFEST.json`, and flips the
+draft to published exactly once. Until it runs, nothing is public and Packit has
+seen nothing.
 
 ```bash
 gh run watch
 gh release view v<X.Y.Z> --json assets --jq '.assets[].name'
 ```
+
+A release that stays a draft failed validation: read the `publish` job, fix the
+cause, and re-run the workflow. Never publish the draft by hand.
 
 `publish-aur` and `publish-apt` push to external package repositories. A failure
 after those succeed is only partially recoverable — check them first when

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -139,8 +139,9 @@ gh release view v<X.Y.Z> --json assets --jq '.assets[].name'
 ```
 
 A release that stays a draft failed validation: read the `publish` job, fix the
-cause, and re-run the workflow. Re-running is safe; publishing the draft by hand
-is not, and `publish` refuses a tag that is already published.
+cause, and re-run the workflow. A re-run before publish succeeds is safe; one
+after success goes red at `verify-creatable` by design. Publishing the draft by
+hand is not safe, and `publish` refuses a tag that is already published.
 
 `publish-aur` and `publish-apt` push to external package repositories. A failure
 after those succeed is only partially recoverable — check them first when

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -120,7 +120,7 @@ Only after explicit confirmation. No AI attribution in the commit or tag message
 
 The `v*` tag triggers `.github/workflows/release.yml`, which has 11 jobs:
 
-```
+```text
 metadata · build · download-ort · prepare-cargo-vendor
 build-deb · build-rpm · build-nix
 publish-apt · publish · publish-aur · trigger-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
     name: Agent Docs Consistency
     runs-on: ubuntu-latest
     container: docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220ada0076185b77857c1813f02de0fa83cf7b
+    permissions:
+      contents: read
     steps:
       - name: Install system dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
       - name: Verify the Arch lane picks the package it means to install
         run: just test-arch-package-select
 
+      - name: Verify the release publishes exactly once
+        run: just test-release-artifacts
+
       - name: Verify release target declarations
         run: python3 test/check-release-matrix.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,16 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write
-  actions: write
+# Deny-all floor: every job asks for exactly the scopes it needs, and only the
+# publish job may write to the release (#235).
+permissions: {}
 
 jobs:
   metadata:
     name: Validate Release Identity
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       cargo-version: ${{ steps.release.outputs.cargo-version }}
       prerelease: ${{ steps.release.outputs.prerelease }}
@@ -37,6 +39,8 @@ jobs:
     name: Build Release Binaries
     runs-on: ubuntu-latest
     needs: metadata
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -57,10 +61,7 @@ jobs:
           mkdir -p release
           cp target/release/facelock release/facelock-x86_64-linux-gnu
           cp target/release/libpam_facelock.so release/pam_facelock.so
-          if [ -f target/release/facelock-polkit-agent ]; then
-            cp target/release/facelock-polkit-agent release/facelock-polkit-agent-x86_64-linux-gnu
-          fi
-          cd release && sha256sum * > SHA256SUMS
+          cp target/release/facelock-polkit-agent release/facelock-polkit-agent-x86_64-linux-gnu
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -68,20 +69,31 @@ jobs:
           name: release-binaries
           path: release/
 
-      - name: Create GitHub Release
+      - name: Attest built binary digests
+        run: .github/workflows/scripts/attest-digests.sh build digests release/*
+
+      - name: Upload binary digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-build
+          path: digests/
+
+      - name: Create the draft GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          # Publish the release with a PAT, not the default GITHUB_TOKEN.
-          # Releases created by GITHUB_TOKEN do not trigger downstream
-          # automation, so Packit's release trigger never fires and COPR
-          # is never built. An empty/missing RELEASE_PAT falls back to
-          # GITHUB_TOKEN, so this is safe before the secret is set.
+          # Write the release with a PAT, not the default GITHUB_TOKEN. Every
+          # builder holds contents: read, and a release published by
+          # GITHUB_TOKEN triggers no downstream automation, so Packit's release
+          # trigger never fires and COPR is never built.
           token: ${{ secrets.RELEASE_PAT }}
+          # Draft until the publish job has validated the whole asset set. A
+          # draft is invisible to Packit, to the AUR recipes and to anyone
+          # following the release feed.
+          draft: true
           files: |
             release/facelock-x86_64-linux-gnu
             release/pam_facelock.so
             release/facelock-polkit-agent-x86_64-linux-gnu
-            release/SHA256SUMS
           generate_release_notes: true
           prerelease: ${{ needs.metadata.outputs.prerelease }}
 
@@ -89,6 +101,8 @@ jobs:
     name: Download ONNX Runtime
     runs-on: ubuntu-latest
     needs: metadata
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -100,6 +114,18 @@ jobs:
           scripts/prepare-ort-bundle.sh prepare ort.tgz onnxruntime
           scripts/prepare-ort-bundle.sh component-tar onnxruntime onnxruntime-bundle.tar.xz
 
+      - name: Attest the reviewed ORT component
+        run: |
+          .github/workflows/scripts/attest-digests.sh download-ort digests \
+            --component onnxruntime=onnxruntime/manifest.json \
+            --component-archive onnxruntime=onnxruntime-bundle.tar.xz
+
+      - name: Upload ORT digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-onnxruntime
+          path: digests/
+
       - name: Upload ORT artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -110,6 +136,8 @@ jobs:
     name: Prepare Cargo Vendor Component
     runs-on: ubuntu-latest
     needs: metadata
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -125,6 +153,17 @@ jobs:
           scripts/prepare-cargo-vendor.sh prepare cargo-vendor
           scripts/prepare-cargo-vendor.sh component-tar cargo-vendor cargo-vendor-bundle.tar.xz
 
+      - name: Attest the exact Cargo vendor component
+        run: |
+          .github/workflows/scripts/attest-digests.sh prepare-cargo-vendor digests \
+            --component-archive cargo-vendor=cargo-vendor-bundle.tar.xz
+
+      - name: Upload Cargo vendor digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-cargo-vendor
+          path: digests/
+
       - name: Upload Cargo vendor artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -135,6 +174,9 @@ jobs:
     name: Build ${{ matrix.suite }} Debian Package
     runs-on: ubuntu-latest
     needs: [metadata, download-ort, prepare-cargo-vendor]
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -277,17 +319,37 @@ jobs:
           name: release-deb-${{ matrix.suite }}
           path: debian-upload/
 
-      - name: Upload .deb to release
+      - name: Attest the built Debian package digest
+        run: |
+          .github/workflows/scripts/attest-digests.sh build-deb digests \
+            --suite '${{ matrix.suite }}' --image '${{ matrix.image }}' \
+            debian-upload/*.deb
+
+      - name: Upload Debian digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-deb-${{ matrix.suite }}
+          path: digests/
+
+      - name: Upload .deb to the draft release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           files: debian-upload/*.deb
 
   build-rpm:
     name: Build RPM Package
     runs-on: ubuntu-latest
     needs: [metadata, build, download-ort]
+    permissions:
+      contents: read
+      actions: read
     container:
       image: registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
+    env:
+      # `container.image` cannot read an env context, so the pinned digest is
+      # written twice. test/release-artifacts-contract.sh holds the two equal.
+      BUILD_IMAGE: registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -325,18 +387,47 @@ jobs:
       - name: Copy RPM to workspace
         run: cp ~/rpmbuild/RPMS/x86_64/*.rpm ./ 2>/dev/null || cp ~/rpmbuild/RPMS/**/*.rpm ./ 2>/dev/null || true
 
-      - name: Validate .rpm contents
-        run: .github/workflows/scripts/validate-rpm.sh "$(ls *.rpm | head -1)" direct
+      - name: Select the package the validated metadata names
+        id: rpm
+        run: |
+          set -euo pipefail
+          source scripts/release-versions.sh
+          evr="$(release_rpm_evr \
+            '${{ needs.metadata.outputs.cargo-version }}' \
+            '${{ needs.metadata.outputs.rpm-counter }}')"
+          # Debug packages are built beside the payload and no validator reads
+          # them; the release carries exactly the package that was inspected.
+          mapfile -t candidates < <(find . -maxdepth 1 -type f \
+            -name "facelock-${evr}.fc*.x86_64.rpm" -printf '%P\n' | LC_ALL=C sort)
+          test "${#candidates[@]}" -eq 1
+          echo "rpm=${candidates[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload .rpm to release
+      - name: Validate .rpm contents
+        run: .github/workflows/scripts/validate-rpm.sh '${{ steps.rpm.outputs.rpm }}' direct
+
+      - name: Attest the validated RPM digest
+        run: |
+          .github/workflows/scripts/attest-digests.sh build-rpm digests \
+            --image "$BUILD_IMAGE" '${{ steps.rpm.outputs.rpm }}'
+
+      - name: Upload RPM digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-rpm
+          path: digests/
+
+      - name: Upload .rpm to the draft release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          files: "*.rpm"
+          token: ${{ secrets.RELEASE_PAT }}
+          files: ${{ steps.rpm.outputs.rpm }}
 
   build-nix:
     name: Validate Nix Build
     runs-on: ubuntu-latest
     needs: metadata
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -359,8 +450,13 @@ jobs:
   publish-aur:
     name: Publish to AUR
     runs-on: ubuntu-latest
-    needs: [metadata, build, build-deb, build-rpm]
+    # facelock-bin pins the published binaries by digest and points users at
+    # release download URLs, so it can only be written once the release is
+    # public.
+    needs: [metadata, publish]
     if: ${{ needs.metadata.outputs.prerelease == 'false' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -381,6 +477,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [metadata, build-deb]
     if: ${{ needs.metadata.outputs.prerelease == 'false' }}
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -434,15 +533,108 @@ jobs:
             dists pool tysmith-archive-keyring.gpg
           echo "APT repo tarball: $(du -h apt-repo.tar.gz | cut -f1)"
 
-      - name: Upload APT repo to release
+      - name: Attest the APT repository digest
+        run: .github/workflows/scripts/attest-digests.sh publish-apt digests apt-repo.tar.gz
+
+      - name: Upload APT digest attestation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digests-apt
+          path: digests/
+
+      - name: Upload APT repo to the draft release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           files: apt-repo.tar.gz
+
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    # Every builder and every validator, so nothing is published that was not
+    # built and inspected first. publish-apt is stable-only: the guard lets a
+    # skipped publisher through and stops on any failure or cancellation.
+    needs: [metadata, build, download-ort, prepare-cargo-vendor, build-deb, build-rpm, build-nix, publish-apt]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    permissions:
+      contents: write
+      actions: read
+    env:
+      # The publication credential, so the published event reaches Packit.
+      GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+      TAG: ${{ github.ref_name }}
+      VERSION: ${{ needs.metadata.outputs.cargo-version }}
+      PRERELEASE: ${{ needs.metadata.outputs.prerelease }}
+      DEBIAN_REVISION: ${{ needs.metadata.outputs.debian-revision }}
+      RPM_COUNTER: ${{ needs.metadata.outputs.rpm-counter }}
+      HELPER: .github/workflows/scripts/release-assets.sh
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The tag object itself, so a signature can be verified.
+          fetch-depth: 0
+
+      - name: Verify the maintainer tag
+        run: $HELPER verify-tag "$TAG" "$VERSION" "$GITHUB_SHA"
+
+      - name: Validate the draft asset set
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >releases.json
+          $HELPER verify-draft "$TAG" "$PRERELEASE" releases.json
+          $HELPER names releases.json "$TAG" >actual-assets
+          $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" builders \
+            >expected-assets
+          $HELPER verify expected-assets actual-assets
+
+      - name: Download the draft assets
+        run: gh release download "$TAG" --dir assets
+
+      - name: Download builder digest attestations
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: release-digests-*
+          path: digests
+
+      - name: Verify every asset against its builder attestation
+        run: $HELPER verify-digests digests assets actual-assets
+
+      - name: Generate MANIFEST.json
+        run: |
+          set -euo pipefail
+          source_sha256="$(curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/$GITHUB_REPOSITORY/archive/refs/tags/$TAG.tar.gz" |
+            sha256sum | cut -d' ' -f1)"
+          $HELPER manifest "$TAG" "$VERSION" "$GITHUB_SHA" "$PRERELEASE" \
+            "$GITHUB_REPOSITORY" "$source_sha256" digests assets actual-assets MANIFEST.json
+          cat MANIFEST.json
+
+      - name: Attach MANIFEST.json to the draft
+        run: gh release upload "$TAG" MANIFEST.json --clobber
+
+      - name: Publish the validated draft exactly once
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >releases.json
+          $HELPER verify-draft "$TAG" "$PRERELEASE" releases.json
+          $HELPER names releases.json "$TAG" >actual-assets
+          $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" final \
+            >expected-assets
+          $HELPER verify expected-assets actual-assets
+          release_id="$($HELPER release-id releases.json "$TAG")"
+          # Only the draft flag moves: the tag and its target commit are inputs
+          # this job verified, never values it writes.
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" -F draft=false >/dev/null
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" --jq '.draft')" = false
+          echo "Published $TAG"
 
   trigger-pages:
     name: Trigger Pages Rebuild
     runs-on: ubuntu-latest
-    needs: [publish-apt]
+    needs: [publish-apt, publish]
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Trigger GitHub Pages workflow
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,11 @@ jobs:
           for prefix in '' debuginfo- debugsource-; do
             mapfile -t candidates < <(find . -maxdepth 1 -type f \
               -name "facelock-${prefix}${evr}.fc*.x86_64.rpm" -printf '%P\n' | LC_ALL=C sort)
-            test "${#candidates[@]}" -eq 1
+            if [ "${#candidates[@]}" -ne 1 ]; then
+              echo "expected exactly one facelock-${prefix}${evr}.fc*.x86_64.rpm, found ${#candidates[@]}:" >&2
+              printf '%s\n' "${candidates[@]}" >&2
+              exit 1
+            fi
             cp "${candidates[0]}" rpm-upload/
             if [ -z "$prefix" ]; then
               echo "rpm=${candidates[0]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ on:
 # publish job may write to the release (#235).
 permissions: {}
 
+# One run per tag. A re-run started while a run is inside publish would pass
+# verify-creatable beside it and the survivor could carry one run's binaries
+# under the other's digests; it queues instead. Never cancel the run in
+# progress: it may be mid-publication.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   metadata:
     name: Validate Release Identity
@@ -442,15 +450,17 @@ jobs:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Check flake
+        # Evaluation is deterministic against flake.lock and gates
+        # publication; a network flake is a re-run, not a pass.
         run: nix flake check ./dist/nix --no-build
-        continue-on-error: true
 
       - name: Build with Nix
         run: nix build ./dist/nix
         continue-on-error: true
         # Nix build may fail if onnxruntime hash changes.
-        # This job validates the expression evaluates, not that
-        # the build succeeds (which depends on nixpkgs state).
+        # This step is advisory: the job gates on the expression
+        # evaluating, not on the build succeeding (which depends on
+        # nixpkgs state).
 
   publish-aur:
     name: Publish to AUR
@@ -667,6 +677,10 @@ jobs:
           $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" final \
             >expected-published
           $HELPER verify expected-published published-assets
+          # Names alone would let one run's binaries sit under another run's
+          # digests: hold each published asset's size, and digest where the
+          # API exposes one, to the manifest, and the manifest to this file.
+          $HELPER verify-published releases.json "$TAG" MANIFEST.json
           release_id="$($HELPER release-id releases.json "$TAG")"
           # Only the draft flag moves: the tag and its target commit are inputs
           # this job verified, never values it writes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,25 +78,6 @@ jobs:
           name: release-digests-build
           path: digests/
 
-      - name: Create the draft GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          # Write the release with a PAT, not the default GITHUB_TOKEN. Every
-          # builder holds contents: read, and a release published by
-          # GITHUB_TOKEN triggers no downstream automation, so Packit's release
-          # trigger never fires and COPR is never built.
-          token: ${{ secrets.RELEASE_PAT }}
-          # Draft until the publish job has validated the whole asset set. A
-          # draft is invisible to Packit, to the AUR recipes and to anyone
-          # following the release feed.
-          draft: true
-          files: |
-            release/facelock-x86_64-linux-gnu
-            release/pam_facelock.so
-            release/facelock-polkit-agent-x86_64-linux-gnu
-          generate_release_notes: true
-          prerelease: ${{ needs.metadata.outputs.prerelease }}
-
   download-ort:
     name: Download ONNX Runtime
     runs-on: ubuntu-latest
@@ -331,12 +312,6 @@ jobs:
           name: release-digests-deb-${{ matrix.suite }}
           path: digests/
 
-      - name: Upload .deb to the draft release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          token: ${{ secrets.RELEASE_PAT }}
-          files: debian-upload/*.deb
-
   build-rpm:
     name: Build RPM Package
     runs-on: ubuntu-latest
@@ -387,7 +362,7 @@ jobs:
       - name: Copy RPM to workspace
         run: cp ~/rpmbuild/RPMS/x86_64/*.rpm ./ 2>/dev/null || cp ~/rpmbuild/RPMS/**/*.rpm ./ 2>/dev/null || true
 
-      - name: Select the package the validated metadata names
+      - name: Select the packages the validated metadata names
         id: rpm
         run: |
           set -euo pipefail
@@ -395,20 +370,27 @@ jobs:
           evr="$(release_rpm_evr \
             '${{ needs.metadata.outputs.cargo-version }}' \
             '${{ needs.metadata.outputs.rpm-counter }}')"
-          # Debug packages are built beside the payload and no validator reads
-          # them; the release carries exactly the package that was inspected.
-          mapfile -t candidates < <(find . -maxdepth 1 -type f \
-            -name "facelock-${evr}.fc*.x86_64.rpm" -printf '%P\n' | LC_ALL=C sort)
-          test "${#candidates[@]}" -eq 1
-          echo "rpm=${candidates[0]}" >> "$GITHUB_OUTPUT"
+          # v0.1.4 published the payload package and its two debug packages.
+          # Each must exist exactly once at the validated version-release;
+          # anything else rpmbuild left behind stays out of the release.
+          mkdir -p rpm-upload
+          for prefix in '' debuginfo- debugsource-; do
+            mapfile -t candidates < <(find . -maxdepth 1 -type f \
+              -name "facelock-${prefix}${evr}.fc*.x86_64.rpm" -printf '%P\n' | LC_ALL=C sort)
+            test "${#candidates[@]}" -eq 1
+            cp "${candidates[0]}" rpm-upload/
+            if [ -z "$prefix" ]; then
+              echo "rpm=${candidates[0]}" >> "$GITHUB_OUTPUT"
+            fi
+          done
 
       - name: Validate .rpm contents
         run: .github/workflows/scripts/validate-rpm.sh '${{ steps.rpm.outputs.rpm }}' direct
 
-      - name: Attest the validated RPM digest
+      - name: Attest the validated RPM digests
         run: |
           .github/workflows/scripts/attest-digests.sh build-rpm digests \
-            --image "$BUILD_IMAGE" '${{ steps.rpm.outputs.rpm }}'
+            --image "$BUILD_IMAGE" rpm-upload/*.rpm
 
       - name: Upload RPM digest attestation
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -416,11 +398,11 @@ jobs:
           name: release-digests-rpm
           path: digests/
 
-      - name: Upload .rpm to the draft release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      - name: Upload the validated RPM set
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.RELEASE_PAT }}
-          files: ${{ steps.rpm.outputs.rpm }}
+          name: release-rpm
+          path: rpm-upload/
 
   build-nix:
     name: Validate Nix Build
@@ -542,11 +524,11 @@ jobs:
           name: release-digests-apt
           path: digests/
 
-      - name: Upload APT repo to the draft release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      - name: Upload the APT repository artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.RELEASE_PAT }}
-          files: apt-repo.tar.gz
+          name: release-apt-repo
+          path: apt-repo.tar.gz
 
   publish:
     name: Publish Release
@@ -560,7 +542,8 @@ jobs:
       contents: write
       actions: read
     env:
-      # The publication credential, so the published event reaches Packit.
+      # The publication credential, so the published event reaches Packit. This
+      # is the only job that holds it, and it compiles nothing.
       GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
       TAG: ${{ github.ref_name }}
       VERSION: ${{ needs.metadata.outputs.cargo-version }}
@@ -575,29 +558,53 @@ jobs:
           fetch-depth: 0
 
       - name: Verify the maintainer tag
-        run: $HELPER verify-tag "$TAG" "$VERSION" "$GITHUB_SHA"
-
-      - name: Validate the draft asset set
+        id: tag
         run: |
           set -euo pipefail
-          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >releases.json
-          $HELPER verify-draft "$TAG" "$PRERELEASE" releases.json
-          $HELPER names releases.json "$TAG" >actual-assets
-          $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" builders \
-            >expected-assets
-          $HELPER verify expected-assets actual-assets
+          $HELPER verify-tag "$TAG" "$VERSION" "$GITHUB_SHA"
+          # An annotated tag makes GITHUB_SHA the tag object, not the commit.
+          echo "commit=$(git rev-parse "${GITHUB_SHA}^{commit}")" >> "$GITHUB_OUTPUT"
 
-      - name: Download the draft assets
-        run: gh release download "$TAG" --dir assets
-
-      - name: Download builder digest attestations
+      - name: Download every builder artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: release-digests-*
-          path: digests
+          # The release payloads and their digest attestations; not the ORT or
+          # Cargo-vendor source components, which no release asset carries.
+          pattern: release-*
+          path: artifacts
+
+      - name: Stage exactly the canonical release assets
+        run: |
+          set -euo pipefail
+          $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" builders \
+            >expected-assets
+          $HELPER stage expected-assets artifacts assets >actual-assets
+          $HELPER verify expected-assets actual-assets
 
       - name: Verify every asset against its builder attestation
-        run: $HELPER verify-digests digests assets actual-assets
+        run: $HELPER verify-digests artifacts assets actual-assets
+
+      - name: Refuse a tag that is already published
+        run: |
+          set -euo pipefail
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases" >releases.json
+          $HELPER verify-creatable "$TAG" releases.json
+
+      - name: Create the draft release with the staged assets
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          # Write the release with a PAT, not the default GITHUB_TOKEN: a
+          # release published by GITHUB_TOKEN triggers no downstream
+          # automation, so Packit's release trigger never fires and COPR is
+          # never built.
+          token: ${{ secrets.RELEASE_PAT }}
+          # Draft until MANIFEST.json is attached and the whole asset set has
+          # been read back. A draft is invisible to Packit, to the AUR recipes
+          # and to anyone following the release feed.
+          draft: true
+          files: assets/*
+          generate_release_notes: true
+          prerelease: ${{ needs.metadata.outputs.prerelease }}
 
       - name: Generate MANIFEST.json
         run: |
@@ -605,8 +612,8 @@ jobs:
           source_sha256="$(curl --proto '=https' --tlsv1.2 -fsSL \
             "https://github.com/$GITHUB_REPOSITORY/archive/refs/tags/$TAG.tar.gz" |
             sha256sum | cut -d' ' -f1)"
-          $HELPER manifest "$TAG" "$VERSION" "$GITHUB_SHA" "$PRERELEASE" \
-            "$GITHUB_REPOSITORY" "$source_sha256" digests assets actual-assets MANIFEST.json
+          $HELPER manifest "$TAG" "$VERSION" '${{ steps.tag.outputs.commit }}' "$PRERELEASE" \
+            "$GITHUB_REPOSITORY" "$source_sha256" artifacts assets actual-assets MANIFEST.json
           cat MANIFEST.json
 
       - name: Attach MANIFEST.json to the draft
@@ -615,12 +622,12 @@ jobs:
       - name: Publish the validated draft exactly once
         run: |
           set -euo pipefail
-          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" >releases.json
+          gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases" >releases.json
           $HELPER verify-draft "$TAG" "$PRERELEASE" releases.json
-          $HELPER names releases.json "$TAG" >actual-assets
+          $HELPER names releases.json "$TAG" >published-assets
           $HELPER expected "$VERSION" "$DEBIAN_REVISION" "$RPM_COUNTER" "$PRERELEASE" final \
-            >expected-assets
-          $HELPER verify expected-assets actual-assets
+            >expected-published
+          $HELPER verify expected-published published-assets
           release_id="$($HELPER release-id releases.json "$TAG")"
           # Only the draft flag moves: the tag and its target commit are inputs
           # this job verified, never values it writes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
     needs: metadata
     permissions:
       contents: read
+    outputs:
+      # The SHA-256 of this job's digests.json. The artifact store is writable
+      # by every job in the run; a job output is recorded under this job alone,
+      # so publish trusts the uploaded attestation only once it hashes to this.
+      attestation: ${{ steps.attest.outputs.sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -70,6 +75,7 @@ jobs:
           path: release/
 
       - name: Attest built binary digests
+        id: attest
         run: .github/workflows/scripts/attest-digests.sh build digests release/*
 
       - name: Upload binary digest attestation
@@ -84,6 +90,8 @@ jobs:
     needs: metadata
     permissions:
       contents: read
+    outputs:
+      attestation: ${{ steps.attest.outputs.sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -96,6 +104,7 @@ jobs:
           scripts/prepare-ort-bundle.sh component-tar onnxruntime onnxruntime-bundle.tar.xz
 
       - name: Attest the reviewed ORT component
+        id: attest
         run: |
           .github/workflows/scripts/attest-digests.sh download-ort digests \
             --component onnxruntime=onnxruntime/manifest.json \
@@ -119,6 +128,8 @@ jobs:
     needs: metadata
     permissions:
       contents: read
+    outputs:
+      attestation: ${{ steps.attest.outputs.sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -135,6 +146,7 @@ jobs:
           scripts/prepare-cargo-vendor.sh component-tar cargo-vendor cargo-vendor-bundle.tar.xz
 
       - name: Attest the exact Cargo vendor component
+        id: attest
         run: |
           .github/workflows/scripts/attest-digests.sh prepare-cargo-vendor digests \
             --component-archive cargo-vendor=cargo-vendor-bundle.tar.xz
@@ -158,6 +170,13 @@ jobs:
     permissions:
       contents: read
       actions: read
+    outputs:
+      # A matrix job shares one outputs map across its legs. Each leg fills
+      # only its own suite's key and leaves the other empty; the service does
+      # not record an empty value over a set one, and publish refuses an empty
+      # one, so the failure direction is a refusal either way.
+      attestation-trixie: ${{ matrix.suite == 'trixie' && steps.attest.outputs.sha256 || '' }}
+      attestation-resolute: ${{ matrix.suite == 'resolute' && steps.attest.outputs.sha256 || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -301,6 +320,7 @@ jobs:
           path: debian-upload/
 
       - name: Attest the built Debian package digest
+        id: attest
         run: |
           .github/workflows/scripts/attest-digests.sh build-deb digests \
             --suite '${{ matrix.suite }}' --image '${{ matrix.image }}' \
@@ -319,6 +339,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+    outputs:
+      attestation: ${{ steps.attest.outputs.sha256 }}
     container:
       image: registry.fedoraproject.org/fedora:44@sha256:fc3ec3da3ce49de0da0bab5a33223e90866c488d5d04fc6612284169e20a1bdb
     env:
@@ -388,6 +410,7 @@ jobs:
         run: .github/workflows/scripts/validate-rpm.sh '${{ steps.rpm.outputs.rpm }}' direct
 
       - name: Attest the validated RPM digests
+        id: attest
         run: |
           .github/workflows/scripts/attest-digests.sh build-rpm digests \
             --image "$BUILD_IMAGE" rpm-upload/*.rpm
@@ -462,6 +485,8 @@ jobs:
     permissions:
       contents: read
       actions: read
+    outputs:
+      attestation: ${{ steps.attest.outputs.sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -516,6 +541,7 @@ jobs:
           echo "APT repo tarball: $(du -h apt-repo.tar.gz | cut -f1)"
 
       - name: Attest the APT repository digest
+        id: attest
         run: .github/workflows/scripts/attest-digests.sh publish-apt digests apt-repo.tar.gz
 
       - name: Upload APT digest attestation
@@ -581,8 +607,21 @@ jobs:
           $HELPER stage expected-assets artifacts assets >actual-assets
           $HELPER verify expected-assets actual-assets
 
+      - name: Record the job outputs that bind each attestation
+        env:
+          # Every needed job's result and outputs, JSON-encoded by the Actions
+          # service. It reaches the helper as a file, never as a shell line: a
+          # builder controls the text of its own output.
+          JOB_OUTPUTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$JOB_OUTPUTS" >job-outputs.json
+
       - name: Verify every asset against its builder attestation
-        run: $HELPER verify-digests artifacts assets actual-assets "$PRERELEASE"
+        # An attestation is trusted only once it hashes to the output its job
+        # recorded: the artifact store is writable by every job in the run, a
+        # job output only by the job that owns it.
+        run: $HELPER verify-digests artifacts job-outputs.json assets actual-assets "$PRERELEASE"
 
       - name: Refuse a tag that is already published
         run: |
@@ -613,7 +652,7 @@ jobs:
             "https://github.com/$GITHUB_REPOSITORY/archive/refs/tags/$TAG.tar.gz" |
             sha256sum | cut -d' ' -f1)"
           $HELPER manifest "$TAG" "$VERSION" '${{ steps.tag.outputs.commit }}' "$PRERELEASE" \
-            "$GITHUB_REPOSITORY" "$source_sha256" artifacts assets actual-assets MANIFEST.json
+            "$GITHUB_REPOSITORY" "$source_sha256" artifacts job-outputs.json assets actual-assets MANIFEST.json
           cat MANIFEST.json
 
       - name: Attach MANIFEST.json to the draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,7 +582,7 @@ jobs:
           $HELPER verify expected-assets actual-assets
 
       - name: Verify every asset against its builder attestation
-        run: $HELPER verify-digests artifacts assets actual-assets
+        run: $HELPER verify-digests artifacts assets actual-assets "$PRERELEASE"
 
       - name: Refuse a tag that is already published
         run: |

--- a/.github/workflows/scripts/attest-digests.sh
+++ b/.github/workflows/scripts/attest-digests.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# One builder's statement of what it produced: the SHA-256 of every artifact it
+# put on the release, the image it built them in, and the reviewed components it
+# consumed. The publish job holds the published bytes to these digests, so a
+# release asset that changed between its builder and publication is refused.
+set -euo pipefail
+
+fail() {
+    echo "attest digests: $*" >&2
+    exit 1
+}
+
+job="${1:-}"
+out_dir="${2:-}"
+[ -n "$job" ] && [ -n "$out_dir" ] ||
+    fail "usage: $0 <job> <out-dir> [--suite S] [--image I] [--component NAME=JSON] [--component-archive NAME=FILE] [asset...]"
+shift 2
+
+suite=""
+image=""
+declare -a assets=()
+declare -a components=()
+declare -a component_archives=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --suite) suite="${2:?--suite needs a value}"; shift 2 ;;
+        --image) image="${2:?--image needs a value}"; shift 2 ;;
+        --component) components+=("${2:?--component needs NAME=JSON}"); shift 2 ;;
+        --component-archive)
+            component_archives+=("${2:?--component-archive needs NAME=FILE}")
+            shift 2
+            ;;
+        --*) fail "unknown option: $1" ;;
+        *) assets+=("$1"); shift ;;
+    esac
+done
+
+mkdir -p "$out_dir"
+JOB="$job" SUITE="$suite" IMAGE="$image" python3 - "$out_dir/digests.json" \
+    "${#components[@]}" "${components[@]+"${components[@]}"}" \
+    "${#component_archives[@]}" "${component_archives[@]+"${component_archives[@]}"}" \
+    "${assets[@]+"${assets[@]}"}" <<'PY'
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def digest(path: Path) -> str:
+    if not path.is_file():
+        raise SystemExit(f"attest digests: {path} is not a file")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+argv = sys.argv[1:]
+output = Path(argv[0])
+cursor = 1
+
+component_count = int(argv[cursor])
+cursor += 1
+component_specs = argv[cursor : cursor + component_count]
+cursor += component_count
+
+archive_count = int(argv[cursor])
+cursor += 1
+archive_specs = argv[cursor : cursor + archive_count]
+cursor += archive_count
+
+assets = {}
+for raw in argv[cursor:]:
+    path = Path(raw)
+    if path.name in assets:
+        raise SystemExit(f"attest digests: two artifacts share the name {path.name}")
+    assets[path.name] = digest(path)
+
+components: dict[str, dict] = {}
+for spec in component_specs:
+    name, _, source = spec.partition("=")
+    components.setdefault(name, {}).update(json.loads(Path(source).read_text(encoding="utf-8")))
+for spec in archive_specs:
+    name, _, source = spec.partition("=")
+    archive = Path(source)
+    components.setdefault(name, {}).update(
+        {"archive": archive.name, "archive_sha256": digest(archive)}
+    )
+
+document = {"job": os.environ["JOB"], "assets": dict(sorted(assets.items()))}
+if os.environ.get("SUITE"):
+    document["suite"] = os.environ["SUITE"]
+if os.environ.get("IMAGE"):
+    document["image"] = os.environ["IMAGE"]
+if components:
+    document["components"] = dict(sorted(components.items()))
+
+output.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+print(f"attest digests: {output} covers {len(assets)} artifact(s)")
+PY

--- a/.github/workflows/scripts/attest-digests.sh
+++ b/.github/workflows/scripts/attest-digests.sh
@@ -4,6 +4,9 @@
 # consumed. The publish job holds the published bytes to these digests, so a
 # release asset that changed between its builder and publication is refused.
 set -euo pipefail
+# The interpreter runs from the builder's checkout; a module planted there must
+# not shadow the standard library.
+export PYTHONSAFEPATH=1
 
 fail() {
     echo "attest digests: $*" >&2
@@ -95,5 +98,14 @@ if components:
     document["components"] = dict(sorted(components.items()))
 
 output.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
-print(f"attest digests: {output} covers {len(assets)} artifact(s)")
+
+# The document's own digest becomes a job output: the artifact store is shared
+# by every job in the run, a job output belongs to this job alone, so the
+# publish job trusts the uploaded document only once it hashes to this value.
+document_sha256 = hashlib.sha256(output.read_bytes()).hexdigest()
+github_output = os.environ.get("GITHUB_OUTPUT")
+if github_output:
+    with open(github_output, "a", encoding="utf-8") as handle:
+        handle.write(f"sha256={document_sha256}\n")
+print(f"attest digests: {output} covers {len(assets)} artifact(s), sha256 {document_sha256}")
 PY

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -42,7 +42,7 @@ MANIFEST_FILE="${FACELOCK_RELEASE_MANIFEST_FILE:-}"
 if [ -z "$MANIFEST_FILE" ]; then
   MANIFEST_FILE="$(mktemp)"
   trap 'rm -f "$MANIFEST_FILE"' EXIT
-  curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/MANIFEST.json" -o "$MANIFEST_FILE"
+  curl --proto '=https' --tlsv1.2 -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/MANIFEST.json" -o "$MANIFEST_FILE"
 fi
 manifest_sha256() {
   python3 - "$MANIFEST_FILE" "$1" <<'PY'

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -5,6 +5,7 @@ VERSION="${1:?Usage: publish-aur.sh <VERSION> <CHECKSUM>}"
 CHECKSUM="${2:?Usage: publish-aur.sh <VERSION> <CHECKSUM>}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../../scripts/release-versions.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/../../../scripts/release-versions.sh"
 release_validate_cargo_version "$VERSION"
 if release_is_prerelease "$VERSION"; then
@@ -29,25 +30,20 @@ if [ -z "${AUR_SSH_KEY:-}" ]; then
   exit 0
 fi
 
-# Set up SSH for AUR
-mkdir -p ~/.ssh
-echo "$AUR_SSH_KEY" > ~/.ssh/aur
-chmod 600 ~/.ssh/aur
-{
-  echo "Host aur.archlinux.org"
-  echo "  IdentityFile ~/.ssh/aur"
-  echo "  User aur"
-} >> ~/.ssh/config
-ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
-
 # Per-binary checksums for facelock-bin come from the release manifest the
 # publish job generates over every published asset (#235). This job runs after
 # publication, so the manifest is the released, validated digest of each binary.
+# They are read and validated before anything touches SSH, so a bad manifest
+# stops here. FACELOCK_RELEASE_MANIFEST_FILE lets the contract test feed one
+# in without the network.
 # GITHUB_REPOSITORY is set by GitHub Actions; fall back to the canonical repo for local runs.
 REPO="${GITHUB_REPOSITORY:-tyvsmith/facelock}"
-MANIFEST_FILE="$(mktemp)"
-trap 'rm -f "$MANIFEST_FILE"' EXIT
-curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/MANIFEST.json" -o "$MANIFEST_FILE"
+MANIFEST_FILE="${FACELOCK_RELEASE_MANIFEST_FILE:-}"
+if [ -z "$MANIFEST_FILE" ]; then
+  MANIFEST_FILE="$(mktemp)"
+  trap 'rm -f "$MANIFEST_FILE"' EXIT
+  curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/MANIFEST.json" -o "$MANIFEST_FILE"
+fi
 manifest_sha256() {
   python3 - "$MANIFEST_FILE" "$1" <<'PY'
 import json
@@ -66,6 +62,25 @@ SHA_POLKIT="$(manifest_sha256 facelock-polkit-agent-x86_64-linux-gnu)"
 : "${SHA_FACELOCK:?missing facelock binary checksum in the release MANIFEST.json}"
 : "${SHA_PAM:?missing pam_facelock.so checksum in the release MANIFEST.json}"
 : "${SHA_POLKIT:?missing polkit agent checksum in the release MANIFEST.json}"
+# Each one pins a published binary for every facelock-bin consumer; a value
+# that is not a SHA-256 must never reach a published recipe.
+for binary_digest in SHA_FACELOCK SHA_PAM SHA_POLKIT; do
+  if ! [[ "${!binary_digest}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "refusing to publish: $binary_digest from the release MANIFEST.json is not a plausible SHA-256: ${!binary_digest}" >&2
+    exit 1
+  fi
+done
+
+# Set up SSH for AUR
+mkdir -p ~/.ssh
+echo "$AUR_SSH_KEY" > ~/.ssh/aur
+chmod 600 ~/.ssh/aur
+{
+  echo "Host aur.archlinux.org"
+  echo "  IdentityFile ~/.ssh/aur"
+  echo "  User aur"
+} >> ~/.ssh/config
+ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
 
 RUNNER_UID="$(id -u)"
 RUNNER_GID="$(id -g)"

--- a/.github/workflows/scripts/publish-aur.sh
+++ b/.github/workflows/scripts/publish-aur.sh
@@ -40,18 +40,32 @@ chmod 600 ~/.ssh/aur
 } >> ~/.ssh/config
 ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
 
-# Per-binary checksums for facelock-bin come from the Release SHA256SUMS file.
+# Per-binary checksums for facelock-bin come from the release manifest the
+# publish job generates over every published asset (#235). This job runs after
+# publication, so the manifest is the released, validated digest of each binary.
 # GITHUB_REPOSITORY is set by GitHub Actions; fall back to the canonical repo for local runs.
 REPO="${GITHUB_REPOSITORY:-tyvsmith/facelock}"
-SHA_FILE="$(mktemp)"
-trap 'rm -f "$SHA_FILE"' EXIT
-curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/SHA256SUMS" -o "$SHA_FILE"
-SHA_FACELOCK=$(awk '/[[:space:]]facelock-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
-SHA_PAM=$(awk '/[[:space:]]pam_facelock\.so$/{print $1}' "$SHA_FILE")
-SHA_POLKIT=$(awk '/[[:space:]]facelock-polkit-agent-x86_64-linux-gnu$/{print $1}' "$SHA_FILE")
-: "${SHA_FACELOCK:?missing facelock binary checksum in Release SHA256SUMS}"
-: "${SHA_PAM:?missing pam_facelock.so checksum in Release SHA256SUMS}"
-: "${SHA_POLKIT:?missing polkit agent checksum in Release SHA256SUMS}"
+MANIFEST_FILE="$(mktemp)"
+trap 'rm -f "$MANIFEST_FILE"' EXIT
+curl -fsSL "https://github.com/${REPO}/releases/download/v${VERSION}/MANIFEST.json" -o "$MANIFEST_FILE"
+manifest_sha256() {
+  python3 - "$MANIFEST_FILE" "$1" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+for asset in manifest.get("assets", []):
+    if asset.get("name") == sys.argv[2]:
+        print(asset["sha256"])
+        break
+PY
+}
+SHA_FACELOCK="$(manifest_sha256 facelock-x86_64-linux-gnu)"
+SHA_PAM="$(manifest_sha256 pam_facelock.so)"
+SHA_POLKIT="$(manifest_sha256 facelock-polkit-agent-x86_64-linux-gnu)"
+: "${SHA_FACELOCK:?missing facelock binary checksum in the release MANIFEST.json}"
+: "${SHA_PAM:?missing pam_facelock.so checksum in the release MANIFEST.json}"
+: "${SHA_POLKIT:?missing polkit agent checksum in the release MANIFEST.json}"
 
 RUNNER_UID="$(id -u)"
 RUNNER_GID="$(id -g)"

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -230,7 +230,16 @@ from pathlib import Path
 
 expected_file, artifacts_dir, assets_dir = sys.argv[1:4]
 
-candidates: list[Path] = [path for path in Path(artifacts_dir).rglob("*") if path.is_file()]
+# A builder's artifact tree is attacker-controlled: a symlink lets it point a
+# canonical name at bytes it does not own (another artifact, or the runner's
+# filesystem). Path.is_file() follows symlinks, so the walk must reject any
+# symlink before that check ever runs, not merely skip stray files.
+candidates: list[Path] = []
+for path in Path(artifacts_dir).rglob("*"):
+    if path.is_symlink():
+        raise SystemExit(f"release assets: refusing to stage a symlink under artifacts: {path}")
+    if path.is_file():
+        candidates.append(path)
 destination = Path(assets_dir)
 destination.mkdir(parents=True, exist_ok=True)
 

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -21,6 +21,9 @@ export ATTESTATIONS_MODULE
 # Loading that module by path would otherwise leave __pycache__ in the checkout,
 # and the recipes that demand a clean tree would fail on it.
 export PYTHONDONTWRITEBYTECODE=1
+# The heredocs below run from the publish job's checkout; a module planted
+# there must not shadow the standard library.
+export PYTHONSAFEPATH=1
 
 fail() {
     echo "release assets: $*" >&2
@@ -83,11 +86,15 @@ expected_assets() {
     fi
 }
 
-# The artifacts that attest this release, as `<slot><TAB><job>`. One slot per
-# `release-digests-*` artifact the workflow uploads: the publish job requires
-# exactly these, so a builder cannot add an artifact of its own and have its
-# claims believed. test/release-artifacts-contract.sh holds this list against
-# the workflow's attest-digests.sh call sites.
+# The artifacts that attest this release, as `<slot><TAB><job><TAB><output>`.
+# One slot per `release-digests-*` artifact the workflow uploads: the publish
+# job requires exactly these, so a builder cannot add an artifact of its own
+# and have its claims believed. The output is the job output under which the
+# job recorded its document's SHA-256; the artifact store is writable by every
+# job in the run, so an attestation is trusted only once it hashes to that
+# value. build-deb is a matrix job with one output per suite.
+# test/release-artifacts-contract.sh holds this list against the workflow's
+# attest-digests.sh call sites and outputs.
 expected_attestations() {
     local prerelease="${1:?}"
     local suite architecture
@@ -97,15 +104,15 @@ expected_attestations() {
         *) fail "prerelease must be true or false, got: $prerelease" ;;
     esac
 
-    printf 'build\tbuild\n'
-    printf 'onnxruntime\tdownload-ort\n'
-    printf 'cargo-vendor\tprepare-cargo-vendor\n'
+    printf 'build\tbuild\tattestation\n'
+    printf 'onnxruntime\tdownload-ort\tattestation\n'
+    printf 'cargo-vendor\tprepare-cargo-vendor\tattestation\n'
     while IFS='	' read -r suite architecture; do
-        printf 'deb-%s\tbuild-deb\n' "$suite"
+        printf 'deb-%s\tbuild-deb\tattestation-%s\n' "$suite" "$suite"
     done < <(debian_suites)
-    printf 'rpm\tbuild-rpm\n'
+    printf 'rpm\tbuild-rpm\tattestation\n'
     if [ "$prerelease" = false ]; then
-        printf 'apt\tpublish-apt\n'
+        printf 'apt\tpublish-apt\tattestation\n'
     fi
 }
 
@@ -335,19 +342,21 @@ PY
 # ---------------------------------------------------------------- attestations
 
 # Every asset was produced by exactly one builder and still has the bytes that
-# builder attested.
+# builder attested. `job_outputs` is the publish job's `toJSON(needs)`: each
+# attestation is trusted only once it hashes to the output its job recorded.
 verify_digests() {
-    local digests_dir="${1:?}" assets_dir="${2:?}" actual_file="${3:?}" prerelease="${4:?}"
+    local digests_dir="${1:?}" job_outputs="${2:?}" assets_dir="${3:?}"
+    local actual_file="${4:?}" prerelease="${5:?}"
     local expected
     expected="$(expected_attestations "$prerelease")"
-    python3 - "$digests_dir" "$assets_dir" "$actual_file" "$expected" <<'PY'
+    python3 - "$digests_dir" "$job_outputs" "$assets_dir" "$actual_file" "$expected" <<'PY'
 import hashlib
 import importlib.util
 import os
 import sys
 from pathlib import Path
 
-digests_dir, assets_dir, actual_file, expected = sys.argv[1:5]
+digests_dir, job_outputs, assets_dir, actual_file, expected = sys.argv[1:6]
 
 spec = importlib.util.spec_from_file_location(
     "release_attestations", os.environ["ATTESTATIONS_MODULE"]
@@ -356,7 +365,7 @@ release_attestations = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(release_attestations)
 
 try:
-    documents = release_attestations.load(digests_dir, expected)
+    documents = release_attestations.load(digests_dir, expected, job_outputs)
 except release_attestations.AttestationError as error:
     raise SystemExit(f"release assets: {error}")
 
@@ -398,11 +407,11 @@ PY
 generate_manifest() {
     local tag="${1:?}" version="${2:?}" commit="${3:?}" prerelease="${4:?}"
     local repository="${5:?}" source_sha256="${6:?}" digests_dir="${7:?}"
-    local assets_dir="${8:?}" actual_file="${9:?}" output="${10:?}"
+    local job_outputs="${8:?}" assets_dir="${9:?}" actual_file="${10:?}" output="${11:?}"
     local expected
     expected="$(expected_attestations "$prerelease")"
-    python3 - "$tag" "$version" "$commit" "$prerelease" "$repository" \
-        "$source_sha256" "$digests_dir" "$assets_dir" "$actual_file" "$output" "$expected" <<'PY'
+    python3 - "$tag" "$version" "$commit" "$prerelease" "$repository" "$source_sha256" \
+        "$digests_dir" "$job_outputs" "$assets_dir" "$actual_file" "$output" "$expected" <<'PY'
 import hashlib
 import importlib.util
 import json
@@ -411,7 +420,7 @@ import sys
 from pathlib import Path
 
 (tag, version, commit, prerelease, repository, source_sha256,
- digests_dir, assets_dir, actual_file, output, expected) = sys.argv[1:12]
+ digests_dir, job_outputs, assets_dir, actual_file, output, expected) = sys.argv[1:13]
 
 spec = importlib.util.spec_from_file_location(
     "release_attestations", os.environ["ATTESTATIONS_MODULE"]
@@ -420,7 +429,7 @@ release_attestations = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(release_attestations)
 
 try:
-    documents = release_attestations.load(digests_dir, expected)
+    documents = release_attestations.load(digests_dir, expected, job_outputs)
     build_images, components = release_attestations.provenance(documents)
 except release_attestations.AttestationError as error:
     raise SystemExit(f"release assets: {error}")
@@ -503,14 +512,14 @@ case "${1:-}" in
         ;;
     verify-digests)
         shift
-        [ "$#" -eq 4 ] ||
-            fail "usage: $0 verify-digests <digests-dir> <assets-dir> <actual-list> <prerelease>"
+        [ "$#" -eq 5 ] ||
+            fail "usage: $0 verify-digests <digests-dir> <job-outputs> <assets-dir> <actual-list> <prerelease>"
         verify_digests "$@"
         ;;
     manifest)
         shift
-        [ "$#" -eq 10 ] ||
-            fail "usage: $0 manifest <tag> <version> <commit> <prerelease> <repository> <source-sha256> <digests-dir> <assets-dir> <actual-list> <output>"
+        [ "$#" -eq 11 ] ||
+            fail "usage: $0 manifest <tag> <version> <commit> <prerelease> <repository> <source-sha256> <digests-dir> <job-outputs> <assets-dir> <actual-list> <output>"
         generate_manifest "$@"
         ;;
     *)

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -248,7 +248,9 @@ for line in Path(expected_file).read_text(encoding="utf-8").splitlines():
     if len(names) > 1 or len(matched) > 1:
         found = ", ".join(sorted(str(path) for path in matched))
         raise SystemExit(
-            f"release assets: more than one builder artifact provides {label}: {found}"
+            f"release assets: more than one builder artifact provides {label}: {found}; "
+            "a builder produced a file it does not own, and re-running only the failed "
+            "job keeps that artifact: fix the builder and re-run all jobs"
         )
     shutil.copy2(matched[0], destination / matched[0].name)
     staged.append(matched[0].name)
@@ -295,17 +297,37 @@ verify_tag() {
 #
 # `verify-creatable` runs before the draft is written: this tag may have no
 # release at all, or the draft an interrupted run left behind, never a published
-# one. `verify-draft` runs before the flip. `names` and `release-id` read the
-# selected release. Accepts a JSON array, one release object, gh's paginated
-# object stream, and gh's slurped pages.
+# one. `verify-draft` runs before the flip. `verify-published` holds every
+# asset the API lists to MANIFEST.json by size, and by digest where the API
+# exposes one, so one run's binaries cannot sit under another run's digests.
+# `names` and `release-id` read the selected release. Accepts a JSON array, one
+# release object, gh's paginated object stream, and gh's slurped pages.
 release_query() {
-    local mode="${1:?}" releases_json="${2:?}" tag="${3:?}" prerelease="${4:-}"
-    python3 - "$mode" "$releases_json" "$tag" "$prerelease" <<'PY'
+    local mode="${1:?}" releases_json="${2:?}" tag="${3:?}" extra="${4:-}"
+    python3 - "$mode" "$releases_json" "$tag" "$extra" <<'PY'
+import hashlib
 import json
 import sys
 from pathlib import Path
 
-mode, path, tag, prerelease = sys.argv[1:5]
+# `extra` is the validated prerelease flag for verify-draft and the local
+# MANIFEST.json path for verify-published.
+mode, path, tag, extra = sys.argv[1:5]
+prerelease = extra
+
+
+def concurrent_drafts(candidates: list) -> str:
+    """Two releases for one tag is what two concurrent runs leave behind; the
+    concurrency group prevents it, and the refusal names the remedy anyway."""
+    commands = " or ".join(
+        f"gh api --method DELETE repos/{{owner}}/{{repo}}/releases/{release.get('id')}"
+        for release in candidates
+    )
+    return (
+        f"release assets: {len(candidates)} releases exist for {tag}; a concurrent run "
+        f"left a second draft behind. Keep the one this run should finish and delete "
+        f"the other with: {commands}"
+    )
 
 
 def load(source: str) -> tuple[list, bool]:
@@ -336,7 +358,7 @@ if mode == "verify-creatable":
         print(f"release assets: no release exists for {tag} yet")
         raise SystemExit(0)
     if len(candidates) > 1:
-        raise SystemExit(f"release assets: {len(candidates)} releases already exist for {tag}")
+        raise SystemExit(concurrent_drafts(candidates))
     release = candidates[0]
     if not release.get("draft"):
         raise SystemExit(
@@ -346,10 +368,10 @@ if mode == "verify-creatable":
     print(f"release assets: reusing the unpublished draft {release.get('id')} for {tag}")
     raise SystemExit(0)
 
-if len(candidates) != 1:
-    raise SystemExit(
-        f"release assets: expected exactly one release for tag {tag}, found {len(candidates)}"
-    )
+if len(candidates) > 1:
+    raise SystemExit(concurrent_drafts(candidates))
+if not candidates:
+    raise SystemExit(f"release assets: expected exactly one release for tag {tag}, found 0")
 release = candidates[0]
 
 if mode == "release-id":
@@ -357,6 +379,40 @@ if mode == "release-id":
 elif mode == "names":
     for asset in release.get("assets", []):
         print(asset["name"])
+elif mode == "verify-published":
+    manifest_path = Path(extra)
+    manifest_bytes = manifest_path.read_bytes()
+    manifest = json.loads(manifest_bytes)
+    expected = {entry["name"]: (entry["size"], entry["sha256"]) for entry in manifest["assets"]}
+    # The manifest cannot cover itself; hold the uploaded copy to this file.
+    expected[manifest_path.name] = (len(manifest_bytes), hashlib.sha256(manifest_bytes).hexdigest())
+    listed = release.get("assets", [])
+    compared = 0
+    for asset in listed:
+        name = asset.get("name")
+        if name not in expected:
+            raise SystemExit(f"release assets: published asset {name} is not covered by {manifest_path.name}")
+        size, sha256 = expected[name]
+        if asset.get("size") != size:
+            raise SystemExit(
+                f"release assets: published asset {name} has size {asset.get('size')}, "
+                f"{manifest_path.name} records {size}"
+            )
+        digest = asset.get("digest")
+        if digest is None:
+            continue
+        # A digest the API exposes in a form this check cannot compare is not
+        # evidence; refuse rather than skip it.
+        if digest != f"sha256:{sha256}":
+            raise SystemExit(
+                f"release assets: published asset {name} has digest {digest}, "
+                f"{manifest_path.name} records sha256:{sha256}"
+            )
+        compared += 1
+    print(
+        f"release assets: {len(listed)} published asset(s) match {manifest_path.name} "
+        f"by size, {compared} by digest"
+    )
 elif mode == "verify-draft":
     if release.get("tag_name") != tag:
         raise SystemExit(
@@ -544,6 +600,11 @@ case "${1:-}" in
         [ "$#" -eq 2 ] || fail "usage: $0 $mode <releases-json> <tag>"
         release_query "$mode" "$1" "$2"
         ;;
+    verify-published)
+        shift
+        [ "$#" -eq 3 ] || fail "usage: $0 verify-published <releases-json> <tag> <manifest>"
+        release_query verify-published "$1" "$2" "$3"
+        ;;
     expected-attestations)
         shift
         [ "$#" -eq 1 ] || fail "usage: $0 expected-attestations <prerelease>"
@@ -562,6 +623,6 @@ case "${1:-}" in
         generate_manifest "$@"
         ;;
     *)
-        fail "usage: $0 {expected|expected-attestations|verify|stage|verify-tag|verify-creatable|verify-draft|names|release-id|verify-digests|manifest}"
+        fail "usage: $0 {expected|expected-attestations|verify|stage|verify-tag|verify-creatable|verify-draft|verify-published|names|release-id|verify-digests|manifest}"
         ;;
 esac

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# Decisions the release publication step delegates, so they can be proven by
+# fixture instead of by tagging: the canonical asset allowlist, the maintainer
+# tag check, the draft check, the builder digest attestations, and the
+# publication manifest.
+#
+# Nothing here writes to the release or to git. `verify-tag` reads a tag and
+# verifies a signature when one is present; it never creates, moves or pushes
+# one.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/release-versions.sh"
+
+MANIFEST_ASSET='MANIFEST.json'
+
+fail() {
+    echo "release assets: $*" >&2
+    exit 1
+}
+
+# An asset name as an anchored ERE that matches only itself.
+literal() {
+    printf '%s\n' "$1" | sed -E 's/[]|.[{}()*+?^$\\]/\\&/g'
+}
+
+# ------------------------------------------------------------------ allowlist
+
+# The canonical asset names for one validated release identity. Each line is
+# `<label><TAB><anchored ERE>`; the RPM's `%{?dist}` tag is decided inside the
+# pinned Fedora container, so that one entry is a pattern bound to the
+# validated epoch-version-release rather than a literal.
+expected_assets() {
+    local version="${1:?}" debian_revision="${2:?}" rpm_counter="${3:?}"
+    local prerelease="${4:?}" stage="${5:?}"
+    local suite architecture debian_version rpm_evr
+
+    case "$stage" in
+        builders | final) ;;
+        *) fail "unknown allowlist stage: $stage (expected builders or final)" ;;
+    esac
+    case "$prerelease" in
+        true | false) ;;
+        *) fail "prerelease must be true or false, got: $prerelease" ;;
+    esac
+    release_validate_cargo_version "$version" || fail "invalid release version: $version"
+
+    printf 'facelock-binary\t%s\n' "$(literal facelock-x86_64-linux-gnu)"
+    printf 'pam-module\t%s\n' "$(literal pam_facelock.so)"
+    printf 'polkit-agent\t%s\n' "$(literal facelock-polkit-agent-x86_64-linux-gnu)"
+
+    while IFS='	' read -r suite architecture; do
+        debian_version="$(release_debian_version "$version" "$debian_revision" "$suite")" ||
+            fail "cannot derive the $suite Debian version"
+        printf 'deb-%s\t%s\n' "$suite" \
+            "$(literal "facelock_${debian_version}_${architecture}.deb")"
+    done < <(debian_suites)
+
+    rpm_evr="$(release_rpm_evr "$version" "$rpm_counter")" ||
+        fail "cannot derive the RPM version-release"
+    printf 'rpm\t%s\\.fc[0-9]+\\.x86_64\\.rpm\n' "$(literal "facelock-${rpm_evr}")"
+
+    if [ "$prerelease" = false ]; then
+        printf 'apt-repo\t%s\n' "$(literal apt-repo.tar.gz)"
+    fi
+    if [ "$stage" = final ]; then
+        printf 'manifest\t%s\n' "$(literal "$MANIFEST_ASSET")"
+    fi
+}
+
+# The published Debian suites and their architectures, from the release matrix.
+debian_suites() {
+    python3 - "$REPO_ROOT/dist/release-matrix.json" <<'PY'
+import json
+import sys
+
+matrix = json.load(open(sys.argv[1], encoding="utf-8"))
+for suite, details in sorted(matrix["apt_suites"].items()):
+    if suite == "compat":
+        continue
+    print(f"{suite}\t{details['architecture']}")
+PY
+}
+
+# Every asset the release carries matches exactly one canonical name, and every
+# canonical name is carried exactly once.
+verify_assets() {
+    local expected_file="${1:?}" actual_file="${2:?}"
+    local -a labels=() patterns=() actual=()
+    local label pattern name matches duplicate
+
+    while IFS='	' read -r label pattern; do
+        [ -n "$label" ] || continue
+        labels+=("$label")
+        patterns+=("$pattern")
+    done <"$expected_file"
+    [ "${#labels[@]}" -gt 0 ] || fail "the canonical allowlist is empty"
+
+    mapfile -t actual < <(grep -v '^[[:space:]]*$' "$actual_file" || true)
+    [ "${#actual[@]}" -gt 0 ] || fail "the release carries no assets"
+
+    duplicate="$(printf '%s\n' "${actual[@]}" | LC_ALL=C sort | uniq -d)"
+    [ -z "$duplicate" ] ||
+        fail "duplicate release asset: $(printf '%s' "$duplicate" | tr '\n' ' ')"
+
+    for name in "${actual[@]}"; do
+        matches=0
+        for pattern in "${patterns[@]}"; do
+            [[ "$name" =~ ^${pattern}$ ]] && matches=$((matches + 1))
+        done
+        [ "$matches" -ne 0 ] || fail "unexpected release asset: $name"
+        [ "$matches" -eq 1 ] ||
+            fail "allowlist overlap: $name matches $matches canonical names"
+    done
+
+    for index in "${!patterns[@]}"; do
+        matches=0
+        for name in "${actual[@]}"; do
+            [[ "$name" =~ ^${patterns[$index]}$ ]] && matches=$((matches + 1))
+        done
+        [ "$matches" -ne 0 ] ||
+            fail "no release asset matches the canonical name ${labels[$index]} (${patterns[$index]})"
+        [ "$matches" -eq 1 ] ||
+            fail "more than one release asset matches the canonical name ${labels[$index]}"
+    done
+
+    echo "release assets: ${#actual[@]} asset(s) match the canonical allowlist"
+}
+
+# ----------------------------------------------------------------- identities
+
+# The maintainer's tag is an input to publication, never an output of it.
+verify_tag() {
+    local tag="${1:?}" version="${2:?}" commit="${3:?}" repo="${4:-.}"
+    local expected_tag tagged_commit object_type
+
+    expected_tag="$(release_tag_from_cargo "$version")" ||
+        fail "cannot derive the release tag for version $version"
+    [ "$tag" = "$expected_tag" ] ||
+        fail "tag $tag does not match the validated version $version (expected $expected_tag)"
+    git -C "$repo" rev-parse -q --verify "refs/tags/$tag" >/dev/null ||
+        fail "tag $tag does not exist in this repository"
+    tagged_commit="$(git -C "$repo" rev-list -n 1 "refs/tags/$tag")" ||
+        fail "tag $tag does not resolve to a commit"
+    [ "$tagged_commit" = "$commit" ] ||
+        fail "tag $tag does not point at the built commit $commit (points at $tagged_commit)"
+
+    object_type="$(git -C "$repo" cat-file -t "refs/tags/$tag")"
+    if [ "$object_type" = tag ] &&
+        git -C "$repo" cat-file tag "$tag" |
+        grep -Eq '^-----BEGIN (PGP|SSH) SIGNATURE-----$'; then
+        git -C "$repo" tag -v "$tag" >/dev/null 2>&1 ||
+            fail "tag $tag signature verification failed; publication needs a verifiable tag"
+        echo "release assets: tag $tag verified at $commit (signature verified)"
+    else
+        echo "release assets: tag $tag verified at $commit (unsigned)"
+    fi
+}
+
+# The release this workflow is about to publish must still be an unpublished
+# draft for this exact tag and channel. A rerun after publication stops here.
+verify_draft() {
+    local tag="${1:?}" prerelease="${2:?}" release_json="${3:?}"
+    python3 - "$tag" "$prerelease" "$release_json" <<'PY'
+import json
+import sys
+
+tag, prerelease, path = sys.argv[1], sys.argv[2] == "true", sys.argv[3]
+releases = json.load(open(path, encoding="utf-8"))
+if isinstance(releases, dict):
+    candidates = [releases] if releases else []
+else:
+    candidates = [entry for entry in releases if entry.get("tag_name") == tag]
+if len(candidates) != 1:
+    raise SystemExit(
+        f"release assets: expected exactly one release for tag {tag}, found {len(candidates)}"
+    )
+release = candidates[0]
+if release.get("tag_name") != tag:
+    raise SystemExit(
+        f"release assets: draft {release.get('id')} belongs to another tag: {release.get('tag_name')}"
+    )
+if not release.get("draft"):
+    raise SystemExit(
+        f"release assets: release {release.get('id')} for {tag} is already published; refusing to publish twice"
+    )
+if bool(release.get("prerelease")) is not prerelease:
+    raise SystemExit(
+        f"release assets: draft {release.get('id')} carries prerelease="
+        f"{release.get('prerelease')}, which is not the validated prerelease identity"
+    )
+print(f"release assets: draft {release.get('id')} for {tag} is unpublished")
+PY
+}
+
+# The single release this tag names, read back from the API listing.
+read_release() {
+    local mode="${1:?}" releases_json="${2:?}" tag="${3:?}"
+    python3 - "$mode" "$releases_json" "$tag" <<'PY'
+import json
+import sys
+
+mode, path, tag = sys.argv[1], sys.argv[2], sys.argv[3]
+releases = json.load(open(path, encoding="utf-8"))
+if isinstance(releases, dict):
+    candidates = [releases] if releases else []
+else:
+    candidates = [release for release in releases if release.get("tag_name") == tag]
+if len(candidates) != 1:
+    raise SystemExit(
+        f"release assets: expected exactly one release for tag {tag}, found {len(candidates)}"
+    )
+release = candidates[0]
+if mode == "release-id":
+    print(release["id"])
+else:
+    for asset in release.get("assets", []):
+        print(asset["name"])
+PY
+}
+
+# ---------------------------------------------------------------- attestations
+
+# Every asset was produced by exactly one builder and still has the bytes that
+# builder attested.
+verify_digests() {
+    local digests_dir="${1:?}" assets_dir="${2:?}" actual_file="${3:?}"
+    python3 - "$digests_dir" "$assets_dir" "$actual_file" "$MANIFEST_ASSET" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+digests_dir, assets_dir, actual_file, manifest_asset = sys.argv[1:5]
+
+attested: dict[str, list[tuple[str, str]]] = {}
+for path in sorted(Path(digests_dir).rglob("*.json")):
+    document = json.loads(path.read_text(encoding="utf-8"))
+    for name, digest in document.get("assets", {}).items():
+        attested.setdefault(name, []).append((document.get("job", path.parent.name), digest))
+
+actual = [line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()]
+
+for name in actual:
+    if name == manifest_asset:
+        continue
+    claims = attested.get(name, [])
+    if not claims:
+        raise SystemExit(f"release assets: {name} is attested by no builder")
+    if len(claims) > 1:
+        jobs = ", ".join(sorted(job for job, _ in claims))
+        raise SystemExit(f"release assets: {name} is attested by more than one builder: {jobs}")
+
+for name, claims in sorted(attested.items()):
+    asset = Path(assets_dir) / name
+    if not asset.is_file():
+        raise SystemExit(f"release assets: attested asset {name} is not present in the release")
+    actual_digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+    for job, digest in claims:
+        if digest != actual_digest:
+            raise SystemExit(
+                f"release assets: {name} does not match the digest {job} attested "
+                f"({digest} attested, {actual_digest} published)"
+            )
+
+print(f"release assets: {len(attested)} asset(s) match their builder attestations")
+PY
+}
+
+# ------------------------------------------------------------------- manifest
+
+# One document covering every published asset plus the source, build-image and
+# component digests the release was built from.
+generate_manifest() {
+    local tag="${1:?}" version="${2:?}" commit="${3:?}" prerelease="${4:?}"
+    local repository="${5:?}" source_sha256="${6:?}" digests_dir="${7:?}"
+    local assets_dir="${8:?}" actual_file="${9:?}" output="${10:?}"
+    python3 - "$tag" "$version" "$commit" "$prerelease" "$repository" \
+        "$source_sha256" "$digests_dir" "$assets_dir" "$actual_file" "$output" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+(tag, version, commit, prerelease, repository, source_sha256,
+ digests_dir, assets_dir, actual_file, output) = sys.argv[1:11]
+
+build_images: dict[str, str] = {}
+components: dict[str, object] = {}
+for path in sorted(Path(digests_dir).rglob("*.json")):
+    document = json.loads(path.read_text(encoding="utf-8"))
+    job = document.get("job", path.parent.name)
+    key = f"{job}:{document['suite']}" if document.get("suite") else job
+    if document.get("image"):
+        build_images[key] = document["image"]
+    for name, value in document.get("components", {}).items():
+        components[name] = value
+
+assets = []
+for name in sorted({line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()}):
+    asset = Path(assets_dir) / name
+    if not asset.is_file():
+        raise SystemExit(f"release assets: {name} is not present in the downloaded release assets")
+    payload = asset.read_bytes()
+    assets.append({
+        "name": name,
+        "size": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    })
+
+manifest = {
+    "schema": "facelock-release-manifest/1",
+    "repository": repository,
+    "tag": tag,
+    "version": version,
+    "commit": commit,
+    "prerelease": prerelease == "true",
+    "source": {
+        "url": f"https://github.com/{repository}/archive/refs/tags/{tag}.tar.gz",
+        "sha256": source_sha256,
+    },
+    "build_images": dict(sorted(build_images.items())),
+    "components": dict(sorted(components.items())),
+    "assets": assets,
+}
+Path(output).write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+print(f"release assets: manifest covers {len(assets)} asset(s)")
+PY
+}
+
+case "${1:-}" in
+    expected)
+        shift
+        [ "$#" -eq 5 ] ||
+            fail "usage: $0 expected <version> <debian-revision> <rpm-counter> <prerelease> <stage>"
+        expected_assets "$@"
+        ;;
+    verify)
+        shift
+        [ "$#" -eq 2 ] || fail "usage: $0 verify <expected-list> <actual-list>"
+        verify_assets "$@"
+        ;;
+    verify-tag)
+        shift
+        [ "$#" -eq 3 ] || [ "$#" -eq 4 ] ||
+            fail "usage: $0 verify-tag <tag> <version> <commit> [repo]"
+        verify_tag "$@"
+        ;;
+    names | release-id)
+        mode="$1"
+        shift
+        [ "$#" -eq 2 ] || fail "usage: $0 $mode <releases-json> <tag>"
+        read_release "$mode" "$1" "$2"
+        ;;
+    verify-draft)
+        shift
+        [ "$#" -eq 3 ] || fail "usage: $0 verify-draft <tag> <prerelease> <release-json>"
+        verify_draft "$@"
+        ;;
+    verify-digests)
+        shift
+        [ "$#" -eq 3 ] ||
+            fail "usage: $0 verify-digests <digests-dir> <assets-dir> <actual-list>"
+        verify_digests "$@"
+        ;;
+    manifest)
+        shift
+        [ "$#" -eq 10 ] ||
+            fail "usage: $0 manifest <tag> <version> <commit> <prerelease> <repository> <source-sha256> <digests-dir> <assets-dir> <actual-list> <output>"
+        generate_manifest "$@"
+        ;;
+    *)
+        fail "usage: $0 {expected|verify|verify-tag|verify-draft|verify-digests|manifest|names|release-id}"
+        ;;
+esac

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -16,6 +16,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 source "$REPO_ROOT/scripts/release-versions.sh"
 
 MANIFEST_ASSET='MANIFEST.json'
+# The checked-in authority for what a release carries and what it is built in.
+RELEASE_MATRIX="${FACELOCK_RELEASE_MATRIX:-$REPO_ROOT/dist/release-matrix.json}"
 ATTESTATIONS_MODULE="${FACELOCK_RELEASE_ATTESTATIONS:-$SCRIPT_DIR/release_attestations.py}"
 export ATTESTATIONS_MODULE
 # Loading that module by path would otherwise leave __pycache__ in the checkout,
@@ -44,7 +46,7 @@ literal() {
 expected_assets() {
     local version="${1:?}" debian_revision="${2:?}" rpm_counter="${3:?}"
     local prerelease="${4:?}" stage="${5:?}"
-    local suite architecture debian_version rpm_evr rpm_kind rpm_prefix
+    local entry suite architecture debian_version rpm_evr rpm_kind rpm_prefix
 
     case "$stage" in
         builders | final) ;;
@@ -60,12 +62,14 @@ expected_assets() {
     printf 'pam-module\t%s\n' "$(literal pam_facelock.so)"
     printf 'polkit-agent\t%s\n' "$(literal facelock-polkit-agent-x86_64-linux-gnu)"
 
-    while IFS='	' read -r suite architecture; do
+    read_debian_suites
+    for entry in "${DEBIAN_SUITES[@]}"; do
+        IFS='	' read -r suite architecture _ <<<"$entry"
         debian_version="$(release_debian_version "$version" "$debian_revision" "$suite")" ||
             fail "cannot derive the $suite Debian version"
         printf 'deb-%s\t%s\n' "$suite" \
             "$(literal "facelock_${debian_version}_${architecture}.deb")"
-    done < <(debian_suites)
+    done
 
     rpm_evr="$(release_rpm_evr "$version" "$rpm_counter")" ||
         fail "cannot derive the RPM version-release"
@@ -86,39 +90,49 @@ expected_assets() {
     fi
 }
 
-# The artifacts that attest this release, as `<slot><TAB><job><TAB><output>`.
-# One slot per `release-digests-*` artifact the workflow uploads: the publish
-# job requires exactly these, so a builder cannot add an artifact of its own
-# and have its claims believed. The output is the job output under which the
-# job recorded its document's SHA-256; the artifact store is writable by every
-# job in the run, so an attestation is trusted only once it hashes to that
-# value. build-deb is a matrix job with one output per suite.
-# test/release-artifacts-contract.sh holds this list against the workflow's
-# attest-digests.sh call sites and outputs.
+# The artifacts that attest this release, one tab-separated line per slot:
+# `<slot> <job> <output> <suite> <image> <components>`, `-` where a slot has
+# none. One slot per `release-digests-*` artifact the workflow uploads: the
+# publish job requires exactly these, so a builder cannot add an artifact of
+# its own and have its claims believed. The output is the job output under
+# which the job recorded its document's SHA-256; the artifact store is writable
+# by every job in the run, so an attestation is trusted only once it hashes to
+# that value. build-deb is a matrix job with one output per suite. The suite,
+# image and component names are what the slot's document must declare, no
+# more and no less: an attestation is a self-report, and the image and
+# component digests it carries reach MANIFEST.json, so the pinned matrix image
+# and the reviewed component set are held here rather than taken from the
+# document. test/release-artifacts-contract.sh holds this list against the
+# workflow's attest-digests.sh call sites and outputs.
 expected_attestations() {
     local prerelease="${1:?}"
-    local suite architecture
+    local entry suite architecture image rpm
 
     case "$prerelease" in
         true | false) ;;
         *) fail "prerelease must be true or false, got: $prerelease" ;;
     esac
 
-    printf 'build\tbuild\tattestation\n'
-    printf 'onnxruntime\tdownload-ort\tattestation\n'
-    printf 'cargo-vendor\tprepare-cargo-vendor\tattestation\n'
-    while IFS='	' read -r suite architecture; do
-        printf 'deb-%s\tbuild-deb\tattestation-%s\n' "$suite" "$suite"
-    done < <(debian_suites)
-    printf 'rpm\tbuild-rpm\tattestation\n'
+    printf 'build\tbuild\tattestation\t-\t-\t-\n'
+    printf 'onnxruntime\tdownload-ort\tattestation\t-\t-\tonnxruntime\n'
+    printf 'cargo-vendor\tprepare-cargo-vendor\tattestation\t-\t-\tcargo-vendor\n'
+    read_debian_suites
+    for entry in "${DEBIAN_SUITES[@]}"; do
+        IFS='	' read -r suite architecture image <<<"$entry"
+        printf 'deb-%s\tbuild-deb\tattestation-%s\t%s\t%s\t-\n' "$suite" "$suite" "$suite" "$image"
+    done
+    rpm="$(rpm_image)" || fail "cannot read the direct RPM image from $RELEASE_MATRIX"
+    [ -n "$rpm" ] || fail "the release matrix pins no direct RPM image: $RELEASE_MATRIX"
+    printf 'rpm\tbuild-rpm\tattestation\t-\t%s\t-\n' "$rpm"
     if [ "$prerelease" = false ]; then
-        printf 'apt\tpublish-apt\tattestation\n'
+        printf 'apt\tpublish-apt\tattestation\t-\t-\t-\n'
     fi
 }
 
-# The published Debian suites and their architectures, from the release matrix.
+# The published Debian suites, their architectures and their pinned images,
+# from the release matrix, as `<suite><TAB><architecture><TAB><image>`.
 debian_suites() {
-    python3 - "$REPO_ROOT/dist/release-matrix.json" <<'PY'
+    python3 - "$RELEASE_MATRIX" <<'PY'
 import json
 import sys
 
@@ -126,8 +140,33 @@ matrix = json.load(open(sys.argv[1], encoding="utf-8"))
 for suite, details in sorted(matrix["apt_suites"].items()):
     if suite == "compat":
         continue
-    print(f"{suite}\t{details['architecture']}")
+    print(f"{suite}\t{details['architecture']}\t{details['image']}")
 PY
+}
+
+# The pinned image the direct RPM is built in. test/check-release-matrix.py
+# holds the workflow's container image to this same row.
+rpm_image() {
+    python3 - "$RELEASE_MATRIX" <<'PY'
+import json
+import sys
+
+matrix = json.load(open(sys.argv[1], encoding="utf-8"))
+print(next(row["image"] for row in matrix["platforms"] if row["id"] == "fedora-44-direct"))
+PY
+}
+
+# The matrix is the authority for what a release carries, so a matrix that
+# cannot be read must stop the allowlist rather than shorten it. A failure
+# inside a process substitution is invisible to `set -e`, and `mapfile` does
+# not report it either; read through a command substitution and floor the
+# result. Fills DEBIAN_SUITES.
+read_debian_suites() {
+    local listing
+    listing="$(debian_suites)" ||
+        fail "cannot read the Debian suites from $RELEASE_MATRIX"
+    [ -n "$listing" ] || fail "the release matrix names no Debian suite: $RELEASE_MATRIX"
+    mapfile -t DEBIAN_SUITES <<<"$listing"
 }
 
 # Every asset the release carries matches exactly one canonical name, and every

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -16,6 +16,11 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 source "$REPO_ROOT/scripts/release-versions.sh"
 
 MANIFEST_ASSET='MANIFEST.json'
+ATTESTATIONS_MODULE="${FACELOCK_RELEASE_ATTESTATIONS:-$SCRIPT_DIR/release_attestations.py}"
+export ATTESTATIONS_MODULE
+# Loading that module by path would otherwise leave __pycache__ in the checkout,
+# and the recipes that demand a clean tree would fail on it.
+export PYTHONDONTWRITEBYTECODE=1
 
 fail() {
     echo "release assets: $*" >&2
@@ -75,6 +80,32 @@ expected_assets() {
     fi
     if [ "$stage" = final ]; then
         printf 'manifest\t%s\n' "$(literal "$MANIFEST_ASSET")"
+    fi
+}
+
+# The artifacts that attest this release, as `<slot><TAB><job>`. One slot per
+# `release-digests-*` artifact the workflow uploads: the publish job requires
+# exactly these, so a builder cannot add an artifact of its own and have its
+# claims believed. test/release-artifacts-contract.sh holds this list against
+# the workflow's attest-digests.sh call sites.
+expected_attestations() {
+    local prerelease="${1:?}"
+    local suite architecture
+
+    case "$prerelease" in
+        true | false) ;;
+        *) fail "prerelease must be true or false, got: $prerelease" ;;
+    esac
+
+    printf 'build\tbuild\n'
+    printf 'onnxruntime\tdownload-ort\n'
+    printf 'cargo-vendor\tprepare-cargo-vendor\n'
+    while IFS='	' read -r suite architecture; do
+        printf 'deb-%s\tbuild-deb\n' "$suite"
+    done < <(debian_suites)
+    printf 'rpm\tbuild-rpm\n'
+    if [ "$prerelease" = false ]; then
+        printf 'apt\tpublish-apt\n'
     fi
 }
 
@@ -306,40 +337,33 @@ PY
 # Every asset was produced by exactly one builder and still has the bytes that
 # builder attested.
 verify_digests() {
-    local digests_dir="${1:?}" assets_dir="${2:?}" actual_file="${3:?}"
-    python3 - "$digests_dir" "$assets_dir" "$actual_file" <<'PY'
+    local digests_dir="${1:?}" assets_dir="${2:?}" actual_file="${3:?}" prerelease="${4:?}"
+    local expected
+    expected="$(expected_attestations "$prerelease")"
+    python3 - "$digests_dir" "$assets_dir" "$actual_file" "$expected" <<'PY'
 import hashlib
-import json
+import importlib.util
+import os
 import sys
 from pathlib import Path
 
-digests_dir, assets_dir, actual_file = sys.argv[1:4]
+digests_dir, assets_dir, actual_file, expected = sys.argv[1:5]
 
+spec = importlib.util.spec_from_file_location(
+    "release_attestations", os.environ["ATTESTATIONS_MODULE"]
+)
+release_attestations = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_attestations)
 
-def attestations(root: str) -> list[Path]:
-    """Digest attestations, and only from the artifacts that carry them.
-
-    The publish job downloads the payload artifacts into the same tree. A
-    `digests.json` anywhere else is a builder claiming provenance for work it
-    did not do, so it stops the release rather than being skipped."""
-    base = Path(root)
-    smuggled = [
-        path
-        for path in sorted(base.rglob("digests.json"))
-        if not path.relative_to(base).parts[0].startswith("release-digests-")
-    ]
-    if smuggled:
-        raise SystemExit(
-            f"release assets: {smuggled[0]} is a digest attestation inside a payload artifact"
-        )
-    return sorted(base.glob("release-digests-*/**/digests.json"))
-
+try:
+    documents = release_attestations.load(digests_dir, expected)
+except release_attestations.AttestationError as error:
+    raise SystemExit(f"release assets: {error}")
 
 attested: dict[str, list[tuple[str, str]]] = {}
-for path in attestations(digests_dir):
-    document = json.loads(path.read_text(encoding="utf-8"))
+for document in documents:
     for name, digest in document.get("assets", {}).items():
-        attested.setdefault(name, []).append((document.get("job", path.parent.name), digest))
+        attested.setdefault(name, []).append((document["job"], digest))
 
 actual = [line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()]
 
@@ -375,45 +399,31 @@ generate_manifest() {
     local tag="${1:?}" version="${2:?}" commit="${3:?}" prerelease="${4:?}"
     local repository="${5:?}" source_sha256="${6:?}" digests_dir="${7:?}"
     local assets_dir="${8:?}" actual_file="${9:?}" output="${10:?}"
+    local expected
+    expected="$(expected_attestations "$prerelease")"
     python3 - "$tag" "$version" "$commit" "$prerelease" "$repository" \
-        "$source_sha256" "$digests_dir" "$assets_dir" "$actual_file" "$output" <<'PY'
+        "$source_sha256" "$digests_dir" "$assets_dir" "$actual_file" "$output" "$expected" <<'PY'
 import hashlib
+import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
 (tag, version, commit, prerelease, repository, source_sha256,
- digests_dir, assets_dir, actual_file, output) = sys.argv[1:11]
+ digests_dir, assets_dir, actual_file, output, expected) = sys.argv[1:12]
 
-def attestations(root: str) -> list[Path]:
-    """Digest attestations, and only from the artifacts that carry them.
+spec = importlib.util.spec_from_file_location(
+    "release_attestations", os.environ["ATTESTATIONS_MODULE"]
+)
+release_attestations = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_attestations)
 
-    The publish job downloads the payload artifacts into the same tree. A
-    `digests.json` anywhere else is a builder claiming provenance for work it
-    did not do, so it stops the release rather than being skipped."""
-    base = Path(root)
-    smuggled = [
-        path
-        for path in sorted(base.rglob("digests.json"))
-        if not path.relative_to(base).parts[0].startswith("release-digests-")
-    ]
-    if smuggled:
-        raise SystemExit(
-            f"release assets: {smuggled[0]} is a digest attestation inside a payload artifact"
-        )
-    return sorted(base.glob("release-digests-*/**/digests.json"))
-
-
-build_images: dict[str, str] = {}
-components: dict[str, object] = {}
-for path in attestations(digests_dir):
-    document = json.loads(path.read_text(encoding="utf-8"))
-    job = document.get("job", path.parent.name)
-    key = f"{job}:{document['suite']}" if document.get("suite") else job
-    if document.get("image"):
-        build_images[key] = document["image"]
-    for name, value in document.get("components", {}).items():
-        components[name] = value
+try:
+    documents = release_attestations.load(digests_dir, expected)
+    build_images, components = release_attestations.provenance(documents)
+except release_attestations.AttestationError as error:
+    raise SystemExit(f"release assets: {error}")
 
 assets = []
 for name in sorted({line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()}):
@@ -486,10 +496,15 @@ case "${1:-}" in
         [ "$#" -eq 2 ] || fail "usage: $0 $mode <releases-json> <tag>"
         release_query "$mode" "$1" "$2"
         ;;
+    expected-attestations)
+        shift
+        [ "$#" -eq 1 ] || fail "usage: $0 expected-attestations <prerelease>"
+        expected_attestations "$@"
+        ;;
     verify-digests)
         shift
-        [ "$#" -eq 3 ] ||
-            fail "usage: $0 verify-digests <digests-dir> <assets-dir> <actual-list>"
+        [ "$#" -eq 4 ] ||
+            fail "usage: $0 verify-digests <digests-dir> <assets-dir> <actual-list> <prerelease>"
         verify_digests "$@"
         ;;
     manifest)
@@ -499,6 +514,6 @@ case "${1:-}" in
         generate_manifest "$@"
         ;;
     *)
-        fail "usage: $0 {expected|verify|stage|verify-tag|verify-creatable|verify-draft|names|release-id|verify-digests|manifest}"
+        fail "usage: $0 {expected|expected-attestations|verify|stage|verify-tag|verify-creatable|verify-draft|names|release-id|verify-digests|manifest}"
         ;;
 esac

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -118,7 +118,8 @@ verify_assets() {
         for pattern in "${patterns[@]}"; do
             [[ "$name" =~ ^${pattern}$ ]] && matches=$((matches + 1))
         done
-        [ "$matches" -ne 0 ] || fail "unexpected release asset: $name"
+        [ "$matches" -ne 0 ] ||
+            fail "unexpected release asset: $name; an earlier run at another version leaves one behind, and it is removed with: gh release delete-asset \"\$TAG\" $name"
         [ "$matches" -eq 1 ] ||
             fail "allowlist overlap: $name matches $matches canonical names"
     done
@@ -314,8 +315,28 @@ from pathlib import Path
 
 digests_dir, assets_dir, actual_file = sys.argv[1:4]
 
+
+def attestations(root: str) -> list[Path]:
+    """Digest attestations, and only from the artifacts that carry them.
+
+    The publish job downloads the payload artifacts into the same tree. A
+    `digests.json` anywhere else is a builder claiming provenance for work it
+    did not do, so it stops the release rather than being skipped."""
+    base = Path(root)
+    smuggled = [
+        path
+        for path in sorted(base.rglob("digests.json"))
+        if not path.relative_to(base).parts[0].startswith("release-digests-")
+    ]
+    if smuggled:
+        raise SystemExit(
+            f"release assets: {smuggled[0]} is a digest attestation inside a payload artifact"
+        )
+    return sorted(base.glob("release-digests-*/**/digests.json"))
+
+
 attested: dict[str, list[tuple[str, str]]] = {}
-for path in sorted(Path(digests_dir).rglob("digests.json")):
+for path in attestations(digests_dir):
     document = json.loads(path.read_text(encoding="utf-8"))
     for name, digest in document.get("assets", {}).items():
         attested.setdefault(name, []).append((document.get("job", path.parent.name), digest))
@@ -364,9 +385,28 @@ from pathlib import Path
 (tag, version, commit, prerelease, repository, source_sha256,
  digests_dir, assets_dir, actual_file, output) = sys.argv[1:11]
 
+def attestations(root: str) -> list[Path]:
+    """Digest attestations, and only from the artifacts that carry them.
+
+    The publish job downloads the payload artifacts into the same tree. A
+    `digests.json` anywhere else is a builder claiming provenance for work it
+    did not do, so it stops the release rather than being skipped."""
+    base = Path(root)
+    smuggled = [
+        path
+        for path in sorted(base.rglob("digests.json"))
+        if not path.relative_to(base).parts[0].startswith("release-digests-")
+    ]
+    if smuggled:
+        raise SystemExit(
+            f"release assets: {smuggled[0]} is a digest attestation inside a payload artifact"
+        )
+    return sorted(base.glob("release-digests-*/**/digests.json"))
+
+
 build_images: dict[str, str] = {}
 components: dict[str, object] = {}
-for path in sorted(Path(digests_dir).rglob("digests.json")):
+for path in attestations(digests_dir):
     document = json.loads(path.read_text(encoding="utf-8"))
     job = document.get("job", path.parent.name)
     key = f"{job}:{document['suite']}" if document.get("suite") else job

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Decisions the release publication step delegates, so they can be proven by
-# fixture instead of by tagging: the canonical asset allowlist, the maintainer
-# tag check, the draft check, the builder digest attestations, and the
-# publication manifest.
+# fixture instead of by tagging: the canonical asset allowlist, staging those
+# assets out of the builders' workflow artifacts, the maintainer tag check, the
+# draft checks, the builder digest attestations, and the publication manifest.
 #
 # Nothing here writes to the release or to git. `verify-tag` reads a tag and
 # verifies a signature when one is present; it never creates, moves or pushes
@@ -30,13 +30,13 @@ literal() {
 # ------------------------------------------------------------------ allowlist
 
 # The canonical asset names for one validated release identity. Each line is
-# `<label><TAB><anchored ERE>`; the RPM's `%{?dist}` tag is decided inside the
-# pinned Fedora container, so that one entry is a pattern bound to the
-# validated epoch-version-release rather than a literal.
+# `<label><TAB><anchored ERE>`; the RPMs' `%{?dist}` tag is decided inside the
+# pinned Fedora container, so those entries are patterns bound to the validated
+# epoch-version-release rather than literals.
 expected_assets() {
     local version="${1:?}" debian_revision="${2:?}" rpm_counter="${3:?}"
     local prerelease="${4:?}" stage="${5:?}"
-    local suite architecture debian_version rpm_evr
+    local suite architecture debian_version rpm_evr rpm_kind rpm_prefix
 
     case "$stage" in
         builders | final) ;;
@@ -61,7 +61,14 @@ expected_assets() {
 
     rpm_evr="$(release_rpm_evr "$version" "$rpm_counter")" ||
         fail "cannot derive the RPM version-release"
-    printf 'rpm\t%s\\.fc[0-9]+\\.x86_64\\.rpm\n' "$(literal "facelock-${rpm_evr}")"
+    # v0.1.4 published the payload package and its two debug packages; the
+    # release keeps all three, each bound to the validated version-release.
+    for rpm_kind in payload debuginfo debugsource; do
+        rpm_prefix=''
+        [ "$rpm_kind" = payload ] || rpm_prefix="$rpm_kind-"
+        printf 'rpm-%s\t%s\\.fc[0-9]+\\.x86_64\\.rpm\n' "$rpm_kind" \
+            "$(literal "facelock-${rpm_prefix}${rpm_evr}")"
+    done
 
     if [ "$prerelease" = false ]; then
         printf 'apt-repo\t%s\n' "$(literal apt-repo.tar.gz)"
@@ -90,7 +97,7 @@ PY
 verify_assets() {
     local expected_file="${1:?}" actual_file="${2:?}"
     local -a labels=() patterns=() actual=()
-    local label pattern name matches duplicate
+    local label pattern name matches duplicate index
 
     while IFS='	' read -r label pattern; do
         [ -n "$label" ] || continue
@@ -130,12 +137,55 @@ verify_assets() {
     echo "release assets: ${#actual[@]} asset(s) match the canonical allowlist"
 }
 
+# -------------------------------------------------------------------- staging
+
+# Collect exactly the canonical assets out of the builders' workflow artifacts.
+# The allowlist decides what a release carries, so nothing else is copied and no
+# builder can smuggle a file in beside the one it was asked to produce.
+stage_assets() {
+    local expected_file="${1:?}" artifacts_dir="${2:?}" assets_dir="${3:?}"
+    python3 - "$expected_file" "$artifacts_dir" "$assets_dir" <<'PY'
+import re
+import shutil
+import sys
+from pathlib import Path
+
+expected_file, artifacts_dir, assets_dir = sys.argv[1:4]
+
+candidates: list[Path] = [path for path in Path(artifacts_dir).rglob("*") if path.is_file()]
+destination = Path(assets_dir)
+destination.mkdir(parents=True, exist_ok=True)
+
+staged: list[str] = []
+for line in Path(expected_file).read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    label, _, pattern = line.partition("\t")
+    matched = [path for path in candidates if re.fullmatch(pattern, path.name)]
+    if not matched:
+        raise SystemExit(
+            f"release assets: no builder artifact provides the canonical asset {label} ({pattern})"
+        )
+    names = {path.name for path in matched}
+    if len(names) > 1 or len(matched) > 1:
+        found = ", ".join(sorted(str(path) for path in matched))
+        raise SystemExit(
+            f"release assets: more than one builder artifact provides {label}: {found}"
+        )
+    shutil.copy2(matched[0], destination / matched[0].name)
+    staged.append(matched[0].name)
+
+for name in staged:
+    print(name)
+PY
+}
+
 # ----------------------------------------------------------------- identities
 
 # The maintainer's tag is an input to publication, never an output of it.
 verify_tag() {
     local tag="${1:?}" version="${2:?}" commit="${3:?}" repo="${4:-.}"
-    local expected_tag tagged_commit object_type
+    local expected_tag tagged_commit built_commit object_type
 
     expected_tag="$(release_tag_from_cargo "$version")" ||
         fail "cannot derive the release tag for version $version"
@@ -145,8 +195,11 @@ verify_tag() {
         fail "tag $tag does not exist in this repository"
     tagged_commit="$(git -C "$repo" rev-list -n 1 "refs/tags/$tag")" ||
         fail "tag $tag does not resolve to a commit"
-    [ "$tagged_commit" = "$commit" ] ||
-        fail "tag $tag does not point at the built commit $commit (points at $tagged_commit)"
+    # GITHUB_SHA is the tag object for an annotated tag; peel both sides.
+    built_commit="$(git -C "$repo" rev-parse -q --verify "${commit}^{commit}")" ||
+        fail "the built revision $commit does not resolve to a commit"
+    [ "$tagged_commit" = "$built_commit" ] ||
+        fail "tag $tag does not point at the built commit $built_commit (points at $tagged_commit)"
 
     object_type="$(git -C "$repo" cat-file -t "refs/tags/$tag")"
     if [ "$object_type" = tag ] &&
@@ -154,71 +207,96 @@ verify_tag() {
         grep -Eq '^-----BEGIN (PGP|SSH) SIGNATURE-----$'; then
         git -C "$repo" tag -v "$tag" >/dev/null 2>&1 ||
             fail "tag $tag signature verification failed; publication needs a verifiable tag"
-        echo "release assets: tag $tag verified at $commit (signature verified)"
+        echo "release assets: tag $tag verified at $built_commit (signature verified)"
     else
-        echo "release assets: tag $tag verified at $commit (unsigned)"
+        echo "release assets: tag $tag verified at $built_commit (unsigned)"
     fi
 }
 
-# The release this workflow is about to publish must still be an unpublished
-# draft for this exact tag and channel. A rerun after publication stops here.
-verify_draft() {
-    local tag="${1:?}" prerelease="${2:?}" release_json="${3:?}"
-    python3 - "$tag" "$prerelease" "$release_json" <<'PY'
+# The release listing this tag names, read back from the API.
+#
+# `verify-creatable` runs before the draft is written: this tag may have no
+# release at all, or the draft an interrupted run left behind, never a published
+# one. `verify-draft` runs before the flip. `names` and `release-id` read the
+# selected release. Accepts a JSON array, one release object, gh's paginated
+# object stream, and gh's slurped pages.
+release_query() {
+    local mode="${1:?}" releases_json="${2:?}" tag="${3:?}" prerelease="${4:-}"
+    python3 - "$mode" "$releases_json" "$tag" "$prerelease" <<'PY'
 import json
 import sys
+from pathlib import Path
 
-tag, prerelease, path = sys.argv[1], sys.argv[2] == "true", sys.argv[3]
-releases = json.load(open(path, encoding="utf-8"))
-if isinstance(releases, dict):
-    candidates = [releases] if releases else []
-else:
-    candidates = [entry for entry in releases if entry.get("tag_name") == tag]
+mode, path, tag, prerelease = sys.argv[1:5]
+
+
+def load(source: str) -> tuple[list, bool]:
+    """Every shape gh emits: a JSON array, one object, a paginated object
+    stream, or slurped pages. The flag says the caller already selected one."""
+    text = Path(source).read_text(encoding="utf-8")
+    try:
+        document = json.loads(text) if text.strip() else []
+    except json.JSONDecodeError:
+        document = [json.loads(line) for line in text.splitlines() if line.strip()]
+    if isinstance(document, dict):
+        return ([document] if document else []), True
+    releases: list = []
+    for entry in document:
+        if isinstance(entry, list):
+            releases.extend(entry)
+        else:
+            releases.append(entry)
+    return releases, False
+
+
+releases, selected = load(path)
+# A single object is a caller-selected release: hold it to the tag it claims.
+candidates = releases if selected else [r for r in releases if r.get("tag_name") == tag]
+
+if mode == "verify-creatable":
+    if not candidates:
+        print(f"release assets: no release exists for {tag} yet")
+        raise SystemExit(0)
+    if len(candidates) > 1:
+        raise SystemExit(f"release assets: {len(candidates)} releases already exist for {tag}")
+    release = candidates[0]
+    if not release.get("draft"):
+        raise SystemExit(
+            f"release assets: release {release.get('id')} for {tag} is already published; "
+            "refusing to publish twice"
+        )
+    print(f"release assets: reusing the unpublished draft {release.get('id')} for {tag}")
+    raise SystemExit(0)
+
 if len(candidates) != 1:
     raise SystemExit(
         f"release assets: expected exactly one release for tag {tag}, found {len(candidates)}"
     )
 release = candidates[0]
-if release.get("tag_name") != tag:
-    raise SystemExit(
-        f"release assets: draft {release.get('id')} belongs to another tag: {release.get('tag_name')}"
-    )
-if not release.get("draft"):
-    raise SystemExit(
-        f"release assets: release {release.get('id')} for {tag} is already published; refusing to publish twice"
-    )
-if bool(release.get("prerelease")) is not prerelease:
-    raise SystemExit(
-        f"release assets: draft {release.get('id')} carries prerelease="
-        f"{release.get('prerelease')}, which is not the validated prerelease identity"
-    )
-print(f"release assets: draft {release.get('id')} for {tag} is unpublished")
-PY
-}
 
-# The single release this tag names, read back from the API listing.
-read_release() {
-    local mode="${1:?}" releases_json="${2:?}" tag="${3:?}"
-    python3 - "$mode" "$releases_json" "$tag" <<'PY'
-import json
-import sys
-
-mode, path, tag = sys.argv[1], sys.argv[2], sys.argv[3]
-releases = json.load(open(path, encoding="utf-8"))
-if isinstance(releases, dict):
-    candidates = [releases] if releases else []
-else:
-    candidates = [release for release in releases if release.get("tag_name") == tag]
-if len(candidates) != 1:
-    raise SystemExit(
-        f"release assets: expected exactly one release for tag {tag}, found {len(candidates)}"
-    )
-release = candidates[0]
 if mode == "release-id":
     print(release["id"])
-else:
+elif mode == "names":
     for asset in release.get("assets", []):
         print(asset["name"])
+elif mode == "verify-draft":
+    if release.get("tag_name") != tag:
+        raise SystemExit(
+            f"release assets: draft {release.get('id')} belongs to another tag: {release.get('tag_name')}"
+        )
+    if not release.get("draft"):
+        raise SystemExit(
+            f"release assets: release {release.get('id')} for {tag} is already published; "
+            "refusing to publish twice"
+        )
+    if bool(release.get("prerelease")) is not (prerelease == "true"):
+        raise SystemExit(
+            f"release assets: draft {release.get('id')} carries prerelease="
+            f"{release.get('prerelease')}, which is not the validated prerelease identity"
+        )
+    print(f"release assets: draft {release.get('id')} for {tag} is unpublished")
+else:
+    raise SystemExit(f"release assets: unknown release query: {mode}")
 PY
 }
 
@@ -228,16 +306,16 @@ PY
 # builder attested.
 verify_digests() {
     local digests_dir="${1:?}" assets_dir="${2:?}" actual_file="${3:?}"
-    python3 - "$digests_dir" "$assets_dir" "$actual_file" "$MANIFEST_ASSET" <<'PY'
+    python3 - "$digests_dir" "$assets_dir" "$actual_file" <<'PY'
 import hashlib
 import json
 import sys
 from pathlib import Path
 
-digests_dir, assets_dir, actual_file, manifest_asset = sys.argv[1:5]
+digests_dir, assets_dir, actual_file = sys.argv[1:4]
 
 attested: dict[str, list[tuple[str, str]]] = {}
-for path in sorted(Path(digests_dir).rglob("*.json")):
+for path in sorted(Path(digests_dir).rglob("digests.json")):
     document = json.loads(path.read_text(encoding="utf-8"))
     for name, digest in document.get("assets", {}).items():
         attested.setdefault(name, []).append((document.get("job", path.parent.name), digest))
@@ -245,8 +323,6 @@ for path in sorted(Path(digests_dir).rglob("*.json")):
 actual = [line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()]
 
 for name in actual:
-    if name == manifest_asset:
-        continue
     claims = attested.get(name, [])
     if not claims:
         raise SystemExit(f"release assets: {name} is attested by no builder")
@@ -273,7 +349,7 @@ PY
 # ------------------------------------------------------------------- manifest
 
 # One document covering every published asset plus the source, build-image and
-# component digests the release was built from.
+# component digests the release was built from. It cannot cover itself.
 generate_manifest() {
     local tag="${1:?}" version="${2:?}" commit="${3:?}" prerelease="${4:?}"
     local repository="${5:?}" source_sha256="${6:?}" digests_dir="${7:?}"
@@ -290,7 +366,7 @@ from pathlib import Path
 
 build_images: dict[str, str] = {}
 components: dict[str, object] = {}
-for path in sorted(Path(digests_dir).rglob("*.json")):
+for path in sorted(Path(digests_dir).rglob("digests.json")):
     document = json.loads(path.read_text(encoding="utf-8"))
     job = document.get("job", path.parent.name)
     key = f"{job}:{document['suite']}" if document.get("suite") else job
@@ -303,7 +379,7 @@ assets = []
 for name in sorted({line.strip() for line in Path(actual_file).read_text(encoding="utf-8").splitlines() if line.strip()}):
     asset = Path(assets_dir) / name
     if not asset.is_file():
-        raise SystemExit(f"release assets: {name} is not present in the downloaded release assets")
+        raise SystemExit(f"release assets: {name} is not present in the staged release assets")
     payload = asset.read_bytes()
     assets.append({
         "name": name,
@@ -343,22 +419,32 @@ case "${1:-}" in
         [ "$#" -eq 2 ] || fail "usage: $0 verify <expected-list> <actual-list>"
         verify_assets "$@"
         ;;
+    stage)
+        shift
+        [ "$#" -eq 3 ] || fail "usage: $0 stage <expected-list> <artifacts-dir> <assets-dir>"
+        stage_assets "$@"
+        ;;
     verify-tag)
         shift
         [ "$#" -eq 3 ] || [ "$#" -eq 4 ] ||
             fail "usage: $0 verify-tag <tag> <version> <commit> [repo]"
         verify_tag "$@"
         ;;
+    verify-creatable)
+        shift
+        [ "$#" -eq 2 ] || fail "usage: $0 verify-creatable <tag> <releases-json>"
+        release_query verify-creatable "$2" "$1"
+        ;;
+    verify-draft)
+        shift
+        [ "$#" -eq 3 ] || fail "usage: $0 verify-draft <tag> <prerelease> <releases-json>"
+        release_query verify-draft "$3" "$1" "$2"
+        ;;
     names | release-id)
         mode="$1"
         shift
         [ "$#" -eq 2 ] || fail "usage: $0 $mode <releases-json> <tag>"
-        read_release "$mode" "$1" "$2"
-        ;;
-    verify-draft)
-        shift
-        [ "$#" -eq 3 ] || fail "usage: $0 verify-draft <tag> <prerelease> <release-json>"
-        verify_draft "$@"
+        release_query "$mode" "$1" "$2"
         ;;
     verify-digests)
         shift
@@ -373,6 +459,6 @@ case "${1:-}" in
         generate_manifest "$@"
         ;;
     *)
-        fail "usage: $0 {expected|verify|verify-tag|verify-draft|verify-digests|manifest|names|release-id}"
+        fail "usage: $0 {expected|verify|stage|verify-tag|verify-creatable|verify-draft|names|release-id|verify-digests|manifest}"
         ;;
 esac

--- a/.github/workflows/scripts/release_attestations.py
+++ b/.github/workflows/scripts/release_attestations.py
@@ -1,0 +1,121 @@
+"""The builders' digest attestations, and the rules that make them evidence.
+
+The publish job downloads every `release-digests-*` artifact into one tree and
+reads provenance out of it. Anything running in a builder can call the Actions
+artifact API and upload an artifact of its own, so the tree is attacker-shaped:
+an extra artifact whose `digests.json` claims another job's identity would put
+forged image and component digests into `MANIFEST.json` while every asset digest
+still checked out.
+
+So the attesting set is pinned rather than merely deduplicated. Exactly the
+expected artifacts must be present, each named for the slot it fills, each
+holding one document, and each declaring the job that slot belongs to. An extra
+artifact, a missing one, a renamed one, or one claiming another job's name stops
+the release.
+
+`release-assets.sh` owns the expected slot list and both of its readers load
+attestations through here, so the rule has one implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ARTIFACT_PREFIX = "release-digests-"
+DOCUMENT_NAME = "digests.json"
+
+
+class AttestationError(Exception):
+    """A statement the release must not be built on."""
+
+
+def expected_slots(spec: str) -> dict[str, str]:
+    """Parse `<slot><TAB><job>` lines into the expected attesting set."""
+    slots: dict[str, str] = {}
+    for line in spec.splitlines():
+        if not line.strip():
+            continue
+        slot, _, job = line.partition("\t")
+        if not slot or not job:
+            raise AttestationError(f"malformed expected attestation: {line!r}")
+        if slot in slots:
+            raise AttestationError(f"expected attestation slot declared twice: {slot}")
+        slots[slot] = job
+    if not slots:
+        raise AttestationError("the expected attesting set is empty")
+    return slots
+
+
+def load(root: str, spec: str) -> list[dict]:
+    """Every attestation under `root`, or an error naming what is wrong.
+
+    Returns the documents in slot order, each with a `slot` key added."""
+    base = Path(root)
+    expected = expected_slots(spec)
+
+    smuggled = [
+        path
+        for path in sorted(base.rglob(DOCUMENT_NAME))
+        if not path.relative_to(base).parts[0].startswith(ARTIFACT_PREFIX)
+    ]
+    if smuggled:
+        raise AttestationError(
+            f"{smuggled[0]} is a digest attestation inside a payload artifact"
+        )
+
+    present = sorted(
+        path.name[len(ARTIFACT_PREFIX):]
+        for path in base.iterdir()
+        if path.is_dir() and path.name.startswith(ARTIFACT_PREFIX)
+    )
+    unexpected = sorted(set(present) - set(expected))
+    if unexpected:
+        raise AttestationError(
+            "no builder attests as "
+            + ", ".join(unexpected)
+            + f"; the release is attested by exactly {', '.join(sorted(expected))}"
+        )
+    missing = sorted(set(expected) - set(present))
+    if missing:
+        raise AttestationError(
+            "no attestation from " + ", ".join(missing) + "; every builder must attest"
+        )
+
+    documents: list[dict] = []
+    for slot in sorted(expected):
+        artifact = base / f"{ARTIFACT_PREFIX}{slot}"
+        found = sorted(artifact.rglob(DOCUMENT_NAME))
+        if len(found) != 1:
+            raise AttestationError(
+                f"attestation {slot} holds {len(found)} {DOCUMENT_NAME} documents, expected one"
+            )
+        document = json.loads(found[0].read_text(encoding="utf-8"))
+        if document.get("job") != expected[slot]:
+            raise AttestationError(
+                f"attestation {slot} declares job {document.get('job')!r}, "
+                f"but that slot belongs to {expected[slot]!r}"
+            )
+        document["slot"] = slot
+        documents.append(document)
+    return documents
+
+
+def provenance(documents: list[dict]) -> tuple[dict[str, str], dict[str, object]]:
+    """The build images and components the attestations agree on.
+
+    Two attestations claiming one key is a contradiction, not a merge."""
+    build_images: dict[str, str] = {}
+    components: dict[str, object] = {}
+    for document in documents:
+        job = document["job"]
+        key = f"{job}:{document['suite']}" if document.get("suite") else job
+        if document.get("image"):
+            if key in build_images:
+                raise AttestationError(f"two attestations claim the build image {key}")
+            build_images[key] = document["image"]
+        for name, value in document.get("components", {}).items():
+            if name in components:
+                raise AttestationError(f"two attestations claim the component {name}")
+            components[name] = value
+    return dict(sorted(build_images.items())), dict(sorted(components.items()))

--- a/.github/workflows/scripts/release_attestations.py
+++ b/.github/workflows/scripts/release_attestations.py
@@ -1,17 +1,25 @@
 """The builders' digest attestations, and the rules that make them evidence.
 
 The publish job downloads every `release-digests-*` artifact into one tree and
-reads provenance out of it. Anything running in a builder can call the Actions
-artifact API and upload an artifact of its own, so the tree is attacker-shaped:
-an extra artifact whose `digests.json` claims another job's identity would put
-forged image and component digests into `MANIFEST.json` while every asset digest
-still checked out.
+reads provenance out of it. Two things make that tree attacker-shaped. Anything
+running in a builder can call the Actions artifact API and upload an artifact
+of its own. And the artifact store is shared by every job in the run and
+writable with any job's runtime token: a builder that runs later can delete
+and re-upload an earlier builder's payload and its attestation as a matching
+pair, and every digest check still passes.
 
-So the attesting set is pinned rather than merely deduplicated. Exactly the
-expected artifacts must be present, each named for the slot it fills, each
+So an artifact is untrusted until it is bound to a job output. Each attesting
+job records the SHA-256 of its own `digests.json` as a job output; the Actions
+service stores that under the job that produced it, where no other job can
+rewrite it. The publish job reads those outputs through `toJSON(needs)`, and an
+attestation is used only after its bytes hash to the value its job recorded. A
+missing output is a refusal, named by slot.
+
+The attesting set is likewise pinned rather than merely deduplicated. Exactly
+the expected artifacts must be present, each named for the slot it fills, each
 holding one document, and each declaring the job that slot belongs to. An extra
-artifact, a missing one, a renamed one, or one claiming another job's name stops
-the release.
+artifact, a missing one, a renamed one, or one claiming another job's name
+stops the release.
 
 `release-assets.sh` owns the expected slot list and both of its readers load
 attestations through here, so the rule has one implementation.
@@ -19,40 +27,57 @@ attestations through here, so the rule has one implementation.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from pathlib import Path
 
 ARTIFACT_PREFIX = "release-digests-"
 DOCUMENT_NAME = "digests.json"
+DIGEST = re.compile(r"[0-9a-f]{64}")
 
 
 class AttestationError(Exception):
     """A statement the release must not be built on."""
 
 
-def expected_slots(spec: str) -> dict[str, str]:
-    """Parse `<slot><TAB><job>` lines into the expected attesting set."""
-    slots: dict[str, str] = {}
+def expected_slots(spec: str) -> dict[str, dict[str, str]]:
+    """Parse `<slot><TAB><job><TAB><output>` lines into the expected attesting set."""
+    slots: dict[str, dict[str, str]] = {}
     for line in spec.splitlines():
         if not line.strip():
             continue
-        slot, _, job = line.partition("\t")
-        if not slot or not job:
+        fields = line.split("\t")
+        if len(fields) != 3 or not all(fields):
             raise AttestationError(f"malformed expected attestation: {line!r}")
+        slot, job, output = fields
         if slot in slots:
             raise AttestationError(f"expected attestation slot declared twice: {slot}")
-        slots[slot] = job
+        slots[slot] = {"job": job, "output": output}
     if not slots:
         raise AttestationError("the expected attesting set is empty")
     return slots
 
 
-def load(root: str, spec: str) -> list[dict]:
+def read_object(path: Path, what: str) -> dict:
+    """A JSON object from `path`, or an attestation error naming `what`."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AttestationError(f"{what} is not valid JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise AttestationError(f"{what} is not a JSON object")
+    return document
+
+
+def load(root: str, spec: str, job_outputs: str) -> list[dict]:
     """Every attestation under `root`, or an error naming what is wrong.
 
+    `job_outputs` is the file the publish job wrote from `toJSON(needs)`.
     Returns the documents in slot order, each with a `slot` key added."""
     base = Path(root)
     expected = expected_slots(spec)
+    needs = read_object(Path(job_outputs), "the job outputs document")
 
     smuggled = [
         path
@@ -84,17 +109,43 @@ def load(root: str, spec: str) -> list[dict]:
 
     documents: list[dict] = []
     for slot in sorted(expected):
+        job, output = expected[slot]["job"], expected[slot]["output"]
         artifact = base / f"{ARTIFACT_PREFIX}{slot}"
         found = sorted(artifact.rglob(DOCUMENT_NAME))
         if len(found) != 1:
             raise AttestationError(
                 f"attestation {slot} holds {len(found)} {DOCUMENT_NAME} documents, expected one"
             )
-        document = json.loads(found[0].read_text(encoding="utf-8"))
-        if document.get("job") != expected[slot]:
+        # The binding comes first: nothing in the document is read until its
+        # bytes are the ones its job recorded.
+        entry = needs.get(job)
+        outputs = entry.get("outputs") if isinstance(entry, dict) else None
+        recorded = outputs.get(output) if isinstance(outputs, dict) else None
+        if not isinstance(recorded, str) or not DIGEST.fullmatch(recorded):
+            raise AttestationError(
+                f"attestation {slot} is not bound to a job output: {job} recorded no "
+                f"{output} digest, so its artifact cannot be trusted"
+            )
+        actual = hashlib.sha256(found[0].read_bytes()).hexdigest()
+        if actual != recorded:
+            raise AttestationError(
+                f"attestation {slot} is not the document {job} recorded as {output} "
+                f"({recorded} recorded, {actual} downloaded); the artifact changed "
+                "after its job finished"
+            )
+        document = read_object(found[0], f"attestation {slot}")
+        if document.get("job") != job:
             raise AttestationError(
                 f"attestation {slot} declares job {document.get('job')!r}, "
-                f"but that slot belongs to {expected[slot]!r}"
+                f"but that slot belongs to {job!r}"
+            )
+        assets = document.get("assets")
+        if not isinstance(assets, dict) or not all(
+            isinstance(name, str) and isinstance(digest, str) and DIGEST.fullmatch(digest)
+            for name, digest in assets.items()
+        ):
+            raise AttestationError(
+                f"attestation {slot} does not map asset names to SHA-256 digests"
             )
         document["slot"] = slot
         documents.append(document)

--- a/.github/workflows/scripts/release_attestations.py
+++ b/.github/workflows/scripts/release_attestations.py
@@ -114,11 +114,10 @@ def load(root: str, spec: str, job_outputs: str) -> list[dict]:
             f"{smuggled[0]} is a digest attestation inside a payload artifact"
         )
 
-    present = sorted(
-        path.name[len(ARTIFACT_PREFIX):]
-        for path in base.iterdir()
-        if path.is_dir() and path.name.startswith(ARTIFACT_PREFIX)
+    prefixed = _no_symlinks(
+        sorted(path for path in base.iterdir() if path.name.startswith(ARTIFACT_PREFIX))
     )
+    present = sorted(path.name[len(ARTIFACT_PREFIX):] for path in prefixed if path.is_dir())
     unexpected = sorted(set(present) - set(expected))
     if unexpected:
         raise AttestationError(
@@ -135,7 +134,7 @@ def load(root: str, spec: str, job_outputs: str) -> list[dict]:
     documents: list[dict] = []
     for slot in sorted(expected):
         job, output = expected[slot]["job"], expected[slot]["output"]
-        artifact = base / f"{ARTIFACT_PREFIX}{slot}"
+        artifact = _no_symlinks([base / f"{ARTIFACT_PREFIX}{slot}"])[0]
         found = _no_symlinks(sorted(artifact.rglob(DOCUMENT_NAME)))
         if len(found) != 1:
             raise AttestationError(

--- a/.github/workflows/scripts/release_attestations.py
+++ b/.github/workflows/scripts/release_attestations.py
@@ -72,6 +72,18 @@ def expected_slots(spec: str) -> dict[str, dict]:
     return slots
 
 
+def _no_symlinks(paths: list[Path]) -> list[Path]:
+    """`paths`, or an attestation error naming the first symlink found.
+
+    The artifact tree these are globbed from is attacker-controlled, and a
+    symlink lets a builder point a trusted-looking name at bytes it does not
+    own; the digest and JSON checks below never run against a followed link."""
+    for path in paths:
+        if path.is_symlink():
+            raise AttestationError(f"{path} is a symlink; refusing to trust it as an attestation")
+    return paths
+
+
 def read_object(path: Path, what: str) -> dict:
     """A JSON object from `path`, or an attestation error naming `what`."""
     try:
@@ -94,7 +106,7 @@ def load(root: str, spec: str, job_outputs: str) -> list[dict]:
 
     smuggled = [
         path
-        for path in sorted(base.rglob(DOCUMENT_NAME))
+        for path in _no_symlinks(sorted(base.rglob(DOCUMENT_NAME)))
         if not path.relative_to(base).parts[0].startswith(ARTIFACT_PREFIX)
     ]
     if smuggled:
@@ -124,7 +136,7 @@ def load(root: str, spec: str, job_outputs: str) -> list[dict]:
     for slot in sorted(expected):
         job, output = expected[slot]["job"], expected[slot]["output"]
         artifact = base / f"{ARTIFACT_PREFIX}{slot}"
-        found = sorted(artifact.rglob(DOCUMENT_NAME))
+        found = _no_symlinks(sorted(artifact.rglob(DOCUMENT_NAME)))
         if len(found) != 1:
             raise AttestationError(
                 f"attestation {slot} holds {len(found)} {DOCUMENT_NAME} documents, expected one"

--- a/.github/workflows/scripts/release_attestations.py
+++ b/.github/workflows/scripts/release_attestations.py
@@ -35,25 +35,38 @@ from pathlib import Path
 ARTIFACT_PREFIX = "release-digests-"
 DOCUMENT_NAME = "digests.json"
 DIGEST = re.compile(r"[0-9a-f]{64}")
+# Everything a document may carry. A field outside this set is a claim the
+# release has no rule for, and is refused rather than ignored.
+DOCUMENT_KEYS = {"job", "assets", "suite", "image", "components"}
 
 
 class AttestationError(Exception):
     """A statement the release must not be built on."""
 
 
-def expected_slots(spec: str) -> dict[str, dict[str, str]]:
-    """Parse `<slot><TAB><job><TAB><output>` lines into the expected attesting set."""
-    slots: dict[str, dict[str, str]] = {}
+def expected_slots(spec: str) -> dict[str, dict]:
+    """Parse the expected attesting set: one tab-separated line per slot,
+    `<slot> <job> <output> <suite> <image> <components>`, `-` for none.
+
+    An attestation is a self-report, so the suite, image and component names
+    each slot may declare are pinned here and held exactly."""
+    slots: dict[str, dict] = {}
     for line in spec.splitlines():
         if not line.strip():
             continue
         fields = line.split("\t")
-        if len(fields) != 3 or not all(fields):
+        if len(fields) != 6 or not all(fields):
             raise AttestationError(f"malformed expected attestation: {line!r}")
-        slot, job, output = fields
+        slot, job, output, suite, image, components = fields
         if slot in slots:
             raise AttestationError(f"expected attestation slot declared twice: {slot}")
-        slots[slot] = {"job": job, "output": output}
+        slots[slot] = {
+            "job": job,
+            "output": output,
+            "suite": None if suite == "-" else suite,
+            "image": None if image == "-" else image,
+            "components": [] if components == "-" else sorted(components.split(",")),
+        }
     if not slots:
         raise AttestationError("the expected attesting set is empty")
     return slots
@@ -138,6 +151,33 @@ def load(root: str, spec: str, job_outputs: str) -> list[dict]:
             raise AttestationError(
                 f"attestation {slot} declares job {document.get('job')!r}, "
                 f"but that slot belongs to {job!r}"
+            )
+        # The provenance a slot may declare is pinned; the document is held to
+        # it exactly, so a swapped image, an invented suite or an added
+        # component never reaches the manifest.
+        suite, image = expected[slot]["suite"], expected[slot]["image"]
+        components = expected[slot]["components"]
+        extra = sorted(set(document) - DOCUMENT_KEYS)
+        if extra:
+            raise AttestationError(
+                f"attestation {slot} declares keys the release does not record: {', '.join(extra)}"
+            )
+        if document.get("suite") != suite:
+            raise AttestationError(
+                f"attestation {slot} declares suite {document.get('suite')!r}, "
+                f"but that slot attests {suite!r}"
+            )
+        if document.get("image") != image:
+            raise AttestationError(
+                f"attestation {slot} declares the build image {document.get('image')!r}, "
+                f"but the release pins {image!r} for that slot"
+            )
+        if not isinstance(document.get("components", {}), dict):
+            raise AttestationError(f"attestation {slot} components is not a JSON object")
+        if sorted(document.get("components", {})) != components:
+            raise AttestationError(
+                f"attestation {slot} declares components {sorted(document.get('components', {}))}, "
+                f"but that slot may declare exactly {components}"
             )
         assets = document.get("assets")
         if not isinstance(assets, dict) or not all(

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2367,6 +2367,14 @@ release until it does.
   artifact of its own, so an extra attestation, a missing one, or one claiming
   another job's identity stops the release rather than being merged into the
   manifest.
+- Each slot declares exactly the provenance the release expects of it. An
+  attestation is a self-report, so the suite a slot fills, the image
+  `dist/release-matrix.json` pins for it, and the component names it may
+  carry are held by `publish` and compared exactly: a swapped image, an
+  invented suite, an added or missing component, or a field the release has no
+  rule for is refused. The matrix is an input publication cannot do without;
+  a matrix that cannot be read, or that names no Debian suite, stops the
+  release rather than shortening the allowlist.
 - Every attestation hashes to the output its job recorded. Artifacts are
   untrusted until bound to a job output: the artifact store is shared by every
   job in the run and writable with any job's runtime token, so a builder that

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2319,47 +2319,60 @@ record is a deliberate act, not the slip this gate exists to catch.
 
 ### Direct release publication
 
-A tag creates a **draft** release. `.github/workflows/release.yml` gives its
-builders `contents: read` and a deny-all workflow default; the `publish` job is
-the only job that may write the release, and it runs after every builder and
-validator. Publication is one flip of the draft flag, performed once.
+Builders in `.github/workflows/release.yml` produce workflow artifacts and
+never touch the release. They hold `contents: read` under a deny-all workflow
+default, and none of them may reference the publication credential or a
+release-writing step. `publish` is the only job that writes the release, the
+only one holding `contents: write` and `RELEASE_PAT`, and the only one that
+compiles nothing. It runs after every builder and validator; a tag has no
+release until it does.
 
-Before that flip, `publish` requires all of:
+`publish` requires all of, in order:
 
 - The tag exists, equals the tag the validated version derives, and points at
-  the commit the workflow built. A tag carrying a PGP or SSH signature must
-  verify. Publication reads the tag; it never creates, moves, or replaces one,
-  and it never sends a tag name or target commitish.
-- The draft carries exactly the canonical assets, no more and no fewer:
+  the commit the workflow built. An annotated tag is peeled on both sides. A
+  tag carrying a PGP or SSH signature must verify. Publication reads the tag;
+  it never creates, moves, or replaces one, and it never sends a tag name or
+  target commitish.
+- Exactly the canonical assets can be staged out of the builders' artifacts, no
+  more and no fewer:
 
-| Asset | Source |
-|-------|--------|
+| Asset | Produced by |
+|-------|-------------|
 | `facelock-x86_64-linux-gnu` | `build` |
 | `pam_facelock.so` | `build` |
 | `facelock-polkit-agent-x86_64-linux-gnu` | `build` |
 | `facelock_<debian-version>_<architecture>.deb`, one per published suite | `build-deb` |
 | `facelock-<rpm-version>-<rpm-release>.fc<N>.x86_64.rpm` | `build-rpm` |
+| `facelock-debuginfo-<rpm-version>-<rpm-release>.fc<N>.x86_64.rpm` | `build-rpm` |
+| `facelock-debugsource-<rpm-version>-<rpm-release>.fc<N>.x86_64.rpm` | `build-rpm` |
 | `apt-repo.tar.gz`, stable releases only | `publish-apt` |
 | `MANIFEST.json` | `publish` |
 
   The Debian and RPM names come from the validated version, Debian revision,
   and RPM counter, so an artifact built from any other identity has no
-  canonical name. Debug RPMs are built beside the payload, are inspected by no
-  validator, and are not published. A duplicate name, an unmatched asset, or a
-  second asset matching one canonical name each fail closed.
-- Every asset matches the SHA-256 its builder attested. Each builder writes a
-  `release-digests-*` artifact naming what it produced, the image it produced it
-  in, and the components it consumed. An asset attested by no builder, or by
-  two, fails closed.
-- The release is still an unpublished draft for this tag and channel. A rerun
-  after publication refuses rather than republishing.
+  canonical name and is never staged. `build-rpm` selects each of its three
+  packages by that identity and validates the payload package. A duplicate
+  name, an unmatched asset, a canonical name two artifacts claim, or a canonical
+  name no artifact provides each fail closed.
+- Every staged asset matches the SHA-256 its builder attested. Each builder
+  writes a `release-digests-*` artifact naming what it produced, the image it
+  produced it in, and the components it consumed. An asset attested by no
+  builder, or by two, fails closed.
+- The tag has no published release. A release already published is refused
+  before anything is written; the draft an interrupted run left behind is
+  reused. Re-running the workflow is therefore safe at any point.
 
-`MANIFEST.json` covers the whole release: the tag, version, commit, and
-prerelease flag; the source tarball URL and digest; the pinned build-image
-digests; the reviewed ONNX Runtime and Cargo-vendor component digests; and the
-name, size, and SHA-256 of every asset, itself included. It replaces the
-`SHA256SUMS` file that covered three binaries and was written before the
-packages existed. `facelock-bin` takes its per-binary checksums from it.
+The draft is created with those assets and the validated prerelease flag, and
+is flipped to published only after the draft's asset list is read back from the
+API and held to the allowlist a second time, `MANIFEST.json` now included.
+
+`MANIFEST.json` covers the release: the tag, version, commit, and prerelease
+flag; the source tarball URL and digest; the pinned build-image digests; the
+reviewed ONNX Runtime and Cargo-vendor component digests; and the name, size,
+and SHA-256 of every other asset. It replaces the `SHA256SUMS` file that
+covered three binaries and was written before the packages existed.
+`facelock-bin` takes its per-binary checksums from it.
 
 ### Debian source and binary package contract
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2361,7 +2361,9 @@ release until it does.
   builder, or by two, fails closed.
 - The tag has no published release. A release already published is refused
   before anything is written; the draft an interrupted run left behind is
-  reused. Re-running the workflow is therefore safe at any point.
+  reused, so a failed run can be re-run. An asset on that draft whose canonical
+  name changed in between, after a Debian revision or RPM counter bump, is
+  refused as unexpected and must be deleted from the draft by hand.
 
 The draft is created with those assets and the validated prerelease flag, and
 is flipped to published only after the draft's asset list is read back from the

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2367,6 +2367,19 @@ release until it does.
   artifact of its own, so an extra attestation, a missing one, or one claiming
   another job's identity stops the release rather than being merged into the
   manifest.
+- Every attestation hashes to the output its job recorded. Artifacts are
+  untrusted until bound to a job output: the artifact store is shared by every
+  job in the run and writable with any job's runtime token, so a builder that
+  runs later can replace an earlier builder's payload and attestation as a
+  matching pair. A job output is recorded by the Actions service under the job
+  that produced it and cannot be rewritten by another job. Each attesting job
+  records the SHA-256 of its `digests.json` as its `attestation` output
+  (`build-deb` records `attestation-<suite>`, each matrix leg setting only its
+  own); `publish` reads them through `toJSON(needs)`, passed by environment
+  and file rather than a shell line, and refuses by slot any attestation whose
+  bytes differ from the recorded value or whose job recorded no output, before
+  anything in the document is read. `verify-digests` and `manifest` share that
+  loader, so neither can skip it.
 - The tag has no published release. A release already published is refused
   before anything is written; the draft an interrupted run left behind is
   reused, so a failed run can be re-run. An asset on that draft whose canonical

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2317,6 +2317,50 @@ the artifacts are maintainer-trust records: preflight checks their shape and the
 binding to HEAD and the matrix, not that a real lane produced them. A forged
 record is a deliberate act, not the slip this gate exists to catch.
 
+### Direct release publication
+
+A tag creates a **draft** release. `.github/workflows/release.yml` gives its
+builders `contents: read` and a deny-all workflow default; the `publish` job is
+the only job that may write the release, and it runs after every builder and
+validator. Publication is one flip of the draft flag, performed once.
+
+Before that flip, `publish` requires all of:
+
+- The tag exists, equals the tag the validated version derives, and points at
+  the commit the workflow built. A tag carrying a PGP or SSH signature must
+  verify. Publication reads the tag; it never creates, moves, or replaces one,
+  and it never sends a tag name or target commitish.
+- The draft carries exactly the canonical assets, no more and no fewer:
+
+| Asset | Source |
+|-------|--------|
+| `facelock-x86_64-linux-gnu` | `build` |
+| `pam_facelock.so` | `build` |
+| `facelock-polkit-agent-x86_64-linux-gnu` | `build` |
+| `facelock_<debian-version>_<architecture>.deb`, one per published suite | `build-deb` |
+| `facelock-<rpm-version>-<rpm-release>.fc<N>.x86_64.rpm` | `build-rpm` |
+| `apt-repo.tar.gz`, stable releases only | `publish-apt` |
+| `MANIFEST.json` | `publish` |
+
+  The Debian and RPM names come from the validated version, Debian revision,
+  and RPM counter, so an artifact built from any other identity has no
+  canonical name. Debug RPMs are built beside the payload, are inspected by no
+  validator, and are not published. A duplicate name, an unmatched asset, or a
+  second asset matching one canonical name each fail closed.
+- Every asset matches the SHA-256 its builder attested. Each builder writes a
+  `release-digests-*` artifact naming what it produced, the image it produced it
+  in, and the components it consumed. An asset attested by no builder, or by
+  two, fails closed.
+- The release is still an unpublished draft for this tag and channel. A rerun
+  after publication refuses rather than republishing.
+
+`MANIFEST.json` covers the whole release: the tag, version, commit, and
+prerelease flag; the source tarball URL and digest; the pinned build-image
+digests; the reviewed ONNX Runtime and Cargo-vendor component digests; and the
+name, size, and SHA-256 of every asset, itself included. It replaces the
+`SHA256SUMS` file that covered three binaries and was written before the
+packages existed. `facelock-bin` takes its per-binary checksums from it.
+
 ### Debian source and binary package contract
 
 Trixie package builds use the official Trixie Backports `cargo` and `rustc`;

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2354,7 +2354,10 @@ release until it does.
   canonical name and is never staged. `build-rpm` selects each of its three
   packages by that identity and validates the payload package. A duplicate
   name, an unmatched asset, a canonical name two artifacts claim, or a canonical
-  name no artifact provides each fail closed.
+  name no artifact provides each fail closed. A canonically named file in an
+  artifact other than its producer's is a builder's extra output; the release
+  fails closed on it, and the failure names the remedy: fix the builder and
+  re-run all jobs, since re-running only the failed job keeps the artifact.
 - Every staged asset matches the SHA-256 its builder attested. Each builder
   writes a `release-digests-<slot>` artifact naming what it produced, the image
   it produced it in, and the components it consumed. An asset attested by no
@@ -2392,11 +2395,20 @@ release until it does.
   before anything is written; the draft an interrupted run left behind is
   reused, so a failed run can be re-run. An asset on that draft whose canonical
   name changed in between, after a Debian revision or RPM counter bump, is
-  refused as unexpected and must be deleted from the draft by hand.
+  refused as unexpected and must be deleted from the draft by hand. Two
+  releases for one tag are refused with the `gh api --method DELETE` command
+  that removes the extra one.
+
+The workflow runs once at a time per tag: `concurrency` is keyed by the ref
+and never cancels the run in progress, so a second run queues rather than
+passing the checks above beside the first. `build-nix` gates publication
+through its flake evaluation; its `nix build` step is advisory.
 
 The draft is created with those assets and the validated prerelease flag, and
 is flipped to published only after the draft's asset list is read back from the
-API and held to the allowlist a second time, `MANIFEST.json` now included.
+API and held to the allowlist a second time, `MANIFEST.json` now included, and
+each published asset's size, and digest where the API exposes one, is held to
+`MANIFEST.json`, the uploaded manifest to the file the job wrote.
 
 `MANIFEST.json` covers the release: the tag, version, commit, and prerelease
 flag; the source tarball URL and digest; the pinned build-image digests; the

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2356,9 +2356,17 @@ release until it does.
   name, an unmatched asset, a canonical name two artifacts claim, or a canonical
   name no artifact provides each fail closed.
 - Every staged asset matches the SHA-256 its builder attested. Each builder
-  writes a `release-digests-*` artifact naming what it produced, the image it
-  produced it in, and the components it consumed. An asset attested by no
-  builder, or by two, fails closed.
+  writes a `release-digests-<slot>` artifact naming what it produced, the image
+  it produced it in, and the components it consumed. An asset attested by no
+  builder, or by two, fails closed, and so does a build image or component two
+  attestations claim.
+- The attesting set is exactly the slots the workflow uploads: `build`,
+  `onnxruntime`, `cargo-vendor`, one `deb-<suite>` per published suite, `rpm`,
+  and, on a stable release, `apt`. Each artifact holds one document declaring
+  the job that slot belongs to. Anything running in a builder can upload an
+  artifact of its own, so an extra attestation, a missing one, or one claiming
+  another job's identity stops the release rather than being merged into the
+  manifest.
 - The tag has no published release. A release already published is refused
   before anything is written; the draft an interrupted run left behind is
   reused, so a failed run can be re-run. An asset on that draft whose canonical

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -85,14 +85,14 @@ git push origin main --tags
 The `.github/workflows/release.yml` workflow:
 
 1. Validates the tag against the checked-in release identity and target matrix
-2. Builds release binaries and creates the GitHub Release **as a draft**
+2. Builds release binaries and uploads them as workflow artifacts
 3. Prepares the pinned ONNX Runtime and lock-bound Cargo-vendor source
    components with their reviewed manifests and checksums
 4. Builds two suite-specific TPM-enabled `.deb` packages for trixie and resolute
 5. Builds the direct `.rpm` package in the pinned Fedora 44 container and validates contents
 6. Validates Nix flake evaluation
 7. Publishes stable releases to the signed, codenamed APT suites, and to the `main` and `legacy` compatibility suites until 0.3.0, if the APT signing secrets are configured
-8. Verifies the tag, validates the draft's assets, writes `MANIFEST.json`, and publishes the draft exactly once
+8. Verifies the tag, assembles and validates every asset, writes `MANIFEST.json`, and publishes the release exactly once
 9. Publishes stable releases to AUR — `facelock`, `facelock-bin`, and `facelock-git` — if `AUR_SSH_KEY` is configured
 10. Triggers GitHub Pages rebuild to include updated APT repo
 
@@ -105,40 +105,58 @@ which reacts to the release the `publish` job makes public in step 8. A draft
 raises no release event, so nothing downstream fires until validation passes.
 See the COPR section below.
 
-#### Draft until validated
+#### Builders build, publish publishes
 
-Step 2 creates the release with `draft: true`, and every later builder appends
-its artifact to that draft. Nothing is public, and no downstream automation has
-seen anything, until the `publish` job says so.
+No builder writes to the release. Each one uploads a workflow artifact and a
+digest attestation naming what it produced, the image it produced it in, and
+the components it consumed. Until the `publish` job runs, the tag has no
+release at all: nothing is public and no downstream automation has seen
+anything.
 
-`publish` is the only job that holds `contents: write`; every other job holds
-`contents: read`, and the workflow's own default is deny-all. It runs after
-every builder and validator, and it:
+That split is the point. Every builder compiles or packages code this project
+does not own, from every dependency's `build.rs` to `rpmbuild` and
+`dpkg-buildpackage`. A builder holding the publication credential is a builder
+that can publish whatever it likes. `publish` compiles nothing, so it is the
+only job that holds `RELEASE_PAT` and the only one with `contents: write`;
+every other job holds `contents: read`, and the workflow's own default is
+deny-all.
+
+`publish` runs after every builder and validator, and it:
 
 - verifies the tag exists, names the validated version, and points at the built
   commit; where the tag carries a signature it must verify. The job reads the
   tag and never creates, moves, or replaces one.
-- holds the draft's asset list to the canonical allowlist derived from the
-  validated version, Debian revision, and RPM counter. An extra asset, a
-  missing one, or two assets claiming one canonical name each stop the release.
-- holds every asset to the SHA-256 its builder attested, so an asset that
-  changed between its build and publication stops the release.
-- writes `MANIFEST.json` over every asset, plus the source tarball digest, the
-  pinned build-image digests, and the reviewed ONNX Runtime and Cargo-vendor
-  component digests. It replaces the three-binary `SHA256SUMS` file, which
-  covered a fraction of the release and was written before most of it existed.
-- flips the draft to published once. Re-running the job against a release that
-  is already published stops with an error rather than republishing.
+- stages exactly the canonical assets out of the builders' artifacts. The
+  allowlist is derived from the validated version, Debian revision, and RPM
+  counter, so an artifact built from another identity has no canonical name and
+  a file a builder added beside the one it was asked to produce is never
+  staged.
+- holds every staged asset to the SHA-256 its builder attested. An asset that
+  changed between its build and publication stops the release, as does one no
+  builder attested or one two builders claim.
+- creates the release as a draft carrying those assets, then writes
+  `MANIFEST.json` over them, plus the source tarball digest, the pinned
+  build-image digests, and the reviewed ONNX Runtime and Cargo-vendor component
+  digests. It replaces the three-binary `SHA256SUMS` file, which covered a
+  fraction of the release and was written before most of it existed.
+- reads the draft back from the API, holds it to the allowlist a last time, and
+  flips it to published once. A tag whose release is already published is
+  refused before anything is written, so re-running the workflow after a
+  failure is safe and re-running it after success changes nothing.
 
 Two consequences for the maintainer:
 
-- **`RELEASE_PAT` is required.** No builder can write the release with its own
-  token, so an unset secret fails the release at its first release write.
+- **`RELEASE_PAT` is required.** It is now the only credential that can write
+  the release, so an unset secret fails the `publish` job.
   `just release-preflight` checks for it.
 - **A signed tag must be verifiable on the runner.** Importing the maintainer's
   public key is release infrastructure tracked by #235; until it lands, an
   unsigned tag is accepted and a signed one that the runner cannot verify stops
   the release.
+
+Every job in the graph gates publication, `build-nix` included. A Nix
+evaluation failure means the release stays a draft; fix the flake and re-run
+the failed jobs, never tag again.
 
 `test/release-artifacts-contract.sh` (`just test-release-artifacts`) proves this
 shape by fixture and by mutation. The workflow itself runs only on a tag, so

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -142,7 +142,11 @@ deny-all.
 - reads the draft back from the API, holds it to the allowlist a last time, and
   flips it to published once. A tag whose release is already published is
   refused before anything is written, so re-running the workflow after a
-  failure is safe and re-running it after success changes nothing.
+  failure is safe and re-running it after success changes nothing. One case
+  needs a hand: if the Debian revision or RPM counter changed between runs, the
+  draft still carries the asset built under the old name, and the readback
+  refuses it. The failure names the file and the command that removes it,
+  `gh release delete-asset`.
 
 Two consequences for the maintainer:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -84,22 +84,65 @@ git push origin main --tags
 
 The `.github/workflows/release.yml` workflow:
 
-1. Builds release binaries and creates a GitHub Release
-2. Prepares the pinned ONNX Runtime and lock-bound Cargo-vendor source
+1. Validates the tag against the checked-in release identity and target matrix
+2. Builds release binaries and creates the GitHub Release **as a draft**
+3. Prepares the pinned ONNX Runtime and lock-bound Cargo-vendor source
    components with their reviewed manifests and checksums
-3. Builds two suite-specific TPM-enabled `.deb` packages for trixie and resolute
-4. Builds the direct `.rpm` package in the pinned Fedora 44 container and validates contents
-5. Validates Nix flake evaluation
-6. Publishes stable releases to AUR — `facelock`, `facelock-bin`, and `facelock-git` — if `AUR_SSH_KEY` is configured
+4. Builds two suite-specific TPM-enabled `.deb` packages for trixie and resolute
+5. Builds the direct `.rpm` package in the pinned Fedora 44 container and validates contents
+6. Validates Nix flake evaluation
 7. Publishes stable releases to the signed, codenamed APT suites, and to the `main` and `legacy` compatibility suites until 0.3.0, if the APT signing secrets are configured
-8. Triggers GitHub Pages rebuild to include updated APT repo
+8. Verifies the tag, validates the draft's assets, writes `MANIFEST.json`, and publishes the draft exactly once
+9. Publishes stable releases to AUR — `facelock`, `facelock-bin`, and `facelock-git` — if `AUR_SSH_KEY` is configured
+10. Triggers GitHub Pages rebuild to include updated APT repo
 
 Validated prerelease tags set the GitHub Release `prerelease` output and upload
 direct artifacts, but skip stable APT and all AUR publication. The workflow
 guards use the validated release identity rather than substring matching.
 
 COPR (Fedora) is **not** built by `release.yml`. It is handled by [Packit](https://packit.dev),
-which reacts to the GitHub Release published in step 1. See the COPR section below.
+which reacts to the release the `publish` job makes public in step 8. A draft
+raises no release event, so nothing downstream fires until validation passes.
+See the COPR section below.
+
+#### Draft until validated
+
+Step 2 creates the release with `draft: true`, and every later builder appends
+its artifact to that draft. Nothing is public, and no downstream automation has
+seen anything, until the `publish` job says so.
+
+`publish` is the only job that holds `contents: write`; every other job holds
+`contents: read`, and the workflow's own default is deny-all. It runs after
+every builder and validator, and it:
+
+- verifies the tag exists, names the validated version, and points at the built
+  commit; where the tag carries a signature it must verify. The job reads the
+  tag and never creates, moves, or replaces one.
+- holds the draft's asset list to the canonical allowlist derived from the
+  validated version, Debian revision, and RPM counter. An extra asset, a
+  missing one, or two assets claiming one canonical name each stop the release.
+- holds every asset to the SHA-256 its builder attested, so an asset that
+  changed between its build and publication stops the release.
+- writes `MANIFEST.json` over every asset, plus the source tarball digest, the
+  pinned build-image digests, and the reviewed ONNX Runtime and Cargo-vendor
+  component digests. It replaces the three-binary `SHA256SUMS` file, which
+  covered a fraction of the release and was written before most of it existed.
+- flips the draft to published once. Re-running the job against a release that
+  is already published stops with an error rather than republishing.
+
+Two consequences for the maintainer:
+
+- **`RELEASE_PAT` is required.** No builder can write the release with its own
+  token, so an unset secret fails the release at its first release write.
+  `just release-preflight` checks for it.
+- **A signed tag must be verifiable on the runner.** Importing the maintainer's
+  public key is release infrastructure tracked by #235; until it lands, an
+  unsigned tag is accepted and a signed one that the runner cannot verify stops
+  the release.
+
+`test/release-artifacts-contract.sh` (`just test-release-artifacts`) proves this
+shape by fixture and by mutation. The workflow itself runs only on a tag, so
+the gate never tags anything to test it.
 
 #### Debian package channels
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -149,26 +149,44 @@ deny-all.
   build-image digests, and the reviewed ONNX Runtime and Cargo-vendor component
   digests. It replaces the three-binary `SHA256SUMS` file, which covered a
   fraction of the release and was written before most of it existed.
-- reads the draft back from the API, holds it to the allowlist a last time, and
-  flips it to published once. A tag whose release is already published is
+- reads the draft back from the API, holds it to the allowlist a last time,
+  holds each published asset's size, and digest where the API exposes one, to
+  `MANIFEST.json` and the uploaded manifest to the file it wrote, and flips
+  the draft to published once. A tag whose release is already published is
   refused before anything is written, so re-running the workflow after a
-  failure is safe and re-running it after success changes nothing. One case
-  needs a hand: if the Debian revision or RPM counter changed between runs, the
-  draft still carries the asset built under the old name, and the readback
-  refuses it. The failure names the file and the command that removes it,
+  failure is safe; re-running it after success goes red by design, at
+  `verify-creatable`, with nothing written. One case needs a hand: if the
+  Debian revision or RPM counter changed between runs, the draft still carries
+  the asset built under the old name, and the readback refuses it. The
+  failure names the file and the command that removes it,
   `gh release delete-asset`.
+
+The workflow runs once at a time per tag (`concurrency` keyed by the ref,
+never cancelling the run in progress), so a re-run started while a run is
+inside `publish` queues behind it instead of racing it. Two drafts for one
+tag, which only a race could leave behind, are refused with the
+`gh api --method DELETE` command that removes the extra one.
+
+A builder's extra output fails the release closed: a canonically named file in
+an artifact the allowlist does not expect it from is refused at staging, and
+the failure says so. Re-running only the failed `publish` job keeps that
+artifact, so the remedy is fixing the builder and re-running all jobs.
 
 Two consequences for the maintainer:
 
 - **`RELEASE_PAT` is required.** It is now the only credential that can write
   the release, so an unset secret fails the `publish` job.
-  `just release-preflight` checks for it.
+  `just release-preflight` checks for it, and fails when it cannot check:
+  without `gh`, or unauthenticated, the check is reported as unchecked and
+  preflight does not pass.
 - **A signed tag must be verifiable on the runner.** Importing the maintainer's
   public key is release infrastructure tracked by #235; until it lands, an
   unsigned tag is accepted and a signed one that the runner cannot verify stops
   the release.
 
-Every job in the graph gates publication, `build-nix` included. A Nix
+Every job in the graph gates publication, `build-nix` included: its flake
+evaluation is deterministic against `flake.lock` and must pass, while its
+`nix build` step is advisory because the build depends on nixpkgs state. An
 evaluation failure means the release stays a draft; fix the flake and re-run
 the failed jobs, never tag again.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -171,6 +171,9 @@ A builder's extra output fails the release closed: a canonically named file in
 an artifact the allowlist does not expect it from is refused at staging, and
 the failure says so. Re-running only the failed `publish` job keeps that
 artifact, so the remedy is fixing the builder and re-running all jobs.
+A partial re-run of a single `build-deb` leg can similarly leave the other
+suite's attestation unbound (`attestation deb-<suite> is not bound to a job
+output`); the remedy is the same, re-run all jobs.
 
 Two consequences for the maintainer:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -134,6 +134,11 @@ deny-all.
 - holds every staged asset to the SHA-256 its builder attested. An asset that
   changed between its build and publication stops the release, as does one no
   builder attested or one two builders claim.
+- holds each attestation to the provenance its slot may declare: the suite,
+  the image `dist/release-matrix.json` pins, and the component names. A
+  builder cannot report another image or an extra component into
+  `MANIFEST.json`; a matrix the job cannot read stops the release instead of
+  shortening the allowlist.
 - trusts an attestation only once it hashes to the job output its builder
   recorded. Artifacts are shared, writable storage for every job in the run;
   a job output belongs to the job that wrote it. An attestation that was

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -134,6 +134,11 @@ deny-all.
 - holds every staged asset to the SHA-256 its builder attested. An asset that
   changed between its build and publication stops the release, as does one no
   builder attested or one two builders claim.
+- trusts an attestation only once it hashes to the job output its builder
+  recorded. Artifacts are shared, writable storage for every job in the run;
+  a job output belongs to the job that wrote it. An attestation that was
+  replaced after its job finished, or whose job recorded no output, is refused
+  by name.
 - creates the release as a draft carrying those assets, then writes
   `MANIFEST.json` over them, plus the source tarball digest, the pinned
   build-image digests, and the reviewed ONNX Runtime and Cargo-vendor component

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -175,7 +175,7 @@ production-ready in the justfile install recipe.
 
 | Format | Location | Status |
 |--------|----------|--------|
-| Raw binaries | `release.yml` | Released. Triggered on `v*` tags. Uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, SHA256SUMS to GitHub Releases. |
+| Raw binaries | `release.yml` | Released. Triggered on `v*` tags. Uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, and the polkit agent to a draft GitHub Release, published with `MANIFEST.json` once every asset validates. |
 | `.deb` | `release.yml` (build-deb job) | Released. Two suite-specific `.deb` artifacts for trixie and resolute are built in CI and uploaded to GitHub Release. Stable releases publish the matching signed APT suites at `tysmith.me/facelock/apt`. |
 | `.rpm` | `release.yml` (build-rpm job) | Released. Built in CI for the GitHub Release asset. COPR builds from source via Packit (`tyvsmith/facelock`) per `releasing.md`. |
 | PKGBUILD (Arch) | `dist/PKGBUILD` | Released. Automated via tag CI; published to AUR (`facelock`, `facelock-git`). References `facelock.install` file. `just test-arch-pkg` builds and installs it. |

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -175,7 +175,7 @@ production-ready in the justfile install recipe.
 
 | Format | Location | Status |
 |--------|----------|--------|
-| Raw binaries | `release.yml` | Released. Triggered on `v*` tags. Uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, and the polkit agent to a draft GitHub Release, published with `MANIFEST.json` once every asset validates. |
+| Raw binaries | `release.yml` | Released. Triggered on `v*` tags. `build` uploads `facelock-x86_64-linux-gnu`, `pam_facelock.so`, and the polkit agent as workflow artifacts; the `publish` job stages them into a draft GitHub Release and publishes it with `MANIFEST.json` once every asset validates. |
 | `.deb` | `release.yml` (build-deb job) | Released. Two suite-specific `.deb` artifacts for trixie and resolute are built in CI and uploaded to GitHub Release. Stable releases publish the matching signed APT suites at `tysmith.me/facelock/apt`. |
 | `.rpm` | `release.yml` (build-rpm job) | Released. Built in CI for the GitHub Release asset. COPR builds from source via Packit (`tyvsmith/facelock`) per `releasing.md`. |
 | PKGBUILD (Arch) | `dist/PKGBUILD` | Released. Automated via tag CI; published to AUR (`facelock`, `facelock-git`). References `facelock.install` file. `just test-arch-pkg` builds and installs it. |

--- a/justfile
+++ b/justfile
@@ -143,12 +143,13 @@ test-legacy-system-assets:
 test-cargo-vendor-contract:
     bash test/cargo-vendor-contract.sh
 
-# The builders create a draft; the publish job holds every asset to the
-# canonical allowlist and to the digest its builder attested, writes
-# MANIFEST.json over all of them, and only then flips the draft. The workflow
-# runs on a tag and nowhere else, so its shape is proven by fixture and by
-# mutation, never by tagging. Cheap enough for `just check`; a gate that runs
-# only in release-preflight is invisible until the day it matters.
+# The builders produce workflow artifacts and never touch the release; the
+# publish job stages exactly the canonical assets out of them, holds each to
+# the digest its builder attested, writes MANIFEST.json over all of them, and
+# only then flips the draft it created. The workflow runs on a tag and nowhere
+# else, so its shape is proven by fixture and by mutation, never by tagging.
+# Cheap enough for `just check`; a gate that runs only in release-preflight is
+# invisible until the day it matters.
 
 # Static contract: the release publishes exactly once, after validation
 test-release-artifacts:

--- a/justfile
+++ b/justfile
@@ -1573,6 +1573,11 @@ release-preflight tag='':
             echo "MISSING: RELEASE_PAT — the release workflow cannot write the release"
             failed=1
         fi
+    else
+        # A check that could not be made is not a pass: without the secret
+        # the tag builds and publishes nothing.
+        echo "UNCHECKED: RELEASE_PAT — gh is missing or not authenticated, so the secret cannot be verified"
+        failed=1
     fi
 
     if [ "$prerelease" -eq 1 ]; then

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ check-package-names-live:
     python3 test/check-package-names-live.py
 
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
-check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-v014-contract
+check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-v014-contract test-release-artifacts
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,
@@ -142,6 +142,17 @@ test-legacy-system-assets:
 # Prove the deterministic, exact Cargo source component used by Debian builds.
 test-cargo-vendor-contract:
     bash test/cargo-vendor-contract.sh
+
+# The builders create a draft; the publish job holds every asset to the
+# canonical allowlist and to the digest its builder attested, writes
+# MANIFEST.json over all of them, and only then flips the draft. The workflow
+# runs on a tag and nowhere else, so its shape is proven by fixture and by
+# mutation, never by tagging. Cheap enough for `just check`; a gate that runs
+# only in release-preflight is invisible until the day it matters.
+
+# Static contract: the release publishes exactly once, after validation
+test-release-artifacts:
+    bash test/release-artifacts-contract.sh
 
 # Static Debian source/metadata/release-consumer contract.
 test-deb-source-contract:
@@ -1517,6 +1528,7 @@ release-preflight tag='':
         test/release-version-contract.sh \
         test/check-release-matrix.py \
         test/check-live-release-channels.py \
+        test/release-artifacts-contract.sh \
         scripts/release-attestation.py \
         .github/workflows/release.yml; do
         if [ -f "$f" ]; then
@@ -1536,6 +1548,7 @@ release-preflight tag='':
     release_check_metadata "$TAG" || failed=1
     bash test/release-version-contract.sh || failed=1
     RELEASE_MATRIX_VERSION="$VERSION" python3 test/check-release-matrix.py || failed=1
+    bash test/release-artifacts-contract.sh || failed=1
     python3 test/check-live-release-channels.py || failed=1
     python3 test/check-live-release-channels.py --channel staging || failed=1
 
@@ -1547,6 +1560,19 @@ release-preflight tag='':
         echo "Mode: stable release — stable APT/AUR secrets and a production COPR release job are required"
     fi
     echo "Note: COPR builds are handled by Packit (.packit.yaml) — no secret required."
+
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        # Every builder holds contents: read, so RELEASE_PAT is the only
+        # credential that can create or publish the release -- for a prerelease
+        # as much as for a stable one. Without it the tag builds and publishes
+        # nothing (#235).
+        if gh secret list | grep -q '^RELEASE_PAT\b'; then
+            echo "OK: RELEASE_PAT configured"
+        else
+            echo "MISSING: RELEASE_PAT — the release workflow cannot write the release"
+            failed=1
+        fi
+    fi
 
     if [ "$prerelease" -eq 1 ]; then
         echo "SKIP: prerelease preflight does not access stable publication secrets"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -151,6 +151,16 @@ for need in "${builders[@]}"; do
 done
 requires_job publish build ||
     fail "the only job with a release step must depend on the builders it publishes"
+# The whole reason creation left `build`: the job that holds the publication
+# credential must not execute code this project does not own.
+publish_statements="$(printf '%s\n' "$publish_job" | grep -v '^[[:space:]]*#')"
+for toolchain in '(^|[^-A-Za-z])cargo[[:space:]]' 'rustup' 'rustc' 'rust-toolchain' \
+    'rpmbuild' 'dpkg-buildpackage' 'just[[:space:]]+build'; do
+    if printf '%s\n' "$publish_statements" | grep -Eq "$toolchain"; then
+        fail "the publish job must not compile or package anything ($toolchain); it holds the publication credential"
+    fi
+done
+
 printf '%s\n' "$publish_job" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
     fail "the publish job must create the GitHub release as a draft"
 # Literal workflow expressions; nothing here is a shell expansion.
@@ -314,7 +324,7 @@ assert_rejects "two assets claiming one canonical name" "more than one release a
 artifacts="$work/artifacts"
 build_artifacts() {
     rm -rf "$artifacts"
-    mkdir -p "$artifacts"/{release-binaries,release-deb-trixie,release-deb-resolute,release-rpm,release-apt-repo,release-digests-build}
+    mkdir -p "$artifacts"/{release-binaries,release-deb-trixie,release-deb-resolute,release-rpm,release-apt-repo}
     printf 'facelock\n' >"$artifacts/release-binaries/facelock-x86_64-linux-gnu"
     printf 'pam\n' >"$artifacts/release-binaries/pam_facelock.so"
     printf 'polkit\n' >"$artifacts/release-binaries/facelock-polkit-agent-x86_64-linux-gnu"
@@ -326,6 +336,21 @@ build_artifacts() {
     printf 'rpm\n' >"$artifacts/release-rpm/facelock-debuginfo-0.2.0-1.fc44.x86_64.rpm"
     printf 'rpm\n' >"$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
     printf 'apt\n' >"$artifacts/release-apt-repo/apt-repo.tar.gz"
+    # The real emitter, so the attestation shape is the one the builders write.
+    local attest="$repo_root/.github/workflows/scripts/attest-digests.sh"
+    "$attest" build "$artifacts/release-digests-build" \
+        "$artifacts"/release-binaries/* >/dev/null
+    "$attest" build-deb "$artifacts/release-digests-deb-trixie" \
+        --suite trixie --image 'docker.io/library/debian:13@sha256:34cd' \
+        "$artifacts"/release-deb-trixie/*.deb >/dev/null
+    "$attest" build-deb "$artifacts/release-digests-deb-resolute" \
+        --suite resolute --image 'docker.io/library/ubuntu:26.04@sha256:6df9' \
+        "$artifacts"/release-deb-resolute/*.deb >/dev/null
+    "$attest" build-rpm "$artifacts/release-digests-rpm" \
+        --image 'registry.fedoraproject.org/fedora:44@sha256:fc3e' \
+        "$artifacts"/release-rpm/*.rpm >/dev/null
+    "$attest" publish-apt "$artifacts/release-digests-apt" \
+        "$artifacts/release-apt-repo/apt-repo.tar.gz" >/dev/null
 }
 
 build_artifacts
@@ -340,6 +365,17 @@ diff <(canonical_assets | LC_ALL=C sort) <(LC_ALL=C sort "$work/actual-staged") 
 if [ -e "$staged/facelock_0.2.0-1~deb13u1_amd64.manifest" ]; then
     fail "staging copied a file the allowlist does not name"
 fi
+
+"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" >/dev/null ||
+    fail "the staged assets did not match the attestations in the same artifact tree"
+
+cat >"$artifacts/release-binaries/digests.json" <<'JSON'
+{"job": "download-ort", "image": "evil.example/img@sha256:dead", "assets": {},
+ "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
+JSON
+assert_rejects "payload artifact claiming another builder's provenance" "inside a payload artifact" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged"
+build_artifacts
 
 rm -f "$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
 assert_rejects "builder artifact missing a canonical asset" "no builder artifact provides" \
@@ -519,6 +555,20 @@ assert_rejects "release asset no builder attested" "attested by no builder" \
     verify-digests "$digests_dir" "$assets_dir" "$work/actual-unattested"
 rm -f "$assets_dir/extra-asset"
 
+# A payload artifact carrying an attestation is a builder claiming provenance
+# for work it did not do; the manifest would record its image and components.
+mkdir -p "$digests_dir/release-binaries"
+cat >"$digests_dir/release-binaries/digests.json" <<'JSON'
+{"job": "download-ort", "image": "evil.example/img@sha256:dead", "assets": {},
+ "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
+JSON
+assert_rejects "digest attestation planted in a payload artifact" "inside a payload artifact" \
+    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
+assert_rejects "forged provenance reaching the manifest" "inside a payload artifact" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$work/forged.json"
+rm -rf "$digests_dir/release-binaries"
+
 mkdir -p "$digests_dir/release-digests-duplicate"
 cat >"$digests_dir/release-digests-duplicate/digests.json" <<JSON
 {"job": "other", "assets": {"pam_facelock.so": "$(asset_digest pam_facelock.so)"}}
@@ -604,6 +654,9 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "builder writing the release directly" \
         's|^      - name: Upload the APT repository artifact$|      - name: Upload the APT repository artifact\n        # uses: softprops/action-gh-release@0000|' \
         "builders produce artifacts only"
+    assert_workflow_mutation_rejected "compiling in the publishing job" \
+        's|^      - name: Verify the maintainer tag$|      - name: Rebuild\n        run: cargo build --release\n\n      - name: Verify the maintainer tag|' \
+        "must not compile or package anything"
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "unverified tag" \
         '/\$HELPER verify-tag /d' \

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -172,8 +172,10 @@ printf '%s\n' "$publish_statements" | grep -Fq 'prerelease: ${{ needs.metadata.o
 # The helper invocations are matched with their trailing space so that a
 # `verify-digests-disabled` lookalike cannot stand in for the real call.
 # shellcheck disable=SC2016
-for step in '$HELPER verify-tag ' '$HELPER stage expected-assets' '$HELPER verify-digests ' \
-    '$HELPER verify-creatable ' 'PRERELEASE" final' 'MANIFEST.json' 'draft=false'; do
+for step in '$HELPER verify-tag ' '$HELPER stage expected-assets' \
+    '$HELPER verify-digests artifacts job-outputs.json ' '$HELPER verify-creatable ' \
+    'PRERELEASE" final' 'artifacts job-outputs.json assets actual-assets MANIFEST.json' \
+    'draft=false'; do
     printf '%s\n' "$publish_statements" | grep -Fq "$step" ||
         fail "the publish job must run ${step% } before the release becomes public"
 done
@@ -225,37 +227,101 @@ printf '%s\n' "$rpm_job" | grep -Fq 'steps.rpm.outputs.rpm' ||
     fail "build-rpm must validate the exact payload package the metadata names"
 
 # The attesting set the helper pins must be exactly the artifacts the workflow
-# uploads. Adding or removing an attesting job moves both or fails here.
+# uploads, each bound to a job output. The artifact store is writable by every
+# job in the run; a job output is recorded under the job that produced it and
+# no other job can rewrite it, so the output is what makes the artifact
+# evidence. Adding or removing an attesting job moves both or fails here.
+
+# The `outputs:` block of one job, as `key: expression` lines.
+job_outputs_block() {
+    job_body "$1" | awk '
+        /^    outputs:/ { inside = 1; next }
+        inside && /^    [A-Za-z]/ { inside = 0 }
+        inside && /^      [a-z]/ { sub(/^ +/, ""); print }
+    '
+}
+
+# The step of one job that runs attest-digests.sh, as its own lines.
+attest_step() {
+    job_body "$1" | awk '
+        function flush() { if (step ~ /attest-digests\.sh/) printf "%s", step; step = "" }
+        /^      - / { flush() }
+        { step = step $0 "\n" }
+        END { flush() }
+    '
+}
+
 workflow_attestations() {
-    local wf_job body attest_job slot suite
+    local wf_job body step attest_job name_pattern outputs line key expression suite slot
     for wf_job in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
         body="$(job_body "$wf_job")"
-        attest_job="$(printf '%s\n' "$body" |
+        step="$(attest_step "$wf_job")"
+        [ -n "$step" ] || fail "job $wf_job runs no attest-digests.sh step"
+        printf '%s\n' "$step" | grep -Eq '^        id: attest$' ||
+            fail "job $wf_job must give its attestation step the id attest so its digest can be a job output"
+        attest_job="$(printf '%s\n' "$step" |
             sed -n 's|.*attest-digests\.sh \([a-z-]*\) .*|\1|p' | head -1)"
-        slot="$(printf '%s\n' "$body" |
+        name_pattern="$(printf '%s\n' "$body" |
             sed -n 's/^ *name: release-digests-\(.*\)$/\1/p' | head -1)"
         [ -n "$attest_job" ] || fail "job $wf_job uploads no digest attestation"
-        [ -n "$slot" ] || fail "job $wf_job names no digest artifact"
-        # A literal workflow expression, and suite names carry no spaces.
-        # shellcheck disable=SC2016,SC2013
-        case "$slot" in
-            *'${{ matrix.suite }}'*)
-                for suite in $(sed -n 's/^deb-\(.*\)	.*/\1/p' <"$attesting_set"); do
-                    printf '%s\t%s\n' \
-                        "$(printf '%s' "$slot" | sed "s/\${{ matrix.suite }}/$suite/")" \
-                        "$attest_job"
-                done
-                ;;
-            *) printf '%s\t%s\n' "$slot" "$attest_job" ;;
-        esac
+        [ -n "$name_pattern" ] || fail "job $wf_job names no digest artifact"
+        outputs="$(job_outputs_block "$wf_job" | grep -E '^attestation' || true)"
+        [ -n "$outputs" ] ||
+            fail "job $wf_job declares no attestation output; publish cannot bind its artifact to the job"
+        while IFS= read -r line; do
+            key="${line%%:*}"
+            expression="${line#*: }"
+            # Literal workflow expressions; nothing here is a shell expansion.
+            # shellcheck disable=SC2016
+            case "$key" in
+                attestation)
+                    [ "$expression" = '${{ steps.attest.outputs.sha256 }}' ] ||
+                        fail "job $wf_job output $key must be the attest step's sha256, not: $expression"
+                    printf '%s\t%s\t%s\n' "$name_pattern" "$attest_job" "$key"
+                    ;;
+                attestation-*)
+                    # A matrix job shares one outputs map across its legs. Each
+                    # leg fills only its own suite's key and leaves the others
+                    # empty, and the service does not record an empty value over
+                    # a set one.
+                    suite="${key#attestation-}"
+                    [ "$expression" = "\${{ matrix.suite == '$suite' && steps.attest.outputs.sha256 || '' }}" ] ||
+                        fail "job $wf_job output $key must be set only by the $suite leg, not: $expression"
+                    slot="$(printf '%s' "$name_pattern" | sed "s/\${{ matrix.suite }}/$suite/")"
+                    [ "$slot" != "$name_pattern" ] ||
+                        fail "job $wf_job declares a per-suite output but its artifact name carries no matrix.suite"
+                    printf '%s\t%s\t%s\n' "$slot" "$attest_job" "$key"
+                    ;;
+            esac
+        done <<<"$outputs"
     done
 }
 
 attesting_set="$(mktemp "${TMPDIR:-/tmp}/facelock-attesting.XXXXXX")"
 "$helper_path" expected-attestations false >"$attesting_set"
 diff <(workflow_attestations | LC_ALL=C sort) <(LC_ALL=C sort "$attesting_set") >/dev/null ||
-    fail "the pinned attesting set differs from the release workflow's attest-digests.sh call sites: $(diff <(workflow_attestations | LC_ALL=C sort) <(LC_ALL=C sort "$attesting_set") | tr '\n' ' ')"
+    fail "the pinned attesting set differs from the release workflow's attestation outputs: $(diff <(workflow_attestations | LC_ALL=C sort) <(LC_ALL=C sort "$attesting_set") | tr '\n' ' ')"
 rm -f "$attesting_set"
+
+# The bindings reach the helper through the environment and a file, never
+# through a shell line: a builder controls the text of its own output.
+[ "$(printf '%s\n' "$publish_statements" | grep -Ec '^ +[A-Z_]+: \$\{\{ toJSON\(needs\) \}\}$' || true)" = 1 ] ||
+    fail "the publish job must pass toJSON(needs) to the helper through exactly one env value"
+[ "$(printf '%s\n' "$publish_job" | grep -c 'toJSON(needs)' || true)" = 1 ] ||
+    fail "toJSON(needs) may appear in the publish job only as that env value"
+# shellcheck disable=SC2016
+printf '%s\n' "$publish_statements" | grep -Eq '^ +printf .%s\\n. "\$JOB_OUTPUTS" >job-outputs\.json$' ||
+    fail "the publish job must write job-outputs.json from the JOB_OUTPUTS env value"
+# shellcheck disable=SC2016
+needs_lines="$(printf '%s\n' "$publish_job" | grep -F '${{ needs.' || true)"
+while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf '%s\n' "$line" | grep -Eq '^ +[A-Za-z_-]+: \$\{\{ needs\.[a-z-]+\.outputs\.[a-z-]+ \}\}$' ||
+        fail "a needs value reaches a shell line of the publish job; pass it through env: $line"
+    case "$line" in
+        *' run: '*) fail "a needs value is interpolated into a run line of the publish job: $line" ;;
+    esac
+done <<<"$needs_lines"
 
 # ------------------------------------------------------------- helper: shape
 
@@ -378,7 +444,11 @@ build_artifacts() {
     printf 'rpm\n' >"$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
     printf 'apt\n' >"$artifacts/release-apt-repo/apt-repo.tar.gz"
     # The real emitter, so the attestation shape is the one the builders write.
+    # It records each document's digest as a step output; capture that here
+    # rather than in the CI step's own GITHUB_OUTPUT.
     local attest="$repo_root/.github/workflows/scripts/attest-digests.sh"
+    local -x GITHUB_OUTPUT="$work/github-output"
+    : >"$GITHUB_OUTPUT"
     "$attest" build "$artifacts/release-digests-build" \
         "$artifacts"/release-binaries/* >/dev/null
     "$attest" build-deb "$artifacts/release-digests-deb-trixie" \
@@ -402,6 +472,38 @@ build_artifacts() {
         --component-archive "onnxruntime=$work/onnxruntime-bundle.tar.xz" >/dev/null
     "$attest" prepare-cargo-vendor "$artifacts/release-digests-cargo-vendor" \
         --component-archive "cargo-vendor=$work/cargo-vendor-bundle.tar.xz" >/dev/null
+    diff <(sed -n 's/^sha256=//p' "$GITHUB_OUTPUT" | LC_ALL=C sort) \
+        <(for document in "$artifacts"/release-digests-*/digests.json; do
+              sha256sum "$document" | cut -d' ' -f1
+          done | LC_ALL=C sort) >/dev/null ||
+        fail "attest-digests.sh did not record each document's SHA-256 as its step output"
+    job_outputs_for "$job_outputs"
+}
+
+# What toJSON(needs) hands the publish job: every needed job's result and
+# outputs, the attestation output being the SHA-256 of each digests.json as the
+# tree stands now. A slot with no artifact is a job that was skipped.
+job_outputs="$work/job-outputs.json"
+job_outputs_for() {
+    "$helper_path" expected-attestations "${2:-false}" >"$work/attesting-spec"
+    python3 - "$artifacts" "$1" "$work/attesting-spec" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+artifacts, output, spec = Path(sys.argv[1]), sys.argv[2], Path(sys.argv[3])
+needs = {"metadata": {"result": "success", "outputs": {"cargo-version": "0.2.0"}}}
+for line in spec.read_text(encoding="utf-8").splitlines():
+    slot, job, key = line.split("\t")[:3]
+    document = artifacts / f"release-digests-{slot}" / "digests.json"
+    entry = needs.setdefault(job, {"result": "success", "outputs": {}})
+    if document.is_file():
+        entry["outputs"][key] = hashlib.sha256(document.read_bytes()).hexdigest()
+    elif not entry["outputs"]:
+        entry["result"] = "skipped"
+Path(output).write_text(json.dumps(needs, indent=2) + "\n", encoding="utf-8")
+PY
 }
 
 build_artifacts
@@ -417,7 +519,7 @@ if [ -e "$staged/facelock_0.2.0-1~deb13u1_amd64.manifest" ]; then
     fail "staging copied a file the allowlist does not name"
 fi
 
-"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" false >/dev/null ||
+"$helper_path" verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false >/dev/null ||
     fail "the staged assets did not match the attestations in the same artifact tree"
 
 cat >"$artifacts/release-binaries/digests.json" <<'JSON'
@@ -425,7 +527,7 @@ cat >"$artifacts/release-binaries/digests.json" <<'JSON'
  "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
 JSON
 assert_rejects "payload artifact claiming another builder's provenance" "inside a payload artifact" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 build_artifacts
 
 rm -f "$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
@@ -576,18 +678,89 @@ echo "release artifacts case: rerun over a draft that already carries the manife
 attested_digest() { sha256sum "$staged/$1" | cut -d' ' -f1; }
 attestation() { printf '%s' "$artifacts/release-digests-$1/digests.json"; }
 
-"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" false >/dev/null ||
+"$helper_path" verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false >/dev/null ||
     fail "assets matching their builder attestations were rejected"
+
+# --- every attestation is bound to the output its job recorded
+
+# The artifact store is shared and writable by every job in the run: a later
+# builder can replace an earlier builder's payload and its attestation with a
+# matching pair. The job output is the one record another job cannot rewrite,
+# so an attestation whose bytes are not the ones its job recorded is refused
+# before anything in it is read.
+python3 - "$(attestation build)" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path))
+open(path, "w").write(json.dumps(document, indent=4) + "\n")
+PY
+assert_rejects "attestation replaced after its job recorded it" "is not the document build recorded" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+assert_rejects "replaced attestation reaching the manifest" "is not the document build recorded" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
+
+unbind() {
+    python3 - "$job_outputs" "$work/job-outputs-$1.json" "$1" "$2" <<'PY'
+import json, sys
+source, target, job, value = sys.argv[1:5]
+needs = json.load(open(source))
+if value == "-":
+    del needs[job]["outputs"]
+else:
+    needs[job]["outputs"]["attestation"] = value
+open(target, "w").write(json.dumps(needs) + "\n")
+PY
+    printf '%s' "$work/job-outputs-$1.json"
+}
+assert_rejects "attesting job that recorded no output" "not bound to a job output" \
+    verify-digests "$artifacts" "$(unbind build -)" "$staged" "$work/actual-staged" false
+assert_rejects "job output that is not a digest" "not bound to a job output" \
+    verify-digests "$artifacts" "$(unbind build-rpm abc)" "$staged" "$work/actual-staged" false
+printf '[]\n' >"$work/job-outputs-list.json"
+assert_rejects "job outputs that are not an object" "is not a JSON object" \
+    verify-digests "$artifacts" "$work/job-outputs-list.json" "$staged" "$work/actual-staged" false
+printf '{"build": \n' >"$work/job-outputs-broken.json"
+assert_rejects "job outputs that are not JSON" "is not valid JSON" \
+    verify-digests "$artifacts" "$work/job-outputs-broken.json" "$staged" "$work/actual-staged" false
+
+# A prerelease skips publish-apt, so its slot has no artifact and no output.
+rm -rf "$artifacts/release-digests-apt" "$artifacts/release-apt-repo"
+job_outputs_for "$work/job-outputs-prerelease.json" true
+"$helper_path" expected 0.2.0 1 1 true builders >"$work/expected-prerelease-builders"
+rm -rf "$work/assets-prerelease"
+"$helper_path" stage "$work/expected-prerelease-builders" "$artifacts" "$work/assets-prerelease" \
+    >"$work/actual-prerelease"
+"$helper_path" verify-digests "$artifacts" "$work/job-outputs-prerelease.json" \
+    "$work/assets-prerelease" "$work/actual-prerelease" true >/dev/null ||
+    fail "a prerelease with the APT publisher skipped was rejected"
+echo "release artifacts case: prerelease without the skipped APT publisher accepted"
+build_artifacts
+
+# A document that is not a JSON object is an attestation error, not a crash.
+printf '{\n' >"$(attestation rpm)"
+job_outputs_for "$job_outputs"
+assert_rejects "attestation that is not JSON" "is not valid JSON" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+assert_rejects "unparseable attestation reaching the manifest" "is not valid JSON" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
+printf '[]\n' >"$(attestation rpm)"
+job_outputs_for "$job_outputs"
+assert_rejects "attestation that is not a JSON object" "is not a JSON object" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
 
 printf 'tampered\n' >"$staged/pam_facelock.so"
 assert_rejects "release asset mutated after its builder attested it" "does not match the digest" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 cp "$artifacts/release-binaries/pam_facelock.so" "$staged/pam_facelock.so"
 
 printf 'smuggled\n' >"$staged/extra-asset"
 { cat "$work/actual-staged"; echo extra-asset; } >"$work/actual-unattested"
 assert_rejects "release asset no builder attested" "attested by no builder" \
-    verify-digests "$artifacts" "$staged" "$work/actual-unattested" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-unattested" false
 rm -f "$staged/extra-asset"
 
 # An attesting artifact may not claim an asset another one produced.
@@ -598,8 +771,9 @@ document = json.load(open(path))
 document["assets"]["pam_facelock.so"] = sys.argv[2]
 open(path, "w").write(json.dumps(document, indent=2) + "\n")
 PY
+job_outputs_for "$job_outputs"
 assert_rejects "two builders claiming one asset" "attested by more than one builder" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 build_artifacts
 
 # --- the attesting set is pinned, not merely deduplicated
@@ -613,10 +787,10 @@ cat >"$artifacts/release-digests-zzz-supplychain/digests.json" <<'JSON'
  "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
 JSON
 assert_rejects "extra digest artifact forging another job's provenance" "no builder attests as" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 assert_rejects "extra digest artifact reaching the manifest" "no builder attests as" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
 build_artifacts
 
 python3 - "$(attestation build)" <<'PY'
@@ -626,24 +800,25 @@ document = json.load(open(path))
 document["job"] = "build-deb"
 open(path, "w").write(json.dumps(document, indent=2) + "\n")
 PY
+job_outputs_for "$job_outputs"
 assert_rejects "attestation declaring a job that is not its slot" "belongs to" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 build_artifacts
 
 rm -rf "$artifacts/release-digests-apt"
 assert_rejects "attesting job that did not attest" "no attestation from" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 build_artifacts
 
 mkdir -p "$artifacts/release-digests-rpm/second"
 cp "$(attestation rpm)" "$artifacts/release-digests-rpm/second/digests.json"
 assert_rejects "attesting artifact holding two documents" "documents, expected one" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 build_artifacts
 
 # A prerelease publishes no APT repository, so publish-apt attests nothing.
 assert_rejects "stable attestation set on a prerelease" "no builder attests as" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" true
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" true
 
 # A payload artifact carrying an attestation is a builder claiming provenance
 # for work it did not do; the manifest would record its image and components.
@@ -652,10 +827,10 @@ cat >"$artifacts/release-binaries/digests.json" <<'JSON'
  "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
 JSON
 assert_rejects "digest attestation planted in a payload artifact" "inside a payload artifact" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
 assert_rejects "forged provenance reaching the manifest" "inside a payload artifact" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
 build_artifacts
 
 # Two attestations claiming one provenance key is a contradiction, not a merge.
@@ -666,16 +841,17 @@ document = json.load(open(path))
 document.setdefault("components", {})["onnxruntime"] = {"version": "666"}
 open(path, "w").write(json.dumps(document, indent=2) + "\n")
 PY
+job_outputs_for "$job_outputs"
 assert_rejects "two attestations claiming one component" "claim the component" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
 build_artifacts
 
 # --- the publication manifest
 
 manifest="$work/MANIFEST.json"
 "$helper_path" manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$manifest" >/dev/null ||
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$manifest" >/dev/null ||
     fail "manifest generation failed for a complete release"
 
 python3 - "$manifest" "$(attested_digest facelock-x86_64-linux-gnu)" <<'PY' ||
@@ -699,7 +875,7 @@ PY
 rm -f "$staged/pam_facelock.so"
 assert_rejects "manifest over an asset that was never staged" "is not present" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$manifest"
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$manifest"
 cp "$artifacts/release-binaries/pam_facelock.so" "$staged/pam_facelock.so"
 # ------------------------------------------------------------------ mutations
 
@@ -732,8 +908,14 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         's/^    unexpected = sorted\(set\(present\) - set\(expected\)\)$/    unexpected = []/' \
         "extra digest artifact forging another job's provenance: helper accepted"
     assert_loader_mutation_rejected "attestations trusted to name their own job" \
-        's/^        if document.get\("job"\) != expected\[slot\]:$/        if False:/' \
+        's/^        if document.get\("job"\) != job:$/        if False:/' \
         "attestation declaring a job that is not its slot: helper accepted"
+    assert_loader_mutation_rejected "attestations not held to their job outputs" \
+        's/^        if actual != recorded:$/        if False:/' \
+        "attestation replaced after its job recorded it: helper accepted"
+    assert_loader_mutation_rejected "a missing job output tolerated" \
+        's/^        if not isinstance\(recorded, str\) or not DIGEST.fullmatch\(recorded\):$/        if False:/' \
+        "attesting job that recorded no output"
 
     assert_workflow_mutation_rejected() {
         local context="$1" expression="$2" needle="$3"
@@ -784,6 +966,18 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "no revalidation before the flip" \
         's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \
         'must run PRERELEASE" final'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "attestation left unbound to its job" \
+        '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \
+        "declares no attestation output"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "one suite of the matrix left unbound" \
+        '/^      attestation-resolute: /d' \
+        "differs from the release workflow's attestation outputs"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "job outputs not passed through env" \
+        's/^          JOB_OUTPUTS: \$\{\{ toJSON\(needs\) \}\}$/          JOB_OUTPUTS: fixed/' \
+        "through exactly one env value"
     assert_workflow_mutation_rejected "pages rebuild before publication" \
         's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
         "trigger-pages must run after the release is published"
@@ -795,6 +989,20 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
         "publishing must not send a tag or target commitish"
 fi
+
+# The helper's Python runs from whatever directory the workflow is in; a module
+# planted there must not shadow the standard library.
+case "$helper_path" in
+    /*) helper_abs="$helper_path" ;;
+    *) helper_abs="$repo_root/$helper_path" ;;
+esac
+mkdir -p "$work/shadow"
+printf 'raise SystemExit("json shadowed from the working directory")\n' >"$work/shadow/json.py"
+[ "$(cd "$work/shadow" && "$helper_abs" release-id "$work/releases-listing.json" v0.2.0)" = 42 ] ||
+    fail "the release asset helper imported a module from its working directory"
+(cd "$work/shadow" && "$helper_abs" expected 0.2.0 1 1 false final >/dev/null) ||
+    fail "the release asset helper imported a module from its working directory"
+echo "release artifacts case: working-directory module shadowing ignored"
 
 # Loading the attestation module must not leave bytecode in the checkout: the
 # recipes that demand a clean tree run right after this gate.

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -684,6 +684,29 @@ assert_rejects "symlink to a directory under artifacts" "refusing to stage a sym
     stage "$builders_expected" "$artifacts" "$work/assets-symlink-dir"
 build_artifacts
 
+# A whole payload artifact directory replaced by a symlink is still caught by
+# the same walk: every entry it yields is checked with is_symlink() before
+# is_file(), so the directory itself is refused before its target is ever
+# read as though it were a builder's own output.
+rm -rf "$artifacts/release-binaries"
+ln -s "$artifacts/release-rpm" "$artifacts/release-binaries"
+assert_rejects "symlinked payload artifact directory" "refusing to stage a symlink" \
+    stage "$builders_expected" "$artifacts" "$work/assets-symlink-payload-dir"
+build_artifacts
+
+# A `release-digests-*` slot itself can be a symlink, pointed at a directory
+# outside the downloaded attestation tree entirely. Path.is_dir() and
+# Path.rglob() both follow it, so the slot must be refused as a symlink
+# before either ever runs, not merely once something under it is inspected.
+rm -rf "$artifacts/release-digests-rpm"
+ln -s "$artifacts/release-rpm" "$artifacts/release-digests-rpm"
+assert_rejects "symlinked attestation slot directory" "is a symlink" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+assert_rejects "symlinked attestation slot directory reaching the manifest" "is a symlink" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
+
 # --- the maintainer tag
 
 fixture_repo="$work/repo"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -10,6 +10,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolved before the cd below: the mutation re-invocations pass this to bash
+# explicitly, so they still find this script regardless of the directory (the
+# repo root, or test/) the outer run started from.
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 cd "$repo_root"
 workflow_path="${FACELOCK_RELEASE_WORKFLOW:-.github/workflows/release.yml}"
 helper_path="${FACELOCK_RELEASE_ASSETS:-.github/workflows/scripts/release-assets.sh}"
@@ -319,7 +323,7 @@ workflow_attestations() {
             sed -n 's/^ *name: release-digests-\(.*\)$/\1/p' | head -1)"
         [ -n "$attest_job" ] || fail "job $wf_job uploads no digest attestation"
         [ -n "$name_pattern" ] || fail "job $wf_job names no digest artifact"
-        suite_arg="$(printf '%s\n' "$call" | sed -n "s/.*--suite '\([^']*\)'.*/\1/p")"
+        suite_arg="$(printf '%s\n' "$call" | sed -n "s/.*--suite ['\"]\([^'\"]*\)['\"].*/\1/p")"
         image_arg="$(printf '%s\n' "$call" | sed -n "s/.*--image ['\"]\([^'\"]*\)['\"].*/\1/p")"
         components="$(printf '%s\n' "$call" | grep -oE -- '--component(-archive)? [a-z-]+=' |
             sed 's/.* //; s/=$//' | LC_ALL=C sort -u | paste -sd, -)"
@@ -661,6 +665,23 @@ cp "$artifacts/release-binaries/pam_facelock.so" "$artifacts/release-rpm/pam_fac
 # failure says what to do: re-running only the failed job keeps the artifact.
 assert_rejects "two builders providing one canonical asset" "fix the builder and re-run all jobs" \
     stage "$builders_expected" "$artifacts" "$work/assets-ambiguous"
+build_artifacts
+
+# A symlink lets a builder point a canonical name at bytes it does not own,
+# including bytes outside the artifact tree entirely; staging must refuse it
+# rather than follow it and copy the link target.
+printf 'forged\n' >"$work/forged-pam-facelock.so"
+rm -f "$artifacts/release-binaries/pam_facelock.so"
+ln -s "$work/forged-pam-facelock.so" "$artifacts/release-binaries/pam_facelock.so"
+assert_rejects "symlink standing in for a canonical asset" "refusing to stage a symlink" \
+    stage "$builders_expected" "$artifacts" "$work/assets-symlink"
+build_artifacts
+
+# A symlink to a directory is still a symlink; the walk must refuse it on
+# sight rather than recurse through it looking for more files to stage.
+ln -s "$artifacts/release-rpm" "$artifacts/release-binaries/sneaky-dir"
+assert_rejects "symlink to a directory under artifacts" "refusing to stage a symlink" \
+    stage "$builders_expected" "$artifacts" "$work/assets-symlink-dir"
 build_artifacts
 
 # --- the maintainer tag
@@ -1149,7 +1170,7 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
             fail "$context mutation did not change the attestation loader"
         fi
         local output
-        if output="$(FACELOCK_RELEASE_ATTESTATIONS="$mutant" bash "$0" 2>&1)"; then
+        if output="$(FACELOCK_RELEASE_ATTESTATIONS="$mutant" bash "$self" 2>&1)"; then
             fail "release artifacts contract accepted $context"
         fi
         printf '%s\n' "$output" | grep -Fq "$needle" ||
@@ -1193,7 +1214,7 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
             fail "$context mutation did not change the release asset helper"
         fi
         local output
-        if output="$(FACELOCK_RELEASE_ASSETS="$mutant" bash "$0" 2>&1)"; then
+        if output="$(FACELOCK_RELEASE_ASSETS="$mutant" bash "$self" 2>&1)"; then
             fail "release artifacts contract accepted $context"
         fi
         printf '%s\n' "$output" | grep -Fq "$needle" ||
@@ -1218,7 +1239,7 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
             fail "$context mutation did not change the workflow"
         fi
         local output
-        if output="$(FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$0" 2>&1)"; then
+        if output="$(FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$self" 2>&1)"; then
             fail "release artifacts contract accepted $context"
         fi
         printf '%s\n' "$output" | grep -Fq "$needle" ||
@@ -1297,6 +1318,19 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "tag rewritten at publication" \
         's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
         "publishing must not send a tag or target commitish"
+
+    # Quote style is not semantics: a double-quoted --suite value must parse
+    # the same as the single-quoted one the workflow uses today, so extraction
+    # cannot silently go blind the day someone swaps the quoting.
+    suite_double_quoted="$mutation_root/release-suite-double-quoted.yml"
+    sed -E 's/--suite .(\$\{\{ matrix\.suite \}\})./--suite "\1"/' \
+        "$workflow_path" >"$suite_double_quoted"
+    cmp -s "$workflow_path" "$suite_double_quoted" &&
+        fail "double-quoted suite mutation did not change the workflow"
+    if ! output="$(FACELOCK_RELEASE_WORKFLOW="$suite_double_quoted" bash "$self" 2>&1)"; then
+        fail "release artifacts contract rejected a double-quoted --suite value: $output"
+    fi
+    echo "release artifacts mutation: double-quoted --suite value accepted"
 fi
 
 # The helper's Python runs from whatever directory the workflow is in; a module

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -251,20 +251,39 @@ attest_step() {
     '
 }
 
+# The image one matrix leg builds in, from the job's `include:` list.
+matrix_image() {
+    job_body "$1" | awk -v suite="$2" '
+        /^          - suite: / { current = $3 }
+        current == suite && /^            image: / { sub(/^            image: /, ""); print; exit }
+    '
+}
+
+# Each slot's expected provenance is what its attest-digests.sh call site
+# declares: the suite, the image, and the component names. The helper pins the
+# same values from dist/release-matrix.json, so a slot cannot report an image
+# or a component the release did not build with.
 workflow_attestations() {
-    local wf_job body step attest_job name_pattern outputs line key expression suite slot
+    local wf_job body step call attest_job name_pattern outputs line key expression suite slot
+    local suite_arg image_arg components image
     for wf_job in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
         body="$(job_body "$wf_job")"
         step="$(attest_step "$wf_job")"
         [ -n "$step" ] || fail "job $wf_job runs no attest-digests.sh step"
         printf '%s\n' "$step" | grep -Eq '^        id: attest$' ||
             fail "job $wf_job must give its attestation step the id attest so its digest can be a job output"
-        attest_job="$(printf '%s\n' "$step" |
+        # The call with its line continuations joined.
+        call="$(printf '%s\n' "$step" | sed -e ':a' -e '/\\$/N; s/\\\n//; ta' | grep -F 'attest-digests.sh')"
+        attest_job="$(printf '%s\n' "$call" |
             sed -n 's|.*attest-digests\.sh \([a-z-]*\) .*|\1|p' | head -1)"
         name_pattern="$(printf '%s\n' "$body" |
             sed -n 's/^ *name: release-digests-\(.*\)$/\1/p' | head -1)"
         [ -n "$attest_job" ] || fail "job $wf_job uploads no digest attestation"
         [ -n "$name_pattern" ] || fail "job $wf_job names no digest artifact"
+        suite_arg="$(printf '%s\n' "$call" | sed -n "s/.*--suite '\([^']*\)'.*/\1/p")"
+        image_arg="$(printf '%s\n' "$call" | sed -n "s/.*--image ['\"]\([^'\"]*\)['\"].*/\1/p")"
+        components="$(printf '%s\n' "$call" | grep -oE -- '--component(-archive)? [a-z-]+=' |
+            sed 's/.* //; s/=$//' | LC_ALL=C sort -u | paste -sd, -)"
         outputs="$(job_outputs_block "$wf_job" | grep -E '^attestation' || true)"
         [ -n "$outputs" ] ||
             fail "job $wf_job declares no attestation output; publish cannot bind its artifact to the job"
@@ -277,7 +296,13 @@ workflow_attestations() {
                 attestation)
                     [ "$expression" = '${{ steps.attest.outputs.sha256 }}' ] ||
                         fail "job $wf_job output $key must be the attest step's sha256, not: $expression"
-                    printf '%s\t%s\t%s\n' "$name_pattern" "$attest_job" "$key"
+                    [ -z "$suite_arg" ] || fail "job $wf_job attests a suite but is not a matrix job"
+                    image="$image_arg"
+                    if [ "$image" = '$BUILD_IMAGE' ]; then
+                        image="$(printf '%s\n' "$body" | awk '/^      BUILD_IMAGE: /{ sub(/^      BUILD_IMAGE: /, ""); print; exit }')"
+                    fi
+                    printf '%s\t%s\t%s\t-\t%s\t%s\n' "$name_pattern" "$attest_job" "$key" \
+                        "${image:--}" "${components:--}"
                     ;;
                 attestation-*)
                     # A matrix job shares one outputs map across its legs. Each
@@ -290,7 +315,14 @@ workflow_attestations() {
                     slot="$(printf '%s' "$name_pattern" | sed "s/\${{ matrix.suite }}/$suite/")"
                     [ "$slot" != "$name_pattern" ] ||
                         fail "job $wf_job declares a per-suite output but its artifact name carries no matrix.suite"
-                    printf '%s\t%s\t%s\n' "$slot" "$attest_job" "$key"
+                    [ "$suite_arg" = '${{ matrix.suite }}' ] ||
+                        fail "job $wf_job must attest the matrix suite, not: $suite_arg"
+                    [ "$image_arg" = '${{ matrix.image }}' ] ||
+                        fail "job $wf_job must attest the matrix image, not: $image_arg"
+                    image="$(matrix_image "$wf_job" "$suite")"
+                    [ -n "$image" ] || fail "job $wf_job pins no image for the $suite leg"
+                    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$slot" "$attest_job" "$key" "$suite" \
+                        "$image" "${components:--}"
                     ;;
             esac
         done <<<"$outputs"
@@ -390,6 +422,24 @@ if grep -q 'MANIFEST' "$builders_expected"; then
     fail "the builder-stage allowlist must not expect the manifest the publish job adds"
 fi
 
+# --- the release matrix is an input the allowlist cannot do without
+
+# A matrix that cannot be read must stop the allowlist, not shorten it: with
+# the Debian entries silently dropped, every other check would still pass.
+printf '{"apt_suites": \n' >"$work/matrix-broken.json"
+python3 - "$work/matrix-compat-only.json" <<'PY'
+import json, sys
+json.dump({"apt_suites": {"compat": {"main": {"source": "trixie"}}}, "platforms": []}, open(sys.argv[1], "w"))
+PY
+FACELOCK_RELEASE_MATRIX="$work/matrix-broken.json" assert_rejects "allowlist from an unreadable matrix" \
+    "cannot read the Debian suites" expected 0.2.0 1 1 false final
+FACELOCK_RELEASE_MATRIX="$work/matrix-compat-only.json" assert_rejects "allowlist from a matrix with no suite" \
+    "names no Debian suite" expected 0.2.0 1 1 false final
+FACELOCK_RELEASE_MATRIX="$work/matrix-broken.json" assert_rejects "attesting set from an unreadable matrix" \
+    "cannot read the Debian suites" expected-attestations false
+FACELOCK_RELEASE_MATRIX="$work/matrix-compat-only.json" assert_rejects "attesting set from a matrix with no suite" \
+    "names no Debian suite" expected-attestations false
+
 # --- allowlist enforcement
 
 canonical_assets() {
@@ -429,6 +479,12 @@ assert_rejects "two assets claiming one canonical name" "more than one release a
 # --- staging out of the builders' artifacts
 
 artifacts="$work/artifacts"
+# The image the release pins for one slot, so the fixture attests what the
+# loader now requires.
+"$helper_path" expected-attestations false >"$work/attesting-spec-stable"
+image_of() {
+    awk -F'\t' -v slot="$1" '$1 == slot { print $5 }' "$work/attesting-spec-stable"
+}
 build_artifacts() {
     rm -rf "$artifacts"
     mkdir -p "$artifacts"/{release-binaries,release-deb-trixie,release-deb-resolute,release-rpm,release-apt-repo}
@@ -452,13 +508,13 @@ build_artifacts() {
     "$attest" build "$artifacts/release-digests-build" \
         "$artifacts"/release-binaries/* >/dev/null
     "$attest" build-deb "$artifacts/release-digests-deb-trixie" \
-        --suite trixie --image 'docker.io/library/debian:13@sha256:34cd' \
+        --suite trixie --image "$(image_of deb-trixie)" \
         "$artifacts"/release-deb-trixie/*.deb >/dev/null
     "$attest" build-deb "$artifacts/release-digests-deb-resolute" \
-        --suite resolute --image 'docker.io/library/ubuntu:26.04@sha256:6df9' \
+        --suite resolute --image "$(image_of deb-resolute)" \
         "$artifacts"/release-deb-resolute/*.deb >/dev/null
     "$attest" build-rpm "$artifacts/release-digests-rpm" \
-        --image 'registry.fedoraproject.org/fedora:44@sha256:fc3e' \
+        --image "$(image_of rpm)" \
         "$artifacts"/release-rpm/*.rpm >/dev/null
     "$attest" publish-apt "$artifacts/release-digests-apt" \
         "$artifacts/release-apt-repo/apt-repo.tar.gz" >/dev/null
@@ -833,7 +889,60 @@ assert_rejects "forged provenance reaching the manifest" "inside a payload artif
     tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
 build_artifacts
 
-# Two attestations claiming one provenance key is a contradiction, not a merge.
+# --- each slot declares exactly the provenance the release expects of it
+
+# An attestation is a self-report. Without a pin, a compromised builder in its
+# own slot could record another image, invent a suite so the pinned image is
+# never recorded under its key, or add component keys the release never built
+# with; the manifest would carry all of it with every asset digest intact.
+restate() {
+    python3 - "$(attestation "$1")" "$2" <<'PY'
+import json, sys
+path, change = sys.argv[1], json.loads(sys.argv[2])
+document = json.load(open(path))
+for key, value in change.items():
+    if value is None:
+        document.pop(key, None)
+    else:
+        document[key] = value
+open(path, "w").write(json.dumps(document, indent=2) + "\n")
+PY
+    job_outputs_for "$job_outputs"
+}
+restate rpm '{"image": "registry.fedoraproject.org/fedora:44@sha256:dead"}'
+assert_rejects "attestation swapping its build image" "declares the build image" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+assert_rejects "swapped build image reaching the manifest" "declares the build image" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
+restate rpm '{"suite": "reproducible"}'
+assert_rejects "attestation inventing a suite" "declares suite" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+restate deb-trixie '{"suite": "resolute"}'
+assert_rejects "attestation claiming another suite" "declares suite" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+restate rpm '{"components": {"sbom": {"sha256": "forged"}}}'
+assert_rejects "attestation adding a component" "declares components" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+restate onnxruntime '{"components": null}'
+assert_rejects "attestation omitting its component" "declares components" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+restate build '{"image": "docker.io/library/ubuntu:24.04@sha256:dead"}'
+assert_rejects "attestation declaring an image its slot has none of" "declares the build image" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+restate build '{"toolchain": {"rustc": "1.95.0"}}'
+assert_rejects "attestation declaring a field the release does not record" "declares keys" \
+    verify-digests "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" false
+build_artifacts
+
+# Two attestations claiming one provenance key is a contradiction, not a merge;
+# the per-slot pin refuses the second claim before the collision is reached.
 python3 - "$(attestation cargo-vendor)" <<'PY'
 import json, sys
 path = sys.argv[1]
@@ -842,7 +951,7 @@ document.setdefault("components", {})["onnxruntime"] = {"version": "666"}
 open(path, "w").write(json.dumps(document, indent=2) + "\n")
 PY
 job_outputs_for "$job_outputs"
-assert_rejects "two attestations claiming one component" "claim the component" \
+assert_rejects "two attestations claiming one component" "declares components" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
     tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$work/forged.json"
 build_artifacts
@@ -916,6 +1025,45 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_loader_mutation_rejected "a missing job output tolerated" \
         's/^        if not isinstance\(recorded, str\) or not DIGEST.fullmatch\(recorded\):$/        if False:/' \
         "attesting job that recorded no output"
+    assert_loader_mutation_rejected "build images taken from the attestation" \
+        's/^        if document.get\("image"\) != image:$/        if False:/' \
+        "attestation swapping its build image: helper accepted"
+    assert_loader_mutation_rejected "component keys taken from the attestation" \
+        's/^        if sorted\(document.get\("components", \{\}\)\) != components:$/        if False:/' \
+        "attestation adding a component: helper accepted"
+
+    # The helper itself, mutated into a tree of its own so the checkout stays
+    # clean: it resolves the repository root from its own location.
+    assert_helper_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local root mutant
+        root="$mutation_root/helper-$(printf '%s' "$context" | tr ' ' '-')"
+        mkdir -p "$root/.github/workflows/scripts"
+        ln -s "$repo_root/scripts" "$root/scripts"
+        ln -s "$repo_root/dist" "$root/dist"
+        cp .github/workflows/scripts/release_attestations.py "$root/.github/workflows/scripts/"
+        mutant="$root/.github/workflows/scripts/release-assets.sh"
+        sed -E "$expression" "$helper_path" >"$mutant"
+        chmod +x "$mutant"
+        if cmp -s "$helper_path" "$mutant"; then
+            fail "$context mutation did not change the release asset helper"
+        fi
+        local output
+        if output="$(FACELOCK_RELEASE_ASSETS="$mutant" bash "$0" 2>&1)"; then
+            fail "release artifacts contract accepted $context"
+        fi
+        printf '%s\n' "$output" | grep -Fq "$needle" ||
+            fail "$context mutation failed for an unrelated reason: $output"
+        echo "release artifacts mutation: $context rejected"
+    }
+
+    # shellcheck disable=SC2016
+    assert_helper_mutation_rejected "an empty suite list tolerated" \
+        's/^    \[ -n "\$listing" \] \|\| fail "the release matrix names no Debian suite.*$/    [ -n "$listing" ] || return 0/' \
+        "allowlist from a matrix with no suite: helper accepted"
+    assert_helper_mutation_rejected "python running with the working directory on its path" \
+        's/^export PYTHONSAFEPATH=1$/: # safe path disabled/' \
+        "imported a module from its working directory"
 
     assert_workflow_mutation_rejected() {
         local context="$1" expression="$2" needle="$3"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# Contract for the direct release artifacts: a draft created once, validated
+# once, and published once.
+#
+# The release workflow runs only on a `v*` tag, so its shape cannot be proven
+# by running it. This gate proves the shape statically and proves the decisions
+# it delegates -- the canonical asset allowlist, the tag check, the draft
+# check, the digest attestations and the manifest -- by fixture.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+workflow_path="${FACELOCK_RELEASE_WORKFLOW:-.github/workflows/release.yml}"
+helper_path="${FACELOCK_RELEASE_ASSETS:-.github/workflows/scripts/release-assets.sh}"
+
+fail() {
+    echo "release artifacts contract: $*" >&2
+    exit 1
+}
+
+# ------------------------------------------------------------------ workflow
+
+[ -f "$workflow_path" ] || fail "missing release workflow: $workflow_path"
+[ -x "$helper_path" ] || fail "release asset helper must be executable: $helper_path"
+
+job_body() {
+    awk -v job="$1" '
+        $0 == "  " job ":" { inside = 1; next }
+        inside && /^  [A-Za-z]/ { inside = 0 }
+        inside { print }
+    ' "$workflow_path"
+}
+
+job_names() {
+    awk '
+        /^jobs:/ { inside = 1; next }
+        inside && /^[A-Za-z]/ { inside = 0 }
+        inside && match($0, /^  [a-z][a-z0-9-]*:$/) {
+            name = $0
+            sub(/^  /, "", name)
+            sub(/:$/, "", name)
+            print name
+        }
+    ' "$workflow_path"
+}
+
+# The `needs:` list of one job, as space-delimited job names.
+job_needs() {
+    job_body "$1" | awk '
+        /^    needs:/ {
+            sub(/^    needs:[[:space:]]*/, "")
+            gsub(/[][,]/, " ")
+            print
+        }
+    ' | tr -s ' '
+}
+
+requires_job() {
+    local job="$1" dependency="$2"
+    case " $(job_needs "$job") " in
+        *" $dependency "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# The `permissions:` body of one job, as `scope: value` lines.
+job_permissions() {
+    job_body "$1" | awk '
+        /^    permissions:/ { inside = 1; next }
+        inside && /^    [A-Za-z]/ { inside = 0 }
+        inside { sub(/^ +/, ""); print }
+    '
+}
+
+builders=(
+    metadata
+    build
+    download-ort
+    prepare-cargo-vendor
+    build-deb
+    build-rpm
+    build-nix
+    publish-apt
+)
+expected_jobs=("${builders[@]}" publish publish-aur trigger-pages)
+
+actual_jobs="$(job_names | LC_ALL=C sort)"
+wanted_jobs="$(printf '%s\n' "${expected_jobs[@]}" | LC_ALL=C sort)"
+[ "$actual_jobs" = "$wanted_jobs" ] ||
+    fail "release jobs drifted; every job needs a permission ceiling and a place in the publish graph: $(echo "$actual_jobs" | tr '\n' ' ')"
+
+# A workflow-level write grant reaches every builder. The floor is deny-all and
+# each job asks for exactly what it needs.
+awk '/^permissions:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside { print }' \
+    "$workflow_path" | grep -q . &&
+    fail "workflow-level permissions must be the deny-all floor, not a scope list"
+grep -Eq '^permissions:[[:space:]]*\{\}[[:space:]]*$' "$workflow_path" ||
+    fail "workflow must declare the deny-all permission floor: permissions: {}"
+
+for job in "${expected_jobs[@]}"; do
+    permissions="$(job_permissions "$job")"
+    [ -n "$permissions" ] || fail "job $job declares no permissions: block"
+    if [ "$job" = publish ]; then
+        printf '%s\n' "$permissions" | grep -Eq '^contents:[[:space:]]*write$' ||
+            fail "the publish job must hold contents: write"
+    else
+        if printf '%s\n' "$permissions" | grep -Eq '^contents:[[:space:]]*write$'; then
+            fail "only the publish job may hold contents: write, not $job"
+        fi
+    fi
+done
+
+build_job="$(job_body build)"
+printf '%s\n' "$build_job" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
+    fail "the build job must create the GitHub release as a draft"
+# Literal workflow expressions; nothing here is a shell expansion.
+# shellcheck disable=SC2016
+printf '%s\n' "$build_job" | grep -Fq 'prerelease: ${{ needs.metadata.outputs.prerelease }}' ||
+    fail "the draft must carry the validated prerelease identity"
+if printf '%s\n' "$build_job" | grep -Fq 'SHA256SUMS'; then
+    fail "the build job must not publish a partial checksum file; MANIFEST.json covers every asset"
+fi
+
+# Every release write goes through the dedicated publication credential, so a
+# builder holding only contents: read cannot reach the release with its own token.
+upload_steps="$(grep -c 'uses: softprops/action-gh-release@' "$workflow_path" || true)"
+# shellcheck disable=SC2016
+upload_tokens="$(grep -cF 'token: ${{ secrets.RELEASE_PAT }}' "$workflow_path" || true)"
+[ "$upload_steps" -ge 1 ] || fail "release workflow uploads no assets to the release"
+[ "$upload_steps" = "$upload_tokens" ] ||
+    fail "every release upload must pass the publication token: $upload_steps step(s), $upload_tokens token(s)"
+
+publish_job="$(job_body publish)"
+for need in "${builders[@]}"; do
+    requires_job publish "$need" ||
+        fail "the publish job must wait for $need before publishing"
+done
+printf '%s\n' "$publish_job" | grep -Fq 'MANIFEST.json' ||
+    fail "the publish job must generate MANIFEST.json"
+printf '%s\n' "$publish_job" | grep -Fq 'release-assets.sh' ||
+    fail "the publish job must validate the draft through the release asset helper"
+printf '%s\n' "$publish_job" | grep -Fq 'draft=false' ||
+    fail "the publish job must flip the validated draft to published"
+
+# Publishing may never mint or move a tag: the maintainer's tag is an input.
+if grep -Eq 'tag_name=|target_commitish' "$workflow_path"; then
+    fail "publishing must not send a tag or target commitish; the tag is verified, never written"
+fi
+if grep -Eq 'git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+(tag|push)([[:space:]]|$)' "$workflow_path"; then
+    fail "the release workflow must not create, move or push a git tag"
+fi
+
+requires_job trigger-pages publish ||
+    fail "trigger-pages must run after the release is published"
+
+publish_aur_job="$(job_body publish-aur)"
+requires_job publish-aur publish ||
+    fail "publish-aur consumes published release assets and must run after publish"
+if printf '%s\n' "$publish_aur_job" | grep -Fq 'SHA256SUMS'; then
+    fail "publish-aur must take its binary digests from MANIFEST.json"
+fi
+grep -Fq 'MANIFEST.json' .github/workflows/scripts/publish-aur.sh ||
+    fail "the AUR publisher must read per-binary digests from the release manifest"
+# shellcheck disable=SC2016
+if grep -Fq 'releases/download/v${VERSION}/SHA256SUMS' .github/workflows/scripts/publish-aur.sh; then
+    fail "the AUR publisher must not fetch the retired SHA256SUMS asset"
+fi
+
+# The RPM container digest is a manifest input, and `container.image` cannot
+# read an env context: the duplicate must be held equal here.
+rpm_job="$(job_body build-rpm)"
+rpm_container_image="$(printf '%s\n' "$rpm_job" | awk '/^      image: /{ sub(/^      image: /, ""); print; exit }')"
+rpm_env_image="$(printf '%s\n' "$rpm_job" | awk '/^      BUILD_IMAGE: /{ sub(/^      BUILD_IMAGE: /, ""); print; exit }')"
+[ -n "$rpm_container_image" ] || fail "build-rpm declares no pinned container image"
+[ "$rpm_container_image" = "$rpm_env_image" ] ||
+    fail "build-rpm BUILD_IMAGE ('$rpm_env_image') must repeat container.image ('$rpm_container_image')"
+
+# Only what a validator inspected may be published.
+printf '%s\n' "$rpm_job" | grep -Fq 'steps.rpm.outputs.rpm' ||
+    fail "build-rpm must upload exactly the RPM its validator inspected"
+
+for digest_producer in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
+    job_body "$digest_producer" | grep -Fq 'release-digests-' ||
+        fail "$digest_producer must attest the digests of what it produced"
+done
+
+# ------------------------------------------------------------- helper: shape
+
+git_command='git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+'
+grep -Eq "${git_command}tag[[:space:]]+-v" "$helper_path" ||
+    fail "tag verification must verify a present signature with git tag -v"
+if grep -Eq "${git_command}tag[[:space:]]+(-[afsm]|[^-])" "$helper_path"; then
+    fail "the release asset helper must never create or move a tag"
+fi
+if grep -Eq "${git_command}push" "$helper_path"; then
+    fail "the release asset helper must never push"
+fi
+
+# ------------------------------------------------------- helper: by fixture
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/facelock-release-artifacts.XXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+assert_rejects() {
+    local context="$1" needle="$2"
+    shift 2
+    local output
+    if output="$("$helper_path" "$@" 2>&1)"; then
+        fail "$context: helper accepted what it must reject"
+    fi
+    printf '%s\n' "$output" | grep -Fq "$needle" ||
+        fail "$context: rejected for an unrelated reason: $output"
+    echo "release artifacts case: $context rejected"
+}
+
+# --- the canonical allowlist
+
+stable_expected="$work/expected-stable"
+"$helper_path" expected 0.2.0 1 1 false final >"$stable_expected"
+for wanted in \
+    'facelock-x86_64-linux-gnu' \
+    'pam_facelock\.so' \
+    'facelock-polkit-agent-x86_64-linux-gnu' \
+    'facelock_0\.2\.0-1~deb13u1_amd64\.deb' \
+    'facelock_0\.2\.0-1~ubuntu26\.04\.1_amd64\.deb' \
+    'facelock-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
+    'apt-repo\.tar\.gz' \
+    'MANIFEST\.json'; do
+    grep -Fq "	$wanted" "$stable_expected" ||
+        fail "canonical stable allowlist omits $wanted: $(cat "$stable_expected")"
+done
+
+prerelease_expected="$work/expected-prerelease"
+"$helper_path" expected 0.2.0-alpha.1 1 1 true final >"$prerelease_expected"
+grep -Fq '	facelock_0\.2\.0~alpha\.1-1~deb13u1_amd64\.deb' "$prerelease_expected" ||
+    fail "prerelease allowlist does not carry the Debian prerelease upstream version"
+grep -Fq '	facelock-0\.2\.0-0\.1\.alpha\.1\.fc[0-9]+\.x86_64\.rpm' "$prerelease_expected" ||
+    fail "prerelease allowlist does not carry the monotonic RPM prerelease release"
+if grep -Fq 'apt-repo' "$prerelease_expected"; then
+    fail "a prerelease publishes no APT repository, so it must not be an expected asset"
+fi
+
+builders_expected="$work/expected-builders"
+"$helper_path" expected 0.2.0 1 1 false builders >"$builders_expected"
+if grep -q 'MANIFEST' "$builders_expected"; then
+    fail "the builder-stage allowlist must not expect the manifest the publish job adds"
+fi
+
+# --- allowlist enforcement
+
+canonical_assets() {
+    cat <<'ASSETS'
+facelock-x86_64-linux-gnu
+pam_facelock.so
+facelock-polkit-agent-x86_64-linux-gnu
+facelock_0.2.0-1~deb13u1_amd64.deb
+facelock_0.2.0-1~ubuntu26.04.1_amd64.deb
+facelock-0.2.0-1.fc44.x86_64.rpm
+apt-repo.tar.gz
+MANIFEST.json
+ASSETS
+}
+
+canonical_assets >"$work/actual-ok"
+"$helper_path" verify "$stable_expected" "$work/actual-ok" >/dev/null ||
+    fail "the canonical asset set was rejected"
+
+{ canonical_assets; echo "facelock-x86_64-linux-musl"; } >"$work/actual-extra"
+assert_rejects "extra release asset" "unexpected release asset" \
+    verify "$stable_expected" "$work/actual-extra"
+
+canonical_assets | grep -Fvx 'pam_facelock.so' >"$work/actual-missing"
+assert_rejects "missing release asset" "no release asset matches" \
+    verify "$stable_expected" "$work/actual-missing"
+
+{ canonical_assets; echo "pam_facelock.so"; } >"$work/actual-duplicate"
+assert_rejects "duplicate asset name" "duplicate release asset" \
+    verify "$stable_expected" "$work/actual-duplicate"
+
+{ canonical_assets; echo "facelock-0.2.0-1.fc45.x86_64.rpm"; } >"$work/actual-collision"
+assert_rejects "two assets claiming one canonical name" "more than one release asset" \
+    verify "$stable_expected" "$work/actual-collision"
+
+# --- the maintainer tag
+
+fixture_repo="$work/repo"
+(
+    # Each fixture subshell isolates itself from the host git configuration.
+    # shellcheck disable=SC2030,SC2031
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    git init -q -b main "$fixture_repo"
+    cd "$fixture_repo"
+    git config user.email release@example.invalid
+    git config user.name Release
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+    echo release >file
+    git add file
+    git commit -qm "release"
+    git tag v0.2.0
+    echo other >file
+    git commit -qam "after the tag"
+) >/dev/null
+tag_commit="$(git -C "$fixture_repo" rev-list -n1 v0.2.0)"
+head_commit="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+"$helper_path" verify-tag v0.2.0 0.2.0 "$tag_commit" "$fixture_repo" >/dev/null ||
+    fail "the maintainer tag at the built commit was rejected"
+
+assert_rejects "tag that does not name the validated version" "does not match the validated version" \
+    verify-tag v0.2.1 0.2.0 "$tag_commit" "$fixture_repo"
+assert_rejects "tag that does not exist" "does not exist" \
+    verify-tag v9.9.9 9.9.9 "$tag_commit" "$fixture_repo"
+assert_rejects "tag that does not point at the built commit" "does not point at the built commit" \
+    verify-tag v0.2.0 0.2.0 "$head_commit" "$fixture_repo"
+
+# A tag carrying a signature block must verify, whatever the block is.
+(
+    # Each fixture subshell isolates itself from the host git configuration.
+    # shellcheck disable=SC2030,SC2031
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    cd "$fixture_repo"
+    git config tag.gpgsign false
+    printf '%s\n' "signed release" "-----BEGIN PGP SIGNATURE-----" "not a signature" "-----END PGP SIGNATURE-----" |
+        git tag -a -F - v0.2.0-rc.1 "$tag_commit"
+) >/dev/null
+assert_rejects "tag whose signature cannot be verified" "signature verification failed" \
+    verify-tag v0.2.0-rc.1 0.2.0-rc.1 "$tag_commit" "$fixture_repo"
+
+# --- the draft is published exactly once
+
+cat >"$work/release-draft.json" <<'JSON'
+{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false}
+JSON
+"$helper_path" verify-draft v0.2.0 false "$work/release-draft.json" >/dev/null ||
+    fail "the unpublished draft for this tag was rejected"
+
+cat >"$work/release-published.json" <<'JSON'
+{"id": 42, "tag_name": "v0.2.0", "draft": false, "prerelease": false}
+JSON
+assert_rejects "publish-only rerun against a published release" "already published" \
+    verify-draft v0.2.0 false "$work/release-published.json"
+
+cat >"$work/release-other-tag.json" <<'JSON'
+{"id": 42, "tag_name": "v0.1.9", "draft": true, "prerelease": false}
+JSON
+assert_rejects "draft belonging to another tag" "another tag" \
+    verify-draft v0.2.0 false "$work/release-other-tag.json"
+
+cat >"$work/release-wrong-channel.json" <<'JSON'
+{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": true}
+JSON
+assert_rejects "draft whose channel differs from the validated identity" "prerelease identity" \
+    verify-draft v0.2.0 false "$work/release-wrong-channel.json"
+
+# The draft is selected out of the API listing, never assumed to be first.
+cat >"$work/releases-listing.json" <<'JSON'
+[{"id": 7, "tag_name": "v0.1.9", "draft": false, "prerelease": false,
+  "assets": [{"name": "facelock-x86_64-linux-gnu"}]},
+ {"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false,
+  "assets": [{"name": "pam_facelock.so"}, {"name": "MANIFEST.json"}]}]
+JSON
+[ "$("$helper_path" release-id "$work/releases-listing.json" v0.2.0)" = 42 ] ||
+    fail "the release id was not read from the API listing"
+[ "$("$helper_path" names "$work/releases-listing.json" v0.2.0 | tr '\n' ' ')" = "pam_facelock.so MANIFEST.json " ] ||
+    fail "the draft asset names were not read from the API listing"
+"$helper_path" verify-draft v0.2.0 false "$work/releases-listing.json" >/dev/null ||
+    fail "the draft for this tag was not selected out of the API listing"
+assert_rejects "tag with no release of its own" "expected exactly one release" \
+    verify-draft v0.3.0 false "$work/releases-listing.json"
+
+# --- builder digest attestations
+
+assets_dir="$work/assets"
+mkdir -p "$assets_dir"
+printf 'facelock\n' >"$assets_dir/facelock-x86_64-linux-gnu"
+printf 'pam\n' >"$assets_dir/pam_facelock.so"
+printf 'manifest placeholder\n' >"$assets_dir/MANIFEST.json"
+asset_digest() { sha256sum "$assets_dir/$1" | cut -d' ' -f1; }
+
+digests_dir="$work/digests"
+mkdir -p "$digests_dir/release-digests-build"
+cat >"$digests_dir/release-digests-build/digests.json" <<JSON
+{
+  "job": "build",
+  "image": "ubuntu-latest",
+  "assets": {
+    "facelock-x86_64-linux-gnu": "$(asset_digest facelock-x86_64-linux-gnu)",
+    "pam_facelock.so": "$(asset_digest pam_facelock.so)"
+  }
+}
+JSON
+
+printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so MANIFEST.json >"$work/actual-attested"
+"$helper_path" verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested" >/dev/null ||
+    fail "assets matching their builder attestations were rejected"
+
+printf 'tampered\n' >"$assets_dir/pam_facelock.so"
+assert_rejects "release asset mutated after its builder attested it" "does not match the digest" \
+    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
+printf 'pam\n' >"$assets_dir/pam_facelock.so"
+
+printf 'smuggled\n' >"$assets_dir/extra-asset"
+printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so extra-asset MANIFEST.json >"$work/actual-unattested"
+assert_rejects "release asset no builder attested" "attested by no builder" \
+    verify-digests "$digests_dir" "$assets_dir" "$work/actual-unattested"
+rm -f "$assets_dir/extra-asset"
+
+mkdir -p "$digests_dir/release-digests-duplicate"
+cat >"$digests_dir/release-digests-duplicate/digests.json" <<JSON
+{"job": "other", "assets": {"pam_facelock.so": "$(asset_digest pam_facelock.so)"}}
+JSON
+assert_rejects "two builders claiming one asset" "attested by more than one builder" \
+    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
+rm -rf "$digests_dir/release-digests-duplicate"
+
+# --- the publication manifest
+
+mkdir -p "$digests_dir/release-digests-deb-trixie"
+cat >"$digests_dir/release-digests-deb-trixie/digests.json" <<'JSON'
+{"job": "build-deb", "suite": "trixie", "image": "docker.io/library/debian:13@sha256:34cd", "assets": {}}
+JSON
+mkdir -p "$digests_dir/release-digests-onnxruntime"
+cat >"$digests_dir/release-digests-onnxruntime/digests.json" <<'JSON'
+{"job": "download-ort", "assets": {},
+ "components": {"onnxruntime": {"version": "1.20.1", "library_sha256": "a5faaf78"}}}
+JSON
+
+manifest="$work/MANIFEST.json"
+"$helper_path" manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$manifest" >/dev/null ||
+    fail "manifest generation failed for a complete release"
+
+python3 - "$manifest" "$(asset_digest facelock-x86_64-linux-gnu)" <<'PY' ||
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+assets = {entry["name"]: entry for entry in manifest["assets"]}
+missing = {"facelock-x86_64-linux-gnu", "pam_facelock.so", "MANIFEST.json"} - set(assets)
+assert not missing, f"manifest omits {sorted(missing)}"
+assert assets["facelock-x86_64-linux-gnu"]["sha256"] == sys.argv[2], "manifest digest is not the asset digest"
+assert all("size" in entry for entry in manifest["assets"]), "manifest omits asset sizes"
+assert manifest["tag"] == "v0.2.0" and manifest["version"] == "0.2.0", "manifest identity drifted"
+assert manifest["source"]["sha256"] == "deadbeef", "manifest omits the source digest"
+assert "archive/refs/tags/v0.2.0" in manifest["source"]["url"], "manifest omits the source archive"
+images = manifest["build_images"]
+assert any("debian:13@sha256" in value for value in images.values()), "manifest omits a build image digest"
+assert manifest["components"]["onnxruntime"]["library_sha256"] == "a5faaf78", "manifest omits the ORT digest"
+PY
+    fail "the generated manifest does not cover every asset and every reviewed digest"
+
+rm -f "$assets_dir/pam_facelock.so"
+assert_rejects "manifest over an asset that was never downloaded" "is not present" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$manifest"
+
+# ------------------------------------------------------------------ mutations
+
+if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ]; then
+    mutation_root="$work/mutations"
+    mkdir -p "$mutation_root"
+
+    assert_workflow_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local mutated
+        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
+        sed -E "$expression" "$workflow_path" >"$mutated"
+        if cmp -s "$workflow_path" "$mutated"; then
+            fail "$context mutation did not change the workflow"
+        fi
+        local output
+        if output="$(FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$0" 2>&1)"; then
+            fail "release artifacts contract accepted $context"
+        fi
+        printf '%s\n' "$output" | grep -Fq "$needle" ||
+            fail "$context mutation failed for an unrelated reason: $output"
+        echo "release artifacts mutation: $context rejected"
+    }
+
+    assert_workflow_mutation_rejected "public release creation" \
+        's/^          draft: true$//' \
+        "must create the GitHub release as a draft"
+    assert_workflow_mutation_rejected "builder holding the release write scope" \
+        '0,/^      contents: read$/s//      contents: write/' \
+        "only the publish job may hold contents: write"
+    assert_workflow_mutation_rejected "pages rebuild before publication" \
+        's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
+        "trigger-pages must run after the release is published"
+    assert_workflow_mutation_rejected "release upload without the publication token" \
+        '0,/^          token: \$\{\{ secrets.RELEASE_PAT \}\}$/s///' \
+        "every release upload must pass the publication token"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "tag rewritten at publication" \
+        's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
+        "publishing must not send a tag or target commitish"
+fi
+
+echo "release artifacts contract: ok"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Contract for the direct release artifacts: a draft created once, validated
-# once, and published once.
+# Contract for the direct release artifacts: builders that only produce
+# workflow artifacts, and one publish job that assembles, validates and
+# publishes them exactly once.
 #
 # The release workflow runs only on a `v*` tag, so its shape cannot be proven
 # by running it. This gate proves the shape statically and proves the decisions
-# it delegates -- the canonical asset allowlist, the tag check, the draft
-# check, the digest attestations and the manifest -- by fixture.
+# it delegates -- the canonical asset allowlist, staging, the tag check, the
+# draft checks, the digest attestations and the manifest -- by fixture.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -91,9 +92,10 @@ wanted_jobs="$(printf '%s\n' "${expected_jobs[@]}" | LC_ALL=C sort)"
 
 # A workflow-level write grant reaches every builder. The floor is deny-all and
 # each job asks for exactly what it needs.
-awk '/^permissions:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside { print }' \
-    "$workflow_path" | grep -q . &&
+if awk '/^permissions:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside { print }' \
+    "$workflow_path" | grep -q .; then
     fail "workflow-level permissions must be the deny-all floor, not a scope list"
+fi
 grep -Eq '^permissions:[[:space:]]*\{\}[[:space:]]*$' "$workflow_path" ||
     fail "workflow must declare the deny-all permission floor: permissions: {}"
 
@@ -110,37 +112,65 @@ for job in "${expected_jobs[@]}"; do
     fi
 done
 
+# A builder that can reach the release is a builder that can publish one. Every
+# job but `publish` compiles or packages untrusted-by-construction code (every
+# dependency's build.rs, rpmbuild, dpkg-buildpackage), so none of them may hold
+# the publication credential or a step that writes the release.
+for job in "${expected_jobs[@]}"; do
+    if [ "$job" = publish ]; then
+        continue
+    fi
+    body="$(job_body "$job")"
+    for forbidden in 'RELEASE_PAT' 'action-gh-release' 'gh release'; do
+        if printf '%s\n' "$body" | grep -Fq "$forbidden"; then
+            fail "job $job must not touch the release ($forbidden); builders produce artifacts only"
+        fi
+    done
+done
+
 build_job="$(job_body build)"
-printf '%s\n' "$build_job" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
-    fail "the build job must create the GitHub release as a draft"
-# Literal workflow expressions; nothing here is a shell expansion.
-# shellcheck disable=SC2016
-printf '%s\n' "$build_job" | grep -Fq 'prerelease: ${{ needs.metadata.outputs.prerelease }}' ||
-    fail "the draft must carry the validated prerelease identity"
+printf '%s\n' "$build_job" | grep -Fq 'name: release-binaries' ||
+    fail "the build job must publish its binaries as a workflow artifact"
 if printf '%s\n' "$build_job" | grep -Fq 'SHA256SUMS'; then
     fail "the build job must not publish a partial checksum file; MANIFEST.json covers every asset"
 fi
 
-# Every release write goes through the dedicated publication credential, so a
-# builder holding only contents: read cannot reach the release with its own token.
-upload_steps="$(grep -c 'uses: softprops/action-gh-release@' "$workflow_path" || true)"
-# shellcheck disable=SC2016
-upload_tokens="$(grep -cF 'token: ${{ secrets.RELEASE_PAT }}' "$workflow_path" || true)"
-[ "$upload_steps" -ge 1 ] || fail "release workflow uploads no assets to the release"
-[ "$upload_steps" = "$upload_tokens" ] ||
-    fail "every release upload must pass the publication token: $upload_steps step(s), $upload_tokens token(s)"
+for producer in build build-deb build-rpm publish-apt; do
+    job_body "$producer" | grep -Eq '^[[:space:]]+name: release-[a-z-]+' ||
+        fail "$producer must hand its release payload to publish as a workflow artifact"
+done
+for digest_producer in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
+    job_body "$digest_producer" | grep -Fq 'release-digests-' ||
+        fail "$digest_producer must attest the digests of what it produced"
+done
 
 publish_job="$(job_body publish)"
 for need in "${builders[@]}"; do
     requires_job publish "$need" ||
         fail "the publish job must wait for $need before publishing"
 done
-printf '%s\n' "$publish_job" | grep -Fq 'MANIFEST.json' ||
-    fail "the publish job must generate MANIFEST.json"
-printf '%s\n' "$publish_job" | grep -Fq 'release-assets.sh' ||
-    fail "the publish job must validate the draft through the release asset helper"
-printf '%s\n' "$publish_job" | grep -Fq 'draft=false' ||
-    fail "the publish job must flip the validated draft to published"
+requires_job publish build ||
+    fail "the only job with a release step must depend on the builders it publishes"
+printf '%s\n' "$publish_job" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
+    fail "the publish job must create the GitHub release as a draft"
+# Literal workflow expressions; nothing here is a shell expansion.
+# shellcheck disable=SC2016
+printf '%s\n' "$publish_job" | grep -Fq 'prerelease: ${{ needs.metadata.outputs.prerelease }}' ||
+    fail "the draft must carry the validated prerelease identity"
+for step in 'verify-tag' 'stage expected-assets' 'verify-digests' 'verify-creatable' \
+    'PRERELEASE" final' 'MANIFEST.json' 'draft=false'; do
+    printf '%s\n' "$publish_job" | grep -Fq "$step" ||
+        fail "the publish job must run $step before the release becomes public"
+done
+
+# Every release write goes through the dedicated publication credential.
+upload_steps="$(grep -c 'uses: softprops/action-gh-release@' "$workflow_path" || true)"
+# shellcheck disable=SC2016
+upload_tokens="$(grep -cF 'token: ${{ secrets.RELEASE_PAT }}' "$workflow_path" || true)"
+[ "$upload_steps" = 1 ] ||
+    fail "exactly one release-writing step may exist, found $upload_steps"
+[ "$upload_steps" = "$upload_tokens" ] ||
+    fail "every release upload must pass the publication token: $upload_steps step(s), $upload_tokens token(s)"
 
 # Publishing may never mint or move a tag: the maintainer's tag is an input.
 if grep -Eq 'tag_name=|target_commitish' "$workflow_path"; then
@@ -177,12 +207,7 @@ rpm_env_image="$(printf '%s\n' "$rpm_job" | awk '/^      BUILD_IMAGE: /{ sub(/^ 
 
 # Only what a validator inspected may be published.
 printf '%s\n' "$rpm_job" | grep -Fq 'steps.rpm.outputs.rpm' ||
-    fail "build-rpm must upload exactly the RPM its validator inspected"
-
-for digest_producer in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
-    job_body "$digest_producer" | grep -Fq 'release-digests-' ||
-        fail "$digest_producer must attest the digests of what it produced"
-done
+    fail "build-rpm must validate the exact payload package the metadata names"
 
 # ------------------------------------------------------------- helper: shape
 
@@ -224,6 +249,8 @@ for wanted in \
     'facelock_0\.2\.0-1~deb13u1_amd64\.deb' \
     'facelock_0\.2\.0-1~ubuntu26\.04\.1_amd64\.deb' \
     'facelock-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
+    'facelock-debuginfo-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
+    'facelock-debugsource-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
     'apt-repo\.tar\.gz' \
     'MANIFEST\.json'; do
     grep -Fq "	$wanted" "$stable_expected" ||
@@ -256,30 +283,73 @@ facelock-polkit-agent-x86_64-linux-gnu
 facelock_0.2.0-1~deb13u1_amd64.deb
 facelock_0.2.0-1~ubuntu26.04.1_amd64.deb
 facelock-0.2.0-1.fc44.x86_64.rpm
+facelock-debuginfo-0.2.0-1.fc44.x86_64.rpm
+facelock-debugsource-0.2.0-1.fc44.x86_64.rpm
 apt-repo.tar.gz
-MANIFEST.json
 ASSETS
 }
 
-canonical_assets >"$work/actual-ok"
+{ canonical_assets; echo MANIFEST.json; } >"$work/actual-ok"
 "$helper_path" verify "$stable_expected" "$work/actual-ok" >/dev/null ||
     fail "the canonical asset set was rejected"
 
-{ canonical_assets; echo "facelock-x86_64-linux-musl"; } >"$work/actual-extra"
+{ canonical_assets; echo MANIFEST.json; echo "facelock-x86_64-linux-musl"; } >"$work/actual-extra"
 assert_rejects "extra release asset" "unexpected release asset" \
     verify "$stable_expected" "$work/actual-extra"
 
-canonical_assets | grep -Fvx 'pam_facelock.so' >"$work/actual-missing"
+{ canonical_assets; echo MANIFEST.json; } | grep -Fvx 'pam_facelock.so' >"$work/actual-missing"
 assert_rejects "missing release asset" "no release asset matches" \
     verify "$stable_expected" "$work/actual-missing"
 
-{ canonical_assets; echo "pam_facelock.so"; } >"$work/actual-duplicate"
+{ canonical_assets; echo MANIFEST.json; echo "pam_facelock.so"; } >"$work/actual-duplicate"
 assert_rejects "duplicate asset name" "duplicate release asset" \
     verify "$stable_expected" "$work/actual-duplicate"
 
-{ canonical_assets; echo "facelock-0.2.0-1.fc45.x86_64.rpm"; } >"$work/actual-collision"
+{ canonical_assets; echo MANIFEST.json; echo "facelock-0.2.0-1.fc45.x86_64.rpm"; } >"$work/actual-collision"
 assert_rejects "two assets claiming one canonical name" "more than one release asset" \
     verify "$stable_expected" "$work/actual-collision"
+
+# --- staging out of the builders' artifacts
+
+artifacts="$work/artifacts"
+build_artifacts() {
+    rm -rf "$artifacts"
+    mkdir -p "$artifacts"/{release-binaries,release-deb-trixie,release-deb-resolute,release-rpm,release-apt-repo,release-digests-build}
+    printf 'facelock\n' >"$artifacts/release-binaries/facelock-x86_64-linux-gnu"
+    printf 'pam\n' >"$artifacts/release-binaries/pam_facelock.so"
+    printf 'polkit\n' >"$artifacts/release-binaries/facelock-polkit-agent-x86_64-linux-gnu"
+    printf 'deb\n' >"$artifacts/release-deb-trixie/facelock_0.2.0-1~deb13u1_amd64.deb"
+    # The staged Debian manifest travels with the package and is not an asset.
+    printf 'manifest\n' >"$artifacts/release-deb-trixie/facelock_0.2.0-1~deb13u1_amd64.manifest"
+    printf 'deb\n' >"$artifacts/release-deb-resolute/facelock_0.2.0-1~ubuntu26.04.1_amd64.deb"
+    printf 'rpm\n' >"$artifacts/release-rpm/facelock-0.2.0-1.fc44.x86_64.rpm"
+    printf 'rpm\n' >"$artifacts/release-rpm/facelock-debuginfo-0.2.0-1.fc44.x86_64.rpm"
+    printf 'rpm\n' >"$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
+    printf 'apt\n' >"$artifacts/release-apt-repo/apt-repo.tar.gz"
+}
+
+build_artifacts
+staged="$work/assets"
+rm -rf "$staged"
+"$helper_path" stage "$builders_expected" "$artifacts" "$staged" >"$work/actual-staged"
+diff <(canonical_assets | LC_ALL=C sort) <(LC_ALL=C sort "$work/actual-staged") >/dev/null ||
+    fail "staging did not collect exactly the canonical assets: $(tr '\n' ' ' <"$work/actual-staged")"
+"$helper_path" verify "$builders_expected" "$work/actual-staged" >/dev/null ||
+    fail "the staged asset set was rejected by its own allowlist"
+[ -f "$staged/apt-repo.tar.gz" ] || fail "staging did not copy the assets it named"
+if [ -e "$staged/facelock_0.2.0-1~deb13u1_amd64.manifest" ]; then
+    fail "staging copied a file the allowlist does not name"
+fi
+
+rm -f "$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
+assert_rejects "builder artifact missing a canonical asset" "no builder artifact provides" \
+    stage "$builders_expected" "$artifacts" "$work/assets-missing"
+
+build_artifacts
+cp "$artifacts/release-binaries/pam_facelock.so" "$artifacts/release-rpm/pam_facelock.so"
+assert_rejects "two builders providing one canonical asset" "more than one builder artifact provides" \
+    stage "$builders_expected" "$artifacts" "$work/assets-ambiguous"
+build_artifacts
 
 # --- the maintainer tag
 
@@ -314,32 +384,70 @@ assert_rejects "tag that does not exist" "does not exist" \
 assert_rejects "tag that does not point at the built commit" "does not point at the built commit" \
     verify-tag v0.2.0 0.2.0 "$head_commit" "$fixture_repo"
 
-# A tag carrying a signature block must verify, whatever the block is.
+# An annotated tag makes GITHUB_SHA the tag object, not the commit it names.
 (
-    # Each fixture subshell isolates itself from the host git configuration.
     # shellcheck disable=SC2030,SC2031
     export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
     cd "$fixture_repo"
     git config tag.gpgsign false
-    printf '%s\n' "signed release" "-----BEGIN PGP SIGNATURE-----" "not a signature" "-----END PGP SIGNATURE-----" |
-        git tag -a -F - v0.2.0-rc.1 "$tag_commit"
+    git tag -a -m "annotated release" v0.2.0-beta.1 "$tag_commit"
+    printf '%s\n' "signed release" "-----BEGIN PGP SIGNATURE-----" "not a signature" \
+        "-----END PGP SIGNATURE-----" | git tag -a -F - v0.2.0-rc.1 "$tag_commit"
 ) >/dev/null
+annotated_object="$(git -C "$fixture_repo" rev-parse v0.2.0-beta.1)"
+[ "$annotated_object" != "$tag_commit" ] || fail "the annotated tag fixture is not a tag object"
+"$helper_path" verify-tag v0.2.0-beta.1 0.2.0-beta.1 "$annotated_object" "$fixture_repo" >/dev/null ||
+    fail "an annotated tag was rejected because GITHUB_SHA names the tag object"
+
 assert_rejects "tag whose signature cannot be verified" "signature verification failed" \
     verify-tag v0.2.0-rc.1 0.2.0-rc.1 "$tag_commit" "$fixture_repo"
 
-# --- the draft is published exactly once
+# --- the draft is created once and published once
 
-cat >"$work/release-draft.json" <<'JSON'
-{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false}
+cat >"$work/releases-none.json" <<'JSON'
+[]
 JSON
-"$helper_path" verify-draft v0.2.0 false "$work/release-draft.json" >/dev/null ||
-    fail "the unpublished draft for this tag was rejected"
+"$helper_path" verify-creatable v0.2.0 "$work/releases-none.json" >/dev/null ||
+    fail "a tag with no release yet was refused its first draft"
+
+cat >"$work/releases-listing.json" <<'JSON'
+[{"id": 7, "tag_name": "v0.1.9", "draft": false, "prerelease": false,
+  "assets": [{"name": "facelock-x86_64-linux-gnu"}]},
+ {"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false,
+  "assets": [{"name": "pam_facelock.so"}, {"name": "MANIFEST.json"}]}]
+JSON
+"$helper_path" verify-creatable v0.2.0 "$work/releases-listing.json" >/dev/null ||
+    fail "the draft an interrupted run left behind was refused"
+[ "$("$helper_path" release-id "$work/releases-listing.json" v0.2.0)" = 42 ] ||
+    fail "the release id was not read from the API listing"
+[ "$("$helper_path" names "$work/releases-listing.json" v0.2.0 | tr '\n' ' ')" = "pam_facelock.so MANIFEST.json " ] ||
+    fail "the draft asset names were not read from the API listing"
+"$helper_path" verify-draft v0.2.0 false "$work/releases-listing.json" >/dev/null ||
+    fail "the draft for this tag was not selected out of the API listing"
+assert_rejects "tag with no release of its own" "expected exactly one release" \
+    verify-draft v0.3.0 false "$work/releases-listing.json"
+
+# gh emits a paginated stream and slurped pages as well as one array.
+printf '%s\n' \
+    '{"id": 7, "tag_name": "v0.1.9", "draft": false, "prerelease": false}' \
+    '{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": []}' \
+    >"$work/releases-stream.json"
+[ "$("$helper_path" release-id "$work/releases-stream.json" v0.2.0)" = 42 ] ||
+    fail "a paginated release stream was not read"
+cat >"$work/releases-slurped.json" <<'JSON'
+[[{"id": 7, "tag_name": "v0.1.9", "draft": false}],
+ [{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": []}]]
+JSON
+[ "$("$helper_path" release-id "$work/releases-slurped.json" v0.2.0)" = 42 ] ||
+    fail "slurped release pages were not read"
 
 cat >"$work/release-published.json" <<'JSON'
 {"id": 42, "tag_name": "v0.2.0", "draft": false, "prerelease": false}
 JSON
 assert_rejects "publish-only rerun against a published release" "already published" \
     verify-draft v0.2.0 false "$work/release-published.json"
+assert_rejects "second run against an already published tag" "already published" \
+    verify-creatable v0.2.0 "$work/release-published.json"
 
 cat >"$work/release-other-tag.json" <<'JSON'
 {"id": 42, "tag_name": "v0.1.9", "draft": true, "prerelease": false}
@@ -353,37 +461,42 @@ JSON
 assert_rejects "draft whose channel differs from the validated identity" "prerelease identity" \
     verify-draft v0.2.0 false "$work/release-wrong-channel.json"
 
-# The draft is selected out of the API listing, never assumed to be first.
-cat >"$work/releases-listing.json" <<'JSON'
-[{"id": 7, "tag_name": "v0.1.9", "draft": false, "prerelease": false,
-  "assets": [{"name": "facelock-x86_64-linux-gnu"}]},
- {"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false,
-  "assets": [{"name": "pam_facelock.so"}, {"name": "MANIFEST.json"}]}]
+# A run interrupted between the manifest upload and the flip must be able to
+# run again: the draft already carries MANIFEST.json, and the final allowlist
+# expects exactly that.
+cat >"$work/release-rerun.json" <<'JSON'
+{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": [
+  {"name": "facelock-x86_64-linux-gnu"}, {"name": "pam_facelock.so"},
+  {"name": "facelock-polkit-agent-x86_64-linux-gnu"},
+  {"name": "facelock_0.2.0-1~deb13u1_amd64.deb"},
+  {"name": "facelock_0.2.0-1~ubuntu26.04.1_amd64.deb"},
+  {"name": "facelock-0.2.0-1.fc44.x86_64.rpm"},
+  {"name": "facelock-debuginfo-0.2.0-1.fc44.x86_64.rpm"},
+  {"name": "facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"},
+  {"name": "apt-repo.tar.gz"}, {"name": "MANIFEST.json"}]}
 JSON
-[ "$("$helper_path" release-id "$work/releases-listing.json" v0.2.0)" = 42 ] ||
-    fail "the release id was not read from the API listing"
-[ "$("$helper_path" names "$work/releases-listing.json" v0.2.0 | tr '\n' ' ')" = "pam_facelock.so MANIFEST.json " ] ||
-    fail "the draft asset names were not read from the API listing"
-"$helper_path" verify-draft v0.2.0 false "$work/releases-listing.json" >/dev/null ||
-    fail "the draft for this tag was not selected out of the API listing"
-assert_rejects "tag with no release of its own" "expected exactly one release" \
-    verify-draft v0.3.0 false "$work/releases-listing.json"
+"$helper_path" verify-creatable v0.2.0 "$work/release-rerun.json" >/dev/null ||
+    fail "a rerun over the draft of an interrupted run was refused"
+"$helper_path" names "$work/release-rerun.json" v0.2.0 >"$work/actual-rerun"
+"$helper_path" verify "$stable_expected" "$work/actual-rerun" >/dev/null ||
+    fail "a rerun whose draft already carries MANIFEST.json was rejected"
+echo "release artifacts case: rerun over a draft that already carries the manifest accepted"
 
 # --- builder digest attestations
 
-assets_dir="$work/assets"
+assets_dir="$work/attested"
+rm -rf "$assets_dir"
 mkdir -p "$assets_dir"
 printf 'facelock\n' >"$assets_dir/facelock-x86_64-linux-gnu"
 printf 'pam\n' >"$assets_dir/pam_facelock.so"
-printf 'manifest placeholder\n' >"$assets_dir/MANIFEST.json"
 asset_digest() { sha256sum "$assets_dir/$1" | cut -d' ' -f1; }
 
 digests_dir="$work/digests"
+rm -rf "$digests_dir"
 mkdir -p "$digests_dir/release-digests-build"
 cat >"$digests_dir/release-digests-build/digests.json" <<JSON
 {
   "job": "build",
-  "image": "ubuntu-latest",
   "assets": {
     "facelock-x86_64-linux-gnu": "$(asset_digest facelock-x86_64-linux-gnu)",
     "pam_facelock.so": "$(asset_digest pam_facelock.so)"
@@ -391,7 +504,7 @@ cat >"$digests_dir/release-digests-build/digests.json" <<JSON
 }
 JSON
 
-printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so MANIFEST.json >"$work/actual-attested"
+printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so >"$work/actual-attested"
 "$helper_path" verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested" >/dev/null ||
     fail "assets matching their builder attestations were rejected"
 
@@ -401,7 +514,7 @@ assert_rejects "release asset mutated after its builder attested it" "does not m
 printf 'pam\n' >"$assets_dir/pam_facelock.so"
 
 printf 'smuggled\n' >"$assets_dir/extra-asset"
-printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so extra-asset MANIFEST.json >"$work/actual-unattested"
+printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so extra-asset >"$work/actual-unattested"
 assert_rejects "release asset no builder attested" "attested by no builder" \
     verify-digests "$digests_dir" "$assets_dir" "$work/actual-unattested"
 rm -f "$assets_dir/extra-asset"
@@ -435,7 +548,7 @@ python3 - "$manifest" "$(asset_digest facelock-x86_64-linux-gnu)" <<'PY' ||
 import json, sys
 manifest = json.load(open(sys.argv[1]))
 assets = {entry["name"]: entry for entry in manifest["assets"]}
-missing = {"facelock-x86_64-linux-gnu", "pam_facelock.so", "MANIFEST.json"} - set(assets)
+missing = {"facelock-x86_64-linux-gnu", "pam_facelock.so"} - set(assets)
 assert not missing, f"manifest omits {sorted(missing)}"
 assert assets["facelock-x86_64-linux-gnu"]["sha256"] == sys.argv[2], "manifest digest is not the asset digest"
 assert all("size" in entry for entry in manifest["assets"]), "manifest omits asset sizes"
@@ -449,7 +562,7 @@ PY
     fail "the generated manifest does not cover every asset and every reviewed digest"
 
 rm -f "$assets_dir/pam_facelock.so"
-assert_rejects "manifest over an asset that was never downloaded" "is not present" \
+assert_rejects "manifest over an asset that was never staged" "is not present" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
     tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$manifest"
 
@@ -482,6 +595,26 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "builder holding the release write scope" \
         '0,/^      contents: read$/s//      contents: write/' \
         "only the publish job may hold contents: write"
+    # The mutation expressions below name literal workflow text, not shell
+    # expansions.
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "builder holding the publication credential" \
+        's/^      - name: Build release$/      - name: Build release\n        env:\n          TOKEN: ${{ secrets.RELEASE_PAT }}/' \
+        "builders produce artifacts only"
+    assert_workflow_mutation_rejected "builder writing the release directly" \
+        's|^      - name: Upload the APT repository artifact$|      - name: Upload the APT repository artifact\n        # uses: softprops/action-gh-release@0000|' \
+        "builders produce artifacts only"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "unverified tag" \
+        '/\$HELPER verify-tag /d' \
+        "must run verify-tag"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "unverified builder attestations" \
+        '/\$HELPER verify-digests /d' \
+        "must run verify-digests"
+    assert_workflow_mutation_rejected "no revalidation before the flip" \
+        '/PRERELEASE" final/d' \
+        'must run PRERELEASE" final'
     assert_workflow_mutation_rejected "pages rebuild before publication" \
         's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
         "trigger-pages must run after the release is published"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -187,6 +187,7 @@ printf '%s\n' "$publish_statements" | grep -Fq 'prerelease: ${{ needs.metadata.o
 for step in '$HELPER verify-tag ' '$HELPER stage expected-assets' \
     '$HELPER verify-digests artifacts job-outputs.json ' '$HELPER verify-creatable ' \
     'PRERELEASE" final' 'artifacts job-outputs.json assets actual-assets MANIFEST.json' \
+    'gh release upload "$TAG" MANIFEST.json' \
     '$HELPER verify-published releases.json "$TAG" MANIFEST.json' 'draft=false'; do
     printf '%s\n' "$publish_statements" | grep -Fq "$step" ||
         fail "the publish job must run ${step% } before the release becomes public"
@@ -1253,6 +1254,10 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "unverified builder attestations" \
         's|^( *)run: \$HELPER verify-digests .*|\1run: ": # verify-digests disabled"|' \
         'must run $HELPER verify-digests'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "manifest upload skipped" \
+        's|^( *)run: gh release upload "\$TAG" MANIFEST\.json --clobber$|\1: # disabled|' \
+        'must run gh release upload "$TAG" MANIFEST.json'
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "no revalidation before the flip" \
         's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -92,12 +92,24 @@ wanted_jobs="$(printf '%s\n' "${expected_jobs[@]}" | LC_ALL=C sort)"
 
 # A workflow-level write grant reaches every builder. The floor is deny-all and
 # each job asks for exactly what it needs.
-if awk '/^permissions:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside { print }' \
+if awk '/^permissions:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside && !/^[[:space:]]*(#|$)/ { print }' \
     "$workflow_path" | grep -q .; then
     fail "workflow-level permissions must be the deny-all floor, not a scope list"
 fi
 grep -Eq '^permissions:[[:space:]]*\{\}[[:space:]]*$' "$workflow_path" ||
     fail "workflow must declare the deny-all permission floor: permissions: {}"
+
+# "Exactly once" needs one run at a time per tag: two runs inside publish
+# both pass verify-creatable, both create or upload, and the survivor can
+# carry one run's binaries under the other's digests. A queued run is fine; a
+# cancelled one is not, because the first run may be mid-publication.
+concurrency_block="$(awk '/^concurrency:/ { inside = 1; next } inside && /^[A-Za-z]/ { inside = 0 } inside && !/^[[:space:]]*(#|$)/ { sub(/^ +/, ""); print }' "$workflow_path")"
+[ -n "$concurrency_block" ] || fail "the release workflow must declare a concurrency group per tag"
+# shellcheck disable=SC2016
+printf '%s\n' "$concurrency_block" | grep -Fxq 'group: release-${{ github.ref }}' ||
+    fail "the release concurrency group must be keyed by the tag ref: $concurrency_block"
+printf '%s\n' "$concurrency_block" | grep -Fxq 'cancel-in-progress: false' ||
+    fail "a release run must queue behind the one in progress, never cancel it: $concurrency_block"
 
 for job in "${expected_jobs[@]}"; do
     permissions="$(job_permissions "$job")"
@@ -175,7 +187,7 @@ printf '%s\n' "$publish_statements" | grep -Fq 'prerelease: ${{ needs.metadata.o
 for step in '$HELPER verify-tag ' '$HELPER stage expected-assets' \
     '$HELPER verify-digests artifacts job-outputs.json ' '$HELPER verify-creatable ' \
     'PRERELEASE" final' 'artifacts job-outputs.json assets actual-assets MANIFEST.json' \
-    'draft=false'; do
+    '$HELPER verify-published releases.json "$TAG" MANIFEST.json' 'draft=false'; do
     printf '%s\n' "$publish_statements" | grep -Fq "$step" ||
         fail "the publish job must run ${step% } before the release becomes public"
 done
@@ -213,6 +225,11 @@ if grep -Fq 'releases/download/v${VERSION}/SHA256SUMS' .github/workflows/scripts
     fail "the AUR publisher must not fetch the retired SHA256SUMS asset"
 fi
 
+# Preflight must not pass on a check it could not make: without gh, or
+# unauthenticated, the RELEASE_PAT check fails closed rather than being skipped.
+grep -Fq 'UNCHECKED: RELEASE_PAT' justfile ||
+    fail "release-preflight must fail closed when it cannot check RELEASE_PAT"
+
 # The RPM container digest is a manifest input, and `container.image` cannot
 # read an env context: the duplicate must be held equal here.
 rpm_job="$(job_body build-rpm)"
@@ -225,6 +242,27 @@ rpm_env_image="$(printf '%s\n' "$rpm_job" | awk '/^      BUILD_IMAGE: /{ sub(/^ 
 # Only what a validator inspected may be published.
 printf '%s\n' "$rpm_job" | grep -Fq 'steps.rpm.outputs.rpm' ||
     fail "build-rpm must validate the exact payload package the metadata names"
+
+# build-nix gates publication through its evaluation, which is deterministic
+# against flake.lock; the build itself depends on nixpkgs state and stays
+# advisory. A gate that cannot fail is not a gate.
+nix_step() {
+    job_body build-nix | awk -v needle="$1" '
+        function flush() { if (index(step, needle)) printf "%s", step; step = "" }
+        /^      - / { flush() }
+        { step = step $0 "\n" }
+        END { flush() }
+    '
+}
+flake_check_step="$(nix_step 'nix flake check')"
+[ -n "$flake_check_step" ] || fail "build-nix must evaluate the flake with nix flake check"
+if printf '%s\n' "$flake_check_step" | grep -Eq '^ +continue-on-error:'; then
+    fail "the flake evaluation must gate publication; drop continue-on-error from nix flake check"
+fi
+nix_build_step="$(nix_step 'nix build')"
+[ -n "$nix_build_step" ] || fail "build-nix must attempt nix build"
+printf '%s\n' "$nix_build_step" | grep -Eq '^ +continue-on-error: true$' ||
+    fail "nix build depends on nixpkgs state and is documented as advisory; it must keep continue-on-error"
 
 # The attesting set the helper pins must be exactly the artifacts the workflow
 # uploads, each bound to a job output. The artifact store is writable by every
@@ -386,6 +424,32 @@ assert_rejects() {
         fail "$context: rejected for an unrelated reason: $output"
     echo "release artifacts case: $context rejected"
 }
+
+# --- the AUR publisher's binary digests
+
+# The AUR recipe pins the published binaries by the digests MANIFEST.json
+# carries; a value that is not a SHA-256 must never reach a published PKGBUILD.
+# The publisher validates them before it touches SSH or the network, so this
+# runs hermetically with a manifest of its own.
+aur_publisher=.github/workflows/scripts/publish-aur.sh
+aur_home="$work/aur-home"
+mkdir -p "$aur_home"
+python3 - "$work/aur-manifest-bad.json" <<'PY'
+import json, sys
+json.dump({"assets": [
+    {"name": "facelock-x86_64-linux-gnu", "sha256": "not-a-digest"},
+    {"name": "pam_facelock.so", "sha256": "a" * 64},
+    {"name": "facelock-polkit-agent-x86_64-linux-gnu", "sha256": "b" * 64},
+]}, open(sys.argv[1], "w"))
+PY
+if aur_output="$(HOME="$aur_home" AUR_SSH_KEY=fixture FACELOCK_RELEASE_MANIFEST_FILE="$work/aur-manifest-bad.json" \
+    bash "$aur_publisher" 0.2.0 "$(printf 'c%.0s' $(seq 64))" 2>&1)"; then
+    fail "the AUR publisher accepted a binary digest that is not a SHA-256"
+fi
+printf '%s\n' "$aur_output" | grep -Fq 'not a plausible SHA-256' ||
+    fail "the AUR publisher refused the bad digest for an unrelated reason: $aur_output"
+[ ! -e "$aur_home/.ssh" ] || fail "the AUR publisher touched SSH before validating the manifest digests"
+echo "release artifacts case: AUR publisher refusing a malformed binary digest rejected"
 
 # --- the canonical allowlist
 
@@ -592,7 +656,9 @@ assert_rejects "builder artifact missing a canonical asset" "no builder artifact
 
 build_artifacts
 cp "$artifacts/release-binaries/pam_facelock.so" "$artifacts/release-rpm/pam_facelock.so"
-assert_rejects "two builders providing one canonical asset" "more than one builder artifact provides" \
+# A builder's extra output under a canonical name fails closed, and the
+# failure says what to do: re-running only the failed job keeps the artifact.
+assert_rejects "two builders providing one canonical asset" "fix the builder and re-run all jobs" \
     stage "$builders_expected" "$artifacts" "$work/assets-ambiguous"
 build_artifacts
 
@@ -705,6 +771,20 @@ cat >"$work/release-wrong-channel.json" <<'JSON'
 JSON
 assert_rejects "draft whose channel differs from the validated identity" "prerelease identity" \
     verify-draft v0.2.0 false "$work/release-wrong-channel.json"
+
+# Two drafts for one tag is what two concurrent runs leave behind. The
+# concurrency group prevents it; the refusal names the remedy anyway.
+cat >"$work/releases-two-drafts.json" <<'JSON'
+[{"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": []},
+ {"id": 43, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": []}]
+JSON
+assert_rejects "two drafts for one tag before creation" "delete the other with" \
+    verify-creatable v0.2.0 "$work/releases-two-drafts.json"
+assert_rejects "two drafts for one tag before the flip" "delete the other with" \
+    verify-draft v0.2.0 false "$work/releases-two-drafts.json"
+{ "$helper_path" verify-creatable v0.2.0 "$work/releases-two-drafts.json" 2>&1 || true; } |
+    grep -Fq 'releases/43' ||
+    fail "the two-drafts refusal must name the ids to delete"
 
 # A run interrupted between the manifest upload and the flip must be able to
 # run again: the draft already carries MANIFEST.json, and the final allowlist
@@ -986,6 +1066,69 @@ assert_rejects "manifest over an asset that was never staged" "is not present" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
     tyvsmith/facelock deadbeef "$artifacts" "$job_outputs" "$staged" "$work/actual-staged" "$manifest"
 cp "$artifacts/release-binaries/pam_facelock.so" "$staged/pam_facelock.so"
+
+# --- the final readback holds every published asset to the manifest
+
+# Names alone would let one run's binaries sit under another run's digests.
+# The listing the API returns carries each asset's size, and a digest where
+# the API exposes one; both are compared with MANIFEST.json, and the manifest
+# itself with the local file.
+published_listing() {
+    # <output> <mode>: the release as the API would list it after upload.
+    python3 - "$manifest" "$1" "$2" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+manifest_path, output, mode = sys.argv[1:4]
+manifest = json.loads(Path(manifest_path).read_text())
+payload = Path(manifest_path).read_bytes()
+assets = [
+    {"name": entry["name"], "size": entry["size"], "digest": f"sha256:{entry['sha256']}"}
+    for entry in manifest["assets"]
+]
+assets.append({"name": "MANIFEST.json", "size": len(payload),
+               "digest": "sha256:" + hashlib.sha256(payload).hexdigest()})
+if mode == "no-digest":
+    for asset in assets:
+        del asset["digest"]
+elif mode == "wrong-size":
+    assets[0]["size"] += 1
+elif mode == "wrong-digest":
+    assets[1]["digest"] = "sha256:" + "0" * 64
+elif mode == "wrong-manifest":
+    assets[-1]["size"] -= 1
+elif mode == "unknown-digest":
+    assets[2]["digest"] = "sha512:" + "0" * 128
+elif mode == "unlisted":
+    assets.append({"name": "facelock-x86_64-linux-musl", "size": 1})
+release = {"id": 42, "tag_name": "v0.2.0", "draft": True, "prerelease": False, "assets": assets}
+Path(output).write_text(json.dumps([release]) + "\n")
+PY
+}
+published_listing "$work/published-ok.json" exact
+"$helper_path" verify-published "$work/published-ok.json" v0.2.0 "$manifest" >/dev/null ||
+    fail "a published asset list matching the manifest was rejected"
+published_listing "$work/published-no-digest.json" no-digest
+"$helper_path" verify-published "$work/published-no-digest.json" v0.2.0 "$manifest" >/dev/null ||
+    fail "an API listing without digests must still pass on sizes"
+echo "release artifacts case: published assets matching the manifest accepted"
+published_listing "$work/published-wrong-size.json" wrong-size
+assert_rejects "published asset whose size differs from the manifest" "size" \
+    verify-published "$work/published-wrong-size.json" v0.2.0 "$manifest"
+published_listing "$work/published-wrong-digest.json" wrong-digest
+assert_rejects "published asset whose digest differs from the manifest" "digest" \
+    verify-published "$work/published-wrong-digest.json" v0.2.0 "$manifest"
+published_listing "$work/published-wrong-manifest.json" wrong-manifest
+assert_rejects "published manifest that is not the generated one" "MANIFEST.json" \
+    verify-published "$work/published-wrong-manifest.json" v0.2.0 "$manifest"
+published_listing "$work/published-unknown-digest.json" unknown-digest
+assert_rejects "published asset with a digest that cannot be compared" "digest" \
+    verify-published "$work/published-unknown-digest.json" v0.2.0 "$manifest"
+published_listing "$work/published-unlisted.json" unlisted
+assert_rejects "published asset the manifest does not cover" "not covered" \
+    verify-published "$work/published-unlisted.json" v0.2.0 "$manifest"
 # ------------------------------------------------------------------ mutations
 
 if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ] &&
@@ -1114,6 +1257,19 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "no revalidation before the flip" \
         's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \
         'must run PRERELEASE" final'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "final readback comparing names only" \
+        's|^( *)\$HELPER verify-published .*|\1: # verify-published disabled|' \
+        'must run $HELPER verify-published'
+    assert_workflow_mutation_rejected "two runs publishing one tag" \
+        '/^concurrency:$/,/^$/d' \
+        "must declare a concurrency group"
+    assert_workflow_mutation_rejected "runs cancelling the one in progress" \
+        's/^  cancel-in-progress: false$/  cancel-in-progress: true/' \
+        "never cancel it"
+    assert_workflow_mutation_rejected "flake evaluation that cannot fail" \
+        's|^        run: nix flake check ./dist/nix --no-build$|        run: nix flake check ./dist/nix --no-build\n        continue-on-error: true|' \
+        "flake evaluation must gate publication"
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "attestation left unbound to its job" \
         '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -219,6 +219,39 @@ rpm_env_image="$(printf '%s\n' "$rpm_job" | awk '/^      BUILD_IMAGE: /{ sub(/^ 
 printf '%s\n' "$rpm_job" | grep -Fq 'steps.rpm.outputs.rpm' ||
     fail "build-rpm must validate the exact payload package the metadata names"
 
+# The attesting set the helper pins must be exactly the artifacts the workflow
+# uploads. Adding or removing an attesting job moves both or fails here.
+workflow_attestations() {
+    local wf_job body attest_job slot suite
+    for wf_job in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
+        body="$(job_body "$wf_job")"
+        attest_job="$(printf '%s\n' "$body" |
+            sed -n 's|.*attest-digests\.sh \([a-z-]*\) .*|\1|p' | head -1)"
+        slot="$(printf '%s\n' "$body" |
+            sed -n 's/^ *name: release-digests-\(.*\)$/\1/p' | head -1)"
+        [ -n "$attest_job" ] || fail "job $wf_job uploads no digest attestation"
+        [ -n "$slot" ] || fail "job $wf_job names no digest artifact"
+        # A literal workflow expression, and suite names carry no spaces.
+        # shellcheck disable=SC2016,SC2013
+        case "$slot" in
+            *'${{ matrix.suite }}'*)
+                for suite in $(sed -n 's/^deb-\(.*\)	.*/\1/p' <"$attesting_set"); do
+                    printf '%s\t%s\n' \
+                        "$(printf '%s' "$slot" | sed "s/\${{ matrix.suite }}/$suite/")" \
+                        "$attest_job"
+                done
+                ;;
+            *) printf '%s\t%s\n' "$slot" "$attest_job" ;;
+        esac
+    done
+}
+
+attesting_set="$(mktemp "${TMPDIR:-/tmp}/facelock-attesting.XXXXXX")"
+"$helper_path" expected-attestations false >"$attesting_set"
+diff <(workflow_attestations | LC_ALL=C sort) <(LC_ALL=C sort "$attesting_set") >/dev/null ||
+    fail "the pinned attesting set differs from the release workflow's attest-digests.sh call sites: $(diff <(workflow_attestations | LC_ALL=C sort) <(LC_ALL=C sort "$attesting_set") | tr '\n' ' ')"
+rm -f "$attesting_set"
+
 # ------------------------------------------------------------- helper: shape
 
 git_command='git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+'
@@ -351,6 +384,16 @@ build_artifacts() {
         "$artifacts"/release-rpm/*.rpm >/dev/null
     "$attest" publish-apt "$artifacts/release-digests-apt" \
         "$artifacts/release-apt-repo/apt-repo.tar.gz" >/dev/null
+    # The two source components carry provenance and no asset of their own.
+    printf '{"component":"onnxruntime","version":"1.20.1","library_sha256":"a5faaf78"}\n' \
+        >"$work/ort-manifest.json"
+    printf 'ort\n' >"$work/onnxruntime-bundle.tar.xz"
+    printf 'vendor\n' >"$work/cargo-vendor-bundle.tar.xz"
+    "$attest" download-ort "$artifacts/release-digests-onnxruntime" \
+        --component "onnxruntime=$work/ort-manifest.json" \
+        --component-archive "onnxruntime=$work/onnxruntime-bundle.tar.xz" >/dev/null
+    "$attest" prepare-cargo-vendor "$artifacts/release-digests-cargo-vendor" \
+        --component-archive "cargo-vendor=$work/cargo-vendor-bundle.tar.xz" >/dev/null
 }
 
 build_artifacts
@@ -366,7 +409,7 @@ if [ -e "$staged/facelock_0.2.0-1~deb13u1_amd64.manifest" ]; then
     fail "staging copied a file the allowlist does not name"
 fi
 
-"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" >/dev/null ||
+"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" false >/dev/null ||
     fail "the staged assets did not match the attestations in the same artifact tree"
 
 cat >"$artifacts/release-binaries/digests.json" <<'JSON'
@@ -374,7 +417,7 @@ cat >"$artifacts/release-binaries/digests.json" <<'JSON'
  "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
 JSON
 assert_rejects "payload artifact claiming another builder's provenance" "inside a payload artifact" \
-    verify-digests "$artifacts" "$staged" "$work/actual-staged"
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
 build_artifacts
 
 rm -f "$artifacts/release-rpm/facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"
@@ -520,85 +563,118 @@ echo "release artifacts case: rerun over a draft that already carries the manife
 
 # --- builder digest attestations
 
-assets_dir="$work/attested"
-rm -rf "$assets_dir"
-mkdir -p "$assets_dir"
-printf 'facelock\n' >"$assets_dir/facelock-x86_64-linux-gnu"
-printf 'pam\n' >"$assets_dir/pam_facelock.so"
-asset_digest() { sha256sum "$assets_dir/$1" | cut -d' ' -f1; }
+# One tree, the one the publish job hands to both readers: payload artifacts
+# beside the attestations that cover them.
+attested_digest() { sha256sum "$staged/$1" | cut -d' ' -f1; }
+attestation() { printf '%s' "$artifacts/release-digests-$1/digests.json"; }
 
-digests_dir="$work/digests"
-rm -rf "$digests_dir"
-mkdir -p "$digests_dir/release-digests-build"
-cat >"$digests_dir/release-digests-build/digests.json" <<JSON
-{
-  "job": "build",
-  "assets": {
-    "facelock-x86_64-linux-gnu": "$(asset_digest facelock-x86_64-linux-gnu)",
-    "pam_facelock.so": "$(asset_digest pam_facelock.so)"
-  }
-}
-JSON
-
-printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so >"$work/actual-attested"
-"$helper_path" verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested" >/dev/null ||
+"$helper_path" verify-digests "$artifacts" "$staged" "$work/actual-staged" false >/dev/null ||
     fail "assets matching their builder attestations were rejected"
 
-printf 'tampered\n' >"$assets_dir/pam_facelock.so"
+printf 'tampered\n' >"$staged/pam_facelock.so"
 assert_rejects "release asset mutated after its builder attested it" "does not match the digest" \
-    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
-printf 'pam\n' >"$assets_dir/pam_facelock.so"
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+cp "$artifacts/release-binaries/pam_facelock.so" "$staged/pam_facelock.so"
 
-printf 'smuggled\n' >"$assets_dir/extra-asset"
-printf '%s\n' facelock-x86_64-linux-gnu pam_facelock.so extra-asset >"$work/actual-unattested"
+printf 'smuggled\n' >"$staged/extra-asset"
+{ cat "$work/actual-staged"; echo extra-asset; } >"$work/actual-unattested"
 assert_rejects "release asset no builder attested" "attested by no builder" \
-    verify-digests "$digests_dir" "$assets_dir" "$work/actual-unattested"
-rm -f "$assets_dir/extra-asset"
+    verify-digests "$artifacts" "$staged" "$work/actual-unattested" false
+rm -f "$staged/extra-asset"
+
+# An attesting artifact may not claim an asset another one produced.
+python3 - "$(attestation rpm)" "$(attested_digest pam_facelock.so)" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path))
+document["assets"]["pam_facelock.so"] = sys.argv[2]
+open(path, "w").write(json.dumps(document, indent=2) + "\n")
+PY
+assert_rejects "two builders claiming one asset" "attested by more than one builder" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+build_artifacts
+
+# --- the attesting set is pinned, not merely deduplicated
+
+# Anything running in a builder can upload an artifact of its own. An extra
+# attestation claiming another job's identity would reach MANIFEST.json with
+# every asset digest still checking out.
+mkdir -p "$artifacts/release-digests-zzz-supplychain"
+cat >"$artifacts/release-digests-zzz-supplychain/digests.json" <<'JSON'
+{"job": "download-ort", "image": "evil.example/img@sha256:dead", "assets": {},
+ "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
+JSON
+assert_rejects "extra digest artifact forging another job's provenance" "no builder attests as" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+assert_rejects "extra digest artifact reaching the manifest" "no builder attests as" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
+
+python3 - "$(attestation build)" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path))
+document["job"] = "build-deb"
+open(path, "w").write(json.dumps(document, indent=2) + "\n")
+PY
+assert_rejects "attestation declaring a job that is not its slot" "belongs to" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+build_artifacts
+
+rm -rf "$artifacts/release-digests-apt"
+assert_rejects "attesting job that did not attest" "no attestation from" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+build_artifacts
+
+mkdir -p "$artifacts/release-digests-rpm/second"
+cp "$(attestation rpm)" "$artifacts/release-digests-rpm/second/digests.json"
+assert_rejects "attesting artifact holding two documents" "documents, expected one" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
+build_artifacts
+
+# A prerelease publishes no APT repository, so publish-apt attests nothing.
+assert_rejects "stable attestation set on a prerelease" "no builder attests as" \
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" true
 
 # A payload artifact carrying an attestation is a builder claiming provenance
 # for work it did not do; the manifest would record its image and components.
-mkdir -p "$digests_dir/release-binaries"
-cat >"$digests_dir/release-binaries/digests.json" <<'JSON'
+cat >"$artifacts/release-binaries/digests.json" <<'JSON'
 {"job": "download-ort", "image": "evil.example/img@sha256:dead", "assets": {},
  "components": {"onnxruntime": {"version": "666", "library_sha256": "forged"}}}
 JSON
 assert_rejects "digest attestation planted in a payload artifact" "inside a payload artifact" \
-    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
+    verify-digests "$artifacts" "$staged" "$work/actual-staged" false
 assert_rejects "forged provenance reaching the manifest" "inside a payload artifact" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$work/forged.json"
-rm -rf "$digests_dir/release-binaries"
+    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
 
-mkdir -p "$digests_dir/release-digests-duplicate"
-cat >"$digests_dir/release-digests-duplicate/digests.json" <<JSON
-{"job": "other", "assets": {"pam_facelock.so": "$(asset_digest pam_facelock.so)"}}
-JSON
-assert_rejects "two builders claiming one asset" "attested by more than one builder" \
-    verify-digests "$digests_dir" "$assets_dir" "$work/actual-attested"
-rm -rf "$digests_dir/release-digests-duplicate"
+# Two attestations claiming one provenance key is a contradiction, not a merge.
+python3 - "$(attestation cargo-vendor)" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path))
+document.setdefault("components", {})["onnxruntime"] = {"version": "666"}
+open(path, "w").write(json.dumps(document, indent=2) + "\n")
+PY
+assert_rejects "two attestations claiming one component" "claim the component" \
+    manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
+    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$work/forged.json"
+build_artifacts
 
 # --- the publication manifest
 
-mkdir -p "$digests_dir/release-digests-deb-trixie"
-cat >"$digests_dir/release-digests-deb-trixie/digests.json" <<'JSON'
-{"job": "build-deb", "suite": "trixie", "image": "docker.io/library/debian:13@sha256:34cd", "assets": {}}
-JSON
-mkdir -p "$digests_dir/release-digests-onnxruntime"
-cat >"$digests_dir/release-digests-onnxruntime/digests.json" <<'JSON'
-{"job": "download-ort", "assets": {},
- "components": {"onnxruntime": {"version": "1.20.1", "library_sha256": "a5faaf78"}}}
-JSON
-
 manifest="$work/MANIFEST.json"
 "$helper_path" manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$manifest" >/dev/null ||
+    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$manifest" >/dev/null ||
     fail "manifest generation failed for a complete release"
 
-python3 - "$manifest" "$(asset_digest facelock-x86_64-linux-gnu)" <<'PY' ||
+python3 - "$manifest" "$(attested_digest facelock-x86_64-linux-gnu)" <<'PY' ||
 import json, sys
 manifest = json.load(open(sys.argv[1]))
 assets = {entry["name"]: entry for entry in manifest["assets"]}
-missing = {"facelock-x86_64-linux-gnu", "pam_facelock.so"} - set(assets)
+missing = {"facelock-x86_64-linux-gnu", "pam_facelock.so", "apt-repo.tar.gz"} - set(assets)
 assert not missing, f"manifest omits {sorted(missing)}"
 assert assets["facelock-x86_64-linux-gnu"]["sha256"] == sys.argv[2], "manifest digest is not the asset digest"
 assert all("size" in entry for entry in manifest["assets"]), "manifest omits asset sizes"
@@ -608,19 +684,48 @@ assert "archive/refs/tags/v0.2.0" in manifest["source"]["url"], "manifest omits 
 images = manifest["build_images"]
 assert any("debian:13@sha256" in value for value in images.values()), "manifest omits a build image digest"
 assert manifest["components"]["onnxruntime"]["library_sha256"] == "a5faaf78", "manifest omits the ORT digest"
+assert "cargo-vendor" in manifest["components"], "manifest omits the Cargo vendor component"
 PY
     fail "the generated manifest does not cover every asset and every reviewed digest"
 
-rm -f "$assets_dir/pam_facelock.so"
+rm -f "$staged/pam_facelock.so"
 assert_rejects "manifest over an asset that was never staged" "is not present" \
     manifest v0.2.0 0.2.0 0000000000000000000000000000000000000000 false \
-    tyvsmith/facelock deadbeef "$digests_dir" "$assets_dir" "$work/actual-attested" "$manifest"
-
+    tyvsmith/facelock deadbeef "$artifacts" "$staged" "$work/actual-staged" "$manifest"
+cp "$artifacts/release-binaries/pam_facelock.so" "$staged/pam_facelock.so"
 # ------------------------------------------------------------------ mutations
 
-if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ]; then
+if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ] &&
+    [ -z "${FACELOCK_RELEASE_ATTESTATIONS:-}" ]; then
     mutation_root="$work/mutations"
     mkdir -p "$mutation_root"
+
+    # The attesting set is the only thing standing between an extra artifact
+    # and forged provenance in MANIFEST.json, so prove the check is load-bearing.
+    assert_loader_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local loader=.github/workflows/scripts/release_attestations.py
+        local mutant
+        mutant="$mutation_root/release_attestations-$(printf '%s' "$context" | tr ' ' '-').py"
+        sed -E "$expression" "$loader" >"$mutant"
+        if cmp -s "$loader" "$mutant"; then
+            fail "$context mutation did not change the attestation loader"
+        fi
+        local output
+        if output="$(FACELOCK_RELEASE_ATTESTATIONS="$mutant" bash "$0" 2>&1)"; then
+            fail "release artifacts contract accepted $context"
+        fi
+        printf '%s\n' "$output" | grep -Fq "$needle" ||
+            fail "$context mutation failed for an unrelated reason: $output"
+        echo "release artifacts mutation: $context rejected"
+    }
+
+    assert_loader_mutation_rejected "an unpinned attesting set" \
+        's/^    unexpected = sorted\(set\(present\) - set\(expected\)\)$/    unexpected = []/' \
+        "extra digest artifact forging another job's provenance: helper accepted"
+    assert_loader_mutation_rejected "attestations trusted to name their own job" \
+        's/^        if document.get\("job"\) != expected\[slot\]:$/        if False:/' \
+        "attestation declaring a job that is not its slot: helper accepted"
 
     assert_workflow_mutation_rejected() {
         local context="$1" expression="$2" needle="$3"
@@ -678,6 +783,12 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "tag rewritten at publication" \
         's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
         "publishing must not send a tag or target commitish"
+fi
+
+# Loading the attestation module must not leave bytecode in the checkout: the
+# recipes that demand a clean tree run right after this gate.
+if [ -e .github/workflows/scripts/__pycache__ ]; then
+    fail "the release asset helper left __pycache__ in the checkout"
 fi
 
 echo "release artifacts contract: ok"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -161,16 +161,21 @@ for toolchain in '(^|[^-A-Za-z])cargo[[:space:]]' 'rustup' 'rustc' 'rust-toolcha
     fi
 done
 
-printf '%s\n' "$publish_job" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
+# Every step assertion reads the comment-stripped statements: a step that was
+# commented out, or replaced by `: # disabled`, must not pass as present.
+printf '%s\n' "$publish_statements" | grep -Eq '^[[:space:]]+draft: true[[:space:]]*$' ||
     fail "the publish job must create the GitHub release as a draft"
 # Literal workflow expressions; nothing here is a shell expansion.
 # shellcheck disable=SC2016
-printf '%s\n' "$publish_job" | grep -Fq 'prerelease: ${{ needs.metadata.outputs.prerelease }}' ||
+printf '%s\n' "$publish_statements" | grep -Fq 'prerelease: ${{ needs.metadata.outputs.prerelease }}' ||
     fail "the draft must carry the validated prerelease identity"
-for step in 'verify-tag' 'stage expected-assets' 'verify-digests' 'verify-creatable' \
-    'PRERELEASE" final' 'MANIFEST.json' 'draft=false'; do
-    printf '%s\n' "$publish_job" | grep -Fq "$step" ||
-        fail "the publish job must run $step before the release becomes public"
+# The helper invocations are matched with their trailing space so that a
+# `verify-digests-disabled` lookalike cannot stand in for the real call.
+# shellcheck disable=SC2016
+for step in '$HELPER verify-tag ' '$HELPER stage expected-assets' '$HELPER verify-digests ' \
+    '$HELPER verify-creatable ' 'PRERELEASE" final' 'MANIFEST.json' 'draft=false'; do
+    printf '%s\n' "$publish_statements" | grep -Fq "$step" ||
+        fail "the publish job must run ${step% } before the release becomes public"
 done
 
 # Every release write goes through the dedicated publication credential.
@@ -257,9 +262,12 @@ rm -f "$attesting_set"
 git_command='git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+'
 grep -Eq "${git_command}tag[[:space:]]+-v" "$helper_path" ||
     fail "tag verification must verify a present signature with git tag -v"
-if grep -Eq "${git_command}tag[[:space:]]+(-[afsm]|[^-])" "$helper_path"; then
-    fail "the release asset helper must never create or move a tag"
-fi
+# Allowlist, not blocklist: the only `git tag` the helper may run is a
+# verification. Anything else (create, delete, move, list) is refused.
+other_tag_commands="$(grep -E "${git_command}tag([[:space:]]|$)" "$helper_path" |
+    grep -Ev "${git_command}tag[[:space:]]+(-v|--verify)([[:space:]]|$)" || true)"
+[ -z "$other_tag_commands" ] ||
+    fail "the release asset helper may only run git tag -v; found: $other_tag_commands"
 if grep -Eq "${git_command}push" "$helper_path"; then
     fail "the release asset helper must never push"
 fi
@@ -757,21 +765,24 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         's/^      - name: Build release$/      - name: Build release\n        env:\n          TOKEN: ${{ secrets.RELEASE_PAT }}/' \
         "builders produce artifacts only"
     assert_workflow_mutation_rejected "builder writing the release directly" \
-        's|^      - name: Upload the APT repository artifact$|      - name: Upload the APT repository artifact\n        # uses: softprops/action-gh-release@0000|' \
+        's|^      - name: Upload the APT repository artifact$|      - name: Write the release\n        uses: softprops/action-gh-release@0000\n\n      - name: Upload the APT repository artifact|' \
         "builders produce artifacts only"
     assert_workflow_mutation_rejected "compiling in the publishing job" \
         's|^      - name: Verify the maintainer tag$|      - name: Rebuild\n        run: cargo build --release\n\n      - name: Verify the maintainer tag|' \
         "must not compile or package anything"
+    # Neutralized, not deleted: the step stays in place as a no-op with its
+    # old text in a comment, which is what a careless edit leaves behind.
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "unverified tag" \
-        '/\$HELPER verify-tag /d' \
-        "must run verify-tag"
+        's|^( *)\$HELPER verify-tag .*|\1: # verify-tag disabled|' \
+        'must run $HELPER verify-tag'
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "unverified builder attestations" \
-        '/\$HELPER verify-digests /d' \
-        "must run verify-digests"
+        's|^( *)run: \$HELPER verify-digests .*|\1run: ": # verify-digests disabled"|' \
+        'must run $HELPER verify-digests'
+    # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "no revalidation before the flip" \
-        '/PRERELEASE" final/d' \
+        's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \
         'must run PRERELEASE" final'
     assert_workflow_mutation_rejected "pages rebuild before publication" \
         's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \


### PR DESCRIPTION
## Summary

- publish the release as a draft, validate every asset and digest, then flip it public exactly once
- keep builders artifact-only: `build`, `build-deb`, `build-rpm`, `publish-apt` upload workflow artifacts and never touch the release
- make `publish` the sole writer: it holds `RELEASE_PAT`, compiles nothing, and creates, validates, and publishes the release
- pin the canonical asset allowlist, rejecting anything extra, missing, or duplicated
- bind each builder's digest attestation to the job output it recorded, with per-slot provenance (image, suite, components) pinned against the same source the workflow uses
- replace `SHA256SUMS` with `MANIFEST.json`, covering every asset plus the source tarball, build images, and component digests
- add a `concurrency` group so two runs can't race one tag's publication
- read the published release back by size and digest before returning
- gate `test/release-artifacts-contract.sh` (`just test-release-artifacts`) in `just check` and `release-preflight`

## Why

Direct release creation let any builder job write to the release under the same credential, so an extra or mutated build output could ship silently, and a mid-flight rerun could publish a mix of two runs' state. This moves every release write into one validated, sole-credentialed job and pins each provenance claim to something a compromised builder cannot forge.

## Reviewer notes

- **artifacts are shared mutable storage**: any job in the run can write any artifact, so an attestation is trusted only once bound to the job output that recorded it, never to artifact content alone
- **debug RPMs kept**: v0.1.4 shipped `facelock-debuginfo`/`facelock-debugsource`, so the allowlist keeps publishing them
- **`RELEASE_PAT` is now load-bearing for prereleases too**: an unset or expired PAT fails the release before publication, not just at hand-off to package repos
- **`build-nix` evaluation gates publication**: `nix flake check` must succeed; `nix build` stays advisory (`continue-on-error`) since it depends on nixpkgs state
- unprovable without a tag: cross-job artifact overwrite reachability, `gh release upload` against a draft, softprops `prerelease` on update, PATCH re-creating a deleted tag

## Validation

- `bash test/release-artifacts-contract.sh`
- `python3 test/check-agent-docs.py`
- `python3 test/check-workflow-policy.py`
- `python3 test/check-release-matrix.py`
- `actionlint .github/workflows/release.yml`
- `just check`

Refs #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Improvements**
  * Releases now use centralized publishing with stricter validation of tags, artifacts, attestations, manifests, and publication status.
  * Stable releases include a `MANIFEST.json` with asset checksums.
  * Packaging evidence must be complete, verifiable, and tied to the exact release commit.
  * Artifact integrity, provenance, and duplicate-publication safeguards have been strengthened.
  * Prereleases bypass stable repositories, while reruns and concurrent publishing are handled more safely.

* **Documentation**
  * Updated release and testing documentation to describe the new validation and publishing requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->