### PR TITLE
fix(daemon): refuse a replacement key over encrypted rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A lost encryption key is never replaced automatically** (#231): the
+  encrypt-by-default keyfile is now created only for a database that holds no
+  encrypted template. On a system whose key artifact went missing, facelock had
+  been writing a fresh key over rows encrypted under the old one; those rows
+  were already unreadable, but the replacement made the loss permanent, because
+  a later restore of the real key no longer matched what had since been
+  written. Every writer of that key now makes the same decision — the daemon,
+  `facelock auth` and the other one-shot commands, `facelock setup`'s automatic
+  encryption policy, and `facelock encrypt` with and without `--generate-key`.
+  A refusal names the encryption method that wrote the rows at risk, the
+  artifact to restore, and `facelock clear` as the deliberate destructive
+  alternative; restoring the key lifts it at the next enrollment attempt with
+  no daemon restart. Enrollment fails closed while it stands, authentication
+  still falls through to the password prompt, a user whose own templates are
+  plaintext keeps authenticating, and the auth path reports the missing key
+  instead of calling the database corrupt. Key creation is now an `O_EXCL`
+  write to a temporary flushed and moved into place with
+  `renameat2(RENAME_NOREPLACE)`, so concurrent daemons resolve to one key and
+  no reader sees a partial one, and a symlink standing at the key path is
+  refused by the reading path as well as the creating one.
+
 - **Enrollment persists atomically** (#308): the daemon and `facelock enroll`
   now hold accepted embeddings in memory and write the model in one store
   transaction after the minimum-capture and angle-diversity gates pass, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -611,15 +611,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   encryption policy, and `facelock encrypt` with and without `--generate-key`.
   A refusal names the encryption method that wrote the rows at risk, the
   artifact to restore, and `facelock clear` as the deliberate destructive
-  alternative; restoring the key lifts it at the next enrollment attempt with
-  no daemon restart. Enrollment fails closed while it stands, authentication
-  still falls through to the password prompt, a user whose own templates are
-  plaintext keeps authenticating, and the auth path reports the missing key
-  instead of calling the database corrupt. Key creation is now an `O_EXCL`
-  write to a temporary flushed and moved into place with
-  `renameat2(RENAME_NOREPLACE)`, so concurrent daemons resolve to one key and
-  no reader sees a partial one, and a symlink standing at the key path is
-  refused by the reading path as well as the creating one.
+  alternative; restoring the key lifts it live on the next authentication or
+  enrollment attempt, no daemon restart. Enrollment fails closed while it
+  stands, authentication still falls through to the password prompt, a user
+  whose own templates are plaintext keeps authenticating, and the auth path
+  reports the missing key instead of calling the database corrupt. Key
+  creation is now an `O_EXCL` write to a temporary flushed and moved into
+  place with `renameat2(RENAME_NOREPLACE)`, so concurrent daemons resolve to
+  one key and no reader sees a partial one, and a symlink standing at the key
+  path is refused by every creating and reading path, `--generate-key`
+  included.
 
 - **Enrollment persists atomically** (#308): the daemon and `facelock enroll`
   now hold accepted embeddings in memory and write the model in one store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tss-esapi",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "facelock-core",
+ "libc",
  "rand 0.10.2",
  "serde",
  "serde_json",

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -36,26 +36,95 @@ fn obtain_sealer(config: &Config) -> Result<facelock_tpm::SoftwareSealer> {
     }
 }
 
-/// The refusal that stops any key writer here from orphaning stored templates,
-/// or `None` when nothing is at risk.
+/// `--generate-key`: check what the replacement would orphan and write the new
+/// key artifact, as one act.
+///
+/// The check and the write are one exclusive section on the store, because
+/// separately they are a race: enrollment persists a template in a single
+/// store transaction (`replace_model_with_embeddings`), and one committing
+/// between a check that found nothing encrypted and the key that replaces the
+/// old one leaves a row nothing can ever decrypt. Under WAL a plain read would
+/// not even see that commit — it reads the snapshot it opened on — so the
+/// window is not narrow, it is unbounded until the query runs. Enrollment's
+/// transaction now waits for this section, and this section waits for it.
 ///
 /// `open_existing`, never `create`: a database that is simply not there yet
 /// has no templates to orphan, and probing must not bring one into being at
 /// whatever path a typo'd config names. Every other failure class is "facelock
-/// cannot tell", which the shared gate turns into a refusal.
-fn key_replacement_refusal(config: &Config) -> Result<Option<String>> {
+/// cannot tell", which is a refusal.
+fn generate_key_serialized(config: &Config) -> Result<()> {
     match crate::direct::open_store_existing(config) {
-        Ok(store) => Ok(facelock_daemon::key_policy::key_creation_refusal(
-            &store, config,
-        )),
-        Err(facelock_store::StoreError::Absent { .. }) => Ok(None),
-        Err(e) => Ok(Some(format!(
+        Ok(store) => store.with_exclusive(|_conn| {
+            if let Some(refusal) = facelock_daemon::key_policy::key_creation_refusal(&store, config)
+            {
+                bail!("{refusal}");
+            }
+            write_key_artifact(config)
+        }),
+        // Nothing to lock and nothing to orphan. A writer that creates this
+        // database from here mints its own key through the shared gate, which
+        // takes the same section on the database it just created.
+        Err(facelock_store::StoreError::Absent { .. }) => write_key_artifact(config),
+        Err(e) => bail!(
             "refusing to write an encryption key: the face database at {} could not be \
              read ({e}), so facelock cannot tell whether existing templates would be \
              orphaned. Fix access to it and retry, or clear the enrollments with \
              `facelock clear`.",
             config.storage.db_path
-        ))),
+        ),
+    }
+}
+
+/// Write the key artifact the configured method uses, and print what an
+/// operator does next. Called with the store's write lock held, unless there
+/// is no database to hold it on.
+fn write_key_artifact(config: &Config) -> Result<()> {
+    match config.encryption.method {
+        EncryptionMethod::Tpm => {
+            #[cfg(feature = "tpm")]
+            {
+                let sealed_path = Path::new(&config.encryption.sealed_key_path);
+                println!(
+                    "Generating and sealing AES key with TPM to {}...",
+                    sealed_path.display()
+                );
+                let pcr = if config.tpm.pcr_binding {
+                    Some(config.tpm.pcr_indices.as_slice())
+                } else {
+                    None
+                };
+                let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
+                    .context("failed to initialize TPM")?;
+                facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
+                    .context("failed to generate and seal key")?;
+                println!("TPM-sealed key generated (permissions: 0600).");
+                Ok(())
+            }
+            #[cfg(not(feature = "tpm"))]
+            {
+                bail!("encryption method is 'tpm' but TPM support is not compiled in");
+            }
+        }
+        // `none` included: `--generate-key` is how an operator mints the key
+        // *before* switching the config to `keyfile`, which the notice below
+        // spells out. Only automatic creation is restricted to the method
+        // that reads the file.
+        EncryptionMethod::Keyfile | EncryptionMethod::None => {
+            let key_path = Path::new(&config.encryption.key_path);
+            println!("Generating encryption key at {}...", key_path.display());
+            facelock_tpm::SoftwareSealer::generate_key_file(key_path)
+                .context("failed to generate encryption key")?;
+            println!("Key generated (permissions: 0600 root-only).");
+            println!(
+                "\nTo encrypt embeddings, run: sudo facelock tpm encrypt\n\
+                 To enable auto-encryption, add to config:\n\
+                 [encryption]\n\
+                 method = \"keyfile\"\n\
+                 key_path = \"{}\"",
+                key_path.display()
+            );
+            Ok(())
+        }
     }
 }
 
@@ -79,52 +148,7 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
         // permanently unrecoverable. It is allowed on a database with nothing
         // encrypted in it, and otherwise refused with `facelock clear` named
         // as the destructive step the operator can take deliberately (#231).
-        if let Some(refusal) = key_replacement_refusal(config)? {
-            bail!("{refusal}");
-        }
-        match config.encryption.method {
-            EncryptionMethod::Tpm => {
-                #[cfg(feature = "tpm")]
-                {
-                    let sealed_path = Path::new(&config.encryption.sealed_key_path);
-                    println!(
-                        "Generating and sealing AES key with TPM to {}...",
-                        sealed_path.display()
-                    );
-                    let pcr = if config.tpm.pcr_binding {
-                        Some(config.tpm.pcr_indices.as_slice())
-                    } else {
-                        None
-                    };
-                    let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                        .context("failed to initialize TPM")?;
-                    facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
-                        .context("failed to generate and seal key")?;
-                    println!("TPM-sealed key generated (permissions: 0600).");
-                    return Ok(());
-                }
-                #[cfg(not(feature = "tpm"))]
-                {
-                    bail!("encryption method is 'tpm' but TPM support is not compiled in");
-                }
-            }
-            _ => {
-                let key_path = Path::new(&config.encryption.key_path);
-                println!("Generating encryption key at {}...", key_path.display());
-                facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-                    .context("failed to generate encryption key")?;
-                println!("Key generated (permissions: 0600 root-only).");
-                println!(
-                    "\nTo encrypt embeddings, run: sudo facelock tpm encrypt\n\
-                     To enable auto-encryption, add to config:\n\
-                     [encryption]\n\
-                     method = \"keyfile\"\n\
-                     key_path = \"{}\"",
-                    key_path.display()
-                );
-                return Ok(());
-            }
-        }
+        return generate_key_serialized(config);
     }
 
     // This command re-seals rows from a query that carries no device id, so
@@ -438,6 +462,52 @@ mod key_gate_tests {
 
         super::run_encrypt(&config_for(&key_path, &db_path), true).unwrap();
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+        cleanup(&db_path);
+    }
+
+    /// The gate's section is the whole act, not just the query: an
+    /// enrollment holding the store keeps `--generate-key` out until it has
+    /// committed, so the row it wrote is one the check can still see.
+    ///
+    /// Timed rather than sampled — the outcome of an uncontended run looks
+    /// identical, and what has to hold is that the command did not decide
+    /// while another writer had the database.
+    #[test]
+    fn generate_key_waits_for_a_writer_holding_the_store() {
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("generate-key-locked");
+        let writer = FaceStore::create(&db_path).unwrap();
+        writer
+            .add_model("alice", "front", &[0.5f32; 512], "e")
+            .unwrap();
+
+        let (announce, section_open) = std::sync::mpsc::channel();
+        let config = config_for(&key_path, &db_path);
+        let command = std::thread::spawn(move || {
+            section_open
+                .recv()
+                .expect("the writer never took the store");
+            let started = Instant::now();
+            (super::run_encrypt(&config, true), started.elapsed())
+        });
+
+        writer
+            .with_exclusive(|_conn| {
+                announce.send(()).expect("the command thread is waiting");
+                std::thread::sleep(Duration::from_millis(200));
+                Ok::<(), facelock_store::StoreError>(())
+            })
+            .unwrap();
+
+        let (result, elapsed) = command.join().unwrap();
+        result.expect("a plaintext database still gets its key");
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "the key was written while another writer held the store: {elapsed:?}"
+        );
         cleanup(&db_path);
     }
 

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -36,10 +36,41 @@ fn obtain_sealer(config: &Config) -> Result<facelock_tpm::SoftwareSealer> {
     }
 }
 
+/// The refusal that stops any key writer here from orphaning stored templates,
+/// or `None` when nothing is at risk.
+///
+/// `open_existing`, never `create`: a database that is simply not there yet
+/// has no templates to orphan, and probing must not bring one into being at
+/// whatever path a typo'd config names. Every other failure class is "facelock
+/// cannot tell", which the shared gate turns into a refusal.
+fn key_replacement_refusal(config: &Config) -> Result<Option<String>> {
+    match crate::direct::open_store_existing(config) {
+        Ok(store) => Ok(facelock_daemon::key_policy::key_creation_refusal(
+            &store, config,
+        )),
+        Err(facelock_store::StoreError::Absent { .. }) => Ok(None),
+        Err(e) => Ok(Some(format!(
+            "refusing to write an encryption key: the face database at {} could not be \
+             read ({e}), so facelock cannot tell whether existing templates would be \
+             orphaned. Fix access to it and retry, or clear the enrollments with \
+             `facelock clear`.",
+            config.storage.db_path
+        ))),
+    }
+}
+
 pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     // Root is established by `main`'s `require_root_for` gate (C6) before
     // `tpm::run` dispatches here.
     if generate_key {
+        // `--generate-key` is an explicit request to *replace* the key, which
+        // is exactly the act that makes rows written under the old one
+        // permanently unrecoverable. It is allowed on a database with nothing
+        // encrypted in it, and otherwise refused with `facelock clear` named
+        // as the destructive step the operator can take deliberately (#231).
+        if let Some(refusal) = key_replacement_refusal(config)? {
+            bail!("{refusal}");
+        }
         match config.encryption.method {
             EncryptionMethod::Tpm => {
                 #[cfg(feature = "tpm")]
@@ -98,23 +129,37 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
         );
     }
 
-    // For non-generate runs, if method is keyfile and key doesn't exist, generate it
-    let key_path = Path::new(&config.encryption.key_path);
-    if config.encryption.method != EncryptionMethod::Tpm && !key_path.exists() {
-        println!("Generating encryption key at {}...", key_path.display());
-        facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-            .context("failed to generate encryption key")?;
-        println!("Key generated (permissions: 0600 root-only).");
-        println!("Proceeding to encrypt embeddings...");
-    }
-
-    let sealer = obtain_sealer(config).context("failed to obtain encryption sealer")?;
-
     // `open_existing`, never `create`: nothing to encrypt or decrypt means a
     // missing database is an error to report, not a file to bring into being
     // at whatever path a typo'd config names.
+    //
+    // Opened *before* any key is written. This command is the one the setup
+    // hint points operators at when encryption looks broken, so it is the one
+    // they run on a system whose key artifact has gone missing — and it used
+    // to mint a replacement over their encrypted rows and then report
+    // "Nothing to do", which is the ratchet the daemon refusal exists to
+    // prevent, reachable from a single privileged command.
     let store = FaceStore::open_existing(Path::new(&config.storage.db_path))
         .context("failed to open face database")?;
+
+    // For non-generate runs, if method is keyfile and key doesn't exist,
+    // generate it — through the gate shared with the daemon, the one-shot path
+    // and `facelock setup`.
+    if config.encryption.method != EncryptionMethod::Tpm {
+        let key_path = Path::new(&config.encryption.key_path);
+        let existed = key_path.exists();
+        if let Some(refusal) =
+            facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config).refusal()
+        {
+            bail!("{refusal}");
+        }
+        if !existed {
+            println!("Generated encryption key at {}.", key_path.display());
+            println!("Proceeding to encrypt embeddings...");
+        }
+    }
+
+    let sealer = obtain_sealer(config).context("failed to obtain encryption sealer")?;
 
     let all = store
         .get_all_embeddings_raw()
@@ -250,6 +295,144 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
 
     println!("Decrypted {decrypted_count} embedding(s) successfully.");
     Ok(())
+}
+
+#[cfg(test)]
+mod key_gate_tests {
+    use facelock_core::config::Config;
+    use facelock_store::FaceStore;
+
+    fn temp_db(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "facelock-encrypt-{name}-{}-{unique}.db",
+            std::process::id()
+        ))
+    }
+
+    fn cleanup(path: &std::path::Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+    }
+
+    fn config_for(key_path: &std::path::Path, db_path: &std::path::Path) -> Config {
+        Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n\
+             [storage]\ndb_path = \"{}\"\n",
+            key_path.display(),
+            db_path.display()
+        ))
+        .unwrap()
+    }
+
+    fn row_sealed_under(key: [u8; 32]) -> Vec<u8> {
+        facelock_tpm::SoftwareSealer::from_key(key)
+            .seal_embedding(&[0.5f32; 512])
+            .unwrap()
+    }
+
+    /// `message/setup.rs` points operators at this command by name when
+    /// encryption looks broken, so it is the command they run on a system
+    /// whose key artifact went missing — and it used to mint a replacement
+    /// over their encrypted rows and report "Nothing to do". One privileged
+    /// command reached the exact ratchet the daemon refusal exists to prevent.
+    #[test]
+    fn encrypt_refuses_to_mint_a_replacement_key_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("mint-hole");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model_raw("alice", "front", &row_sealed_under([0x11; 32]), true, "e")
+                .unwrap();
+        }
+
+        let error = format!(
+            "{:#}",
+            super::run_encrypt(&config_for(&key_path, &db_path), false).unwrap_err()
+        );
+        assert!(
+            error.contains("software-encrypted") && error.contains("facelock clear"),
+            "the refusal must name what is at risk and the remedy: {error}"
+        );
+        assert!(!key_path.exists(), "a replacement key was written");
+        cleanup(&db_path);
+    }
+
+    /// `--generate-key` truncates in place, which is right when an operator
+    /// asked for a new key and catastrophic when rows were written under the
+    /// old one. It stays allowed on a database with nothing encrypted in it.
+    #[test]
+    fn generate_key_refuses_to_truncate_a_live_key_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("generate-key");
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let before = std::fs::read(&key_path).unwrap();
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model_raw("alice", "front", &row_sealed_under([0x11; 32]), true, "e")
+                .unwrap();
+        }
+
+        let error = format!(
+            "{:#}",
+            super::run_encrypt(&config_for(&key_path, &db_path), true).unwrap_err()
+        );
+        assert!(error.contains("facelock clear"), "{error}");
+        assert_eq!(
+            std::fs::read(&key_path).unwrap(),
+            before,
+            "the live key was overwritten in place"
+        );
+        cleanup(&db_path);
+    }
+
+    #[test]
+    fn generate_key_still_works_when_nothing_is_encrypted() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("generate-key-clean");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "e")
+                .unwrap();
+        }
+
+        super::run_encrypt(&config_for(&key_path, &db_path), true).unwrap();
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+        cleanup(&db_path);
+    }
+
+    /// The command's own job still works: a plaintext database gets its key
+    /// minted and its rows encrypted.
+    #[test]
+    fn encrypt_still_mints_a_key_for_a_plaintext_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("plaintext");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "e")
+                .unwrap();
+        }
+
+        super::run_encrypt(&config_for(&key_path, &db_path), false).unwrap();
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+
+        let store = FaceStore::open_existing(&db_path).unwrap();
+        let (sealed, unsealed) = store.count_sealed().unwrap();
+        assert_eq!((sealed, unsealed), (1, 0));
+        cleanup(&db_path);
+    }
 }
 
 #[cfg(test)]

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -61,9 +61,13 @@ fn generate_key_serialized(config: &Config) -> Result<()> {
             }
             write_key_artifact(config)
         }),
-        // Nothing to lock and nothing to orphan. A writer that creates this
-        // database from here mints its own key through the shared gate, which
-        // takes the same section on the database it just created.
+        // Nothing to lock and nothing to orphan yet. "Mints its own key
+        // through the shared gate" is true only if the key file is *also*
+        // absent at that creator's `stat` — `ensure_encrypt_by_default_key`'s
+        // fast path skips the lock entirely when a key is already there. If a
+        // concurrent daemon creates the database and reads that existing key
+        // through the lock-free path, a row it seals before the replacement
+        // below lands is orphaned. Documented, not closed.
         Err(facelock_store::StoreError::Absent { .. }) => write_key_artifact(config),
         Err(e) => bail!(
             "refusing to write an encryption key: the face database at {} could not be \

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -59,6 +59,17 @@ fn key_replacement_refusal(config: &Config) -> Result<Option<String>> {
     }
 }
 
+/// Whether `decision` means *this* call minted the key file, for the notice
+/// `run_encrypt` prints. `Present` covers two different histories — the key
+/// was already there, or a concurrent creator published one first — and both
+/// get no "Generated" credit.
+fn key_was_generated(decision: &facelock_daemon::key_policy::KeyfileDecision) -> bool {
+    matches!(
+        decision,
+        facelock_daemon::key_policy::KeyfileDecision::Created
+    )
+}
+
 pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     // Root is established by `main`'s `require_root_for` gate (C6) before
     // `tpm::run` dispatches here.
@@ -147,13 +158,16 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     // and `facelock setup`.
     if config.encryption.method != EncryptionMethod::Tpm {
         let key_path = Path::new(&config.encryption.key_path);
-        let existed = key_path.exists();
-        if let Some(refusal) =
-            facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config).refusal()
-        {
+        let decision = facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config);
+        if let Some(refusal) = decision.refusal() {
             bail!("{refusal}");
         }
-        if !existed {
+        // The decision, not a pre-gate `exists()` sample: that sample races a
+        // concurrent creator. It can read `false` and then lose the gate's
+        // exclusive create to the other process, which leaves `decision`
+        // `Present` — that call wrote nothing, so it gets no "Generated"
+        // credit (round 1 of #231).
+        if key_was_generated(&decision) {
             println!("Generated encryption key at {}.", key_path.display());
             println!("Proceeding to encrypt embeddings...");
         }
@@ -300,7 +314,23 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
 #[cfg(test)]
 mod key_gate_tests {
     use facelock_core::config::Config;
+    use facelock_daemon::key_policy::KeyfileDecision;
     use facelock_store::FaceStore;
+
+    /// The bug this replaces: `run_encrypt` used to print "Generated" from a
+    /// `key_path.exists()` sample taken *before* the gate ran, so a call that
+    /// raced a concurrent creator and lost — `decision` is `Present`, not
+    /// `Created` — still reported having generated the key. Driving the
+    /// mapping off `decision` itself makes that history unrepresentable: a
+    /// lost race and an already-there key are both `Present`.
+    #[test]
+    fn only_created_is_reported_as_generated() {
+        assert!(super::key_was_generated(&KeyfileDecision::Created));
+        assert!(!super::key_was_generated(&KeyfileDecision::Present));
+        assert!(!super::key_was_generated(&KeyfileDecision::Refused(
+            "irrelevant".into()
+        )));
+    }
 
     fn temp_db(name: &str) -> std::path::PathBuf {
         let unique = std::time::SystemTime::now()

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -180,7 +180,11 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     // For non-generate runs, if method is keyfile and key doesn't exist,
     // generate it — through the gate shared with the daemon, the one-shot path
     // and `facelock setup`.
-    if config.encryption.method != EncryptionMethod::Tpm {
+    // Keyfile only. `tpm` keeps its key sealed elsewhere, and `none` has no
+    // reader for a key file at all — minting one there left a live AES key on
+    // disk for a plaintext database, seconds before `obtain_sealer` refused
+    // the run for having no encryption method configured.
+    if config.encryption.method == EncryptionMethod::Keyfile {
         let key_path = Path::new(&config.encryption.key_path);
         let decision = facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config);
         if let Some(refusal) = decision.refusal() {
@@ -507,6 +511,33 @@ mod key_gate_tests {
         assert!(
             elapsed >= Duration::from_millis(100),
             "the key was written while another writer held the store: {elapsed:?}"
+        );
+        cleanup(&db_path);
+    }
+
+    /// `method = "none"` has no reader for a key file: the implicit branch
+    /// used to mint one for a plaintext database and then fail the run at
+    /// `obtain_sealer`, leaving a live AES key on disk that nothing had asked
+    /// for and nothing would use.
+    #[test]
+    fn the_implicit_branch_mints_no_key_for_method_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("method-none");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "e")
+                .unwrap();
+        }
+        let mut config = config_for(&key_path, &db_path);
+        config.encryption.method = facelock_core::config::EncryptionMethod::None;
+
+        let error = format!("{:#}", super::run_encrypt(&config, false).unwrap_err());
+        assert!(error.contains("no encryption method configured"), "{error}");
+        assert!(
+            !key_path.exists(),
+            "a key was minted for a plaintext database"
         );
         cleanup(&db_path);
     }

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1730,6 +1730,24 @@ mod orphan_guard_tests {
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
     }
 
+    /// The policy runs while the config still says `method = "none"` — that
+    /// is the only state that reaches it — and the shared gate mints only for
+    /// `keyfile`. Asking it about the method the config is about to hold is
+    /// what keeps the automatic policy able to create the key at all.
+    #[test]
+    fn the_auto_policy_mints_while_the_config_still_says_none() {
+        use facelock_core::config::EncryptionMethod;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        let mut config = config_with_key(&db_path, &key_path);
+        config.encryption.method = EncryptionMethod::None;
+
+        assert!(keygen_refusal(&config).unwrap().is_none());
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+    }
+
     /// A fresh install: no database yet, so nothing to orphan — and the probe
     /// must not bring one into being at whatever path the config names.
     #[test]
@@ -2720,8 +2738,14 @@ fn keygen_refusal(config: &Config) -> anyhow::Result<Option<String>> {
             config.storage.db_path
         ),
     };
+    // The gate mints only for `method = "keyfile"`, and the caller reaches
+    // here precisely because the method is still `none` — it is about to
+    // write `keyfile` a few lines later. Ask the gate the question it will be
+    // answering, not the one the config still says.
+    let mut as_keyfile = config.clone();
+    as_keyfile.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
     Ok(
-        facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config)
+        facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, &as_keyfile)
             .refusal()
             .map(str::to_string),
     )

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1668,6 +1668,97 @@ mod orphan_guard_tests {
             "models present must keep the existing prompt/bail path: {chain}"
         );
     }
