### PR TITLE
ci(release): fail a release whose COPR build never lands

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -118,12 +118,12 @@ Only after explicit confirmation. No AI attribution in the commit or tag message
 
 ## Step 6: Watch the publish
 
-The `v*` tag triggers `.github/workflows/release.yml`, which has 11 jobs:
+The `v*` tag triggers `.github/workflows/release.yml`, which has 12 jobs:
 
 ```text
 metadata · build · download-ort · prepare-cargo-vendor
 build-deb · build-rpm · build-nix
-publish-apt · publish · publish-aur · trigger-pages
+publish-apt · publish · publish-aur · verify-copr · trigger-pages
 ```
 
 Every builder produces workflow artifacts and nothing else. `publish` is the
@@ -146,6 +146,13 @@ hand is not safe, and `publish` refuses a tag that is already published.
 `publish-aur` and `publish-apt` push to external package repositories. A failure
 after those succeed is only partially recoverable — check them first when
 triaging a bad release.
+
+`verify-copr` publishes nothing. Packit submits the COPR build off the published
+release event, outside this run, so the job polls the public COPR API for the
+released EVR and goes red if it never lands (#333). A red `verify-copr` over a
+green `publish` means the release shipped everywhere but Fedora: read the Packit
+check runs on the tag commit, then `docs/releasing.md` → "Why v0.1.4 never
+reached COPR".
 
 ## Guardrails
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -692,6 +692,28 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" --jq '.draft')" = false
           echo "Published $TAG"
 
+  verify-copr:
+    name: Verify Production COPR
+    runs-on: ubuntu-latest
+    # Packit builds COPR off the published release event, outside this run and
+    # after it. Nothing here can make that build happen; this job is only the
+    # deadline that makes its absence a failed release instead of a discovery
+    # three months later (#333). Stable only: a prerelease never reaches
+    # production COPR.
+    needs: [metadata, publish]
+    if: ${{ needs.metadata.outputs.prerelease == 'false' }}
+    timeout-minutes: 100
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Wait for Packit to publish the release build
+        run: |
+          .github/workflows/scripts/verify-copr.sh \
+            "${{ needs.metadata.outputs.cargo-version }}" \
+            "${{ needs.metadata.outputs.rpm-counter }}"
+
   trigger-pages:
     name: Trigger Pages Rebuild
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/verify-copr.sh
+++ b/.github/workflows/scripts/verify-copr.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for production COPR to serve the release that was just published.
+#
+# Packit reacts to the published release event and submits the COPR builds
+# itself, so nothing in this workflow can report on them. When that submission
+# fails there is no failed job anywhere -- only three red check runs on the tag
+# commit that nobody is watching. That is how v0.1.4 was tagged, published, and
+# never built, while COPR served 0.1.3 for three months (#333).
+#
+# This is the deadline that turns that silence into a failed release run. It
+# publishes nothing and can undo nothing: the release is already public by the
+# time it starts. It only makes the omission loud on the day it happens.
+
+VERSION="${1:?Usage: verify-copr.sh <VERSION> <RPM_COUNTER>}"
+RPM_COUNTER="${2:?Usage: verify-copr.sh <VERSION> <RPM_COUNTER>}"
+# Three chroots, each a full from-source Rust build in a mock chroot, queued
+# behind whatever else COPR is building. Ninety minutes is slack over what that
+# has taken, not an estimate of it.
+DEADLINE_SECONDS="${COPR_VERIFY_DEADLINE_SECONDS:-5400}"
+INTERVAL_SECONDS="${COPR_VERIFY_INTERVAL_SECONDS:-120}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=../../../scripts/release-versions.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/release-versions.sh"
+
+release_validate_cargo_version "$VERSION"
+if release_is_prerelease "$VERSION"; then
+  echo "refusing to verify prerelease $VERSION against production COPR" >&2
+  exit 1
+fi
+EVR="$(release_rpm_evr "$VERSION" "$RPM_COUNTER")"
+
+echo "=== Waiting for production COPR to serve facelock-$EVR ==="
+deadline=$((SECONDS + DEADLINE_SECONDS))
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+  status=0
+  python3 "$REPO_ROOT/test/check-live-release-channels.py" \
+    --channel production --expect-evr "$EVR" || status=$?
+  case "$status" in
+    0)
+      echo "Production COPR serves facelock-$EVR after $attempt check(s)"
+      exit 0
+      ;;
+    2)
+      # Not yet: a build still running, or none submitted. Only the deadline
+      # tells those apart, and only in one direction.
+      ;;
+    *)
+      # The checker printed the reason above, and it is not always the build:
+      # it compares the project's enabled chroots first, so drift there stops
+      # the poll too. Naming a cause here would name the wrong one.
+      echo "The live release-channel check failed; see its output above" >&2
+      exit 1
+      ;;
+  esac
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "Production COPR did not serve facelock-$EVR within ${DEADLINE_SECONDS}s" >&2
+    echo "Check the Packit check runs on the tag commit and the COPR project:" >&2
+    echo "  https://github.com/${GITHUB_REPOSITORY:-tyvsmith/facelock}/commits/${GITHUB_REF_NAME:-$VERSION}" >&2
+    echo "  https://copr.fedorainfracloud.org/coprs/tyvsmith/facelock/builds/" >&2
+    echo "A submission that fails on a Copr project update means .packit.yaml" >&2
+    echo "asked for a chroot the project does not have enabled; see docs/releasing.md." >&2
+    exit 1
+  fi
+  sleep "$INTERVAL_SECONDS"
+done

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@
       "trigger": "ignore",
       "owner": "tyvsmith",
       "project": "facelock",
+      "update_release": false,
       "targets": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,7 +613,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serve the pinned predecessor. The setup guide now asks for the admin
   permission Packit actually needs. The v0.1.4 build is not backfilled — 0.2.0
   supersedes it — and that gap is recorded against both EVRs so it excuses
