### PR TITLE
fix(test): compare the arch package version in one spelling

### DIFF
--- a/scripts/release-versions.sh
+++ b/scripts/release-versions.sh
@@ -246,17 +246,20 @@ release_arch_version() {
 # it) carry this Cargo version? The two spellings coincide only for a stable
 # release, so the Cargo side is mapped through release_arch_pkgver and compared
 # for equality. Equality, not a substring: 0.1.4 must not answer for 0.1.41.
-# pkgrel is a packaging counter the binary cannot report, so it is not compared.
+# pkgrel is a packaging counter the binary cannot report, so it is not compared
+# beyond parsing it off: an optional epoch prefix and an optional .N pkgrel
+# subrelease are both real forms `pacman -Q` can print, and neither may widen
+# the pkgver comparison into a loophole.
 release_arch_version_carries_cargo() {
     local arch_version="${1:-}"
     local cargo_version="${2:-}"
     local expected
     expected="$(release_arch_pkgver "$cargo_version")" || return 1
-    if [[ ! "$arch_version" =~ ^([^-]+)-([1-9][0-9]*)$ ]]; then
-        echo "invalid Arch package version '$arch_version' (expected pkgver-pkgrel)" >&2
+    if [[ ! "$arch_version" =~ ^([0-9]+:)?([^-:]+)-([1-9][0-9]*)(\.[1-9][0-9]*)?$ ]]; then
+        echo "invalid Arch package version '$arch_version' (expected [epoch:]pkgver-pkgrel[.subrelease])" >&2
         return 1
     fi
-    [ "${BASH_REMATCH[1]}" = "$expected" ]
+    [ "${BASH_REMATCH[2]}" = "$expected" ]
 }
 
 release_rpm_version() {

--- a/scripts/release-versions.sh
+++ b/scripts/release-versions.sh
@@ -242,6 +242,23 @@ release_arch_version() {
     printf '%s-%s\n' "$pkgver" "$revision"
 }
 
+# Does an installed Arch package version (pkgver-pkgrel, as `pacman -Q` prints
+# it) carry this Cargo version? The two spellings coincide only for a stable
+# release, so the Cargo side is mapped through release_arch_pkgver and compared
+# for equality. Equality, not a substring: 0.1.4 must not answer for 0.1.41.
+# pkgrel is a packaging counter the binary cannot report, so it is not compared.
+release_arch_version_carries_cargo() {
+    local arch_version="${1:-}"
+    local cargo_version="${2:-}"
+    local expected
+    expected="$(release_arch_pkgver "$cargo_version")" || return 1
+    if [[ ! "$arch_version" =~ ^([^-]+)-([1-9][0-9]*)$ ]]; then
+        echo "invalid Arch package version '$arch_version' (expected pkgver-pkgrel)" >&2
+        return 1
+    fi
+    [ "${BASH_REMATCH[1]}" = "$expected" ]
+}
+
 release_rpm_version() {
     release_base_version "${1:-}"
 }

--- a/test/Containerfile.arch-e2e
+++ b/test/Containerfile.arch-e2e
@@ -40,6 +40,11 @@ RUN useradd -m builder && \
 COPY dist/PKGBUILD dist/PKGBUILD-bin dist/PKGBUILD-git dist/facelock.install /recipe/
 
 COPY .github/workflows/scripts/run-networkless.sh /run-networkless.sh
+# The validator compares what the installed binary reports against what pacman
+# records, and those are two different spellings of one release. The mapping
+# between them belongs to the release tooling, so the validator sources it
+# rather than restating it.
+COPY scripts/release-versions.sh /release-versions.sh
 COPY test/arch-pkgbuild-dependency-contract.sh /arch-pkgbuild-dependency-contract.sh
 COPY test/build-arch-source-package.sh /build-arch-source-package.sh
 COPY test/arch-package-e2e-validate.sh /arch-package-e2e-validate.sh

--- a/test/arch-package-e2e-validate.sh
+++ b/test/arch-package-e2e-validate.sh
@@ -49,6 +49,20 @@ mode_is() {
 }
 export -f mode_is
 
+# `facelock --version` prints the Cargo version (0.2.0-alpha.1); `pacman -Q`
+# prints the Arch one (0.2.0alpha1-1). Those spellings coincide only for a
+# stable release, so compare them through the release tooling's own conversion
+# rather than by looking for one inside the other.
+reports_packaged_version() {
+    # shellcheck source=../scripts/release-versions.sh
+    # shellcheck disable=SC1091  # the path is the one inside the container image
+    source /release-versions.sh
+    release_arch_version_carries_cargo \
+        "$(pacman -Q facelock | awk 'NR == 1 { print $2 }')" \
+        "$(/usr/bin/facelock --version | awk 'NR == 1 { print $2 }')"
+}
+export -f reports_packaged_version
+
 echo "=== Arch package validation (built from dist/PKGBUILD) ==="
 echo ""
 
@@ -150,7 +164,7 @@ done
 # --- the first commands a user types ------------------------------------------
 
 run_test "facelock --version reports the packaged version" \
-    "/usr/bin/facelock --version | grep -q \"\$(pacman -Q facelock | cut -d' ' -f2 | cut -d- -f1)\""
+    "reports_packaged_version"
 run_test "facelock --help exits successfully" "/usr/bin/facelock --help >/dev/null"
 run_test "facelock setup --help exits successfully" "/usr/bin/facelock setup --help >/dev/null"
 run_test "facelock tpm --help exits successfully" "/usr/bin/facelock tpm --help >/dev/null"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -111,6 +111,16 @@ assert_does_not_carry 0.2.0beta1-1 0.2.0-rc.1
 assert_rejected release_arch_version_carries_cargo 0.1.4-1 0.1.4-alpha1
 assert_rejected release_arch_version_carries_cargo 0.1.4 0.1.4
 assert_rejected release_arch_version_carries_cargo 0.1.4-0 0.1.4
+# `pacman -Q` may also print a nonzero epoch prefix and a pkgrel subrelease;
+# both are real forms and must still carry through to the same pkgver match.
+assert_carries 1:0.2.0alpha1-1 0.2.0-alpha.1
+assert_carries 0.2.0alpha1-1.1 0.2.0-alpha.1
+assert_carries 2:0.1.4-3.2 0.1.4
+# Neither form may become a loophole: the epoch and subrelease must not widen
+# the comparison past the pkgver capture.
+assert_does_not_carry 1:0.1.41-1 0.1.4
+assert_rejected release_arch_version_carries_cargo :0.1.4-1 0.1.4
+assert_rejected release_arch_version_carries_cargo 0.1.4- 0.1.4
 
 # The Arch end-to-end validator must reach the pairing through this contract
 # rather than restating the conversion or matching one spelling inside another.

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -73,6 +73,56 @@ assert_eq "0.2.0" "$(release_rpm_version 0.2.0-alpha.1)" "RPM Version"
 assert_eq "0.1.alpha.1" "$(release_rpm_release 0.2.0-alpha.1 1)" "RPM prerelease Release"
 assert_eq "1" "$(release_rpm_release 0.2.0 99)" "RPM stable Release"
 
+# What an installed Arch package records and what its binary reports are two
+# spellings of one release, and they coincide only for a stable version. The
+# Arch end-to-end validator pairs them through this predicate.
+assert_carries() {
+    local arch_version="$1"
+    local cargo_version="$2"
+    if ! release_arch_version_carries_cargo "$arch_version" "$cargo_version"; then
+        fail "Arch package $arch_version should carry Cargo version $cargo_version"
+    fi
+}
+
+assert_does_not_carry() {
+    local arch_version="$1"
+    local cargo_version="$2"
+    if release_arch_version_carries_cargo "$arch_version" "$cargo_version" 2>/dev/null; then
+        fail "Arch package $arch_version must not carry Cargo version $cargo_version"
+    fi
+}
+
+assert_carries 0.1.4-1 0.1.4
+assert_carries 0.2.0alpha1-1 0.2.0-alpha.1
+assert_carries 0.2.0alpha1-2 0.2.0-alpha.1
+assert_carries 0.2.0beta2-1 0.2.0-beta.2
+assert_carries 0.2.0rc1-1 0.2.0-rc.1
+assert_carries 0.2.0-1 0.2.0
+# The pairing is equality, not containment: the substring match this replaced
+# let a 0.1.41 binary answer for a 0.1.4 package.
+assert_does_not_carry 0.1.4-1 0.1.41
+assert_does_not_carry 0.1.41-1 0.1.4
+# A prerelease binary in a stable package, and the reverse, are both mismatches.
+assert_does_not_carry 0.2.0-1 0.2.0-alpha.1
+assert_does_not_carry 0.2.0alpha1-1 0.2.0
+assert_does_not_carry 0.2.0alpha1-1 0.2.0-alpha.2
+assert_does_not_carry 0.2.0beta1-1 0.2.0-rc.1
+# Neither side may be waved through unparsed.
+assert_rejected release_arch_version_carries_cargo 0.1.4-1 0.1.4-alpha1
+assert_rejected release_arch_version_carries_cargo 0.1.4 0.1.4
+assert_rejected release_arch_version_carries_cargo 0.1.4-0 0.1.4
+
+# The Arch end-to-end validator must reach the pairing through this contract
+# rather than restating the conversion or matching one spelling inside another.
+arch_e2e_validator="$repo_root/test/arch-package-e2e-validate.sh"
+grep -Fq 'release_arch_version_carries_cargo' "$arch_e2e_validator" ||
+    fail "the Arch end-to-end validator no longer pairs versions through release-versions.sh"
+grep -Fq 'source /release-versions.sh' "$arch_e2e_validator" ||
+    fail "the Arch end-to-end validator no longer sources the release conversion contract"
+grep -Fq 'COPY scripts/release-versions.sh /release-versions.sh' \
+    "$repo_root/test/Containerfile.arch-e2e" ||
+    fail "the Arch end-to-end image no longer carries the release conversion contract"
+
 release_validate_transition 0.1.4 0.2.0-alpha.1
 release_validate_transition 0.2.0-alpha.1 0.2.0-alpha.1
 release_validate_transition 0.2.0-alpha.1 0.2.0-alpha.2


### PR DESCRIPTION
## Summary

- pair `facelock --version` with `pacman -Q` through `release_arch_pkgver` rather than `grep -q`
- compare for equality, so a `0.1.41` binary no longer satisfies a `0.1.4` package
- add `release_arch_version_carries_cargo` beside the other Arch conversions
- carry `scripts/release-versions.sh` into the Arch end-to-end image, so the validator sources the rule instead of restating it
- pin the pairing for stable, alpha, beta and rc in the release version contract
- keep the assertion in the version contract, which owns shape; ordering stays with `release-native-ordering.sh`, the only place `vercmp` lives

## Why

The Arch end-to-end validator derived its expected string from the Arch pkgver, then looked for it inside `facelock --version`, which prints the Cargo version. Those spellings coincide only for a stable release: pacman records `0.2.0alpha1-1` where the binary reports `0.2.0-alpha.1`, so the match was impossible and the lane failed for every prerelease, aborting `just test-packaging-matrix` at `0.2.0-alpha.1`. `grep -q` also made it a substring test rather than an equality one, so the assertion could pass on a wrong version.

## Validation

- `just test-arch-pkg`
- `bash test/release-version-contract.sh`, including mutation runs that collapse the equality back to containment, drop the dot-stripping from `release_arch_pkgver`, and cut the validator's use of the predicate
- `bash test/release-native-ordering.sh arch`
- `python3 test/check-release-matrix.py`
- `just check`
- `shellcheck -x` on the touched scripts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Arch package validation for epoch-prefixed versions and `.N` package subreleases.
  - Ensured comparisons use the packaged version correctly while ignoring package release suffixes.
  - Prevented false matches from malformed or partially matching version strings.

- **Tests**
  - Added coverage for valid epoch and subrelease formats, mismatches, prereleases, and invalid versions.
  - Added end-to-end checks confirming package validation uses the shared version comparison rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->