+
+    // --- The automatic policy's own gate (#231) ---
+    //
+    // `handle_orphan_models_before_keygen` guards the explicit `--encryption`
+    // choices, and asks a stricter question than the daemon's: *any* model,
+    // with an offer to clear. `setup_encryption_auto` is reached by
+    // `run_non_interactive` with no flag at all — the command `debian/postinst`
+    // tells operators to run — and had no guard whatever. It now shares the
+    // daemon's gate, which is the one that can distinguish rows a new key
+    // would orphan from rows it would not.
+
+    fn config_with_key(db_path: &Path, key_path: &Path) -> Config {
+        let mut config = config_with_db(db_path);
+        config.encryption.key_path = key_path.to_string_lossy().into_owned();
+        config
+    }
+
+    #[test]
+    fn the_auto_policy_refuses_to_mint_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            let sealed = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+                .seal_embedding(&[0.5f32; 512])
+                .unwrap();
+            store
+                .add_model_raw("alice", "front", &sealed, true, "embedder")
+                .unwrap();
+        }
+
+        let refusal = keygen_refusal(&config_with_key(&db_path, &key_path))
+            .unwrap()
+            .expect("the auto policy must refuse over encrypted rows");
+        assert!(
+            refusal.contains("software-encrypted") && refusal.contains("facelock clear"),
+            "{refusal}"
+        );
+        assert!(!key_path.exists(), "a replacement key was written");
+    }
+
+    #[test]
+    fn the_auto_policy_still_mints_for_a_plaintext_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "embedder")
+                .unwrap();
+        }
+
+        assert!(
+            keygen_refusal(&config_with_key(&db_path, &key_path))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+    }
+
+    /// A fresh install: no database yet, so nothing to orphan — and the probe
+    /// must not bring one into being at whatever path the config names.
+    #[test]
+    fn the_auto_policy_mints_on_a_fresh_install_without_creating_a_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+
+        assert!(
+            keygen_refusal(&config_with_key(&db_path, &key_path))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+        assert!(!db_path.exists(), "the key gate must not create a database");
+    }
+
+    #[test]
+    fn the_auto_policy_refuses_when_the_database_cannot_be_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        std::fs::write(&db_path, b"not a sqlite database").unwrap();
+
+        let err = keygen_refusal(&config_with_key(&db_path, &key_path)).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(chain.contains("could not be read"), "{chain}");
+        assert!(!key_path.exists());
+    }
 }
 
 fn wizard_encryption_setup(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
@@ -2602,6 +2693,40 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Run the shared key gate for a setup path that is about to mint the
+/// encrypt-by-default key file, returning the refusal if there is one.
+///
+/// `open_existing`, never `create`: a database that is not there yet holds no
+/// templates to orphan, and the probe must not create one to prove it. Every
+/// other failure class means facelock cannot tell, which is a refusal.
+fn keygen_refusal(config: &Config) -> anyhow::Result<Option<String>> {
+    // An absent database holds no template to orphan, and the probe must not
+    // create one to prove it — but the rest of the gate (the symlink check,
+    // the exclusive create) still has to run, and an empty store is exactly
+    // what an absent database is.
+    let absent_store;
+    let store = match crate::direct::open_store_existing(config) {
+        Ok(store) => store,
+        Err(facelock_store::StoreError::Absent { .. }) => {
+            absent_store = facelock_store::FaceStore::open_memory()
+                .context("failed to open an empty store for the key gate")?;
+            absent_store
+        }
+        Err(e) => bail!(
+            "refusing to generate a new encryption key: the face database at {} could \
+             not be read ({e}), so facelock cannot tell whether existing templates \
+             would be orphaned. Fix access to it and re-run, or clear models first \
+             with: sudo facelock clear",
+            config.storage.db_path
+        ),
+    };
+    Ok(
+        facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, config)
+            .refusal()
+            .map(str::to_string),
+    )
+}
+
 /// Auto-configure encryption in non-interactive mode.
 /// Prefers TPM-sealed key if TPM is available, falls back to keyfile.
 fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
@@ -2645,11 +2770,20 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
         }
     }
 
-    // Fall back to keyfile
+    // Fall back to keyfile. Through the gate shared with the daemon, the
+    // one-shot path and `facelock encrypt`, so no writer of this key can drift
+    // on when a replacement may be written over encrypted templates (#231).
+    // `handle_orphan_models_before_keygen` still guards the interactive
+    // `--encryption` choices with a stricter question (any model at all, with
+    // an offer to clear); this is the backstop for the automatic policy, which
+    // `run_non_interactive` reaches with no flag at all — the command
+    // `debian/postinst` tells operators to run.
     let key_path = Path::new(&config.encryption.key_path);
-    if !key_path.exists() {
-        facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-            .context("failed to generate encryption key")?;
+    let existed = key_path.exists();
+    if let Some(refusal) = keygen_refusal(config)? {
+        bail!("{refusal}");
+    }
+    if !existed && key_path.exists() {
         Terminal.info(&SetupMessage::GeneratedKeyfileAt {
             path: key_path.display().to_string(),
         });

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -226,16 +226,22 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
 
 /// Initialize a software sealer based on encryption config.
 /// Returns `None` if encryption is disabled.
-fn init_software_sealer(config: &Config) -> anyhow::Result<Option<facelock_tpm::SoftwareSealer>> {
+fn init_software_sealer(
+    config: &Config,
+    store: &FaceStore,
+) -> anyhow::Result<Option<facelock_tpm::SoftwareSealer>> {
     match config.encryption.method {
         EncryptionMethod::Keyfile => {
             let key_path = Path::new(&config.encryption.key_path);
             // Encrypt-by-default (finding #8): generate the key on first use so
-            // the keyfile default actually encrypts new templates.
-            if !key_path.exists() {
-                facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-                    .context("failed to auto-generate encryption key")?;
-                debug!("generated encryption key at {}", key_path.display());
+            // the keyfile default actually encrypts new templates. Shared with
+            // the daemon so the two paths cannot drift on when a replacement
+            // key may be written (#231, Track K task 7/8).
+            if !key_path.exists()
+                && let Some(refusal) =
+                    facelock_daemon::handler::missing_key_replacement_refusal(store, key_path)
+            {
+                anyhow::bail!(refusal);
             }
             Ok(Some(
                 facelock_tpm::SoftwareSealer::from_key_file(key_path)
@@ -275,7 +281,7 @@ pub fn load_user_embeddings(
     config: &Config,
     user: &str,
 ) -> anyhow::Result<Vec<(u32, facelock_core::types::FaceEmbedding)>> {
-    let software_sealer = init_software_sealer(config)?;
+    let software_sealer = init_software_sealer(config, store)?;
 
     // Fast path: nothing is configured that could have written encrypted rows.
     // `seal_database` forces the raw path even without a software sealer, so a
@@ -322,7 +328,7 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
     let mut engine = load_engine(config)?;
 
     // Initialize sealer if encryption is configured
-    let software_sealer = init_software_sealer(config)?;
+    let software_sealer = init_software_sealer(config, &store)?;
 
     // Shared with daemon mode (facelock-daemon/src/enroll.rs): same quality
     // gate, angle-diversity check, rejection breakdown, and deadline. A local
@@ -554,5 +560,63 @@ warmup_frames = 9
         let loaded = load_user_embeddings(&store, &config, "alice").unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].1, emb);
+    }
+}
+
+#[cfg(test)]
+mod missing_key_tests {
+    use super::*;
+
+    // --- #231 Track K task 7: the oneshot path makes the same refusal ---
+
+    /// The daemon and the oneshot path both auto-generate the encrypt-by-default
+    /// key, so a refusal implemented in only one of them is no refusal at all:
+    /// `facelock auth` runs when the daemon is not there, which is exactly the
+    /// situation an operator hits after a failed upgrade.
+    #[test]
+    fn oneshot_refuses_to_replace_a_missing_key_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap();
+
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &[0x02u8; 96], true, "embedder")
+            .unwrap();
+
+        let error = init_software_sealer(&config, &store)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("encrypted") && error.contains("key"),
+            "refusal must name the missing key over encrypted rows: {error}"
+        );
+        assert!(
+            !key_path.exists(),
+            "a replacement key was written over encrypted rows"
+        );
+    }
+
+    #[test]
+    fn oneshot_still_creates_the_key_for_a_plaintext_only_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap();
+
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &[0u8; 2048], false, "embedder")
+            .unwrap();
+
+        assert!(init_software_sealer(&config, &store).unwrap().is_some());
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -225,28 +225,44 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
 }
 
 /// Initialize a software sealer based on encryption config.
-/// Returns `None` if encryption is disabled.
+///
+/// Returns the sealer and, when a configured method has none, the reason —
+/// mirroring the daemon's posture rather than propagating. That difference was
+/// not cosmetic: a hard failure here is taken by *every* one-shot caller
+/// (`auth`, `test`, `bench`, `preview`), and the encrypted-row check that
+/// produces it is global to the store, so one user's encrypted row disabled
+/// face authentication for every plaintext-only user on the machine — a
+/// lockout the daemon transport did not have. Enrollment fails closed on the
+/// reason ([`enroll`]); everything else serves the rows it can read.
+///
+/// `Err` stays `Err` for the TPM method, whose failures are configuration
+/// errors rather than a missing artifact the operator can restore.
 fn init_software_sealer(
     config: &Config,
     store: &FaceStore,
-) -> anyhow::Result<Option<facelock_tpm::SoftwareSealer>> {
+) -> anyhow::Result<(Option<facelock_tpm::SoftwareSealer>, Option<String>)> {
     match config.encryption.method {
         EncryptionMethod::Keyfile => {
             let key_path = Path::new(&config.encryption.key_path);
             // Encrypt-by-default (finding #8): generate the key on first use so
-            // the keyfile default actually encrypts new templates. Shared with
-            // the daemon so the two paths cannot drift on when a replacement
-            // key may be written (#231, Track K task 7/8).
-            if !key_path.exists()
-                && let Some(refusal) =
-                    facelock_daemon::handler::missing_key_replacement_refusal(store, key_path)
+            // the keyfile default actually encrypts new templates. The gate is
+            // `facelock_daemon::key_policy`, shared with the daemon, `facelock
+            // setup` and `facelock encrypt`, so no writer of this key can
+            // drift on when a replacement may be written (#231).
+            if let Some(refusal) =
+                facelock_daemon::key_policy::ensure_encrypt_by_default_key(store, config).refusal()
             {
-                anyhow::bail!(refusal);
+                debug!("{refusal}");
+                return Ok((None, Some(refusal.to_string())));
             }
-            Ok(Some(
-                facelock_tpm::SoftwareSealer::from_key_file(key_path)
-                    .context("failed to initialize software encryption sealer")?,
-            ))
+            match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
+                Ok(sealer) => Ok((Some(sealer), None)),
+                Err(e) => {
+                    let reason = format!("{} keyfile could not be read: {e}", key_path.display());
+                    debug!("{reason}");
+                    Ok((None, Some(reason)))
+                }
+            }
         }
         EncryptionMethod::Tpm => {
             #[cfg(feature = "tpm")]
@@ -257,7 +273,7 @@ fn init_software_sealer(
                 let key = tpm.unseal_key_from_file(sealed_path).with_context(|| {
                     format!("failed to unseal AES key from {}", sealed_path.display())
                 })?;
-                Ok(Some(facelock_tpm::SoftwareSealer::from_key(key)))
+                Ok((Some(facelock_tpm::SoftwareSealer::from_key(key)), None))
             }
             #[cfg(not(feature = "tpm"))]
             {
@@ -267,7 +283,7 @@ fn init_software_sealer(
                 );
             }
         }
-        EncryptionMethod::None => Ok(None),
+        EncryptionMethod::None => Ok((None, None)),
     }
 }
 
@@ -281,12 +297,18 @@ pub fn load_user_embeddings(
     config: &Config,
     user: &str,
 ) -> anyhow::Result<Vec<(u32, facelock_core::types::FaceEmbedding)>> {
-    let software_sealer = init_software_sealer(config, store)?;
+    let (software_sealer, sealer_error) = init_software_sealer(config, store)?;
 
     // Fast path: nothing is configured that could have written encrypted rows.
     // `seal_database` forces the raw path even without a software sealer, so a
-    // TPM-sealed blob is never misread as a raw embedding.
-    if !facelock_daemon::embeddings::needs_raw_rows(config, software_sealer.is_some()) {
+    // TPM-sealed blob is never misread as a raw embedding — and so does an
+    // unavailable sealer, so an encrypted blob is never reported as store
+    // corruption (same rule as the daemon).
+    if !facelock_daemon::embeddings::needs_raw_rows(
+        config,
+        software_sealer.is_some(),
+        sealer_error.is_some(),
+    ) {
         return store
             .get_user_embeddings(user)
             .context("storage error loading embeddings");
@@ -307,7 +329,10 @@ pub fn load_user_embeddings(
             sealer: None,
         },
     )
-    .map_err(|message| anyhow::anyhow!(message))
+    .map_err(|message| match &sealer_error {
+        Some(reason) => anyhow::anyhow!("{message} — {reason}"),
+        None => anyhow::anyhow!(message),
+    })
 }
 
 /// Direct enrollment — returns (model_id, embedding_count).
@@ -327,8 +352,22 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
     let store = open_store(config)?;
     let mut engine = load_engine(config)?;
 
-    // Initialize sealer if encryption is configured
-    let software_sealer = init_software_sealer(config, &store)?;
+    // Initialize sealer if encryption is configured. Enrollment is the one
+    // one-shot path that fails CLOSED on an unavailable sealer: writing the
+    // template anyway would store a biometric as plaintext, which is the
+    // downgrade `ensure_enroll_encryption_allowed` exists to make explicit.
+    let (software_sealer, sealer_error) = init_software_sealer(config, &store)?;
+    if config.encryption.method != EncryptionMethod::None && software_sealer.is_none() {
+        let cause = sealer_error.unwrap_or_else(|| {
+            "the configured encryption sealer could not be initialized".to_string()
+        });
+        bail!(
+            "refusing to enroll: {cause} Storing your face would otherwise fall back to \
+             plaintext. Fix the keyfile path/permissions (or set encryption.method = \
+             \"none\" with security.allow_plaintext = true to intentionally store \
+             plaintext)."
+        );
+    }
 
     // Shared with daemon mode (facelock-daemon/src/enroll.rs): same quality
     // gate, angle-diversity check, rejection breakdown, and deadline. A local
@@ -567,33 +606,49 @@ warmup_frames = 9
 mod missing_key_tests {
     use super::*;
 
-    // --- #231 Track K task 7: the oneshot path makes the same refusal ---
+    // --- #231: the one-shot path makes the same decision as the daemon ---
 
-    /// The daemon and the oneshot path both auto-generate the encrypt-by-default
-    /// key, so a refusal implemented in only one of them is no refusal at all:
-    /// `facelock auth` runs when the daemon is not there, which is exactly the
-    /// situation an operator hits after a failed upgrade.
+    fn config_for(key_path: &Path) -> Config {
+        Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap()
+    }
+
+    fn software_encrypted_row() -> Vec<u8> {
+        facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+            .seal_embedding(&[0.5f32; 512])
+            .unwrap()
+    }
+
+    /// The daemon and the one-shot path both auto-generate the
+    /// encrypt-by-default key, so a refusal implemented in only one of them is
+    /// no refusal at all: `facelock auth` runs when the daemon is not there,
+    /// which is exactly the situation an operator hits after a failed upgrade.
     #[test]
     fn oneshot_refuses_to_replace_a_missing_key_over_encrypted_rows() {
         let dir = tempfile::tempdir().unwrap();
         let key_path = dir.path().join("encryption.key");
-        let config = Config::parse(&format!(
-            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
-            key_path.display()
-        ))
-        .unwrap();
+        let config = config_for(&key_path);
 
         let store = FaceStore::open_memory().unwrap();
         store
-            .add_model_raw("alice", "front", &[0x02u8; 96], true, "embedder")
+            .add_model_raw(
+                "alice",
+                "front",
+                &software_encrypted_row(),
+                true,
+                "embedder",
+            )
             .unwrap();
 
-        let error = init_software_sealer(&config, &store)
-            .unwrap_err()
-            .to_string();
+        let (sealer, reason) = init_software_sealer(&config, &store).unwrap();
+        assert!(sealer.is_none());
+        let reason = reason.expect("the refusal must be recorded");
         assert!(
-            error.contains("encrypted") && error.contains("key"),
-            "refusal must name the missing key over encrypted rows: {error}"
+            reason.contains("software-encrypted") && reason.contains("facelock clear"),
+            "refusal must name what is at risk and the remedy: {reason}"
         );
         assert!(
             !key_path.exists(),
@@ -605,18 +660,68 @@ mod missing_key_tests {
     fn oneshot_still_creates_the_key_for_a_plaintext_only_database() {
         let dir = tempfile::tempdir().unwrap();
         let key_path = dir.path().join("encryption.key");
-        let config = Config::parse(&format!(
-            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
-            key_path.display()
-        ))
-        .unwrap();
+        let config = config_for(&key_path);
 
         let store = FaceStore::open_memory().unwrap();
         store
             .add_model_raw("alice", "front", &[0u8; 2048], false, "embedder")
             .unwrap();
 
-        assert!(init_software_sealer(&config, &store).unwrap().is_some());
+        let (sealer, reason) = init_software_sealer(&config, &store).unwrap();
+        assert!(sealer.is_some());
+        assert!(reason.is_none());
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+    }
+
+    /// The refusal is global to the store — one user's encrypted row is what
+    /// triggers it — but its consequence must not be. A hard failure here took
+    /// face authentication away from every plaintext-only user on the machine,
+    /// on the transport that runs precisely when the daemon is unavailable.
+    /// The daemon serves those users; so does this.
+    #[test]
+    fn a_plaintext_user_still_loads_while_another_users_row_forces_the_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("bob", "front", &software_encrypted_row(), true, "embedder")
+            .unwrap();
+        let emb = [0.25f32; 512];
+        store.add_model("alice", "front", &emb, "embedder").unwrap();
+
+        let loaded = load_user_embeddings(&store, &config, "alice").unwrap();
+        assert_eq!(loaded.len(), 1, "alice must still be able to face-auth");
+        assert_eq!(loaded[0].1, emb);
+        assert!(!key_path.exists(), "and no key was minted to do it");
+    }
+
+    /// The user who *does* own an encrypted row gets a decrypt failure that
+    /// names the missing key — never a store-corruption report, which would
+    /// send them to reinstall the one file still holding their enrollments.
+    #[test]
+    fn an_encrypted_user_gets_the_refusal_not_a_corruption_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("bob", "front", &software_encrypted_row(), true, "embedder")
+            .unwrap();
+
+        let error = format!(
+            "{:#}",
+            load_user_embeddings(&store, &config, "bob").unwrap_err()
+        );
+        assert!(
+            error.contains("facelock clear") && error.contains("software-encrypted"),
+            "the load failure must carry the refusal: {error}"
+        );
+        assert!(
+            !error.contains("corrupt"),
+            "a missing key is not a corrupt database: {error}"
+        );
     }
 }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -370,10 +370,11 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
             "the configured encryption sealer could not be initialized".to_string()
         });
         bail!(
-            "refusing to enroll: {cause} Storing your face would otherwise fall back to \
+            "refusing to enroll: {} Storing your face would otherwise fall back to \
              plaintext. Fix the keyfile path/permissions (or set encryption.method = \
              \"none\" with security.allow_plaintext = true to intentionally store \
-             plaintext)."
+             plaintext).",
+            facelock_daemon::key_policy::sentence(&cause)
         );
     }
 

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -258,7 +258,15 @@ fn init_software_sealer(
             match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
                 Ok(sealer) => Ok((Some(sealer), None)),
                 Err(e) => {
-                    let reason = format!("{} keyfile could not be read: {e}", key_path.display());
+                    // Same as the daemon: an unreadable key over encrypted
+                    // rows must name what is at risk, not just the byte count.
+                    let complaint =
+                        format!("{} keyfile could not be read: {e}", key_path.display());
+                    let reason =
+                        match facelock_daemon::key_policy::encrypted_rows_at_risk(store, config) {
+                            Some(at_risk) => format!("{complaint} — {at_risk}"),
+                            None => complaint,
+                        };
                     debug!("{reason}");
                     Ok((None, Some(reason)))
                 }

--- a/crates/facelock-core/src/fs_security.rs
+++ b/crates/facelock-core/src/fs_security.rs
@@ -64,6 +64,53 @@ pub fn create_truncate_file(path: &Path, mode: u32) -> io::Result<File> {
     Ok(file)
 }
 
+/// Create `path` exclusively, never following a symlink and never truncating
+/// an existing file.
+///
+/// `create_truncate_file` is the right primitive for a file this process owns
+/// outright. It is the wrong one for a secret two processes may reach for at
+/// the same instant: `O_TRUNC` lets the second writer empty the first writer's
+/// file, and whichever process reads it in between gets a key nobody's rows
+/// were written under. `O_EXCL` makes the race resolve in the kernel — exactly
+/// one caller creates the file, the rest are told `AlreadyExists` and can read
+/// what the winner wrote. `O_NOFOLLOW` keeps a planted symlink from turning
+/// the creation into a write primitive aimed somewhere else.
+///
+/// Returns `Ok(None)` when the path already exists, which is a normal outcome
+/// for a concurrent creator rather than an error.
+pub fn create_new_file(path: &Path, mode: u32) -> io::Result<Option<File>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        options.mode(mode);
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+
+    match options.open(path) {
+        Ok(file) => Ok(Some(file)),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Flush `path`'s directory entry so a file created in it survives a crash.
+///
+/// `sync_all` on the file itself only promises the data; the name that reaches
+/// it lives in the parent directory and needs its own fsync.
+pub fn sync_parent_dir(path: &Path) -> io::Result<()> {
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    File::open(parent)?.sync_all()
+}
+
 pub fn open_append_file(path: &Path, mode: u32) -> io::Result<File> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;

--- a/crates/facelock-core/src/fs_security.rs
+++ b/crates/facelock-core/src/fs_security.rs
@@ -68,6 +68,34 @@ pub fn create_truncate_file(path: &Path, mode: u32) -> io::Result<File> {
     Ok(file)
 }
 
+/// [`create_truncate_file`], refusing to follow a symlink at `path`.
+///
+/// `create_truncate_file` has to stay willing to follow one — some of its
+/// callers legitimately write through a symlinked config path — so it cannot
+/// grow `O_NOFOLLOW` itself. A caller that has already judged `path` (a
+/// symlink pre-check for the clearer refusal message) and truncates in place
+/// rather than staging-and-renaming wants this one instead: without it, a
+/// link planted in the gap between that check and the open is followed, and
+/// the "truncate in place" write lands wherever the link points.
+pub fn create_truncate_file_nofollow(path: &Path, mode: u32) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+
+    #[cfg(unix)]
+    {
+        options.mode(mode);
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+
+    let file = options.open(path)?;
+    ensure_mode(path, mode)?;
+    Ok(file)
+}
+
 /// Create `path` exclusively, never following a symlink and never truncating
 /// an existing file.
 ///
@@ -400,6 +428,40 @@ mod tests {
     }
 
     #[cfg(unix)]
+    /// The gap `create_truncate_file_nofollow` exists to close: a plain
+    /// `create_truncate_file` would follow a symlink planted between a
+    /// caller's own pre-check and this open, truncating whatever it points
+    /// at. `O_NOFOLLOW` on an existing symlink is `ELOOP`, not the plain
+    /// `AlreadyExists` `create_new_file`'s `O_EXCL` reports for the same
+    /// shape — and either way the target is never reached.
+    #[test]
+    fn create_truncate_file_nofollow_refuses_a_symlink_leaving_the_target_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("elsewhere");
+        fs::write(&target, b"not a key").unwrap();
+        let link = dir.path().join("secret");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let error = create_truncate_file_nofollow(&link, 0o600).unwrap_err();
+        assert_eq!(
+            error.raw_os_error(),
+            Some(libc::ELOOP),
+            "O_NOFOLLOW on an existing symlink is ELOOP: {error}"
+        );
+        assert_eq!(
+            fs::read(&target).unwrap(),
+            b"not a key",
+            "the truncate must never reach the link's target"
+        );
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the refusal must not remove the link it found"
+        );
+    }
+
     #[test]
     fn open_no_follow_refuses_a_symlink_and_is_symlink_says_why() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/facelock-core/src/fs_security.rs
