### PR TITLE
test(upgrade): prove v0.1.4 state survives upgrade and rollback

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,6 +19,7 @@ paths:
 | 3d | Arch package from `dist/PKGBUILD` | `just test-arch-pkg` |
 | 3e | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
 | 3f | Fedora COPR path, rebuilt from source on system ORT | `just test-copr-lanes` |
+| 3g | Released v0.1.4 upgrade and rollback, deb and rpm | `just test-upgrade-v014` |
 | 3a | Arch container E2E, camera-free | `just test-arch-camera-free` |
 | 3b | Arch container E2E (daemon), needs a camera | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot), needs a camera | `just test-arch-oneshot` |

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -42,10 +42,40 @@ need `podman`; none in the routing table needs a camera.
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
 | File layout, installed paths | `just test-arch-layout` |
 | D-Bus policy, daemon authorization, pre-flight exit codes, schema migrations | `just test-arch-camera-free` |
+| Store migrations, encryption keys, TPM sealing, maintainer scripts touching state | `just test-upgrade-v014` |
 
 `just test-deb` delegates to both exact supported-suite package gates. The
 remaining quick syntax-level check is `just test-rpm` (Fedora container), which
 is weaker than `test-rpm-pkg` because it does not install and boot.
+
+## Upgrading from what users already run
+
+`just test-upgrade-v014` is the only lane that installs a real published
+artifact. It downloads the v0.1.4 .deb and the v0.1.4 fc44 .rpm, pinned by asset
+id and SHA256 in `dist/release-matrix.json`, builds predecessor state with the
+**released** binary (plaintext rows, keyfile-encrypted rows, mixed rows, and two
+swtpm-sealed shapes), upgrades through apt or dnf to the locally built
+candidate, and then downgrades back.
+
+Run it after any change to store migrations, the encryption or TPM key paths, or
+a maintainer script that touches `/var/lib/facelock` or `/etc/facelock`. Those
+are the changes a fresh-install lane cannot see: every other packaging recipe
+starts from nothing, so a migration that destroys an upgraded database passes
+all of them.
+
+Two cheap halves run without podman and are worth knowing:
+
+- `just test-upgrade-v014-contract` catches a declared state shape or fault case
+  with no implementation, a proof function nothing calls, and a lane
+  Containerfile that grew its own digest. Seconds, no network.
+- `just test-upgrade-v014-pins` asks GitHub whether the pinned assets are still
+  the assets it serves. Needs `gh`, catches a re-uploaded predecessor.
+
+The full lane needs the reviewed ONNX models (`just link-models`) and has no
+partial-run opt-out: the rollback proof turns on the candidate daemon having
+opened and migrated the database first, and a daemon without models cannot
+start. It takes the better part of an hour, most of it building the candidate
+.deb from source.
 
 ## Which Fedora
 

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -74,8 +74,12 @@ Two cheap halves run without podman and are worth knowing:
 The full lane needs the reviewed ONNX models (`just link-models`) and has no
 partial-run opt-out: the rollback proof turns on the candidate daemon having
 opened and migrated the database first, and a daemon without models cannot
-start. It takes the better part of an hour, most of it building the candidate
-.deb from source.
+start. A cached run is about twenty minutes; a cold one is considerably more,
+most of it building the candidate .deb from source.
+
+That runtime is why the lane is local-only by design: `packaging.yml` does not
+run it, and a nightly-only job is the follow-up. Run it yourself before pushing
+a change that reaches stored state.
 
 ## Which Fedora
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,6 +622,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is refused by every creating and reading path, `--generate-key`
   included.
 
