### PR TITLE
ci(release): claim the provisioned staging copr project

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@
     },
     {
       "job": "copr_build",
-      "trigger": "ignore",
+      "trigger": "pull_request",
       "manual_trigger": true,
       "owner": "tyvsmith",
       "project": "facelock-testing",

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -74,7 +74,7 @@
       ],
       "provisioning_issue": 236,
       "managed_by_this_change": false,
-      "provisioned": false
+      "provisioned": true
     }
   },
   "arch": {

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -61,6 +61,7 @@
       "optional_experimental_chroots": [
         "fedora-rawhide-x86_64"
       ],
+      "required_forge_project": "github.com/tyvsmith/facelock",
       "prerelease_publication": false
     },
     "staging": {
@@ -72,6 +73,7 @@
         "fedora-44-x86_64",
         "fedora-45-x86_64"
       ],
+      "required_forge_project": "github.com/tyvsmith/facelock",
       "provisioning_issue": 236,
       "managed_by_this_change": false,
       "provisioned": true

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2164,6 +2164,14 @@ Only an explicit `provisioned: false` skips a channel. `copr_channels.production
 declares no such switch and must never grow one, so the production comparison
 always queries its authority.
 
+A channel comparison covers three properties, not one. The live chroot set must
+match the channel's declared chroots. `enable_net` must be true, because the RPM
+builds from source and `cargo` fetches crates during `%build`. The project's
+Packit forge allowlist must contain `copr_channels.<channel>.required_forge_project`,
+which is `github.com/tyvsmith/facelock` for both channels. Builder permission for
+the `packit` user is outside this contract: COPR serves project permissions only
+to an authenticated owner, so a public comparison cannot make that claim.
+
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and
 how fresh each channel's repository metadata was.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2107,8 +2107,9 @@ live module is exercised per code by the `facelock-map-*` fixtures in
 
 `dist/release-matrix.json` is the checked-in release-target authority. A strict
 prerelease tag has the form `vX.Y.Z-{alpha,beta,rc}.N`; it creates a GitHub
-prerelease and direct artifacts, but it must not publish to stable APT, stable AUR, or production COPR. Staging COPR infrastructure is owned by issue #236
-and is not provisioned or modified by the prerelease identity workflow.
+prerelease and direct artifacts, but it must not publish to stable APT, stable AUR, or production COPR. The staging COPR project exists; the remaining
+staging infrastructure is owned by issue #236, and neither is modified by the
+prerelease identity workflow.
 
 A stable `vX.Y.Z` tag may publish to stable APT and AUR only after validated
 release metadata classifies it as stable. Production COPR additionally
@@ -2149,11 +2150,15 @@ contract. While `provisioned` is false the job must carry `trigger: ignore` and
 is dispatched by hand; when it is true the job must carry
 `trigger: pull_request`. Either value alone fails the release matrix contract,
 so the project cannot be declared live without the job that builds into it, and
-the job cannot chase a project that does not exist. A third assertion holds
-`provisioned` false until issue #236 creates the project, so provisioning is
-three reviewed edits: the switch, the trigger, and retiring that assertion.
-While the switch is false, `test/check-live-release-channels.py --channel
-staging` reports `not provisioned` and contacts nothing.
+the job cannot chase a project that does not exist. The switch is true: the
+project exists with exactly the declared chroots. Provisioning it took three
+reviewed edits: the switch, the trigger, and retiring the assertion that held
+`provisioned` false until issue #236 created the project. `manual_trigger`
+stays true on either setting, so a pull request offers the staging build rather
+than starting it. While the switch is false,
+`test/check-live-release-channels.py --channel staging` reports
+`not provisioned` and contacts nothing; while it is true that comparison
+queries the live project on every pull request and in preflight.
 
 Only an explicit `provisioned: false` skips a channel. `copr_channels.production`
 declares no such switch and must never grow one, so the production comparison

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -616,12 +616,17 @@ crate feature `api-20` keeps the binary compatible with Fedora's runtime.)
 3. Install the **Packit-as-a-Service** GitHub App on the repository:
    https://github.com/marketplace/packit-as-a-service
 4. In the COPR project → Settings → Permissions, grant the `packit` user
-   **builder** permission so Packit can build into the existing project. If an
-   "allowed forge projects" field is present, add `github.com/tyvsmith/facelock`.
+   **builder** permission so Packit can build into the existing project. In the
+   "allowed forge projects" field, add `github.com/tyvsmith/facelock`.
 5. In the COPR project → Settings, enable **"Enable internet access during
    builds"**. The RPM is built from source and `cargo` fetches crates from
    crates.io during `%build`; COPR's build chroot is network-isolated by
    default, so this toggle is required or the build fails resolving crates.
+
+Step 4's allowlist and step 5 apply to both channels and are checked on every
+pull request by `python3 test/check-live-release-channels.py`, which reads them
+off the public project response. Builder permission is not public, so it stays a
+hand-confirmed step.
 
 Verify the COPR build locally before relying on it with `just test-copr`, which
 reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot and
@@ -635,8 +640,17 @@ points at production; staging below is where a candidate gets built.
 
 The project exists, with exactly the `fedora-43-x86_64`, `fedora-44-x86_64`,
 and `fedora-45-x86_64` chroots, internet access during builds enabled, and
-`packit` holding builder permission. `dist/release-matrix.json` records that as
-`copr_channels.staging.provisioned: true`.
+`github.com/tyvsmith/facelock` on its Packit forge allowlist. Those three
+properties are contract-checked on every pull request, not just described here:
+`test/check-live-release-channels.py` reads all of them off the project response
+and fails on any of them. `dist/release-matrix.json` records the claim as
+`copr_channels.staging.provisioned: true` and holds the expected forge project
+in `copr_channels.staging.required_forge_project`.
+
+Builder permission for the `packit` user is the one setup step no gate can see.
+COPR serves project permissions only to an authenticated owner, so the checker,
+which reads the public project API, cannot compare them. Confirm that one by
+hand in the web UI.
 
 `.packit.yaml` declares a second `copr_build` job for it, on
 `trigger: pull_request` with `manual_trigger: true`. Packit therefore offers the
@@ -645,9 +659,10 @@ build on a pull request and a maintainer dispatches it by hand with a
 publishes into staging.
 
 `python3 test/check-live-release-channels.py --channel staging` now queries the
-real project and compares its chroots with the checked-in authority, on every
-pull request in CI and again in `just release-preflight`. A chroot that appears
-or disappears in COPR fails that gate.
+real project and compares it with the checked-in authority, on every pull
+request in CI and again in `just release-preflight`. A chroot that appears or
+disappears in COPR fails that gate, as does internet access switched off or a
+forge allowlist that stops naming this repository.
 
 The trigger and the switch move together, and `test/check-release-matrix.py`
 enforces the pairing in both directions: `provisioned: true` requires

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -593,10 +593,10 @@ Rawhide for release fails the matrix check.
 `.packit.yaml` deliberately uses JSON syntax, which is a valid YAML subset.
 Release guards therefore parse its jobs semantically with the Python standard
 library instead of comparing YAML spelling; general YAML outside that subset
-fails closed. The production project is `tyvsmith/facelock`. The planned
-prerelease staging project is `tyvsmith/facelock-testing`, but provisioning or
-changing it belongs to issue #236 and is not performed by this release-identity
-change.
+fails closed. The production project is `tyvsmith/facelock`; the prerelease
+staging project is `tyvsmith/facelock-testing`, covered below. Issue #236 still
+owns the remaining staging infrastructure, so changing the project's chroots or
+permissions belongs there, not to a release-identity change.
 
 The COPR RPM is built **from source** with the spec's default
 `%bcond_with bundled_ort` mode and does **not** bundle ONNX Runtime. Its
@@ -628,41 +628,42 @@ reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot and
 checks that the payload has no bundle while its dependencies select Fedora ORT.
 
 Only a stable-tagged config with the deliberately restored production release
-trigger can populate production COPR automatically. Do not point a prerelease
-tag at production while staging is unavailable.
+trigger can populate production COPR automatically. A prerelease tag never
+points at production; staging below is where a candidate gets built.
 
 ##### Staging COPR (`tyvsmith/facelock-testing`)
 
-`.packit.yaml` declares a second `copr_build` job, for
-`tyvsmith/facelock-testing`. It carries `trigger: ignore`, so nothing runs it
-automatically: a maintainer dispatches it by hand with a `/packit build`
-comment. A tag never publishes into staging.
+The project exists, with exactly the `fedora-43-x86_64`, `fedora-44-x86_64`,
+and `fedora-45-x86_64` chroots, internet access during builds enabled, and
+`packit` holding builder permission. `dist/release-matrix.json` records that as
+`copr_channels.staging.provisioned: true`.
 
-The project does not exist yet. Issue #236 owns creating it and granting Packit
-builder access; until then `dist/release-matrix.json` keeps
-`copr_channels.staging.provisioned` false and
-`python3 test/check-live-release-channels.py --channel staging` reports `not
-provisioned` and queries nothing.
+`.packit.yaml` declares a second `copr_build` job for it, on
+`trigger: pull_request` with `manual_trigger: true`. Packit therefore offers the
+build on a pull request and a maintainer dispatches it by hand with a
+`/packit build` comment; nothing builds into staging on its own, and a tag never
+publishes into staging.
 
-The trigger and that switch move together, and `test/check-release-matrix.py`
-enforces the pairing. While `provisioned` is false the staging job must stay on
-`trigger: ignore`; a pull-request trigger would aim every pull request's Packit
-run at a project that answers 404.
+`python3 test/check-live-release-channels.py --channel staging` now queries the
+real project and compares its chroots with the checked-in authority, on every
+pull request in CI and again in `just release-preflight`. A chroot that appears
+or disappears in COPR fails that gate.
 
-Provisioning is therefore three edits, and the contract rejects any two of them
-without the third. Create the project with exactly the Fedora 43, 44, and 45
-chroots, then:
+The trigger and the switch move together, and `test/check-release-matrix.py`
+enforces the pairing in both directions: `provisioned: true` requires
+`trigger: pull_request`, and `provisioned: false` requires `trigger: ignore`.
+Setting the switch back without moving the trigger, or the reverse, fails the
+release matrix contract. The pairing is what stops a pull-request trigger from
+aiming every Packit run at a project that answers 404.
 
-1. set `copr_channels.staging.provisioned` to true in `dist/release-matrix.json`
-2. move the staging job in `.packit.yaml` to `trigger: pull_request`
-3. delete the `staging COPR provisioning must stay unclaimed until issue #236
-   creates the project` assertion from `test/check-release-matrix.py`
-
-The third edit is the point of review: that assertion exists so provisioning
-cannot be claimed by a config change alone, and retiring it is the moment
-someone confirms the project really exists. From then on the same checker
-compares the live project with the checked-in authority on every pull request
-and in preflight.
+Provisioning was three edits, and the contract rejected any two of them without
+the third: the switch in `dist/release-matrix.json`, the trigger in
+`.packit.yaml`, and retiring the `staging COPR provisioning must stay unclaimed
+until issue #236 creates the project` assertion in
+`test/check-release-matrix.py`. That third assertion existed so provisioning
+could not be claimed by a config change alone; retiring it was the moment
+someone confirmed the project really exists. The live comparison above is what
+holds the claim honest from here.
 
 Staging tolerates no optional experimental chroot. Production accepts Rawhide's
 presence or absence; in staging any chroot beyond the supported three is drift.

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -57,8 +57,12 @@ try:
     project = channel["project"]
     api_url = channel["api_url"]
     required_chroot_list = channel["required_supported_chroots"]