+++ b/crates/facelock-core/src/fs_security.rs
@@ -3,6 +3,10 @@ use std::io::{self, Write};
 use std::path::Path;
 
 #[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub fn ensure_mode(path: &Path, mode: u32) -> io::Result<()> {
@@ -76,11 +80,33 @@ pub fn create_truncate_file(path: &Path, mode: u32) -> io::Result<File> {
 /// what the winner wrote. `O_NOFOLLOW` keeps a planted symlink from turning
 /// the creation into a write primitive aimed somewhere else.
 ///
+/// The mode is set twice on purpose: `O_CREAT` applies it through the umask,
+/// so a caller running under a restrictive umask would otherwise get a file
+/// *tighter* than asked for — and one running under a permissive one, on a
+/// kernel where the open mode is advisory, a file looser than asked for. The
+/// explicit `ensure_mode` makes the requested mode the mode on disk either
+/// way, exactly as `create_truncate_file` does.
+///
+/// The parent directory is **not** created. This primitive writes secrets, and
+/// a `create_dir_all` here would mint the directory holding them at whatever
+/// the ambient umask happened to be; packaging (tmpfiles, the spec, the
+/// scriptlets) owns those directories and their modes. A missing parent is an
+/// error that names it.
+///
 /// Returns `Ok(None)` when the path already exists, which is a normal outcome
 /// for a concurrent creator rather than an error.
 pub fn create_new_file(path: &Path, mode: u32) -> io::Result<Option<File>> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty())
+        && !parent.is_dir()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "parent directory {} does not exist; it is created by installation, \
+                 not by the process writing into it",
+                parent.display()
+            ),
+        ));
     }
 
     let mut options = OpenOptions::new();
@@ -93,9 +119,89 @@ pub fn create_new_file(path: &Path, mode: u32) -> io::Result<Option<File>> {
     }
 
     match options.open(path) {
-        Ok(file) => Ok(Some(file)),
+        Ok(file) => {
+            ensure_mode(path, mode)?;
+            Ok(Some(file))
+        }
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(None),
         Err(error) => Err(error),
+    }
+}
+
+/// Open `path` for reading without traversing a symlink at the final
+/// component.
+///
+/// `std::fs::read` follows links, so a link planted where a secret is expected
+/// silently redirects the read to whatever it names. Every reader of a
+/// facelock key artifact goes through here so the read path refuses exactly
+/// what the create path refuses.
+pub fn open_no_follow(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+
+    #[cfg(unix)]
+    {
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+
+    options.open(path)
+}
+
+/// True when `path` itself is a symlink, without following it.
+///
+/// A separate fact from "the path exists": `Path::exists` follows links, so it
+/// answers about the target. Callers that must refuse a planted link need the
+/// question asked of the name.
+pub fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .is_ok_and(|m| m.file_type().is_symlink())
+}
+
+/// Move `from` onto `to` atomically, refusing to replace an existing `to`.
+///
+/// The raw `renameat2` syscall, for the same reason the purge engine uses it
+/// raw (`crates/facelock-core/src/purge/fd.rs`): an old libc must not be able
+/// to substitute a check-then-rename fallback, which is precisely the race
+/// this call exists to close. `libc::SYS_renameat2` is arch-correct, and a
+/// kernel without the syscall fails closed with `ENOSYS`.
+///
+/// An existing destination — regular file, directory, or symlink, dangling or
+/// not — is `EEXIST`, and `from` is left where it is for the caller to clean
+/// up. That is what makes this the placement step for a staged secret: the
+/// loser of a race never overwrites the winner, and never publishes a
+/// half-written file under the real name, because the name only ever appears
+/// atomically over a file that is already complete.
+pub fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let from_c = CString::new(from.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let to_c = CString::new(to.as_os_str().as_bytes())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        // SAFETY: both pointers are NUL-terminated and live for the call.
+        let ret = unsafe {
+            libc::syscall(
+                libc::SYS_renameat2,
+                libc::AT_FDCWD,
+                from_c.as_ptr(),
+                libc::AT_FDCWD,
+                to_c.as_ptr(),
+                libc::RENAME_NOREPLACE as libc::c_uint,
+            )
+        };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (from, to);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "no-replace rename is only implemented on unix",
+        ))
     }
 }
 
@@ -187,5 +293,142 @@ mod tests {
     fn ensure_private_dir_rejects_shared_system_dir() {
         let err = ensure_private_dir(Path::new("/tmp"), 0o750).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    // --- The exclusive-create / no-replace-rename pair (#231) ---------------
+
+    #[cfg(unix)]
+    #[test]
+    fn create_new_file_applies_the_requested_mode_over_the_umask() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+
+        // 0666 not because anything should ever be that mode, but because
+        // every ordinary umask clips at least one of its bits: a mode that
+        // survives intact proves the explicit `ensure_mode` ran rather than
+        // the file inheriting whatever `O_CREAT` was allowed to give it. The
+        // key file's own 0600 is asserted where the key is created.
+        create_new_file(&path, 0o666).unwrap().unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o666, "the requested mode must survive the umask");
+    }
+
+    #[test]
+    fn create_new_file_reports_an_existing_path_instead_of_replacing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        fs::write(&path, b"the winner's bytes").unwrap();
+
+        assert!(
+            create_new_file(&path, 0o600).unwrap().is_none(),
+            "an existing file is a losing race, not an error"
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"the winner's bytes");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_new_file_refuses_a_symlink_standing_at_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("elsewhere");
+        let path = dir.path().join("secret");
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        // A dangling link is the dangerous shape: `O_CREAT|O_EXCL` without
+        // `O_NOFOLLOW` would create the *target*, turning the link into a
+        // write primitive aimed wherever it points.
+        assert!(create_new_file(&path, 0o600).unwrap().is_none());
+        assert!(!target.exists(), "the link target must not be created");
+    }
+
+    #[test]
+    fn create_new_file_names_a_missing_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("not-installed");
+        let path = parent.join("secret");
+
+        let err = create_new_file(&path, 0o600).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(
+            err.to_string().contains("not-installed"),
+            "the error must name the directory that is missing: {err}"
+        );
+        assert!(
+            !parent.exists(),
+            "a secret writer must not mint its own parent directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rename_noreplace_refuses_every_shape_of_existing_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let occupied = dir.path().join("occupied");
+        let dangling = dir.path().join("dangling");
+        fs::write(&staged, b"new").unwrap();
+        fs::write(&occupied, b"old").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("gone"), &dangling).unwrap();
+
+        for destination in [&occupied, &dangling] {
+            let err = rename_noreplace(&staged, destination).unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EEXIST),
+                "{} must not be replaced",
+                destination.display()
+            );
+        }
+        assert_eq!(fs::read(&occupied).unwrap(), b"old");
+        assert!(
+            staged.exists(),
+            "the loser keeps its staging file to clean up"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rename_noreplace_publishes_onto_a_free_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let published = dir.path().join("published");
+        fs::write(&staged, b"complete").unwrap();
+
+        rename_noreplace(&staged, &published).unwrap();
+        assert_eq!(fs::read(&published).unwrap(), b"complete");
+        assert!(!staged.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_no_follow_refuses_a_symlink_and_is_symlink_says_why() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real");
+        let link = dir.path().join("link");
+        fs::write(&target, b"payload").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert!(is_symlink(&link));
+        assert!(!is_symlink(&target));
+        assert!(
+            link.exists(),
+            "`exists` follows the link — that is the trap"
+        );
+        assert!(open_no_follow(&link).is_err());
+        assert_eq!(
+            std::io::Read::bytes(open_no_follow(&target).unwrap())
+                .collect::<io::Result<Vec<u8>>>()
+                .unwrap(),
+            b"payload"
+        );
+    }
+
+    #[test]
+    fn sync_parent_dir_flushes_an_existing_parent_and_tolerates_a_bare_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+        fs::write(&path, b"x").unwrap();
+        sync_parent_dir(&path).unwrap();
+        sync_parent_dir(Path::new("bare-name")).unwrap();
     }
 }

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -62,15 +62,29 @@ impl TpmAccess<'_> {
     }
 }
 
-/// True when the store must be read through the raw-row path: either a
-/// software sealer is active, or `tpm.seal_database` says TPM-sealed rows may
-/// exist. The `seal_database` half matters even when the sealer failed to
-/// initialize (or TPM support is not compiled in): the fast path would hand
-/// sealed blobs to callers as if they were raw embeddings, which at best
+/// True when the store must be read through the raw-row path: a software
+/// sealer is active, `tpm.seal_database` says TPM-sealed rows may exist, or a
+/// configured encryption method has no usable sealer at all.
+///
+/// The first two are about rows that *can* be decrypted. The third is about
+/// rows that cannot, and it matters for the same reason: the fast path would
+/// hand sealed blobs to callers as if they were raw embeddings, which at best
 /// reports a misleading "corrupt store" and at worst misreads a template (the
-/// B3 class — the handler previously made exactly this mistake).
-pub fn needs_raw_rows(config: &Config, software_sealer_active: bool) -> bool {
-    software_sealer_active || config.tpm.seal_database
+/// B3 class — the handler previously made exactly this mistake). A daemon
+/// refusing to mint a replacement key is exactly that state, and telling an
+/// operator whose key went missing that their database is corrupt sends them
+/// to reinstall the one file that still holds their enrollments.
+///
+/// The raw path is not a fallback to a worse answer here: a user whose rows
+/// are all plaintext still authenticates through it, and a user whose rows are
+/// encrypted gets a decrypt failure naming the missing key. Both beat a
+/// corruption report.
+pub fn needs_raw_rows(
+    config: &Config,
+    software_sealer_active: bool,
+    sealer_unavailable: bool,
+) -> bool {
+    software_sealer_active || config.tpm.seal_database || sealer_unavailable
 }
 
 /// Decrypt raw `(id, blob, sealed, device_id)` rows into embeddings.
@@ -531,10 +545,21 @@ mod tests {
     #[test]
     fn seal_database_forces_raw_rows_without_a_sealer() {
         let sealed = Config::parse("[tpm]\nseal_database = true\n").unwrap();
-        assert!(needs_raw_rows(&sealed, false));
+        assert!(needs_raw_rows(&sealed, false, false));
 
         let plain = Config::parse("").unwrap();
-        assert!(!needs_raw_rows(&plain, false));
-        assert!(needs_raw_rows(&plain, true));
+        assert!(!needs_raw_rows(&plain, false, false));
+        assert!(needs_raw_rows(&plain, true, false));
+    }
+
+    /// A refused sealer is the third way encrypted rows can be present with
+    /// nothing to decrypt them. Taking the fast path there hands a 2077-byte
+    /// blob to a caller expecting 2048 raw bytes, and the store reports the
+    /// database as corrupt — sending an operator whose key merely went missing
+    /// to reinstall the file that still holds their enrollments.
+    #[test]
+    fn a_refused_sealer_forces_raw_rows() {
+        let plain = Config::parse("").unwrap();
+        assert!(needs_raw_rows(&plain, false, true));
     }
 }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -722,10 +722,17 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 );
                 Ok(sealer)
             }
-            Err(e) => Err(format!(
-                "{} keyfile could not be created/read: {e}",
-                key_path.display()
-            )),
+            Err(e) => {
+                let complaint = format!("{} keyfile could not be read: {e}", key_path.display());
+                // A key that cannot be read leaves an operator holding
+                // encrypted rows in exactly the predicament a missing one
+                // does. The generic byte-count complaint names neither what
+                // is at risk nor the artifact that brings it back.
+                match crate::key_policy::encrypted_rows_at_risk(store, config) {
+                    Some(at_risk) => Err(format!("{complaint} — {at_risk}")),
+                    None => Err(complaint),
+                }
+            }
         }
     }
 

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -603,64 +603,6 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     preview_embeddings: Option<PreviewEmbeddings>,
 }
 
-/// Decide whether the encrypt-by-default key may be created, given that the
-/// configured key artifact is missing.
-///
-/// Returns `None` when creation went ahead (or was won by a concurrent
-/// creator), and `Some(refusal)` naming why no key was written.
-///
-/// Two facts have to be kept apart here. A fresh keyfile system has no key and
-/// no encrypted row, and wants one made for it — that is the encrypt-by-default
-/// finding this auto-generation exists for. A system whose key artifact went
-/// missing *does* have encrypted rows, and writing a fresh key there replaces
-/// the only thing that could ever have read them: the rows stay unreadable
-/// either way, but a later restore of the real key no longer matches what the
-/// daemon has since written. So the second case writes nothing and says so.
-///
-/// A store that cannot answer is treated as the second case. "No encrypted
-/// rows" and "the store could not be asked" are different facts, and conflating
-/// them is what makes a destructive path fail open.
-pub fn missing_key_replacement_refusal(
-    store: &FaceStore,
-    key_path: &std::path::Path,
-) -> Option<String> {
-    match store.count_sealed() {
-        Ok((0, _)) => match facelock_tpm::SoftwareSealer::create_key_file_exclusive(key_path) {
-            Ok(true) => {
-                info!(
-                    "generated encryption key at {} (encrypt-by-default)",
-                    key_path.display()
-                );
-                None
-            }
-            // Another process created it between the existence check and the
-            // create. Nothing is wrong; the read-back below is authoritative.
-            Ok(false) => None,
-            // Not necessarily fatal on its own — the read-back may still find a
-            // usable key — so this only warns and lets that check decide.
-            Err(e) => {
-                warn!(
-                    "failed to auto-generate encryption key at {}: {e}",
-                    key_path.display()
-                );
-                None
-            }
-        },
-        Ok((encrypted, _)) => Some(format!(
-            "{} is missing while {encrypted} encrypted template row(s) exist: refusing to \
-             write a replacement key, which would make those rows permanently unrecoverable. \
-             Restore the original key file, or clear the encrypted enrollments with \
-             `facelock clear` before enrolling again.",
-            key_path.display()
-        )),
-        Err(e) => Some(format!(
-            "{} is missing and the store could not be asked whether encrypted rows exist \
-             ({e}): refusing to write a replacement key.",
-            key_path.display()
-        )),
-    }
-}
-
 impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -695,44 +637,25 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         let mut sealer_init_error: Option<String> = None;
         let software_sealer = match config.encryption.method {
             EncryptionMethod::Keyfile => {
-                let key_path = std::path::Path::new(&config.encryption.key_path);
-                // Encrypt-by-default (finding #8): auto-generate the key on first
-                // use so a keyfile default actually encrypts. Only ever for a
-                // database that holds no encrypted row — see
-                // `missing_key_replacement_refusal` for why a replacement over
-                // encrypted state is refused instead (#231, Track K task 7/8).
-                if !key_path.exists()
-                    && let Some(refusal) = missing_key_replacement_refusal(&store, key_path)
-                {
-                    warn!("{refusal}");
-                    sealer_init_error = Some(refusal);
-                }
-                if sealer_init_error.is_some() {
-                    None
-                } else {
-                    match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
-                        Ok(sealer) => {
-                            info!(
-                                "software encryption sealer initialized from {}",
-                                key_path.display()
-                            );
-                            Some(sealer)
-                        }
-                        Err(e) => {
-                            // Fail CLOSED on enroll: record the cause so `handle`
-                            // refuses to enroll rather than silently storing the
-                            // biometric template as plaintext (finding: silent
-                            // plaintext downgrade).
-                            let msg = format!(
-                                "{} keyfile could not be created/read: {e}",
-                                key_path.display()
-                            );
-                            warn!(
-                                "software encryption sealer unavailable — enroll will be refused: {msg}"
-                            );
-                            sealer_init_error = Some(msg);
-                            None
-                        }
+                // Encrypt-by-default (finding #8): auto-generate the key on
+                // first use so a keyfile default actually encrypts — but only
+                // for a database that holds no encrypted row. `key_policy` is
+                // the one gate; the daemon, the one-shot path, `facelock
+                // setup` and `facelock encrypt` all mint through it, because a
+                // refusal wired into one writer is not a refusal (#231).
+                match Self::resolve_keyfile_sealer(&config, &store) {
+                    Ok(sealer) => Some(sealer),
+                    // Fail CLOSED on enroll: record the cause so `handle`
+                    // refuses to enroll rather than silently storing the
+                    // biometric template as plaintext (finding: silent
+                    // plaintext downgrade). Auth is untouched and keeps
+                    // falling through to password.
+                    Err(msg) => {
+                        warn!(
+                            "software encryption sealer unavailable — enroll will be refused: {msg}"
+                        );
+                        sealer_init_error = Some(msg);
+                        None
                     }
                 }
             }
@@ -779,6 +702,68 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         })
     }
 
+    /// Resolve the keyfile sealer: mint the encrypt-by-default key when that
+    /// is allowed, then read it. `Err` is the reason enroll must fail closed.
+    fn resolve_keyfile_sealer(
+        config: &Config,
+        store: &FaceStore,
+    ) -> Result<facelock_tpm::SoftwareSealer, String> {
+        let key_path = std::path::Path::new(&config.encryption.key_path);
+        if let Some(refusal) =
+            crate::key_policy::ensure_encrypt_by_default_key(store, config).refusal()
+        {
+            return Err(refusal.to_string());
+        }
+        match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
+            Ok(sealer) => {
+                info!(
+                    "software encryption sealer initialized from {}",
+                    key_path.display()
+                );
+                Ok(sealer)
+            }
+            Err(e) => Err(format!(
+                "{} keyfile could not be created/read: {e}",
+                key_path.display()
+            )),
+        }
+    }
+
+    /// Re-ask whether the keyfile sealer is available, for a handler that is
+    /// currently refusing.
+    ///
+    /// The refusal names an artifact to restore. Deciding once at construction
+    /// meant the operator restored the key, did exactly what they were told,
+    /// and was told the same thing again — the message's next suggestion being
+    /// `facelock clear`, which destroys the enrollments the restore just
+    /// saved. A fix that looks like a no-op is a fix nobody completes, so the
+    /// enrollment that follows a restore re-reads the key.
+    ///
+    /// Only the keyfile method: a TPM sealer that cannot initialize fails
+    /// handler construction outright, so no handler is ever live in that
+    /// state. Re-running the gate is a `stat` and one small query, on a path
+    /// that already refuses.
+    fn refresh_software_sealer(&mut self) {
+        if self.sealer_init_error.is_none()
+            || self.config.encryption.method != EncryptionMethod::Keyfile
+        {
+            return;
+        }
+        match Self::resolve_keyfile_sealer(&self.config, &self.store) {
+            Ok(sealer) => {
+                info!("encryption key is readable again — enrollment is no longer refused");
+                self.software_sealer = Some(sealer);
+                self.sealer_init_error = None;
+                // The compare set was decrypted (or not) under the old
+                // decision; the next frame reloads it under this one.
+                self.preview_embeddings = None;
+            }
+            // Still refused — but report the *current* reason, which may name
+            // a different artifact than the one construction found.
+            Err(msg) => self.sealer_init_error = Some(msg),
+        }
+    }
+
     /// Close the camera if its warm hold has run out. Called from the
     /// daemon's [`CAMERA_POLL_INTERVAL`] tick; a tick that finds the handler
     /// locked simply misses, because the deadline is absolute.
@@ -802,7 +787,18 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         &mut self,
         user: &str,
     ) -> Result<Vec<(u32, facelock_core::types::FaceEmbedding)>, DaemonResponse> {
-        if !crate::embeddings::needs_raw_rows(&self.config, self.software_sealer.is_some()) {
+        // The third argument is the one that reads oddly and matters most.
+        // With the sealer refused there is no sealer, so the fast path used to
+        // hand a 2077-byte encrypted blob to the caller as a raw embedding and
+        // the store called the database corrupt. The rows are unreadable
+        // either way; which of the two things the operator is told decides
+        // whether they restore a key or reinstall a database.
+        let refusal = self.sealer_init_error.clone();
+        if !crate::embeddings::needs_raw_rows(
+            &self.config,
+            self.software_sealer.is_some(),
+            refusal.is_some(),
+        ) {
             // Fast path: no encryption, use standard method (no overhead)
             return self
                 .store
@@ -827,7 +823,15 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             self.software_sealer.as_ref(),
             crate::embeddings::TpmAccess::Held(self.tpm_sealer.as_mut()),
         )
-        .map_err(|message| DaemonResponse::Error { message })
+        .map_err(|message| DaemonResponse::Error {
+            // Carry the refusal into the auth path's own line. "no key is
+            // configured" is true and useless; the operator needs the artifact
+            // to restore, and this is the message they will actually see.
+            message: match &refusal {
+                Some(reason) => format!("{message} — {reason}"),
+                None => message,
+            },
+        })
     }
 
     /// Serve a request that nobody can cancel.
@@ -881,6 +885,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     warn!(user, "enroll refused: {message}");
                     return DaemonResponse::Error { message };
                 }