+- **The Debian package declares its shared-library dependencies** (#231): the
+  package is built from `debian/control`, which uses `${shlibs:Depends}` so
+  dpkg-shlibdeps derives the list from the binary itself. v0.1.4 wrote its
+  control file with a hand-written `libpam-runtime, dbus` and never mentioned
+  libxkbcommon0, which the binary links, so that release could not start on a
+  minimal Debian 13 and `apt install -f` had nothing to repair.
+
 - **Enrollment persists atomically** (#308): the daemon and `facelock enroll`
   now hold accepted embeddings in memory and write the model in one store
   transaction after the minimum-capture and angle-diversity gates pass, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,6 +622,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is refused by every creating and reading path, `--generate-key`
   included.
 
+
+- **An upgrade from v0.1.4 keeps face authentication switched on** (#231):
+  v0.1.4's `pam-auth-update` profile shipped `Default: yes`, so installing that
+  release enabled Facelock in `common-auth` without asking. The packaged profile
+  is `Default: no` now, which governs fresh installs only: upgrading does not
+  retire a profile an existing system already has enabled, and the released-
+  predecessor lane fails if an upgrade edits the global stack in either
+  direction. Disable it deliberately with `pam-auth-update` if you do not want
+  it.
+
 - **The Debian package declares its shared-library dependencies** (#231): the
   package is built from `debian/control`, which uses `${shlibs:Depends}` so
   dpkg-shlibdeps derives the list from the binary itself. v0.1.4 wrote its

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -88,6 +88,39 @@
       "production_copr_requires_stable_tagged_config": true
     }
   },
+  "predecessors": {
+    "reviewed_on": "2026-09-02",
+    "resolved_with": "gh api repos/tyvsmith/facelock/releases/tags/v0.1.4",
+    "repository": "tyvsmith/facelock",
+    "v0.1.4": {
+      "tag": "v0.1.4",
+      "release_id": 332190914,
+      "published_at": "2026-05-31T18:54:26Z",
+      "upstream_version": "0.1.4",
+      "lanes": {
+        "deb-trixie": {
+          "suite": "trixie",
+          "asset_id": 434624113,
+          "asset_node_id": "RA_kwDORmgtH84Z59Zx",
+          "name": "facelock_0.1.4-1_amd64.deb",
+          "url": "https://github.com/tyvsmith/facelock/releases/download/v0.1.4/facelock_0.1.4-1_amd64.deb",
+          "sha256": "58bda7490c94b224a2ed3903c6204150cf317786d397569968a2511226ed17d8",
+          "size": 10975164,
+          "package_version": "0.1.4-1"
+        },
+        "rpm-fedora": {
+          "release": "44",
+          "asset_id": 434633109,
+          "asset_node_id": "RA_kwDORmgtH84Z5_mV",
+          "name": "facelock-0.1.4-1.fc44.x86_64.rpm",
+          "url": "https://github.com/tyvsmith/facelock/releases/download/v0.1.4/facelock-0.1.4-1.fc44.x86_64.rpm",
+          "sha256": "e8d3858adbf001676cc1d25171702c396e6ed22dd2a8c4f0d064a8c2febb3a0b",
+          "size": 12568681,
+          "package_version": "0.1.4-1.fc44"
+        }
+      }
+    }
+  },
   "platforms": [
     {
       "id": "debian-13",

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3384,6 +3384,53 @@ Only failed authentication attempts are recorded in `rate_limit`, and only those
 
 **Enrollment precondition (#309).** Every non-NULL `device_id` matches its own enrolling camera at the `security.device_match_granularity` in force when it was enrolled (a `model` row does not match after switching to `unit`; re-enroll). Under `model`, a camera missing either the vendor or the product id is stored NULL (legacy-governed). Under `unit`, a camera with no non-empty serial, or with no full vendor:product identity, is refused: a `unit` enrollment never stores a NULL row, which would bind to nothing. With `bind_templates_to_device = true` and `bind_legacy_templates = false`, a camera with no usable identity is refused at any granularity, since the NULL row it would store could never authenticate. The check (`Config::ensure_enrollment_binding_allowed`, which delegates the coupling half to `SecurityConfig::ensure_enrollment_binding_allowed`) runs once per enrollment, after the camera is open and before the first model write, in both the daemon `Enroll` path and the direct path; a refusal is an ordinary enroll error naming the key and the remedy, and leaves no row behind. It never re-judges an existing template, so it can refuse a new enrollment but never lock an authentication out.
 
+### Upgrade and downgrade contract
+
+An upgrade preserves everything the previous release wrote and changes only the
+schema version and the columns a migration adds. Specifically, across a native
+package upgrade:
+
+- **Embeddings keep their bytes.** A row encrypted by an earlier release
+  decrypts to the same plaintext under the same key. The upgrade never
+  re-encrypts, re-seals, or rewrites a row.
+- **Key artifacts are never replaced.** `encryption.key` and
+  `encryption.key.sealed` keep their bytes, mode and owner. No maintainer script
+  creates, reseals or reads a key, and none changes PCR selection.
+- **A missing key over encrypted rows is fatal, never replaced.** When the key
+  artifact is gone and the database still holds encrypted rows, the daemon and
+  the one-shot path refuse to write a replacement and say why. Enrollment is
+  refused; authentication keeps falling through to password. Writing a fresh key
+  there would make a later restore of the real key useless.
+- **The default key is created only for a plaintext-only legacy database with no
+  key artifact.** Creation is `O_CREAT | O_EXCL | O_NOFOLLOW` with the file and
+  its parent directory flushed, so concurrent starts resolve to exactly one key
+  and a symlink at the key path is refused rather than followed.
+- **Config, models, enrollment markers and audit data are untouched.**
+  Administrator edits to `/etc/facelock/config.toml` survive.
+- **Modes converge to ADR 010** without content changing, and the retired
+  `facelock` group is removed if an older install left one.
+- **PAM is never activated by an upgrade.** An existing service file keeps its
+  bytes; the packaged Debian profile is registered but not selected, and no
+  authselect profile is reinstated on Fedora.
+
+**Migration failure never resets the database.** A migration that cannot finish
+(full filesystem, interrupted process, corrupt page) leaves the database exactly
+as it was and reports the failure. Recreating a database it could not migrate
+would destroy every enrollment on the machine and look like a clean first run.
+
+**Downgrade is supported back to v0.1.4, with one limit.** Migrations are
+additive and forward-only: there is no down-migration from V6, and a package
+downgrade leaves `schema_version` at 6. What is guaranteed is that the older
+release still opens that database, reads its rows, and decrypts what it
+encrypted, because V6 only adds a nullable `face_models.device_id` column that
+older queries never name. What is **not** guaranteed is that rows written by the
+newer release carry data the older one understands: a `device_id` recorded after
+the upgrade is invisible to v0.1.4, so a template enrolled on the alpha and then
+rolled back is uncoupled from its camera rather than refused.
+
+`just test-upgrade-v014` is the gate for all of the above. It runs both halves
+against the real published v0.1.4 artifacts; see `docs/releasing.md`.
+
 ## IPC Protocol
 
 D-Bus system bus (`org.facelock.Daemon`). Only used in daemon mode.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -3405,8 +3405,14 @@ package upgrade:
   key artifact.** Creation is `O_CREAT | O_EXCL | O_NOFOLLOW` with the file and
   its parent directory flushed, so concurrent starts resolve to exactly one key
   and a symlink at the key path is refused rather than followed.
-- **Config, models, enrollment markers and audit data are untouched.**
-  Administrator edits to `/etc/facelock/config.toml` survive.
+- **Config, models and audit data are untouched.** Administrator edits to
+  `/etc/facelock/config.toml` survive.
+- **Enrollment markers keep their owner and mode, and their content is
+  reconciled.** The marker is the one piece of state an upgrade is supposed to
+  rewrite: a marker that disagrees with the database is rewritten at daemon
+  startup, so `facelock is-enrolled` cannot answer "not enrolled" for a user
+  whose templates are present (#137). Byte identity is deliberately not the
+  contract here, because it would preserve a marker that lies.
 - **Modes converge to ADR 010** without content changing, and the retired
   `facelock` group is removed if an older install left one.
 - **PAM is never activated by an upgrade.** An existing service file keeps its

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -754,8 +754,11 @@ version exactly. The native comparator inside the container decides either way,
 so a lane can never quietly become a downgrade test. Whatever version it lands
 on is spelled by `scripts/release-versions.sh`, the same file the release
 workflow uses, so a pre-release candidate reaches the lane as
-`0.2.0~alpha.3-1~deb13u1` and as `Version: 0.2.0` / `Release: 0.1.alpha.3`
-rather than in a Cargo spelling neither packager would ever ship.
+`0.2.0~alpha.3-1~deb13u1` rather than in a Cargo spelling neither packager
+would ever ship. The RPM release counter it passes is local to the lane, not
+the series counter from "Prerelease identity conversions" above: the lane's
+only ordering requirement is against the published predecessor, never against
+a previously published prerelease.
 
 **Upgraders from v0.1.4 already have face authentication enabled.** That
 release's `pam-auth-update` profile shipped `Default: yes`, so installing it

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -759,6 +759,12 @@ as it found it, and the lane fails if it is edited in either direction. Removing
 an enabled profile would take face authentication away from someone using it, so
 the lane treats that as the more dangerous direction, not a clean result.
 
+**Where it runs.** Locally, by design: a cached run is about twenty minutes and
+a cold one considerably more, so `packaging.yml` does not carry it and a
+nightly-only job is the follow-up. `just check` runs the container-free contract
+(`just test-upgrade-v014-contract`), so a broken lane definition still fails
+every pull request.
+
 **Rollback.** The candidate daemon starts and migrates the database before the
 downgrade, so the predecessor is handed the file production would hand it. V6
 has no down-migration and the schema stays at 6 after the package rolls back.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -702,3 +702,48 @@ Since facelock is a PAM module, broken releases can lock users out. Every releas
 6. Not change PAM auth semantics without explicit changelog entry
 5. Preserve `/etc/pam.d/sudo` backup on install (`/var/lib/facelock/pam-backups/sudo.<timestamp>`)
 6. Default to `PAM_IGNORE` on internal errors (fall through to password)
+
+### Upgrading from the last release
+
+`just test-upgrade-v014` proves that state written by v0.1.4 survives an upgrade
+to the candidate and a rollback back to v0.1.4. Two lanes, Debian trixie and
+Fedora 44, each install the real published artifact rather than a synthesized
+older build of the candidate.
+
+**What the lanes pin.** `dist/release-matrix.json` carries a `predecessors` block
+holding the GitHub release id, the asset id, the SHA256 and the byte size of
+each predecessor artifact. The lane Containerfiles take those as build args and
+carry no digest of their own, so one review changes the pin everywhere.
+`just test-upgrade-v014-pins` asks the release API whether those assets are still
+the assets it serves, which is how a re-uploaded or substituted predecessor gets
+caught before a lane silently proves something about a different file.
+
+**What the lanes build.** Predecessor state comes from the released v0.1.4
+binary, never from the candidate: plaintext rows, keyfile-encrypted rows, mixed
+rows, and two swtpm-sealed shapes, one PCR-bound and one not. Each shape also
+carries a modified config, the reviewed models, an enrollment marker, an audit
+log and a hand-wired PAM service, because v0.1.4 has no `facelock pam`
+subcommand and that is the shape a real upgrade finds.
+
+**What each lane proves after the upgrade.** The V5 database reaches V6 with
+legacy rows at `device_id = NULL`. A known embedding still decrypts to the exact
+plaintext it was enrolled as, which a file hash cannot show: a preserved key and
+a preserved ciphertext nobody can open any more hash identically. No key
+artifact is replaced and none appears that was not there before. Modes converge
+to ADR 010 without content changing. The administrator's PAM service is
+byte-identical, a correct password still authenticates, and a wrong one still
+fails.
+
+**Version ordering on a development tree.** Until `just release` bumps the
+workspace, the candidate .deb built from the tree is `0.1.4-1~deb13u1`, which
+sorts *below* the published `0.1.4-1`. The lanes build the same payload as an
+upgrade-test version instead and print a note saying so. Bumping the workspace
+past 0.1.4 removes the note, and the lane then tests the shipped version exactly.
+The native comparator inside the container decides either way, so a lane can
+never quietly become a downgrade test.
+
+**Rollback.** The candidate daemon starts and migrates the database before the
+downgrade, so the predecessor is handed the file production would hand it. V6
+has no down-migration and the schema stays at 6 after the package rolls back.
+See `docs/contracts.md` for what that does and does not guarantee.
+

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -718,6 +718,14 @@ carry no digest of their own, so one review changes the pin everywhere.
 the assets it serves, which is how a re-uploaded or substituted predecessor gets
 caught before a lane silently proves something about a different file.
 
+**What the lane images carry.** Each image installs the runtime libraries the
+released binary needs before the predecessor goes on. v0.1.4 wrote its Debian
+control file by hand and never declared libxkbcommon0, which its own binary
+links, so that release cannot start on a minimal Debian 13 at all. The candidate
+is built from `debian/control` and derives the list with `${shlibs:Depends}`.
+Nothing is masked by supplying it: candidate dependency resolution belongs to
+`test/deb-dependency-closure.sh` on a pristine suite base.
+
 **What the lanes build.** Predecessor state comes from the released v0.1.4
 binary, never from the candidate: plaintext rows, keyfile-encrypted rows, mixed
 rows, and two swtpm-sealed shapes, one PCR-bound and one not. Each shape also

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -738,9 +738,11 @@ legacy rows at `device_id = NULL`. A known embedding still decrypts to the exact
 plaintext it was enrolled as, which a file hash cannot show: a preserved key and
 a preserved ciphertext nobody can open any more hash identically. No key
 artifact is replaced and none appears that was not there before. Modes converge
-to ADR 010 without content changing. The administrator's PAM service is
-byte-identical, a correct password still authenticates, and a wrong one still
-fails.
+to ADR 010 without content changing. The enrollment marker keeps its owner and
+mode and its content is reconciled against the database rather than preserved
+byte for byte — the one piece of state the upgrade is supposed to rewrite
+(#137). The administrator's PAM service is byte-identical, a correct password
+still authenticates, and a wrong one still fails.
 
 **Version ordering on a development tree.** Until `just release` bumps the
 workspace, the candidate .deb built from the tree is `0.1.4-1~deb13u1`, which

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -737,10 +737,11 @@ fails.
 **Version ordering on a development tree.** Until `just release` bumps the
 workspace, the candidate .deb built from the tree is `0.1.4-1~deb13u1`, which
 sorts *below* the published `0.1.4-1`. The lanes build the same payload as an
-upgrade-test version instead and print a note saying so. Bumping the workspace
-past 0.1.4 removes the note, and the lane then tests the shipped version exactly.
-The native comparator inside the container decides either way, so a lane can
-never quietly become a downgrade test.
+upgrade-test version instead, and every run prints the version it chose and why.
+Once the workspace version sorts above 0.1.4 the re-versioning stops and
+`FACELOCK_UPGRADE_TEST_VERSION` becomes a no-op: the lane installs the shipped
+version exactly. The native comparator inside the container decides either way,
+so a lane can never quietly become a downgrade test.
 
 **Rollback.** The candidate daemon starts and migrates the database before the
 downgrade, so the predecessor is handed the file production would hand it. V6

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -751,6 +751,14 @@ Once the workspace version sorts above 0.1.4 the re-versioning stops and
 version exactly. The native comparator inside the container decides either way,
 so a lane can never quietly become a downgrade test.
 
+**Upgraders from v0.1.4 already have face authentication enabled.** That
+release's `pam-auth-update` profile shipped `Default: yes`, so installing it
+switched Facelock on in `common-auth`. The packaged profile is `Default: no`
+now, which applies to fresh installs; an upgrade leaves the global stack exactly
+as it found it, and the lane fails if it is edited in either direction. Removing
+an enabled profile would take face authentication away from someone using it, so
+the lane treats that as the more dangerous direction, not a clean result.
+
 **Rollback.** The candidate daemon starts and migrates the database before the
 downgrade, so the predecessor is handed the file production would hand it. V6
 has no down-migration and the schema stays at 6 after the package rolls back.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -751,7 +751,11 @@ upgrade-test version instead, and every run prints the version it chose and why.
 Once the workspace version sorts above 0.1.4 the re-versioning stops and
 `FACELOCK_UPGRADE_TEST_VERSION` becomes a no-op: the lane installs the shipped
 version exactly. The native comparator inside the container decides either way,
-so a lane can never quietly become a downgrade test.
+so a lane can never quietly become a downgrade test. Whatever version it lands
+on is spelled by `scripts/release-versions.sh`, the same file the release
+workflow uses, so a pre-release candidate reaches the lane as
+`0.2.0~alpha.3-1~deb13u1` and as `Version: 0.2.0` / `Release: 0.1.alpha.3`
+rather than in a Cargo spelling neither packager would ever ship.
 
 **Upgraders from v0.1.4 already have face authentication enabled.** That
 release's `pam-auth-update` profile shipped `Default: yes`, so installing it

--- a/justfile
+++ b/justfile
@@ -1218,7 +1218,7 @@ test-upgrade-v014-pins:
     bash test/upgrade-v014-predecessor.sh rpm-fedora --verify-live
 
 # Debian half: install the real v0.1.4 .deb, upgrade to the candidate, roll back
-test-upgrade-v014-deb: test-upgrade-v014-contract (_require-models "1")
+test-upgrade-v014-deb: test-upgrade-v014-contract _require-models
     #!/usr/bin/env bash
     set -euo pipefail
     artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-v014-deb.XXXXXX")"
@@ -1228,7 +1228,7 @@ test-upgrade-v014-deb: test-upgrade-v014-contract (_require-models "1")
     test/run-upgrade-v014-systemd.sh deb facelock-upgrade-v014-deb "$candidate"
 
 # Fedora half: same proof against the released fc44 RPM
-test-upgrade-v014-rpm: test-upgrade-v014-contract (_require-models "1") _require-release-binaries
+test-upgrade-v014-rpm: test-upgrade-v014-contract _require-models _require-release-binaries
     #!/usr/bin/env bash
     set -euo pipefail
     test/build-upgrade-v014-image.sh rpm facelock-upgrade-v014-rpm

--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ check-package-names-live:
     python3 test/check-package-names-live.py
 
 # Run all checks (test + lint + format + audit + PAM standalone surface + agent docs)
-check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy
+check: test lint fmt-check audit check-pam-standalone check-agent-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-v014-contract
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,
@@ -1207,6 +1207,35 @@ test-rpm-smoke release="45": (_fedora-lane-image release) _require-release-binar
 
 # Every declared Fedora release target at its declared lifecycle depth
 test-rpm-lanes: (test-rpm-pkg "43") (test-rpm-pkg "44") (test-rpm-smoke "45")
+
+# Released-predecessor upgrade lanes (#231) — container-free half, runs anywhere
+test-upgrade-v014-contract:
+    bash test/upgrade-v014-contract.sh
+
+# Confirm the pinned v0.1.4 assets are still the assets GitHub serves (needs gh)
+test-upgrade-v014-pins:
+    bash test/upgrade-v014-predecessor.sh deb-trixie --verify-live
+    bash test/upgrade-v014-predecessor.sh rpm-fedora --verify-live
+
+# Debian half: install the real v0.1.4 .deb, upgrade to the candidate, roll back
+test-upgrade-v014-deb: test-upgrade-v014-contract (_require-models "1")
+    #!/usr/bin/env bash
+    set -euo pipefail
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-v014-deb.XXXXXX")"
+    trap 'rm -rf -- "$artifact_dir"' EXIT
+    candidate="$artifact_dir/facelock-candidate.deb"
+    test/build-upgrade-v014-image.sh deb facelock-upgrade-v014-deb "$candidate"
+    test/run-upgrade-v014-systemd.sh deb facelock-upgrade-v014-deb "$candidate"
+
+# Fedora half: same proof against the released fc44 RPM
+test-upgrade-v014-rpm: test-upgrade-v014-contract (_require-models "1") _require-release-binaries
+    #!/usr/bin/env bash
+    set -euo pipefail
+    test/build-upgrade-v014-image.sh rpm facelock-upgrade-v014-rpm
+    test/run-upgrade-v014-systemd.sh rpm facelock-upgrade-v014-rpm
+
+# Both released-predecessor upgrade lanes — the stable entrypoint for #231
+test-upgrade-v014: test-upgrade-v014-deb test-upgrade-v014-rpm
 
 # Packit config schema gate — runs the real `packit` in a digest-pinned Fedora container
 test-packit-config:

--- a/test/Containerfile.upgrade-v014-deb
+++ b/test/Containerfile.upgrade-v014-deb
@@ -1,0 +1,39 @@
+# Debian upgrade lane (#231, Track K): the released v0.1.4 .deb baked in, the
+# locally built candidate mounted at run time.
+#
+# BASE_IMAGE is the booted Debian runtime image test/build-deb-package-image.sh
+# produces — it already carries systemd, pamtester, python3 and the swtpm stack
+# this lane drives. Nothing about the candidate is fetched here.
+#
+# The predecessor pin arrives as build args rather than as a literal, because
+# dist/release-matrix.json is the single place that pin is reviewed;
+# test/check-release-matrix.py fails if a digest reappears in this file.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG FACELOCK_PREDECESSOR_URL
+ARG FACELOCK_PREDECESSOR_SHA256
+ARG FACELOCK_PREDECESSOR_SIZE
+ARG FACELOCK_PREDECESSOR_VERSION
+ARG FACELOCK_CANDIDATE_VERSION
+
+# Size as well as digest: a truncated or proxy-rewritten fetch that still
+# happens to be some valid .deb is caught by the digest, and a fetch that
+# silently returned an error page is caught by the size before sha256sum has to
+# explain itself.
+RUN mkdir -p /artifacts && \
+    curl --proto '=https' --tlsv1.2 --output /artifacts/facelock-predecessor.deb \
+        -fsSL "$FACELOCK_PREDECESSOR_URL" && \
+    printf '%s  %s\n' "$FACELOCK_PREDECESSOR_SHA256" /artifacts/facelock-predecessor.deb \
+        | sha256sum -c - && \
+    test "$(stat -c %s /artifacts/facelock-predecessor.deb)" = "$FACELOCK_PREDECESSOR_SIZE" && \
+    test "$(dpkg-deb --field /artifacts/facelock-predecessor.deb Version)" \
+        = "$FACELOCK_PREDECESSOR_VERSION" && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_SHA256" > /artifacts/predecessor.sha256 && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_VERSION" > /artifacts/predecessor.version && \
+    printf '%s\n' "$FACELOCK_CANDIDATE_VERSION" > /artifacts/candidate.version
+
+COPY test/upgrade-v014-lane.sh /upgrade-v014-lane.sh
+RUN chmod +x /upgrade-v014-lane.sh
+
+CMD ["/lib/systemd/systemd"]

--- a/test/Containerfile.upgrade-v014-deb
+++ b/test/Containerfile.upgrade-v014-deb
@@ -11,6 +11,20 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+# Harness tooling, not a candidate dependency. The released v0.1.4 .deb
+# hand-wrote `Depends: libpam-runtime, dbus, libtss2-esys-3.0.2-0t64` and missed
+# libxkbcommon0, which its own binary links against, so v0.1.4's `facelock`
+# refuses to start on a clean Debian 13. The candidate uses ${shlibs:Depends}
+# and declares it. This lane builds predecessor state with the released binary,
+# so it has to supply what that release forgot to ask for.
+#
+# Nothing is masked by this: dependency resolution for the candidate is
+# test/deb-dependency-closure.sh's job on a pristine suite base, not this
+# lane's. The two Fedora lane images install libxkbcommon for the same reason.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libxkbcommon0 && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG FACELOCK_PREDECESSOR_URL
 ARG FACELOCK_PREDECESSOR_SHA256
 ARG FACELOCK_PREDECESSOR_SIZE

--- a/test/Containerfile.upgrade-v014-rpm
+++ b/test/Containerfile.upgrade-v014-rpm
@@ -21,7 +21,14 @@ ARG FACELOCK_CANDIDATE_VERSION
 #
 # `--with bundled_ort` matches the base image's own build, so the candidate
 # carries the same reviewed runtime the host binaries were linked against.
-RUN dnf -y remove facelock && \
+# The base image leaves /etc/pam.d/facelock-test referencing pam_facelock.so,
+# and the candidate's %preun refuses removal while any PAM service does
+# ("... is an administrator-managed PAM reference"). That guard is deliberate
+# and pkg-validate.sh tests it; getting past it means dropping the reference
+# first, which is what pkg-validate.sh:647 does before its own removal tests.
+# This lane writes its own PAM service and never uses that one.
+RUN rm -f /etc/pam.d/facelock-test && \
+    dnf -y remove facelock && \
     rm -f /facelock-test-package.rpm /facelock-test-upgrade.rpm && \
     cd /build && \
     /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "$FACELOCK_CANDIDATE_VERSION" direct && \

--- a/test/Containerfile.upgrade-v014-rpm
+++ b/test/Containerfile.upgrade-v014-rpm
@@ -1,0 +1,61 @@
+# Fedora upgrade lane (#231, Track K): the released v0.1.4 fc44 RPM baked in
+# beside a candidate built here from the same host binaries and the production
+# spec.
+#
+# BASE_IMAGE is the image test/Containerfile.rpm-e2e produces. Deriving from it
+# rather than repeating it keeps one copy of the reviewed ONNX Runtime fetch and
+# one copy of the pamtester and shadow-file accommodations; this file only adds
+# what an upgrade lane needs on top.
+#
+# The predecessor pin arrives as build args rather than as a literal, because
+# dist/release-matrix.json is the single place that pin is reviewed;
+# test/check-release-matrix.py fails if a digest reappears in this file.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG FACELOCK_CANDIDATE_VERSION
+
+# The base image installs its own 0.0.0 fixture package. Remove it: this lane
+# starts from the released predecessor, and a leftover install would make the
+# first transaction an upgrade from something that was never published.
+#
+# `--with bundled_ort` matches the base image's own build, so the candidate
+# carries the same reviewed runtime the host binaries were linked against.
+RUN dnf -y remove facelock && \
+    rm -f /facelock-test-package.rpm /facelock-test-upgrade.rpm && \
+    cd /build && \
+    /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "$FACELOCK_CANDIDATE_VERSION" direct && \
+    mkdir -p /artifacts && \
+    cp "$(find /build -maxdepth 1 -name 'facelock-*.rpm' -print -quit)" \
+        /artifacts/facelock-candidate.rpm && \
+    test "$(rpm -qp --qf '%{VERSION}' /artifacts/facelock-candidate.rpm)" \
+        = "$FACELOCK_CANDIDATE_VERSION" && \
+    printf '%s\n' "$(rpm -qp --qf '%{VERSION}-%{RELEASE}' /artifacts/facelock-candidate.rpm)" \
+        > /artifacts/candidate.version && \
+    rm -rf ~/rpmbuild /build/*.rpm
+
+# swtpm for the sealed shapes, rpmdevtools for the native version comparator the
+# lane uses to prove the candidate really does sort above the predecessor.
+RUN dnf -y install --setopt=install_weak_deps=False \
+        swtpm swtpm-tools tpm2-tools rpmdevtools sqlite && \
+    dnf clean all
+
+ARG FACELOCK_PREDECESSOR_URL
+ARG FACELOCK_PREDECESSOR_SHA256
+ARG FACELOCK_PREDECESSOR_SIZE
+ARG FACELOCK_PREDECESSOR_VERSION
+
+RUN curl --proto '=https' --tlsv1.2 --output /artifacts/facelock-predecessor.rpm \
+        -fsSL "$FACELOCK_PREDECESSOR_URL" && \
+    printf '%s  %s\n' "$FACELOCK_PREDECESSOR_SHA256" /artifacts/facelock-predecessor.rpm \
+        | sha256sum -c - && \
+    test "$(stat -c %s /artifacts/facelock-predecessor.rpm)" = "$FACELOCK_PREDECESSOR_SIZE" && \
+    test "$(rpm -qp --qf '%{VERSION}-%{RELEASE}' /artifacts/facelock-predecessor.rpm)" \
+        = "$FACELOCK_PREDECESSOR_VERSION" && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_SHA256" > /artifacts/predecessor.sha256 && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_VERSION" > /artifacts/predecessor.version
+
+COPY test/upgrade-v014-lane.sh /upgrade-v014-lane.sh
+RUN chmod +x /upgrade-v014-lane.sh
+
+CMD ["/usr/lib/systemd/systemd"]

--- a/test/Containerfile.upgrade-v014-rpm
+++ b/test/Containerfile.upgrade-v014-rpm
@@ -13,7 +13,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG FACELOCK_CANDIDATE_VERSION
+ARG FACELOCK_CANDIDATE_RPM_VERSION
+ARG FACELOCK_CANDIDATE_RPM_RELEASE
 
 # The base image installs its own 0.0.0 fixture package. Remove it: this lane
 # starts from the released predecessor, and a leftover install would make the
@@ -31,12 +32,15 @@ RUN rm -f /etc/pam.d/facelock-test && \
     dnf -y remove facelock && \
     rm -f /facelock-test-package.rpm /facelock-test-upgrade.rpm && \
     cd /build && \
-    /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh "$FACELOCK_CANDIDATE_VERSION" direct && \
+    /run-networkless.sh bash /build/test/build-rpm-prebuilt.sh \
+        "$FACELOCK_CANDIDATE_RPM_VERSION" direct "$FACELOCK_CANDIDATE_RPM_RELEASE" && \
     mkdir -p /artifacts && \
     cp "$(find /build -maxdepth 1 -name 'facelock-*.rpm' -print -quit)" \
         /artifacts/facelock-candidate.rpm && \
     test "$(rpm -qp --qf '%{VERSION}' /artifacts/facelock-candidate.rpm)" \
-        = "$FACELOCK_CANDIDATE_VERSION" && \
+        = "$FACELOCK_CANDIDATE_RPM_VERSION" && \
+    candidate_release="$(rpm -qp --qf '%{RELEASE}' /artifacts/facelock-candidate.rpm)" && \
+    test "${candidate_release%.fc*}" = "$FACELOCK_CANDIDATE_RPM_RELEASE" && \
     printf '%s\n' "$(rpm -qp --qf '%{VERSION}-%{RELEASE}' /artifacts/facelock-candidate.rpm)" \
         > /artifacts/candidate.version && \
     rm -rf ~/rpmbuild /build/*.rpm

--- a/test/build-rpm-prebuilt.sh
+++ b/test/build-rpm-prebuilt.sh
@@ -5,13 +5,22 @@ set -euo pipefail
 
 VERSION="${1:-0.0.0}"
 CHANNEL="${2:-direct}"
+# The Release field, without the dist tag. Callers that only have a stable
+# version leave it alone; a caller packaging a pre-release has to pass the
+# release pipeline's answer (`0.<counter>.alpha.N`), because RPM keeps the
+# pre-release in Release and rpmbuild will not accept a hyphen in Version.
+RPM_RELEASE="${3:-1}"
 case "$CHANNEL" in
     direct|copr) ;;
     *) echo "unknown RPM test channel: $CHANNEL" >&2; exit 2 ;;
 esac
+case "$VERSION" in
+    *-*) echo "RPM Version cannot carry a pre-release suffix: $VERSION" >&2; exit 2 ;;
+esac
 
 echo "=== Building RPM from pre-built binaries ==="
 echo "Version: ${VERSION}"
+echo "Release: ${RPM_RELEASE}%{?dist}"
 
 # Set up rpmbuild tree
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
@@ -20,7 +29,7 @@ mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 cp dist/facelock.spec ~/rpmbuild/SPECS/facelock.spec
 cp dist/rpm/facelock-authselect-retirement-guard ~/rpmbuild/SOURCES/facelock-authselect-retirement-guard
 sed -i "s|^Version:.*|Version:        ${VERSION}|" ~/rpmbuild/SPECS/facelock.spec
-sed -i "s|^Release:.*|Release:        1%{?dist}|" ~/rpmbuild/SPECS/facelock.spec
+sed -i "s|^Release:.*|Release:        ${RPM_RELEASE}%{?dist}|" ~/rpmbuild/SPECS/facelock.spec
 sed -i 's|^cargo build.*|true|g' ~/rpmbuild/SPECS/facelock.spec
 # Create source tarball INCLUDING target/release/ (pre-built binaries)
 tar --exclude=.git \

--- a/test/build-upgrade-v014-image.sh
+++ b/test/build-upgrade-v014-image.sh
@@ -19,14 +19,30 @@ family="${1:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-out
 image="${2:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
 
 candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)"
+workspace_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
+predecessor_version="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" \
+    "$([ "$family" = deb ] && echo deb-trixie || echo rpm-fedora)" upstream_version)"
+
+# Always say which version the candidate is built as and why. A lane that
+# silently re-versions is a lane whose result nobody can interpret later.
 if [ "$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" restamped)" = true ]; then
-    workspace_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
     cat >&2 <<EOF
-NOTE: the workspace is at $workspace_version, which does not sort above the
-      pinned v0.1.4 predecessor. The candidate payload is built and versioned as
-      $candidate_version so this stays an upgrade lane rather than a downgrade.
-      Bumping the workspace past 0.1.4 makes this note go away and the lane test
-      the shipped version exactly.
+NOTE: candidate version $candidate_version (re-versioned).
+      The workspace is at $workspace_version, which does not sort above the
+      pinned v$predecessor_version predecessor, so the candidate payload is built
+      and versioned as $candidate_version to keep this an upgrade rather than a
+      downgrade. Override with FACELOCK_UPGRADE_TEST_VERSION. Once the workspace
+      version sorts above $predecessor_version this re-versioning stops happening
+      and the override does nothing: the lane then installs the shipped version
+      exactly. The native package comparator inside the container decides either
+      way, so a wrong value here fails the lane rather than passing quietly.
+EOF
+else
+    cat >&2 <<EOF
+NOTE: candidate version $candidate_version (as built).
+      The workspace version already sorts above the pinned v$predecessor_version
+      predecessor, so the lane installs the candidate exactly as it ships and
+      FACELOCK_UPGRADE_TEST_VERSION is ignored.
 EOF
 fi
 

--- a/test/build-upgrade-v014-image.sh
+++ b/test/build-upgrade-v014-image.sh
@@ -107,6 +107,40 @@ case "$family" in
             echo "usage: build-upgrade-v014-image.sh rpm <image>" >&2
             exit 2
         }
+        # The Fedora lane packages host-built binaries rather than compiling in
+        # the container, so binaries that are not this checkout make the lane
+        # test something else. That is not hypothetical: a green Debian half and
+        # a red Fedora half once turned out to be one lane running the rebased
+        # daemon and the other running binaries from eight days earlier.
+        #
+        # Only the opt-out path needs policing. When the recipe builds them
+        # itself, cargo's dependency tracking is authoritative and an mtime
+        # comparison here only invents failures -- libpam_facelock.so does not
+        # depend on the daemon's sources, so cargo rightly leaves it alone when
+        # only those change.
+        if [ "${FACELOCK_RELEASE_BINARIES_PREBUILT:-0}" = 1 ]; then
+            newest_source="$(git -C "$repo_root" ls-files -z -- \
+                '*.rs' 'Cargo.toml' 'Cargo.lock' |
+                xargs -0 stat -c %Y | sort -n | tail -1)"
+            for binary in facelock facelock-polkit-agent libpam_facelock.so; do
+                built="$(stat -c %Y "$repo_root/target/release/$binary" 2>/dev/null || echo 0)"
+                [ "$built" -ge "$newest_source" ] || {
+                    cat >&2 <<EOF
+ERROR: target/release/$binary is older than the workspace source.
+
+FACELOCK_RELEASE_BINARIES_PREBUILT=1 says these binaries are ready to package,
+and the Fedora lane packages them as-is, so the lane would test code that is not
+this checkout. Rebuild them:
+
+  just build-release
+
+or unset FACELOCK_RELEASE_BINARIES_PREBUILT and let the recipe do it.
+EOF
+                    exit 1
+                }
+            done
+        fi
+
         release="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" rpm-fedora release)"
         base_fedora="$(bash "$repo_root/test/fedora-lane-image.sh" "$release")"
         ort_version="$(

--- a/test/build-upgrade-v014-image.sh
+++ b/test/build-upgrade-v014-image.sh
@@ -15,6 +15,15 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The candidate version is a Cargo version, and neither packager spells one the
+# way Cargo does. `0.2.0-alpha.3` is `0.2.0~alpha.3-1~deb13u1` to dpkg and
+# `Version: 0.2.0` / `Release: 0.1.alpha.3` to rpm; the hyphenated form is not
+# a version either would ever ship, and the Debian one sorts *above* the real
+# release, so the "is this an upgrade" guard below would not notice it. Derive
+# both from the same file the release pipeline derives them from rather than
+# splicing strings here.
+# shellcheck source=/dev/null
+source "$repo_root/scripts/release-versions.sh"
 family="${1:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
 image="${2:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
 
@@ -73,16 +82,25 @@ case "$family" in
         # archive is the assembler's own, byte for byte.
         built_version="$(podman run --rm -v "$raw_candidate:/work:Z" "$base_image" \
             dpkg-deb --field /work/facelock.deb Version)"
+
+        # The revision comes from the package the assembler just built rather
+        # than from a constant here, so the two cannot drift apart; the suite
+        # is trixie because that is what this lane asked for above. Everything
+        # after the last hyphen is the Debian revision, and the suite suffix
+        # rides on it -- splitting at the *first* hyphen loses that the moment
+        # the upstream version carries one.
+        built_revision="${built_version##*-}"
+        lane_version="$(release_debian_version "$candidate_version" \
+            "${built_revision%%\~*}" trixie)"
         podman run --rm -v "$raw_candidate:/work:Z" \
-            -e "CANDIDATE_VERSION=$candidate_version" "$base_image" \
+            -e "LANE_VERSION=$lane_version" "$base_image" \
             bash -euo pipefail -c '
                 target="$(dpkg-deb --field /work/facelock.deb Version)"
-                lane="$CANDIDATE_VERSION-${target#*-}"
-                if [ "$target" = "$lane" ]; then
+                if [ "$target" = "$LANE_VERSION" ]; then
                     cp /work/facelock.deb /work/candidate.deb
                 else
                     dpkg-deb --raw-extract /work/facelock.deb /work/root
-                    sed -i -E "s/^Version:.*/Version: $lane/" /work/root/DEBIAN/control
+                    sed -i -E "s/^Version:.*/Version: $LANE_VERSION/" /work/root/DEBIAN/control
                     dpkg-deb --build --root-owner-group /work/root /work/candidate.deb >/dev/null
                 fi
                 dpkg --compare-versions "$(dpkg-deb --field /work/candidate.deb Version)" \
@@ -90,7 +108,11 @@ case "$family" in
                     [ "$(dpkg-deb --field /work/candidate.deb Version)" = "$target" ]
                 dpkg-deb --field /work/candidate.deb Version > /work/candidate.version
             '
-        lane_version="$(cat "$raw_candidate/candidate.version")"
+        stamped_version="$(cat "$raw_candidate/candidate.version")"
+        [ "$stamped_version" = "$lane_version" ] || {
+            echo "re-stamped candidate reports $stamped_version, expected $lane_version" >&2
+            exit 1
+        }
         echo "candidate .deb: $built_version -> $lane_version"
 
         mapfile -t pin_args < <(predecessor_build_args deb-trixie)
@@ -156,10 +178,17 @@ EOF
         podman build --build-arg "BASE_IMAGE=$base_fedora" \
             --build-arg "ORT_VERSION=$ort_version" \
             -t "$base_image" -f "$repo_root/test/Containerfile.rpm-e2e" "$repo_root"
+        # RPM has nowhere to put a pre-release inside Version: rpmbuild rejects
+        # a hyphen there outright, and the release pipeline puts the base
+        # version in Version and the pre-release in Release instead. Counter 1
+        # matches what `just release` writes for the first build of a version.
+        rpm_version="$(release_rpm_version "$candidate_version")"
+        rpm_release="$(release_rpm_release "$candidate_version" 1)"
         mapfile -t pin_args < <(predecessor_build_args rpm-fedora)
         podman build \
             --build-arg "BASE_IMAGE=$base_image" \
-            --build-arg "FACELOCK_CANDIDATE_VERSION=$candidate_version" \
+            --build-arg "FACELOCK_CANDIDATE_RPM_VERSION=$rpm_version" \
+            --build-arg "FACELOCK_CANDIDATE_RPM_RELEASE=$rpm_release" \
             "${pin_args[@]}" \
             -t "$image" -f "$repo_root/test/Containerfile.upgrade-v014-rpm" "$repo_root"
         ;;

--- a/test/build-upgrade-v014-image.sh
+++ b/test/build-upgrade-v014-image.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Build one released-predecessor upgrade lane image (#231, Track K).
+#
+# Usage:
+#   build-upgrade-v014-image.sh deb <image> <candidate-deb-output>
+#   build-upgrade-v014-image.sh rpm <image>
+#
+# The Debian half reuses test/build-deb-package-image.sh, so the candidate is
+# the same artifact the Debian lifecycle gate proves; the Fedora half derives
+# from test/Containerfile.rpm-e2e for the same reason. Neither lane invents its
+# own packaging path.
+#
+# Image tags are taken as arguments rather than fixed, because two lanes sharing
+# a constant tag silently overwrite each other when they run at the same time.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+family="${1:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
+image="${2:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
+
+candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)"
+if [ "$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" restamped)" = true ]; then
+    workspace_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
+    cat >&2 <<EOF
+NOTE: the workspace is at $workspace_version, which does not sort above the
+      pinned v0.1.4 predecessor. The candidate payload is built and versioned as
+      $candidate_version so this stays an upgrade lane rather than a downgrade.
+      Bumping the workspace past 0.1.4 makes this note go away and the lane test
+      the shipped version exactly.
+EOF
+fi
+
+# Emits an alternating --build-arg / KEY=VALUE stream for `mapfile`, so the
+# pin reaches podman as argv entries rather than through a word-split string.
+predecessor_build_args() {
+    local lane="$1" line
+    while IFS= read -r line; do
+        printf '%s\n--build-arg\n' "$line" | tac
+    done < <(bash "$repo_root/test/upgrade-v014-predecessor.sh" "$lane" --build-args)
+}
+
+case "$family" in
+    deb)
+        candidate_output="${3:?usage: build-upgrade-v014-image.sh deb <image> <candidate-deb-output>}"
+        [ "$#" -eq 3 ] || {
+            echo "usage: build-upgrade-v014-image.sh deb <image> <candidate-deb-output>" >&2
+            exit 2
+        }
+        base_image="$image-base"
+        raw_candidate="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-v014-deb.XXXXXX")"
+        trap 'rm -rf -- "$raw_candidate"' EXIT
+        "$repo_root/test/build-deb-package-image.sh" trixie "$base_image" \
+            "$raw_candidate/facelock.deb"
+
+        # Re-version the built candidate when the workspace has not been bumped
+        # past the predecessor yet. Only DEBIAN/control changes; the payload
+        # archive is the assembler's own, byte for byte.
+        built_version="$(podman run --rm -v "$raw_candidate:/work:Z" "$base_image" \
+            dpkg-deb --field /work/facelock.deb Version)"
+        podman run --rm -v "$raw_candidate:/work:Z" \
+            -e "CANDIDATE_VERSION=$candidate_version" "$base_image" \
+            bash -euo pipefail -c '
+                target="$(dpkg-deb --field /work/facelock.deb Version)"
+                lane="$CANDIDATE_VERSION-${target#*-}"
+                if [ "$target" = "$lane" ]; then
+                    cp /work/facelock.deb /work/candidate.deb
+                else
+                    dpkg-deb --raw-extract /work/facelock.deb /work/root
+                    sed -i -E "s/^Version:.*/Version: $lane/" /work/root/DEBIAN/control
+                    dpkg-deb --build --root-owner-group /work/root /work/candidate.deb >/dev/null
+                fi
+                dpkg --compare-versions "$(dpkg-deb --field /work/candidate.deb Version)" \
+                    gt "$target" ||
+                    [ "$(dpkg-deb --field /work/candidate.deb Version)" = "$target" ]
+                dpkg-deb --field /work/candidate.deb Version > /work/candidate.version
+            '
+        lane_version="$(cat "$raw_candidate/candidate.version")"
+        echo "candidate .deb: $built_version -> $lane_version"
+
+        mapfile -t pin_args < <(predecessor_build_args deb-trixie)
+        podman build \
+            --build-arg "BASE_IMAGE=$base_image" \
+            --build-arg "FACELOCK_CANDIDATE_VERSION=$lane_version" \
+            "${pin_args[@]}" \
+            -t "$image" -f "$repo_root/test/Containerfile.upgrade-v014-deb" "$repo_root"
+
+        install -m 0444 -- "$raw_candidate/candidate.deb" "$candidate_output"
+        ;;
+    rpm)
+        [ "$#" -eq 2 ] || {
+            echo "usage: build-upgrade-v014-image.sh rpm <image>" >&2
+            exit 2
+        }
+        release="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" rpm-fedora release)"
+        base_fedora="$(bash "$repo_root/test/fedora-lane-image.sh" "$release")"
+        ort_version="$(
+            for ort in /usr/lib/libonnxruntime.so /usr/lib64/libonnxruntime.so; do
+                if [ -e "$ort" ]; then
+                    readlink -f "$ort" | grep -oP '\d+\.\d+\.\d+$'
+                    exit
+                fi
+            done
+            echo "1.20.1"
+        )"
+        base_image="$image-base"
+        podman build --build-arg "BASE_IMAGE=$base_fedora" \
+            --build-arg "ORT_VERSION=$ort_version" \
+            -t "$base_image" -f "$repo_root/test/Containerfile.rpm-e2e" "$repo_root"
+        mapfile -t pin_args < <(predecessor_build_args rpm-fedora)
+        podman build \
+            --build-arg "BASE_IMAGE=$base_image" \
+            --build-arg "FACELOCK_CANDIDATE_VERSION=$candidate_version" \
+            "${pin_args[@]}" \
+            -t "$image" -f "$repo_root/test/Containerfile.upgrade-v014-rpm" "$repo_root"
+        ;;
+    *)
+        echo "unsupported upgrade lane family: $family" >&2
+        exit 2
+        ;;
+esac

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1383,3 +1383,139 @@ for retired_recipe in ("just test-deb-pkg", "just test-deb-tpm-pkg"):
     require(retired_recipe not in packaging_skill, f"packaging skill retains {retired_recipe}")
 
 print("release matrix contract: OK")
+
+# ---------------------------------------------------------------------------
+# Released predecessors (#231, Track K)
+#
+# Separate block on purpose: everything above reasons about what this release
+# publishes, this one reasons about what an installed system is upgrading FROM.
+# The upgrade lanes (`just test-upgrade-v014`) download real GitHub release
+# assets, so the pin has to be strong enough that a re-uploaded or substituted
+# asset fails the lane instead of silently changing what was proven. Asset id
+# plus SHA256 plus byte size is that pin: the id survives a rename, the digest
+# survives an id reuse, and the size makes a truncated fetch loud.
+# ---------------------------------------------------------------------------
+predecessors = matrix.get("predecessors")
+require(isinstance(predecessors, dict), "release matrix must declare a predecessors block")
+require(
+    predecessors.get("repository") == "tyvsmith/facelock",
+    f"predecessors must pin this repository, got {predecessors.get('repository')!r}",
+)
+require(
+    isinstance(predecessors.get("reviewed_on"), str)
+    and re.fullmatch(r"\d{4}-\d{2}-\d{2}", predecessors["reviewed_on"]) is not None,
+    "predecessors.reviewed_on must be an ISO date",
+)
+require(
+    isinstance(predecessors.get("resolved_with"), str)
+    and "releases/tags/" in predecessors["resolved_with"],
+    "predecessors.resolved_with must name the release API query the pins came from",
+)
+
+predecessor_tags = sorted(key for key in predecessors if key.startswith("v"))
+require(
+    predecessor_tags == ["v0.1.4"],
+    f"predecessors must pin exactly the v0.1.4 release, got {predecessor_tags}",
+)
+
+declared_apt_suites = set(matrix["apt_suites"]) - {"compat"}
+declared_fedora_releases = {
+    target.split("-")[1]
+    for target in matrix["fedora"]["staging_copr_targets"]
+    if re.fullmatch(r"fedora-[1-9][0-9]*-.*", target)
+}
+
+for tag in predecessor_tags:
+    release = predecessors[tag]
+    require(release.get("tag") == tag, f"{tag} predecessor tag key and value disagree")
+    require(
+        isinstance(release.get("release_id"), int) and release["release_id"] > 0,
+        f"{tag} predecessor must pin a numeric GitHub release id",
+    )
+    require(
+        isinstance(release.get("published_at"), str) and release["published_at"].endswith("Z"),
+        f"{tag} predecessor must record the release publication timestamp",
+    )
+    upstream = release.get("upstream_version")
+    require(
+        isinstance(upstream, str) and tag == f"v{upstream}",
+        f"{tag} predecessor upstream_version must match its tag, got {upstream!r}",
+    )
+    require(
+        version_triple(upstream) <= version_triple(workspace_version()),
+        f"{tag} predecessor is not older than the workspace version {workspace_version()}",
+    )
+
+    lanes = release.get("lanes")
+    require(isinstance(lanes, dict) and lanes, f"{tag} predecessor must declare upgrade lanes")
+    require(
+        set(lanes) == {"deb-trixie", "rpm-fedora"},
+        f"{tag} predecessor lanes must be exactly the deb and rpm halves, got {sorted(lanes)}",
+    )
+    for lane_name, lane in lanes.items():
+        label = f"{tag} predecessor lane {lane_name}"
+        require(
+            isinstance(lane.get("asset_id"), int) and lane["asset_id"] > 0,
+            f"{label} must pin a numeric release asset id",
+        )
+        require(
+            isinstance(lane.get("asset_node_id"), str)
+            and lane["asset_node_id"].startswith("RA_"),
+            f"{label} must pin the asset node id alongside the numeric id",
+        )
+        require(
+            isinstance(lane.get("size"), int) and lane["size"] > 0,
+            f"{label} must pin the asset byte size",
+        )
+        digest = lane.get("sha256")
+        require(
+            isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest) is not None,
+            f"{label} must pin a lowercase SHA256, got {digest!r}",
+        )
+        name = lane.get("name")
+        require(isinstance(name, str) and name, f"{label} must name the asset")
+        require(
+            lane.get("url")
+            == f"https://github.com/{predecessors['repository']}/releases/download/{tag}/{name}",
+            f"{label} url must be the canonical release download URL for {name}",
+        )
+        require(
+            isinstance(lane.get("package_version"), str) and lane["package_version"],
+            f"{label} must record the native package version it installs as",
+        )
+        require(
+            lane["package_version"].startswith(upstream),
+            f"{label} package version {lane['package_version']!r} is not a {upstream} build",
+        )
+    require(
+        lanes["deb-trixie"]["suite"] in declared_apt_suites,
+        f"{tag} deb predecessor names an undeclared APT suite: {lanes['deb-trixie']['suite']}",
+    )
+    require(
+        lanes["rpm-fedora"]["release"] in declared_fedora_releases,
+        f"{tag} rpm predecessor names an undeclared Fedora release: {lanes['rpm-fedora']['release']}",
+    )
+
+# The retired-authselect-profile fixture downloads the same released RPM from a
+# hardcoded pin that predates this block. Two pins for one artifact is one pin
+# too many, so they are held equal here rather than left to drift apart.
+authselect_rpm_digest = predecessors["v0.1.4"]["lanes"]["rpm-fedora"]["sha256"]
+for relative_path in ("test/Containerfile.rpm-authselect", "test/build-rpm-authselect-fixtures.sh"):
+    require(
+        authselect_rpm_digest in (ROOT / relative_path).read_text(),
+        f"{relative_path} pins a different v0.1.4 RPM digest than the release matrix",
+    )
+
+# The upgrade lanes must read the pin from here rather than carry their own.
+for relative_path in (
+    "test/Containerfile.upgrade-v014-deb",
+    "test/Containerfile.upgrade-v014-rpm",
+):
+    lane_source = (ROOT / relative_path).read_text()
+    embedded = re.findall(r"\b[0-9a-f]{64}\b", lane_source)
+    require(
+        not embedded,
+        f"{relative_path} hardcodes a digest instead of taking the release-matrix pin: {embedded}",
+    )
+
+print("released predecessor contract: OK")

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -294,6 +294,13 @@ cp "$repo_root/test/Containerfile.copr-e2e" "$matrix_root/test/"
 cp "$repo_root/test/Containerfile.fedora" "$matrix_root/test/"
 cp "$repo_root/.dockerignore" "$matrix_root/"
 cp "$repo_root/test/fedora-lane-image.sh" "$matrix_root/test/"
