### PR TITLE
fix(dist): compute a correctly ranked version for facelock-git builds

### DIFF
--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -20,9 +20,24 @@ options=(!lto)
 source=("$pkgname::git+$url.git")
 sha256sums=('SKIP')
 
+# A build from main has to outrank every published facelock, or pacman refuses
+# it as an upgrade and AUR helpers report this package as permanently out of
+# date. Three things earn that (#330):
+#
+#   --tags        every release tag since v0.1.2 is lightweight; without this,
+#                 describe finds only the annotated v0.1.0-rc4 and each build
+#                 claims to descend from it.
+#   --match       the repository carries non-version tags (`assets`), and the
+#                 nearest one wins if it is not filtered out.
+#   s/^v//        pacman ranks an alphabetic first segment below a numeric one,
+#                 so a surviving `v` sorts the build under every release.
+#
+# Held to that shape by test/release-version-contract.sh; the ordering it buys
+# is decided by vercmp in test/release-native-ordering.sh.
 pkgver() {
     cd "$pkgname"
-    git describe --long --abbrev=7 | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+    git describe --long --tags --abbrev=7 --match 'v[0-9]*' |
+        sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -20,24 +20,45 @@ options=(!lto)
 source=("$pkgname::git+$url.git")
 sha256sums=('SKIP')
 
-# A build from main has to outrank every published facelock, or pacman refuses
-# it as an upgrade and AUR helpers report this package as permanently out of
-# date. Three things earn that (#330):
+# A build has to land strictly between the release it descends from and the next
+# one. Below the first and pacman refuses it as an upgrade, so AUR helpers report
+# this package as permanently out of date; above the second and it blocks the
+# real release. Four things earn that, and all four were faults (#330):
 #
 #   --tags        every release tag since v0.1.2 is lightweight; without this,
 #                 describe finds only the annotated v0.1.0-rc4 and each build
 #                 claims to descend from it.
 #   --match       the repository carries non-version tags (`assets`), and the
 #                 nearest one wins if it is not filtered out.
-#   s/^v//        pacman ranks an alphabetic first segment below a numeric one,
+#   ${tag#v}      pacman ranks an alphabetic first segment below a numeric one,
 #                 so a surviving `v` sorts the build under every release.
+#   ${x//[-.]/}   the prerelease suffix converts the way release_arch_pkgver
+#                 converts it for the released package: v0.2.0-alpha.1 becomes
+#                 0.2.0alpha1, not 0.2.0.alpha.1. pacman compares separator runs
+#                 before segments, so the dotted form outranks 0.2.0alpha2,
+#                 0.2.0beta1 and the stable 0.2.0 alike.
 #
-# Held to that shape by test/release-version-contract.sh; the ordering it buys
-# is decided by vercmp in test/release-native-ordering.sh.
+# Held to this shape by test/release-version-contract.sh; the ordering it buys is
+# decided by vercmp in test/release-native-ordering.sh. scripts/release-versions.sh
+# carries the same shape as release_arch_git_pkgver, which is what those two read.
 pkgver() {
     cd "$pkgname"
-    git describe --long --tags --abbrev=7 --match 'v[0-9]*' |
-        sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+
+    local described tag base suffix count object
+    described="$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')"
+
+    # --long always ends in -<commits>-g<object>, so the two right-most fields
+    # come off to leave the tag, which carries a dash of its own on a prerelease.
+    tag="${described%-*-*}"
+    count="${described#"$tag"-}"
+    object="${count#*-}"
+    count="${count%-*}"
+
+    tag="${tag#v}"
+    base="${tag%%-*}"
+    suffix="${tag#"$base"}"
+
+    printf '%s%s.r%s.%s\n' "$base" "${suffix//[-.]/}" "$count" "$object"
 }
 
 prepare() {

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -45,8 +45,12 @@ sha256sums=('SKIP')
 pkgver() {
     cd "$pkgname"
 
+    # Failing here is the right answer when no release tag is reachable: makepkg
+    # stops with "failed to update pkgver". Without the guard the expansions
+    # below would build a version out of an empty string and ship it, because
+    # what they produce still satisfies makepkg's pkgver character check.
     local described tag base suffix count object
-    described="$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')"
+    described="$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" || return 1
 
     # --long always ends in -<commits>-g<object>, so the two right-most fields
     # come off to leave the tag, which carries a dash of its own on a prerelease.

--- a/dist/PKGBUILD-git
+++ b/dist/PKGBUILD-git
@@ -23,7 +23,8 @@ sha256sums=('SKIP')
 # A build has to land strictly between the release it descends from and the next
 # one. Below the first and pacman refuses it as an upgrade, so AUR helpers report
 # this package as permanently out of date; above the second and it blocks the
-# real release. Four things earn that, and all four were faults (#330):
+# real release. Four things earn that, and all four were broken. #330 reported
+# the first and third; the other two are the same bug in the same expression:
 #
 #   --tags        every release tag since v0.1.2 is lightweight; without this,
 #                 describe finds only the annotated v0.1.0-rc4 and each build

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -802,19 +802,22 @@ not drift. What a build installs is whatever `pkgver()` computes at build time:
 <released pkgver>.r<commits since that tag>.g<7-char object name>
 ```
 
-so a build from `main` today is `0.1.4.r650.ga8c48b7`. Two properties make that
+so a build from `main` today is `0.1.4.r650.ga8c48b7`, and one from a
+`v0.2.0-alpha.1` checkout is `0.2.0alpha1.r7.gdeadbee`. Two properties make that
 version usable, and both are enforced rather than assumed:
 
 - it must outrank the release it descends from, or pacman refuses the upgrade
   and every AUR helper reports the package as permanently out of date
 - it must rank below the next release, or the git package blocks the real one
 
-Getting there needs `git describe --long --tags --match 'v[0-9]*'` and a
-stripped leading `v`. Every release tag since `v0.1.2` is lightweight, so a
-`--tags`-less describe walks back to the last annotated tag (`v0.1.0-rc4`); the
-repository also carries a non-version tag (`assets`) that `--match` filters out;
-and pacman ranks an alphabetic first segment below a numeric one, so a surviving
-`v` sorts the build under every release. All three were live faults (#330).
+Four things earn that, and all four were live faults (#330):
+
+| | |
+|---|---|
+| `--tags` | Every release tag since `v0.1.2` is lightweight. Without it, describe walks back to the last annotated tag, `v0.1.0-rc4`. |
+| `--match 'v[0-9]*'` | The repository carries a non-version tag (`assets`), and describe takes it whenever it sits nearer HEAD. |
+| stripped leading `v` | pacman ranks an alphabetic first segment below a numeric one, so a surviving `v` sorts the build under every release. |
+| converted prerelease suffix | `v0.2.0-alpha.1` becomes `0.2.0alpha1`, the same conversion the released package gets. pacman compares separator runs before segments, so keeping the punctuation ranks the build above `0.2.0alpha2`, `0.2.0beta1` and the stable `0.2.0` alike. |
 
 `test/release-version-contract.sh` holds the recipe to that shape against a
 synthetic tag graph, and `test/release-native-ordering.sh` hands the result to

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -791,6 +791,36 @@ targets, lifecycle depth, and immutable environment identities. Release
 preflight, CI, and release metadata checks validate that authority; `just
 release` does not rewrite it.
 
+### The version `facelock-git` actually installs
+
+`dist/PKGBUILD-git`'s `pkgver` field is display only. AUR's web page and
+`.SRCINFO` show it because `makepkg --printsrcinfo` runs without a checkout to
+describe, and `just release` keeps it level with the release so the page does
+not drift. What a build installs is whatever `pkgver()` computes at build time:
+
+```
+<released pkgver>.r<commits since that tag>.g<7-char object name>
+```
+
+so a build from `main` today is `0.1.4.r650.ga8c48b7`. Two properties make that
+version usable, and both are enforced rather than assumed:
+
+- it must outrank the release it descends from, or pacman refuses the upgrade
+  and every AUR helper reports the package as permanently out of date
+- it must rank below the next release, or the git package blocks the real one
+
+Getting there needs `git describe --long --tags --match 'v[0-9]*'` and a
+stripped leading `v`. Every release tag since `v0.1.2` is lightweight, so a
+`--tags`-less describe walks back to the last annotated tag (`v0.1.0-rc4`); the
+repository also carries a non-version tag (`assets`) that `--match` filters out;
+and pacman ranks an alphabetic first segment below a numeric one, so a surviving
+`v` sorts the build under every release. All three were live faults (#330).
+
+`test/release-version-contract.sh` holds the recipe to that shape against a
+synthetic tag graph, and `test/release-native-ordering.sh` hands the result to
+`vercmp` inside the pinned Arch container. `release_arch_git_pkgver` in
+`scripts/release-versions.sh` is the one definition both read.
+
 ## ONNX Runtime Bundling
 
 The `ort` crate is built with feature `api-20`, so facelock requires ONNX Runtime

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -798,13 +798,15 @@ release` does not rewrite it.
 describe, and `just release` keeps it level with the release so the page does
 not drift. What a build installs is whatever `pkgver()` computes at build time:
 
-```
-<released pkgver>.r<commits since that tag>.g<7-char object name>
+```text
+<released pkgver>.r<commits since that tag>.g<abbreviated object name>
 ```
 
-so a build from `main` today is `0.1.4.r650.ga8c48b7`, and one from a
-`v0.2.0-alpha.1` checkout is `0.2.0alpha1.r7.gdeadbee`. Two properties make that
-version usable, and both are enforced rather than assumed:
+`git describe --abbrev=7` sets a floor, not a width: the object name is seven
+hex characters, or more where seven would be ambiguous. So a build off `v0.1.4`
+reads like `0.1.4.r650.ga8c48b7`, and one off `v0.2.0-alpha.1` like
+`0.2.0alpha1.r7.gdeadbee`. Two properties make that version usable, and both are
+enforced rather than assumed:
 
 - it must outrank the release it descends from, or pacman refuses the upgrade
   and every AUR helper reports the package as permanently out of date

--- a/scripts/release-versions.sh
+++ b/scripts/release-versions.sh
@@ -210,6 +210,29 @@ release_arch_pkgver() {
     fi
 }
 
+# What dist/PKGBUILD-git's pkgver() produces: the newest release the build
+# descends from, plus the commit distance and abbreviated object name. The
+# recipe computes it from `git describe` and cannot source this file -- it runs
+# from an AUR checkout -- so this is the shape both sides are held to, by
+# test/release-version-contract.sh against the recipe and by
+# test/release-native-ordering.sh against vercmp. Keep the two in step (#330).
+release_arch_git_pkgver() {
+    local version="${1:-}"
+    local commits="${2:-}"
+    local object="${3:-}"
+    local pkgver
+    pkgver="$(release_arch_pkgver "$version")" || return 1
+    if [[ ! "$commits" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        echo "invalid commit distance '$commits'" >&2
+        return 1
+    fi
+    if [[ ! "$object" =~ ^[0-9a-f]{7,40}$ ]]; then
+        echo "invalid abbreviated object name '$object'" >&2
+        return 1
+    fi
+    printf '%s.r%s.g%s\n' "$pkgver" "$commits" "$object"
+}
+
 release_arch_version() {
     local version="${1:-}"
     local revision="${2:-}"

--- a/test/release-native-ordering.sh
+++ b/test/release-native-ordering.sh
@@ -69,3 +69,29 @@ for ((index = 0; index + 1 < ${#versions[@]}; index++)); do
 done
 
 echo "native $kind ordering: OK (${versions[*]})"
+
+# facelock-git is versioned by dist/PKGBUILD-git's pkgver(), which appends
+# `.r<commits>.g<sha>` to the newest release tag it can reach. That has to land
+# strictly between the release it descends from and the next one, or the AUR
+# package is unupgradeable in one direction and blocks the real release in the
+# other (#330). The recipe's half -- that it produces this shape at all -- is
+# test/release-version-contract.sh; pacman decides the ordering, so it is
+# decided here.
+if [ "$kind" = arch ]; then
+    git_build_pairs=(
+        "$(release_arch_pkgver 0.1.4)|$(release_arch_git_pkgver 0.1.4 650 a8c48b7)"
+        "$(release_arch_git_pkgver 0.1.4 650 a8c48b7)|$(release_arch_pkgver 0.2.0-alpha.1)"
+        "$(release_arch_pkgver 0.2.0-alpha.1)|$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)"
+        "$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)|$(release_arch_pkgver 0.2.0-alpha.2)"
+        "$(release_arch_pkgver 0.2.0-rc.1)|$(release_arch_git_pkgver 0.2.0-rc.1 2 facefee)"
+        "$(release_arch_git_pkgver 0.2.0-rc.1 2 facefee)|$(release_arch_pkgver 0.2.0)"
+        "$(release_arch_pkgver 0.2.0)|$(release_arch_git_pkgver 0.2.0 1 c0ffee1)"
+    )
+    for pair in "${git_build_pairs[@]}"; do
+        if ! compare "${pair%%|*}" "${pair##*|}"; then
+            echo "native arch facelock-git ordering failed: ${pair%%|*} !< ${pair##*|}" >&2
+            exit 1
+        fi
+    done
+    echo "native arch facelock-git ordering: OK (${#git_build_pairs[@]} pairs)"
+fi

--- a/test/release-native-ordering.sh
+++ b/test/release-native-ordering.sh
@@ -68,7 +68,7 @@ for ((index = 0; index + 1 < ${#versions[@]}; index++)); do
     fi
 done
 
-echo "native $kind ordering: OK (${versions[*]})"
+echo "native $kind release ordering: OK (${versions[*]})"
 
 # facelock-git is versioned by dist/PKGBUILD-git's pkgver(), which appends
 # `.r<commits>.g<sha>` to the newest release tag it can reach. That has to land

--- a/test/release-native-ordering.sh
+++ b/test/release-native-ordering.sh
@@ -83,6 +83,11 @@ if [ "$kind" = arch ]; then
         "$(release_arch_git_pkgver 0.1.4 650 a8c48b7)|$(release_arch_pkgver 0.2.0-alpha.1)"
         "$(release_arch_pkgver 0.2.0-alpha.1)|$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)"
         "$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)|$(release_arch_pkgver 0.2.0-alpha.2)"
+        # A prerelease build has to stay under every later release of the same
+        # base, not just the next alpha. Keeping the tag's punctuation cleared
+        # all three of these at once.
+        "$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)|$(release_arch_pkgver 0.2.0-beta.1)"
+        "$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)|$(release_arch_pkgver 0.2.0)"
         "$(release_arch_pkgver 0.2.0-rc.1)|$(release_arch_git_pkgver 0.2.0-rc.1 2 facefee)"
         "$(release_arch_git_pkgver 0.2.0-rc.1 2 facefee)|$(release_arch_pkgver 0.2.0)"
         "$(release_arch_pkgver 0.2.0)|$(release_arch_git_pkgver 0.2.0 1 c0ffee1)"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -60,6 +60,15 @@ assert_eq "true" "$(release_github_prerelease 0.2.0-alpha.1)" "GitHub alpha clas
 assert_eq "false" "$(release_github_prerelease 0.2.0)" "GitHub stable classification"
 assert_eq "0.2.0~alpha.1" "$(release_debian_upstream 0.2.0-alpha.1)" "Debian upstream"
 assert_eq "0.2.0alpha1" "$(release_arch_pkgver 0.2.0-alpha.1)" "Arch pkgver"
+assert_eq "0.1.4.r650.ga8c48b7" "$(release_arch_git_pkgver 0.1.4 650 a8c48b7)" "Arch VCS pkgver"
+assert_eq "0.2.0alpha1.r7.gdeadbee" "$(release_arch_git_pkgver 0.2.0-alpha.1 7 deadbee)" "Arch VCS prerelease pkgver"
+assert_eq "0.1.4.r0.ga8c48b7" "$(release_arch_git_pkgver 0.1.4 0 a8c48b7)" "Arch VCS pkgver at the tagged commit"
+assert_rejected release_arch_git_pkgver 0.1.4 -1 a8c48b7
+assert_rejected release_arch_git_pkgver 0.1.4 07 a8c48b7
+assert_rejected release_arch_git_pkgver 0.1.4 650 ga8c48b7
+assert_rejected release_arch_git_pkgver 0.1.4 650 A8C48B7
+assert_rejected release_arch_git_pkgver 0.1.4 650 a8c48
+assert_rejected release_arch_git_pkgver v0.1.4 650 a8c48b7
 assert_eq "0.2.0" "$(release_rpm_version 0.2.0-alpha.1)" "RPM Version"
 assert_eq "0.1.alpha.1" "$(release_rpm_release 0.2.0-alpha.1 1)" "RPM prerelease Release"
 assert_eq "1" "$(release_rpm_release 0.2.0 99)" "RPM stable Release"
@@ -2556,5 +2565,64 @@ if (
     fail "just release accepted a prerelease after the same RPM Version reached stable"
 fi
 git -C "$release_repo" diff --quiet || fail "rejected stable-to-prerelease transition changed release metadata"
+
+# dist/PKGBUILD-git computes its version at build time from `git describe`, so
+# nothing in the tree records what a build will actually be called. #330 was two
+# faults in that one pipeline, and neither surfaces without a real tag graph:
+# `--long` without `--tags` sees annotated tags only -- every release tag since
+# v0.1.2 is lightweight, so describe walked back to v0.1.0-rc4 -- and the tag's
+# leading `v` survived into the pkgver, where pacman ranks an alphabetic first
+# segment below a numeric one. The result sorted below the released package, so
+# it could never be installed as an upgrade.
+#
+# Reproduce that tag graph and hold the recipe to the version it must produce.
+# Ordering is not decided here: pacman decides it, in
+# test/release-native-ordering.sh, which is the only place vercmp exists.
+git_pkgver_src="$tmp_root/git-pkgver"
+git_pkgver_repo="$git_pkgver_src/facelock-git"
+mkdir -p "$git_pkgver_repo"
+git -C "$git_pkgver_repo" init -q
+git -C "$git_pkgver_repo" config user.name pkgver-test
+git -C "$git_pkgver_repo" config user.email pkgver-test@example.invalid
+
+git_pkgver_commit() {
+    : > "$git_pkgver_repo/$1"
+    git -C "$git_pkgver_repo" add -A
+    git -C "$git_pkgver_repo" -c commit.gpgsign=false commit -qm "$1"
+}
+
+git_pkgver_commit rc-base
+# The one annotated tag, and the oldest. A `--tags`-less describe finds only
+# this one, however many releases came after it.
+git -C "$git_pkgver_repo" -c tag.gpgsign=false tag -a v0.1.0-rc4 -m v0.1.0-rc4
+git_pkgver_commit release
+# Lightweight, like v0.1.2 and every release tag since.
+git -C "$git_pkgver_repo" tag v0.1.4
+git_pkgver_commit assets-payload
+# A lightweight tag that is not a version, nearer HEAD than the release tag.
+# facelock carries exactly one of these (`assets`); describe has to skip it, or
+# the pkgver becomes `assets.rN.g...` and sorts below every release.
+git -C "$git_pkgver_repo" tag assets
+git_pkgver_commit post-release-1
+git_pkgver_commit post-release-2
+
+git_pkgver_head="$(git -C "$git_pkgver_repo" rev-parse --short=7 HEAD)"
+git_pkgver_output="$(
+    cd "$git_pkgver_src"
+    # The recipe itself, not a copy of its pipeline: sourcing sets pkgname and
+    # defines pkgver() exactly as makepkg does, with the checkout's parent as
+    # the working directory.
+    # shellcheck source=/dev/null
+    source "$repo_root/dist/PKGBUILD-git"
+    pkgver
+)"
+assert_eq \
+    "$(release_arch_git_pkgver 0.1.4 3 "$git_pkgver_head")" \
+    "$git_pkgver_output" \
+    "facelock-git pkgver over a real tag graph"
+case "$git_pkgver_output" in
+    [0-9]*) ;;
+    *) fail "facelock-git pkgver does not start with a digit: $git_pkgver_output" ;;
+esac
 
 echo "release version contract: OK"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -2667,4 +2667,15 @@ assert_eq \
     "$(git_pkgver_run)" \
     "facelock-git pkgver at the release tag itself"
 
+# No reachable release tag. describe fails, and pkgver() has to fail with it:
+# the expansions would otherwise assemble a version out of an empty string, and
+# `.r.` clears makepkg's pkgver character check, so a nonsense version would ship
+# instead of the build stopping.
+git_pkgver_init untagged
+git_pkgver_commit base
+git -C "$git_pkgver_repo" tag assets
+if git_pkgver_output="$(git_pkgver_run 2>/dev/null)"; then
+    fail "facelock-git pkgver invented a version with no release tag: $git_pkgver_output"
+fi
+
 echo "release version contract: OK"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -2567,30 +2567,47 @@ fi
 git -C "$release_repo" diff --quiet || fail "rejected stable-to-prerelease transition changed release metadata"
 
 # dist/PKGBUILD-git computes its version at build time from `git describe`, so
-# nothing in the tree records what a build will actually be called. #330 was two
-# faults in that one pipeline, and neither surfaces without a real tag graph:
-# `--long` without `--tags` sees annotated tags only -- every release tag since
-# v0.1.2 is lightweight, so describe walked back to v0.1.0-rc4 -- and the tag's
-# leading `v` survived into the pkgver, where pacman ranks an alphabetic first
-# segment below a numeric one. The result sorted below the released package, so
-# it could never be installed as an upgrade.
+# nothing in the tree records what a build will actually be called, and every
+# fault in #330 needed a real tag graph to show itself. `--long` without `--tags`
+# saw annotated tags only -- every release tag since v0.1.2 is lightweight, so
+# describe walked back to v0.1.0-rc4; the tag's leading `v` reached the pkgver,
+# where pacman ranks an alphabetic first segment below a numeric one; and the
+# prerelease suffix kept the punctuation the released package drops, which
+# reverses the comparison in the other direction.
 #
-# Reproduce that tag graph and hold the recipe to the version it must produce.
+# Reproduce both graphs and hold the recipe to the version it must produce.
 # Ordering is not decided here: pacman decides it, in
 # test/release-native-ordering.sh, which is the only place vercmp exists.
 git_pkgver_src="$tmp_root/git-pkgver"
-git_pkgver_repo="$git_pkgver_src/facelock-git"
-mkdir -p "$git_pkgver_repo"
-git -C "$git_pkgver_repo" init -q
-git -C "$git_pkgver_repo" config user.name pkgver-test
-git -C "$git_pkgver_repo" config user.email pkgver-test@example.invalid
 
+git_pkgver_repo=
 git_pkgver_commit() {
     : > "$git_pkgver_repo/$1"
     git -C "$git_pkgver_repo" add -A
     git -C "$git_pkgver_repo" -c commit.gpgsign=false commit -qm "$1"
 }
 
+git_pkgver_init() {
+    git_pkgver_repo="$git_pkgver_src/$1/facelock-git"
+    mkdir -p "$git_pkgver_repo"
+    git -C "$git_pkgver_repo" init -q
+    git -C "$git_pkgver_repo" config user.name pkgver-test
+    git -C "$git_pkgver_repo" config user.email pkgver-test@example.invalid
+}
+
+# The recipe itself, not a copy of its transform: sourcing sets pkgname and
+# defines pkgver() exactly as makepkg does, with the checkout's parent as the
+# working directory.
+git_pkgver_run() {
+    (
+        cd "$(dirname "$git_pkgver_repo")"
+        # shellcheck source=/dev/null
+        source "$repo_root/dist/PKGBUILD-git"
+        pkgver
+    )
+}
+
+git_pkgver_init stable
 git_pkgver_commit rc-base
 # The one annotated tag, and the oldest. A `--tags`-less describe finds only
 # this one, however many releases came after it.
@@ -2607,22 +2624,45 @@ git_pkgver_commit post-release-1
 git_pkgver_commit post-release-2
 
 git_pkgver_head="$(git -C "$git_pkgver_repo" rev-parse --short=7 HEAD)"
-git_pkgver_output="$(
-    cd "$git_pkgver_src"
-    # The recipe itself, not a copy of its pipeline: sourcing sets pkgname and
-    # defines pkgver() exactly as makepkg does, with the checkout's parent as
-    # the working directory.
-    # shellcheck source=/dev/null
-    source "$repo_root/dist/PKGBUILD-git"
-    pkgver
-)"
+git_pkgver_output="$(git_pkgver_run)"
 assert_eq \
     "$(release_arch_git_pkgver 0.1.4 3 "$git_pkgver_head")" \
     "$git_pkgver_output" \
-    "facelock-git pkgver over a real tag graph"
+    "facelock-git pkgver over a stable tag graph"
 case "$git_pkgver_output" in
     [0-9]*) ;;
     *) fail "facelock-git pkgver does not start with a digit: $git_pkgver_output" ;;
 esac
+
+# The next release is a prerelease, and its tag carries punctuation the released
+# pkgver drops (v0.2.0-alpha.1 -> 0.2.0alpha1). Keeping it produces
+# 0.2.0.alpha.1.rN.g..., which pacman ranks above 0.2.0alpha2, 0.2.0beta1 and the
+# stable 0.2.0, because it compares separator runs before it compares segments.
+git_pkgver_init prerelease
+git_pkgver_commit base
+git -C "$git_pkgver_repo" tag v0.2.0-alpha.1
+git_pkgver_commit post-alpha-1
+git_pkgver_commit post-alpha-2
+git_pkgver_commit post-alpha-3
+
+git_pkgver_head="$(git -C "$git_pkgver_repo" rev-parse --short=7 HEAD)"
+git_pkgver_output="$(git_pkgver_run)"
+assert_eq \
+    "$(release_arch_git_pkgver 0.2.0-alpha.1 3 "$git_pkgver_head")" \
+    "$git_pkgver_output" \
+    "facelock-git pkgver over a prerelease tag graph"
+case "$git_pkgver_output" in
+    *.alpha.*) fail "facelock-git pkgver kept the prerelease punctuation: $git_pkgver_output" ;;
+esac
+
+# Straight off a release tag, before any commit lands on top of it.
+git_pkgver_init tagged
+git_pkgver_commit base
+git -C "$git_pkgver_repo" tag v0.1.4
+git_pkgver_head="$(git -C "$git_pkgver_repo" rev-parse --short=7 HEAD)"
+assert_eq \
+    "$(release_arch_git_pkgver 0.1.4 0 "$git_pkgver_head")" \
+    "$(git_pkgver_run)" \
+    "facelock-git pkgver at the release tag itself"
 
 echo "release version contract: OK"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -2568,14 +2568,16 @@ git -C "$release_repo" diff --quiet || fail "rejected stable-to-prerelease trans
 
 # dist/PKGBUILD-git computes its version at build time from `git describe`, so
 # nothing in the tree records what a build will actually be called, and every
-# fault in #330 needed a real tag graph to show itself. `--long` without `--tags`
-# saw annotated tags only -- every release tag since v0.1.2 is lightweight, so
-# describe walked back to v0.1.0-rc4; the tag's leading `v` reached the pkgver,
-# where pacman ranks an alphabetic first segment below a numeric one; and the
-# prerelease suffix kept the punctuation the released package drops, which
-# reverses the comparison in the other direction.
+# fault here needed a real tag graph to show itself. #330 reported two: `--long`
+# without `--tags` saw annotated tags only, and every release tag since v0.1.2 is
+# lightweight, so describe walked back to v0.1.0-rc4; and the tag's leading `v`
+# reached the pkgver, where pacman ranks an alphabetic first segment below a
+# numeric one. Two more came out of fixing those: a non-version tag nearer HEAD
+# was taken over the release tag, and the prerelease suffix kept the punctuation
+# the released package drops, which reverses the comparison in the other
+# direction.
 #
-# Reproduce both graphs and hold the recipe to the version it must produce.
+# Reproduce those graphs and hold the recipe to the version it must produce.
 # Ordering is not decided here: pacman decides it, in
 # test/release-native-ordering.sh, which is the only place vercmp exists.
 git_pkgver_src="$tmp_root/git-pkgver"


### PR DESCRIPTION
## Summary

- add `--tags` to `dist/PKGBUILD-git`'s `git describe`, so lightweight release tags are visible
- add `--match 'v[0-9]*'`, so a non-version tag nearer HEAD cannot become the pkgver
- strip the tag's leading `v`
- convert the prerelease suffix the way the released package converts it: `v0.2.0-alpha.1` gives `0.2.0alpha1.rN.gSHA`, not `0.2.0.alpha.1.rN.gSHA`
- fail the build when no release tag is reachable, instead of assembling a version out of an empty string
- make `release_arch_git_pkgver` the one definition of that shape, read by both the recipe contract and the vercmp ordering lane
- document what `facelock-git` installs, as distinct from the display `pkgver` AUR shows

## Why

`pkgver()` asked for the newest tag but never said `--tags`, so it saw annotated tags only. Every release tag since `v0.1.2` is lightweight, leaving `v0.1.0-rc4` as the newest one it could find, and the `v` survived into a version whose first segment pacman sorts below any number. A build from `main` came out as `v0.1.0.rc4.r759.ga8c48b7`, which `vercmp` ranks under the released `0.1.4` — unupgradeable by pacman, permanently out of date to every AUR helper.

Two faults beyond the report share the cause, which is that no gate ever had a tag graph to run the recipe against. `--tags` alone would take the lightweight `assets` tag the repository already carries, the moment it sat nearer HEAD. And the sed turned every dash into a dot, so a build off `v0.2.0-alpha.1` became `0.2.0.alpha.1.rN.gSHA`; pacman compares separator runs before segments, so that outranks `0.2.0alpha2`, `0.2.0beta1` and the stable `0.2.0` alike. `0.2.0-alpha.1` is the next release, so the git package would have blocked it.

## Reviewer notes

- **The recipe is no longer a one-liner.** The sed cannot express the prerelease conversion, so the transform is parameter expansion over `describe --long`'s guaranteed `-<commits>-g<object>` tail.
- **Two gates, one shape.** `release-version-contract.sh` sources the shipped recipe and runs it against synthetic tag graphs; `release-native-ordering.sh` hands the shape to `vercmp` in the pinned Arch container. Neither duplicates the other's half.
- `.SRCINFO` still advertises the static `pkgver`. That gap is inherent to a VCS package and is what the justfile already keeps synced; the built version now simply outranks it.

## Validation

- `just test-release-matrix`, including the three native ordering lanes in their pinned containers
- `just check`
- mutation check: removed `--tags`, `--match`, the `v` strip, the suffix conversion and the no-tag guard one at a time, confirming the contract test fails on each
- `makepkg --printsrcinfo` on the edited recipe, confirming `.SRCINFO` still advertises the static `pkgver`

Fixes #330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Arch package version generation for `facelock-git`, including commit distance, abbreviated commit identifiers, and prerelease formatting.
  - Ensured development package versions sort correctly around stable, prerelease, beta, and final releases.
  - Improved release tag selection and handling of unrelated tags and tagged or untagged repositories.

- **Documentation**
  - Clarified version calculation examples, release ordering, tag selection, prerelease handling, and Git edge cases.
  - Documented that abbreviated Git object names may exceed seven characters when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->