+                // An operator who restored the key artifact the refusal named
+                // gets to enrol, without restarting the daemon to prove it.
+                self.refresh_software_sealer();
                 // Fail CLOSED: an encryption method is configured but its sealer
                 // could not be initialized (e.g. keyfile IO/permission error).
                 // Refuse to enroll rather than silently storing the biometric

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -748,8 +748,10 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     ///
     /// Only the keyfile method: a TPM sealer that cannot initialize fails
     /// handler construction outright, so no handler is ever live in that
-    /// state. Re-running the gate is a `stat` and one small query, on a path
-    /// that already refuses.
+    /// state. Re-running the gate is one `stat` once the key file is back.
+    /// While it stays absent that fast path can't fire: the gate opens an
+    /// exclusive store section over one projection query, and can wait up
+    /// to the busy timeout behind a concurrent enrollment.
     fn refresh_software_sealer(&mut self) {
         if self.sealer_init_error.is_none()
             || self.config.encryption.method != EncryptionMethod::Keyfile
@@ -1152,8 +1154,10 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     ) -> DaemonResponse {
         // An operator who restored the key artifact the refusal named gets a
         // real compare on the next authentication attempt, not just the next
-        // enrollment — this is one `lstat` while the refusal holds, and a
-        // no-op once it doesn't.
+        // enrollment — this is one `lstat` once the key is back, and a no-op
+        // once the refusal is gone. While the key stays absent, it is instead
+        // an exclusive store section over one projection query, which can
+        // wait up to the busy timeout behind a concurrent enrollment.
         self.refresh_software_sealer();
 
         // A storage failure here must surface as an error, never fold into an

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -603,6 +603,64 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     preview_embeddings: Option<PreviewEmbeddings>,
 }
 
+/// Decide whether the encrypt-by-default key may be created, given that the
+/// configured key artifact is missing.
+///
+/// Returns `None` when creation went ahead (or was won by a concurrent
+/// creator), and `Some(refusal)` naming why no key was written.
+///
+/// Two facts have to be kept apart here. A fresh keyfile system has no key and
+/// no encrypted row, and wants one made for it — that is the encrypt-by-default
+/// finding this auto-generation exists for. A system whose key artifact went
+/// missing *does* have encrypted rows, and writing a fresh key there replaces
+/// the only thing that could ever have read them: the rows stay unreadable
+/// either way, but a later restore of the real key no longer matches what the
+/// daemon has since written. So the second case writes nothing and says so.
+///
+/// A store that cannot answer is treated as the second case. "No encrypted
+/// rows" and "the store could not be asked" are different facts, and conflating
+/// them is what makes a destructive path fail open.
+pub fn missing_key_replacement_refusal(
+    store: &FaceStore,
+    key_path: &std::path::Path,
+) -> Option<String> {
+    match store.count_sealed() {
+        Ok((0, _)) => match facelock_tpm::SoftwareSealer::create_key_file_exclusive(key_path) {
+            Ok(true) => {
+                info!(
+                    "generated encryption key at {} (encrypt-by-default)",
+                    key_path.display()
+                );
+                None
+            }
+            // Another process created it between the existence check and the
+            // create. Nothing is wrong; the read-back below is authoritative.
+            Ok(false) => None,
+            // Not necessarily fatal on its own — the read-back may still find a
+            // usable key — so this only warns and lets that check decide.
+            Err(e) => {
+                warn!(
+                    "failed to auto-generate encryption key at {}: {e}",
+                    key_path.display()
+                );
+                None
+            }
+        },
+        Ok((encrypted, _)) => Some(format!(
+            "{} is missing while {encrypted} encrypted template row(s) exist: refusing to \
+             write a replacement key, which would make those rows permanently unrecoverable. \
+             Restore the original key file, or clear the encrypted enrollments with \
+             `facelock clear` before enrolling again.",
+            key_path.display()
+        )),
+        Err(e) => Some(format!(
+            "{} is missing and the store could not be asked whether encrypted rows exist \
+             ({e}): refusing to write a replacement key.",
+            key_path.display()
+        )),
+    }
+}
+
 impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -639,45 +697,42 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             EncryptionMethod::Keyfile => {
                 let key_path = std::path::Path::new(&config.encryption.key_path);
                 // Encrypt-by-default (finding #8): auto-generate the key on first
-                // use so a keyfile default actually encrypts. Safe — if a key was
-                // lost, any prior encrypted rows were already unreadable, and a new
-                // key only affects future writes; plaintext rows stay readable.
-                if !key_path.exists() {
-                    match facelock_tpm::SoftwareSealer::generate_key_file(key_path) {
-                        Ok(()) => info!(
-                            "generated encryption key at {} (encrypt-by-default)",
-                            key_path.display()
-                        ),
-                        // Not necessarily fatal on its own; the read-back below is
-                        // the authoritative check for whether encryption works.
-                        Err(e) => warn!(
-                            "failed to auto-generate encryption key at {}: {e}",
-                            key_path.display()
-                        ),
-                    }
+                // use so a keyfile default actually encrypts. Only ever for a
+                // database that holds no encrypted row — see
+                // `missing_key_replacement_refusal` for why a replacement over
+                // encrypted state is refused instead (#231, Track K task 7/8).
+                if !key_path.exists()
+                    && let Some(refusal) = missing_key_replacement_refusal(&store, key_path)
+                {
+                    warn!("{refusal}");
+                    sealer_init_error = Some(refusal);
                 }
-                match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
-                    Ok(sealer) => {
-                        info!(
-                            "software encryption sealer initialized from {}",
-                            key_path.display()
-                        );
-                        Some(sealer)
-                    }
-                    Err(e) => {
-                        // Fail CLOSED on enroll: record the cause so `handle`
-                        // refuses to enroll rather than silently storing the
-                        // biometric template as plaintext (finding: silent
-                        // plaintext downgrade).
-                        let msg = format!(
-                            "{} keyfile could not be created/read: {e}",
-                            key_path.display()
-                        );
-                        warn!(
-                            "software encryption sealer unavailable — enroll will be refused: {msg}"
-                        );
-                        sealer_init_error = Some(msg);
-                        None
+                if sealer_init_error.is_some() {
+                    None
+                } else {
+                    match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
+                        Ok(sealer) => {
+                            info!(
+                                "software encryption sealer initialized from {}",
+                                key_path.display()
+                            );
+                            Some(sealer)
+                        }
+                        Err(e) => {
+                            // Fail CLOSED on enroll: record the cause so `handle`
+                            // refuses to enroll rather than silently storing the
+                            // biometric template as plaintext (finding: silent
+                            // plaintext downgrade).
+                            let msg = format!(
+                                "{} keyfile could not be created/read: {e}",
+                                key_path.display()
+                            );
+                            warn!(
+                                "software encryption sealer unavailable — enroll will be refused: {msg}"
+                            );
+                            sealer_init_error = Some(msg);
+                            None
+                        }
                     }
                 }
             }

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -893,7 +893,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     return DaemonResponse::Error { message };
                 }
                 // An operator who restored the key artifact the refusal named
-                // gets to enrol, without restarting the daemon to prove it.
+                // gets to enroll, without restarting the daemon to prove it.
                 self.refresh_software_sealer();
                 // Fail CLOSED: an encryption method is configured but its sealer
                 // could not be initialized (e.g. keyfile IO/permission error).
@@ -909,10 +909,11 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                         "the configured encryption sealer could not be initialized".to_string()
                     });
                     let message = format!(
-                        "refusing to enroll: {cause} Storing your face would otherwise fall \
+                        "refusing to enroll: {} Storing your face would otherwise fall \
                          back to plaintext. Fix the keyfile path/permissions (or set \
                          encryption.method = \"none\" with security.allow_plaintext = true to \
-                         intentionally store plaintext)."
+                         intentionally store plaintext).",
+                        crate::key_policy::sentence(&cause)
                     );
                     warn!(user, "enroll refused (encryption unavailable): {message}");
                     return DaemonResponse::Error { message };

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -909,7 +909,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                         "the configured encryption sealer could not be initialized".to_string()
                     });
                     let message = format!(
-                        "refusing to enroll: {cause}. Storing your face would otherwise fall \
+                        "refusing to enroll: {cause} Storing your face would otherwise fall \
                          back to plaintext. Fix the keyfile path/permissions (or set \
                          encryption.method = \"none\" with security.allow_plaintext = true to \
                          intentionally store plaintext)."
@@ -1149,6 +1149,12 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         intent: AuthIntent,
         cancel: &CancelToken,
     ) -> DaemonResponse {
+        // An operator who restored the key artifact the refusal named gets a
+        // real compare on the next authentication attempt, not just the next
+        // enrollment — this is one `lstat` while the refusal holds, and a
+        // no-op once it doesn't.
+        self.refresh_software_sealer();
+
         // A storage failure here must surface as an error, never fold into an
         // empty model list (C3, issue #105): empty `models` means an empty
         // device-allowed set, a guaranteed "no match", and a rate-limit charge

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -1,0 +1,372 @@
+//! The one gate every writer of the encrypt-by-default key goes through.
+//!
+//! Encrypt-by-default means a keyfile system with no key file gets one made
+//! for it. That is right exactly once — on a system that has never encrypted
+//! anything. On a system whose key artifact went *missing*, the same act
+//! writes a replacement over a database full of rows encrypted under the old
+//! key: the rows are unreadable either way, but a later restore of the real
+//! key no longer matches what facelock has since written, and an operator who
+//! still had a backup loses their enrollments for good.
+//!
+//! Four places used to mint that key independently — the daemon at startup,
+//! the one-shot direct path, `facelock setup`'s auto policy, and `facelock
+//! encrypt` — and a refusal wired into one of them is not a refusal. They all
+//! come here now. The pure predicate ([`key_creation_refusal`]) and the step
+//! that actually writes ([`ensure_encrypt_by_default_key`]) are separate so a
+//! caller that only wants the decision — `facelock encrypt --generate-key`,
+//! which replaces a key rather than creating one — can ask for it without a
+//! function called "refusal" writing a file as a side effect.
+//!
+//! Errors are plain strings for the same reason `crate::embeddings`'s are:
+//! they cross D-Bus, land in logs, and are wrapped by each caller's own error
+//! type (`DaemonResponse::Error`, `anyhow`).
+
+use std::path::Path;
+
+use facelock_core::config::{Config, EncryptionMethod};
+use facelock_store::FaceStore;
+use tracing::info;
+
+/// What the gate decided about the configured key file.
+#[derive(Debug)]
+pub enum KeyfileDecision {
+    /// A key file is already at the path — either it was there all along, or a
+    /// concurrent creator published one first. This call wrote nothing; read
+    /// what is there.
+    Present,
+    /// This call created the key file.
+    Created,
+    /// No key was written. The string says why, which artifact is missing, and
+    /// what the operator can do about it.
+    Refused(String),
+}
+
+impl KeyfileDecision {
+    /// The refusal text, for a caller that only needs to know whether the gate
+    /// said no.
+    pub fn refusal(&self) -> Option<&str> {
+        match self {
+            KeyfileDecision::Refused(message) => Some(message),
+            KeyfileDecision::Present | KeyfileDecision::Created => None,
+        }
+    }
+}
+
+/// Whether a *new* encryption key may be minted for `store`. Writes nothing,
+/// either way.
+///
+/// `None` means no stored template would be orphaned by a new key. `Some` is
+/// the refusal, naming the encryption method that wrote the rows at risk, the
+/// artifact to restore, and the explicit destructive alternative.
+///
+/// Two facts have to be kept apart. A store that answers "no encrypted rows"
+/// and a store that *cannot be asked* are different things, and conflating
+/// them is what makes a destructive path fail open — so a failing query is a
+/// refusal, not a licence.
+///
+/// The question is asked of each row's blob, not of the `sealed` column. That
+/// column is one bit every method sets: it cannot tell a TPM-sealed row from a
+/// keyfile-sealed one, so the old message told operators of TPM systems to
+/// restore a key file that had never existed, and it stayed set on a row whose
+/// ciphertext had since been replaced with plaintext, refusing to mint a key
+/// nothing needed. The version byte at the head of the blob is the fact.
+pub fn key_creation_refusal(store: &FaceStore, config: &Config) -> Option<String> {
+    let target = configured_key_artifact(config);
+
+    let shapes = match store.embedding_blob_shapes() {
+        Ok(shapes) => shapes,
+        Err(e) => {
+            return Some(format!(
+                "refusing to write an encryption key at {target}: the face database could \
+                 not be read ({e}), so facelock cannot tell whether encrypted templates \
+                 would be orphaned. Fix access to {} and retry, or clear the enrollments \
+                 with `facelock clear`.",
+                config.storage.db_path
+            ));
+        }
+    };
+
+    let software = shapes
+        .iter()
+        .filter(|(head, len)| facelock_tpm::is_software_encrypted_shape(*head, *len))
+        .count();
+    let tpm = shapes
+        .iter()
+        .filter(|(head, len)| facelock_tpm::is_sealed_shape(*head, *len))
+        .count();
+
+    if software == 0 && tpm == 0 {
+        return None;
+    }
+
+    let mut at_risk = Vec::new();
+    if software > 0 {
+        at_risk.push(format!(
+            "{software} row(s) are software-encrypted (method \"keyfile\", key file {})",
+            config.encryption.key_path
+        ));
+    }
+    if tpm > 0 {
+        at_risk.push(format!(
+            "{tpm} row(s) are TPM-sealed (method \"tpm\", sealed key {})",
+            config.encryption.sealed_key_path
+        ));
+    }
+
+    Some(format!(
+        "refusing to write an encryption key at {target}: {}. A new key cannot read \
+         them, and writing one makes a later restore of the original useless. Restore \
+         the key artifacts for the encryption method that wrote those rows, or clear \
+         the encrypted enrollments with `facelock clear` and enrol again. Nothing needs \
+         restarting — the key is re-checked on the next enrollment attempt.",
+        at_risk.join("; ")
+    ))
+}
+
+/// Create the encrypt-by-default key file if — and only if — the database
+/// holds no encrypted template.
+///
+/// This is the gate the daemon and the one-shot path run before reading the
+/// key. It is consulted *unconditionally*, not only when the key looks absent:
+/// `Path::exists` follows a symlink, so a link planted at `key_path` used to
+/// answer "the key is there" and skip every check, leaving the reader to load
+/// whatever the link named.
+pub fn ensure_encrypt_by_default_key(store: &FaceStore, config: &Config) -> KeyfileDecision {
+    let key_path = Path::new(&config.encryption.key_path);
+
+    match key_path.symlink_metadata() {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return KeyfileDecision::Refused(facelock_tpm::symlink_key_refusal(key_path));
+        }
+        Ok(_) => return KeyfileDecision::Present,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        // "The key is missing" and "the key path cannot be inspected" are
+        // different facts, and only the first authorizes writing.
+        Err(e) => {
+            return KeyfileDecision::Refused(format!(
+                "refusing to write an encryption key at {}: the path could not be \
+                 inspected ({e}), so facelock cannot tell whether a key is already there.",
+                key_path.display()
+            ));
+        }
+    }
+
+    if let Some(refusal) = key_creation_refusal(store, config) {
+        return KeyfileDecision::Refused(refusal);
+    }
+
+    match facelock_tpm::SoftwareSealer::create_key_file_exclusive(key_path) {
+        Ok(true) => {
+            info!(
+                "generated encryption key at {} (encrypt-by-default)",
+                key_path.display()
+            );
+            KeyfileDecision::Created
+        }
+        // Another process published between the inspection and the create.
+        // Its file is complete by construction; the caller reads it.
+        Ok(false) => KeyfileDecision::Present,
+        Err(e) => KeyfileDecision::Refused(format!(
+            "no encryption key could be created at {}: {e}",
+            key_path.display()
+        )),
+    }
+}
+
+/// The key artifact the *configured* method would write, for the refusal's
+/// opening clause. The rows at risk may have been written by the other method;
+/// the refusal names both, and this names the one about to be replaced.
+fn configured_key_artifact(config: &Config) -> &str {
+    match config.encryption.method {
+        EncryptionMethod::Tpm => &config.encryption.sealed_key_path,
+        EncryptionMethod::Keyfile | EncryptionMethod::None => &config.encryption.key_path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_for(key_path: &Path) -> Config {
+        Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap()
+    }
+
+    fn software_encrypted_row() -> Vec<u8> {
+        facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+            .seal_embedding(&[0.5f32; 512])
+            .unwrap()
+    }
+
+    #[test]
+    fn a_software_encrypted_row_refuses_and_names_the_keyfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &software_encrypted_row(), true, "e")
+            .unwrap();
+
+        let refusal = key_creation_refusal(&store, &config).expect("must refuse");
+        assert!(refusal.contains("software-encrypted"), "{refusal}");
+        assert!(
+            refusal.contains(&key_path.display().to_string()),
+            "{refusal}"
+        );
+        assert!(refusal.contains("facelock clear"), "{refusal}");
+        assert!(!key_path.exists(), "the predicate must write nothing");
+    }
+
+    /// The rows a keyfile system finds may have been written by the TPM
+    /// method. Telling that operator to restore a key file they never had is
+    /// a remedy that cannot be followed.
+    #[test]
+    fn tpm_sealed_rows_under_a_keyfile_config_name_the_tpm_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let mut config = config_for(&key_path);
+        config.encryption.sealed_key_path = "/etc/facelock/sealed.key".into();
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &[0x01u8; 200], true, "e")
+            .unwrap();
+
+        let refusal = key_creation_refusal(&store, &config).expect("must refuse");
+        assert!(refusal.contains("TPM-sealed"), "{refusal}");
+        assert!(refusal.contains("/etc/facelock/sealed.key"), "{refusal}");
+    }
+
+    /// The `sealed` flag alone is not evidence. A row whose ciphertext was
+    /// replaced with a plaintext template — `facelock decrypt` writing a
+    /// 2048-byte blob, a half-finished migration — keeps the bit set, and
+    /// refusing over it strands a system that has nothing left to protect.
+    #[test]
+    fn a_sealed_flag_over_a_plaintext_template_is_not_an_encrypted_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &[0u8; 2048], true, "e")
+            .unwrap();
+
+        assert!(key_creation_refusal(&store, &config).is_none());
+        assert_eq!(
+            store.count_sealed().unwrap(),
+            (1, 0),
+            "the flag is still set"
+        );
+    }
+
+    #[test]
+    fn a_plaintext_only_database_still_gets_its_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw("alice", "front", &[0u8; 2048], false, "e")
+            .unwrap();
+
+        assert!(matches!(
+            ensure_encrypt_by_default_key(&store, &config),
+            KeyfileDecision::Created
+        ));
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+        assert_eq!(
+            std::os::unix::fs::PermissionsExt::mode(
+                &std::fs::metadata(&key_path).unwrap().permissions()
+            ) & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn an_existing_key_is_present_and_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let config = config_for(&key_path);
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let before = std::fs::read(&key_path).unwrap();
+        let store = FaceStore::open_memory().unwrap();
+
+        assert!(matches!(
+            ensure_encrypt_by_default_key(&store, &config),
+            KeyfileDecision::Present
+        ));
+        assert_eq!(std::fs::read(&key_path).unwrap(), before);
+    }
+
+    /// `docs/contracts.md` promises the symlink refusal. It was unreachable:
+    /// the gate ran only when `exists()` was false, and `exists()` follows the
+    /// link, so a link to a real file looked like a key that was already
+    /// there.
+    #[test]
+    fn a_resolvable_symlink_at_the_key_path_is_its_own_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("attacker.key");
+        facelock_tpm::SoftwareSealer::generate_key_file(&target).unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink(&target, &key_path).unwrap();
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+
+        let decision = ensure_encrypt_by_default_key(&store, &config);
+        let refusal = decision.refusal().expect("a link is a refusal");
+        assert!(refusal.contains("symlink"), "{refusal}");
+    }
+
+    #[test]
+    fn a_dangling_symlink_at_the_key_path_is_the_same_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink(dir.path().join("gone"), &key_path).unwrap();
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+
+        // `exists()` is false for a dangling link, so this used to reach the
+        // creator, which errored — and the caller downgraded that error to a
+        // warning and carried on as though no refusal had been made.
+        assert!(!key_path.exists());
+        let decision = ensure_encrypt_by_default_key(&store, &config);
+        let refusal = decision.refusal().expect("a link is a refusal");
+        assert!(refusal.contains("symlink"), "{refusal}");
+    }
+
+    /// A store that cannot be asked is not a store that answered "nothing to
+    /// protect". This is the arm that decides whether a destructive path fails
+    /// open.
+    #[test]
+    fn a_store_that_cannot_be_asked_refuses() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("faces.db");
+        let key_path = dir.path().join("encryption.key");
+        let mut config = config_for(&key_path);
+        config.storage.db_path = db_path.display().to_string();
+
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model_raw("alice", "front", &software_encrypted_row(), true, "e")
+                .unwrap();
+        }
+        facelock_test_support::schema_faults::break_face_embeddings_table(&db_path);
+        let store = FaceStore::open_existing(&db_path).unwrap();
+
+        let decision = ensure_encrypt_by_default_key(&store, &config);
+        let refusal = decision.refusal().expect("an unaskable store must refuse");
+        assert!(
+            refusal.contains("could not be read"),
+            "the refusal must name the store failure, not invent an answer: {refusal}"
+        );
+        assert!(
+            refusal.contains(&db_path.display().to_string()),
+            "{refusal}"
+        );
+        assert!(!key_path.exists());
+    }
+}

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -130,7 +130,7 @@ pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<Stri
         "{}. A new key cannot read them, and writing one makes a later restore of the \
          original useless. Restore the key artifacts for the encryption method that \
          wrote those rows, or clear the encrypted enrollments with `facelock clear` and \
-         enrol again. The daemon re-checks the key on the next authentication or \
+         enroll again. The daemon re-checks the key on the next authentication or \
          enrollment attempt.",
         found.join("; ")
     ))
@@ -183,6 +183,21 @@ pub fn ensure_encrypt_by_default_key(store: &FaceStore, config: &Config) -> Keyf
             "no encryption key could be created at {}: {e}",
             key_path.display()
         )),
+    }
+}
+
+/// `cause`, ended as a sentence — a period appended unless it already ends
+/// with `.`, `!` or `?`.
+///
+/// The enroll refusal splices a cause into `"{cause} {next sentence}"`. Some
+/// causes are hand-written with a trailing period; others — an `io::Error`'s
+/// `Display`, `"the configured encryption sealer could not be initialized"` —
+/// are not, and without this the two sentences ran together with no
+/// punctuation between them at all.
+pub fn sentence(cause: &str) -> String {
+    match cause.chars().next_back() {
+        Some('.') | Some('!') | Some('?') => cause.to_string(),
+        _ => format!("{cause}."),
     }
 }
 
