### PR TITLE
fix(ci): stop git auto maintenance racing the packaging context

### DIFF
--- a/test/build-deb-package-image.sh
+++ b/test/build-deb-package-image.sh
@@ -50,7 +50,13 @@ esac
 context="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-context.XXXXXX")"
 artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-artifacts.XXXXXX")"
 rebuild_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-rebuild-output.XXXXXX")"
-trap 'rm -rf -- "$context" "$artifact_dir" "$rebuild_dir"' EXIT
+cleanup() {
+    # The context holds a Git repository; retry once so that a straggling writer
+    # cannot turn scratch cleanup into a spurious lane failure.
+    rm -rf -- "$context" "$artifact_dir" "$rebuild_dir" 2>/dev/null ||
+        rm -rf -- "$context" "$artifact_dir" "$rebuild_dir"
+}
+trap cleanup EXIT
 "$repo_root/test/prepare-deb-test-context.sh" "$context" >/dev/null
 
 # Container engines omit .git from COPY even when an alternate empty ignore

--- a/test/build-deb-package-image.sh
+++ b/test/build-deb-package-image.sh
@@ -51,10 +51,13 @@ context="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-context.XXXXXX")"
 artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-artifacts.XXXXXX")"
 rebuild_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-deb-rebuild-output.XXXXXX")"
 cleanup() {
+    local status=$?
     # The context holds a Git repository; retry once so that a straggling writer
-    # cannot turn scratch cleanup into a spurious lane failure.
+    # cannot turn scratch cleanup into a spurious lane failure. Cleanup must never
+    # decide the exit status, so restore whatever the script had already reached.
     rm -rf -- "$context" "$artifact_dir" "$rebuild_dir" 2>/dev/null ||
-        rm -rf -- "$context" "$artifact_dir" "$rebuild_dir"
+        rm -rf -- "$context" "$artifact_dir" "$rebuild_dir" || true
+    exit "$status"
 }
 trap cleanup EXIT
 "$repo_root/test/prepare-deb-test-context.sh" "$context" >/dev/null

--- a/test/deb-source-contract.sh
+++ b/test/deb-source-contract.sh
@@ -870,6 +870,17 @@ grep -Fq 'prepare-deb-test-context.sh' test/build-deb-package-image.sh ||
 grep -Fq 'tar -C "$context" -cf "$context/facelock-git-metadata.tar" .git' \
     test/build-deb-package-image.sh ||
     fail "Debian image builder must transport the isolated context Git metadata explicitly"
+# That transport reads .git directly, so nothing may rewrite it concurrently.
+# Git detaches `git maintenance run --auto` after `git commit`, which repacks and
+# prunes objects out from under the read; the prepared context must disable it.
+# shellcheck disable=SC2016
+grep -Fq 'git -C "$destination" config maintenance.auto false' \
+    test/prepare-deb-test-context.sh ||
+    fail "prepared context must disable detached auto maintenance before .git is transported"
+# shellcheck disable=SC2016
+grep -Fq 'git -C "$destination" config gc.auto 0' \
+    test/prepare-deb-test-context.sh ||
+    fail "prepared context must disable automatic gc before .git is transported"
 for containerfile in "${debian_builders[@]}"; do
     grep -Fq 'tar -xf /build/facelock-git-metadata.tar -C /build' "$containerfile" ||
         fail "$containerfile must restore the exact tagged Git metadata before source packaging"

--- a/test/prepare-deb-test-context.sh
+++ b/test/prepare-deb-test-context.sh
@@ -19,6 +19,13 @@ git -C "$repo_root" ls-files --cached --others --exclude-standard -z |
     tar -C "$destination" -xf -
 
 git -C "$destination" init --quiet
+# `git commit` below detaches `git maintenance run --auto`, which repacks and
+# prunes .git/objects in the background. Callers transport this repository by
+# reading .git directly, so that detached process races the read and deletes
+# loose objects mid-copy. A throwaway one-commit repository gains nothing from
+# maintenance, so switch it off for every command run against this repository.
+git -C "$destination" config maintenance.auto false
+git -C "$destination" config gc.auto 0
 # The destination contains only the restricted candidate file set copied
 # above, so force-add preserves tracked paths that are ignored in a fresh
 # repository (for example, checked-in internal documentation).