+    required_forge_project = channel["required_forge_project"]
 except (KeyError, TypeError) as error:
     fail(f"release matrix has no complete {args.channel} COPR authority: {error}")
+
+if not isinstance(required_forge_project, str) or not required_forge_project:
+    fail(f"release matrix {args.channel} COPR required forge project must be a non-empty string")
 
 required_chroots = chroot_set(required_chroot_list, f"{args.channel} COPR required supported chroots")
 # Production tolerates one optional experimental chroot (Rawhide); staging has
@@ -129,6 +133,32 @@ if (
         f"got owner={response.get('ownername')!r}, name={response.get('name')!r}, "
         f"full_name={response.get('full_name')!r}"
     )
+# Two project settings docs/releasing.md promises, checked here because the same
+# response already carries them and neither is inferable from the chroot set.
+# Both are public: COPR returns them to an anonymous caller for a project it does
+# not own, so this holds from a fork. Builder permission is not here; COPR serves
+# project permissions only to an authenticated owner, so the release guide keeps
+# it as a setup step rather than a claim this gate can make.
+if response.get("enable_net") is not True:
+    fail(
+        f"{args.channel} COPR {owner}/{project} builds have no internet access "
+        f"(enable_net={response.get('enable_net')!r}); the RPM builds from source and cargo "
+        "fetches crates during %build, so a build without it fails resolving crates. "
+        'Enable Settings -> "Enable internet access during builds" in the COPR web UI'
+    )
+forge_projects = response.get("packit_forge_projects_allowed")
+if not isinstance(forge_projects, list) or not all(isinstance(entry, str) for entry in forge_projects):
+    fail(
+        f"{args.channel} COPR API response has no valid packit_forge_projects_allowed list: "
+        f"{forge_projects!r}"
+    )
+if required_forge_project not in forge_projects:
+    fail(
+        f"{args.channel} COPR {owner}/{project} does not accept Packit builds from "
+        f"{required_forge_project}; allowed={sorted(forge_projects)}. "
+        'Add it under Settings -> "allowed forge projects" in the COPR web UI'
+    )
+
 chroot_repos = response.get("chroot_repos")
 if not isinstance(chroot_repos, dict) or not all(isinstance(chroot, str) for chroot in chroot_repos):
     fail(f"{args.channel} COPR API response has no valid chroot_repos object")