@@ -348,6 +363,27 @@ mod tests {
         let decision = ensure_encrypt_by_default_key(&store, &config);
         let refusal = decision.refusal().expect("a link is a refusal");
         assert!(refusal.contains("symlink"), "{refusal}");
+    }
+
+    #[test]
+    fn sentence_appends_a_period_when_the_cause_has_no_terminal_punctuation() {
+        // The two fallback causes at the enroll refusal sites (#231 round 1):
+        // a bare constant and an `io::Error` `Display`, neither punctuated.
+        assert_eq!(
+            sentence("the configured encryption sealer could not be initialized"),
+            "the configured encryption sealer could not be initialized."
+        );
+        assert_eq!(
+            sentence("keyfile could not be read: No such file or directory (os error 2)"),
+            "keyfile could not be read: No such file or directory (os error 2)."
+        );
+    }
+
+    #[test]
+    fn sentence_leaves_existing_terminal_punctuation_alone() {
+        assert_eq!(sentence("already refused."), "already refused.");
+        assert_eq!(sentence("already refused!"), "already refused!");
+        assert_eq!(sentence("already refused?"), "already refused?");
     }
 
     /// A store that cannot be asked is not a store that answered "nothing to

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -72,15 +72,28 @@ impl KeyfileDecision {
 /// nothing needed. The version byte at the head of the blob is the fact.
 pub fn key_creation_refusal(store: &FaceStore, config: &Config) -> Option<String> {
     let target = configured_key_artifact(config);
+    let at_risk = encrypted_rows_at_risk(store, config)?;
+    Some(format!(
+        "refusing to write an encryption key at {target}: {at_risk}"
+    ))
+}
 
+/// What a lost key would cost, and how to get it back — or `None` when the
+/// store holds nothing a key could orphan.
+///
+/// Split from [`key_creation_refusal`] because the same facts are needed by a
+/// caller that is *not* about to write a key: a key file that exists but
+/// cannot be read leaves an operator in exactly the same predicament, and
+/// "keyfile could not be read: expected 32 bytes, got 12" tells them nothing
+/// about what is at risk or which artifact brings it back.
+pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<String> {
     let shapes = match store.embedding_blob_shapes() {
         Ok(shapes) => shapes,
         Err(e) => {
             return Some(format!(
-                "refusing to write an encryption key at {target}: the face database could \
-                 not be read ({e}), so facelock cannot tell whether encrypted templates \
-                 would be orphaned. Fix access to {} and retry, or clear the enrollments \
-                 with `facelock clear`.",
+                "the face database could not be read ({e}), so facelock cannot tell \
+                 whether encrypted templates would be orphaned. Fix access to {} and \
+                 retry, or clear the enrollments with `facelock clear`.",
                 config.storage.db_path
             ));
         }
@@ -99,27 +112,26 @@ pub fn key_creation_refusal(store: &FaceStore, config: &Config) -> Option<String
         return None;
     }
 
-    let mut at_risk = Vec::new();
+    let mut found = Vec::new();
     if software > 0 {
-        at_risk.push(format!(
+        found.push(format!(
             "{software} row(s) are software-encrypted (method \"keyfile\", key file {})",
             config.encryption.key_path
         ));
     }
     if tpm > 0 {
-        at_risk.push(format!(
+        found.push(format!(
             "{tpm} row(s) are TPM-sealed (method \"tpm\", sealed key {})",
             config.encryption.sealed_key_path
         ));
     }
 
     Some(format!(
-        "refusing to write an encryption key at {target}: {}. A new key cannot read \
-         them, and writing one makes a later restore of the original useless. Restore \
-         the key artifacts for the encryption method that wrote those rows, or clear \
-         the encrypted enrollments with `facelock clear` and enrol again. Nothing needs \
-         restarting — the key is re-checked on the next enrollment attempt.",
-        at_risk.join("; ")
+        "{}. A new key cannot read them, and writing one makes a later restore of the \
+         original useless. Restore the key artifacts for the encryption method that \
+         wrote those rows, or clear the encrypted enrollments with `facelock clear` and \
+         enrol again. The daemon re-checks the key on the next enrollment attempt.",
+        found.join("; ")
     ))
 }
 

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -36,6 +36,10 @@ pub enum KeyfileDecision {
     Present,
     /// This call created the key file.
     Created,
+    /// The configured method keeps no key file — `tpm` seals its key, `none`
+    /// stores templates in plaintext — so there was nothing to create. Not a
+    /// refusal: nothing was wrong, and nothing was written either.
+    NotApplicable,
     /// No key was written. The string says why, which artifact is missing, and
     /// what the operator can do about it.
     Refused(String),
@@ -47,7 +51,9 @@ impl KeyfileDecision {
     pub fn refusal(&self) -> Option<&str> {
         match self {
             KeyfileDecision::Refused(message) => Some(message),
-            KeyfileDecision::Present | KeyfileDecision::Created => None,
+            KeyfileDecision::Present
+            | KeyfileDecision::Created
+            | KeyfileDecision::NotApplicable => None,
         }
     }
 }
@@ -136,8 +142,8 @@ pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<Stri
     ))
 }
 
-/// Create the encrypt-by-default key file if — and only if — the database
-/// holds no encrypted template.
+/// Create the encrypt-by-default key file if — and only if — the configured
+/// method is `keyfile` and the database holds no encrypted template.
 ///
 /// This is the gate the daemon and the one-shot path run before reading the
 /// key. It is consulted *unconditionally*, not only when the key looks absent:
@@ -150,6 +156,17 @@ pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<Stri
 /// locked is a refusal, on the same "cannot tell" reasoning as a store that
 /// cannot be queried.
 pub fn ensure_encrypt_by_default_key(store: &FaceStore, config: &Config) -> KeyfileDecision {
+    // Only the keyfile method has a key file to create. `none` stores
+    // templates in plaintext and `tpm` seals its key elsewhere, so minting
+    // `encryption.key_path` for either leaves a live AES key on disk that
+    // nothing reads — and, for `none`, one whose reader refuses it a moment
+    // later anyway. The guard lives here rather than at each call site for
+    // the reason the module exists: a rule wired into one writer is not a
+    // rule.
+    if config.encryption.method != EncryptionMethod::Keyfile {
+        return KeyfileDecision::NotApplicable;
+    }
+
     let key_path = Path::new(&config.encryption.key_path);
 
     // A key that is already there means this call writes nothing, and nothing
@@ -345,6 +362,34 @@ mod tests {
             (1, 0),
             "the flag is still set"
         );
+    }
+
+    /// The gate mints the key file for the one method that reads it. Under
+    /// `none` the branch that used to run here left a live AES key at
+    /// `key_path` for a plaintext database, which the sealer then refused
+    /// anyway; under `tpm` the key that matters is the sealed one.
+    #[test]
+    fn a_method_that_keeps_no_key_file_creates_nothing() {
+        for method in ["none", "tpm"] {
+            let dir = tempfile::tempdir().unwrap();
+            let key_path = dir.path().join("encryption.key");
+            let config = Config::parse(&format!(
+                "[encryption]\nmethod = \"{method}\"\nkey_path = \"{}\"\n",
+                key_path.display()
+            ))
+            .unwrap();
+            let store = FaceStore::open_memory().unwrap();
+
+            let decision = ensure_encrypt_by_default_key(&store, &config);
+            assert!(
+                matches!(decision, KeyfileDecision::NotApplicable),
+                "method {method}: {decision:?}"
+            );
+            assert!(
+                !key_path.exists(),
+                "method {method} minted a key file nothing reads"
+            );
+        }
     }
 
     /// The auth path runs this gate before every read of the key, so the

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -130,7 +130,8 @@ pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<Stri
         "{}. A new key cannot read them, and writing one makes a later restore of the \
          original useless. Restore the key artifacts for the encryption method that \
          wrote those rows, or clear the encrypted enrollments with `facelock clear` and \
-         enrol again. The daemon re-checks the key on the next enrollment attempt.",
+         enrol again. The daemon re-checks the key on the next authentication or \
+         enrollment attempt.",
         found.join("; ")
     ))
 }

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -185,7 +185,10 @@ pub fn ensure_encrypt_by_default_key(store: &FaceStore, config: &Config) -> Keyf
     // this call it can commit a row sealed under the current key between the
     // question and the answer — and that row is exactly what the refusal
     // exists to protect. Held only across a `stat`, one projection query and
-    // a 32-byte create.
+    // a 32-byte create — with one exception: `facelock encrypt
+    // --generate-key` under `method = "tpm"` holds its own such section
+    // across a TPM round trip (`generate_and_seal_key`), so a slow TPM can
+    // push a concurrent enrollment into the busy timeout.
     store
         .with_exclusive(|_conn| Ok::<_, StoreError>(decide_and_create(store, config)))
         .unwrap_or_else(|e| KeyfileDecision::Refused(unlockable_store_refusal(config, &e)))

--- a/crates/facelock-daemon/src/key_policy.rs
+++ b/crates/facelock-daemon/src/key_policy.rs
@@ -24,7 +24,7 @@
 use std::path::Path;
 
 use facelock_core::config::{Config, EncryptionMethod};
-use facelock_store::FaceStore;
+use facelock_store::{FaceStore, StoreError};
 use tracing::info;
 
 /// What the gate decided about the configured key file.
@@ -144,7 +144,64 @@ pub fn encrypted_rows_at_risk(store: &FaceStore, config: &Config) -> Option<Stri
 /// `Path::exists` follows a symlink, so a link planted at `key_path` used to
 /// answer "the key is there" and skip every check, leaving the reader to load
 /// whatever the link named.
+///
+/// The check and the write are one exclusive section on `store`, so an
+/// enrollment cannot land a sealed row in between; a store that cannot be
+/// locked is a refusal, on the same "cannot tell" reasoning as a store that
+/// cannot be queried.
 pub fn ensure_encrypt_by_default_key(store: &FaceStore, config: &Config) -> KeyfileDecision {
+    let key_path = Path::new(&config.encryption.key_path);
+
+    // A key that is already there means this call writes nothing, and nothing
+    // to write is nothing to serialize. Worth its own `stat` because the auth
+    // path runs this gate before every read of the key: in the steady state
+    // it stays off the database's write lock entirely. Anything else — a
+    // symlink, a missing key, a path that cannot be inspected — is a decision
+    // that may write, and is taken under the lock.
+    if matches!(key_path.symlink_metadata(), Ok(m) if !m.file_type().is_symlink()) {
+        return KeyfileDecision::Present;
+    }
+
+    // One exclusive section over the whole decision. The row check and the
+    // key write have to be indivisible: enrollment persists a template in a
+    // single store transaction, so unless it is excluded for the length of
+    // this call it can commit a row sealed under the current key between the
+    // question and the answer — and that row is exactly what the refusal
+    // exists to protect. Held only across a `stat`, one projection query and
+    // a 32-byte create.
+    store
+        .with_exclusive(|_conn| Ok::<_, StoreError>(decide_and_create(store, config)))
+        .unwrap_or_else(|e| KeyfileDecision::Refused(unlockable_store_refusal(config, &e)))
+}
+
+/// The refusal for a store the gate could not take the lock on.
+///
+/// A database another process is *writing* is a wait-and-retry, and saying
+/// "could not be read" of it would send an operator hunting a permissions
+/// problem that is not there. Every other failure to begin the section is the
+/// same "facelock cannot tell" the query path reports, down to the remedy.
+fn unlockable_store_refusal(config: &Config, error: &StoreError) -> String {
+    let target = configured_key_artifact(config);
+    let db_path = &config.storage.db_path;
+    match error {
+        StoreError::Busy { .. } => format!(
+            "refusing to write an encryption key at {target}: the face database at \
+             {db_path} is held by another process ({error}), so facelock cannot rule out \
+             an enrollment sealing a template under the key this would replace. Retry \
+             once it is free."
+        ),
+        _ => format!(
+            "refusing to write an encryption key at {target}: the face database at \
+             {db_path} could not be read ({error}), so facelock cannot tell whether \
+             existing templates would be orphaned. Fix access to it and retry, or clear \
+             the enrollments with `facelock clear`."
+        ),
+    }
+}
+
+/// The decision itself, with the store's write lock already held by
+/// [`ensure_encrypt_by_default_key`].
+fn decide_and_create(store: &FaceStore, config: &Config) -> KeyfileDecision {
     let key_path = Path::new(&config.encryption.key_path);
 
     match key_path.symlink_metadata() {
@@ -287,6 +344,88 @@ mod tests {
             store.count_sealed().unwrap(),
             (1, 0),
             "the flag is still set"
+        );
+    }
+
+    /// The auth path runs this gate before every read of the key, so the
+    /// steady state — a key that is already there, nothing to write — must
+    /// not queue behind the database's write lock. Asserted from inside
+    /// another connection's exclusive section: a gate that took the lock
+    /// would sit here until the busy timeout and then refuse.
+    #[test]
+    fn an_existing_key_is_decided_without_taking_the_write_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("faces.db");
+        let key_path = dir.path().join("encryption.key");
+        let mut config = config_for(&key_path);
+        config.storage.db_path = db_path.display().to_string();
+        facelock_tpm::SoftwareSealer::generate_key_file(&key_path).unwrap();
+
+        let writer = FaceStore::create(&db_path).unwrap();
+        let reader = FaceStore::open_existing(&db_path).unwrap();
+        writer
+            .with_exclusive(|_conn| {
+                let decision = ensure_encrypt_by_default_key(&reader, &config);
+                assert!(
+                    matches!(decision, KeyfileDecision::Present),
+                    "an existing key must be reported without the lock: {decision:?}"
+                );
+                Ok::<(), StoreError>(())
+            })
+            .unwrap();
+    }
+
+    /// The race the exclusive section closes (#231): the row check and the key
+    /// write are one act, so a writer holding the store — an enrollment
+    /// persisting its model in a single transaction — keeps the gate out
+    /// until it has committed, rather than the gate reading a snapshot taken
+    /// before that commit and minting over the row.
+    ///
+    /// Timed rather than sampled: the gate's own decision looks the same
+    /// either way, and what has to hold is that it did not proceed while the
+    /// writer had the database.
+    #[test]
+    fn the_gate_waits_for_a_writer_holding_the_store() {
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("faces.db");
+        let key_path = dir.path().join("encryption.key");
+        let mut config = config_for(&key_path);
+        config.storage.db_path = db_path.display().to_string();
+        let writer = FaceStore::create(&db_path).unwrap();
+
+        let (announce, section_open) = std::sync::mpsc::channel();
+        let gate_config = config.clone();
+        let gate_db = db_path.clone();
+        let gate = std::thread::spawn(move || {
+            let store = FaceStore::open_existing(&gate_db).unwrap();
+            section_open
+                .recv()
+                .expect("the writer never took the store");
+            let started = Instant::now();
+            (
+                ensure_encrypt_by_default_key(&store, &gate_config),
+                started.elapsed(),
+            )
+        });
+
+        writer
+            .with_exclusive(|_conn| {
+                announce.send(()).expect("the gate thread is waiting");
+                std::thread::sleep(Duration::from_millis(200));
+                Ok::<(), StoreError>(())
+            })
+            .unwrap();
+
+        let (decision, elapsed) = gate.join().unwrap();
+        assert!(
+            matches!(decision, KeyfileDecision::Created),
+            "a plaintext database still gets its key: {decision:?}"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "the gate decided while the writer held the store: {elapsed:?}"
         );
     }
 

--- a/crates/facelock-daemon/src/lib.rs
+++ b/crates/facelock-daemon/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cancel;
 pub mod embeddings;
 pub mod enroll;
 pub mod handler;
+pub mod key_policy;
 pub mod liveness;
 pub mod quality;
 pub mod rate_limit;

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1995,3 +1995,108 @@ fn a_failed_compare_set_load_is_not_cached() {
         "the frame after the store is repaired must reload, not serve a cached failure"
     );
 }
+
+// --- #231 Track K task 7: a missing key over encrypted rows is never replaced ---
+
+/// The encrypt-by-default auto-generation exists so a keyfile default actually
+/// encrypts on a fresh system. On an upgraded system whose key artifact went
+/// missing it was doing something else entirely: writing a *replacement* key
+/// over a database full of rows encrypted under the old one. Those rows were
+/// already unreadable, but the new key made the loss permanent and silent — a
+/// later backup restore of the real key would no longer match what the daemon
+/// had since written.
+#[test]
+fn missing_key_over_encrypted_rows_is_never_replaced() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("missing-key-encrypted-rows");
+    let mut config = test_config();
+    config.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
+    config.encryption.key_path = key_path.display().to_string();
+    config.storage.db_path = db_path.display().to_string();
+
+    // A row that was encrypted under a key this system no longer has.
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw("alice", "front", &[0x02u8; 96], true, "embedder")
+        .unwrap();
+
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
+    let mut handler = Handler::new(
+        config,
+        MockFaceEngine::no_faces(),
+        store,
+        RateLimiter::new(5, 60),
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !key_path.exists(),
+        "a replacement key was written over encrypted rows: {}",
+        key_path.display()
+    );
+
+    // Enroll still fails closed, and the message has to name the missing key
+    // rather than a generic keyfile error, or the operator cannot tell a lost
+    // key from a permissions problem.
+    match handler.handle(DaemonRequest::Enroll {
+        user: "alice".to_string(),
+        label: "second".to_string(),
+    }) {
+        DaemonResponse::Error { message } => assert!(
+            message.contains("encrypted") && message.contains("key"),
+            "refusal must name the missing key over encrypted rows: {message}"
+        ),
+        other => panic!("enroll must be refused while the key is missing, got: {other:?}"),
+    }
+
+    cleanup_db(&db_path);
+}
+
+/// The other half: a genuinely fresh keyfile system still gets its key made
+/// for it. Removing the auto-generation altogether would silently stop
+/// encrypting new enrollments, which is the finding it was added for.
+#[test]
+fn missing_key_over_plaintext_only_rows_is_still_created() {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("missing-key-plaintext-rows");
+    let mut config = test_config();
+    config.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
+    config.encryption.key_path = key_path.display().to_string();
+    config.storage.db_path = db_path.display().to_string();
+
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw("alice", "front", &[0u8; 2048], false, "embedder")
+        .unwrap();
+
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
+    let _handler = Handler::new(
+        config,
+        MockFaceEngine::no_faces(),
+        store,
+        RateLimiter::new(5, 60),
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        key_path.exists(),
+        "a plaintext-only legacy database must still get its default key"
+    );
+    assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+
+    cleanup_db(&db_path);
+}

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -2161,6 +2161,50 @@ fn authenticate_in_the_refusal_state_names_the_key_not_corruption() {
     cleanup_db(&db_path);
 }
 
+/// A key file that exists but cannot be read — truncated by a full disk, half
+/// restored, replaced by a stray file — leaves an operator in exactly the
+/// predicament a missing key does. "expected 32 bytes, got 12" names neither
+/// what is at risk nor the artifact that brings it back.
+#[test]
+fn a_malformed_key_over_encrypted_rows_names_what_is_at_risk() {
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("malformed-key");
+    std::fs::write(&key_path, b"truncated").unwrap();
+
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw(
+            "alice",
+            "front",
+            &software_encrypted_row(),
+            true,
+            "embedder",
+        )
+        .unwrap();
+
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
+    match handler.handle(DaemonRequest::Enroll {
+        user: "alice".to_string(),
+        label: "second".to_string(),
+    }) {
+        DaemonResponse::Error { message } => {
+            assert!(
+                message.contains("software-encrypted") && message.contains("facelock clear"),
+                "a malformed key must carry the same remedy as a missing one: {message}"
+            );
+        }
+        other => panic!("enroll must be refused on an unreadable key, got: {other:?}"),
+    }
+    assert_eq!(
+        std::fs::read(&key_path).unwrap(),
+        b"truncated",
+        "an unreadable key is never replaced either"
+    );
+
+    cleanup_db(&db_path);
+}
+
 /// The refusal is global to the store — one user's encrypted row triggers it —
 /// but a user whose own templates are plaintext must keep authenticating.
 #[test]

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -2288,3 +2288,59 @@ fn restoring_the_key_lifts_the_refusal_without_a_restart() {
 
     cleanup_db(&db_path);
 }