-  nothing else and retires itself.
+  nothing else and retires itself. Only preflight consults the record; the
+  release job asks about the release it is publishing and cannot be silenced
+  by it.
+- **Production COPR publishes the EVR the versioning contract promises**
+  (#333): the production `copr_build` job now carries `update_release: false`.
+  Packit's default rewrites `Release: 1%{?dist}` to `1.{timestamp}.{ref}`, so
+  COPR would have served `0.2.0-1.20260904220135575676.v0.2.0` while every
+  other channel served `0.2.0-1`. Staging keeps the suffix, which its
+  per-pull-request NVRs need, and its served comparison stays a prefix while
+  production's is an equality; `test/check-release-matrix.py` holds the flag
+  and the comparison together so neither channel can move one alone. The
+  documented recovery build now passes `--no-update-release`, because the
+  Packit CLI reads package-level config rather than a job's. Whether
+  packit-service applies the per-job flag on a real release event is not
+  provable locally; the first stable tag after this change is the proof.
 - **A lost encryption key is never replaced automatically** (#231): the
   encrypt-by-default keyfile is now created only for a database that holds no
   encrypted template. On a system whose key artifact went missing, facelock had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A COPR build that never lands now fails the release** (#333): production
+  COPR served 0.1.3 for the three months v0.1.4 was the current release. Packit
+  ran and submitted nothing: `.packit.yaml` listed a chroot the project did not
+  have enabled, so Packit tried to edit the project, lacked the permission to,
+  and aborted every target. Nothing anywhere compared what the channel served
+  with what the release should have produced, so the failure was three red
+  check runs on a tag commit and no failed job. `test/check-live-release-channels.py`
+  now compares the served EVR as well as the enabled chroots; the release
+  workflow's `verify-copr` job polls for it after publication and fails the run
+  when it never appears; and `just release-preflight` requires production to
+  serve the pinned predecessor. The setup guide now asks for the admin
+  permission Packit actually needs. The v0.1.4 build is not backfilled — 0.2.0
+  supersedes it — and that gap is recorded against both EVRs so it excuses
+  nothing else and retires itself.
 - **A lost encryption key is never replaced automatically** (#231): the
   encrypt-by-default keyfile is now created only for a database that holds no
   encrypted template. On a system whose key artifact went missing, facelock had

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -53,6 +53,8 @@
       "owner": "tyvsmith",
       "project": "facelock",
       "api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
+      "package": "facelock",
+      "package_api_url": "https://copr.fedorainfracloud.org/api_3/package?ownername=tyvsmith&projectname=facelock&packagename=facelock&with_latest_build=True&with_latest_succeeded_build=True",
       "required_supported_chroots": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",
@@ -62,12 +64,19 @@
         "fedora-rawhide-x86_64"
       ],
       "required_forge_project": "github.com/tyvsmith/facelock",
-      "prerelease_publication": false
+      "prerelease_publication": false,
+      "served_evr_gap": {
+        "expected_evr": "0.1.4-1",
+        "served_evr": "0.1.3-1",
+        "issue": 333
+      }
     },
     "staging": {
       "owner": "tyvsmith",
       "project": "facelock-testing",
       "api_url": "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock-testing",
+      "package": "facelock",
+      "package_api_url": "https://copr.fedorainfracloud.org/api_3/package?ownername=tyvsmith&projectname=facelock-testing&packagename=facelock&with_latest_build=True&with_latest_succeeded_build=True",
       "required_supported_chroots": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",
@@ -106,6 +115,7 @@
       "release_id": 332190914,
       "published_at": "2026-05-31T18:54:26Z",
       "upstream_version": "0.1.4",
+      "rpm_evr": "0.1.4-1",
       "lanes": {
         "deb-trixie": {
           "suite": "trixie",

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -65,6 +65,7 @@
       ],
       "required_forge_project": "github.com/tyvsmith/facelock",
       "prerelease_publication": false,
+      "served_evr_exact": true,
       "served_evr_gap": {
         "expected_evr": "0.1.4-1",
         "served_evr": "0.1.3-1",
@@ -83,6 +84,7 @@
         "fedora-45-x86_64"
       ],
       "required_forge_project": "github.com/tyvsmith/facelock",
+      "served_evr_exact": false,
       "provisioning_issue": 236,
       "managed_by_this_change": false,
       "provisioned": true

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2168,18 +2168,24 @@ A channel comparison covers three properties, not one. The live chroot set must
 match the channel's declared chroots. `enable_net` must be true, because the RPM
 builds from source and `cargo` fetches crates during `%build`. The project's
 Packit forge allowlist must contain `copr_channels.<channel>.required_forge_project`,
-which is `github.com/tyvsmith/facelock` for both channels. Builder permission for
-the `packit` user is outside this contract: COPR serves project permissions only
-to an authenticated owner, so a public comparison cannot make that claim.
+which is `github.com/tyvsmith/facelock` for both channels. The `packit` user's
+admin permission is outside this contract: COPR serves project permissions only
+to an authenticated owner, so a public comparison cannot make that claim. It is
+the grant that failed silently for v0.1.4, which is why the release guide keeps
+it as a hand-confirmed setup step.
 
-Enabled chroots are the shape of a channel, not its contents. A second
-comparison asks what the channel serves:
+Those three are the shape of a channel, not its contents. A second comparison
+asks what it serves:
 `test/check-live-release-channels.py --expect-evr <EVR>` requires the project's
 latest **succeeded** build to carry the expected EVR. The latest succeeded build
 is what the channel serves; the latest build of any state says only whether the
-awaited one is running or dead. The expected EVR is a prefix ending at a dot,
-because Packit rewrites the spec's `Release` with a snapshot suffix: `0.2.0-1`
-matches `0.2.0-1.20260904220135.v0.2.0` and does not match `0.2.0-11`.
+awaited one is running or dead. How strictly the EVR is read is the channel's
+`served_evr_exact`, and it tracks whether that channel's Packit job pins the
+release. Production carries `update_release: false` and is compared exactly.
+Staging keeps Packit's `1.{timestamp}.{ref}` suffix, which its per-pull-request
+NVRs need, so it is compared as a prefix ending at a dot: `0.2.0-1` matches
+`0.2.0-1.20260904220135.v0.2.0` and never `0.2.0-11`. The Packit flag and the
+comparison move together or the release matrix contract fails.
 
 That build's chroot list is reported, never required. It is what the build
 covered, not what the repository serves, and a single-chroot rebuild becomes the
@@ -2199,9 +2205,16 @@ A release that production COPR never received may be recorded as
 `copr_channels.production.served_evr_gap`, naming the EVR owed, the EVR served,
 and the issue that owns it. The record is pinned at both ends: it must excuse
 exactly the pinned predecessor's EVR, and it stops matching the moment the
-channel serves anything other than the EVR it names, under the same prefix rule.
-It excuses no other release, and the next predecessor pin fails the matrix
-contract until it is updated or deleted.
+channel serves anything other than the EVR it names. Both ends are read under
+the channel's own `served_evr_exact`, so on production a suffixed rebuild of the
+EVR the record names no longer matches it.
+
+Only `--expect-predecessor` consults the record. A gap describes a release that
+already shipped without reaching COPR, which is preflight's question;
+`verify-copr` asks `--expect-evr` about the release it is publishing, and a
+record that could answer that would silence the job on the failure it exists to
+report. The record excuses no other release, and the next predecessor pin fails
+the matrix contract until it is updated or deleted.
 
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2172,6 +2172,37 @@ which is `github.com/tyvsmith/facelock` for both channels. Builder permission fo
 the `packit` user is outside this contract: COPR serves project permissions only
 to an authenticated owner, so a public comparison cannot make that claim.
 
+Enabled chroots are the shape of a channel, not its contents. A second
+comparison asks what the channel serves:
+`test/check-live-release-channels.py --expect-evr <EVR>` requires the project's
+latest **succeeded** build to carry the expected EVR. The latest succeeded build
+is what the channel serves; the latest build of any state says only whether the
+awaited one is running or dead. The expected EVR is a prefix ending at a dot,
+because Packit rewrites the spec's `Release` with a snapshot suffix: `0.2.0-1`
+matches `0.2.0-1.20260904220135.v0.2.0` and does not match `0.2.0-11`.
+
+That build's chroot list is reported, never required. It is what the build
+covered, not what the repository serves, and a single-chroot rebuild becomes the
+latest succeeded build while an earlier complete one still serves the rest.
+Which chroots a channel must enable is the project comparison's contract.
+
+Exit status separates a verdict from a wait — 1 for a build of the expected EVR
+that failed, was canceled, or was skipped; 2 for a build still running, never
+submitted, or a query that could not be made; only a poller
+distinguishes them, and every other caller treats both as failure. The release
+workflow's `verify-copr` job polls it after publication, because Packit submits
+the COPR build off the published release event and no job in the release run can
+observe that submission. `just release-preflight` runs `--expect-predecessor`,
+which resolves the EVR from the pinned predecessor's `rpm_evr`.
+
+A release that production COPR never received may be recorded as
+`copr_channels.production.served_evr_gap`, naming the EVR owed, the EVR served,
+and the issue that owns it. The record is pinned at both ends: it must excuse
+exactly the pinned predecessor's EVR, and it stops matching the moment the
+channel serves anything other than the EVR it names, under the same prefix rule.
+It excuses no other release, and the next predecessor pin fails the matrix
+contract until it is updated or deleted.
+
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and
 how fresh each channel's repository metadata was.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -702,10 +702,17 @@ real release event: `just test-copr` builds its SRPM through the CLI, which
 reads package-level config, so that lane still carries the snapshot suffix and
 proves the package builds rather than the EVR it will be published under.
 **The first stable tag after this change is the proof.** If that release
-publishes a suffixed EVR anyway, `verify-copr` fails on an otherwise healthy
-build; the fix is to move `update_release` from the job to the top level of
-`.packit.yaml` and flip staging's `served_evr_exact` accordingly, not to loosen
-the comparison.
+publishes a suffixed EVR anyway, the service ignored the job-level flag and
+`verify-copr` fails on an otherwise healthy build. The response is to delete
+`update_release` from the production job and set its `served_evr_exact` back to
+false, taking the suffix on both channels again.
+
+Do **not** hoist `update_release` to the top level to force it. Top level
+reaches staging too, and staging builds every pull request into one project:
+without the snapshot suffix two pull requests produce the same NVR. Scoping the
+flag to the production job is the whole reason production and staging can differ
+here, so the fallback for a flag the service ignores is to stop asking for the
+canonical EVR, not to ask for it somewhere that breaks the other channel.
 
 `just release-preflight` asks the same question about the previous release:
 `test/check-live-release-channels.py --expect-predecessor` requires production

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -103,7 +103,11 @@ guards use the validated release identity rather than substring matching.
 COPR (Fedora) is **not** built by `release.yml`. It is handled by [Packit](https://packit.dev),
 which reacts to the release the `publish` job makes public in step 8. A draft
 raises no release event, so nothing downstream fires until validation passes.
-See the COPR section below.
+The workflow does *watch*: a stable run's `verify-copr` job polls the public
+COPR API for the released EVR and fails the run if it never appears. It builds
+nothing and can undo nothing — the release is already public by then — it only
+makes a failed Packit submission loud on the day it happens. See the COPR
+section below.
 
 #### Builders build, publish publishes
 
@@ -489,9 +493,12 @@ secret — it is driven by Packit. Preflight and CI also read the public
 production COPR API and require its enabled chroots to equal the checked-in
 authority: Fedora 43/44/45 are required and Rawhide is the only optional
 experimental chroot. Rawhide may be present or absent; a missing required
-chroot or any unknown extra is release-blocking drift. The checker never
-modifies the project. Preflight always runs `packit config validate --offline`
-against `.packit.yaml`, in the digest-pinned Fedora container built from
+chroot or any unknown extra is release-blocking drift. Preflight goes one step
+further than CI and asks what production COPR actually serves: the EVR of the
+predecessor pinned in `dist/release-matrix.json`. The checker never modifies the
+project. Preflight always runs
+`packit config validate --offline` against `.packit.yaml`, in the digest-pinned
+Fedora container built from
 `test/Containerfile.packit` — the same real schema gate `just test-copr` runs,
 reachable without a host `packit` install. It has no skip path: podman is a
 preflight prerequisite, and without it the gate fails rather than passing
@@ -616,8 +623,12 @@ crate feature `api-20` keeps the binary compatible with Fedora's runtime.)
 3. Install the **Packit-as-a-Service** GitHub App on the repository:
    https://github.com/marketplace/packit-as-a-service
 4. In the COPR project → Settings → Permissions, grant the `packit` user
-   **builder** permission so Packit can build into the existing project. In the
-   "allowed forge projects" field, add `github.com/tyvsmith/facelock`.
+   **admin** permission, and in the "allowed forge projects" field add
+   `github.com/tyvsmith/facelock`. Builder permission is enough to build and not
+   enough to edit the project, which is a distinction Packit makes for you: it
+   reconciles the project against `.packit.yaml` before submitting anything, and
+   a reconciliation it is not allowed to perform aborts every target. See
+   "Why v0.1.4 never reached COPR" below.
 5. In the COPR project → Settings, enable **"Enable internet access during
    builds"**. The RPM is built from source and `cargo` fetches crates from
    crates.io during `%build`; COPR's build chroot is network-isolated by
@@ -625,8 +636,8 @@ crate feature `api-20` keeps the binary compatible with Fedora's runtime.)
 
 Step 4's allowlist and step 5 apply to both channels and are checked on every
 pull request by `python3 test/check-live-release-channels.py`, which reads them
-off the public project response. Builder permission is not public, so it stays a
-hand-confirmed step.
+off the public project response. The permission grant is not public, so it stays
+a hand-confirmed step -- and it is the one that failed silently for v0.1.4.
 
 Verify the COPR build locally before relying on it with `just test-copr`, which
 reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot and
@@ -635,6 +646,69 @@ checks that the payload has no bundle while its dependencies select Fedora ORT.
 Only a stable-tagged config with the deliberately restored production release
 trigger can populate production COPR automatically. A prerelease tag never
 points at production; staging below is where a candidate gets built.
+
+##### Why v0.1.4 never reached COPR
+
+Packit was installed, the release trigger was correct, and the release event
+reached it. Every target still failed at submission with `Copr project update
+failed for 'tyvsmith/facelock' project.`, thirteen seconds after publication
+(#333).
+
+Packit reconciles the COPR project against `.packit.yaml` before it submits
+anything, and it edits the project whenever the config's `targets` are not
+already a subset of the project's enabled chroots. The v0.1.4 config listed
+`fedora-42-x86_64`, which the project had never enabled and which COPR no
+longer offers. Editing a COPR project requires **admin**, and until this
+section was written the setup steps above asked for builder. One chroot the
+project did not have cost all three builds. v0.1.3 failed identically and
+reached COPR only because it was submitted by hand fourteen minutes later.
+
+Two rules follow, and both are enforced:
+
+- **`.packit.yaml` targets must be a subset of the project's enabled chroots.**
+  The release matrix binds `fedora.packit_release_targets` to
+  `copr_channels.production.required_supported_chroots`, and
+  `test/check-live-release-channels.py` requires the live project to enable
+  every one of them, so a target the project lacks fails before the tag.
+- **A COPR build that never lands must fail something.** Nothing in the release
+  run can observe Packit's submission — it happens outside the run, after
+  publication — so the release workflow's `verify-copr` job polls the public
+  COPR API for the released EVR and fails the run when it never appears. Before
+  this existed, the chroot comparison passed on every day of the three months
+  COPR served 0.1.3.
+
+The EVR COPR serves is **not** the one in the conversion table above. Packit's
+default `fix-spec-file` action rewrites `Release: 1%{?dist}` to
+`1.{timestamp}.{ref}`, so a v0.2.0 release lands in COPR as
+`facelock-0.2.0-1.20260904220135575676.v0.2.0`, not `facelock-0.2.0-1`. The
+served comparison therefore takes the release matrix's EVR as a prefix ending at
+a dot: `0.2.0-1` and `0.2.0-1.<anything>` both satisfy it, `0.2.0-11` does not.
+Setting `update_release: false` on the production job would make COPR match the
+other channels exactly; that is a change to what COPR publishes and has not been
+made.
+
+`just release-preflight` asks the same question about the previous release:
+`test/check-live-release-channels.py --expect-predecessor` requires production
+COPR to serve the EVR pinned in `predecessors`. The v0.1.4 build was never
+backfilled — 0.2.0 supersedes it — so that gap is recorded in
+`copr_channels.production.served_evr_gap` and reported rather than failed. The
+record names both EVRs and issue #333, and it retires itself: once the
+predecessor pin moves past v0.1.4 the release matrix contract fails until the
+record is deleted.
+
+A recovery after a failed submission is a hand-submitted build from a checkout
+of the tag. Packit reacts only to *new* release events, so re-publishing is not
+an option:
+
+```bash
+git checkout vX.Y.Z
+packit build in-copr --owner tyvsmith --project facelock \
+    --targets fedora-43-x86_64,fedora-44-x86_64,fedora-45-x86_64
+```
+
+`--targets` defaults to Rawhide alone, so pass the supported set. This takes the
+same reconciliation path the service does, so it fails the same way if the
+project cannot be edited.
 
 ##### Staging COPR (`tyvsmith/facelock-testing`)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -677,15 +677,35 @@ Two rules follow, and both are enforced:
   this existed, the chroot comparison passed on every day of the three months
   COPR served 0.1.3.
 
-The EVR COPR serves is **not** the one in the conversion table above. Packit's
-default `fix-spec-file` action rewrites `Release: 1%{?dist}` to
-`1.{timestamp}.{ref}`, so a v0.2.0 release lands in COPR as
-`facelock-0.2.0-1.20260904220135575676.v0.2.0`, not `facelock-0.2.0-1`. The
-served comparison therefore takes the release matrix's EVR as a prefix ending at
-a dot: `0.2.0-1` and `0.2.0-1.<anything>` both satisfy it, `0.2.0-11` does not.
-Setting `update_release: false` on the production job would make COPR match the
-other channels exactly; that is a change to what COPR publishes and has not been
-made.
+Packit's default `fix-spec-file` action rewrites `Release: 1%{?dist}` to
+`1.{timestamp}.{ref}`, which would publish a v0.2.0 release as
+`facelock-0.2.0-1.20260904220135575676.v0.2.0` rather than the
+`facelock-0.2.0-1` the conversion table promises. The production `copr_build`
+job therefore carries `update_release: false`, and production's served
+comparison is an equality.
+
+Staging keeps the default. It builds every pull request into one project, so
+its NVRs have to differ from each other, and the snapshot suffix is what makes
+them; its comparison ends at the boundary dot instead, accepting `0.2.0-1` and
+`0.2.0-1.<anything>` while still refusing `0.2.0-11`. The flag and the
+comparison are one contract in `test/check-release-matrix.py`: neither channel
+can change one without the other, because either half alone reds every stable
+release.
+
+**What is proven, and what is not.** The schema accepts the per-job flag
+(`just test-packit-config`), Packit's own config parser resolves it to `False`
+for the production job while staging stays `True`, and `packit srpm` with the
+flag set produces `facelock-0.2.0-1.fc44.src.rpm` against
+`facelock-0.2.0-1.20260904220135575676.master.0.g7d8eef8.fc44.src.rpm` without
+it. What no local check can reach is packit-service applying the job's flag on a
+real release event: `just test-copr` builds its SRPM through the CLI, which
+reads package-level config, so that lane still carries the snapshot suffix and
+proves the package builds rather than the EVR it will be published under.
+**The first stable tag after this change is the proof.** If that release
+publishes a suffixed EVR anyway, `verify-copr` fails on an otherwise healthy
+build; the fix is to move `update_release` from the job to the top level of
+`.packit.yaml` and flip staging's `served_evr_exact` accordingly, not to loosen
+the comparison.
 
 `just release-preflight` asks the same question about the previous release:
 `test/check-live-release-channels.py --expect-predecessor` requires production
@@ -702,13 +722,19 @@ an option:
 
 ```bash
 git checkout vX.Y.Z
-packit build in-copr --owner tyvsmith --project facelock \
-    --targets fedora-43-x86_64,fedora-44-x86_64,fedora-45-x86_64
+packit srpm --no-update-release
+copr-cli build tyvsmith/facelock facelock-X.Y.Z-1.*.src.rpm \
+    -r fedora-43-x86_64 -r fedora-44-x86_64 -r fedora-45-x86_64
 ```
 
-`--targets` defaults to Rawhide alone, so pass the supported set. This takes the
-same reconciliation path the service does, so it fails the same way if the
-project cannot be edited.
+`--no-update-release` is not optional. The Packit CLI reads package-level
+config, not a job's, so it would otherwise apply the snapshot suffix the
+production job pins off and hand production an EVR its own gate refuses.
+`packit build in-copr` has no equivalent flag, which is why the recovery goes
+through `copr-cli` with an SRPM built locally. Name the three supported chroots:
+`copr-cli build` with no `-r` builds every chroot the project has enabled, which
+picks up the optional Rawhide one. This path needs a COPR API token in
+`~/.config/copr`, which the Packit CLI did not.
 
 ##### Staging COPR (`tyvsmith/facelock-testing`)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -684,6 +684,19 @@ Packit's default `fix-spec-file` action rewrites `Release: 1%{?dist}` to
 job therefore carries `update_release: false`, and production's served
 comparison is an equality.
 
+The mismatch would not stay cosmetic. RPM ranks the suffixed build above the
+canonical one:
+
+```text
+0.2.0-1.fc44 < 0.2.0-1.20260904220135575676.master.0.g7d9ffe7.fc44
+```
+
+So on a machine with both the COPR repo and a directly installed RPM of the same
+release, COPR wins every `dnf update` and the version the other channels ship
+never takes hold. Packit's own documentation warns that an inherited release
+suffix breaks NVR ordering. Pinning the release is what keeps every channel's
+0.2.0 the same 0.2.0.
+
 Staging keeps the default. It builds every pull request into one project, so
 its NVRs have to differ from each other, and the snapshot suffix is what makes
 them; its comparison ends at the boundary dot instead, accepting `0.2.0-1` and

--- a/justfile
+++ b/justfile
@@ -1552,6 +1552,11 @@ release-preflight tag='':
     bash test/release-artifacts-contract.sh || failed=1
     python3 test/check-live-release-channels.py || failed=1
     python3 test/check-live-release-channels.py --channel staging || failed=1
+    # Enabled chroots say the project is shaped right; they say nothing about
+    # what it serves. The v0.1.4 COPR build never landed and the chroot check
+    # passed for three months (#333), so preflight asks production for the EVR
+    # the pinned predecessor should have left behind.
+    python3 test/check-live-release-channels.py --expect-predecessor || failed=1
 
     echo ""
     echo "== GitHub release secret checks =="

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -324,14 +324,32 @@ served_evr = build_evr(succeeded)
 served_chroots = build_chroots(succeeded)
 
 
-def matches(evr: str | None) -> bool:
-    """Packit rewrites `Release` to `<release>.<snapshot>` unless told not to.
+# How strictly this channel's EVR is read, decided by whether its Packit job
+# pins the release. Production sets `update_release: false`, so it publishes the
+# EVR the conversion table promises and is compared exactly. Staging keeps
+# Packit's `1.{timestamp}.{ref}` suffix, which its per-pull-request NVRs need,
+# so its comparison ends at the boundary dot instead. `check-release-matrix.py`
+# holds this value and the Packit flag together; neither moves alone.
+exact = channel.get("served_evr_exact")
+if not isinstance(exact, bool):
+    fail(
+        f"release matrix {args.channel} COPR authority must declare a boolean "
+        f"served EVR comparison: {exact!r}"
+    )
 
-    A release-triggered build of 0.2.0 lands as `0.2.0-1.20260904220135.v0.2.0`,
-    not `0.2.0-1`, so the expected EVR is a prefix and not an equality. The
-    boundary dot matters: it keeps `0.2.0-1` from matching `0.2.0-11`.
-    """
-    return evr == expected_evr or (evr is not None and evr.startswith(f"{expected_evr}."))
+
+def carries(evr: str | None, wanted: str) -> bool:
+    """Is `evr` the build `wanted` names? Exactly, or under a release suffix."""
+    if evr is None:
+        return False
+    if exact:
+        return evr == wanted
+    # The boundary dot keeps `0.2.0-1` from swallowing `0.2.0-11`.
+    return evr == wanted or evr.startswith(f"{wanted}.")
+
+
+def matches(evr: str | None) -> bool:
+    return carries(evr, expected_evr)
 
 
 if matches(served_evr):
@@ -343,14 +361,19 @@ if matches(served_evr):
 
 # A gap the maintainer has already accepted, pinned to both EVRs so it cannot
 # outlive itself: the moment the channel serves anything else, the recorded
-# gap stops matching and this stops excusing anything. The served side takes the
-# same prefix rule as the expected side, or a snapshot-suffixed rebuild of the
-# very EVR the record names would stop matching it.
-gap = channel.get("served_evr_gap")
+# gap stops matching and this stops excusing anything. The served side is read
+# under the channel's own rule, so it tightens and loosens with the expected
+# side rather than drifting away from it.
+#
+# Only `--expect-predecessor` consults it. A gap is a statement about a release
+# that already shipped without reaching COPR, and preflight is the only caller
+# asking about one. `verify-copr` asks about the release it is publishing right
+# now with `--expect-evr`, and a record that could answer that question would
+# silence the job on the very failure it exists to make loud -- reachable,
+# because a predecessor may be pinned at the workspace version.
+gap = channel.get("served_evr_gap") if args.expect_predecessor else None
 gap_served = gap.get("served_evr") if isinstance(gap, dict) else None
-gap_matches_served = isinstance(gap_served, str) and served_evr is not None and (
-    served_evr == gap_served or served_evr.startswith(f"{gap_served}.")
-)
+gap_matches_served = isinstance(gap_served, str) and carries(served_evr, gap_served)
 if isinstance(gap, dict) and gap.get("expected_evr") == expected_evr and gap_matches_served:
     print(
         f"served release channel contract: KNOWN GAP ({args.channel} COPR "

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Compare public release-channel state with the checked-in authority."""
+"""Compare public release-channel state with the checked-in authority.
+
+Two halves. The project half compares a COPR project's enabled chroots with the
+targets the release matrix declares. The served half, requested with
+`--expect-evr` or `--expect-predecessor`, compares the EVR the project's latest
+succeeded build carries with the EVR that release should have produced.
+
+Exit status is 0 when both halves hold, 1 on a verdict that will not change on
+its own, and 2 when the expected build has simply not arrived yet -- a build
+still running, or none submitted. Only a poller distinguishes the last two; for
+everyone else 2 is a failure like any other.
+"""
 
 from __future__ import annotations
 
@@ -13,11 +24,23 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = ROOT / "dist" / "release-matrix.json"
+# COPR build states a build never leaves. `skipped` is one of them: COPR uses it
+# when the same NVR was already built, and that earlier build is what
+# `latest_succeeded` reports. Every other state -- running, pending, importing,
+# and the ones COPR may add later -- is read as "not yet", so a state this file
+# has not heard of costs a wait rather than a wrong verdict.
+TERMINAL_STATES = frozenset({"failed", "canceled", "cancelled", "skipped"})
 
 
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def pending(message: str) -> None:
+    """Exit 2: not yet, and it might still arrive. Any non-poller reads this as failure."""
+    print(f"PENDING: {message}", file=sys.stderr)
+    raise SystemExit(2)
 
 
 def load_json(path: Path, description: str) -> object:
@@ -48,7 +71,29 @@ parser.add_argument(
     type=Path,
     help="read a COPR project response fixture instead of the public API",
 )
+served = parser.add_mutually_exclusive_group()
+served.add_argument(
+    "--expect-evr",
+    help="also require the channel to serve this RPM EVR as its latest build",
+)
+served.add_argument(
+    "--expect-predecessor",
+    action="store_true",
+    help="also require the channel to serve the released predecessor the matrix pins",
+)
+parser.add_argument(
+    "--package-response-file",
+    type=Path,
+    help="read a COPR package response fixture instead of the public API",
+)
 args = parser.parse_args()
+# An expectation given as an empty string is a caller whose EVR came out empty,
+# not a caller asking for nothing. Skipping the served half there would report a
+# green verification of nothing at all.
+if args.expect_evr is not None and not args.expect_evr:
+    fail("--expect-evr was given an empty EVR")
+if args.package_response_file and not (args.expect_evr or args.expect_predecessor):
+    fail("--package-response-file needs an expected EVR to compare it against")
 
 matrix = load_json(MATRIX_PATH, "release matrix")
 try:
@@ -106,9 +151,13 @@ if args.response_file:
 elif declared_provisioned is False:
     provisioning_issue = channel.get("provisioning_issue")
     owed_to = f"; issue #{provisioning_issue} owns it" if provisioning_issue else ""
+    # Nothing to compare against, including any EVR the caller asked for: an
+    # unprovisioned channel has no project, so this says so rather than
+    # reporting a served version it never looked up.
+    asked = " and its served EVR" if (args.expect_evr or args.expect_predecessor) else ""
     print(
         f"live release channel contract: SKIPPED ({args.channel} COPR "
-        f"{owner}/{project} is not provisioned{owed_to})"
+        f"{owner}/{project} is not provisioned{owed_to}; its chroots{asked} went unchecked)"
     )
     raise SystemExit(0)
 else:
@@ -117,7 +166,10 @@ else:
         with urllib.request.urlopen(request, timeout=20) as remote:
             response = json.load(remote)
     except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        fail(f"cannot read the public {args.channel} COPR API: {error}")
+        # A read that did not happen is not a verdict. Preflight and CI fail on
+        # this either way; the release poller retries instead of reddening a
+        # published release over one 5xx from COPR.
+        pending(f"cannot read the public {args.channel} COPR API: {error}")
 
 if not isinstance(response, dict):
     fail(f"{args.channel} COPR API response is not an object")
@@ -179,3 +231,147 @@ print(
     f"live={sorted(live_chroots)}; enable_net=True; "
     f"packit forge={required_forge_project})"
 )
+
+# Enabled chroots prove the project is shaped right; they prove nothing about
+# what it serves. v0.1.4 failed Packit's build submission on every target and
+# the project stayed correct, so this half of the checker existed and passed
+# for the three months COPR served 0.1.3 (#333). Comparing the served EVR is
+# what turns that into a release-time failure.
+if not (args.expect_evr or args.expect_predecessor):
+    raise SystemExit(0)
+
+if args.expect_predecessor:
+    predecessors = matrix.get("predecessors")
+    if not isinstance(predecessors, dict):
+        fail("release matrix declares no predecessors block")
+    tags = sorted(tag for tag in predecessors if tag.startswith("v"))
+    if len(tags) != 1:
+        fail(f"release matrix must pin exactly one released predecessor, found {tags}")
+    expected_evr = predecessors[tags[0]].get("rpm_evr")
+    if not isinstance(expected_evr, str) or not expected_evr:
+        fail(f"release matrix predecessor {tags[0]} declares no RPM EVR")
+    expected_for = f" (pinned predecessor {tags[0]})"
+else:
+    expected_evr = args.expect_evr
+    expected_for = ""
+
+package = channel.get("package")
+package_api_url = channel.get("package_api_url")
+if not isinstance(package, str) or not package:
+    fail(f"release matrix {args.channel} COPR authority names no package")
+if not isinstance(package_api_url, str) or not package_api_url:
+    fail(f"release matrix {args.channel} COPR authority declares no package API URL")
+
+if args.package_response_file:
+    package_response = load_json(args.package_response_file, f"{args.channel} COPR package fixture")
+else:
+    package_request = urllib.request.Request(
+        package_api_url, headers={"User-Agent": "facelock-release-matrix/1"}
+    )
+    try:
+        with urllib.request.urlopen(package_request, timeout=20) as remote:
+            package_response = json.load(remote)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        pending(f"cannot read the public {args.channel} COPR package API: {error}")
+
+if not isinstance(package_response, dict):
+    fail(f"{args.channel} COPR package API response is not an object")
+if (
+    package_response.get("ownername") != owner
+    or package_response.get("projectname") != project
+    or package_response.get("name") != package
+):
+    fail(
+        f"{args.channel} COPR package identity drifted: "
+        f"expected {owner}/{project}/{package}, "
+        f"got owner={package_response.get('ownername')!r}, "
+        f"project={package_response.get('projectname')!r}, "
+        f"name={package_response.get('name')!r}"
+    )
+
+builds = package_response.get("builds") or {}
+if not isinstance(builds, dict):
+    fail(f"{args.channel} COPR package API response has no valid builds object")
+
+
+def build_evr(build: object) -> str | None:
+    if not isinstance(build, dict):
+        return None
+    version = (build.get("source_package") or {}).get("version")
+    return version if isinstance(version, str) else None
+
+
+def build_chroots(build: object) -> set[str]:
+    chroots = build.get("chroots") if isinstance(build, dict) else None
+    if not isinstance(chroots, list):
+        return set()
+    return {chroot for chroot in chroots if isinstance(chroot, str)}
+
+
+# What the channel serves is the latest *succeeded* build. `latest` is only the
+# most recently submitted one -- a rebuild, a retry, a backfill -- and reading
+# the served version off it would report a channel as behind while it is still
+# serving the right EVR.
+succeeded = builds.get("latest_succeeded")
+latest = builds.get("latest")
+served_evr = build_evr(succeeded)
+# Reported, never required. A build's chroot list is what that build covered,
+# which is not what the repository serves: a single-chroot rebuild -- the
+# documented recovery from a failed submission -- becomes the newest succeeded
+# build while the earlier complete one still serves the other two. Requiring
+# every chroot here would call that channel broken. The enabled-chroot contract
+# is the project half's, above.
+served_chroots = build_chroots(succeeded)
+
+
+def matches(evr: str | None) -> bool:
+    """Packit rewrites `Release` to `<release>.<snapshot>` unless told not to.
+
+    A release-triggered build of 0.2.0 lands as `0.2.0-1.20260904220135.v0.2.0`,
+    not `0.2.0-1`, so the expected EVR is a prefix and not an equality. The
+    boundary dot matters: it keeps `0.2.0-1` from matching `0.2.0-11`.
+    """
+    return evr == expected_evr or (evr is not None and evr.startswith(f"{expected_evr}."))
+
+
+if matches(served_evr):
+    print(
+        f"served release channel contract: OK ({args.channel} COPR {owner}/{project} "
+        f"serves {package}-{served_evr}; newest build covered {sorted(served_chroots)})"
+    )
+    raise SystemExit(0)
+
+# A gap the maintainer has already accepted, pinned to both EVRs so it cannot
+# outlive itself: the moment the channel serves anything else, the recorded
+# gap stops matching and this stops excusing anything. The served side takes the
+# same prefix rule as the expected side, or a snapshot-suffixed rebuild of the
+# very EVR the record names would stop matching it.
+gap = channel.get("served_evr_gap")
+gap_served = gap.get("served_evr") if isinstance(gap, dict) else None
+gap_matches_served = isinstance(gap_served, str) and served_evr is not None and (
+    served_evr == gap_served or served_evr.startswith(f"{gap_served}.")
+)
+if isinstance(gap, dict) and gap.get("expected_evr") == expected_evr and gap_matches_served:
+    print(
+        f"served release channel contract: KNOWN GAP ({args.channel} COPR "
+        f"{owner}/{project} serves {package}-{served_evr}, not the expected "
+        f"{expected_evr}; issue #{gap.get('issue')} owns it)"
+    )
+    raise SystemExit(0)
+
+latest_evr = build_evr(latest)
+latest_state = latest.get("state") if isinstance(latest, dict) else None
+detail = (
+    f"{args.channel} COPR {owner}/{project} does not serve "
+    f"{package}-{expected_evr}{expected_for}: "
+    f"latest succeeded build is {served_evr!r} on {sorted(served_chroots)}; "
+    f"latest build is {latest_evr!r} state={latest_state!r}"
+)
+# A build of the expected EVR that is already dead is a verdict; polling it to a
+# deadline would delay the same failure by an hour. Everything else is a build
+# that has not happened yet, which only a deadline can turn into a failure. The
+# release job polls, so it needs the two told apart -- and a caller that does
+# not poll treats both as failure.
+if matches(latest_evr) and latest_state in TERMINAL_STATES:
+    fail(detail)
+pending(detail)

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -132,6 +132,19 @@ require(
     == "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock",
     "production COPR public API drifted",
 )
+require(production_copr.get("package") == "facelock", "production COPR package name drifted")
+# The two build flags are the query, not a detail. Without them COPR answers with
+# the package's source configuration and no build at all, and the served-EVR half
+# of the checker would have nothing to compare (#333). It needs both: the latest
+# succeeded build is what the channel serves, the latest build of any state is
+# what says whether the one it is waiting for is running or dead.
+require(
+    production_copr.get("package_api_url")
+    == "https://copr.fedorainfracloud.org/api_3/package?ownername=tyvsmith"
+    "&projectname=facelock&packagename=facelock"
+    "&with_latest_build=True&with_latest_succeeded_build=True",
+    "production COPR package API drifted",
+)
 required_supported_chroots = require_string_set(
     production_copr.get("required_supported_chroots"),
     expected_copr_targets,
@@ -176,6 +189,20 @@ require(
     staging_copr.get("api_url")
     == "https://copr.fedorainfracloud.org/api_3/project?ownername=tyvsmith&projectname=facelock-testing",
     "staging COPR public API drifted",
+)
+require(staging_copr.get("package") == "facelock", "staging COPR package name drifted")
+require(
+    staging_copr.get("package_api_url")
+    == "https://copr.fedorainfracloud.org/api_3/package?ownername=tyvsmith"
+    "&projectname=facelock-testing&packagename=facelock"
+    "&with_latest_build=True&with_latest_succeeded_build=True",
+    "staging COPR package API drifted",
+)
+# Only production has a released history to fall short of, and only production
+# is queried unconditionally.
+require(
+    "served_evr_gap" not in staging_copr,
+    "staging COPR must not record a served EVR gap",
 )
 require_string_set(
     staging_copr.get("required_supported_chroots"),
@@ -713,6 +740,14 @@ require(live_channel_command in justfile, "release preflight does not compare li
 staging_channel_command = f"{live_channel_command} --channel staging"
 require(staging_channel_command in ci_workflow, "CI does not compare the staging release channel")
 require(staging_channel_command in justfile, "release preflight does not compare the staging release channel")
+# Chroots are the shape of a channel, not its contents. Preflight also asks
+# whether production actually serves the predecessor it pinned above: the v0.1.4
+# build never landed and nothing noticed for three months (#333).
+predecessor_channel_command = f"{live_channel_command} --expect-predecessor"
+require(
+    predecessor_channel_command in justfile,
+    "release preflight does not require production COPR to serve the pinned predecessor",
+)
 require(
     "scripts/release-attestation.py" in justfile,
     "release preflight does not require the pre-tag release attestation renderer",
@@ -1577,6 +1612,12 @@ for tag in predecessor_tags:
         version_triple(upstream) <= version_triple(workspace_version()),
         f"{tag} predecessor is not older than the workspace version {workspace_version()}",
     )
+    # A predecessor is a stable release, so its RPM Release is always 1. This is
+    # the EVR `just release-preflight` requires production COPR to serve.
+    require(
+        release.get("rpm_evr") == f"{upstream}-1",
+        f"{tag} predecessor rpm_evr must be {upstream}-1, got {release.get('rpm_evr')!r}",
+    )
 
     lanes = release.get("lanes")
     require(isinstance(lanes, dict) and lanes, f"{tag} predecessor must declare upgrade lanes")
@@ -1626,6 +1667,35 @@ for tag in predecessor_tags:
     require(
         lanes["rpm-fedora"]["release"] in declared_fedora_releases,
         f"{tag} rpm predecessor names an undeclared Fedora release: {lanes['rpm-fedora']['release']}",
+    )
+
+# Production COPR never received the v0.1.4 build: Packit's submission failed on
+# every target and nobody noticed for three months (#333). Preflight requires
+# the channel to serve the predecessor, so that unfixed history is recorded as a
+# gap rather than silently tolerated. The record is pinned to both EVRs -- the
+# one owed and the one served -- and to the predecessor above, so it cannot
+# outlive what it excuses: the next predecessor pin makes it fail here, and any
+# change to what COPR serves makes it stop matching in the live checker.
+served_evr_gap = production_copr.get("served_evr_gap")
+if served_evr_gap is not None:
+    require(isinstance(served_evr_gap, dict), "production COPR served EVR gap must be an object")
+    require(
+        set(served_evr_gap) == {"expected_evr", "served_evr", "issue"},
+        f"production COPR served EVR gap fields drifted: {sorted(served_evr_gap)}",
+    )
+    require(
+        served_evr_gap.get("expected_evr") == predecessors[predecessor_tags[0]]["rpm_evr"],
+        "production COPR served EVR gap must excuse the pinned predecessor, "
+        f"got {served_evr_gap.get('expected_evr')!r}",
+    )
+    require(
+        isinstance(served_evr_gap.get("served_evr"), str)
+        and served_evr_gap["served_evr"] != served_evr_gap["expected_evr"],
+        "production COPR served EVR gap must record a served EVR that differs from the expected one",
+    )
+    require(
+        served_evr_gap.get("issue") == 333,
+        "production COPR served EVR gap must stay owned by issue #333",
     )
 
 # The retired-authselect-profile fixture downloads the same released RPM from a

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -462,6 +462,18 @@ require(
     staging_job.get("owner") == staging_copr["owner"],
     "Packit staging COPR owner disagrees with the release matrix",
 )
+# The other half of the pin. Staging builds every pull request into one project,
+# so its NVRs have to differ from each other; Packit's snapshot suffix is what
+# makes them. Pinning the release there would collide two pull requests on one
+# NVR, so the flag stays off the job and the comparison stays a prefix.
+require(
+    "update_release" not in staging_job,
+    "Packit staging COPR job must keep Packit's release suffix so its per-pull-request NVRs differ",
+)
+require(
+    staging_copr.get("served_evr_exact") is False,
+    "staging COPR must compare the served EVR as a prefix, because its Packit job keeps the suffix",
+)
 # The trigger tracks provisioning. While the project does not exist, `ignore`
 # keeps the job hand-dispatched (`/packit build`), because a pull-request
 # trigger would aim every pull request's Packit run at a project that answers
@@ -503,6 +515,23 @@ production_trigger = production_job.get("trigger")
 require(
     production_trigger in {"ignore", "release"},
     f"Packit production COPR trigger must be 'ignore' or 'release', got {production_trigger!r}",
+)
+# `update_release` and `served_evr_exact` are one contract, held here so neither
+# can move alone. Packit's default rewrites `Release: 1%{?dist}` to
+# `1.{timestamp}.{ref}`, and production pins it off so COPR serves the EVR the
+# conversion table promises. Tightening the served comparison to an equality
+# without that pin reds every stable release; dropping the pin while the
+# comparison stays exact does the same (#333). Staging keeps the default: its
+# pull-request builds need distinct NVRs, so its comparison stays a prefix.
+production_update_release = production_job.get("update_release")
+require(
+    production_update_release is False,
+    "Packit production COPR job must pin update_release: false so COPR serves the "
+    f"canonical EVR, got {production_update_release!r}",
+)
+require(
+    production_copr.get("served_evr_exact") is True,
+    "production COPR must compare the served EVR exactly, because its Packit job pins the release",
 )
 if release_version is not None and "-" not in release_version:
     require(

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -87,7 +87,7 @@ builders=(
     build-nix
     publish-apt
 )
-expected_jobs=("${builders[@]}" publish publish-aur trigger-pages)
+expected_jobs=("${builders[@]}" publish publish-aur verify-copr trigger-pages)
 
 actual_jobs="$(job_names | LC_ALL=C sort)"
 wanted_jobs="$(printf '%s\n' "${expected_jobs[@]}" | LC_ALL=C sort)"
@@ -216,6 +216,19 @@ fi
 
 requires_job trigger-pages publish ||
     fail "trigger-pages must run after the release is published"
+
+# Packit reacts to the published release event, so the COPR build it submits
+# cannot even start before publish. A verifier that ran earlier would be
+# checking the previous release (#333).
+verify_copr_job="$(job_body verify-copr)"
+requires_job verify-copr publish ||
+    fail "verify-copr waits on a build Packit submits after publication and must run after publish"
+printf '%s\n' "$verify_copr_job" | grep -Fq "needs.metadata.outputs.prerelease == 'false'" ||
+    fail "verify-copr must be stable-only; a prerelease never reaches production COPR"
+printf '%s\n' "$verify_copr_job" | grep -Eq '^ +timeout-minutes: [0-9]+$' ||
+    fail "verify-copr polls and must carry its own timeout"
+grep -Fq 'check-live-release-channels.py' .github/workflows/scripts/verify-copr.sh ||
+    fail "verify-copr must compare the served EVR with the live release-channel checker"
 
 publish_aur_job="$(job_body publish-aur)"
 requires_job publish-aur publish ||
@@ -1334,6 +1347,15 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "pages rebuild before publication" \
         's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
         "trigger-pages must run after the release is published"
+    assert_workflow_mutation_rejected "COPR verification dropped" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^  trigger-pages:$/!d}' \
+        "release jobs drifted"
+    assert_workflow_mutation_rejected "COPR verification open to prereleases" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    if: /d}' \
+        "verify-copr must be stable-only"
+    assert_workflow_mutation_rejected "COPR verification polling without a deadline" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    timeout-minutes: /d}' \
+        "verify-copr polls and must carry its own timeout"
     assert_workflow_mutation_rejected "release upload without the publication token" \
         '0,/^          token: \$\{\{ secrets.RELEASE_PAT \}\}$/s///' \
         "every release upload must pass the publication token"

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1659,6 +1659,169 @@ live_channel_authority_case \
     staging \
     "must declare no optional experimental chroots"
 
+# The served half (#333). Enabled chroots passed on every day of the three
+# months production COPR served 0.1.3 while v0.1.4 was the current release, so
+# these cases compare what the project's latest build actually carries. Exit 2
+# means "not yet, and it may still arrive": the release job polls on it, and
+# every other caller treats it as failure.
+#
+# A COPR package answer carries two builds: `latest_succeeded` is what the
+# channel serves, `latest` is the most recently submitted build in any state.
+# The fixture writes both, because the checker reads each for a different
+# question and a fixture that collapsed them would prove neither.
+served_package_fixture() {
+    local path="$1" project="$2" served_evr="$3" latest_evr="$4" latest_state="$5"
+    shift 5
+    local chroots="" chroot
+    for chroot in "$@"; do
+        chroots="${chroots:+$chroots, }\"$chroot\""
+    done
+    local succeeded="null"
+    if [ -n "$served_evr" ]; then
+        succeeded="{\"state\": \"succeeded\", \"chroots\": [$chroots],"
+        succeeded="$succeeded \"source_package\": {\"name\": \"facelock\", \"version\": \"$served_evr\"}}"
+    fi
+    local newest="null"
+    if [ -n "$latest_evr" ]; then
+        newest="{\"state\": \"$latest_state\", \"chroots\": [$chroots],"
+        newest="$newest \"source_package\": {\"name\": \"facelock\", \"version\": \"$latest_evr\"}}"
+    fi
+    cat > "$path" <<JSON
+{
+  "ownername": "tyvsmith",
+  "projectname": "$project",
+  "name": "facelock",
+  "builds": {
+    "latest": $newest,
+    "latest_succeeded": $succeeded
+  }
+}
+JSON
+    python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$path" ||
+        fail "served package fixture $path is not valid JSON"
+}
+
+served_case() {
+    local context="$1" package_fixture="$2" evr="$3" expected_status="$4" needle="$5"
+    local output status=0
+    output=$(python3 "$repo_root/test/check-live-release-channels.py" \
+        --response-file "$live_copr_supported_with_rawhide" \
+        --package-response-file "$package_fixture" \
+        --expect-evr "$evr" 2>&1) || status=$?
+    [ "$status" = "$expected_status" ] ||
+        fail "served EVR case '$context' exited $status, expected $expected_status: $output"
+    case "$output" in
+        *"$needle"*) ;;
+        *) fail "served EVR case '$context' was rejected for another reason: $output" ;;
+    esac
+    echo "release channel case: $context"
+}
+
+served_all_chroots=(fedora-43-x86_64 fedora-44-x86_64 fedora-45-x86_64 fedora-rawhide-x86_64)
+# served_package_fixture <path> <project> <served EVR> <latest EVR> <latest state> <chroots...>
+served_package_fixture "$tmp_root/served-ok.json" facelock 0.9.9-1 0.9.9-1 succeeded "${served_all_chroots[@]}"
+# What Packit actually publishes. Its default fix-spec-file action rewrites
+# `Release: 1%{?dist}` to `1.<timestamp>.<ref>`, so an exact EVR comparison
+# would red every stable release even when COPR built all three chroots.
+served_package_fixture "$tmp_root/served-snapshot.json" facelock \
+    0.9.9-1.20260904220135575676.v0.9.9 0.9.9-1.20260904220135575676.v0.9.9 succeeded \
+    "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-adjacent.json" facelock 0.9.9-11 0.9.9-11 succeeded \
+    "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-stale.json" facelock 0.9.8-1 0.9.8-1 succeeded "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-failed.json" facelock 0.9.8-1 0.9.9-1 failed "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-running.json" facelock 0.9.8-1 0.9.9-1 running "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-skipped.json" facelock 0.9.8-1 0.9.9-1 skipped "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-partial.json" facelock 0.9.9-1 0.9.9-1 succeeded \
+    fedora-43-x86_64 fedora-44-x86_64
+served_package_fixture "$tmp_root/served-other-project.json" facelock-testing 0.9.9-1 0.9.9-1 succeeded \
+    "${served_all_chroots[@]}"
+# The channel still serves the expected EVR while an unrelated later build sits
+# on top of it: a rebuild, a retry, a chroot backfill. Reading the served
+# version off `latest` would call that a regression.
+served_package_fixture "$tmp_root/served-newer-failure.json" facelock 0.9.9-1 1.0.0-1 failed \
+    "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-never-built.json" facelock "" "" "" "${served_all_chroots[@]}"
+
+served_case "served expected EVR accepted" \
+    "$tmp_root/served-ok.json" 0.9.9-1 0 "serves facelock-0.9.9-1"
+# COPR reports `skipped` when the same NVR was already built, so that build is
+# dead and the earlier one is what `latest_succeeded` already answered with.
+served_case "skipped build of the expected EVR rejected outright" \
+    "$tmp_root/served-skipped.json" 0.9.9-1 1 "state='skipped'"
+served_case "Packit's snapshot release suffix accepted" \
+    "$tmp_root/served-snapshot.json" 0.9.9-1 0 "serves facelock-0.9.9-1.20260904220135575676.v0.9.9"
+# The prefix ends at a dot. Without that boundary `0.9.9-1` would accept
+# `0.9.9-11`, a different rebuild of the same version.
+served_case "adjacent release number not accepted as a prefix" \
+    "$tmp_root/served-adjacent.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+served_case "served predecessor EVR reported as not yet published" \
+    "$tmp_root/served-stale.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+# A failed build of the expected EVR is a verdict, not a wait: polling it to a
+# deadline would delay the failure by an hour and change nothing.
+served_case "failed build of the expected EVR rejected outright" \
+    "$tmp_root/served-failed.json" 0.9.9-1 1 "state='failed'"
+served_case "running build of the expected EVR left to finish" \
+    "$tmp_root/served-running.json" 0.9.9-1 2 "state='running'"
+# A build's chroot list is what that build covered, not what the repository
+# serves. A single-chroot rebuild is the documented recovery from a failed
+# submission and becomes the newest succeeded build; requiring every chroot of
+# it would call a healthy channel broken.
+served_case "partial rebuild on top of a complete build accepted" \
+    "$tmp_root/served-partial.json" 0.9.9-1 0 "newest build covered ['fedora-43-x86_64', 'fedora-44-x86_64']"
+served_case "package answering for another project rejected" \
+    "$tmp_root/served-other-project.json" 0.9.9-1 1 "package identity drifted"
+served_case "later unrelated build does not unseat the served EVR" \
+    "$tmp_root/served-newer-failure.json" 0.9.9-1 0 "serves facelock-0.9.9-1"
+served_case "project that has never built the package reported" \
+    "$tmp_root/served-never-built.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+
+# The recorded gap excuses exactly the EVR it names, against exactly the EVR it
+# says is served, so the cases read both out of the authority rather than
+# restating them. No gap recorded means nothing to prove, and the cases retire
+# with the record instead of failing for a reason that looks unrelated.
+served_gap_expected="$(python3 -c 'import json,sys; print((json.load(open(sys.argv[1]))["copr_channels"]["production"].get("served_evr_gap") or {}).get("expected_evr",""))' "$repo_root/dist/release-matrix.json")"
+served_gap_served="$(python3 -c 'import json,sys; print((json.load(open(sys.argv[1]))["copr_channels"]["production"].get("served_evr_gap") or {}).get("served_evr",""))' "$repo_root/dist/release-matrix.json")"
+if [ -n "$served_gap_expected" ]; then
+    served_package_fixture "$tmp_root/served-gap.json" facelock \
+        "$served_gap_served" "$served_gap_served" succeeded "${served_all_chroots[@]}"
+    served_case "recorded gap accepted for the EVR it names" \
+        "$tmp_root/served-gap.json" "$served_gap_expected" 0 "KNOWN GAP"
+    served_case "recorded gap does not excuse another EVR" \
+        "$tmp_root/served-gap.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+    # Packit's snapshot suffix must not unstick the record either: a rebuild of
+    # the very EVR the gap names is still the EVR the gap names.
+    served_package_fixture "$tmp_root/served-gap-snapshot.json" facelock \
+        "$served_gap_served.20260904220135575676.rebuild" \
+        "$served_gap_served.20260904220135575676.rebuild" succeeded "${served_all_chroots[@]}"
+    served_case "recorded gap survives a snapshot-suffixed rebuild of the served EVR" \
+        "$tmp_root/served-gap-snapshot.json" "$served_gap_expected" 0 "KNOWN GAP"
+else
+    echo "release channel case: no served EVR gap recorded, nothing to excuse"
+fi
+
+served_no_expectation_status=0
+served_no_expectation_output=$(python3 "$repo_root/test/check-live-release-channels.py" \
+    --package-response-file "$tmp_root/served-ok.json" 2>&1) || served_no_expectation_status=$?
+[ "$served_no_expectation_status" != 0 ] ||
+    fail "live channel checker accepted a package fixture with nothing to compare it against"
+case "$served_no_expectation_output" in
+    *"needs an expected EVR"*) ;;
+    *) fail "live channel checker rejected a bare package fixture for another reason: $served_no_expectation_output" ;;
+esac
+echo "release channel case: package fixture without an expectation rejected"
+
+served_empty_evr_status=0
+served_empty_evr_output=$(python3 "$repo_root/test/check-live-release-channels.py" \
+    --response-file "$live_copr_supported_with_rawhide" --expect-evr "" 2>&1) || served_empty_evr_status=$?
+[ "$served_empty_evr_status" != 0 ] ||
+    fail "live channel checker green-lit an empty expected EVR: $served_empty_evr_output"
+case "$served_empty_evr_output" in
+    *"empty EVR"*) ;;
+    *) fail "live channel checker rejected an empty EVR for another reason: $served_empty_evr_output" ;;
+esac
+echo "release channel case: empty expected EVR rejected"
+
 # Pre-tag staging attestation (#236, Track M2 task 5). The document binds the
 # candidate commit, the EVRs each channel serves, artifact and repository
 # digests, signing identities, and how fresh the repository metadata was. Every

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -1638,6 +1638,31 @@ case "$live_offline_output" in
 esac
 echo "release channel case: production queries its authority on every run"
 
+# The release pin and the comparison it licenses are one contract. Either half
+# alone reds every stable release: an unpinned production job publishes a
+# suffixed EVR the exact comparison refuses, and a pinned job read with the
+# loose comparison stops catching the drift the pin exists to prevent (#333).
+assert_matrix_mutation_rejected \
+    "production Packit job dropping its release pin" \
+    ".packit.yaml" \
+    's/^      "update_release": false,$//' \
+    "must pin update_release: false"
+assert_matrix_mutation_rejected \
+    "production comparison loosened while the job stays pinned" \
+    "dist/release-matrix.json" \
+    's/"served_evr_exact": true/"served_evr_exact": false/' \
+    "must compare the served EVR exactly"
+assert_matrix_mutation_rejected \
+    "staging Packit job pinned into NVR collisions" \
+    ".packit.yaml" \
+    's/^      "manual_trigger": true,$/      "manual_trigger": true,\n      "update_release": false,/' \
+    "must keep Packit's release suffix"
+assert_matrix_mutation_rejected \
+    "staging comparison tightened while the job keeps its suffix" \
+    "dist/release-matrix.json" \
+    's/"served_evr_exact": false/"served_evr_exact": true/' \
+    "must compare the served EVR as a prefix"
+
 live_channel_authority_case \
     "production authority without optional experimental chroots" \
     's/"optional_experimental_chroots"/"retired_experimental_chroots"/' \
@@ -1720,12 +1745,17 @@ served_case() {
 served_all_chroots=(fedora-43-x86_64 fedora-44-x86_64 fedora-45-x86_64 fedora-rawhide-x86_64)
 # served_package_fixture <path> <project> <served EVR> <latest EVR> <latest state> <chroots...>
 served_package_fixture "$tmp_root/served-ok.json" facelock 0.9.9-1 0.9.9-1 succeeded "${served_all_chroots[@]}"
-# What Packit actually publishes. Its default fix-spec-file action rewrites
-# `Release: 1%{?dist}` to `1.<timestamp>.<ref>`, so an exact EVR comparison
-# would red every stable release even when COPR built all three chroots.
+# What Packit publishes when nothing pins the release: its default
+# fix-spec-file action rewrites `Release: 1%{?dist}` to `1.<timestamp>.<ref>`.
+# Production pins it off (`update_release: false`), so this shape reaching
+# production means the pin stopped working and must not be accepted. Staging
+# keeps the suffix and accepts the same fixture below.
 served_package_fixture "$tmp_root/served-snapshot.json" facelock \
     0.9.9-1.20260904220135575676.v0.9.9 0.9.9-1.20260904220135575676.v0.9.9 succeeded \
     "${served_all_chroots[@]}"
+served_package_fixture "$tmp_root/served-snapshot-staging.json" facelock-testing \
+    0.9.9-1.20260904220135575676.v0.9.9 0.9.9-1.20260904220135575676.v0.9.9 succeeded \
+    fedora-43-x86_64 fedora-44-x86_64 fedora-45-x86_64
 served_package_fixture "$tmp_root/served-adjacent.json" facelock 0.9.9-11 0.9.9-11 succeeded \
     "${served_all_chroots[@]}"
 served_package_fixture "$tmp_root/served-stale.json" facelock 0.9.8-1 0.9.8-1 succeeded "${served_all_chroots[@]}"
@@ -1749,12 +1779,39 @@ served_case "served expected EVR accepted" \
 # dead and the earlier one is what `latest_succeeded` already answered with.
 served_case "skipped build of the expected EVR rejected outright" \
     "$tmp_root/served-skipped.json" 0.9.9-1 1 "state='skipped'"
-served_case "Packit's snapshot release suffix accepted" \
-    "$tmp_root/served-snapshot.json" 0.9.9-1 0 "serves facelock-0.9.9-1.20260904220135575676.v0.9.9"
-# The prefix ends at a dot. Without that boundary `0.9.9-1` would accept
-# `0.9.9-11`, a different rebuild of the same version.
-served_case "adjacent release number not accepted as a prefix" \
+# Production compares exactly, so an unpinned release reaching it is drift.
+served_case "Packit's snapshot release suffix rejected on production" \
+    "$tmp_root/served-snapshot.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+served_case "exact EVR still accepted on production" \
+    "$tmp_root/served-ok.json" 0.9.9-1 0 "serves facelock-0.9.9-1"
+served_case "adjacent release number rejected on production" \
     "$tmp_root/served-adjacent.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
+
+# Staging keeps Packit's suffix, so it keeps the looser comparison. The two
+# channels reading the same fixture differently is the point of binding the
+# comparison to the Packit job rather than hardcoding one rule.
+served_staging_case() {
+    local context="$1" package_fixture="$2" evr="$3" expected_status="$4" needle="$5"
+    local output status=0
+    output=$(python3 "$repo_root/test/check-live-release-channels.py" --channel staging \
+        --response-file "$staging_copr_supported_only" \
+        --package-response-file "$package_fixture" \
+        --expect-evr "$evr" 2>&1) || status=$?
+    [ "$status" = "$expected_status" ] ||
+        fail "staging EVR case '$context' exited $status, expected $expected_status: $output"
+    case "$output" in
+        *"$needle"*) ;;
+        *) fail "staging EVR case '$context' was rejected for another reason: $output" ;;
+    esac
+    echo "release channel case: $context"
+}
+
+served_package_fixture "$tmp_root/served-adjacent-staging.json" facelock-testing 0.9.9-11 0.9.9-11 \
+    succeeded fedora-43-x86_64 fedora-44-x86_64 fedora-45-x86_64
+served_staging_case "Packit snapshot release suffix accepted on staging" \
+    "$tmp_root/served-snapshot-staging.json" 0.9.9-1 0 "serves facelock-0.9.9-1.20260904220135575676.v0.9.9"
+served_staging_case "adjacent release number rejected on staging" \
+    "$tmp_root/served-adjacent-staging.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
 served_case "served predecessor EVR reported as not yet published" \
     "$tmp_root/served-stale.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
 # A failed build of the expected EVR is a verdict, not a wait: polling it to a
@@ -1782,20 +1839,45 @@ served_case "project that has never built the package reported" \
 # with the record instead of failing for a reason that looks unrelated.
 served_gap_expected="$(python3 -c 'import json,sys; print((json.load(open(sys.argv[1]))["copr_channels"]["production"].get("served_evr_gap") or {}).get("expected_evr",""))' "$repo_root/dist/release-matrix.json")"
 served_gap_served="$(python3 -c 'import json,sys; print((json.load(open(sys.argv[1]))["copr_channels"]["production"].get("served_evr_gap") or {}).get("served_evr",""))' "$repo_root/dist/release-matrix.json")"
+# A gap answers only the predecessor question, so its cases ask it that way.
+# `--expect-predecessor` resolves the EVR from the matrix, which is the same
+# EVR the record must name.
+served_predecessor_case() {
+    local context="$1" package_fixture="$2" expected_status="$3" needle="$4"
+    local output status=0
+    output=$(python3 "$repo_root/test/check-live-release-channels.py" --expect-predecessor \
+        --response-file "$live_copr_supported_with_rawhide" \
+        --package-response-file "$package_fixture" 2>&1) || status=$?
+    [ "$status" = "$expected_status" ] ||
+        fail "predecessor EVR case '$context' exited $status, expected $expected_status: $output"
+    case "$output" in
+        *"$needle"*) ;;
+        *) fail "predecessor EVR case '$context' was rejected for another reason: $output" ;;
+    esac
+    echo "release channel case: $context"
+}
+
 if [ -n "$served_gap_expected" ]; then
     served_package_fixture "$tmp_root/served-gap.json" facelock \
         "$served_gap_served" "$served_gap_served" succeeded "${served_all_chroots[@]}"
-    served_case "recorded gap accepted for the EVR it names" \
-        "$tmp_root/served-gap.json" "$served_gap_expected" 0 "KNOWN GAP"
+    served_predecessor_case "recorded gap accepted for the predecessor it names" \
+        "$tmp_root/served-gap.json" 0 "KNOWN GAP"
+    # The record excuses a release that already shipped. `verify-copr` asks
+    # about the one it is publishing, and a record that could answer that would
+    # silence the job on the failure it exists to make loud.
+    served_case "recorded gap does not excuse the release being published" \
+        "$tmp_root/served-gap.json" "$served_gap_expected" 2 \
+        "does not serve facelock-$served_gap_expected"
     served_case "recorded gap does not excuse another EVR" \
         "$tmp_root/served-gap.json" 0.9.9-1 2 "does not serve facelock-0.9.9-1"
-    # Packit's snapshot suffix must not unstick the record either: a rebuild of
-    # the very EVR the gap names is still the EVR the gap names.
+    # The record is read under the channel's own rule. Production pins the
+    # release, so a suffixed EVR appearing there means the pin stopped working,
+    # and the record must not paper over it.
     served_package_fixture "$tmp_root/served-gap-snapshot.json" facelock \
         "$served_gap_served.20260904220135575676.rebuild" \
         "$served_gap_served.20260904220135575676.rebuild" succeeded "${served_all_chroots[@]}"
-    served_case "recorded gap survives a snapshot-suffixed rebuild of the served EVR" \
-        "$tmp_root/served-gap-snapshot.json" "$served_gap_expected" 0 "KNOWN GAP"
+    served_predecessor_case "recorded gap does not excuse a suffixed rebuild on the pinned channel" \
+        "$tmp_root/served-gap-snapshot.json" 2 "does not serve facelock-$served_gap_expected"
 else
     echo "release channel case: no served EVR gap recorded, nothing to excuse"
 fi


### PR DESCRIPTION
## Summary

- compare the EVR production COPR serves, not just the chroots it enables
- pin `update_release: false` on the production `copr_build` job so COPR publishes `0.2.0-1`, the EVR the conversion table promises
- add a stable-only `verify-copr` job that polls for that EVR after publication and reds the run when it never lands
- require `just release-preflight` to find the pinned predecessor's EVR in production
- record v0.1.4's missing build as `copr_channels.production.served_evr_gap`, readable only by preflight
- correct the COPR setup step: Packit needs `admin`, not `builder`, to reconcile a project it does not own

## Why

Packit ran on v0.1.4 and submitted nothing. `.packit.yaml` listed
`fedora-42-x86_64`, a chroot the project had never enabled, so Packit tried to
edit the project, held only builder permission, and aborted all three targets.
The failure left three red check runs on a tag commit and no failed job, and
because nothing compared what a channel serves with what its release should have
produced, COPR sat on 0.1.3 for three months.

## Reviewer notes

- **The EVR pin and the comparison are one contract.** Production carries
  `update_release: false` and is compared exactly; staging keeps Packit's
  `1.{timestamp}.{ref}` suffix, which its per-pull-request NVRs need, and is
  compared as a prefix ending at a dot. `check-release-matrix.py` holds each
  channel's flag and `served_evr_exact` together, with four mutation cases,
  because either half alone reds every stable release.
- **Not fully provable before a real stable tag.** The schema accepts the
  per-job flag, Packit's config parser resolves it to `False` for production and
  `True` for staging, and `packit srpm` with it set produces
  `facelock-0.2.0-1.fc44.src.rpm` against
  `facelock-0.2.0-1.20260904234626592330.master.0.g7d8eef8.fc44.src.rpm`
  without it. What no local check reaches is packit-service applying a *job's*
  flag on a release event — `just test-copr` goes through the CLI, which reads
  package-level config. If the first stable tag publishes a suffixed EVR anyway,
  hoist `update_release` to the top level and flip staging's `served_evr_exact`;
  do not loosen the comparison.
- **Exit 2 means "not yet."** A build still running, none submitted, or a query
  that failed. Only the poller distinguishes it from exit 1; preflight and CI
  treat both as failure.
- **The serving build's chroot list is reported, never required.** It is what
  that build covered, not what the repository serves, and the single-chroot
  recovery rebuild would otherwise read as a broken channel.
- **The gap answers preflight's question only.** `verify-copr` asks about the
  release it is publishing, so a record cannot silence it. The gap must excuse
  exactly the pinned predecessor's EVR, so moving that pin past v0.1.4 fails the
  matrix contract until the record is deleted.
- 0.1.4 is not backfilled. 0.2.0 supersedes it.

## Validation

- Packit's config parser over `.packit.yaml`, to confirm the per-job flag
  resolves per job rather than per package
- `packit srpm` with and without the pin, to establish the EVR each produces
- `just test-packit-config`
- `verify-copr.sh` against the live COPR API: served, deadline, and
  prerelease-refusal paths
- 15 served-EVR channel cases and 4 pin-drift matrix mutations in
  `test/release-version-contract.sh`
- three workflow-mutation cases: job dropped, prerelease guard dropped, timeout
  dropped
- `check-release-matrix.py`, `release-artifacts-contract.sh`,
  `check-agent-docs.py`, `check-workflow-policy.py`, `cargo test -p facelock-cli
  conformance`

Fixes #333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable releases now verify that the expected package version is available in production COPR before completing.
  * Release preflight checks confirm the pinned predecessor package is present and correct.
  * Production and staging package-version validation now follows channel-specific rules.
  * Release checks provide clearer status and diagnostic information for pending or failed builds.

* **Documentation**
  * Updated release guidance with COPR verification requirements, failure diagnosis, and recovery procedures.
  * Clarified production and staging package-version policies and release-channel contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->