@@ -146,5 +176,6 @@ if missing or extra:
 
 print(
     f"live release channel contract: OK ({args.channel} COPR {owner}/{project}; "
-    f"live={sorted(live_chroots)})"
+    f"live={sorted(live_chroots)}; enable_net=True; "
+    f"packit forge={required_forge_project})"
 )

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -146,6 +146,18 @@ require(
     required_supported_chroots.isdisjoint(optional_experimental_chroots),
     "production COPR required supported and optional experimental chroots must be disjoint",
 )
+# Both channels build from this repository and no other, so both declare the
+# forge project COPR must allow Packit to build from. It lives here rather than
+# inside test/check-live-release-channels.py because that checker's contract is
+# to compare public state against the checked-in authority; a repository
+# identity hardcoded in the checker would make the checker its own authority.
+# `enable_net` gets no key: true is its only correct value, and a setting with
+# one legal value is a place for drift to hide rather than a choice to record.
+expected_forge_project = "github.com/tyvsmith/facelock"
+require(
+    production_copr.get("required_forge_project") == expected_forge_project,
+    f"production COPR required forge project drifted: {production_copr.get('required_forge_project')!r}",
+)
 require(
     "expected_enabled_chroots" not in production_copr,
     "production COPR authority must separate required supported and optional experimental chroots",
@@ -176,6 +188,10 @@ require_string_set(
 require(
     "optional_experimental_chroots" not in staging_copr,
     "staging COPR must not declare optional experimental chroots",
+)
+require(
+    staging_copr.get("required_forge_project") == expected_forge_project,
+    f"staging COPR required forge project drifted: {staging_copr.get('required_forge_project')!r}",
 )
 require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisioning must remain owned by issue #236")
 require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -181,10 +181,10 @@ require(staging_copr.get("provisioning_issue") == 236, "staging COPR provisionin
 require(staging_copr.get("managed_by_this_change") is False, "issue #234 cannot provision staging COPR")
 # `provisioned` is the maintainer's switch. It gates two things at once: it is
 # the only thing that lets test/check-live-release-channels.py query the staging
-# project, and it decides which trigger the staging Packit job may carry. While
-# it is false that checker reports "not provisioned" and touches no network,
-# which is what keeps the staging fixtures in release-version-contract.sh
-# offline. The trigger half is checked with the Packit jobs below.
+# project, and it decides which trigger the staging Packit job may carry. It is
+# true now that the project exists, so that checker compares the live project on
+# every run; while it is false the checker reports "not provisioned" and touches
+# no network. The trigger half is checked with the Packit jobs below.
 require(
     isinstance(staging_copr.get("provisioned"), bool),
     f"staging COPR provisioned must be a boolean: {staging_copr.get('provisioned')!r}",
@@ -403,10 +403,9 @@ for job_index, job in enumerate(packit_jobs):
             targets == staging_copr_targets,
             f"Packit staging COPR targets drifted: {sorted(targets)}",
         )
-# The staging job is what will build a candidate commit into facelock-testing
-# once #236 provisions it. It must exist now so its shape is reviewed before
-# the project does, and it must stay pull-request/manual: a release trigger
-# would make a tag publish into staging without any of the wave 4 proof.
+# The staging job builds a candidate commit into facelock-testing, which now
+# exists. It must stay pull-request/manual: a release trigger would make a tag
+# publish into staging without any of the wave 4 proof.
 staging_jobs = [
     job
     for job in packit_jobs
@@ -420,11 +419,12 @@ require(
     staging_job.get("owner") == staging_copr["owner"],
     "Packit staging COPR owner disagrees with the release matrix",
 )
-# The trigger tracks provisioning. Until the project exists, `ignore` keeps the
-# job hand-dispatched (`/packit build`), because a pull-request trigger would
-# aim every pull request's Packit run at a project that answers 404. Once the
-# maintainer creates it they flip `provisioned` and the trigger together, and
-# this pairing is what stops one moving without the other.
+# The trigger tracks provisioning. While the project does not exist, `ignore`
+# keeps the job hand-dispatched (`/packit build`), because a pull-request
+# trigger would aim every pull request's Packit run at a project that answers
+# 404. The maintainer flips `provisioned` and the trigger together, and this
+# pairing is what stops one moving without the other. `manual_trigger` stays
+# true either way, so a pull request offers the build rather than starting it.
 expected_staging_trigger = "pull_request" if staging_provisioned else "ignore"
 require(
     staging_job.get("trigger") == expected_staging_trigger,
@@ -434,10 +434,6 @@ require(
 require(
     staging_job.get("manual_trigger") is True,
     "Packit staging COPR job must stay manually triggered",
-)
-require(
-    staging_provisioned is False,
-    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
 )
 # Two COPR projects exist and no more. Without a bound, a job aimed at a third
 # project passes every check above simply by choosing allowlisted targets, and
@@ -695,10 +691,9 @@ require(
 live_channel_command = "python3 test/check-live-release-channels.py"
 require(live_channel_command in ci_workflow, "CI does not compare live release channels with the checked-in authority")
 require(live_channel_command in justfile, "release preflight does not compare live release channels with the checked-in authority")
-# Staging is unprovisioned, so this run reports "not provisioned" and stops.
-# It is wired now anyway: the flag is what turns the checked-in staging
-# authority into a gate the day #236 creates the project, and an unwired flag
-# is the failure mode this file exists to catch.
+# Staging is provisioned, so this run compares the live project with the
+# checked-in staging authority. The flag has to stay wired in both places: an
+# unwired flag is the failure mode this file exists to catch.
 staging_channel_command = f"{live_channel_command} --channel staging"
 require(staging_channel_command in ci_workflow, "CI does not compare the staging release channel")
 require(staging_channel_command in justfile, "release preflight does not compare the staging release channel")
@@ -707,8 +702,8 @@ require(
     "release preflight does not require the pre-tag release attestation renderer",
 )
 # The staging channel and the attestation are contracts, not just scripts: a
-# reader has to be able to find out that staging exists, that it is not
-# provisioned yet, and what flipping that switch turns on.
+# reader has to be able to find out that staging exists, what its provisioning
+# switch is, and what flipping that switch turns on.
 staging_doc_claims = {
     "docs/releasing.md": (
         "tyvsmith/facelock-testing",

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1226,6 +1226,10 @@ cat > "$live_copr_supported_only" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock",
   "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1238,6 +1242,10 @@ cat > "$live_copr_supported_with_rawhide" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock",
   "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1251,6 +1259,10 @@ cat > "$live_copr_missing_supported" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock",
   "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1263,6 +1275,10 @@ cat > "$live_copr_unknown_extra" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock",
   "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1277,6 +1293,10 @@ cat > "$live_copr_wrong_project" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock-testing",
   "full_name": "tyvsmith/facelock-testing",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1301,6 +1321,71 @@ if python3 "$repo_root/test/check-live-release-channels.py" --response-file "$li
 fi
 echo "release channel case: wrong-project rejected"
 echo "release channel case: Rawhide-in-Packit-targets rejected"
+
+# Project settings, not chroots. docs/releasing.md promises internet access
+# during builds and a Packit forge allowlist naming this repository; both ride
+# on the response the checker already fetches, so both are contract-checked
+# rather than described. A build without net fails resolving crates, and a
+# project that stops allowing this forge stops accepting Packit builds at all.
+live_copr_net_disabled="$tmp_root/live-copr-net-disabled.json"
+live_copr_forge_missing="$tmp_root/live-copr-forge-missing.json"
+cat > "$live_copr_net_disabled" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "enable_net": false,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+cat > "$live_copr_forge_missing" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock",
+  "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/someone-else/facelock"
+  ],
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+assert_live_channel_response_rejected() {
+    local context="$1"
+    local channel="$2"
+    local response_file="$3"
+    local diagnostic="$4"
+    local output
+    if output=$(python3 "$repo_root/test/check-live-release-channels.py" --channel "$channel" \
+        --response-file "$response_file" 2>&1); then
+        fail "live channel checker accepted $context"
+    fi
+    case "$output" in
+        *"$diagnostic"*) ;;
+        *) fail "live channel checker rejected $context for another reason: $output" ;;
+    esac
+    echo "release channel case: $context rejected"
+}
+
+assert_live_channel_response_rejected \
+    "production builds without internet access" \
+    production "$live_copr_net_disabled" \
+    "production COPR tyvsmith/facelock builds have no internet access"
+assert_live_channel_response_rejected \
+    "production forge allowlist without this repository" \
+    production "$live_copr_forge_missing" \
+    "does not accept Packit builds from github.com/tyvsmith/facelock"
 
 # Staging (#236). The project exists now, so both sides of the provisioning
 # switch are written here rather than read from the tree: an unprovisioned
@@ -1346,6 +1431,10 @@ cat > "$staging_copr_supported_only" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock-testing",
   "full_name": "tyvsmith/facelock-testing",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1358,6 +1447,10 @@ cat > "$staging_copr_missing_supported" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock-testing",
   "full_name": "tyvsmith/facelock-testing",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/"
@@ -1369,6 +1462,10 @@ cat > "$staging_copr_rawhide_extra" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock-testing",
   "full_name": "tyvsmith/facelock-testing",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1382,6 +1479,10 @@ cat > "$staging_copr_wrong_project" <<'JSON'
   "ownername": "tyvsmith",
   "name": "facelock",
   "full_name": "tyvsmith/facelock",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
   "chroot_repos": {
     "fedora-43-x86_64": "https://example.invalid/43/",
     "fedora-44-x86_64": "https://example.invalid/44/",
@@ -1442,6 +1543,47 @@ if python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
     fail "live staging checker accepted the production project identity"
 fi
 echo "release channel case: staging wrong-project rejected"
+
+staging_copr_net_disabled="$tmp_root/staging-copr-net-disabled.json"
+staging_copr_forge_missing="$tmp_root/staging-copr-forge-missing.json"
+cat > "$staging_copr_net_disabled" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "enable_net": false,
+  "packit_forge_projects_allowed": [
+    "github.com/tyvsmith/facelock"
+  ],
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+cat > "$staging_copr_forge_missing" <<'JSON'
+{
+  "ownername": "tyvsmith",
+  "name": "facelock-testing",
+  "full_name": "tyvsmith/facelock-testing",
+  "enable_net": true,
+  "packit_forge_projects_allowed": [],
+  "chroot_repos": {
+    "fedora-43-x86_64": "https://example.invalid/43/",
+    "fedora-44-x86_64": "https://example.invalid/44/",
+    "fedora-45-x86_64": "https://example.invalid/45/"
+  }
+}
+JSON
+assert_live_channel_response_rejected \
+    "staging builds without internet access" \
+    staging "$staging_copr_net_disabled" \
+    "staging COPR tyvsmith/facelock-testing builds have no internet access"
+assert_live_channel_response_rejected \
+    "staging forge allowlist emptied" \
+    staging "$staging_copr_forge_missing" \
+    "staging COPR tyvsmith/facelock-testing does not accept Packit builds from"
 if python3 "$repo_root/test/check-live-release-channels.py" --channel nonsense \
     --response-file "$staging_copr_supported_only" >/dev/null 2>&1; then
     fail "live channel checker accepted an undeclared channel"
@@ -1501,6 +1643,16 @@ live_channel_authority_case \
     's/"optional_experimental_chroots"/"retired_experimental_chroots"/' \
     production \
     "omits its optional experimental chroots"
+live_channel_authority_case \
+    "production authority without a required forge project" \
+    's/"required_forge_project"/"retired_forge_project"/' \
+    production \
+    "has no complete production COPR authority"
+live_channel_authority_case \
+    "staging authority with an empty required forge project" \
+    's@"required_forge_project": "github.com/tyvsmith/facelock"@"required_forge_project": ""@' \
+    staging \
+    "required forge project must be a non-empty string"
 live_channel_authority_case \
     "staging authority granted optional experimental chroots" \
     's/"provisioned": true/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": true/' \

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -789,13 +789,13 @@ valid_packit_staging_root="$tmp_root/packit-valid-staging"
 cp -R "$matrix_root" "$valid_packit_staging_root"
 replace_packit_staging_job \
     "$valid_packit_staging_root/.packit.yaml" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
 RELEASE_MATRIX_VERSION=0.2.0 python3 "$valid_packit_staging_root/test/check-release-matrix.py" >/dev/null
 echo "release matrix Packit case: exact facelock-testing staging targets accepted"
 
 assert_extra_packit_job_rejected \
     "second facelock-testing staging job" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 
 assert_extra_packit_job_rejected \
     "third copr_build job with allowlisted targets" \
@@ -814,14 +814,14 @@ assert_extra_packit_job_rejected \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing Rawhide target" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
     "targets Rawhide"
 assert_extra_packit_job_rejected \
     "Rawhide target outside production and staging" \
     '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing incomplete staging targets" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
     "Packit staging COPR targets drifted"
 assert_extra_packit_job_rejected \
     "duplicate targets outside production and staging" \
@@ -1045,10 +1045,11 @@ assert_matrix_mutation_rejected \
     ".packit.yaml" \
     's/"fedora-45-x86_64"/"fedora-rawhide-x86_64"/'
 
-# Staging COPR publication (#236). The project is not provisioned, so every
-# guard here is config shape: the Packit job that will build into it, the
-# checked-in authority it must agree with, and the fact that neither may reach
-# Rawhide or the production project.
+# Staging COPR publication (#236). The project is provisioned now, so the tree
+# carries the claimed shape: the switch true and the Packit job on the
+# pull-request trigger. The guards here are still config shape: the job that
+# builds into it, the checked-in authority it must agree with, and the fact that
+# neither may reach Rawhide or the production project.
 assert_matrix_mutation_rejected \
     "production COPR granted a provisioning switch" \
     "dist/release-matrix.json" \
@@ -1067,11 +1068,11 @@ assert_matrix_mutation_rejected \
 assert_matrix_mutation_rejected \
     "staging COPR granted an optional experimental chroot" \
     "dist/release-matrix.json" \
-    's/"provisioned": false/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": false/' \
+    's/"provisioned": true/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": true/' \
     "staging COPR must not declare optional experimental chroots"
 assert_staging_packit_job_rejected \
     "Packit staging job deleted" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"tyvsmith","project":"facelock-retired","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-retired","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit must define exactly one staging COPR job"
 assert_staging_packit_job_rejected \
     "Packit staging job made release-triggered" \
@@ -1079,32 +1080,74 @@ assert_staging_packit_job_rejected \
     "Packit staging COPR trigger"
 assert_staging_packit_job_rejected \
     "Packit staging job made automatic" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":false,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":false,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR job must stay manually triggered"
 assert_staging_packit_job_rejected \
     "Packit staging job owner drifted" \
-    '{"job":"copr_build","trigger":"ignore","manual_trigger":true,"owner":"packit","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"packit","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR owner"
 
 # The staging trigger and copr_channels.staging.provisioned move together. An
 # unprovisioned project must not be the target of every pull request's Packit
 # run, and a provisioned one that stays hand-dispatched is a gate nobody runs.
+# Both sides are pinned rather than inherited: a case that took its starting
+# switch from the tree would only ever exercise whichever way the tree is set,
+# and would stop proving the pairing the moment the maintainer flips it. Each
+# case below writes the switch and the trigger it wants and checks they took.
+pin_staging_provisioning() {
+    local root="$1"
+    local provisioned="$2"
+    local trigger="$3"
+    rm -rf "$root"
+    cp -R "$matrix_root" "$root"
+    python3 - "$root" "$provisioned" "$trigger" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+provisioned = sys.argv[2] == "true"
+trigger = sys.argv[3]
+matrix_path = root / "dist" / "release-matrix.json"
+packit_path = root / ".packit.yaml"
+
+matrix = json.loads(matrix_path.read_text())
+staging = matrix["copr_channels"]["staging"]
+if not isinstance(staging.get("provisioned"), bool):
+    raise SystemExit("the staging authority carries no provisioning switch to pin")
+staging["provisioned"] = provisioned
+matrix_path.write_text(json.dumps(matrix, indent=2) + "\n")
+
+config = json.loads(packit_path.read_text())
+staging_jobs = [job for job in config["jobs"] if job.get("project") == "facelock-testing"]
+if len(staging_jobs) != 1:
+    raise SystemExit(f"expected exactly one staging Packit job to pin, found {len(staging_jobs)}")
+staging_jobs[0]["trigger"] = trigger
+packit_path.write_text(json.dumps(config, indent=2) + "\n")
+
+# Guard the pin itself: read both files back, so an edit that stops writing one
+# of them fails here instead of quietly letting the case inherit the tree.
+written_staging = json.loads(matrix_path.read_text())["copr_channels"]["staging"]
+if written_staging["provisioned"] is not provisioned:
+    raise SystemExit(f"the staging provisioning pin did not take: {written_staging['provisioned']!r}")
+written_jobs = [
+    job for job in json.loads(packit_path.read_text())["jobs"] if job.get("project") == "facelock-testing"
+]
+if len(written_jobs) != 1 or written_jobs[0].get("trigger") != trigger:
+    raise SystemExit("the staging trigger pin did not take")
+PY
+}
+
 staging_pairing_index=0
 assert_staging_provisioning_pair_rejected() {
     local context="$1"
-    local matrix_expression="$2"
-    local staging_job_json="$3"
+    local provisioned="$2"
+    local trigger="$3"
     local diagnostic="$4"
     local mutation_root="$tmp_root/staging-pairing-$staging_pairing_index"
     local checker_output
     staging_pairing_index=$((staging_pairing_index + 1))
-    cp -R "$matrix_root" "$mutation_root"
-    if [ -n "$matrix_expression" ]; then
-        sed -i "$matrix_expression" "$mutation_root/dist/release-matrix.json"
-    fi
-    if [ -n "$staging_job_json" ]; then
-        replace_packit_staging_job "$mutation_root/.packit.yaml" "$staging_job_json"
-    fi
+    pin_staging_provisioning "$mutation_root" "$provisioned" "$trigger"
     if checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$mutation_root/test/check-release-matrix.py" 2>&1); then
         fail "release matrix checker accepted drift: $context"
     fi
@@ -1115,52 +1158,38 @@ assert_staging_provisioning_pair_rejected() {
     echo "release matrix staging pairing case: $context rejected"
 }
 
+assert_staging_provisioning_pair_accepted() {
+    local context="$1"
+    local provisioned="$2"
+    local trigger="$3"
+    local case_root="$tmp_root/staging-pairing-accepted-$provisioned"
+    local checker_output
+    pin_staging_provisioning "$case_root" "$provisioned" "$trigger"
+    if ! checker_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$case_root/test/check-release-matrix.py" 2>&1); then
+        fail "release matrix checker rejected $context: $checker_output"
+    fi
+    echo "release matrix staging pairing case: $context accepted"
+}
+
 assert_staging_provisioning_pair_rejected \
     "unprovisioned staging job triggered by pull requests" \
-    "" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    false pull_request \
     "must be 'ignore' while copr_channels.staging.provisioned is False"
 assert_staging_provisioning_pair_rejected \
-    "provisioned staging left on the manual trigger" \
-    's/"provisioned": false/"provisioned": true/' \
-    "" \
+    "provisioned staging left on the hand-dispatched trigger" \
+    true ignore \
     "must be 'pull_request' while copr_channels.staging.provisioned is True"
-assert_staging_provisioning_pair_rejected \
-    "staging claimed as provisioned with its pull-request trigger restored" \
-    's/"provisioned": false/"provisioned": true/' \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
-    "staging COPR provisioning must stay unclaimed"
 
-# Provisioning is three edits, and docs/releasing.md says so: flip the switch,
-# move the staging job to the pull-request trigger, and retire the pin that
-# keeps the switch unclaimed. The pairing cases above prove no two of them pass
-# alone; this proves the three together do, so the procedure is reachable.
-provisioned_root="$tmp_root/matrix-staging-provisioned"
-cp -R "$matrix_root" "$provisioned_root"
-sed -i 's/"provisioned": false/"provisioned": true/' "$provisioned_root/dist/release-matrix.json"
-replace_packit_staging_job \
-    "$provisioned_root/.packit.yaml" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
-python3 - "$provisioned_root/test/check-release-matrix.py" <<'PY'
-import pathlib
-import sys
+# The other direction. Retiring the unclaimed-provisioning pin when #236 created
+# the project must not have replaced it with the mirror pin: the switch stays a
+# switch, so both matched pairs pass and the maintainer can set it back.
+assert_staging_provisioning_pair_accepted \
+    "provisioned staging on the pull-request trigger" \
+    true pull_request
+assert_staging_provisioning_pair_accepted \
+    "unprovisioned staging held on the hand-dispatched trigger" \
+    false ignore
 
-path = pathlib.Path(sys.argv[1])
-content = path.read_text()
-pin = """require(
-    staging_provisioned is False,
-    "staging COPR provisioning must stay unclaimed until issue #236 creates the project",
-)
-"""
-if pin not in content:
-    raise SystemExit("the unclaimed-provisioning pin is not the block the provisioning procedure retires")
-path.write_text(content.replace(pin, "", 1))
-PY
-if provisioned_output=$(RELEASE_MATRIX_VERSION=0.2.0 python3 "$provisioned_root/test/check-release-matrix.py" 2>&1); then
-    echo "release matrix staging pairing case: the three provisioning edits together accepted"
-else
-    fail "release matrix checker rejected the documented provisioning procedure: $provisioned_output"
-fi
 assert_matrix_mutation_rejected \
     "staging channel comparison dropped from CI" \
     ".github/workflows/ci.yml" \
@@ -1273,9 +1302,41 @@ fi
 echo "release channel case: wrong-project rejected"
 echo "release channel case: Rawhide-in-Packit-targets rejected"
 
-# Staging (#236). The project does not exist yet, so the unprovisioned run must
-# report that and touch no network; check-release-matrix.py pins
-# copr_channels.staging.provisioned to false, which is what keeps this offline.
+# Staging (#236). The project exists now, so both sides of the provisioning
+# switch are written here rather than read from the tree: an unprovisioned
+# authority must report the skip and touch no network, a provisioned one must
+# query. Every comparison below runs from a response fixture, so nothing in
+# this file contacts COPR either way.
+pin_staging_live_authority() {
+    python3 - "$1" "$2" "$3" "${4:-}" <<'PY'
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+destination = pathlib.Path(sys.argv[2])
+provisioned = sys.argv[3] == "true"
+api_url = sys.argv[4]
+
+matrix = json.loads(source.read_text())
+staging = matrix["copr_channels"]["staging"]
+if not isinstance(staging.get("provisioned"), bool):
+    raise SystemExit("the staging authority carries no provisioning switch to pin")
+staging["provisioned"] = provisioned
+if api_url:
+    staging["api_url"] = api_url
+destination.write_text(json.dumps(matrix, indent=2) + "\n")
+
+# Guard the pin: a fixture that stopped writing the switch would inherit the
+# tree's and silently test whichever side the tree happens to be on.
+written = json.loads(destination.read_text())["copr_channels"]["staging"]
+if written["provisioned"] is not provisioned:
+    raise SystemExit(f"the staging provisioning pin did not take: {written['provisioned']!r}")
+if api_url and written["api_url"] != api_url:
+    raise SystemExit("the staging API pin did not take")
+PY
+}
+
 staging_copr_supported_only="$tmp_root/staging-copr-supported-only.json"
 staging_copr_missing_supported="$tmp_root/staging-copr-missing-supported.json"
 staging_copr_rawhide_extra="$tmp_root/staging-copr-rawhide-extra.json"
@@ -1331,12 +1392,38 @@ JSON
 python3 "$repo_root/test/check-live-release-channels.py" --channel production \
     --response-file "$live_copr_supported_only" >/dev/null
 echo "release channel case: explicit production channel accepted"
-staging_unprovisioned_output=$(python3 "$repo_root/test/check-live-release-channels.py" --channel staging)
+# The skip path is still real code, and it is pinned to its own baseline: the
+# tree's staging authority is provisioned, so a run against the live matrix
+# would query COPR instead of reporting the skip this case is about.
+staging_unprovisioned_root="$tmp_root/live-channel-staging-unprovisioned"
+mkdir -p "$staging_unprovisioned_root/dist" "$staging_unprovisioned_root/test"
+cp "$repo_root/test/check-live-release-channels.py" "$staging_unprovisioned_root/test/"
+pin_staging_live_authority "$repo_root/dist/release-matrix.json" \
+    "$staging_unprovisioned_root/dist/release-matrix.json" false
+staging_unprovisioned_output=$(python3 "$staging_unprovisioned_root/test/check-live-release-channels.py" --channel staging)
 case "$staging_unprovisioned_output" in
     *"staging COPR tyvsmith/facelock-testing is not provisioned"*) ;;
     *) fail "live staging checker did not report the unprovisioned project: $staging_unprovisioned_output" ;;
 esac
 echo "release channel case: staging not provisioned reported"
+
+# The other side of the switch, pinned the same way. A provisioned staging
+# authority must query rather than skip, so this one points at a closed local
+# port: a skip would print the unprovisioned line instead of a failed read, and
+# nothing here reaches COPR to prove it.
+staging_offline_root="$tmp_root/live-channel-staging-offline"
+mkdir -p "$staging_offline_root/dist" "$staging_offline_root/test"
+cp "$repo_root/test/check-live-release-channels.py" "$staging_offline_root/test/"
+pin_staging_live_authority "$repo_root/dist/release-matrix.json" \
+    "$staging_offline_root/dist/release-matrix.json" true "http://127.0.0.1:1/"
+if staging_offline_output=$(python3 "$staging_offline_root/test/check-live-release-channels.py" --channel staging 2>&1); then
+    fail "live channel checker skipped the staging query instead of performing it: $staging_offline_output"
+fi
+case "$staging_offline_output" in
+    *"cannot read the public staging COPR API"*) ;;
+    *) fail "live channel checker did not report a failed staging query: $staging_offline_output" ;;
+esac
+echo "release channel case: provisioned staging queries its authority"
 python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
     --response-file "$staging_copr_supported_only" >/dev/null
 echo "release channel case: staging supported-only accepted"
@@ -1416,7 +1503,7 @@ live_channel_authority_case \
     "omits its optional experimental chroots"
 live_channel_authority_case \
     "staging authority granted optional experimental chroots" \
-    's/"provisioned": false/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": false/' \
+    's/"provisioned": true/"optional_experimental_chroots": ["fedora-rawhide-x86_64"], "provisioned": true/' \
     staging \
     "must declare no optional experimental chroots"
 


### PR DESCRIPTION
## Summary

- set `copr_channels.staging.provisioned` to true in `dist/release-matrix.json`
- move the `facelock-testing` Packit job to `trigger: pull_request`, still `manual_trigger: true`
- retire the `staging COPR provisioning must stay unclaimed until issue #236 creates the project` assertion
- check `enable_net` and the Packit forge allowlist against the live project, not just its chroots
- add `copr_channels.<channel>.required_forge_project` as the checked-in expectation for that allowlist
- pin the staging pairing and live-channel fixtures to the switch each case writes, instead of inheriting the tree's
- rewrite the `docs/releasing.md` staging section and the `docs/contracts.md` staging paragraph for the provisioned state

## Why

`tyvsmith/facelock-testing` now exists with exactly `fedora-43-x86_64`, `fedora-44-x86_64`, and `fedora-45-x86_64`, internet access during builds enabled, and `packit` holding builder permission. The tree still asserted the project was unclaimed, which kept the staging job hand-dispatched and made the live staging comparison a no-op skip. The release matrix contract accepts the switch, the trigger, and the unclaimed assertion only as a set, so all three move here.

## Reviewer notes

- **the third edit is the review point.** The retired assertion existed so provisioning could not be claimed by a config change alone. Its deletion is the moment someone confirms the project really exists; the live query below is what holds the claim honest from here.
- **the live checker now hits COPR, and compares three properties.** `python3 test/check-live-release-channels.py --channel staging` runs on every pull request and in `just release-preflight`. A chroot added or removed in COPR fails it, so does `enable_net` switched off, so does a forge allowlist that stops naming this repository.
- **builder permission is deliberately not checked.** COPR serves project permissions only to an authenticated owner, so the public comparison cannot make that claim; `docs/releasing.md` names it as the one hand-confirmed setup step rather than implying the gate covers it.
- **the forge expectation lives in the matrix, not the script.** The checker's contract is to compare public state against the checked-in authority; a repository identity hardcoded in the checker would make the checker its own authority. `enable_net` gets no matrix key, because true is its only correct value.
- **fixtures no longer read the tree's switch.** Both pairing cases and both live-channel cases write the `provisioned` value and trigger they test and check the write took, so the pairing keeps being proved in both directions whichever way the tree is set. Without that, this branch's own edits would have made the fixture self-referential.
- **the switch stays a switch.** A new accepted case covers `provisioned: false` with `trigger: ignore`, so retiring the unclaimed pin did not quietly replace it with its mirror.

## Validation

- `python3 test/check-release-matrix.py`, and again with `RELEASE_MATRIX_VERSION=0.2.0-alpha.1`
- `bash test/release-version-contract.sh`
- `python3 test/check-live-release-channels.py --channel staging` and the production run
- mutation check: disabling the `enable_net` assertion fails the contract
- probed the COPR API anonymously for projects this account does not own, confirming both enforced fields are public
- `python3 test/check-agent-docs.py`
- `just check`
- `just test-packit-config`

Refs #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests can now trigger prerelease staging builds through the testing COPR workflow.
  - Manual triggering remains available for staging builds.
  - Staging builds support live-project validation against the configured release matrix.

- **Documentation**
  - Updated release and contract documentation to describe staging setup, build triggers, required forge access, network requirements, and validation checks.
  - Documented Arch VCS package version generation and validation.

- **Tests**
  - Expanded production and staging validation for provisioning, triggers, chroots, network access, approved forge projects, and package-version consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->