+
+/// The restore-lifts-the-refusal fix above only ran `refresh_software_sealer`
+/// from the `Enroll` arm. Authentication went through
+/// `handle_authenticate_prechecked` instead, so a key restored by an operator
+/// still refused every authentication until the daemon was enrolled into or
+/// restarted — the one thing "restore the key artifact" was supposed to fix
+/// without either.
+#[test]
+fn restoring_the_key_lifts_the_refusal_for_authentication() {
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("refusal-restore-auth");
+
+    let real_key = [0x11u8; 32];
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw(
+            "alice",
+            "front",
+            &software_encrypted_row(),
+            true,
+            "embedder",
+        )
+        .unwrap();
+
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
+    match handler.handle_authenticate(
+        "alice".to_string(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    ) {
+        DaemonResponse::Error { message } => assert!(
+            message.contains("software-encrypted") && message.contains("facelock clear"),
+            "must start in the refusal state: {message}"
+        ),
+        other => panic!("expected the refusal, got: {other:?}"),
+    }
+
+    // The operator restores the key from backup, exactly as instructed.
+    std::fs::write(&key_path, real_key).unwrap();
+
+    // No enrollment, no restart: the very next authenticate call must get a
+    // real compare against alice's decrypted templates rather than the stale
+    // refusal from before the restore.
+    let response = handler.handle_authenticate(
+        "alice".to_string(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    );
+    assert!(
+        !matches!(response, DaemonResponse::Error { .. }),
+        "the restored key must lift the refusal for authentication too: {response:?}"
+    );
+
+    cleanup_db(&db_path);
+}

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1996,7 +1996,43 @@ fn a_failed_compare_set_load_is_not_cached() {
     );
 }
 
-// --- #231 Track K task 7: a missing key over encrypted rows is never replaced ---
+// --- #231: a missing key over encrypted rows is never replaced ---
+
+/// A template row as a real system holds one: version byte, nonce, ciphertext
+/// and tag, 2077 bytes. Short `[0x02; 96]` stand-ins pass the version-byte
+/// check but not the load path, so they cannot show what an operator actually
+/// sees when the key behind them is gone.
+fn software_encrypted_row() -> Vec<u8> {
+    facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+        .seal_embedding(&[0.5f32; 512])
+        .unwrap()
+}
+
+fn keyfile_handler(
+    key_path: &Path,
+    db_path: &Path,
+    store: FaceStore,
+) -> facelock_daemon::handler::Handler<MockCamera, MockFaceEngine> {
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let mut config = test_config();
+    config.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
+    config.encryption.key_path = key_path.display().to_string();
+    config.storage.db_path = db_path.display().to_string();
+
+    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
+    Handler::new(
+        config,
+        MockFaceEngine::no_faces(),
+        store,
+        RateLimiter::new(5, 60),
+        CameraCaps::default(),
+        Some(factory),
+        None,
+    )
+    .unwrap()
+}
 
 /// The encrypt-by-default auto-generation exists so a keyfile default actually
 /// encrypts on a fresh system. On an upgraded system whose key artifact went
@@ -2007,35 +2043,22 @@ fn a_failed_compare_set_load_is_not_cached() {
 /// had since written.
 #[test]
 fn missing_key_over_encrypted_rows_is_never_replaced() {
-    use facelock_daemon::handler::Handler;
-    use facelock_daemon::rate_limit::RateLimiter;
-
     let dir = tempfile::tempdir().unwrap();
     let key_path = dir.path().join("encryption.key");
     let db_path = temp_db_path("missing-key-encrypted-rows");
-    let mut config = test_config();
-    config.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
-    config.encryption.key_path = key_path.display().to_string();
-    config.storage.db_path = db_path.display().to_string();
 
-    // A row that was encrypted under a key this system no longer has.
     let store = FaceStore::create(&db_path).unwrap();
     store
-        .add_model_raw("alice", "front", &[0x02u8; 96], true, "embedder")
+        .add_model_raw(
+            "alice",
+            "front",
+            &software_encrypted_row(),
+            true,
+            "embedder",
+        )
         .unwrap();
 
-    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
-    let mut handler = Handler::new(
-        config,
-        MockFaceEngine::no_faces(),
-        store,
-        RateLimiter::new(5, 60),
-        CameraCaps::default(),
-        Some(factory),
-        None,
-    )
-    .unwrap();
-
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
     assert!(
         !key_path.exists(),
         "a replacement key was written over encrypted rows: {}",
@@ -2050,8 +2073,8 @@ fn missing_key_over_encrypted_rows_is_never_replaced() {
         label: "second".to_string(),
     }) {
         DaemonResponse::Error { message } => assert!(
-            message.contains("encrypted") && message.contains("key"),
-            "refusal must name the missing key over encrypted rows: {message}"
+            message.contains("software-encrypted") && message.contains("facelock clear"),
+            "refusal must name what is at risk and the remedy: {message}"
         ),
         other => panic!("enroll must be refused while the key is missing, got: {other:?}"),
     }
@@ -2064,39 +2087,160 @@ fn missing_key_over_encrypted_rows_is_never_replaced() {
 /// encrypting new enrollments, which is the finding it was added for.
 #[test]
 fn missing_key_over_plaintext_only_rows_is_still_created() {
-    use facelock_daemon::handler::Handler;
-    use facelock_daemon::rate_limit::RateLimiter;
-
     let dir = tempfile::tempdir().unwrap();
     let key_path = dir.path().join("encryption.key");
     let db_path = temp_db_path("missing-key-plaintext-rows");
-    let mut config = test_config();
-    config.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
-    config.encryption.key_path = key_path.display().to_string();
-    config.storage.db_path = db_path.display().to_string();
 
     let store = FaceStore::create(&db_path).unwrap();
     store
         .add_model_raw("alice", "front", &[0u8; 2048], false, "embedder")
         .unwrap();
 
-    let factory: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(64, 64, 5)));
-    let _handler = Handler::new(
-        config,
-        MockFaceEngine::no_faces(),
-        store,
-        RateLimiter::new(5, 60),
-        CameraCaps::default(),
-        Some(factory),
-        None,
-    )
-    .unwrap();
+    let _handler = keyfile_handler(&key_path, &db_path, store);
 
     assert!(
         key_path.exists(),
         "a plaintext-only legacy database must still get its default key"
     );
     assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+
+    cleanup_db(&db_path);
+}
+
+/// Authentication in the refusal state must not report the database as
+/// corrupt. With no sealer the load used to take the plaintext fast path,
+/// which handed a 2077-byte encrypted blob to a caller expecting 2048 raw
+/// bytes; the store answered "invalid embedding blob size — the database is
+/// corrupt", and the operator whose key merely went missing was told to
+/// replace the one file still holding their enrollments.
+///
+/// The response stays an error, which the PAM module maps to `PAM_IGNORE`:
+/// no match, no rate-limit charge, and the password prompt behind it. That is
+/// the no-lockout contract, unchanged.
+#[test]
+fn authenticate_in_the_refusal_state_names_the_key_not_corruption() {
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("refusal-auth-message");
+
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw(
+            "alice",
+            "front",
+            &software_encrypted_row(),
+            true,
+            "embedder",
+        )
+        .unwrap();
+
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
+    let response = handler.handle_authenticate(
+        "alice".to_string(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    );
+
+    match response {
+        DaemonResponse::Error { message } => {
+            assert!(
+                !message.contains("corrupt"),
+                "a missing key is not a corrupt database: {message}"
+            );
+            assert!(
+                message.contains("facelock clear") && message.contains("software-encrypted"),
+                "the auth path must carry the refusal: {message}"
+            );
+        }
+        DaemonResponse::AuthResult(result) => {
+            assert!(!result.matched, "nothing may authenticate without the key");
+        }
+        other => panic!("unexpected authenticate response: {other:?}"),
+    }
+
+    cleanup_db(&db_path);
+}
+
+/// The refusal is global to the store — one user's encrypted row triggers it —
+/// but a user whose own templates are plaintext must keep authenticating.
+#[test]
+fn a_plaintext_user_still_loads_while_the_sealer_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("refusal-plaintext-user");
+
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw("bob", "front", &software_encrypted_row(), true, "embedder")
+        .unwrap();
+    store
+        .add_model("alice", "front", &[0.25f32; 512], "embedder")
+        .unwrap();
+
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
+    // `MockFaceEngine::no_faces` means the scan finds nobody, so the outcome
+    // is a clean no-match; what matters is that the *load* succeeded rather
+    // than erroring out from under her.
+    let response = handler.handle_authenticate(
+        "alice".to_string(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    );
+    assert!(
+        !matches!(response, DaemonResponse::Error { .. }),
+        "alice's compare set must still load: {response:?}"
+    );
+
+    cleanup_db(&db_path);
+}
+
+/// The refusal tells the operator to restore the key artifact. Deciding once
+/// at construction meant they restored it, did exactly what they were told,
+/// and were told the same thing again — with `facelock clear` as the message's
+/// next suggestion, which destroys the enrollments the restore just saved.
+#[test]
+fn restoring_the_key_lifts_the_refusal_without_a_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let key_path = dir.path().join("encryption.key");
+    let db_path = temp_db_path("refusal-restore");
+
+    let real_key = [0x11u8; 32];
+    let store = FaceStore::create(&db_path).unwrap();
+    store
+        .add_model_raw(
+            "alice",
+            "front",
+            &software_encrypted_row(),
+            true,
+            "embedder",
+        )
+        .unwrap();
+
+    let mut handler = keyfile_handler(&key_path, &db_path, store);
+    match handler.handle(DaemonRequest::Enroll {
+        user: "alice".to_string(),
+        label: "second".to_string(),
+    }) {
+        DaemonResponse::Error { message } => assert!(message.contains("facelock clear")),
+        other => panic!("expected the refusal, got: {other:?}"),
+    }
+
+    // The operator restores the key from backup, exactly as instructed.
+    std::fs::write(&key_path, real_key).unwrap();
+
+    // The enrollment that follows gets past the encryption gate. It still
+    // fails — `MockFaceEngine::no_faces` never captures a face — but on
+    // capture, not on a stale decision from before the restore.
+    match handler.handle(DaemonRequest::Enroll {
+        user: "alice".to_string(),
+        label: "second".to_string(),
+    }) {
+        DaemonResponse::Error { message } => assert!(
+            message.contains("no face"),
+            "the restored key must lift the refusal and let capture run: {message}"
+        ),
+        other => panic!("unexpected post-restore enroll response: {other:?}"),
+    }
 
     cleanup_db(&db_path);
 }

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rusqlite::params;
 
@@ -18,6 +18,23 @@ use crate::migrations::run_migrations;
 /// from more than one angle (#308). The daemon's enrollment loop derives its
 /// minimum-capture count from this constant, so the two cannot drift.
 pub const MIN_EMBEDDINGS_PER_MODEL: usize = 3;
+
+/// How long an operation waits for another connection's write lock before
+/// giving up with [`StoreError::Busy`].
+///
+/// Facelock's writers genuinely exclude each other: an enrollment commits its
+/// model in one transaction, and the encryption-key gate holds an exclusive
+/// section across its row check and its key write
+/// ([`FaceStore::with_exclusive`]). Both are short — one small query and a
+/// 32-byte file — so the alternative to waiting is failing an enrollment
+/// because a key check happened to be in flight. Five seconds is far longer
+/// than either section and far shorter than any caller's own deadline.
+///
+/// Set explicitly even though rusqlite happens to apply the same value to
+/// every connection it opens: that default is undocumented, and whether a
+/// concurrent enrollment waits or fails is not a property to leave resting on
+/// it.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 pub struct FaceStore {
@@ -135,6 +152,8 @@ impl FaceStore {
             .map_err(|e| StoreError::classify(db_path, e))?;
         run_migrations(db_path, &conn)?;
         secure_database_files(db_path)?;
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| StoreError::classify(db_path, e))?;
         Ok(Self {
             conn,
             path: db_path.to_path_buf(),
@@ -181,6 +200,60 @@ impl FaceStore {
     /// Classify a rusqlite failure from this store's connection.
     fn err(&self, e: rusqlite::Error) -> StoreError {
         StoreError::classify(&self.path, e)
+    }
+
+    /// Begin a write transaction that takes the database's write lock now,
+    /// not at its first write statement.
+    ///
+    /// `BEGIN IMMEDIATE`, never `BEGIN DEFERRED`. A deferred transaction that
+    /// reads before it writes has to *promote* a read transaction to a write
+    /// one, and SQLite will not run the busy handler for that — the two
+    /// waiters could deadlock — so it fails with `SQLITE_BUSY` at once
+    /// however long [`BUSY_TIMEOUT`] is. Today's transactions all write with
+    /// their first statement and so would wait anyway; taking the lock at
+    /// `BEGIN` costs them nothing and keeps a later read-then-write edit from
+    /// quietly turning a wait into a failed enrollment.
+    fn write_tx(&self) -> Result<rusqlite::Transaction<'_>> {
+        rusqlite::Transaction::new_unchecked(&self.conn, rusqlite::TransactionBehavior::Immediate)
+            .map_err(|e| self.err(e))
+    }
+
+    /// Run `f` with this connection holding the database's write lock, and
+    /// release it only once `f` has returned.
+    ///
+    /// `BEGIN EXCLUSIVE`, so the lock is taken before `f` runs rather than at
+    /// its first write: `f` may only read and still excludes every writer.
+    /// That is what the encryption-key gate needs. It asks whether any stored
+    /// blob is encrypted and then writes the key artifact, and those two steps
+    /// have to be one indivisible act — under WAL a plain read sees the
+    /// snapshot it opened on, so an enrollment committing a sealed row between
+    /// the question and the answer produces a row the new key cannot read
+    /// (#231). Enrollment's own write is one transaction
+    /// ([`Self::replace_model_with_embeddings`]), so the two serialize.
+    ///
+    /// `f` is handed this store's own connection, so a query issued through
+    /// `&self` from inside the closure runs inside the same transaction — but
+    /// a method that opens a transaction of its own (every write on this type)
+    /// cannot: SQLite has no nested transactions, and such a call fails rather
+    /// than silently escaping the section.
+    ///
+    /// Returning `Err` — or unwinding — rolls the section back. The section
+    /// holds no writes of its own, so rollback and commit differ only in name.
+    pub fn with_exclusive<T, E>(
+        &self,
+        f: impl FnOnce(&rusqlite::Connection) -> std::result::Result<T, E>,
+    ) -> std::result::Result<T, E>
+    where
+        E: From<StoreError>,
+    {
+        let tx = rusqlite::Transaction::new_unchecked(
+            &self.conn,
+            rusqlite::TransactionBehavior::Exclusive,
+        )
+        .map_err(|e| E::from(self.err(e)))?;
+        let value = f(&tx)?;
+        tx.commit().map_err(|e| E::from(self.err(e)))?;
+        Ok(value)
     }
 
     /// Add a face model with its embedding. Returns the new model ID.
@@ -235,7 +308,7 @@ impl FaceStore {
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
+        let tx = self.write_tx()?;
 
         let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
 
@@ -510,7 +583,7 @@ impl FaceStore {
         embedder_model: &str,
         device_id: Option<&str>,
     ) -> Result<u32> {
-        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
+        let tx = self.write_tx()?;
 
         let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
@@ -559,7 +632,7 @@ impl FaceStore {
             });
         }
 
-        let tx = self.conn.unchecked_transaction().map_err(|e| self.err(e))?;
+        let tx = self.write_tx()?;
 
         // Cascades to the old model's embeddings (`ON DELETE CASCADE`, with
         // foreign keys on for every connection this crate opens).
@@ -1817,5 +1890,90 @@ mod tests {
         let bob_row = all.iter().find(|(_, u, _, _)| u == "bob").unwrap();
         assert!(bob_row.3);
         assert_eq!(bob_row.2, vec![0x01; 50]);
+    }
+
+    /// The guarantee the encryption-key gate is built on (#231): while a
+    /// section is open, an enrollment cannot commit — it waits, and lands
+    /// only after the section has ended.
+    ///
+    /// The enrollment runs on its own connection, as the daemon's does, and
+    /// starts only once the section is known to be open. The flag is cleared
+    /// at the end of the closure, before the lock is released, so a write
+    /// that observed it still set would have to have slipped inside.
+    #[test]
+    fn an_exclusive_section_holds_off_an_enrollment_until_it_ends() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("facelock.db");
+        let holder = FaceStore::create(&db).unwrap();
+        let section_open = Arc::new(AtomicBool::new(true));
+
+        let (announce, wait_for_section) = std::sync::mpsc::channel();
+        let enroller_path = db.clone();
+        let observed = Arc::clone(&section_open);
+        let enrollment = std::thread::spawn(move || {
+            let enroller = FaceStore::open_existing(&enroller_path).unwrap();
+            wait_for_section.recv().expect("section never opened");
+            let started = std::time::Instant::now();
+            let blobs = vec![vec![0u8; 8]; MIN_EMBEDDINGS_PER_MODEL];
+            let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+            let result =
+                enroller.replace_model_with_embeddings("alice", "front", &refs, false, "e", None);
+            (result, observed.load(Ordering::SeqCst), started.elapsed())
+        });
+
+        holder
+            .with_exclusive(|_conn| {
+                announce.send(()).expect("the enrollment thread is waiting");
+                // Long enough that the enrollment is certainly blocked on the
+                // lock, far short of the store's busy timeout.
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                section_open.store(false, Ordering::SeqCst);
+                Ok::<(), StoreError>(())
+            })
+            .unwrap();
+
+        let (result, saw_section_open, elapsed) = enrollment.join().unwrap();
+        assert!(
+            result.is_ok(),
+            "the enrollment must wait for the section, not fail: {result:?}"
+        );
+        assert!(
+            !saw_section_open,
+            "the enrollment committed while the section was still open"
+        );
+        assert!(
+            elapsed >= std::time::Duration::from_millis(100),
+            "the enrollment did not block on the section: {elapsed:?}"
+        );
+        assert_eq!(holder.list_models("alice").unwrap().len(), 1);
+    }
+
+    /// A section that ends in `Err` still ends: the transaction rolls back and
+    /// the next writer gets the lock.
+    #[test]
+    fn a_failed_exclusive_section_releases_the_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path().join("facelock.db");
+        let store = FaceStore::create(&db).unwrap();
+
+        let err = store
+            .with_exclusive(|_conn| {
+                Err::<(), _>(StoreError::Query {
+                    path: db.clone(),
+                    detail: "refused".into(),
+                })
+            })
+            .unwrap_err();
+        assert!(matches!(err, StoreError::Query { .. }), "got {err:?}");
+
+        let blobs = vec![vec![0u8; 8]; MIN_EMBEDDINGS_PER_MODEL];
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+        FaceStore::open_existing(&db)
+            .unwrap()
+            .replace_model_with_embeddings("alice", "front", &refs, false, "e", None)
+            .expect("the lock must be released when the section fails");
     }
 }

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -148,12 +148,15 @@ impl FaceStore {
     /// WAL, foreign keys, migrations, restrictive file modes. Only the flags
     /// used to obtain `conn` differ between them.
     fn init(conn: rusqlite::Connection, db_path: &Path) -> Result<Self> {
+        // First, not rusqlite's default: migrations below can contend with a
+        // concurrent writer, and should wait on the timeout this crate
+        // chose rather than whatever rusqlite starts a connection with.
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| StoreError::classify(db_path, e))?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .map_err(|e| StoreError::classify(db_path, e))?;
         run_migrations(db_path, &conn)?;
         secure_database_files(db_path)?;
-        conn.busy_timeout(BUSY_TIMEOUT)
-            .map_err(|e| StoreError::classify(db_path, e))?;
         Ok(Self {
             conn,
             path: db_path.to_path_buf(),

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -631,6 +631,43 @@ impl FaceStore {
         Ok((sealed, unsealed))
     }
 
+    /// The version byte and byte length of every stored embedding blob.
+    ///
+    /// Returns one `(first_byte, len)` per row; `first_byte` is `None` for an
+    /// empty blob.
+    ///
+    /// This exists so a caller can classify rows by *encryption shape* — how
+    /// many templates are software-encrypted, how many TPM-sealed — without
+    /// reading templates. [`Self::count_sealed`] cannot answer that question:
+    /// the `sealed` column is one bit that every method sets, so a TPM system
+    /// and a keyfile system look identical through it, and a row whose flag
+    /// outlived its ciphertext looks encrypted when it is not. The blob's own
+    /// version byte is the fact. Selecting whole rows to reach that byte would
+    /// pull every plaintext biometric template into the caller's memory,
+    /// outside the wiping discipline the read paths keep; SQLite does the
+    /// projection instead.
+    pub fn embedding_blob_shapes(&self) -> Result<Vec<(Option<u8>, usize)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT substr(embedding, 1, 1), length(embedding) FROM face_embeddings")
+            .map_err(|e| self.err(e))?;
+        let rows = stmt
+            .query_map([], |row| {
+                // `substr` over a zero-length blob is NULL, not an empty
+                // blob — the one row shape that would otherwise turn a
+                // classification query into a type error.
+                let head: Option<Vec<u8>> = row.get(0)?;
+                let len: i64 = row.get(1)?;
+                Ok((
+                    head.as_deref().and_then(<[u8]>::first).copied(),
+                    len.max(0) as usize,
+                ))
+            })
+            .map_err(|e| self.err(e))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| self.err(e))
+    }
+
     /// Get all embeddings (all users) as raw bytes with sealed flag.
     /// Returns (embedding_id, model_user, raw_bytes, sealed) tuples.
     #[allow(clippy::type_complexity)]
@@ -1103,6 +1140,32 @@ mod tests {
         let (s, u) = store.count_sealed().unwrap();
         assert_eq!(s, 1);
         assert_eq!(u, 2);
+    }
+
+    #[test]
+    fn embedding_blob_shapes_report_the_version_byte_not_the_sealed_flag() {
+        let store = FaceStore::open_memory().unwrap();
+        // A flag that outlived its ciphertext: sealed = 1 over a plaintext
+        // 2048-byte template. `count_sealed` calls this encrypted; the blob
+        // says otherwise, and a caller deciding whether a new key would
+        // orphan anything needs the blob's answer.
+        store
+            .add_model_raw("alice", "stale-flag", &[0u8; 2048], true, "e")
+            .unwrap();
+        store
+            .add_model_raw("bob", "software", &[0x02u8; 96], true, "e")
+            .unwrap();
+        store
+            .add_model_raw("carol", "empty", &[], true, "e")
+            .unwrap();
+
+        let mut shapes = store.embedding_blob_shapes().unwrap();
+        shapes.sort();
+        assert_eq!(
+            shapes,
+            vec![(None, 0), (Some(0x00), 2048), (Some(0x02), 96)]
+        );
+        assert_eq!(store.count_sealed().unwrap(), (3, 0));
     }
 
     #[test]

--- a/crates/facelock-test-support/src/schema_faults.rs
+++ b/crates/facelock-test-support/src/schema_faults.rs
@@ -90,6 +90,68 @@ pub fn break_face_models_table(db_path: &Path) {
     }
 }
 
+/// Make every query that walks `face_embeddings` (or its index) report
+/// corruption, while leaving a database that still opens and migrates cleanly.
+///
+/// Same page-type mismatch as [`break_face_models_table`], aimed at the other
+/// table. Its callers are the guards that must distinguish "the store says
+/// there are no encrypted templates" from "the store could not be asked":
+/// minting an encryption key on the second answer is what orphans real
+/// enrollments, so the failing-query path needs a test of its own and no
+/// public store API can produce a database that fails one query.
+///
+/// **Schema coupling:** `face_embeddings` has one explicit index,
+/// `idx_face_embeddings_model`. It has no `sqlite_autoindex_*` — its
+/// uniqueness comes from `INTEGER PRIMARY KEY`, which is the rowid itself.
+/// Add new indexes here when the schema grows them, or a query served
+/// entirely from a new index will succeed where the test expects failure.
+pub fn break_face_embeddings_table(db_path: &Path) {
+    let conn = rusqlite::Connection::open(db_path).expect("open database for fault injection");
+    conn.execute_batch("CREATE TABLE e1(x); CREATE INDEX ei1 ON e1(x);")
+        .expect("create donor pages");
+
+    let page = |name: &str| -> i64 {
+        conn.query_row(
+            "SELECT rootpage FROM sqlite_master WHERE name = ?1",
+            [name],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|e| panic!("donor page {name} has no rootpage: {e}"))
+    };
+    let (p_e1, p_ei1) = (page("e1"), page("ei1"));
+
+    conn.execute_batch(&format!(
+        "PRAGMA writable_schema=ON;
+         UPDATE sqlite_master SET rootpage={p_ei1} WHERE name='face_embeddings';
+         UPDATE sqlite_master SET rootpage={p_e1} WHERE name='idx_face_embeddings_model';
+         DELETE FROM sqlite_master WHERE name IN ('e1','ei1');
+         PRAGMA writable_schema=OFF;",
+    ))
+    .expect("repoint face_embeddings rootpages");
+
+    // An UPDATE that matched nothing leaves a *working* table, and the test
+    // that depends on this would then silently assert nothing.
+    for name in ["face_embeddings", "idx_face_embeddings_model"] {
+        let repointed: i64 = conn
+            .query_row(
+                "SELECT rootpage FROM sqlite_master WHERE name = ?1",
+                [name],
+                |r| r.get(0),
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "schema object {name} is gone, so the fault was not injected \
+                     — update break_face_embeddings_table for the current schema: {e}"
+                )
+            });
+        assert!(
+            [p_e1, p_ei1].contains(&repointed),
+            "{name} was not repointed at a donor page; the schema changed and \
+             break_face_embeddings_table needs re-deriving"
+        );
+    }
+}
+
 /// Remove the `embedder_model` column from `face_models`, so a query that
 /// selects it fails while the database as a whole stays open and usable.
 ///

--- a/crates/facelock-tpm/Cargo.toml
+++ b/crates/facelock-tpm/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 zeroize = "1"
 aes-gcm = "0.11"
 rand = "0.10"
+libc = "0.2"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/facelock-tpm/Cargo.toml
+++ b/crates/facelock-tpm/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.10"
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"
 
 [features]
 tpm = ["dep:tss-esapi"]