+# The released-predecessor upgrade lanes (#231). check-release-matrix.py holds
+# the v0.1.4 RPM digest equal across the authselect fixture and the matrix, and
+# refuses a lane Containerfile that grew a digest of its own, so all three have
+# to be staged or the checker dies before asserting either.
+cp "$repo_root/test/build-rpm-authselect-fixtures.sh" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.upgrade-v014-deb" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.upgrade-v014-rpm" "$matrix_root/test/"
 cp "$repo_root/.github/workflows/packaging.yml" "$matrix_root/.github/workflows/"
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
 cp "$repo_root/test/packit-config-validate.sh" "$matrix_root/test/"

--- a/test/run-upgrade-v014-systemd.sh
+++ b/test/run-upgrade-v014-systemd.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Boot one released-predecessor upgrade lane under systemd and run its harness.
+#
+# Usage:
+#   run-upgrade-v014-systemd.sh deb <image> <candidate.deb>
+#   run-upgrade-v014-systemd.sh rpm <image>
+#
+# systemd is not optional here. The lane starts and stops the packaged daemon,
+# and the rollback proof turns on the candidate daemon having actually opened
+# and migrated the database before the downgrade — none of which a container
+# without an init can do.
+set -euo pipefail
+
+family="${1:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
+image="${2:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
+
+mounts=()
+case "$family" in
+    deb)
+        candidate="${3:?usage: run-upgrade-v014-systemd.sh deb <image> <candidate.deb>}"
+        [ "$#" -eq 3 ] || {
+            echo "usage: run-upgrade-v014-systemd.sh deb <image> <candidate.deb>" >&2
+            exit 2
+        }
+        [ -f "$candidate" ] && [ ! -L "$candidate" ] || {
+            echo "candidate package is not a regular file: $candidate" >&2
+            exit 1
+        }
+        candidate="$(cd "$(dirname "$candidate")" && pwd)/$(basename "$candidate")"
+        mounts+=(-v "$candidate:/artifacts/facelock-candidate.deb:ro,Z")
+        ;;
+    rpm)
+        [ "$#" -eq 2 ] || {
+            echo "usage: run-upgrade-v014-systemd.sh rpm <image>" >&2
+            exit 2
+        }
+        ;;
+    *)
+        echo "unsupported upgrade lane family: $family" >&2
+        exit 2
+        ;;
+esac
+
+# The reviewed models, staged read-only. Unlike the package validator there is
+# no partial-run opt-out: without models the candidate daemon cannot start, and
+# a lane that skipped the daemon would report a rollback proof it never made.
+shopt -s nullglob
+onnx=(models/*.onnx)
+shopt -u nullglob
+if [ "${#onnx[@]}" -eq 0 ]; then
+    cat >&2 <<'EOF'
+ERROR: no models/*.onnx in this checkout.
+
+The upgrade lane starts the candidate daemon so the database is migrated by the
+thing that migrates it in production, then downgrades under it. Without models
+the daemon cannot load, so there is nothing to prove. Stage them first:
+
+  just link-models
+EOF
+    exit 1
+fi
+mounts+=(-v "$PWD/models:/facelock-test-models:ro")
+
+# --shm-size: the disk-full fault fills /dev/shm to get a real ENOSPC out of
+# the kernel rather than simulating one. 16M is small enough to fill in a
+# second and large enough for the fixture database that lives there.
+cid="$(podman run -d --rm --systemd=always --security-opt unmask=ALL \
+    --shm-size=16m "${mounts[@]}" "$image")"
+trap 'podman rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+booted=
+for _ in $(seq 1 120); do
+    state="$(podman exec "$cid" systemctl is-system-running 2>/dev/null || true)"
+    case "$state" in
+        running | degraded)
+            booted=1
+            break
+            ;;
+    esac
+    sleep 1
+done
+[ -n "$booted" ] || {
+    podman exec "$cid" systemctl --failed --no-pager 2>&1 || true
+    echo "ERROR: the upgrade lane container did not boot" >&2
+    exit 1
+}
+
+podman exec "$cid" /upgrade-v014-lane.sh "$family"

--- a/test/run-upgrade-v014-systemd.sh
+++ b/test/run-upgrade-v014-systemd.sh
@@ -11,6 +11,7 @@
 # without an init can do.
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 family="${1:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
 image="${2:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
 
@@ -45,7 +46,7 @@ esac
 # no partial-run opt-out: without models the candidate daemon cannot start, and
 # a lane that skipped the daemon would report a rollback proof it never made.
 shopt -s nullglob
-onnx=(models/*.onnx)
+onnx=("$repo_root"/models/*.onnx)
 shopt -u nullglob
 if [ "${#onnx[@]}" -eq 0 ]; then
     cat >&2 <<'EOF'
@@ -59,7 +60,12 @@ the daemon cannot load, so there is nothing to prove. Stage them first:
 EOF
     exit 1
 fi
-mounts+=(-v "$PWD/models:/facelock-test-models:ro")
+# `z`, not `Z`: on an SELinux-enforcing host an unlabelled bind mount is denied
+# outright, and the private label `Z` would take the models away from whatever
+# else is reading them — the tree is hardlinked across worktrees and both lane
+# halves can be running at once. Shared and read-only is what a model directory
+# wants.
+mounts+=(-v "$repo_root/models:/facelock-test-models:ro,z")
 
 # --shm-size: the disk-full fault fills /dev/shm to get a real ENOSPC out of
 # the kernel rather than simulating one. 16M is small enough to fill in a

--- a/test/upgrade-v014-candidate-version.sh
+++ b/test/upgrade-v014-candidate-version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Decide which version the upgrade lanes build the candidate as.
+#
+# An upgrade lane needs a candidate that sorts strictly above the pinned
+# predecessor, and on a development tree it does not have one: the workspace
+# version stays at the last release until `just release` bumps it, so the .deb
+# built from it is `0.1.4-1~deb13u1` — *below* the published `0.1.4-1`, and the
+# lane would be testing a downgrade.
+#
+# So the version is chosen, not assumed. When the workspace version already
+# sorts above the predecessor the candidate is built exactly as it ships; when
+# it does not, the lane builds the same payload as the upgrade-test version
+# below and says so. This mirrors what the retired-authselect fixture already
+# does (test/build-rpm-authselect-fixtures.sh builds its candidate at 0.2.0),
+# and the native comparator inside the container is still the authority — a
+# wrong answer here fails the lane rather than passing quietly.
+#
+# Usage: upgrade-v014-candidate-version.sh <version|restamped>
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+field="${1:?usage: upgrade-v014-candidate-version.sh <version|restamped>}"
+[ "$#" -eq 1 ] || {
+    echo "usage: upgrade-v014-candidate-version.sh <version|restamped>" >&2
+    exit 2
+}
+
+FACELOCK_UPGRADE_TEST_VERSION="${FACELOCK_UPGRADE_TEST_VERSION:-0.2.0}" \
+python3 - "$repo_root" "$field" <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+
+root, field = Path(sys.argv[1]), sys.argv[2]
+
+
+def triple(version):
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not match:
+        raise SystemExit(f"unparseable version: {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+matrix = __import__("json").loads((root / "dist/release-matrix.json").read_text())
+predecessor = matrix["predecessors"]["v0.1.4"]["upstream_version"]
+
+cargo = (root / "Cargo.toml").read_text()
+match = re.search(r'(?m)^version = "([^"]+)"', cargo)
+if not match:
+    raise SystemExit("workspace version not found in Cargo.toml")
+workspace = match.group(1)
+
+if triple(workspace) > triple(predecessor):
+    version, restamped = workspace, "false"
+else:
+    version, restamped = os.environ["FACELOCK_UPGRADE_TEST_VERSION"], "true"
+
+if triple(version) <= triple(predecessor):
+    raise SystemExit(
+        f"upgrade-test version {version} does not sort above predecessor {predecessor}"
+    )
+
+print(version if field == "version" else restamped)
+PY

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -129,6 +129,17 @@ if grep -nE 'grep -F[a-z]*q "\$\(sha256sum' "$lane" >/dev/null; then
     fail "the lane looks up a digest without proving the file exists; use assert_file_digest_in_snapshot"
 fi
 
+# The invariant snapshot must hash model file content, not just record name,
+# size and mode: an upgrade that rewrites a model at the same size and mode
+# would otherwise pass "preserve models" without the bytes ever being compared.
+# Deleting the hash line from snapshot_model_files must turn this rule red.
+model_snapshot_body="$(sed -n '/^snapshot_model_files() {/,/^}/p' "$lane")"
+[ -n "$model_snapshot_body" ] || fail "the lane defines no snapshot_model_files"
+printf '%s\n' "$model_snapshot_body" | grep -q 'sha256sum' ||
+    fail "snapshot_model_files does not hash model file content"
+grep -Eq '^[[:space:]]+snapshot_model_files$' "$lane" ||
+    fail "snapshot_invariant_state never calls snapshot_model_files"
+
 # The absent-marker lookup must be whole-line. One key path is a prefix of the
 # other, so an unanchored match reports a preserved key as a newly created one
 # and the "no replacement key" proof inverts.

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -272,6 +272,83 @@ candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" ve
     fail "the candidate version does not resolve"
 [ -n "$candidate_version" ] || fail "the candidate version is empty"
 
+# --- and is spelled the way each packager spells it ------------------------
+#
+# The candidate version is a Cargo version, and `0.2.0-alpha.3` is legal there:
+# test/check-release-matrix.py accepts -alpha.N, -beta.N and -rc.N in the
+# workspace version. Neither packager accepts it as written. Debian spells it
+# `0.2.0~alpha.3-1~deb13u1`; RPM refuses a hyphen in Version at all and splits
+# it into `Version: 0.2.0` / `Release: 0.1.alpha.3`. Splicing the Cargo form
+# into a package version installs something that never ships -- and in Debian
+# it sorts *above* the real release, so the lane's own upgrade guard stays
+# quiet while it proves the wrong thing.
+
+builder="$repo_root/test/build-upgrade-v014-image.sh"
+# shellcheck disable=SC2016 # the builder's own source line is the literal sought
+grep -Fq 'source "$repo_root/scripts/release-versions.sh"' "$builder" ||
+    fail "the image builder no longer derives packaging versions from scripts/release-versions.sh"
+for helper in release_debian_version release_rpm_version release_rpm_release; do
+    grep -Fq "$helper" "$builder" || fail "the image builder no longer calls $helper"
+done
+# shellcheck disable=SC2016 # the retired splice is the literal sought
+if grep -Fq '${target#*-}' "$builder"; then
+    fail "the image builder still cuts the Debian revision at the first hyphen"
+fi
+for arg in FACELOCK_CANDIDATE_RPM_VERSION FACELOCK_CANDIDATE_RPM_RELEASE; do
+    grep -Eq "^ARG $arg\$" "$repo_root/test/Containerfile.upgrade-v014-rpm" ||
+        fail "test/Containerfile.upgrade-v014-rpm does not take $arg as a build arg"
+done
+# shellcheck disable=SC2016 # the helper's own default is the literal sought
+grep -Fq 'RPM_RELEASE="${3:-1}"' "$repo_root/test/build-rpm-prebuilt.sh" ||
+    fail "test/build-rpm-prebuilt.sh no longer takes an RPM Release field"
+
+# shellcheck source=/dev/null
+source "$repo_root/scripts/release-versions.sh"
+
+predecessor_deb="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie package_version)"
+predecessor_rpm="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" rpm-fedora package_version)"
+
+assert_version() {
+    local expected="$1" actual="$2" context="$3"
+    [ "$actual" = "$expected" ] || fail "$context: expected '$expected', got '$actual'"
+}
+
+for probe in \
+    "0.2.0|0.2.0-1~deb13u1|0.2.0|1" \
+    "0.2.0-alpha.3|0.2.0~alpha.3-1~deb13u1|0.2.0|0.1.alpha.3"; do
+    IFS='|' read -r probe_version want_deb want_rpm_version want_rpm_release <<<"$probe"
+    assert_version "$want_deb" "$(release_debian_version "$probe_version" 1 trixie)" \
+        "Debian version for candidate $probe_version"
+    assert_version "$want_rpm_version" "$(release_rpm_version "$probe_version")" \
+        "RPM Version for candidate $probe_version"
+    assert_version "$want_rpm_release" "$(release_rpm_release "$probe_version" 1)" \
+        "RPM Release for candidate $probe_version"
+
+    # The native comparators are the authority the lane defers to, so ask them
+    # here too where they happen to be installed. A host without them still
+    # gets every string above checked; it just does not get the ordering half.
+    if command -v dpkg >/dev/null 2>&1; then
+        dpkg --compare-versions "$want_deb" gt "$predecessor_deb" ||
+            fail "$want_deb does not sort above the pinned predecessor $predecessor_deb"
+    else
+        dpkg_absent=1
+    fi
+    if command -v rpmdev-vercmp >/dev/null 2>&1; then
+        # rpmdev-vercmp exits 11 when the first argument is the newer one.
+        vercmp_status=0
+        rpmdev-vercmp "$want_rpm_version-$want_rpm_release" "$predecessor_rpm" \
+            >/dev/null 2>&1 || vercmp_status=$?
+        [ "$vercmp_status" -eq 11 ] ||
+            fail "$want_rpm_version-$want_rpm_release does not sort above the pinned predecessor $predecessor_rpm"
+    else
+        rpmdev_absent=1
+    fi
+done
+[ -z "${dpkg_absent:-}" ] ||
+    echo "NOTE: dpkg is not installed; the Debian ordering half was not run" >&2
+[ -z "${rpmdev_absent:-}" ] ||
+    echo "NOTE: rpmdev-vercmp is not installed; the RPM ordering half was not run" >&2
+
 # --- the entrypoints stay wired -------------------------------------------
 
 justfile="$repo_root/justfile"

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -136,6 +136,12 @@ if grep -n 'grep -Fq "absent|' "$lane" >/dev/null; then
     fail "the lane matches absent markers unanchored; use grep -Fxq"
 fi
 
+# The Fedora lane packages host-built binaries, so it can test code that is not
+# this checkout. The freshness guard in the image builder is the only thing that
+# notices, and a green run without it means nothing.
+grep -q 'is older than the workspace source' "$repo_root/test/build-upgrade-v014-image.sh" ||
+    fail "the Fedora lane no longer refuses release binaries older than the source"
+
 # The concurrent-key case has to separate O_EXCL from O_TRUNC. One key file on
 # disk is true under both, so counting the racers that logged a creation is the
 # assertion that carries the claim, and it must not quietly disappear.

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -90,6 +90,7 @@ run_shape_body="$(sed -n '/^run_shape() {/,/^}/p' "$lane")"
 for proof in \
     assert_schema_v6_with_null_device_id \
     assert_known_embedding_decrypts \
+    assert_enrollment_marker_reconciled \
     assert_key_artifacts_preserved \
     assert_adr010_modes \
     assert_pam_path_intact \

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -94,6 +94,7 @@ for proof in \
     assert_key_artifacts_preserved \
     assert_adr010_modes \
     record_pam_enabled_state \
+    record_adr010_modes \
     assert_pam_path_intact \
     assert_real_password_behavior \
     assert_no_replacement_key_over_encrypted_state \
@@ -106,6 +107,13 @@ for proof in \
         fail "run_shape never calls $proof, so no shape proves it"
 done
 
+# Both key-refusal variants stay. "Malformed" is the case an operator actually
+# hits, and it was absent from the first version of this lane.
+for variant in missing malformed; do
+    grep -q "assert_key_refusal \"\$shape\" $variant" "$lane" ||
+        fail "the lane no longer exercises a $variant key over encrypted rows"
+done
+
 # The rollback half has its own acceptance bullets; same rule.
 downgrade_body="$(sed -n '/^assert_downgrade_usable() {/,/^}/p' "$lane")"
 for proof in pkg_downgrade assert_real_password_behavior assert_swtpm_state_untouched; do
@@ -113,12 +121,26 @@ for proof in pkg_downgrade assert_real_password_behavior assert_swtpm_state_unto
         fail "assert_downgrade_usable never calls $proof"
 done
 
+# A snapshot digest lookup must prove the file exists first. `sha256sum` on a
+# missing path prints nothing, and grep with an empty pattern matches every
+# line, so the unguarded shape passes loudest exactly when the file is gone.
+# assert_file_digest_in_snapshot is the guarded form.
+if grep -nE 'grep -F[a-z]*q "\$\(sha256sum' "$lane" >/dev/null; then
+    fail "the lane looks up a digest without proving the file exists; use assert_file_digest_in_snapshot"
+fi
+
 # The absent-marker lookup must be whole-line. One key path is a prefix of the
 # other, so an unanchored match reports a preserved key as a newly created one
 # and the "no replacement key" proof inverts.
 if grep -n 'grep -Fq "absent|' "$lane" >/dev/null; then
     fail "the lane matches absent markers unanchored; use grep -Fxq"
 fi
+
+# The concurrent-key case has to separate O_EXCL from O_TRUNC. One key file on
+# disk is true under both, so counting the racers that logged a creation is the
+# assertion that carries the claim, and it must not quietly disappear.
+grep -q 'racers that created the key' "$lane" ||
+    fail "the concurrent-key case no longer counts how many racers created the key"
 
 # --- one known-embedding fixture, one digest ------------------------------
 
@@ -128,6 +150,20 @@ lifecycle_digest="$(grep -oE '"[0-9a-f]{64}"' "$repo_root/test/deb-package-lifec
     tr -d '"' | head -1)"
 [ "$lane_digest" = "$lifecycle_digest" ] ||
     fail "known-embedding digest drifted from the Debian lifecycle gate: $lane_digest vs $lifecycle_digest"
+
+# The decryption proof must name the model it reads. Scanning for "the first
+# 2048-byte blob" finds the mixed shape's plaintext copy of the same fixture, so
+# a decrypt that did nothing would pass.
+grep -Eq '^shape_probe_label\(\)' "$lane" ||
+    fail "the lane defines no shape_probe_label"
+for caller in assert_known_embedding_decrypts assert_downgrade_usable; do
+    body="$(sed -n "/^$caller() {/,/^}/p" "$lane")"
+    [ -n "$body" ] || fail "$caller not found in the lane harness"
+    printf '%s\n' "$body" | grep -q probe_known_embedding_digest ||
+        fail "$caller does not compare the known embedding's plaintext digest"
+    printf '%s\n' "$body" | grep -Eq 'shape_probe_label "\$shape"' ||
+        fail "$caller does not pin the row it reads to the shape's model label"
+done
 
 # --- the lane Containerfiles take the pin, never carry one ----------------
 

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -93,6 +93,7 @@ for proof in \
     assert_enrollment_marker_reconciled \
     assert_key_artifacts_preserved \
     assert_adr010_modes \
+    record_pam_enabled_state \
     assert_pam_path_intact \
     assert_real_password_behavior \
     assert_no_replacement_key_over_encrypted_state \

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -184,6 +184,7 @@ for caller in assert_known_embedding_decrypts assert_downgrade_usable; do
     [ -n "$body" ] || fail "$caller not found in the lane harness"
     printf '%s\n' "$body" | grep -q probe_known_embedding_digest ||
         fail "$caller does not compare the known embedding's plaintext digest"
+    # shellcheck disable=SC2016 # the lane's own `"$shape"` is the literal sought
     printf '%s\n' "$body" | grep -Eq 'shape_probe_label "\$shape"' ||
         fail "$caller does not pin the row it reads to the shape's model label"
 done

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -163,10 +163,16 @@ grep -q 'racers that created the key' "$lane" ||
 
 lane_digest="$(sed -n 's/^KNOWN_EMBEDDING_SHA256=\([0-9a-f]\{64\}\)$/\1/p' "$lane")"
 [ -n "$lane_digest" ] || fail "the lane pins no known-embedding digest"
+# `|| true` because an empty grep exits 1, and under `set -e` that ends this
+# script before either branch below runs: the gate would report nothing at all
+# about the one thing this section exists to compare.
 lifecycle_digest="$(grep -oE '"[0-9a-f]{64}"' "$repo_root/test/deb-package-lifecycle.sh" |
-    tr -d '"' | head -1)"
-[ "$lane_digest" = "$lifecycle_digest" ] ||
+    tr -d '"' | head -1)" || true
+if [ -z "$lifecycle_digest" ]; then
+    fail "test/deb-package-lifecycle.sh pins no known-embedding digest to compare against"
+elif [ "$lane_digest" != "$lifecycle_digest" ]; then
     fail "known-embedding digest drifted from the Debian lifecycle gate: $lane_digest vs $lifecycle_digest"
+fi
 
 # The decryption proof must name the model it reads. Scanning for "the first
 # 2048-byte blob" finds the mixed shape's plaintext copy of the same fixture, so

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Container-free contract for the released-predecessor upgrade lanes (#231).
+#
+# `just test-upgrade-v014` boots two containers, builds a package in each, and
+# takes the better part of an hour. Everything that can rot without a container
+# is checked here instead, so the failure arrives in seconds:
+#
+#   * a declared state shape or fault case with no implementation behind it
+#   * a proof function that exists but nothing calls — the rot mode
+#     .claude/rules/testing.md names explicitly
+#   * the known-embedding digest drifting apart from the Debian lifecycle gate's
+#     copy of the same fixture
+#   * a lane Containerfile growing its own predecessor pin
+#   * a candidate version that does not sort above the predecessor
+#
+# It is wired into `just check` through the lane recipes and can be run alone.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lane="$repo_root/test/upgrade-v014-lane.sh"
+failures=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    failures=$((failures + 1))
+}
+
+require_file() {
+    [ -f "$1" ] || fail "missing lane file: ${1#"$repo_root"/}"
+}
+
+# --- the lane files exist and parse ---------------------------------------
+
+for path in \
+    "$repo_root/test/upgrade-v014-lane.sh" \
+    "$repo_root/test/upgrade-v014-predecessor.sh" \
+    "$repo_root/test/upgrade-v014-candidate-version.sh" \
+    "$repo_root/test/build-upgrade-v014-image.sh" \
+    "$repo_root/test/run-upgrade-v014-systemd.sh" \
+    "$repo_root/test/Containerfile.upgrade-v014-deb" \
+    "$repo_root/test/Containerfile.upgrade-v014-rpm"; do
+    require_file "$path"
+done
+[ "$failures" -eq 0 ] || exit 1
+
+for script in \
+    "$repo_root/test/upgrade-v014-lane.sh" \
+    "$repo_root/test/upgrade-v014-predecessor.sh" \
+    "$repo_root/test/upgrade-v014-candidate-version.sh" \
+    "$repo_root/test/build-upgrade-v014-image.sh" \
+    "$repo_root/test/run-upgrade-v014-systemd.sh"; do
+    bash -n "$script" || fail "${script#"$repo_root"/} does not parse"
+    [ -x "$script" ] || fail "${script#"$repo_root"/} is not executable"
+done
+
+# --- every declared shape and fault is implemented and dispatched ---------
+
+lane_array() {
+    sed -n "s/^$1=(\(.*\))\$/\1/p" "$lane"
+}
+
+shapes="$(lane_array SHAPES)"
+faults="$(lane_array FAULTS)"
+[ -n "$shapes" ] || fail "the lane declares no state shapes"
+[ -n "$faults" ] || fail "the lane declares no fault cases"
+
+for shape in $shapes; do
+    function_name="seed_shape_${shape//-/_}"
+    grep -Eq "^$function_name\(\)" "$lane" ||
+        fail "declared shape '$shape' has no $function_name implementation"
+    grep -Eq "^[[:space:]]+$shape\)[[:space:]]+$function_name" "$lane" ||
+        fail "declared shape '$shape' is not dispatched by seed_shape"
+done
+
+for fault in $faults; do
+    function_name="fault_${fault//-/_}"
+    grep -Eq "^$function_name\(\)" "$lane" ||
+        fail "declared fault '$fault' has no $function_name implementation"
+    grep -Eq "^[[:space:]]+$fault\)[[:space:]]+$function_name" "$lane" ||
+        fail "declared fault '$fault' is not dispatched by run_faults"
+done
+
+# --- every proof the issue names is actually invoked ----------------------
+#
+# A proof function defined but never called is worse than a missing one: the
+# lane still reports PASS, and the name in the source says the thing was
+# checked. Each entry here is an acceptance bullet of #231.
+run_shape_body="$(sed -n '/^run_shape() {/,/^}/p' "$lane")"
+[ -n "$run_shape_body" ] || fail "run_shape not found in the lane harness"
+for proof in \
+    assert_schema_v6_with_null_device_id \
+    assert_known_embedding_decrypts \
+    assert_key_artifacts_preserved \
+    assert_adr010_modes \
+    assert_pam_path_intact \
+    assert_real_password_behavior \
+    assert_no_replacement_key_over_encrypted_state \
+    record_swtpm_state \
+    assert_swtpm_state_untouched \
+    open_database_with_candidate_daemon \
+    assert_downgrade_usable; do
+    grep -Eq "^$proof\(\)" "$lane" || fail "the lane defines no $proof"
+    printf '%s\n' "$run_shape_body" | grep -q "$proof" ||
+        fail "run_shape never calls $proof, so no shape proves it"
+done
+
+# The rollback half has its own acceptance bullets; same rule.
+downgrade_body="$(sed -n '/^assert_downgrade_usable() {/,/^}/p' "$lane")"
+for proof in pkg_downgrade assert_real_password_behavior assert_swtpm_state_untouched; do
+    printf '%s\n' "$downgrade_body" | grep -q "$proof" ||
+        fail "assert_downgrade_usable never calls $proof"
+done
+
+# --- one known-embedding fixture, one digest ------------------------------
+
+lane_digest="$(sed -n 's/^KNOWN_EMBEDDING_SHA256=\([0-9a-f]\{64\}\)$/\1/p' "$lane")"
+[ -n "$lane_digest" ] || fail "the lane pins no known-embedding digest"
+lifecycle_digest="$(grep -oE '"[0-9a-f]{64}"' "$repo_root/test/deb-package-lifecycle.sh" |
+    tr -d '"' | head -1)"
+[ "$lane_digest" = "$lifecycle_digest" ] ||
+    fail "known-embedding digest drifted from the Debian lifecycle gate: $lane_digest vs $lifecycle_digest"
+
+# --- the lane Containerfiles take the pin, never carry one ----------------
+
+for containerfile in \
+    "$repo_root/test/Containerfile.upgrade-v014-deb" \
+    "$repo_root/test/Containerfile.upgrade-v014-rpm"; do
+    for arg in FACELOCK_PREDECESSOR_URL FACELOCK_PREDECESSOR_SHA256 \
+        FACELOCK_PREDECESSOR_SIZE FACELOCK_PREDECESSOR_VERSION; do
+        grep -Eq "^ARG $arg\$" "$containerfile" ||
+            fail "${containerfile#"$repo_root"/} does not take $arg as a build arg"
+    done
+    if grep -qE '\b[0-9a-f]{64}\b' "$containerfile"; then
+        fail "${containerfile#"$repo_root"/} carries its own digest instead of the matrix pin"
+    fi
+done
+
+# --- the pin resolves, and resolves to the matrix -------------------------
+
+for pair in "deb-trixie:deb" "rpm-fedora:rpm"; do
+    lane_name="${pair%%:*}"
+    resolved="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" "$lane_name" --build-args)" ||
+        fail "predecessor lane $lane_name does not resolve"
+    for key in URL SHA256 SIZE NAME VERSION; do
+        printf '%s\n' "$resolved" | grep -q "^FACELOCK_PREDECESSOR_$key=." ||
+            fail "predecessor lane $lane_name resolved no $key"
+    done
+done
+
+# --- the candidate sorts above the predecessor ----------------------------
+
+candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)" ||
+    fail "the candidate version does not resolve"
+[ -n "$candidate_version" ] || fail "the candidate version is empty"
+
+# --- the entrypoints stay wired -------------------------------------------
+
+justfile="$repo_root/justfile"
+for recipe in test-upgrade-v014 test-upgrade-v014-deb test-upgrade-v014-rpm \
+    test-upgrade-v014-contract test-upgrade-v014-pins; do
+    grep -Eq "^$recipe([ :])" "$justfile" || fail "justfile has no $recipe recipe"
+done
+grep -q "test/build-upgrade-v014-image.sh deb" "$justfile" ||
+    fail "test-upgrade-v014-deb does not build its lane image"
+grep -q "test/build-upgrade-v014-image.sh rpm" "$justfile" ||
+    fail "test-upgrade-v014-rpm does not build its lane image"
+
+skill="$repo_root/.claude/skills/packaging-test/SKILL.md"
+grep -q 'just test-upgrade-v014' "$skill" ||
+    fail "the packaging-test skill does not route anything to just test-upgrade-v014"
+
+if [ "$failures" -ne 0 ]; then
+    echo "FAIL: $failures upgrade-lane contract violation(s)" >&2
+    exit 1
+fi
+
+echo "upgrade lane contract: OK ($(printf '%s' "$shapes" | wc -w) shapes, $(printf '%s' "$faults" | wc -w) faults, candidate $candidate_version)"

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -216,6 +216,56 @@ for pair in "deb-trixie:deb" "rpm-fedora:rpm"; do
     done
 done
 
+# --- --verify-live judges a live asset the way the pin means it -----------
+#
+# The real thing needs `gh` and the network, so it never runs in `just check`
+# and its comparison logic is exactly the kind that rots unseen. Drive it
+# against a stub `gh` instead: what matters is which live answers are fatal
+# (a moved name, size or digest) and which are not (an asset GitHub carries no
+# digest for, which is null on the wire and must not read as a substitution).
+
+verify_live_stub() {
+    local answer="$1" stub_dir status=0
+    stub_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-gh-stub.XXXXXX")"
+    cat >"$stub_dir/gh" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "$answer"
+STUB
+    chmod +x "$stub_dir/gh"
+    PATH="$stub_dir:$PATH" bash "$repo_root/test/upgrade-v014-predecessor.sh" \
+        deb-trixie --verify-live >"$stub_dir/out" 2>&1 || status=$?
+    printf '%s\n' "$status"
+    cat "$stub_dir/out"
+    rm -rf "$stub_dir"
+}
+
+pinned_name="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie name)"
+pinned_size="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie size)"
+pinned_sha="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie sha256)"
+tab="$(printf '\t')"
+
+assert_verify_live() {
+    local label="$1" answer="$2" want_status="$3" want_text="$4" result status
+    result="$(verify_live_stub "$answer")"
+    status="$(printf '%s\n' "$result" | head -1)"
+    [ "$status" = "$want_status" ] ||
+        fail "--verify-live on $label exited $status, expected $want_status"
+    printf '%s\n' "$result" | grep -Fq "$want_text" ||
+        fail "--verify-live on $label did not report '$want_text'"
+}
+
+assert_verify_live "the pinned asset" \
+    "$pinned_name$tab$pinned_size${tab}sha256:$pinned_sha" 0 "unchanged"
+assert_verify_live "an asset with no digest" \
+    "$pinned_name$tab$pinned_size$tab" 0 "serves no digest"
+assert_verify_live "a digest that moved" \
+    "$pinned_name$tab$pinned_size${tab}sha256:${pinned_sha//?/0}" 1 \
+    "serves a different digest"
+assert_verify_live "a size that moved" \
+    "$pinned_name$tab$((pinned_size + 1))${tab}sha256:$pinned_sha" 1 \
+    "pinned asset $(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie asset_id) changed"
+assert_verify_live "a deleted asset" "" 1 "no longer serves asset id"
+
 # --- the candidate sorts above the predecessor ----------------------------
 
 candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)" ||

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -113,6 +113,13 @@ for proof in pkg_downgrade assert_real_password_behavior assert_swtpm_state_unto
         fail "assert_downgrade_usable never calls $proof"
 done
 
+# The absent-marker lookup must be whole-line. One key path is a prefix of the
+# other, so an unanchored match reports a preserved key as a newly created one
+# and the "no replacement key" proof inverts.
+if grep -n 'grep -Fq "absent|' "$lane" >/dev/null; then
+    fail "the lane matches absent markers unanchored; use grep -Fxq"
+fi
+
 # --- one known-embedding fixture, one digest ------------------------------
 
 lane_digest="$(sed -n 's/^KNOWN_EMBEDDING_SHA256=\([0-9a-f]\{64\}\)$/\1/p' "$lane")"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -50,6 +50,12 @@ STATE_ROOT=/run/facelock-upgrade-v014
 LOG=/tmp/facelock-upgrade-v014.log
 PAM_SERVICE=facelock-upgrade-v014
 PAM_PATH="/etc/pam.d/$PAM_SERVICE"
+# The stack a distribution actually authenticates through, as opposed to the
+# lane's own service. An upgrade must not edit it in either direction.
+case "${1:-}" in
+    deb) GLOBAL_PAM=/etc/pam.d/common-auth ;;
+    *) GLOBAL_PAM=/etc/pam.d/system-auth ;;
+esac
 PASSWORD_USER=testuser
 CORRECT_PASSWORD="test"
 WRONG_PASSWORD=definitely-not-the-password
@@ -496,8 +502,25 @@ snapshot_file() {
 # schema version and the device_id column: those are what the migration is for,
 # and asserting them separately keeps "changed as designed" from hiding inside
 # "changed".
+snapshot_path_any() {
+    local path="$1"
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        printf 'absent|%s\n' "$path"
+        return
+    fi
+    LC_ALL=C stat -c 'entry|%n|%F|%a|%u|%g' -- "$path"
+    if [ -L "$path" ]; then
+        printf 'link|%s|' "$path"
+        readlink -- "$path"
+    fi
+    if [ -f "$path" ]; then
+        sha256sum -- "$path" | sed 's|^|content|'
+    fi
+}
+
 snapshot_invariant_state() {
     local path
+    snapshot_path_any "$GLOBAL_PAM"
     for path in \
         /etc/facelock/config.toml \
         /etc/facelock/encryption.key \
@@ -742,25 +765,49 @@ EOF
         fail "the retired facelock group survived the upgrade"
 }
 
+# v0.1.4's pam-configs profile shipped `Default: yes`, so installing that
+# release ran pam-auth-update --package and turned face authentication on in
+# common-auth without anyone asking. The candidate ships `Default: no`.
+#
+# So the contract an upgrade has to meet is not "facelock is absent from the
+# global stack" -- on a v0.1.4 system it is present, and removing it would
+# silently take face authentication away from someone using it. It is that the
+# upgrade leaves the stack exactly as it found it, in either direction. The
+# byte comparison lives in the invariant snapshot; this records the verdict in
+# a form a reader of the log can act on.
+record_pam_enabled_state() {
+    local shape="$1"
+    pam_enabled_state >"$STATE_ROOT/$shape.pam-enabled"
+}
+
+pam_enabled_state() {
+    if [ -f "$GLOBAL_PAM" ] && grep -q pam_facelock.so "$GLOBAL_PAM"; then
+        echo enabled
+    else
+        echo disabled
+    fi
+}
+
 assert_pam_path_intact() {
-    local before="$1"
+    local before="$1" shape="$2"
     grep -Fq "$(sha256sum "$PAM_PATH")" "$before" ||
         fail "the upgrade rewrote the administrator's PAM service: $PAM_PATH"
+    assert_eq "$(cat "$STATE_ROOT/$shape.pam-enabled")" "$(pam_enabled_state)" \
+        "whether Facelock is enabled in $GLOBAL_PAM across the upgrade"
     case "$FAMILY" in
         deb)
-            # The packaged profile is registered, never selected: an upgrade
-            # that switched a system to face auth on its own is a lockout.
             [ -f /usr/share/pam-configs/facelock ] ||
                 fail "the candidate did not register its pam-configs profile"
-            ! grep -q pam_facelock.so /etc/pam.d/common-auth ||
-                fail "the upgrade activated Facelock in common-auth"
+            # The packaged default flipped to `no` in the candidate. That governs
+            # a fresh install only; it must never retire a profile an existing
+            # system already has enabled.
+            grep -Eq '^Default:[[:space:]]*no$' /usr/share/pam-configs/facelock ||
+                fail "the candidate profile no longer defaults to off for fresh installs"
             ;;
         rpm)
             # The authselect profile was retired; an upgrade must not put one back.
             [ ! -e /usr/share/authselect/vendor/facelock ] ||
                 fail "the upgrade reinstated the retired authselect profile"
-            ! grep -q pam_facelock.so /etc/pam.d/system-auth 2>/dev/null ||
-                fail "the upgrade activated Facelock in system-auth"
             ;;
     esac
 }
@@ -853,6 +900,7 @@ run_shape() {
     snapshot_invariant_state >"$STATE_ROOT/$shape.before"
 
     record_swtpm_state
+    record_pam_enabled_state "$shape"
     pkg_upgrade "$CANDIDATE" || fail "the native upgrade to the candidate failed"
     assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_installed_version)" \
         "installed candidate version after upgrade"
@@ -871,7 +919,7 @@ run_shape() {
     assert_enrollment_marker_reconciled
     assert_key_artifacts_preserved "$STATE_ROOT/$shape.before"
     assert_adr010_modes
-    assert_pam_path_intact "$STATE_ROOT/$shape.before"
+    assert_pam_path_intact "$STATE_ROOT/$shape.before" "$shape"
     assert_real_password_behavior
     assert_no_replacement_key_over_encrypted_state "$shape"
     pass "$shape state survives $(cat "$PREDECESSOR_VERSION_FILE") to $(cat "$CANDIDATE_VERSION_FILE")"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -378,12 +378,34 @@ stage_models() {
         fail "no reviewed ONNX models staged at /facelock-test-models"
 }
 
+# The layout v0.1.4 leaves behind. Its postinst runs systemd-sysusers and
+# systemd-tmpfiles and then chowns the state directories to root:facelock 0750
+# (models to root:root 0755); ADR 010 retired that group and tightened those
+# modes. Seeding the new modes here, as this lane first did, meant the upgrade
+# had nothing to tighten and every mode assertion passed on state the lane had
+# already put in the right shape.
+#
+# `pam-backups` is deliberately absent: it is new-layout, and the candidate's
+# postinst has to create it.
+seed_legacy_layout() {
+    local legacy_group=root
+    if getent group facelock >/dev/null 2>&1; then
+        legacy_group=facelock
+    fi
+    install -d /var/lib/facelock /var/lib/facelock/models \
+        /var/log/facelock /var/log/facelock/snapshots
+    chown "root:$legacy_group" /var/lib/facelock /var/log/facelock \
+        /var/log/facelock/snapshots
+    chmod 0750 /var/lib/facelock /var/log/facelock /var/log/facelock/snapshots
+    chown root:root /var/lib/facelock/models
+    chmod 0755 /var/lib/facelock/models
+    # Holds the enrollment marker, so it has to exist; created loose so the
+    # tightening to 0711 is exercised too.
+    install -d -m0750 /var/lib/facelock/enrolled
+}
+
 seed_common_state() {
-    install -d -m0711 /var/lib/facelock
-    install -d -m0755 /var/lib/facelock/models
-    install -d -m0711 /var/lib/facelock/enrolled
-    install -d -m0700 /var/lib/facelock/pam-backups /var/log/facelock
-    install -d -m0700 /var/log/facelock/snapshots
+    seed_legacy_layout
 
     # The reviewed models the candidate daemon has to load, plus a payload of
     # this lane's own: an upgrade has no business touching either, and both
@@ -629,40 +651,94 @@ PY
         "legacy rows left with a non-NULL device_id"
 }
 
+# Which model's first embedding is the known fixture for a given shape. The
+# mixed shape is why this exists: it holds an encrypted model and a plaintext
+# one, both carrying the known blob, so "the first 2048-byte blob" would find
+# the plaintext copy and a decrypt that did nothing would pass.
+shape_probe_label() {
+    case "$1" in
+        plaintext) echo plaintext ;;
+        keyfile) echo keyfile ;;
+        mixed) echo encrypted-half ;;
+        tpm-pcr-unbound | tpm-pcr-bound) echo tpm ;;
+        *) fail "no probe label for shape: $1" ;;
+    esac
+}
+
+# SQLite's online backup API, not `cp`. A live WAL means the file on disk is not
+# the whole database, and a checkpoint landing mid-copy turns the probe into a
+# corruption failure that has nothing to do with what is under test.
+copy_database_for_probe() {
+    local destination="$1"
+    python3 - /var/lib/facelock/facelock.db "$destination" <<'PROBE_COPY_PY'
+import sqlite3
+import sys
+
+source = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+target = sqlite3.connect(sys.argv[2])
+with target:
+    source.backup(target)
+target.close()
+source.close()
+PROBE_COPY_PY
+}
+
+# The blob stored against one model's first embedding, as a digest. Fails
+# loudly if the row is missing or is not a raw 512-float embedding, so a blob
+# left encrypted is a failure rather than a digest that happens not to match.
+probe_known_embedding_digest() {
+    local probe_db="$1" label="$2"
+    python3 - "$probe_db" "$label" <<'PROBE_DIGEST_PY'
+import hashlib
+import sqlite3
+import sys
+
+connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+row = connection.execute(
+    "SELECT fe.embedding FROM face_embeddings AS fe "
+    "JOIN face_models AS fm ON fm.id = fe.model_id "
+    "WHERE fm.label = ? ORDER BY fe.id LIMIT 1",
+    (sys.argv[2],),
+).fetchone()
+connection.close()
+if row is None:
+    raise SystemExit(f"no embedding row for model label {sys.argv[2]!r}")
+blob = row[0]
+if len(blob) != 2048:
+    raise SystemExit(
+        f"embedding for {sys.argv[2]!r} is {len(blob)} bytes, not a decrypted "
+        "512-float embedding"
+    )
+print(hashlib.sha256(blob).hexdigest())
+PROBE_DIGEST_PY
+}
+
+# Stage a copy of the live database plus a config pointing at it, so a decrypt
+# run for evidence never touches the state under test.
+stage_probe() {
+    local probe="$1"
+    rm -rf "$probe"
+    install -d -m0700 "$probe"
+    copy_database_for_probe "$probe/probe.db"
+    sed "s|^db_path = .*|db_path = \"$probe/probe.db\"|" \
+        /etc/facelock/config.toml >"$probe/config.toml"
+}
+
 # The proof a file hash cannot give: take the blob the released binary wrote,
 # decrypt it with the candidate and the preserved key, and compare the
 # plaintext to the digest this lane pinned before any of it was encrypted.
 assert_known_embedding_decrypts() {
-    local shape="$1" probe=/tmp/facelock-decrypt-probe
-    rm -rf "$probe"
-    install -d -m0700 "$probe"
-    cp /var/lib/facelock/facelock.db "$probe/probe.db"
-    sed "s|^db_path = .*|db_path = \"$probe/probe.db\"|" \
-        /etc/facelock/config.toml >"$probe/config.toml"
+    local shape="$1" probe=/tmp/facelock-decrypt-probe label digest
+    label="$(shape_probe_label "$shape")"
+    stage_probe "$probe"
 
     if [ "$shape" != plaintext ]; then
         facelock --config "$probe/config.toml" tpm decrypt >>"$LOG" 2>&1 ||
             fail "the candidate could not decrypt rows the released binary encrypted"
     fi
 
-    local digest
-    digest="$(python3 - "$probe/probe.db" <<'PY'
-import hashlib
-import sqlite3
-import sys
-
-connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
-blobs = [
-    row[0]
-    for row in connection.execute(
-        "SELECT fe.embedding FROM face_embeddings AS fe "
-        "JOIN face_models AS fm ON fm.id = fe.model_id ORDER BY fm.label, fe.id"
-    )
-]
-connection.close()
-print(next((hashlib.sha256(b).hexdigest() for b in blobs if len(b) == 2048), "none"))
-PY
-)"
+    digest="$(probe_known_embedding_digest "$probe/probe.db" "$label")" ||
+        fail "the known embedding for '$label' was not recoverable after the upgrade"
     assert_eq "$KNOWN_EMBEDDING_SHA256" "$digest" \
         "known embedding plaintext recovered after the upgrade"
     rm -rf "$probe"
@@ -751,50 +827,87 @@ assert_key_artifacts_preserved() {
 }
 
 # The candidate must refuse to write a replacement key when encrypted rows are
-# present and the key artifact is gone — the upgrade-day failure that turns a
-# recoverable backup restore into permanent loss.
+# present and the key artifact is missing or unusable -- the upgrade-day failure
+# that turns a recoverable backup restore into permanent loss.
+#
+# Two shapes carry a plaintext keyfile over encrypted rows and so can have that
+# key taken away: `keyfile` and `mixed`. The others are skipped for a reason,
+# not for coverage: `plaintext` has no encrypted row to protect and is the one
+# state where creating a key is allowed, and the TPM shapes keep their key
+# sealed rather than on disk, so removing the plaintext artifact would prove
+# nothing about the key actually in use. TPM unseal failure is
+# test/tpm-pcr-e2e.sh's subject.
 assert_no_replacement_key_over_encrypted_state() {
     local shape="$1"
     case "$shape" in
         keyfile | mixed) ;;
         *) return 0 ;;
     esac
-    local saved="$STATE_ROOT/key.saved" output=/tmp/facelock-replacement-key.log status=0
-    stop_packaged_daemon
+    local saved="$STATE_ROOT/key.saved"
     cp /etc/facelock/encryption.key "$saved"
-    rm -f /etc/facelock/encryption.key
 
-    # The daemon must keep running: refusing to write a key must not turn an
-    # authentication that already falls through to password into a lockout.
-    # Exit 124 is the timeout firing on a daemon that is still up.
-    RUST_LOG=warn timeout --foreground 30 facelock daemon >"$output" 2>&1 || status=$?
-    if [ -e /etc/facelock/encryption.key ]; then
-        install -m0600 "$saved" /etc/facelock/encryption.key
-        fail "the candidate wrote a replacement key over encrypted rows"
-    fi
-    [ "$status" = 124 ] || {
-        tail -20 "$output" >&2
-        install -m0600 "$saved" /etc/facelock/encryption.key
-        fail "the daemon stopped serving when its key went missing (exit $status)"
-    }
-    grep -qi 'refusing to write a replacement key' "$output" || {
-        tail -20 "$output" >&2
-        install -m0600 "$saved" /etc/facelock/encryption.key
-        fail "the refusal did not name the missing key over encrypted rows"
-    }
+    # Missing, then malformed. "Malformed" is the case an operator actually
+    # hits: a truncated key from a half-finished restore or a filled disk looks
+    # present, and a replacement written over it is just as final as one
+    # written over nothing.
+    assert_key_refusal "$shape" missing "$saved"
+    assert_key_refusal "$shape" malformed "$saved"
 
     install -m0600 "$saved" /etc/facelock/encryption.key
     rm -f "$saved"
 }
 
-# ADR 010 modes. The packaged scriptlets tighten these on an upgrade from a
-# release that predates the layout; content must be untouched while they do.
-assert_adr010_modes() {
-    local expected path
-    while read -r expected path; do
-        [ -e "$path" ] || continue
-        assert_eq "$expected" "$(stat -c '%a:%u:%g' "$path")" "ADR 010 metadata for $path"
-    done <<'EOF'
+assert_key_refusal() {
+    local shape="$1" variant="$2" saved="$3"
+    local output="/tmp/facelock-replacement-key-$variant.log" status=0
+    stop_packaged_daemon
+    case "$variant" in
+        missing) rm -f /etc/facelock/encryption.key ;;
+        malformed)
+            printf 'not-a-key' >/etc/facelock/encryption.key
+            chmod 0600 /etc/facelock/encryption.key
+            ;;
+        *) fail "unknown key-refusal variant: $variant" ;;
+    esac
+
+    # The daemon must keep running: refusing to write a key must not turn an
+    # authentication that already falls through to password into a lockout.
+    # Exit 124 is the timeout firing on a daemon that is still up.
+    RUST_LOG=warn timeout --foreground 30 facelock daemon >"$output" 2>&1 || status=$?
+
+    # The key must be exactly as this function left it. Anything else means the
+    # daemon wrote over it.
+    local now="absent"
+    if [ -e /etc/facelock/encryption.key ]; then
+        now="$(stat -c %s /etc/facelock/encryption.key)"
+    fi
+    local want="absent"
+    [ "$variant" = malformed ] && want=9
+    [ "$now" = "$want" ] || {
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the candidate replaced a $variant key over encrypted rows (size now $now)"
+    }
+    [ "$status" = 124 ] || {
+        tail -20 "$output" >&2
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the daemon stopped serving on a $variant key (exit $status)"
+    }
+    grep -qiE 'refusing to write a replacement key|could not be created/read' "$output" || {
+        tail -20 "$output" >&2
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the daemon did not report the $variant key over encrypted rows"
+    }
+    # Password still works with the key unusable: that fall-through is the whole
+    # reason refusing to write a replacement is the safe choice.
+    assert_real_password_behavior
+    install -m0600 "$saved" /etc/facelock/encryption.key
+    pass "$shape refuses a replacement over a $variant key and keeps serving"
+}
+
+# The paths ADR 010 governs and the mode each must end up at. Read by both the
+# pre-upgrade recording and the post-upgrade assertion, so the two cannot drift.
+adr010_expectations() {
+    cat <<'EOF'
 711:0:0 /var/lib/facelock
 755:0:0 /var/lib/facelock/models
 711:0:0 /var/lib/facelock/enrolled
@@ -804,22 +917,54 @@ assert_adr010_modes() {
 600:0:0 /var/lib/facelock/facelock.db
 600:0:0 /var/log/facelock/audit.jsonl
 EOF
+}
+
+record_adr010_modes() {
+    local shape="$1" expected path
+    : >"$STATE_ROOT/$shape.modes"
+    while read -r expected path; do
+        if [ -e "$path" ]; then
+            printf '%s %s\n' "$(stat -c '%a:%u:%g' "$path")" "$path" \
+                >>"$STATE_ROOT/$shape.modes"
+        else
+            printf 'absent %s\n' "$path" >>"$STATE_ROOT/$shape.modes"
+        fi
+    done < <(adr010_expectations)
+}
+
+# ADR 010 modes. The packaged scriptlets tighten these on an upgrade from a
+# release that predates the layout; content must be untouched while they do.
+#
+# Every path is required to exist afterwards. A `continue` on a missing path
+# made all of this optional, and `pam-backups` in particular only exists
+# because the candidate's postinst creates it -- so its absence is the failure
+# this is here to catch, not a case to skip.
+assert_adr010_modes() {
+    local shape="$1" expected path actual before tightened=0
+    while read -r expected path; do
+        [ -e "$path" ] ||
+            fail "ADR 010 path missing after the upgrade: $path"
+        actual="$(stat -c '%a:%u:%g' "$path")"
+        assert_eq "$expected" "$actual" "ADR 010 metadata for $path"
+        before="$(awk -v p="$path" '$2 == p {print $1}' "$STATE_ROOT/$shape.modes")"
+        if [ -n "$before" ] && [ "$before" != "$expected" ]; then
+            tightened=$((tightened + 1))
+        fi
+    done < <(adr010_expectations)
+
+    # At least one path has to have actually moved. If the predecessor already
+    # left everything at the ADR 010 values, this lane is asserting nothing
+    # about the upgrade and the legacy seeding above has silently stopped
+    # working.
+    [ "$tightened" -gt 0 ] ||
+        fail "no ADR 010 path changed across the upgrade: nothing was tightened"
+
     # ADR 010 retired the group outright; an upgrade from a release that had
     # one must remove it rather than leave a group owning nothing.
     ! getent group facelock >/dev/null 2>&1 ||
         fail "the retired facelock group survived the upgrade"
 }
 
-# v0.1.4's pam-configs profile shipped `Default: yes`, so installing that
-# release ran pam-auth-update --package and turned face authentication on in
-# common-auth without anyone asking. The candidate ships `Default: no`.
-#
-# So the contract an upgrade has to meet is not "facelock is absent from the
-# global stack" -- on a v0.1.4 system it is present, and removing it would
-# silently take face authentication away from someone using it. It is that the
-# upgrade leaves the stack exactly as it found it, in either direction. The
-# byte comparison lives in the invariant snapshot; this records the verdict in
-# a form a reader of the log can act on.
 record_pam_enabled_state() {
     local shape="$1"
     pam_enabled_state >"$STATE_ROOT/$shape.pam-enabled"
@@ -833,10 +978,23 @@ pam_enabled_state() {
     fi
 }
 
+# `grep -F "$(sha256sum "$path")"` matches every line of the snapshot when the
+# file is gone, because sha256sum prints nothing and the empty pattern matches.
+# So the file has to be proved present before its digest is looked up.
+assert_file_digest_in_snapshot() {
+    local path="$1" snapshot="$2" description="$3" line
+    [ -f "$path" ] && [ ! -L "$path" ] ||
+        fail "$description: $path is missing or is not a regular file"
+    line="$(sha256sum -- "$path")"
+    [ -n "$line" ] || fail "$description: could not digest $path"
+    grep -Fxq -- "$line" "$snapshot" ||
+        fail "$description: $path changed"
+}
+
 assert_pam_path_intact() {
     local before="$1" shape="$2"
-    grep -Fq "$(sha256sum "$PAM_PATH")" "$before" ||
-        fail "the upgrade rewrote the administrator's PAM service: $PAM_PATH"
+    assert_file_digest_in_snapshot "$PAM_PATH" "$before" \
+        "the upgrade rewrote the administrator's PAM service"
     assert_eq "$(cat "$STATE_ROOT/$shape.pam-enabled")" "$(pam_enabled_state)" \
         "whether Facelock is enabled in $GLOBAL_PAM across the upgrade"
     case "$FAMILY" in
@@ -923,7 +1081,7 @@ MARKER_COUNT_PY
 # --- rollback --------------------------------------------------------------
 
 assert_downgrade_usable() {
-    local shape="$1" probe=/tmp/facelock-rollback-probe
+    local shape="$1" probe=/tmp/facelock-rollback-probe label digest
     case_name="$shape-downgrade"
 
     record_swtpm_state
@@ -933,24 +1091,28 @@ assert_downgrade_usable() {
         "installed version after downgrade"
     ensure_system_bus
 
-    # V6 has no down-migration. The predecessor must still open the database
-    # the candidate migrated and count its rows. `tpm status` is the readback
-    # rather than `list`, which in v0.1.4 is a D-Bus call to a daemon this
-    # phase deliberately does not run.
+    # V6 has no down-migration. The predecessor must still open the database the
+    # candidate migrated and read its enrollment state. `tpm status` is the
+    # readback rather than `list`, which in v0.1.4 is a D-Bus call to a daemon
+    # this phase deliberately does not run.
     released_facelock tpm status >>"$LOG" 2>&1 ||
-        fail "the released binary could not read the V6 database after rollback"
+        fail "the released binary could not open the V6 database after rollback"
     assert_eq 6 "$(schema_version)" "schema version is not rolled back by a package downgrade"
 
+    # The rollback claim is that the old binary can still *read the templates*,
+    # so it decrypts the known embedding and the plaintext is compared. An exit
+    # code alone would pass on a decrypt that quietly did nothing.
+    label="$(shape_probe_label "$shape")"
+    stage_probe "$probe"
     if [ "$shape" != plaintext ]; then
-        rm -rf "$probe"
-        install -d -m0700 "$probe"
-        cp /var/lib/facelock/facelock.db "$probe/probe.db"
-        sed "s|^db_path = .*|db_path = \"$probe/probe.db\"|" \
-            /etc/facelock/config.toml >"$probe/config.toml"
         released_facelock --config "$probe/config.toml" decrypt >>"$LOG" 2>&1 ||
             fail "the released binary could not decrypt its own rows after rollback"
-        rm -rf "$probe"
     fi
+    digest="$(probe_known_embedding_digest "$probe/probe.db" "$label")" ||
+        fail "the known embedding for '$label' was not recoverable after rollback"
+    assert_eq "$KNOWN_EMBEDDING_SHA256" "$digest" \
+        "known embedding plaintext recovered by the released binary after rollback"
+    rm -rf "$probe"
 
     assert_real_password_behavior
     assert_swtpm_state_untouched
@@ -981,6 +1143,7 @@ run_shape() {
 
     record_swtpm_state
     record_pam_enabled_state "$shape"
+    record_adr010_modes "$shape"
     pkg_upgrade "$CANDIDATE" || fail "the native upgrade to the candidate failed"
     assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_installed_version)" \
         "installed candidate version after upgrade"
@@ -999,7 +1162,7 @@ run_shape() {
     assert_known_embedding_decrypts "$shape"
     assert_enrollment_marker_reconciled
     assert_key_artifacts_preserved "$STATE_ROOT/$shape.before"
-    assert_adr010_modes
+    assert_adr010_modes "$shape"
     assert_pam_path_intact "$STATE_ROOT/$shape.before" "$shape"
     assert_real_password_behavior
     assert_no_replacement_key_over_encrypted_state "$shape"
@@ -1336,18 +1499,21 @@ FAULT_CORRUPT_PY
 
 fault_concurrent_key_creation() {
     case_name="fault-concurrent-key-creation"
-    local target="$FAULT_ROOT/concurrent" keys
+    local target="$FAULT_ROOT/concurrent" keys creators digest
     seed_fault_database "$target"
     # A plaintext-only legacy database with no key artifact: the one state where
     # creating the default key is allowed at all.
     [ ! -e "$target/encryption.key" ] || fail "the concurrent fixture already has a key"
     stop_packaged_daemon
 
-    for _ in $(seq 1 8); do
+    # RUST_LOG=info so the creation line is emitted, and one log per racer so
+    # the count below cannot be confused by interleaved writes.
+    local index
+    for index in $(seq 1 8); do
         (
-            RUST_LOG=warn timeout --foreground 40 \
+            RUST_LOG=info timeout --foreground 40 \
                 facelock --config "$target/config.toml" daemon \
-                >>"$target/daemon.log" 2>&1 || true
+                >"$target/race-$index.log" 2>&1 || true
         ) &
     done
     wait
@@ -1357,12 +1523,24 @@ fault_concurrent_key_creation() {
     assert_eq 32 "$(stat -c %s "$target/encryption.key")" "concurrently created key size"
     assert_eq "600:0:0" "$(stat -c '%a:%u:%g' "$target/encryption.key")" \
         "concurrently created key metadata"
-    # Exactly one winner. O_EXCL is what makes that true: with O_TRUNC the last
-    # writer replaces the key the first one's rows were sealed under, and a
-    # reader in between gets a half-written key.
     keys="$(find "$target" -maxdepth 1 -name 'encryption.key*' | wc -l)"
     assert_eq 1 "$keys" "key artifacts after a concurrent creation race"
-    pass "concurrent key creation resolves to exactly one key"
+
+    # The assertion that actually separates O_EXCL from O_TRUNC. One key file on
+    # disk is true either way: with O_TRUNC every racer creates and writes,
+    # each overwriting the last, and the file count stays one. With O_EXCL
+    # exactly one racer creates it and the other seven are told AlreadyExists
+    # and read what the winner wrote, so exactly one of them logs the creation.
+    creators="$(cat "$target"/race-*.log | grep -c 'generated encryption key' || true)"
+    assert_eq 1 "$creators" "racers that created the key"
+
+    # And the winner's bytes are the bytes that survive: a later start must read
+    # the existing key, never replace it.
+    digest="$(sha256sum "$target/encryption.key" | cut -d' ' -f1)"
+    run_fault_daemon "$target" 20 >/dev/null
+    assert_eq "$digest" "$(sha256sum "$target/encryption.key" | cut -d' ' -f1)" \
+        "the existing key survived a later daemon start"
+    pass "concurrent key creation resolves to exactly one key, written once"
 }
 
 run_faults() {

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -345,7 +345,11 @@ seed_common_state() {
     stage_models
     printf '%s\n' upgrade-lane-payload >/var/lib/facelock/models/upgrade-lane.payload
     chmod 0644 /var/lib/facelock/models/upgrade-lane.payload
-    printf '%s\n' '{"models":1,"updated":"2026-01-01T00:00:00Z"}' \
+    # Deliberately stale: v0.1.4 shipped no enrollment markers, so an upgraded
+    # system's marker either does not exist or describes a database it has since
+    # diverged from. The candidate daemon reconciles it at startup (#137), and
+    # `assert_enrollment_marker_reconciled` is what proves it did.
+    printf '%s\n' '{"models":0,"updated":"2020-01-01T00:00:00Z"}' \
         >/var/lib/facelock/enrolled/testuser
     chown testuser:testuser /var/lib/facelock/enrolled/testuser
     chmod 0600 /var/lib/facelock/enrolled/testuser
@@ -499,7 +503,6 @@ snapshot_invariant_state() {
         /etc/facelock/encryption.key \
         /etc/facelock/encryption.key.sealed \
         /var/lib/facelock/models/upgrade-lane.payload \
-        /var/lib/facelock/enrolled/testuser \
         /var/lib/facelock/setup.complete \
         /var/log/facelock/audit.jsonl \
         /var/log/facelock/snapshots/upgrade-lane.jpg \
@@ -599,6 +602,74 @@ PY
     assert_eq "$KNOWN_EMBEDDING_SHA256" "$digest" \
         "known embedding plaintext recovered after the upgrade"
     rm -rf "$probe"
+}
+
+# The enrollment marker is the one piece of state an upgrade is *supposed* to
+# rewrite. `facelock is-enrolled` reads it, v0.1.4 never wrote one, and a marker
+# left describing a database it has diverged from answers "not enrolled" for a
+# user whose face authentication works (#137). So the contract is not byte
+# identity, which would happily preserve a marker that lies. It is that the
+# marker still exists, is still the user's own private file, and now agrees with
+# the database.
+assert_enrollment_marker_reconciled() {
+    local marker=/var/lib/facelock/enrolled/testuser expected
+    expected="$(sqlite_query "SELECT COUNT(*) FROM face_models WHERE user = 'testuser'")"
+    python3 - "$marker" "$(id -u testuser)" "$(id -g testuser)" "$expected" <<'MARKER_PY'
+import datetime
+import json
+import os
+import stat
+import sys
+
+path, expected_uid, expected_gid, expected_models = (
+    sys.argv[1],
+    int(sys.argv[2]),
+    int(sys.argv[3]),
+    int(sys.argv[4]),
+)
+
+descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+try:
+    info = os.fstat(descriptor)
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        raise SystemExit(f"enrollment marker is not a single-link regular file: {path}")
+    if stat.S_IMODE(info.st_mode) != 0o600:
+        raise SystemExit(
+            f"enrollment marker mode is {stat.S_IMODE(info.st_mode):o}, expected 600"
+        )
+    if (info.st_uid, info.st_gid) != (expected_uid, expected_gid):
+        raise SystemExit(
+            f"enrollment marker owner is {info.st_uid}:{info.st_gid}, "
+            f"expected {expected_uid}:{expected_gid}"
+        )
+    with os.fdopen(descriptor, encoding="utf-8") as handle:
+        descriptor = -1
+        marker = json.load(handle)
+finally:
+    if descriptor >= 0:
+        os.close(descriptor)
+
+if set(marker) != {"models", "updated"}:
+    raise SystemExit(f"enrollment marker has unexpected fields: {sorted(marker)!r}")
+if type(marker["models"]) is not int or marker["models"] != expected_models:
+    raise SystemExit(
+        f"enrollment marker says {marker['models']!r} models, "
+        f"the database holds {expected_models}"
+    )
+updated = marker["updated"]
+try:
+    parsed = datetime.datetime.fromisoformat(str(updated).replace("Z", "+00:00"))
+except (TypeError, ValueError) as error:
+    raise SystemExit(f"enrollment marker timestamp is invalid: {updated!r}") from error
+if parsed.tzinfo is None:
+    raise SystemExit(f"enrollment marker timestamp has no timezone: {updated!r}")
+# The fixture is stamped 2020; anything at or before that means nothing
+# reconciled it and the assertion above passed only by luck.
+if parsed <= datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc):
+    raise SystemExit(
+        f"enrollment marker was never reconciled: still stamped {updated!r}"
+    )
+MARKER_PY
 }
 
 assert_key_artifacts_preserved() {
@@ -797,6 +868,7 @@ run_shape() {
 
     assert_schema_v6_with_null_device_id
     assert_known_embedding_decrypts "$shape"
+    assert_enrollment_marker_reconciled
     assert_key_artifacts_preserved "$STATE_ROOT/$shape.before"
     assert_adr010_modes
     assert_pam_path_intact "$STATE_ROOT/$shape.before"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -174,6 +174,15 @@ ensure_system_bus() {
 # daemon. A foreground `facelock daemon` started afterwards cannot claim
 # org.facelock.Daemon and exits non-zero -- which reads exactly like the daemon
 # refusing to serve, and is not.
+# The candidate refuses to be uninstalled while a PAM service still references
+# pam_facelock.so, so the reference goes first. The predecessor has no such
+# guard, which is why the Debian half never needed this: after a rollback it is
+# always v0.1.4 that gets removed.
+remove_installed_package() {
+    rm -f "$PAM_PATH"
+    pkg_remove
+}
+
 stop_packaged_daemon() {
     [ -d /run/systemd/system ] || return 0
     systemctl stop facelock-daemon.service >>"$LOG" 2>&1 || true
@@ -918,7 +927,7 @@ run_shape() {
     case_name="$shape"
     log "$FAMILY upgrade shape: $shape"
 
-    if pkg_is_installed; then pkg_remove; fi
+    if pkg_is_installed; then remove_installed_package; fi
     wipe_state
     pkg_install "$PREDECESSOR" || fail "the pinned predecessor did not install"
     ensure_system_bus
@@ -1344,7 +1353,7 @@ done
 # The faults run against the candidate, so install it once more and leave it in
 # place: a fault case is about the candidate's migration, not the predecessor's.
 case_name="fault-setup"
-if pkg_is_installed; then pkg_remove; fi
+if pkg_is_installed; then remove_installed_package; fi
 wipe_state
 pkg_install "$CANDIDATE" || fail "the candidate did not install for the fault matrix"
 ensure_system_bus

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -917,6 +917,7 @@ assert_key_refusal() {
     # get them back. Pinning the opening clause made this red on wording when
     # the message was reworded, while a daemon that logged the opening and
     # nothing else would have passed.
+    # shellcheck disable=SC2015 # deliberate: either grep failing takes the block
     grep -qE 'row\(s\) are (software-encrypted|TPM-sealed)' "$output" &&
         grep -qF 'facelock clear' "$output" || {
         tail -20 "$output" >&2

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -595,9 +595,25 @@ snapshot_invariant_state() {
         "$PAM_PATH"; do
         snapshot_file "$path"
     done
-    find /var/lib/facelock/models -maxdepth 1 -type f -printf 'model|%f|%s|%m\n' |
-        LC_ALL=C sort
+    snapshot_model_files
     snapshot_rows
+}
+
+# Model files by content, not just name/size/mode. Size and mode alone let an
+# upgrade that rewrites a model file at the same size and permissions pass the
+# "preserve models" check without ever proving the bytes didn't change; the
+# sha256 closes that gap the same way snapshot_file does for the other
+# invariant files.
+snapshot_model_files() {
+    local name mpath
+    while IFS= read -r name; do
+        mpath="/var/lib/facelock/models/$name"
+        printf 'model|%s|%s|%s|%s\n' \
+            "$name" \
+            "$(LC_ALL=C stat -c '%s' -- "$mpath")" \
+            "$(LC_ALL=C stat -c '%a' -- "$mpath")" \
+            "$(sha256sum -- "$mpath" | cut -d' ' -f1)"
+    done < <(find /var/lib/facelock/models -maxdepth 1 -type f -printf '%f\n' | LC_ALL=C sort)
 }
 
 # Row identity by content, not by file digest: the database file legitimately

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -157,6 +157,28 @@ case "$FAMILY" in
         ;;
 esac
 
+# The bus the daemon needs, and the daemon that would otherwise be holding it.
+#
+# dbus arrives as a dependency of the facelock transaction, so its socket unit
+# was never started at boot and /run/dbus/system_bus_socket does not exist until
+# something starts it. deb-package-lifecycle.sh's assert_system_bus_available
+# does the same thing for the same reason.
+ensure_system_bus() {
+    [ -d /run/systemd/system ] || return 0
+    systemctl start dbus.socket >>"$LOG" 2>&1 || true
+    [ -S /run/dbus/system_bus_socket ] ||
+        fail "system bus socket is missing after a package transaction"
+}
+
+# pamtester reaches pam_facelock.so, which can D-Bus-activate the packaged
+# daemon. A foreground `facelock daemon` started afterwards cannot claim
+# org.facelock.Daemon and exits non-zero -- which reads exactly like the daemon
+# refusing to serve, and is not.
+stop_packaged_daemon() {
+    [ -d /run/systemd/system ] || return 0
+    systemctl stop facelock-daemon.service >>"$LOG" 2>&1 || true
+}
+
 # --- pinned-artifact preconditions ----------------------------------------
 
 assert_pinned_artifacts() {
@@ -719,6 +741,7 @@ assert_no_replacement_key_over_encrypted_state() {
         *) return 0 ;;
     esac
     local saved="$STATE_ROOT/key.saved" output=/tmp/facelock-replacement-key.log status=0
+    stop_packaged_daemon
     cp /etc/facelock/encryption.key "$saved"
     rm -f /etc/facelock/encryption.key
 
@@ -834,6 +857,7 @@ assert_real_password_behavior() {
 # written to". So the daemon runs for real before the downgrade.
 open_database_with_candidate_daemon() {
     local output=/tmp/facelock-candidate-daemon.log pid
+    stop_packaged_daemon
     RUST_LOG=warn facelock daemon >"$output" 2>&1 &
     pid=$!
     for _ in $(seq 1 120); do
@@ -856,6 +880,7 @@ assert_downgrade_usable() {
         fail "the package manager refused to downgrade to the pinned predecessor"
     assert_eq "$(cat "$PREDECESSOR_VERSION_FILE")" "$(pkg_installed_version)" \
         "installed version after downgrade"
+    ensure_system_bus
 
     # V6 has no down-migration. The predecessor must still open the database
     # the candidate migrated and count its rows. `tpm status` is the readback
@@ -896,6 +921,7 @@ run_shape() {
     if pkg_is_installed; then pkg_remove; fi
     wipe_state
     pkg_install "$PREDECESSOR" || fail "the pinned predecessor did not install"
+    ensure_system_bus
     assert_eq "$(cat "$PREDECESSOR_VERSION_FILE")" "$(pkg_installed_version)" \
         "installed predecessor version"
 
@@ -907,6 +933,7 @@ run_shape() {
     pkg_upgrade "$CANDIDATE" || fail "the native upgrade to the candidate failed"
     assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_installed_version)" \
         "installed candidate version after upgrade"
+    ensure_system_bus
     assert_swtpm_state_untouched
 
     open_database_with_candidate_daemon
@@ -1019,6 +1046,7 @@ EOF
 # and `$target/daemon.log` says which.
 run_fault_daemon() {
     local target="$1" seconds="${2:-30}" status=0
+    stop_packaged_daemon
     RUST_LOG="${RUST_LOG:-warn}" timeout --foreground "$seconds" \
         facelock --config "$target/config.toml" daemon \
         >"$target/daemon.log" 2>&1 || status=$?
@@ -1246,6 +1274,7 @@ fault_concurrent_key_creation() {
     # A plaintext-only legacy database with no key artifact: the one state where
     # creating the default key is allowed at all.
     [ ! -e "$target/encryption.key" ] || fail "the concurrent fixture already has a key"
+    stop_packaged_daemon
 
     for _ in $(seq 1 8); do
         (
@@ -1302,6 +1331,8 @@ case_name="fault-setup"
 if pkg_is_installed; then pkg_remove; fi
 wipe_state
 pkg_install "$CANDIDATE" || fail "the candidate did not install for the fault matrix"
+ensure_system_bus
+stop_packaged_daemon
 install -d -m0755 /var/lib/facelock/models
 if [ -d /facelock-test-models ]; then
     for model in /facelock-test-models/*.onnx; do

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -892,13 +892,17 @@ assert_key_refusal() {
         install -m0600 "$saved" /etc/facelock/encryption.key
         fail "the daemon stopped serving on a $variant key (exit $status)"
     }
-    # Matches the refusal, not one release's phrasing of it. The security
-    # review that owns this message has already moved it once, from "refusing
-    # to write a replacement key" to "refusing to write an encryption key at
-    # <path>", and this lane is stacked under that work. Pinning the sentence
-    # would make the harness red on wording; requiring the daemon to say it is
-    # refusing to write or mint a key keeps the assertion.
-    grep -qiE 'refus[a-z]* to (write|mint)[^.]*key|could not be created/read' "$output" || {
+    # Assert what the message has to *contain*, not how it opens. The two
+    # variants reach the operator by different routes -- a missing key raises
+    # "refusing to write an encryption key at <path>", a malformed one raises
+    # "keyfile could not be read: ... must be exactly 32 bytes, got 9" -- but
+    # both carry the same tail from `key_policy::encrypted_rows_at_risk`, and
+    # that tail is the actual contract: say which rows are at risk and how to
+    # get them back. Pinning the opening clause made this red on wording when
+    # the message was reworded, while a daemon that logged the opening and
+    # nothing else would have passed.
+    grep -qE 'row\(s\) are (software-encrypted|TPM-sealed)' "$output" &&
+        grep -qF 'facelock clear' "$output" || {
         tail -20 "$output" >&2
         install -m0600 "$saved" /etc/facelock/encryption.key
         fail "the daemon did not report the $variant key over encrypted rows"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -1,0 +1,1168 @@
+#!/usr/bin/env bash
+# Released-predecessor upgrade and rollback proof (#231, Track K).
+#
+# Runs inside a booted container that already holds two artifacts:
+#
+#   /artifacts/facelock-predecessor.<ext>  the real published v0.1.4 asset,
+#                                          pinned by asset id + SHA256 in
+#                                          dist/release-matrix.json
+#   /artifacts/facelock-candidate.<ext>    the locally built candidate
+#
+# Predecessor state is built with the **released** binary, not with this
+# checkout's: the question is whether what v0.1.4 actually wrote survives, and
+# a fixture written by the candidate would only prove the candidate agrees with
+# itself. Every encrypted shape is encrypted by the 0.1.4 binary under a key
+# 0.1.4 generated (or sealed, against a software TPM).
+#
+# What each shape proves after a native package-manager upgrade:
+#   * the V5 database migrated to V6 and legacy rows carry device_id = NULL
+#   * a **known embedding still decrypts** — the plaintext bytes are compared,
+#     not the file hash, because a file hash cannot tell a preserved key from a
+#     preserved ciphertext nobody can open any more
+#   * no key artifact was replaced, and none appeared that did not exist before
+#   * modes converged to ADR 010 without touching content
+#   * the pre-existing PAM path is byte-identical and still authenticates, with
+#     a real correct password succeeding and a real wrong password failing
+#
+# Then the candidate is downgraded back to v0.1.4 — after the candidate daemon
+# has opened and migrated the database — and the released binary has to still
+# read its own encrypted rows. V6 has no down-migration, so this is the only
+# thing that says whether shipping the alpha strands a rollback.
+set -euo pipefail
+
+FAMILY="${1:-}"
+case "$FAMILY" in
+    deb) EXT=deb ;;
+    rpm) EXT=rpm ;;
+    *)
+        echo "usage: upgrade-v014-lane.sh <deb|rpm>" >&2
+        exit 2
+        ;;
+esac
+
+PREDECESSOR="/artifacts/facelock-predecessor.$EXT"
+CANDIDATE="/artifacts/facelock-candidate.$EXT"
+PREDECESSOR_SHA256_FILE=/artifacts/predecessor.sha256
+PREDECESSOR_VERSION_FILE=/artifacts/predecessor.version
+CANDIDATE_VERSION_FILE=/artifacts/candidate.version
+
+STATE_ROOT=/run/facelock-upgrade-v014
+LOG=/tmp/facelock-upgrade-v014.log
+PAM_SERVICE=facelock-upgrade-v014
+PAM_PATH="/etc/pam.d/$PAM_SERVICE"
+PASSWORD_USER=testuser
+CORRECT_PASSWORD="test"
+WRONG_PASSWORD=definitely-not-the-password
+TCTI="swtpm:host=127.0.0.1,port=2321"
+
+# The embedding every shape enrolls, as `struct.pack("<512f", (i+1)/512)`.
+# Same fixture the Debian lifecycle gate uses, so one pinned digest describes
+# the known plaintext in both places.
+KNOWN_EMBEDDING_SHA256=82a0081de4c338fc91c362ed4d2ab615bca1dd45152aaa713322b5482078ddee
+
+# Every state shape this lane builds with the released binary. A shape added
+# here without a `seed_shape_*` function fails immediately rather than being
+# skipped, and test/upgrade-v014-contract.sh holds this list against the
+# functions that implement it.
+SHAPES=(plaintext keyfile mixed tpm-pcr-unbound tpm-pcr-bound)
+
+# Every fault the migration has to survive without resetting or recreating the
+# database. Same rule: named here, implemented as `fault_*`, checked by the
+# contract gate.
+FAULTS=(disk-full interrupted corrupt-database concurrent-key-creation)
+
+case_name=init
+
+log() {
+    printf '\n=== %s ===\n' "$*"
+}
+
+fail() {
+    echo "FAIL [$FAMILY $case_name]: $*" >&2
+    if [ -s "$LOG" ]; then
+        echo "--- last 40 lines of package manager output ---" >&2
+        tail -40 "$LOG" >&2
+    fi
+    exit 1
+}
+
+pass() {
+    printf 'TEST: %s upgrade %s ... PASS\n' "$FAMILY" "$1"
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" label="$3"
+    [ "$actual" = "$expected" ] ||
+        fail "$label: expected '$expected', got '$actual'"
+}
+
+# --- package manager, per family ------------------------------------------
+
+case "$FAMILY" in
+    deb)
+        pkg_install() { apt-get install -y --no-install-recommends "$1" >>"$LOG" 2>&1; }
+        pkg_upgrade() { apt-get install -y --no-install-recommends "$1" >>"$LOG" 2>&1; }
+        pkg_downgrade() {
+            apt-get install -y --no-install-recommends --allow-downgrades "$1" >>"$LOG" 2>&1
+        }
+        pkg_remove() { apt-get remove -y facelock >>"$LOG" 2>&1; }
+        pkg_installed_version() { dpkg-query -W -f='${Version}' facelock 2>/dev/null; }
+        pkg_is_installed() { [ "$(dpkg-query -W -f='${Status}' facelock 2>/dev/null)" = "install ok installed" ]; }
+        pkg_version_gt() { dpkg --compare-versions "$1" gt "$2"; }
+        pkg_file_version() { dpkg-deb --field "$1" Version; }
+        ;;
+    rpm)
+        pkg_install() { dnf install -y "$1" >>"$LOG" 2>&1; }
+        pkg_upgrade() { dnf upgrade -y "$1" >>"$LOG" 2>&1; }
+        pkg_downgrade() { dnf downgrade -y "$1" >>"$LOG" 2>&1; }
+        pkg_remove() { dnf remove -y facelock >>"$LOG" 2>&1; }
+        pkg_installed_version() { rpm -q --qf '%{VERSION}-%{RELEASE}' facelock 2>/dev/null; }
+        pkg_is_installed() { rpm -q facelock >/dev/null 2>&1; }
+        pkg_version_gt() {
+            # rpmdev-vercmp exits 11 when the first argument is newer.
+            local status=0
+            rpmdev-vercmp "$1" "$2" >/dev/null 2>&1 || status=$?
+            [ "$status" -eq 11 ]
+        }
+        pkg_file_version() { rpm -qp --qf '%{VERSION}-%{RELEASE}' "$1" 2>/dev/null; }
+        ;;
+esac
+
+# --- pinned-artifact preconditions ----------------------------------------
+
+assert_pinned_artifacts() {
+    case_name=pinned-artifacts
+    local expected_digest actual_digest expected_version
+
+    for artifact in "$PREDECESSOR" "$CANDIDATE"; do
+        [ -f "$artifact" ] && [ ! -L "$artifact" ] ||
+            fail "lane artifact missing or not a regular file: $artifact"
+    done
+
+    # Re-check the digest at run time, not only at image build time. The image
+    # layer that fetched it and the container that installs it are different
+    # moments, and only the second one is the thing under test.
+    expected_digest="$(cat "$PREDECESSOR_SHA256_FILE")"
+    actual_digest="$(sha256sum "$PREDECESSOR" | cut -d' ' -f1)"
+    assert_eq "$expected_digest" "$actual_digest" "pinned predecessor SHA256"
+
+    expected_version="$(cat "$PREDECESSOR_VERSION_FILE")"
+    assert_eq "$expected_version" "$(pkg_file_version "$PREDECESSOR")" \
+        "pinned predecessor package version"
+    assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_file_version "$CANDIDATE")" \
+        "candidate package version"
+
+    # An upgrade lane that is secretly a downgrade proves nothing. The native
+    # comparator decides, not string order.
+    pkg_version_gt "$(pkg_file_version "$CANDIDATE")" "$(pkg_file_version "$PREDECESSOR")" ||
+        fail "candidate $(pkg_file_version "$CANDIDATE") does not sort above predecessor $(pkg_file_version "$PREDECESSOR")"
+    pass "pinned predecessor and a strictly newer candidate"
+}
+
+# --- software TPM ----------------------------------------------------------
+
+start_swtpm() {
+    case_name=swtpm
+    export TPM2TOOLS_TCTI="$TCTI"
+    mkdir -p /tmp/swtpm
+    swtpm socket --tpm2 \
+        --server type=tcp,port=2321 \
+        --ctrl type=tcp,port=2322 \
+        --tpmstate dir=/tmp/swtpm \
+        --flags startup-clear \
+        --daemon
+    local started=0
+    for _ in $(seq 1 30); do
+        if tpm2_pcrread sha256:16 >/dev/null 2>&1; then
+            started=1
+            break
+        fi
+        tpm2_startup -c >/dev/null 2>&1 || true
+        sleep 0.3
+    done
+    [ "$started" = 1 ] || fail "swtpm not reachable via $TCTI"
+}
+
+# The TPM's own state plus the PCR bank the bound shape seals against. swtpm
+# rewrites its state file on its own schedule, so this is only ever compared
+# across a single package transaction: recorded immediately before, checked
+# immediately after. That window is exactly what Track K task 12 forbids a
+# maintainer script from touching.
+swtpm_state_digest() {
+    {
+        find /tmp/swtpm -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum
+        tpm2_pcrread sha256:16 2>/dev/null || echo "pcr-unreadable"
+    } | sha256sum | cut -d' ' -f1
+}
+
+record_swtpm_state() {
+    swtpm_state_digest >"$STATE_ROOT/swtpm.before"
+}
+
+assert_swtpm_state_untouched() {
+    assert_eq "$(cat "$STATE_ROOT/swtpm.before")" "$(swtpm_state_digest)" \
+        "software TPM state and PCR 16 across the package transaction"
+}
+
+# --- state fixtures, written by the RELEASED binary ------------------------
+
+write_config() {
+    local shape="$1" method="${2:-}"
+    [ -n "$method" ] || method="$(config_method "$shape")"
+    install -d -m0755 /etc/facelock
+    cat >/etc/facelock/config.toml <<EOF
+[storage]
+db_path = "/var/lib/facelock/facelock.db"
+
+[daemon]
+model_dir = "/var/lib/facelock/models"
+
+[device]
+path = "/dev/video0"
+
+[encryption]
+method = "$method"
+key_path = "/etc/facelock/encryption.key"
+sealed_key_path = "/etc/facelock/encryption.key.sealed"
+
+[tpm]
+pcr_binding = $(config_pcr_binding "$shape")
+pcr_indices = [16]
+tcti = "$TCTI"
+
+[security]
+allow_plaintext = true
+EOF
+    chmod 0644 /etc/facelock/config.toml
+}
+
+config_method() {
+    case "$1" in
+        plaintext) echo none ;;
+        keyfile | mixed) echo keyfile ;;
+        tpm-pcr-unbound | tpm-pcr-bound) echo keyfile ;;
+        *) fail "no encryption method for shape: $1" ;;
+    esac
+}
+
+config_pcr_binding() {
+    case "$1" in
+        tpm-pcr-bound) echo true ;;
+        *) echo false ;;
+    esac
+}
+
+# Three embeddings per model, matching what a real enrollment writes since the
+# store floor landed. The first is the known fixture whose plaintext this lane
+# compares after the upgrade; the other two exist so the row count is what a
+# 0.1.4 enrollment would actually have left behind.
+insert_plaintext_rows() {
+    local label="$1"
+    python3 - "$label" <<'PY'
+import sqlite3
+import struct
+import sys
+
+label = sys.argv[1]
+connection = sqlite3.connect("/var/lib/facelock/facelock.db")
+connection.execute("PRAGMA journal_mode=WAL")
+connection.execute(
+    "INSERT INTO face_models (user, label, created_at, embedder_model) "
+    "VALUES (?, ?, ?, ?)",
+    ("testuser", label, 1700000000, "arcface"),
+)
+model_id = connection.execute(
+    "SELECT id FROM face_models WHERE user = ? AND label = ?",
+    ("testuser", label),
+).fetchone()[0]
+known = struct.pack("<512f", *((index + 1) / 512 for index in range(512)))
+for offset in range(3):
+    blob = known if offset == 0 else struct.pack(
+        "<512f", *((index + 1 + offset) / 512 for index in range(512))
+    )
+    connection.execute(
+        "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (?, ?, 0)",
+        (model_id, blob),
+    )
+connection.commit()
+connection.close()
+PY
+}
+
+released_facelock() {
+    facelock "$@"
+}
+
+# The daemon loads models at startup, so the shape phases need the real ones.
+# The lane runner stages them read-only at /facelock-test-models; a lane without
+# them cannot open the database with the candidate daemon and says so rather
+# than quietly proving less.
+stage_models() {
+    local model staged=0
+    for model in /facelock-test-models/*.onnx; do
+        [ -f "$model" ] || continue
+        install -m0644 "$model" /var/lib/facelock/models/
+        staged=$((staged + 1))
+    done
+    [ "$staged" -gt 0 ] ||
+        fail "no reviewed ONNX models staged at /facelock-test-models"
+}
+
+seed_common_state() {
+    install -d -m0711 /var/lib/facelock
+    install -d -m0755 /var/lib/facelock/models
+    install -d -m0711 /var/lib/facelock/enrolled
+    install -d -m0700 /var/lib/facelock/pam-backups /var/log/facelock
+    install -d -m0700 /var/log/facelock/snapshots
+
+    # The reviewed models the candidate daemon has to load, plus a payload of
+    # this lane's own: an upgrade has no business touching either, and both
+    # historically got moved or re-owned. The payload is deliberately not an
+    # .onnx, so a stray file never reaches the engine's model discovery.
+    stage_models
+    printf '%s\n' upgrade-lane-payload >/var/lib/facelock/models/upgrade-lane.payload
+    chmod 0644 /var/lib/facelock/models/upgrade-lane.payload
+    printf '%s\n' '{"models":1,"updated":"2026-01-01T00:00:00Z"}' \
+        >/var/lib/facelock/enrolled/testuser
+    chown testuser:testuser /var/lib/facelock/enrolled/testuser
+    chmod 0600 /var/lib/facelock/enrolled/testuser
+    printf '%s\n' complete >/var/lib/facelock/setup.complete
+    chmod 0600 /var/lib/facelock/setup.complete
+    printf '%s\n' '{"event":"auth","user":"testuser"}' >/var/log/facelock/audit.jsonl
+    chmod 0600 /var/log/facelock/audit.jsonl
+    printf '%s\n' snapshot >/var/log/facelock/snapshots/upgrade-lane.jpg
+    chmod 0600 /var/log/facelock/snapshots/upgrade-lane.jpg
+
+    # The PAM path an 0.1.4 administrator would have wired by hand: v0.1.4 has
+    # no `facelock pam` subcommand, so this is the shape the upgrade actually
+    # finds on a real system.
+    install -Dm0644 /dev/stdin "$PAM_PATH" <<EOF
+#%PAM-1.0
+auth      sufficient pam_facelock.so
+auth      required   pam_unix.so
+account   required   pam_unix.so
+EOF
+}
+
+# The released binary creates and migrates its own database. Nothing here uses
+# a candidate command: `facelock` on PATH is v0.1.4 for the whole seed phase.
+#
+# v0.1.4 has exactly one subcommand that opens the store read-write and runs
+# migrations without a camera: `facelock encrypt`. `list` is a D-Bus call to the
+# daemon and `tpm status` opens read-only, so neither creates a schema. Every
+# shape therefore bootstraps its database through the keyfile path and then
+# becomes whatever shape it is.
+seed_released_database() {
+    released_facelock encrypt --generate-key >>"$LOG" 2>&1 ||
+        fail "the released binary could not generate its encryption key"
+    released_facelock encrypt >>"$LOG" 2>&1 ||
+        fail "the released binary could not create and migrate its database"
+    [ -f /var/lib/facelock/facelock.db ] ||
+        fail "the released binary did not create its database"
+    assert_eq 5 "$(schema_version)" "schema version written by the released binary"
+}
+
+seed_shape_plaintext() {
+    # A legacy plaintext install: no key artifact at all, which is the one state
+    # the candidate is allowed to create a default key for.
+    rm -f /etc/facelock/encryption.key
+    write_config plaintext
+    insert_plaintext_rows plaintext
+    assert_eq "0|3" "$(sealed_counts)" "plaintext shape row encryption"
+}
+
+seed_shape_keyfile() {
+    insert_plaintext_rows keyfile
+    released_facelock encrypt >>"$LOG" 2>&1 ||
+        fail "the released binary could not encrypt its rows"
+    assert_eq "3|0" "$(sealed_counts)" "keyfile shape row encryption"
+}
+
+seed_shape_mixed() {
+    insert_plaintext_rows encrypted-half
+    released_facelock encrypt >>"$LOG" 2>&1 ||
+        fail "the released binary could not encrypt its rows"
+    # A second enrollment that never went through `encrypt`: the mixed database
+    # a user gets by enrolling again after turning encryption on.
+    insert_plaintext_rows plaintext-half
+    assert_eq "3|3" "$(sealed_counts)" "mixed shape row encryption"
+}
+
+seed_shape_tpm_common() {
+    released_facelock tpm seal-key >>"$LOG" 2>&1 ||
+        fail "the released binary could not seal its key against swtpm"
+    [ -s /etc/facelock/encryption.key.sealed ] ||
+        fail "sealing produced no sealed key artifact"
+    # `tpm seal-key` flips the configured method; make sure it did, because a
+    # shape that stayed on the plaintext keyfile would prove the wrong thing.
+    grep -Eq '^[[:space:]]*method[[:space:]]*=[[:space:]]*"tpm"' /etc/facelock/config.toml ||
+        fail "sealing did not move the configured encryption method to tpm"
+    insert_plaintext_rows tpm
+    released_facelock encrypt >>"$LOG" 2>&1 ||
+        fail "the released binary could not encrypt rows under the sealed key"
+    assert_eq "3|0" "$(sealed_counts)" "TPM shape row encryption"
+}
+
+seed_shape_tpm_pcr_unbound() { seed_shape_tpm_common; }
+seed_shape_tpm_pcr_bound() { seed_shape_tpm_common; }
+
+seed_shape() {
+    local shape="$1"
+    # Bootstrap on the keyfile path whatever the shape, because that is the only
+    # released code path that will create the schema. `write_config` keeps the
+    # shape's own PCR selection from the first byte, so a bound shape seals
+    # under the PCRs it is meant to.
+    write_config "$shape" keyfile
+    seed_common_state
+    seed_released_database
+    case "$shape" in
+        plaintext) seed_shape_plaintext ;;
+        keyfile) seed_shape_keyfile ;;
+        mixed) seed_shape_mixed ;;
+        tpm-pcr-unbound) seed_shape_tpm_pcr_unbound ;;
+        tpm-pcr-bound) seed_shape_tpm_pcr_bound ;;
+        *) fail "no seed function for declared shape: $shape" ;;
+    esac
+    # An administrator edit, added last so a released command that rewrites the
+    # config cannot erase the thing the upgrade has to preserve.
+    printf '\n# facelock upgrade-lane administrator marker (%s)\n' "$shape" \
+        >>/etc/facelock/config.toml
+}
+
+# --- database inspection ---------------------------------------------------
+
+schema_version() {
+    sqlite_query "SELECT COALESCE(MAX(version), 0) FROM schema_version"
+}
+
+sealed_counts() {
+    sqlite_query \
+        "SELECT (SELECT COUNT(*) FROM face_embeddings WHERE sealed != 0) || '|' || \
+                (SELECT COUNT(*) FROM face_embeddings WHERE sealed = 0)"
+}
+
+sqlite_query() {
+    python3 - "$1" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect("file:/var/lib/facelock/facelock.db?mode=ro", uri=True)
+print(connection.execute(sys.argv[1]).fetchone()[0])
+connection.close()
+PY
+}
+
+# --- snapshots -------------------------------------------------------------
+
+snapshot_file() {
+    local path="$1"
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+        printf 'absent|%s\n' "$path"
+        return
+    fi
+    [ -f "$path" ] && [ ! -L "$path" ] || fail "not a regular file: $path"
+    LC_ALL=C stat -c 'file|%n|%a|%u|%g|%s' -- "$path"
+    sha256sum -- "$path"
+}
+
+# Everything an upgrade must leave byte-identical. Deliberately excludes the
+# schema version and the device_id column: those are what the migration is for,
+# and asserting them separately keeps "changed as designed" from hiding inside
+# "changed".
+snapshot_invariant_state() {
+    local path
+    for path in \
+        /etc/facelock/config.toml \
+        /etc/facelock/encryption.key \
+        /etc/facelock/encryption.key.sealed \
+        /var/lib/facelock/models/upgrade-lane.payload \
+        /var/lib/facelock/enrolled/testuser \
+        /var/lib/facelock/setup.complete \
+        /var/log/facelock/audit.jsonl \
+        /var/log/facelock/snapshots/upgrade-lane.jpg \
+        "$PAM_PATH"; do
+        snapshot_file "$path"
+    done
+    find /var/lib/facelock/models -maxdepth 1 -type f -printf 'model|%f|%s|%m\n' |
+        LC_ALL=C sort
+    snapshot_rows
+}
+
+# Row identity by content, not by file digest: the database file legitimately
+# changes across a migration, so comparing it byte for byte would either fail
+# always or be relaxed into proving nothing.
+snapshot_rows() {
+    python3 - <<'PY'
+import hashlib
+import sqlite3
+
+connection = sqlite3.connect("file:/var/lib/facelock/facelock.db?mode=ro", uri=True)
+rows = connection.execute(
+    "SELECT fm.user, fm.label, fm.created_at, fm.embedder_model, fe.embedding, fe.sealed "
+    "FROM face_models AS fm JOIN face_embeddings AS fe ON fe.model_id = fm.id "
+    "ORDER BY fm.label, fe.id"
+).fetchall()
+connection.close()
+if not rows:
+    raise SystemExit("snapshot found no enrollment rows")
+for user, label, created_at, embedder, blob, sealed in rows:
+    print(
+        f"row|{user}|{label}|{created_at}|{embedder}|{sealed}|"
+        f"{len(blob)}|{hashlib.sha256(blob).hexdigest()}"
+    )
+PY
+}
+
+# --- post-upgrade proofs ---------------------------------------------------
+
+assert_schema_v6_with_null_device_id() {
+    assert_eq 6 "$(schema_version)" "schema version after the candidate opened the database"
+    local columns
+    columns="$(python3 - <<'PY'
+import sqlite3
+
+connection = sqlite3.connect("file:/var/lib/facelock/facelock.db?mode=ro", uri=True)
+print(
+    ",".join(row[1] for row in connection.execute("PRAGMA table_info(face_models)"))
+)
+connection.close()
+PY
+)"
+    case ",$columns," in
+        *,device_id,*) ;;
+        *) fail "V6 migration did not add face_models.device_id (columns: $columns)" ;;
+    esac
+    # Legacy rows must stay uncoupled. A migration that invented a device id
+    # would bind every existing template to whatever camera happened to be
+    # plugged in during the upgrade.
+    assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE device_id IS NOT NULL')" \
+        "legacy rows left with a non-NULL device_id"
+}
+
+# The proof a file hash cannot give: take the blob the released binary wrote,
+# decrypt it with the candidate and the preserved key, and compare the
+# plaintext to the digest this lane pinned before any of it was encrypted.
+assert_known_embedding_decrypts() {
+    local shape="$1" probe=/tmp/facelock-decrypt-probe
+    rm -rf "$probe"
+    install -d -m0700 "$probe"
+    cp /var/lib/facelock/facelock.db "$probe/probe.db"
+    sed "s|^db_path = .*|db_path = \"$probe/probe.db\"|" \
+        /etc/facelock/config.toml >"$probe/config.toml"
+
+    if [ "$shape" != plaintext ]; then
+        facelock --config "$probe/config.toml" tpm decrypt >>"$LOG" 2>&1 ||
+            fail "the candidate could not decrypt rows the released binary encrypted"
+    fi
+
+    local digest
+    digest="$(python3 - "$probe/probe.db" <<'PY'
+import hashlib
+import sqlite3
+import sys
+
+connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+blobs = [
+    row[0]
+    for row in connection.execute(
+        "SELECT fe.embedding FROM face_embeddings AS fe "
+        "JOIN face_models AS fm ON fm.id = fe.model_id ORDER BY fm.label, fe.id"
+    )
+]
+connection.close()
+print(next((hashlib.sha256(b).hexdigest() for b in blobs if len(b) == 2048), "none"))
+PY
+)"
+    assert_eq "$KNOWN_EMBEDDING_SHA256" "$digest" \
+        "known embedding plaintext recovered after the upgrade"
+    rm -rf "$probe"
+}
+
+assert_key_artifacts_preserved() {
+    local before="$1" path
+    # Nothing appeared that was not there before. A replacement key written
+    # beside the real one is the failure this catches.
+    for path in /etc/facelock/encryption.key /etc/facelock/encryption.key.sealed; do
+        if grep -Fq "absent|$path" "$before" && [ -e "$path" ]; then
+            fail "the upgrade created a key artifact that did not exist before: $path"
+        fi
+    done
+}
+
+# The candidate must refuse to write a replacement key when encrypted rows are
+# present and the key artifact is gone — the upgrade-day failure that turns a
+# recoverable backup restore into permanent loss.
+assert_no_replacement_key_over_encrypted_state() {
+    local shape="$1"
+    case "$shape" in
+        keyfile | mixed) ;;
+        *) return 0 ;;
+    esac
+    local saved="$STATE_ROOT/key.saved" output=/tmp/facelock-replacement-key.log status=0
+    cp /etc/facelock/encryption.key "$saved"
+    rm -f /etc/facelock/encryption.key
+
+    # The daemon must keep running: refusing to write a key must not turn an
+    # authentication that already falls through to password into a lockout.
+    # Exit 124 is the timeout firing on a daemon that is still up.
+    RUST_LOG=warn timeout --foreground 30 facelock daemon >"$output" 2>&1 || status=$?
+    if [ -e /etc/facelock/encryption.key ]; then
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the candidate wrote a replacement key over encrypted rows"
+    fi
+    [ "$status" = 124 ] || {
+        tail -20 "$output" >&2
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the daemon stopped serving when its key went missing (exit $status)"
+    }
+    grep -qi 'refusing to write a replacement key' "$output" || {
+        tail -20 "$output" >&2
+        install -m0600 "$saved" /etc/facelock/encryption.key
+        fail "the refusal did not name the missing key over encrypted rows"
+    }
+
+    install -m0600 "$saved" /etc/facelock/encryption.key
+    rm -f "$saved"
+}
+
+# ADR 010 modes. The packaged scriptlets tighten these on an upgrade from a
+# release that predates the layout; content must be untouched while they do.
+assert_adr010_modes() {
+    local expected path
+    while read -r expected path; do
+        [ -e "$path" ] || continue
+        assert_eq "$expected" "$(stat -c '%a:%u:%g' "$path")" "ADR 010 metadata for $path"
+    done <<'EOF'
+711:0:0 /var/lib/facelock
+755:0:0 /var/lib/facelock/models
+711:0:0 /var/lib/facelock/enrolled
+700:0:0 /var/lib/facelock/pam-backups
+700:0:0 /var/log/facelock
+700:0:0 /var/log/facelock/snapshots
+600:0:0 /var/lib/facelock/facelock.db
+600:0:0 /var/log/facelock/audit.jsonl
+EOF
+    # ADR 010 retired the group outright; an upgrade from a release that had
+    # one must remove it rather than leave a group owning nothing.
+    ! getent group facelock >/dev/null 2>&1 ||
+        fail "the retired facelock group survived the upgrade"
+}
+
+assert_pam_path_intact() {
+    local before="$1"
+    grep -Fq "$(sha256sum "$PAM_PATH")" "$before" ||
+        fail "the upgrade rewrote the administrator's PAM service: $PAM_PATH"
+    case "$FAMILY" in
+        deb)
+            # The packaged profile is registered, never selected: an upgrade
+            # that switched a system to face auth on its own is a lockout.
+            [ -f /usr/share/pam-configs/facelock ] ||
+                fail "the candidate did not register its pam-configs profile"
+            ! grep -q pam_facelock.so /etc/pam.d/common-auth ||
+                fail "the upgrade activated Facelock in common-auth"
+            ;;
+        rpm)
+            # The authselect profile was retired; an upgrade must not put one back.
+            [ ! -e /usr/share/authselect/vendor/facelock ] ||
+                fail "the upgrade reinstated the retired authselect profile"
+            ! grep -q pam_facelock.so /etc/pam.d/system-auth 2>/dev/null ||
+                fail "the upgrade activated Facelock in system-auth"
+            ;;
+    esac
+}
+
+assert_real_password_behavior() {
+    printf '%s\n' "$CORRECT_PASSWORD" |
+        timeout --foreground 60 pamtester "$PAM_SERVICE" "$PASSWORD_USER" authenticate \
+            >>"$LOG" 2>&1 ||
+        fail "the correct password no longer authenticates through $PAM_SERVICE"
+    if printf '%s\n' "$WRONG_PASSWORD" |
+        timeout --foreground 60 pamtester "$PAM_SERVICE" "$PASSWORD_USER" authenticate \
+            >>"$LOG" 2>&1; then
+        fail "a wrong password authenticated through $PAM_SERVICE"
+    fi
+}
+
+# --- the candidate daemon actually opens the database ----------------------
+#
+# The rollback question is not "does v0.1.4 read a V6 file" in the abstract, it
+# is "does it read the file the alpha daemon has already opened, migrated and
+# written to". So the daemon runs for real before the downgrade.
+open_database_with_candidate_daemon() {
+    local output=/tmp/facelock-candidate-daemon.log pid
+    RUST_LOG=warn facelock daemon >"$output" 2>&1 &
+    pid=$!
+    for _ in $(seq 1 120); do
+        if [ "$(schema_version)" = 6 ]; then break; fi
+        sleep 0.5
+    done
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    assert_eq 6 "$(schema_version)" "schema version after the candidate daemon ran"
+}
+
+# --- rollback --------------------------------------------------------------
+
+assert_downgrade_usable() {
+    local shape="$1" probe=/tmp/facelock-rollback-probe
+    case_name="$shape-downgrade"
+
+    record_swtpm_state
+    pkg_downgrade "$PREDECESSOR" ||
+        fail "the package manager refused to downgrade to the pinned predecessor"
+    assert_eq "$(cat "$PREDECESSOR_VERSION_FILE")" "$(pkg_installed_version)" \
+        "installed version after downgrade"
+
+    # V6 has no down-migration. The predecessor must still open the database
+    # the candidate migrated and count its rows. `tpm status` is the readback
+    # rather than `list`, which in v0.1.4 is a D-Bus call to a daemon this
+    # phase deliberately does not run.
+    released_facelock tpm status >>"$LOG" 2>&1 ||
+        fail "the released binary could not read the V6 database after rollback"
+    assert_eq 6 "$(schema_version)" "schema version is not rolled back by a package downgrade"
+
+    if [ "$shape" != plaintext ]; then
+        rm -rf "$probe"
+        install -d -m0700 "$probe"
+        cp /var/lib/facelock/facelock.db "$probe/probe.db"
+        sed "s|^db_path = .*|db_path = \"$probe/probe.db\"|" \
+            /etc/facelock/config.toml >"$probe/config.toml"
+        released_facelock --config "$probe/config.toml" decrypt >>"$LOG" 2>&1 ||
+            fail "the released binary could not decrypt its own rows after rollback"
+        rm -rf "$probe"
+    fi
+
+    assert_real_password_behavior
+    assert_swtpm_state_untouched
+    pass "$shape rollback to $(cat "$PREDECESSOR_VERSION_FILE") stays usable"
+}
+
+# --- one shape, end to end -------------------------------------------------
+
+wipe_state() {
+    rm -rf /etc/facelock /var/lib/facelock /var/log/facelock "$PAM_PATH"
+    rm -f "$STATE_ROOT"/*.before "$STATE_ROOT"/*.after 2>/dev/null || true
+}
+
+run_shape() {
+    local shape="$1"
+    case_name="$shape"
+    log "$FAMILY upgrade shape: $shape"
+
+    if pkg_is_installed; then pkg_remove; fi
+    wipe_state
+    pkg_install "$PREDECESSOR" || fail "the pinned predecessor did not install"
+    assert_eq "$(cat "$PREDECESSOR_VERSION_FILE")" "$(pkg_installed_version)" \
+        "installed predecessor version"
+
+    seed_shape "$shape"
+    snapshot_invariant_state >"$STATE_ROOT/$shape.before"
+
+    record_swtpm_state
+    pkg_upgrade "$CANDIDATE" || fail "the native upgrade to the candidate failed"
+    assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_installed_version)" \
+        "installed candidate version after upgrade"
+    assert_swtpm_state_untouched
+
+    open_database_with_candidate_daemon
+
+    snapshot_invariant_state >"$STATE_ROOT/$shape.after"
+    cmp -s "$STATE_ROOT/$shape.before" "$STATE_ROOT/$shape.after" || {
+        diff -u "$STATE_ROOT/$shape.before" "$STATE_ROOT/$shape.after" >&2 || true
+        fail "the upgrade changed state it had to preserve"
+    }
+
+    assert_schema_v6_with_null_device_id
+    assert_known_embedding_decrypts "$shape"
+    assert_key_artifacts_preserved "$STATE_ROOT/$shape.before"
+    assert_adr010_modes
+    assert_pam_path_intact "$STATE_ROOT/$shape.before"
+    assert_real_password_behavior
+    assert_no_replacement_key_over_encrypted_state "$shape"
+    pass "$shape state survives $(cat "$PREDECESSOR_VERSION_FILE") to $(cat "$CANDIDATE_VERSION_FILE")"
+
+    assert_downgrade_usable "$shape"
+}
+
+# --- fault cases -----------------------------------------------------------
+#
+# Every one of these asks the same question: when the migration cannot finish,
+# does the database survive? A migration that resets or recreates a database it
+# could not migrate destroys every enrollment on the machine, and the failure
+# then looks exactly like a clean first run.
+#
+# The migrating command is `facelock daemon`, because that is what migrates in
+# production: `FaceStore::create` runs inside its startup, ahead of the D-Bus
+# name it never gets to claim here. Each case runs it against its own config,
+# so nothing here can reach the system database.
+
+FAULT_ROOT=/run/facelock-upgrade-v014/fault
+# Filled to capacity for the disk-full case. /dev/shm is a real filesystem with
+# a real, small size limit, so the ENOSPC is the kernel's rather than a
+# simulation, and it needs no privilege this lane does not already have.
+FAULT_FULL_ROOT=/dev/shm/facelock-fault-full
+
+seed_fault_database() {
+    local target="$1"
+    rm -rf "$target"
+    install -d -m0700 "$target"
+    python3 - "$target/facelock.db" <<'FAULT_SEED_PY'
+import sqlite3
+import struct
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.executescript(
+    """
+    CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+    CREATE TABLE face_models (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user TEXT NOT NULL,
+        label TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        embedder_model TEXT NOT NULL DEFAULT '',
+        UNIQUE(user, label)
+    );
+    CREATE INDEX idx_face_models_user ON face_models(user);
+    CREATE TABLE face_embeddings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        model_id INTEGER NOT NULL REFERENCES face_models(id) ON DELETE CASCADE,
+        embedding BLOB NOT NULL,
+        sealed INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX idx_face_embeddings_model ON face_embeddings(model_id);
+    CREATE TABLE rate_limit (user TEXT NOT NULL, attempt_time INTEGER NOT NULL);
+    CREATE INDEX idx_rate_limit_user ON rate_limit(user);
+    INSERT INTO schema_version (version) VALUES (5);
+    """
+)
+connection.execute(
+    "INSERT INTO face_models (user, label, created_at, embedder_model) "
+    "VALUES ('testuser', 'fault', 1700000000, 'arcface')"
+)
+blob = struct.pack("<512f", *((index + 1) / 512 for index in range(512)))
+for _ in range(3):
+    connection.execute(
+        "INSERT INTO face_embeddings (model_id, embedding, sealed) VALUES (1, ?, 0)",
+        (blob,),
+    )
+connection.commit()
+connection.close()
+FAULT_SEED_PY
+    cat >"$target/config.toml" <<EOF
+[storage]
+db_path = "$target/facelock.db"
+
+[daemon]
+model_dir = "/var/lib/facelock/models"
+
+[device]
+path = "/dev/video0"
+
+[encryption]
+method = "keyfile"
+key_path = "$target/encryption.key"
+
+[security]
+allow_plaintext = true
+EOF
+}
+
+# The daemon, bounded. Exit 124 means it was still running when the timeout
+# fired, which is the healthy outcome; any other status is a startup failure,
+# and `$target/daemon.log` says which.
+run_fault_daemon() {
+    local target="$1" seconds="${2:-30}" status=0
+    RUST_LOG="${RUST_LOG:-warn}" timeout --foreground "$seconds" \
+        facelock --config "$target/config.toml" daemon \
+        >"$target/daemon.log" 2>&1 || status=$?
+    printf '%s\n' "$status"
+}
+
+fault_inode() {
+    stat -c %i "$1/facelock.db"
+}
+
+fault_schema_version() {
+    python3 - "$1/facelock.db" <<'FAULT_SCHEMA_PY'
+import sqlite3
+import sys
+
+try:
+    connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+    print(
+        connection.execute(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version"
+        ).fetchone()[0]
+    )
+    connection.close()
+except Exception as error:  # noqa: BLE001 - the value is the diagnosis
+    print(f"unreadable: {error}")
+FAULT_SCHEMA_PY
+}
+
+fault_row_count() {
+    python3 - "$1/facelock.db" <<'FAULT_ROWS_PY'
+import sqlite3
+import sys
+
+try:
+    connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+    print(connection.execute("SELECT COUNT(*) FROM face_embeddings").fetchone()[0])
+    connection.close()
+except Exception as error:  # noqa: BLE001 - the value is the diagnosis
+    print(f"unreadable: {error}")
+FAULT_ROWS_PY
+}
+
+fault_face_models_readable() {
+    python3 - "$1/facelock.db" <<'FAULT_READABLE_PY'
+import sqlite3
+import sys
+
+try:
+    connection = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+    connection.execute("SELECT COUNT(*) FROM face_models").fetchone()
+    connection.close()
+    print("readable")
+except Exception:  # noqa: BLE001 - only the verdict matters
+    print("unreadable")
+FAULT_READABLE_PY
+}
+
+# Nothing below means anything unless the same command, in the same container,
+# migrates a healthy database. Without this, a daemon that failed to start for
+# an unrelated reason would satisfy every "the migration failed" assertion.
+fault_positive_control() {
+    case_name="fault-positive-control"
+    local target="$FAULT_ROOT/control" status
+    seed_fault_database "$target"
+    status="$(run_fault_daemon "$target" 45)"
+    assert_eq 6 "$(fault_schema_version "$target")" \
+        "positive control: the candidate daemon migrates a healthy V5 database"
+    assert_eq 3 "$(fault_row_count "$target")" "positive control: rows after migration"
+    [ "$status" = 124 ] || {
+        tail -20 "$target/daemon.log" >&2
+        fail "positive control: the candidate daemon did not stay up (exit $status)"
+    }
+    pass "positive control: a healthy V5 database migrates to V6"
+}
+
+# Shared by the failure cases: the file is the same file, its rows are still
+# there, and its schema was not carried forward.
+assert_fault_database_survived() {
+    local target="$1" inode="$2" rows="$3" label="$4"
+    assert_eq "$inode" "$(fault_inode "$target")" \
+        "$label: the database was replaced rather than left alone"
+    assert_eq 5 "$(fault_schema_version "$target")" "$label: schema version"
+    assert_eq "$rows" "$(fault_row_count "$target")" "$label: row count"
+}
+
+fault_disk_full() {
+    case_name="fault-disk-full"
+    local target="$FAULT_FULL_ROOT" inode rows status
+    seed_fault_database "$target"
+    inode="$(fault_inode "$target")"
+    rows="$(fault_row_count "$target")"
+
+    # Fill the filesystem the database lives on. dd stops at ENOSPC by itself,
+    # and the probe below refuses to continue if it did not.
+    dd if=/dev/zero of="$target/ballast" bs=64k status=none 2>/dev/null || true
+    if dd if=/dev/zero of="$target/probe" bs=64k count=1 status=none 2>/dev/null; then
+        rm -f "$target/probe" "$target/ballast"
+        fail "the disk-full fixture is not full: $target still accepts writes"
+    fi
+
+    status="$(run_fault_daemon "$target" 45)"
+    rm -f "$target/ballast"
+    [ "$status" != 124 ] || {
+        tail -20 "$target/daemon.log" >&2
+        fail "the daemon kept running on a database it could not migrate"
+    }
+    assert_fault_database_survived "$target" "$inode" "$rows" "disk-full migration"
+    rm -rf "$target"
+    pass "a disk-full migration leaves the database intact"
+}
+
+fault_interrupted() {
+    case_name="fault-interrupted"
+    local target="$FAULT_ROOT/interrupted" inode rows holder migrator
+    seed_fault_database "$target"
+    inode="$(fault_inode "$target")"
+    rows="$(fault_row_count "$target")"
+
+    # Hold the write lock so the migration blocks mid-flight, then kill it.
+    python3 - "$target/facelock.db" "$target/holder.ready" "$target/holder.stop" \
+        <<'FAULT_HOLDER_PY' &
+import pathlib
+import sqlite3
+import sys
+import time
+
+connection = sqlite3.connect(sys.argv[1], isolation_level=None)
+connection.execute("BEGIN EXCLUSIVE")
+pathlib.Path(sys.argv[2]).touch()
+stop = pathlib.Path(sys.argv[3])
+while not stop.exists():
+    time.sleep(0.1)
+connection.rollback()
+connection.close()
+FAULT_HOLDER_PY
+    holder=$!
+    for _ in $(seq 1 100); do
+        if [ -f "$target/holder.ready" ]; then break; fi
+        sleep 0.1
+    done
+    [ -f "$target/holder.ready" ] || fail "the exclusive-lock holder never started"
+
+    RUST_LOG=warn facelock --config "$target/config.toml" daemon \
+        >"$target/daemon.log" 2>&1 &
+    migrator=$!
+    sleep 20
+    kill -KILL "$migrator" 2>/dev/null || true
+    wait "$migrator" 2>/dev/null || true
+    touch "$target/holder.stop"
+    wait "$holder" 2>/dev/null || true
+
+    assert_fault_database_survived "$target" "$inode" "$rows" "interrupted migration"
+    pass "an interrupted migration leaves the database intact"
+}
+
+fault_corrupt_database() {
+    case_name="fault-corrupt-database"
+    local target="$FAULT_ROOT/corrupt" inode status
+    seed_fault_database "$target"
+
+    # Repoint face_models at a page of the wrong btree type: the database still
+    # opens, and only fails when a query walks the table. Same trick as
+    # facelock_test_support::schema_faults::break_face_models_table, which is
+    # the Rust-side owner of this schema coupling.
+    python3 - "$target/facelock.db" <<'FAULT_CORRUPT_PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.executescript(
+    "CREATE TABLE d1(x); CREATE INDEX di1 ON d1(x); CREATE TABLE d2(x);"
+)
+
+
+def page(name):
+    return connection.execute(
+        "SELECT rootpage FROM sqlite_master WHERE name = ?", (name,)
+    ).fetchone()[0]
+
+
+donors = (page("d1"), page("di1"), page("d2"))
+connection.executescript(
+    f"""
+    PRAGMA writable_schema=ON;
+    UPDATE sqlite_master SET rootpage={donors[1]} WHERE name='face_models';
+    UPDATE sqlite_master SET rootpage={donors[0]} WHERE name='idx_face_models_user';
+    UPDATE sqlite_master SET rootpage={donors[2]} WHERE name='sqlite_autoindex_face_models_1';
+    DELETE FROM sqlite_master WHERE name IN ('d1','di1','d2');
+    PRAGMA writable_schema=OFF;
+    """
+)
+for name in ("face_models", "idx_face_models_user", "sqlite_autoindex_face_models_1"):
+    if (
+        connection.execute(
+            "SELECT rootpage FROM sqlite_master WHERE name = ?", (name,)
+        ).fetchone()[0]
+        not in donors
+    ):
+        raise SystemExit(f"fault injection did not repoint {name}")
+connection.commit()
+connection.close()
+FAULT_CORRUPT_PY
+    assert_eq unreadable "$(fault_face_models_readable "$target")" \
+        "fault injection did not make face_models unreadable"
+    inode="$(fault_inode "$target")"
+
+    status="$(run_fault_daemon "$target" 45)"
+    [ "$status" != 124 ] || {
+        tail -20 "$target/daemon.log" >&2
+        fail "the daemon served a database whose enrollment table cannot be read"
+    }
+    assert_eq "$inode" "$(fault_inode "$target")" \
+        "the corrupt database was replaced instead of refused"
+    # Anything that "repaired" the database by recreating it would leave
+    # face_models readable again. It must not be.
+    assert_eq unreadable "$(fault_face_models_readable "$target")" \
+        "the corrupt database was silently rebuilt"
+    pass "a corrupt database is refused, never reset"
+}
+
+fault_concurrent_key_creation() {
+    case_name="fault-concurrent-key-creation"
+    local target="$FAULT_ROOT/concurrent" keys
+    seed_fault_database "$target"
+    # A plaintext-only legacy database with no key artifact: the one state where
+    # creating the default key is allowed at all.
+    [ ! -e "$target/encryption.key" ] || fail "the concurrent fixture already has a key"
+
+    for _ in $(seq 1 8); do
+        (
+            RUST_LOG=warn timeout --foreground 40 \
+                facelock --config "$target/config.toml" daemon \
+                >>"$target/daemon.log" 2>&1 || true
+        ) &
+    done
+    wait
+
+    [ -f "$target/encryption.key" ] ||
+        fail "no key was created for a plaintext-only legacy database"
+    assert_eq 32 "$(stat -c %s "$target/encryption.key")" "concurrently created key size"
+    assert_eq "600:0:0" "$(stat -c '%a:%u:%g' "$target/encryption.key")" \
+        "concurrently created key metadata"
+    # Exactly one winner. O_EXCL is what makes that true: with O_TRUNC the last
+    # writer replaces the key the first one's rows were sealed under, and a
+    # reader in between gets a half-written key.
+    keys="$(find "$target" -maxdepth 1 -name 'encryption.key*' | wc -l)"
+    assert_eq 1 "$keys" "key artifacts after a concurrent creation race"
+    pass "concurrent key creation resolves to exactly one key"
+}
+
+run_faults() {
+    install -d -m0700 "$FAULT_ROOT"
+    fault_positive_control
+    local fault
+    for fault in "${FAULTS[@]}"; do
+        case "$fault" in
+            disk-full) fault_disk_full ;;
+            interrupted) fault_interrupted ;;
+            corrupt-database) fault_corrupt_database ;;
+            concurrent-key-creation) fault_concurrent_key_creation ;;
+            *) fail "no implementation for declared fault: $fault" ;;
+        esac
+    done
+}
+
+# --- entry point -----------------------------------------------------------
+
+install -d -m0700 "$STATE_ROOT"
+: >"$LOG"
+
+assert_pinned_artifacts
+start_swtpm
+
+for shape in "${SHAPES[@]}"; do
+    run_shape "$shape"
+done
+
+# The faults run against the candidate, so install it once more and leave it in
+# place: a fault case is about the candidate's migration, not the predecessor's.
+case_name="fault-setup"
+if pkg_is_installed; then pkg_remove; fi
+wipe_state
+pkg_install "$CANDIDATE" || fail "the candidate did not install for the fault matrix"
+install -d -m0755 /var/lib/facelock/models
+if [ -d /facelock-test-models ]; then
+    for model in /facelock-test-models/*.onnx; do
+        if [ -f "$model" ]; then install -m0644 "$model" /var/lib/facelock/models/; fi
+    done
+fi
+run_faults
+
+echo
+echo "OK: $FAMILY v0.1.4 upgrade, rollback and fault matrix"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -143,7 +143,17 @@ case "$FAMILY" in
     rpm)
         pkg_install() { dnf install -y "$1" >>"$LOG" 2>&1; }
         pkg_upgrade() { dnf upgrade -y "$1" >>"$LOG" 2>&1; }
-        pkg_downgrade() { dnf downgrade -y "$1" >>"$LOG" 2>&1; }
+        # `dnf downgrade` on a local file is the supported path; `rpm -Uvh
+        # --oldpackage` is the other real one an administrator would reach for.
+        # The fallback prints, so a run that needed it says so rather than
+        # quietly proving something about a different command.
+        pkg_downgrade() {
+            if dnf downgrade -y "$1" >>"$LOG" 2>&1; then
+                return 0
+            fi
+            echo "NOTE: dnf downgrade refused $1; falling back to rpm -Uvh --oldpackage" >&2
+            rpm -Uvh --oldpackage "$1" >>"$LOG" 2>&1
+        }
         pkg_remove() { dnf remove -y facelock >>"$LOG" 2>&1; }
         pkg_installed_version() { rpm -q --qf '%{VERSION}-%{RELEASE}' facelock 2>/dev/null; }
         pkg_is_installed() { rpm -q facelock >/dev/null 2>&1; }
@@ -869,13 +879,45 @@ open_database_with_candidate_daemon() {
     stop_packaged_daemon
     RUST_LOG=warn facelock daemon >"$output" 2>&1 &
     pid=$!
+    # Wait for the outcome, not for a proxy that races it.
+    # `reconcile_enrollment_markers` runs at daemon.rs:346, *before*
+    # `build_handler_from`, and the migration happens inside it -- so the store
+    # reaches V6 partway through reconciliation. Polling on the schema version
+    # alone stopped the daemon mid-reconcile, which the Debian half won by luck
+    # and the Fedora half lost.
     for _ in $(seq 1 120); do
-        if [ "$(schema_version)" = 6 ]; then break; fi
+        if [ "$(schema_version)" = 6 ] &&
+            [ "$(marker_model_count)" = "$(database_model_count)" ]; then
+            break
+        fi
         sleep 0.5
     done
     kill -TERM "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
+    if [ "$(marker_model_count)" != "$(database_model_count)" ]; then
+        echo "--- candidate daemon output ---" >&2
+        tail -20 "$output" >&2 || true
+    fi
     assert_eq 6 "$(schema_version)" "schema version after the candidate daemon ran"
+}
+
+database_model_count() {
+    sqlite_query "SELECT COUNT(*) FROM face_models WHERE user = 'testuser'"
+}
+
+# Never fails: a marker that is absent or unreadable is a value the caller
+# compares, not an error that stops the poll.
+marker_model_count() {
+    python3 - /var/lib/facelock/enrolled/testuser <<'MARKER_COUNT_PY' 2>/dev/null || echo unknown
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        print(json.load(handle)["models"])
+except Exception:  # noqa: BLE001 - any failure is just "not yet"
+    print("unknown")
+MARKER_COUNT_PY
 }
 
 # --- rollback --------------------------------------------------------------

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -892,7 +892,13 @@ assert_key_refusal() {
         install -m0600 "$saved" /etc/facelock/encryption.key
         fail "the daemon stopped serving on a $variant key (exit $status)"
     }
-    grep -qiE 'refusing to write a replacement key|could not be created/read' "$output" || {
+    # Matches the refusal, not one release's phrasing of it. The security
+    # review that owns this message has already moved it once, from "refusing
+    # to write a replacement key" to "refusing to write an encryption key at
+    # <path>", and this lane is stacked under that work. Pinning the sentence
+    # would make the harness red on wording; requiring the daemon to say it is
+    # refusing to write or mint a key keeps the assertion.
+    grep -qiE 'refus[a-z]* to (write|mint)[^.]*key|could not be created/read' "$output" || {
         tail -20 "$output" >&2
         install -m0600 "$saved" /etc/facelock/encryption.key
         fail "the daemon did not report the $variant key over encrypted rows"

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -1204,7 +1204,7 @@ FAULT_HOLDER_PY
 
 fault_corrupt_database() {
     case_name="fault-corrupt-database"
-    local target="$FAULT_ROOT/corrupt" inode status
+    local target="$FAULT_ROOT/corrupt" inode rows status
     seed_fault_database "$target"
 
     # Repoint face_models at a page of the wrong btree type: the database still
@@ -1253,18 +1253,34 @@ FAULT_CORRUPT_PY
         "fault injection did not make face_models unreadable"
     inode="$(fault_inode "$target")"
 
+    rows="$(fault_row_count "$target")"
     status="$(run_fault_daemon "$target" 45)"
-    [ "$status" != 124 ] || {
+
+    # The daemon is required to keep serving. Exiting on a corrupt database
+    # would take D-Bus activation down with it, and a PAM module that cannot
+    # reach the daemon is one step from a machine nobody can log into. Falling
+    # through to password with the corruption reported is the safe direction,
+    # so it is asserted rather than merely tolerated.
+    [ "$status" = 124 ] || {
         tail -20 "$target/daemon.log" >&2
-        fail "the daemon served a database whose enrollment table cannot be read"
+        fail "the daemon stopped serving on a corrupt database (exit $status)"
+    }
+    # Reported, not swallowed. A daemon that silently treats an unreadable
+    # enrollment table as "nobody is enrolled" is how a corrupt database turns
+    # into a quiet, permanent loss of face authentication.
+    grep -Eqi 'corrupt|malformed' "$target/daemon.log" || {
+        tail -20 "$target/daemon.log" >&2
+        fail "the daemon never named the corruption it hit"
     }
     assert_eq "$inode" "$(fault_inode "$target")" \
-        "the corrupt database was replaced instead of refused"
+        "the corrupt database was replaced instead of left alone"
     # Anything that "repaired" the database by recreating it would leave
     # face_models readable again. It must not be.
     assert_eq unreadable "$(fault_face_models_readable "$target")" \
         "the corrupt database was silently rebuilt"
-    pass "a corrupt database is refused, never reset"
+    assert_eq "$rows" "$(fault_row_count "$target")" \
+        "embedding rows after a corrupt-database start"
+    pass "a corrupt database is reported and left alone, never reset"
 }
 
 fault_concurrent_key_creation() {

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -100,12 +100,21 @@ assert_eq() {
 
 case "$FAMILY" in
     deb)
-        pkg_install() { apt-get install -y --no-install-recommends "$1" >>"$LOG" 2>&1; }
-        pkg_upgrade() { apt-get install -y --no-install-recommends "$1" >>"$LOG" 2>&1; }
-        pkg_downgrade() {
-            apt-get install -y --no-install-recommends --allow-downgrades "$1" >>"$LOG" 2>&1
+        # `apt-get update` before every transaction, the same as
+        # test/deb-package-lifecycle.sh:162. The runtime image ends with
+        # `rm -rf /var/lib/apt/lists/*`, so without it APT knows about no
+        # archive at all and the candidate's own `Depends: dbus` is
+        # "not installable" rather than merely absent.
+        apt_transaction() {
+            DEBIAN_FRONTEND=noninteractive apt-get update >>"$LOG" 2>&1
+            DEBIAN_FRONTEND=noninteractive apt-get "$@" >>"$LOG" 2>&1
         }
-        pkg_remove() { apt-get remove -y facelock >>"$LOG" 2>&1; }
+        pkg_install() { apt_transaction install -y --no-install-recommends "$1"; }
+        pkg_upgrade() { apt_transaction install -y --no-install-recommends "$1"; }
+        pkg_downgrade() {
+            apt_transaction install -y --no-install-recommends --allow-downgrades "$1"
+        }
+        pkg_remove() { apt_transaction remove -y facelock; }
         pkg_installed_version() { dpkg-query -W -f='${Version}' facelock 2>/dev/null; }
         pkg_is_installed() { [ "$(dpkg-query -W -f='${Status}' facelock 2>/dev/null)" = "install ok installed" ]; }
         pkg_version_gt() { dpkg --compare-versions "$1" gt "$2"; }

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -699,8 +699,11 @@ assert_key_artifacts_preserved() {
     local before="$1" path
     # Nothing appeared that was not there before. A replacement key written
     # beside the real one is the failure this catches.
+    # -x, not a bare -F: "encryption.key" is a prefix of "encryption.key.sealed",
+    # so an unanchored match finds the sealed path's absent line and reports a
+    # key that was there all along as newly created.
     for path in /etc/facelock/encryption.key /etc/facelock/encryption.key.sealed; do
-        if grep -Fq "absent|$path" "$before" && [ -e "$path" ]; then
+        if grep -Fxq "absent|$path" "$before" && [ -e "$path" ]; then
             fail "the upgrade created a key artifact that did not exist before: $path"
         fi
     done

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -105,9 +105,23 @@ case "$FAMILY" in
         # `rm -rf /var/lib/apt/lists/*`, so without it APT knows about no
         # archive at all and the candidate's own `Depends: dbus` is
         # "not installable" rather than merely absent.
+        #
+        # --force-confdef/--force-confold take dpkg's own documented default
+        # action for a modified conffile ("keep your current version") without
+        # a prompt, which is what unattended-upgrades does on a real machine.
+        # It is needed here and not in the synthesized-predecessor lane because
+        # that lane rebuilds the candidate's own payload as the older package,
+        # so its packaged config.toml is byte-identical across the upgrade and
+        # dpkg never asks. A real v0.1.4 ships a different config.toml, so the
+        # modified file this lane plants does provoke the prompt -- and an
+        # unanswered prompt is `end of file on stdin at conffile prompt`, not a
+        # preserved config.
         apt_transaction() {
             DEBIAN_FRONTEND=noninteractive apt-get update >>"$LOG" 2>&1
-            DEBIAN_FRONTEND=noninteractive apt-get "$@" >>"$LOG" 2>&1
+            DEBIAN_FRONTEND=noninteractive apt-get \
+                -o Dpkg::Options::=--force-confdef \
+                -o Dpkg::Options::=--force-confold \
+                "$@" >>"$LOG" 2>&1
         }
         pkg_install() { apt_transaction install -y --no-install-recommends "$1"; }
         pkg_upgrade() { apt_transaction install -y --no-install-recommends "$1"; }

--- a/test/upgrade-v014-predecessor.sh
+++ b/test/upgrade-v014-predecessor.sh
@@ -16,6 +16,9 @@
 # --verify-live needs `gh` and network. It never downloads the asset: it asks
 # the release API what the pinned asset id is now and rejects a name, size or
 # digest that moved. A re-upload gets a new id, so a stale id is equally fatal.
+# The API's `digest` is nullable, so an asset it does not carry one for is
+# reported rather than refused — the lane image still checks the pinned SHA256
+# against the bytes it downloads.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -77,20 +80,47 @@ case "$field" in
         repository="$(read_lane repository)"
         tag="$(read_lane tag)"
         asset_id="$(read_lane asset_id)"
+        # `.digest // ""` because the field is nullable: GitHub has computed a
+        # SHA256 for every asset uploaded since June 2025, but an older asset
+        # can still answer null. Folded into the identity string, that null
+        # would be reported as "the pinned asset changed", which sends a
+        # maintainer looking for a substituted artifact that does not exist.
         live="$(gh api "repos/$repository/releases/tags/$tag" \
-            --jq ".assets[] | select(.id == $asset_id) | \"\(.name)\t\(.size)\t\(.digest)\"")"
+            --jq ".assets[] | select(.id == $asset_id) | \"\(.name)\t\(.size)\t\(.digest // \"\")\"")"
         [ -n "$live" ] || {
             echo "FAIL: release $tag no longer serves asset id $asset_id (re-uploaded or deleted)" >&2
             exit 1
         }
-        expected="$(read_lane name)	$(read_lane size)	sha256:$(read_lane sha256)"
-        [ "$live" = "$expected" ] || {
+        IFS=$'\t' read -r live_name live_size live_digest <<<"$live"
+        expected_name="$(read_lane name)"
+        expected_size="$(read_lane size)"
+        expected_digest="sha256:$(read_lane sha256)"
+        if [ "$live_name" != "$expected_name" ] || [ "$live_size" != "$expected_size" ]; then
             echo "FAIL: pinned asset $asset_id changed" >&2
-            echo "  expected: $expected" >&2
-            echo "  live:     $live" >&2
+            echo "  expected: $expected_name ($expected_size bytes)" >&2
+            echo "  live:     $live_name ($live_size bytes)" >&2
             exit 1
-        }
-        echo "predecessor $lane: asset $asset_id unchanged ($(read_lane name))"
+        fi
+        case "$live_digest" in
+            "" | null)
+                # Absence is not evidence of tampering, and refusing on it would
+                # make the pin gate unrunnable for an asset GitHub never
+                # digested. The digest is still enforced where it decides
+                # something: the lane image verifies the downloaded bytes
+                # against it before the predecessor is installed.
+                echo "NOTE: release $tag serves no digest for asset $asset_id;" \
+                    "name and size match, and the lane still verifies" \
+                    "$expected_digest against the downloaded bytes" >&2
+                ;;
+            "$expected_digest") ;;
+            *)
+                echo "FAIL: pinned asset $asset_id serves a different digest" >&2
+                echo "  expected: $expected_digest" >&2
+                echo "  live:     $live_digest" >&2
+                exit 1
+                ;;
+        esac
+        echo "predecessor $lane: asset $asset_id unchanged ($expected_name)"
         ;;
     *)
         read_lane "$field"

--- a/test/upgrade-v014-predecessor.sh
+++ b/test/upgrade-v014-predecessor.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Resolve one pinned released predecessor from dist/release-matrix.json.
+#
+# The upgrade lanes (#231) install a real published artifact, so the pin has to
+# be strong enough that a re-uploaded or substituted asset fails the lane rather
+# than quietly changing what it proved. `dist/release-matrix.json` holds that
+# pin — asset id, node id, SHA256 and byte size — and this script is the only
+# reader. Lane Containerfiles take the fields as build args and never carry a
+# digest of their own; test/check-release-matrix.py enforces that.
+#
+# Usage:
+#   upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field>
+#   upgrade-v014-predecessor.sh <lane> --build-args     # podman --build-arg list
+#   upgrade-v014-predecessor.sh <lane> --verify-live    # re-resolve against the API
+#
+# --verify-live needs `gh` and network. It never downloads the asset: it asks
+# the release API what the pinned asset id is now and rejects a name, size or
+# digest that moved. A re-upload gets a new id, so a stale id is equally fatal.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lane="${1:?usage: upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
+field="${2:?usage: upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
+[ "$#" -eq 2 ] || {
+    echo "usage: upgrade-v014-predecessor.sh <lane> <field|--build-args|--verify-live>" >&2
+    exit 2
+}
+
+case "$lane" in
+    deb-trixie | rpm-fedora) ;;
+    *)
+        echo "unknown predecessor lane: $lane" >&2
+        exit 2
+        ;;
+esac
+
+read_lane() {
+    python3 - "$repo_root/dist/release-matrix.json" "$lane" "$1" <<'PY'
+import json
+import sys
+
+matrix_path, lane, field = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(matrix_path, encoding="utf-8") as handle:
+    matrix = json.load(handle)
+
+release = matrix["predecessors"]["v0.1.4"]
+row = release["lanes"][lane]
+if field == "tag":
+    print(release["tag"])
+elif field == "upstream_version":
+    print(release["upstream_version"])
+elif field == "release_id":
+    print(release["release_id"])
+elif field == "repository":
+    print(matrix["predecessors"]["repository"])
+else:
+    if field not in row:
+        raise SystemExit(f"unknown predecessor field: {field}")
+    print(row[field])
+PY
+}
+
+case "$field" in
+    --build-args)
+        printf '%s\n' \
+            "FACELOCK_PREDECESSOR_URL=$(read_lane url)" \
+            "FACELOCK_PREDECESSOR_SHA256=$(read_lane sha256)" \
+            "FACELOCK_PREDECESSOR_SIZE=$(read_lane size)" \
+            "FACELOCK_PREDECESSOR_NAME=$(read_lane name)" \
+            "FACELOCK_PREDECESSOR_VERSION=$(read_lane package_version)"
+        ;;
+    --verify-live)
+        command -v gh >/dev/null 2>&1 || {
+            echo "FAIL: --verify-live needs the gh CLI" >&2
+            exit 1
+        }
+        repository="$(read_lane repository)"
+        tag="$(read_lane tag)"
+        asset_id="$(read_lane asset_id)"
+        live="$(gh api "repos/$repository/releases/tags/$tag" \
+            --jq ".assets[] | select(.id == $asset_id) | \"\(.name)\t\(.size)\t\(.digest)\"")"
+        [ -n "$live" ] || {
+            echo "FAIL: release $tag no longer serves asset id $asset_id (re-uploaded or deleted)" >&2
+            exit 1
+        }
+        expected="$(read_lane name)	$(read_lane size)	sha256:$(read_lane sha256)"
+        [ "$live" = "$expected" ] || {
+            echo "FAIL: pinned asset $asset_id changed" >&2
+            echo "  expected: $expected" >&2
+            echo "  live:     $live" >&2
+            exit 1
+        }
+        echo "predecessor $lane: asset $asset_id unchanged ($(read_lane name))"
+        ;;
+    *)
+        read_lane "$field"
+        ;;
+esac


### PR DESCRIPTION
## Summary

- add `just test-upgrade-v014`: two booted lanes, Debian trixie and Fedora 44, each installing the real published v0.1.4 artifact
- pin both predecessors by release id, asset id, SHA256 and byte size under a new `predecessors` key in `dist/release-matrix.json`, resolved by `test/upgrade-v014-predecessor.sh` and re-verifiable against the release API
- build predecessor state with the **released** binary in five shapes: plaintext, keyfile, mixed, and swtpm-sealed with PCR binding on and off
- upgrade through apt and dnf, then prove V5 to V6 with legacy `device_id` NULL, the known embedding's plaintext recovered against a pinned digest, no key artifact created, config, models, marker, audit log and administrator PAM service preserved
- judge ADR 010 modes against what v0.1.4's postinst leaves (`root:facelock 0750`, no `pam-backups`) and require at least one path to have moved
- judge the PAM service and the global stack against pre-upgrade state, in either direction, rather than against an absolute
- prove a real correct password still authenticates and a real wrong one still fails, and that swtpm state and PCR 16 are untouched across each transaction
- prove a missing and a malformed key over encrypted rows are refused with no replacement written and the daemon still serving
- downgrade back to v0.1.4 after the candidate daemon has opened and migrated the database, and recover the same plaintext with the released binary
- add five fault cases behind a positive control: disk-full, interrupted, corrupt database, and an eight-way concurrent key-creation race
- add `test/upgrade-v014-contract.sh` to `just check`: a container-free gate refusing a declared shape or fault with no implementation, a proof nothing calls, an unanchored digest lookup, and a lane Containerfile carrying its own pin
- pick the candidate version, building the same payload as `0.2.0` while the workspace does not sort above the predecessor, with the native comparator deciding inside the container

## Why

Unit schema tests say nothing about the packages people actually run. Nothing
proved that a database, encryption key, sealed TPM blob or PAM configuration
written by v0.1.4 survives an upgrade, and nothing proved the alpha can be
rolled back off a machine it has already migrated. Every other packaging lane
starts from nothing, so a migration that destroys an upgraded database passes
all of them.

## Reviewer notes

- **stacked on #326** — merge that first; these lanes are the only end-to-end coverage of its key-policy work on real packages
- **local-only by design** — a cached run is about twenty minutes, so `packaging.yml` does not carry it and a nightly job is the follow-up; the container-free contract still runs in `just check`
- **v0.1.4's deb under-declares its dependencies** — hand-written `Depends` with no `libxkbcommon0`, which its binary links, so that release cannot start on a minimal Debian 13; the lane images supply it and `CHANGELOG.md` records the `${shlibs:Depends}` fix
- **v0.1.4's pam-configs profile ships `Default: yes`** — installing that release enabled face auth in `common-auth` without asking, so an upgrade must not retire it; removing an enabled profile is the dangerous direction and the lane fails on it
- **`make_lower_package` can never reach the conffile prompt** — it rebuilds the candidate's own payload as the older package, so the packaged config is byte-identical and dpkg never asks; the Debian lifecycle lane's config-preservation claim is untested against a real version change, and wants a follow-up issue
- **the lane requires the daemon to survive a corrupt database** — it stays up, names the corruption and leaves the file alone; exiting would take D-Bus activation down and put a machine one step from unloggable-into

## Validation

- `just test-upgrade-v014`, both lanes, against this branch rebased onto #326
- `just check`, including the new container-free lane contract
- `python3 test/check-release-matrix.py` and `bash test/release-version-contract.sh`
- `shellcheck -x` on the six new lane scripts

Refs #231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Upgrading from v0.1.4 now preserves existing face-authentication enablement.
  - Debian packages now automatically include required shared-library dependencies, including `libxkbcommon0`.
  - Enrollment markers retain their ownership and permissions while synchronizing stale content.
  - Migration failures no longer replace or reset the database.

- **Improvements**
  - Upgrades and rollbacks now validate preservation of embeddings, encryption keys, configuration, models, audit data, permissions, and PAM settings.
  - Compatibility testing now covers Debian and RPM upgrades and rollbacks to v0.1.4.
  - Fedora packaging validation now includes additional repository and lifecycle coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->