--- a/test/verify-deb-test-context.sh
+++ b/test/verify-deb-test-context.sh
@@ -14,6 +14,14 @@ fail() {
 git -C "$candidate_repo" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1 ||
     fail "candidate has no source commit"
 
+# Callers copy this repository by reading .git directly. Git's post-commit auto
+# maintenance detaches and rewrites .git/objects underneath such a read, so the
+# prepared repository must have both auto maintenance and auto gc switched off.
+[ "$(git -C "$candidate_repo" config --type=bool --get maintenance.auto 2>/dev/null || true)" = "false" ] ||
+    fail "candidate repository must disable detached auto maintenance"
+[ "$(git -C "$candidate_repo" config --type=int --get gc.auto 2>/dev/null || true)" = "0" ] ||
+    fail "candidate repository must disable automatic gc"
+
 verification_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-context-verification.XXXXXX")"
 trap 'rm -rf -- "$verification_root"' EXIT
 candidate_paths="$verification_root/candidate-paths"

--- a/test/verify-deb-test-context.sh
+++ b/test/verify-deb-test-context.sh
@@ -17,9 +17,11 @@ git -C "$candidate_repo" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1 ||
 # Callers copy this repository by reading .git directly. Git's post-commit auto
 # maintenance detaches and rewrites .git/objects underneath such a read, so the
 # prepared repository must have both auto maintenance and auto gc switched off.
-[ "$(git -C "$candidate_repo" config --type=bool --get maintenance.auto 2>/dev/null || true)" = "false" ] ||
+# Read only the repository's own configuration: a global setting on the machine
+# running this would otherwise satisfy the check while the candidate lacks it.
+[ "$(git -C "$candidate_repo" config --local --type=bool --get maintenance.auto 2>/dev/null || true)" = "false" ] ||
     fail "candidate repository must disable detached auto maintenance"
-[ "$(git -C "$candidate_repo" config --type=int --get gc.auto 2>/dev/null || true)" = "0" ] ||
+[ "$(git -C "$candidate_repo" config --local --type=int --get gc.auto 2>/dev/null || true)" = "0" ] ||
     fail "candidate repository must disable automatic gc"
 
 verification_root="$(mktemp -d "${TMPDIR:-/tmp}/facelock-context-verification.XXXXXX")"


### PR DESCRIPTION
## Summary

- disable `maintenance.auto` and `gc.auto` on the prepared Debian candidate repository
- assert that in `verify-deb-test-context.sh`, so every lane that prepares a context checks it
- pin it as text in `deb-source-contract.sh`, next to the existing pins on the same transport
- retry scratch cleanup in `build-deb-package-image.sh` so a straggling writer cannot fail the lane
- keep shipping `.git`: the assembler runs `git describe --tags --exact-match HEAD` to enforce the exact-tag source build

## Why

`test/prepare-deb-test-context.sh` builds a throwaway one-commit repository, and its closing `git commit` detaches `git maintenance run --auto`. That background process repacks and prunes `.git/objects` while `build-deb-package-image.sh` is tarring the same `.git` into the build context, so tar reads objects as they are deleted and the lane dies leaving an undeletable temp directory. It took out `test-deb-trixie-pkg` twice on #323, `test-deb-resolute-pkg` on #324, and #324's trixie rerun. Excluding `.git` is not an option here, so the fix removes the only writer that can touch it instead.

## Validation

- `just check`
- `test/check-release-matrix.py`, `test/release-version-contract.sh`, `test/check-agent-docs.py`
- `shellcheck -x` on the four touched helpers
- `just test-deb-trixie-pkg` end to end on the recipe that failed
- mutation check on the new guard, dropping the config lines from the prepare helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Debian package test workflows now verify that Git automatic maintenance and garbage collection are disabled during repository preparation.
  * Validation now checks these settings specifically in the candidate repository’s local configuration.
  * Added explicit validation errors when required Git settings are not configured correctly.

* **Chores**
  * Improved cleanup handling for Debian package test environments by preserving the original exit status and tolerating failures during temporary resource removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->