--- a/crates/facelock-tpm/src/lib.rs
+++ b/crates/facelock-tpm/src/lib.rs
@@ -3,6 +3,6 @@ pub mod sealing;
 
 pub use pcr::{PcrBaseline, PcrVerifier};
 pub use sealing::{
-    SoftwareSealer, TpmSealer, generate_and_seal_key, is_encrypted, is_sealed,
-    is_software_encrypted, raw_embedding_size,
+    SoftwareSealer, TpmSealer, generate_and_seal_key, is_encrypted, is_sealed, is_sealed_shape,
+    is_software_encrypted, is_software_encrypted_shape, raw_embedding_size, symlink_key_refusal,
 };

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -836,7 +836,7 @@ impl SoftwareSealer {
     pub fn from_key_file(path: &std::path::Path) -> Result<Self> {
         use std::io::Read;
 
-        let mut file = facelock_core::fs_security::open_no_follow(path).map_err(|e| {
+        let file = facelock_core::fs_security::open_no_follow(path).map_err(|e| {
             if facelock_core::fs_security::is_symlink(path) {
                 FacelockError::Encryption(symlink_key_refusal(path))
             } else {
@@ -846,15 +846,30 @@ impl SoftwareSealer {
                 ))
             }
         })?;
-        let mut data = zeroize::Zeroizing::new(Vec::with_capacity(AES_KEY_SIZE));
-        file.read_to_end(&mut data).map_err(|e| {
-            FacelockError::Encryption(format!("failed to read key file {}: {e}", path.display()))
-        })?;
+        // Bounded read: a valid key file is never more than `AES_KEY_SIZE`
+        // bytes, so `key_path` pointed at something else — a log file, a
+        // misconfigured path — must not be read into memory in full before
+        // the length check below gets to run. One byte past the expected
+        // size is enough to know the file is too big without reading the
+        // rest of it.
+        let mut data = zeroize::Zeroizing::new(Vec::with_capacity(AES_KEY_SIZE + 1));
+        file.take((AES_KEY_SIZE + 1) as u64)
+            .read_to_end(&mut data)
+            .map_err(|e| {
+                FacelockError::Encryption(format!(
+                    "failed to read key file {}: {e}",
+                    path.display()
+                ))
+            })?;
         if data.len() != AES_KEY_SIZE {
+            let got = if data.len() > AES_KEY_SIZE {
+                format!("more than {AES_KEY_SIZE}")
+            } else {
+                data.len().to_string()
+            };
             return Err(FacelockError::Encryption(format!(
-                "key file {} must be exactly {AES_KEY_SIZE} bytes, got {}",
-                path.display(),
-                data.len()
+                "key file {} must be exactly {AES_KEY_SIZE} bytes, got {got}",
+                path.display()
             )));
         }
         let mut key = [0u8; AES_KEY_SIZE];
@@ -870,15 +885,16 @@ impl SoftwareSealer {
     /// Generate a new random 256-bit key and write it to a file at 0600.
     ///
     /// The file is created at mode 0600 in the same `open(2)` that creates it
-    /// (via `fs_security::create_truncate_file`), so it is never momentarily
-    /// world/group-readable — closing the create-then-`chmod` TOCTOU window
-    /// (finding #11). The key material is flushed to disk with `sync_all` and
-    /// zeroized from memory before returning.
+    /// (via `fs_security::create_truncate_file_nofollow`), so it is never
+    /// momentarily world/group-readable — closing the create-then-`chmod`
+    /// TOCTOU window (finding #11). The key material is flushed to disk with
+    /// `sync_all` and zeroized from memory before returning.
     ///
-    /// Refuses a symlink at `path` up front: `create_truncate_file` opens
-    /// with `O_NOFOLLOW`, so the symlink case would otherwise surface as a
-    /// generic I/O failure rather than the refusal every other key writer
-    /// gives.
+    /// Refuses a symlink at `path` up front, for a clearer message than the
+    /// generic I/O failure `open`'s `ELOOP` would otherwise surface as. The
+    /// open itself is `create_truncate_file_nofollow`, which carries its own
+    /// `O_NOFOLLOW` — the pre-check alone would leave a link planted in the
+    /// gap between it and the open free to be followed.
     pub fn generate_key_file(path: &std::path::Path) -> Result<()> {
         use rand::Rng;
         use std::io::Write;
@@ -892,13 +908,17 @@ impl SoftwareSealer {
         rand::rng().fill_bytes(&mut key);
 
         let write_result = (|| -> Result<()> {
-            let mut file =
-                facelock_core::fs_security::create_truncate_file(path, 0o600).map_err(|e| {
+            let mut file = facelock_core::fs_security::create_truncate_file_nofollow(path, 0o600)
+                .map_err(|e| {
+                if facelock_core::fs_security::is_symlink(path) {
+                    FacelockError::Encryption(symlink_key_refusal(path))
+                } else {
                     FacelockError::Encryption(format!(
                         "failed to create key file {}: {e}",
                         path.display()
                     ))
-                })?;
+                }
+            })?;
             file.write_all(&key)
                 .and_then(|()| file.sync_all())
                 .map_err(|e| {
@@ -1493,6 +1513,50 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A key file is never legitimately larger than 32 bytes. Before this,
+    /// `from_key_file` `read_to_end`'d the whole thing before checking the
+    /// length — unbounded if `key_path` pointed at something huge. The read
+    /// must stop a byte past the expected size, so the error can never report
+    /// the file's true (unread) length.
+    #[test]
+    fn software_sealer_from_key_file_oversized_is_refused_without_reading_it_all() {
+        let dir = std::env::temp_dir().join("facelock_key_oversized_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let key_path = dir.join("oversized.key");
+        std::fs::write(&key_path, [0u8; 64]).unwrap(); // 64 bytes instead of 32
+
+        let err = SoftwareSealer::from_key_file(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("32"),
+            "error should mention the expected size: {err}"
+        );
+        assert!(
+            !err.contains("64"),
+            "the true (unread) length must never appear — the bounded read \
+             cannot know it: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn software_sealer_from_key_file_exact_size_still_loads() {
+        let dir = std::env::temp_dir().join("facelock_key_exact_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let key_path = dir.join("exact.key");
+        std::fs::write(&key_path, [0x7Au8; AES_KEY_SIZE]).unwrap();
+
+        SoftwareSealer::from_key_file(&key_path).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn software_sealer_from_key_file_missing() {
         let result = SoftwareSealer::from_key_file(std::path::Path::new("/nonexistent/key.file"));
@@ -1880,8 +1944,10 @@ mod tests {
 
         // `--generate-key` and `setup --encryption keyfile` both call this
         // primitive directly, not `create_key_file_exclusive`. It must refuse
-        // the symlink itself rather than relying on `O_NOFOLLOW` inside
-        // `create_truncate_file` to surface as a generic I/O error.
+        // the symlink itself, with the clearer message the pre-check gives —
+        // `create_truncate_file_nofollow`'s own `O_NOFOLLOW` is the backstop
+        // for a link planted after this check runs, exercised directly on
+        // the primitive in facelock-core's own tests (ELOOP).
         let error = SoftwareSealer::generate_key_file(&key_path)
             .unwrap_err()
             .to_string();

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -874,10 +874,19 @@ impl SoftwareSealer {
     /// world/group-readable — closing the create-then-`chmod` TOCTOU window
     /// (finding #11). The key material is flushed to disk with `sync_all` and
     /// zeroized from memory before returning.
+    ///
+    /// Refuses a symlink at `path` up front: `create_truncate_file` opens
+    /// with `O_NOFOLLOW`, so the symlink case would otherwise surface as a
+    /// generic I/O failure rather than the refusal every other key writer
+    /// gives.
     pub fn generate_key_file(path: &std::path::Path) -> Result<()> {
         use rand::Rng;
         use std::io::Write;
         use zeroize::Zeroize;
+
+        if facelock_core::fs_security::is_symlink(path) {
+            return Err(FacelockError::Encryption(symlink_key_refusal(path)));
+        }
 
         let mut key = [0u8; AES_KEY_SIZE];
         rand::rng().fill_bytes(&mut key);
@@ -1859,6 +1868,35 @@ mod tests {
             "a link at the key path is its own refusal, not an I/O failure: {error}"
         );
         assert_eq!(std::fs::read(&target).unwrap(), b"not a key");
+    }
+
+    #[test]
+    fn generate_key_file_refuses_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("elsewhere.key");
+        std::fs::write(&target, b"not a key").unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink(&target, &key_path).unwrap();
+
+        // `--generate-key` and `setup --encryption keyfile` both call this
+        // primitive directly, not `create_key_file_exclusive`. It must refuse
+        // the symlink itself rather than relying on `O_NOFOLLOW` inside
+        // `create_truncate_file` to surface as a generic I/O error.
+        let error = SoftwareSealer::generate_key_file(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("symlink"),
+            "a link at the key path is its own refusal, not an I/O failure: {error}"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"not a key");
+        assert!(
+            std::fs::symlink_metadata(&key_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the refusal must not remove the link it found"
+        );
     }
 
     /// A symlink that resolves is the shape that used to slip through every

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -881,6 +881,69 @@ impl SoftwareSealer {
         write_result
     }
 
+    /// Create the default encryption key, refusing to replace one that exists.
+    ///
+    /// This is the auto-generation primitive: the one called when nobody asked
+    /// for a key and the code is about to make one anyway. `generate_key_file`
+    /// truncates, which is correct when an operator explicitly asked to
+    /// regenerate and wrong here — two daemons starting at once would each
+    /// write a key over the other's, and the rows one of them then encrypts
+    /// become unreadable to the key that survives. Creation is `O_CREAT |
+    /// O_EXCL | O_NOFOLLOW`, and both the file and its parent directory are
+    /// flushed before the caller is told the key exists.
+    ///
+    /// Returns `Ok(true)` if this call created the key and `Ok(false)` if
+    /// another creator won the race, in which case the existing file is left
+    /// exactly as it is and the caller should read it.
+    pub fn create_key_file_exclusive(path: &std::path::Path) -> Result<bool> {
+        use rand::Rng;
+        use std::io::Write;
+        use zeroize::Zeroize;
+
+        let mut key = [0u8; AES_KEY_SIZE];
+        rand::rng().fill_bytes(&mut key);
+
+        let write_result = (|| -> Result<bool> {
+            let created =
+                facelock_core::fs_security::create_new_file(path, 0o600).map_err(|e| {
+                    FacelockError::Encryption(format!(
+                        "failed to create key file {}: {e}",
+                        path.display()
+                    ))
+                })?;
+            let Some(mut file) = created else {
+                // `O_EXCL` reports a symlink as an existing file, so "someone
+                // else won the race" and "a symlink is planted at the key
+                // path" arrive identically. They are not the same fact: the
+                // second means the key the caller is about to read lives
+                // wherever the link points. Name it rather than follow it.
+                if path
+                    .symlink_metadata()
+                    .is_ok_and(|m| m.file_type().is_symlink())
+                {
+                    return Err(FacelockError::Encryption(format!(
+                        "refusing to use a symlink as the encryption key: {}",
+                        path.display()
+                    )));
+                }
+                return Ok(false);
+            };
+            file.write_all(&key)
+                .and_then(|()| file.sync_all())
+                .and_then(|()| facelock_core::fs_security::sync_parent_dir(path))
+                .map_err(|e| {
+                    FacelockError::Encryption(format!(
+                        "failed to write key file {}: {e}",
+                        path.display()
+                    ))
+                })?;
+            Ok(true)
+        })();
+
+        key.zeroize();
+        write_result
+    }
+
     /// Encrypt an embedding using AES-256-GCM.
     ///
     /// Returns: `0x02 | 12-byte nonce | ciphertext | 16-byte tag`
@@ -1622,6 +1685,52 @@ mod tests {
         assert_eq!(idx, Some(vec![0, 7]));
         assert_eq!(pubb, &[0xDE, 0xAD]);
         assert_eq!(privb, &[0xBE, 0xEF, 0x00]);
+    }
+
+    // --- Exclusive default-key creation (#231, Track K task 8) ---
+
+    #[test]
+    fn create_key_file_exclusive_creates_a_root_only_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+
+        assert!(SoftwareSealer::create_key_file_exclusive(&key_path).unwrap());
+
+        let metadata = std::fs::metadata(&key_path).unwrap();
+        assert_eq!(metadata.len(), AES_KEY_SIZE as u64);
+        assert_eq!(
+            std::os::unix::fs::PermissionsExt::mode(&metadata.permissions()) & 0o777,
+            0o600
+        );
+        SoftwareSealer::from_key_file(&key_path).unwrap();
+    }
+
+    #[test]
+    fn create_key_file_exclusive_never_replaces_an_existing_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        SoftwareSealer::generate_key_file(&key_path).unwrap();
+        let original = std::fs::read(&key_path).unwrap();
+
+        // The loser of a creation race is told so, and the winner's bytes are
+        // still the bytes on disk: an O_TRUNC create here would hand one of the
+        // two processes a key nobody's rows were written under.
+        assert!(!SoftwareSealer::create_key_file_exclusive(&key_path).unwrap());
+        assert_eq!(std::fs::read(&key_path).unwrap(), original);
+    }
+
+    #[test]
+    fn create_key_file_exclusive_refuses_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("elsewhere.key");
+        std::fs::write(&target, b"not a key").unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink(&target, &key_path).unwrap();
+
+        // O_NOFOLLOW: a symlink planted at the key path must not become a
+        // write primitive pointed at whatever it names.
+        assert!(SoftwareSealer::create_key_file_exclusive(&key_path).is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"not a key");
     }
 
     #[test]

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -824,13 +824,36 @@ impl SoftwareSealer {
     /// Create a new SoftwareSealer from a key file.
     ///
     /// The key file must contain exactly 32 bytes (256 bits) of key material.
+    ///
+    /// The open is `O_NOFOLLOW`. `std::fs::read` follows a symlink, so a link
+    /// planted at `encryption.key_path` used to hand this reader whatever it
+    /// named — while the creation path refused the very same link. A refusal
+    /// only one of the two paths makes is not a refusal, so the symlink gets
+    /// its own message here too, distinct from an I/O failure.
+    ///
+    /// The bytes are read into a wiping buffer: a plain `read` leaves a copy
+    /// of the key in freed heap for the life of the process.
     pub fn from_key_file(path: &std::path::Path) -> Result<Self> {
-        let data = std::fs::read(path).map_err(|e| {
+        use std::io::Read;
+
+        let mut file = facelock_core::fs_security::open_no_follow(path).map_err(|e| {
+            if facelock_core::fs_security::is_symlink(path) {
+                FacelockError::Encryption(symlink_key_refusal(path))
+            } else {
+                FacelockError::Encryption(format!(
+                    "failed to read key file {}: {e}",
+                    path.display()
+                ))
+            }
+        })?;
+        let mut data = zeroize::Zeroizing::new(Vec::with_capacity(AES_KEY_SIZE));
+        file.read_to_end(&mut data).map_err(|e| {
             FacelockError::Encryption(format!("failed to read key file {}: {e}", path.display()))
         })?;
         if data.len() != AES_KEY_SIZE {
             return Err(FacelockError::Encryption(format!(
-                "key file must be exactly {AES_KEY_SIZE} bytes, got {}",
+                "key file {} must be exactly {AES_KEY_SIZE} bytes, got {}",
+                path.display(),
                 data.len()
             )));
         }
@@ -888,9 +911,17 @@ impl SoftwareSealer {
     /// truncates, which is correct when an operator explicitly asked to
     /// regenerate and wrong here — two daemons starting at once would each
     /// write a key over the other's, and the rows one of them then encrypts
-    /// become unreadable to the key that survives. Creation is `O_CREAT |
-    /// O_EXCL | O_NOFOLLOW`, and both the file and its parent directory are
-    /// flushed before the caller is told the key exists.
+    /// become unreadable to the key that survives.
+    ///
+    /// The key is therefore *staged*, not created in place. `O_EXCL` alone
+    /// makes only the name atomic: the 32 bytes are written after the create,
+    /// so a second starter that arrives in between sees a file that exists,
+    /// skips every gate keyed on its absence, and reads zero bytes — a
+    /// spurious "the key is corrupt" on a system whose key is merely three
+    /// microseconds old. Instead the bytes go to an `O_EXCL` temporary beside
+    /// the key at 0600, are flushed, and only then take the real name through
+    /// `renameat2(RENAME_NOREPLACE)`. The name never refers to an incomplete
+    /// file, and the loser of the rename reads the winner's complete one.
     ///
     /// Returns `Ok(true)` if this call created the key and `Ok(false)` if
     /// another creator won the race, in which case the existing file is left
@@ -900,44 +931,59 @@ impl SoftwareSealer {
         use std::io::Write;
         use zeroize::Zeroize;
 
+        // A symlink standing where the key belongs is its own fact, and not
+        // one `renameat2` can report: it answers `EEXIST` for a link exactly
+        // as it does for a real file, and "someone else won the race" is the
+        // wrong thing to tell an operator whose key path has been redirected.
+        if facelock_core::fs_security::is_symlink(path) {
+            return Err(FacelockError::Encryption(symlink_key_refusal(path)));
+        }
+
         let mut key = [0u8; AES_KEY_SIZE];
         rand::rng().fill_bytes(&mut key);
 
         let write_result = (|| -> Result<bool> {
-            let created =
-                facelock_core::fs_security::create_new_file(path, 0o600).map_err(|e| {
-                    FacelockError::Encryption(format!(
-                        "failed to create key file {}: {e}",
-                        path.display()
-                    ))
-                })?;
-            let Some(mut file) = created else {
-                // `O_EXCL` reports a symlink as an existing file, so "someone
-                // else won the race" and "a symlink is planted at the key
-                // path" arrive identically. They are not the same fact: the
-                // second means the key the caller is about to read lives
-                // wherever the link points. Name it rather than follow it.
-                if path
-                    .symlink_metadata()
-                    .is_ok_and(|m| m.file_type().is_symlink())
-                {
-                    return Err(FacelockError::Encryption(format!(
-                        "refusing to use a symlink as the encryption key: {}",
-                        path.display()
-                    )));
-                }
-                return Ok(false);
-            };
-            file.write_all(&key)
+            let (staged, mut file) = stage_key_file(path)?;
+            let staged_write = file
+                .write_all(&key)
                 .and_then(|()| file.sync_all())
-                .and_then(|()| facelock_core::fs_security::sync_parent_dir(path))
                 .map_err(|e| {
                     FacelockError::Encryption(format!(
-                        "failed to write key file {}: {e}",
-                        path.display()
+                        "failed to write the staged key file {}: {e}",
+                        staged.display()
                     ))
-                })?;
-            Ok(true)
+                });
+            drop(file);
+            if let Err(e) = staged_write {
+                let _ = std::fs::remove_file(&staged);
+                return Err(e);
+            }
+
+            match facelock_core::fs_security::rename_noreplace(&staged, path) {
+                Ok(()) => {
+                    // The name is only durable once its directory entry is.
+                    facelock_core::fs_security::sync_parent_dir(path).map_err(|e| {
+                        FacelockError::Encryption(format!(
+                            "failed to flush the directory holding {}: {e}",
+                            path.display()
+                        ))
+                    })?;
+                    Ok(true)
+                }
+                Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+                    // Someone else published first. Their file is complete by
+                    // construction, so the caller simply reads it.
+                    let _ = std::fs::remove_file(&staged);
+                    Ok(false)
+                }
+                Err(e) => {
+                    let _ = std::fs::remove_file(&staged);
+                    Err(FacelockError::Encryption(format!(
+                        "failed to move the staged key into place at {}: {e}",
+                        path.display()
+                    )))
+                }
+            }
         })();
 
         key.zeroize();
@@ -1139,16 +1185,92 @@ impl Drop for ZeroizingBytes {
 /// Detect whether a blob is TPM-sealed (version byte 0x01 no-PCR, or 0x03
 /// PCR-bound) rather than a raw 2048-byte embedding.
 pub fn is_sealed(data: &[u8]) -> bool {
-    !data.is_empty()
-        && (data[0] == SEALED_VERSION_BYTE || data[0] == SEALED_PCR_VERSION_BYTE)
-        && data.len() != RAW_EMBEDDING_SIZE
+    is_sealed_shape(data.first().copied(), data.len())
 }
 
 /// Detect whether a blob is software-encrypted (version byte 0x02).
 pub fn is_software_encrypted(data: &[u8]) -> bool {
-    !data.is_empty()
-        && data[0] == SOFTWARE_ENCRYPTED_VERSION_BYTE
-        && data.len() != RAW_EMBEDDING_SIZE
+    is_software_encrypted_shape(data.first().copied(), data.len())
+}
+
+/// [`is_sealed`] for a caller holding a blob's version byte and length but not
+/// the blob.
+///
+/// The store can project those two columns out of SQLite directly. A caller
+/// that only needs to *classify* rows — how many templates are encrypted, and
+/// under which method — has no business pulling every plaintext template into
+/// memory to find out, outside the wiping discipline the read paths keep. Same
+/// rule, one implementation, so the two spellings cannot drift.
+pub fn is_sealed_shape(first_byte: Option<u8>, len: usize) -> bool {
+    matches!(
+        first_byte,
+        Some(SEALED_VERSION_BYTE) | Some(SEALED_PCR_VERSION_BYTE)
+    ) && len != RAW_EMBEDDING_SIZE
+}
+
+/// [`is_software_encrypted`] for a caller holding a blob's version byte and
+/// length but not the blob. See [`is_sealed_shape`].
+pub fn is_software_encrypted_shape(first_byte: Option<u8>, len: usize) -> bool {
+    first_byte == Some(SOFTWARE_ENCRYPTED_VERSION_BYTE) && len != RAW_EMBEDDING_SIZE
+}
+
+/// The one refusal every path gives for a symlink standing where the
+/// encryption key file belongs.
+///
+/// One string, because the creator and the reader must describe the same fact
+/// the same way: a link at the key path is not "the key is missing" and not
+/// "the key is corrupt", it is a key path pointing somewhere else, and the
+/// remedy is different from either.
+pub fn symlink_key_refusal(path: &std::path::Path) -> String {
+    format!(
+        "refusing to use a symlink as the encryption key file: {} is a symbolic link. \
+         Replace it with the key file itself, or point encryption.key_path at the \
+         real file.",
+        path.display()
+    )
+}
+
+/// Open an `O_EXCL` staging file beside `path`, at 0600, for the bytes that
+/// will take `path`'s name once they are complete and flushed.
+///
+/// The name is unique per attempt and hidden (leading dot) so a crash between
+/// create and rename leaves an obvious orphan rather than something that looks
+/// like a key. A collision is retried rather than treated as failure: the pid
+/// and clock can repeat across containers sharing a mount.
+fn stage_key_file(path: &std::path::Path) -> Result<(std::path::PathBuf, std::fs::File)> {
+    const ATTEMPTS: u32 = 8;
+
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("encryption.key");
+
+    for attempt in 0..ATTEMPTS {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let staged = parent.join(format!(
+            ".{name}.new-{}-{unique:x}-{attempt}",
+            std::process::id()
+        ));
+        match facelock_core::fs_security::create_new_file(&staged, 0o600) {
+            Ok(Some(file)) => return Ok((staged, file)),
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(FacelockError::Encryption(format!(
+                    "failed to create the staged key file {}: {e}",
+                    staged.display()
+                )));
+            }
+        }
+    }
+
+    Err(FacelockError::Encryption(format!(
+        "failed to create a staging file for {} after {ATTEMPTS} attempts",
+        path.display()
+    )))
 }
 
 /// Detect whether a blob is encrypted (either TPM-sealed or software-encrypted).
@@ -1729,8 +1851,181 @@ mod tests {
 
         // O_NOFOLLOW: a symlink planted at the key path must not become a
         // write primitive pointed at whatever it names.
-        assert!(SoftwareSealer::create_key_file_exclusive(&key_path).is_err());
+        let error = SoftwareSealer::create_key_file_exclusive(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("symlink"),
+            "a link at the key path is its own refusal, not an I/O failure: {error}"
+        );
         assert_eq!(std::fs::read(&target).unwrap(), b"not a key");
+    }
+
+    /// A symlink that resolves is the shape that used to slip through every
+    /// gate: `Path::exists` follows it, so the caller never asked whether a
+    /// key was missing, and `std::fs::read` then loaded the link target as the
+    /// key. The reader has to refuse what the creator refuses.
+    #[test]
+    fn from_key_file_refuses_a_symlink_to_a_valid_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("attacker.key");
+        SoftwareSealer::generate_key_file(&target).unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink(&target, &key_path).unwrap();
+
+        assert!(
+            key_path.exists(),
+            "`exists` follows the link — that is the trap"
+        );
+        let error = SoftwareSealer::from_key_file(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("symlink"),
+            "the read path must name the link rather than load its target: {error}"
+        );
+    }
+
+    #[test]
+    fn from_key_file_refuses_a_symlink_to_a_device() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        std::os::unix::fs::symlink("/dev/null", &key_path).unwrap();
+
+        let error = SoftwareSealer::from_key_file(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("symlink"),
+            "a link to a device is the same refusal, not a length complaint: {error}"
+        );
+    }
+
+    /// `O_EXCL` alone publishes the *name* before the bytes. A reader that
+    /// arrives in that window used to see a key file of zero length and report
+    /// it as corrupt. Staging the bytes under another name and moving them in
+    /// with `RENAME_NOREPLACE` closes the window by construction: at every
+    /// instant the key path either does not exist or holds all 32 bytes.
+    #[test]
+    fn create_key_file_exclusive_never_publishes_a_partial_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(9));
+
+        let watcher = {
+            let key_path = key_path.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+                let mut seen_complete = false;
+                while std::time::Instant::now() < deadline {
+                    match std::fs::metadata(&key_path) {
+                        Ok(m) => {
+                            assert_eq!(
+                                m.len(),
+                                AES_KEY_SIZE as u64,
+                                "the key path was observed holding a partial key"
+                            );
+                            seen_complete = true;
+                        }
+                        Err(_) => continue,
+                    }
+                }
+                seen_complete
+            })
+        };
+
+        let creators: Vec<_> = (0..8)
+            .map(|_| {
+                let key_path = key_path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    let created = SoftwareSealer::create_key_file_exclusive(&key_path);
+                    // A loser is told "read what the winner wrote", so it must
+                    // be readable the instant it is told that. Under a
+                    // create-then-write scheme this is where it reads zero
+                    // bytes and calls a three-microsecond-old key corrupt.
+                    if matches!(created, Ok(false)) {
+                        SoftwareSealer::from_key_file(&key_path)
+                            .expect("the loser must be able to read the winner's key at once");
+                    }
+                    created
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = creators.into_iter().map(|h| h.join().unwrap()).collect();
+        assert!(watcher.join().unwrap(), "the watcher never saw the key");
+        assert_eq!(
+            results.iter().filter(|r| matches!(r, Ok(true))).count(),
+            1,
+            "exactly one creator publishes the key"
+        );
+        assert!(results.iter().all(|r| r.is_ok()), "a loser is not an error");
+        // Every loser must be able to read what the winner wrote.
+        SoftwareSealer::from_key_file(&key_path).unwrap();
+    }
+
+    #[test]
+    fn create_key_file_exclusive_leaves_no_staging_file_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        SoftwareSealer::create_key_file_exclusive(&key_path).unwrap();
+        // The loser's staging file has to go too, or a busy boot litters the
+        // directory that holds the key with near-miss key files.
+        assert!(!SoftwareSealer::create_key_file_exclusive(&key_path).unwrap());
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("encryption.key")]);
+    }
+
+    #[test]
+    fn create_key_file_exclusive_names_a_missing_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("not-installed").join("encryption.key");
+
+        let error = SoftwareSealer::create_key_file_exclusive(&key_path)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("not-installed"),
+            "the error must name the directory installation was meant to create: {error}"
+        );
+        assert!(!dir.path().join("not-installed").exists());
+    }
+
+    #[test]
+    fn blob_shape_predicates_agree_with_their_byte_slice_forms() {
+        let cases: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![0x02; 96],
+            vec![0x02; RAW_EMBEDDING_SIZE],
+            vec![0x01; 200],
+            vec![0x03; 200],
+            vec![0x00; RAW_EMBEDDING_SIZE],
+            vec![0x01; RAW_EMBEDDING_SIZE],
+        ];
+        for blob in cases {
+            assert_eq!(
+                is_software_encrypted(&blob),
+                is_software_encrypted_shape(blob.first().copied(), blob.len()),
+                "software: {:?}/{}",
+                blob.first(),
+                blob.len()
+            );
+            assert_eq!(
+                is_sealed(&blob),
+                is_sealed_shape(blob.first().copied(), blob.len()),
+                "sealed: {:?}/{}",
+                blob.first(),
+                blob.len()
+            );
+        }
     }
 
     #[test]

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3126,7 +3126,9 @@ a decrypt failure — never a lockout.
 **Encryption key creation (#231).** The keyfile is created at mode `0600` when it is
 absent **and the database holds no encrypted template**, and never otherwise. Encrypted is
 decided by each blob's version byte, not the `sealed` column. A store that cannot be
-queried counts as encrypted rows existing. Creation is an `O_EXCL | O_NOFOLLOW` write to a
+queried counts as encrypted rows existing, and so does one that cannot be locked: the row
+check and the key write run inside one exclusive store transaction, which serializes them
+against the single transaction an enrollment commits its template in. Creation is an `O_EXCL | O_NOFOLLOW` write to a
 temporary beside the key, flushed, then `renameat2(RENAME_NOREPLACE)` onto the key path
 with the parent directory flushed: concurrent creators resolve to exactly one key, an
 existing key is never truncated, and the key path never holds a partial file. A **symlink

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3128,14 +3128,19 @@ absent **and the database holds no encrypted template**, and never otherwise. En
 decided by each blob's version byte, not the `sealed` column. A store that cannot be
 queried counts as encrypted rows existing, and so does one that cannot be locked: the row
 check and the key write run inside one exclusive store transaction, which serializes them
-against the single transaction an enrollment commits its template in. Automatic creation
-happens only for `method = "keyfile"`; `--generate-key` is the explicit way to mint a key
-before switching the method to it. Creation is an `O_EXCL | O_NOFOLLOW` write to a
-temporary beside the key, flushed, then `renameat2(RENAME_NOREPLACE)` onto the key path
-with the parent directory flushed: concurrent creators resolve to exactly one key, an
-existing key is never truncated, and the key path never holds a partial file. A **symlink
-at the key path is refused** by both the creating and the reading path; the reader opens
-`O_NOFOLLOW`. The same gate governs every writer of that key — the daemon, the one-shot
+against the single transaction an enrollment commits its template in. That ordering is the
+whole guarantee — it does not invalidate a key a running daemon has already cached in
+memory, so `--generate-key` against a live daemon is a known limit, not closed by this gate
+(follow-up). Automatic creation happens only for `method = "keyfile"`; `--generate-key` is
+the explicit way to mint a key before switching the method to it. Creation is an `O_EXCL |
+O_NOFOLLOW` write to a temporary beside the key, flushed, then
+`renameat2(RENAME_NOREPLACE)` onto the key path with the parent directory flushed:
+concurrent creators resolve to exactly one key, an existing key is never truncated, and the
+key path never holds a partial file — true of the *create* path
+(`create_key_file_exclusive`). The *replace* path (`generate_key_file`, what
+`--generate-key` calls) truncates the key file in place instead. A **symlink at the key
+path is refused** by both the creating and the reading path; the reader opens `O_NOFOLLOW`.
+The same gate governs every writer of that key — the daemon, the one-shot
 commands, `facelock setup`'s automatic encryption policy, and `facelock encrypt` with and
 without `--generate-key`; `--generate-key` replaces a live key and is refused over
 encrypted rows, naming `facelock clear` as the deliberate destructive step.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3119,10 +3119,28 @@ setup Flag Composition"). See "facelock pam
 Semantics" above for the resolution rules themselves.
 
 **Encryption defaults (Plan 04).** `encryption.method` defaults to `keyfile`: face
-templates are encrypted at rest by default. The keyfile is auto-generated at mode `0600`
-on first use if absent. `method = "none"` (plaintext) is **refused at enrollment** unless
-`security.allow_plaintext = true`. Auth always degrades to password on a decrypt failure —
-never a lockout.
+templates are encrypted at rest by default. `method = "none"` (plaintext) is **refused at
+enrollment** unless `security.allow_plaintext = true`. Auth always degrades to password on
+a decrypt failure — never a lockout.
+
+**Encryption key creation (#231).** The keyfile is created at mode `0600` when it is
+absent **and the database holds no encrypted template**, and never otherwise. Encrypted is
+decided by each blob's version byte, not the `sealed` column. A store that cannot be
+queried counts as encrypted rows existing. Creation is an `O_EXCL | O_NOFOLLOW` write to a
+temporary beside the key, flushed, then `renameat2(RENAME_NOREPLACE)` onto the key path
+with the parent directory flushed: concurrent creators resolve to exactly one key, an
+existing key is never truncated, and the key path never holds a partial file. A **symlink
+at the key path is refused** by both the creating and the reading path; the reader opens
+`O_NOFOLLOW`. The same gate governs every writer of that key — the daemon, the one-shot
+commands, `facelock setup`'s automatic encryption policy, and `facelock encrypt` with and
+without `--generate-key`; `--generate-key` replaces a live key and is refused over
+encrypted rows, naming `facelock clear` as the deliberate destructive step.
+
+A refusal fails enrollment closed and leaves authentication alone: the auth path reads raw
+rows, serves the templates it can decrypt, reports the missing key rather than store
+corruption for those it cannot, and still falls through to the password prompt. Restoring
+the key artifact lifts the refusal at the next enrollment attempt without restarting the
+daemon.
 
 **Enrollment atomicity (#308).** An enrollment writes to the store exactly once, at the
 end: after every accepted embedding has passed the minimum-capture and angle-diversity

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3139,8 +3139,8 @@ encrypted rows, naming `facelock clear` as the deliberate destructive step.
 A refusal fails enrollment closed and leaves authentication alone: the auth path reads raw
 rows, serves the templates it can decrypt, reports the missing key rather than store
 corruption for those it cannot, and still falls through to the password prompt. Restoring
-the key artifact lifts the refusal at the next enrollment attempt without restarting the
-daemon.
+the key artifact lifts the refusal at the next authentication or enrollment attempt without
+restarting the daemon.
 
 **Enrollment atomicity (#308).** An enrollment writes to the store exactly once, at the
 end: after every accepted embedding has passed the minimum-capture and angle-diversity

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3128,7 +3128,9 @@ absent **and the database holds no encrypted template**, and never otherwise. En
 decided by each blob's version byte, not the `sealed` column. A store that cannot be
 queried counts as encrypted rows existing, and so does one that cannot be locked: the row
 check and the key write run inside one exclusive store transaction, which serializes them
-against the single transaction an enrollment commits its template in. Creation is an `O_EXCL | O_NOFOLLOW` write to a
+against the single transaction an enrollment commits its template in. Automatic creation
+happens only for `method = "keyfile"`; `--generate-key` is the explicit way to mint a key
+before switching the method to it. Creation is an `O_EXCL | O_NOFOLLOW` write to a
 temporary beside the key, flushed, then `renameat2(RENAME_NOREPLACE)` onto the key path
 with the parent directory flushed: concurrent creators resolve to exactly one key, an
 existing key is never truncated, and the key path never holds a partial file. A **symlink

--- a/docs/security.md
+++ b/docs/security.md
@@ -575,6 +575,14 @@ of that key goes through the same gate: the daemon, `facelock auth` and the othe
 commands, `facelock setup`'s automatic policy, and both branches of `facelock encrypt`
 (`--generate-key` included, which replaces a live key rather than creating one).
 
+**The check and the write are one exclusive transaction on the store**, so the question and
+the act cannot be separated by an enrollment. Enrollment persists a template in a single
+store transaction of its own, so it either commits before the check looks — where the
+refusal sees it — or waits until the key is in place. Without that section a plain read
+would not even observe the commit: under WAL it reads the snapshot it opened on. A store
+that cannot be locked is a refusal on the same reasoning as one that cannot be queried, and
+says which of the two happened.
+
 Creation is atomic and never destructive. The 32 bytes are written to an `O_EXCL |
 O_NOFOLLOW` temporary beside the key at mode `0600` in a single `open(2)` create-at-mode
 (no create-then-`chmod` window — finding #11), flushed, then moved onto the key path with

--- a/docs/security.md
+++ b/docs/security.md
@@ -583,16 +583,22 @@ would not even observe the commit: under WAL it reads the snapshot it opened on.
 that cannot be locked is a refusal on the same reasoning as one that cannot be queried, and
 says which of the two happened. Automatic creation is further restricted to `method =
 "keyfile"`, the only method that reads the file; `--generate-key` still mints one under
-`none`, which is how an operator bootstraps a key before switching the method over.
+`none`, which is how an operator bootstraps a key before switching the method over. The
+guarantee is about ordering a row's commit against a key write through the store; it does
+not invalidate a key a running daemon has already cached in memory — replacing the key file
+while the daemon keeps running (`facelock encrypt --generate-key` against a live system) is
+a known limit, not covered here (follow-up).
 
 Creation is atomic and never destructive. The 32 bytes are written to an `O_EXCL |
 O_NOFOLLOW` temporary beside the key at mode `0600` in a single `open(2)` create-at-mode
 (no create-then-`chmod` window — finding #11), flushed, then moved onto the key path with
 `renameat2(RENAME_NOREPLACE)` and the parent directory flushed. Two daemons starting at
 once therefore resolve to one key rather than each overwriting the other's, and no reader
-ever observes the key path holding a partial file. A **symlink at the key path is its own
-refusal** on every path, creating and reading alike: the reader opens `O_NOFOLLOW`, so a
-planted link is never followed to whatever it names.
+ever observes the key path holding a partial file — true of the *create* path
+(`create_key_file_exclusive`). The *replace* path (`generate_key_file`, what
+`--generate-key` calls) truncates the key file in place instead. A **symlink at the key
+path is its own refusal** on every path, creating and reading alike: the reader opens
+`O_NOFOLLOW`, so a planted link is never followed to whatever it names.
 
 **What a refusal does.** Enrollment fails closed — facelock will not store a biometric
 template as plaintext because encryption is unavailable. Authentication is unaffected and

--- a/docs/security.md
+++ b/docs/security.md
@@ -581,7 +581,9 @@ store transaction of its own, so it either commits before the check looks — wh
 refusal sees it — or waits until the key is in place. Without that section a plain read
 would not even observe the commit: under WAL it reads the snapshot it opened on. A store
 that cannot be locked is a refusal on the same reasoning as one that cannot be queried, and
-says which of the two happened.
+says which of the two happened. Automatic creation is further restricted to `method =
+"keyfile"`, the only method that reads the file; `--generate-key` still mints one under
+`none`, which is how an operator bootstraps a key before switching the method over.
 
 Creation is atomic and never destructive. The 32 bytes are written to an `O_EXCL |
 O_NOFOLLOW` temporary beside the key at mode `0600` in a single `open(2)` create-at-mode

--- a/docs/security.md
+++ b/docs/security.md
@@ -592,8 +592,8 @@ open. The auth path reports the missing key, never "the database is corrupt".
 
 **Recovery** is to restore the key artifact for the method that wrote the rows —
 `encryption.key_path` for `keyfile`, `encryption.sealed_key_path` for `tpm` — from backup.
-No restart is needed: the daemon re-reads the key on the next enrollment attempt, so a
-restore lifts the refusal live. The destructive alternative, for an operator who has no
+The daemon re-reads the key on the next enrollment attempt, so a restore lifts the
+refusal live without restarting anything. The destructive alternative, for an operator who has no
 backup, is `facelock clear` followed by re-enrollment.
 
 **Known limits.**

--- a/docs/security.md
+++ b/docs/security.md
@@ -561,10 +561,54 @@ Face embeddings are **biometric data**. Unlike passwords, they cannot be changed
 
 Face templates are **encrypted at rest by default** (`encryption.method = "keyfile"`, finding
 #8). Embeddings are AES-256-GCM encrypted with a 256-bit key held in a key file
-(`keyfile`) or a TPM-sealed key (`tpm`). The keyfile is auto-generated at mode `0600` on
-first use if absent, in a single `open(2)` create-at-mode (no create-then-`chmod` window —
-finding #11). The TPM method seals the AES key at rest; it is unsealed at daemon startup and
-held in memory.
+(`keyfile`) or a TPM-sealed key (`tpm`). The TPM method seals the AES key at rest; it is
+unsealed at daemon startup and held in memory.
+
+**The keyfile is created for a database that holds no encrypted template, and only then**
+(#231). "Encrypted" is decided by each stored blob's own version byte, not by the `sealed`
+column, which cannot tell a TPM-sealed row from a keyfile-sealed one. A missing key over
+encrypted rows is refused: those rows are unreadable either way, but writing a replacement
+makes a later restore of the real key useless, and that is the one loss facelock can still
+prevent. A store that *cannot be asked* counts as encrypted rows existing — "no rows" and
+"no answer" are different facts, and only the first authorizes writing a key. Every writer
+of that key goes through the same gate: the daemon, `facelock auth` and the other one-shot
+commands, `facelock setup`'s automatic policy, and both branches of `facelock encrypt`
+(`--generate-key` included, which replaces a live key rather than creating one).
+
+Creation is atomic and never destructive. The 32 bytes are written to an `O_EXCL |
+O_NOFOLLOW` temporary beside the key at mode `0600` in a single `open(2)` create-at-mode
+(no create-then-`chmod` window — finding #11), flushed, then moved onto the key path with
+`renameat2(RENAME_NOREPLACE)` and the parent directory flushed. Two daemons starting at
+once therefore resolve to one key rather than each overwriting the other's, and no reader
+ever observes the key path holding a partial file. A **symlink at the key path is its own
+refusal** on every path, creating and reading alike: the reader opens `O_NOFOLLOW`, so a
+planted link is never followed to whatever it names.
+
+**What a refusal does.** Enrollment fails closed — facelock will not store a biometric
+template as plaintext because encryption is unavailable. Authentication is unaffected and
+keeps falling through to the password prompt, and a user whose own templates are plaintext
+still authenticates normally even while another user's encrypted row holds the refusal
+open. The auth path reports the missing key, never "the database is corrupt".
+
+**Recovery** is to restore the key artifact for the method that wrote the rows —
+`encryption.key_path` for `keyfile`, `encryption.sealed_key_path` for `tpm` — from backup.
+No restart is needed: the daemon re-reads the key on the next enrollment attempt, so a
+restore lifts the refusal live. The destructive alternative, for an operator who has no
+backup, is `facelock clear` followed by re-enrollment.
+
+**Known limits.**
+
+- The gate asks the database named by `storage.db_path`. A configuration that points at the
+  wrong path finds an empty database, correctly concludes nothing would be orphaned, and
+  mints a key. `facelock setup`'s interactive `--encryption` choices carry a stricter guard
+  (`handle_orphan_models_before_keygen`, which refuses on *any* stored model and offers to
+  clear); the automatic policy does not, because on a genuine fresh install there is
+  nothing to distinguish it from.
+- Under `ProtectSystem=strict` the shipped daemon unit cannot write `/etc/facelock` at all,
+  so it cannot create `/etc/facelock/encryption.key`: on that unit the key is created by
+  installation or by a privileged `facelock setup` / `facelock encrypt` run, and the daemon
+  only ever reads it. A daemon that finds no key refuses enrollment as above rather than
+  falling back to plaintext.
 
 Plaintext storage (`method = "none"`) is an explicit opt-out: enrollment **refuses** to write
 plaintext biometric templates unless `security.allow_plaintext = true`, and warns prominently

--- a/docs/security.md
+++ b/docs/security.md
@@ -592,9 +592,9 @@ open. The auth path reports the missing key, never "the database is corrupt".
 
 **Recovery** is to restore the key artifact for the method that wrote the rows —
 `encryption.key_path` for `keyfile`, `encryption.sealed_key_path` for `tpm` — from backup.
-The daemon re-reads the key on the next enrollment attempt, so a restore lifts the
-refusal live without restarting anything. The destructive alternative, for an operator who has no
-backup, is `facelock clear` followed by re-enrollment.
+The daemon re-reads the key on the next authentication or enrollment attempt, so a restore
+lifts the refusal live without restarting anything. The destructive alternative, for an
+operator who has no backup, is `facelock clear` followed by re-enrollment.
 
 **Known limits.**
 


### PR DESCRIPTION
## Summary

- route every default-key writer (daemon start, oneshot, `setup` without an encryption flag, both `facelock encrypt` branches) through one shared gate (`key_policy`) that refuses to mint a key while software-encrypted rows exist, naming the method, the artifact path, and the remedy
- classify rows by blob shape, not the `sealed` column, so a TPM-sealed row under a keyfile config names the right artifact
- refuse `--generate-key` over encrypted rows and name `facelock clear` as the deliberate destructive step
- stage key creation (`O_EXCL` temp, 0600, fsync, `renameat2(RENAME_NOREPLACE)`, parent fsync) so a concurrent reader never observes an empty key
- refuse a symlink at the key path on every creating and reading path
- re-check the gate on the next authentication or enrollment attempt, so a restored key lifts the refusal live
- name the key in the refusal, never "corrupt", and keep plaintext-only users authenticating on both transports
- update docs and changelog

## Why

The daemon minted a fresh key whenever the file was absent, with no check for what it was about to orphan. On a system whose key artifact went missing, that silently discarded every encrypted enrollment and made a later restore of the real key useless, because the rows had since been re-encrypted under the replacement. The upgrade harness for #231 needed the refusal provable end to end, not just at the one call site it was first noticed in.

## Reviewer notes

- **no lockout**: the refusal maps to `PAM_IGNORE` on both transports, falling through to the password prompt
- **enrollment fails closed**: a template is never stored plaintext because the sealer is unavailable
- **known limits**: an empty or just-created store still mints a key (nothing to orphan yet); under `ProtectSystem=strict` `/etc/facelock` is read-only for the daemon, so the daemon-side create path is exercised only outside the unit

## Validation

- `cargo test -p facelock-core -p facelock-tpm -p facelock-daemon -p facelock-cli`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `just pot`

Refs #231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Encryption keys are no longer automatically replaced when encrypted templates may depend on them.
  - Key creation is restricted to safe cases, protected against concurrent changes, and rejects symlinked paths.
  - Database inspection failures are handled cautiously to help prevent data loss.

- **Authentication & Enrollment**
  - Missing or unreadable keys block enrollment with actionable recovery guidance.
  - Authentication and password fallback remain available where possible.
  - Restoring a key is detected without restarting the service.

- **Documentation**
  - Updated encryption and security guidance describes recovery procedures and safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->