### PR TITLE
fix(ci): trust the workspace checkout in the release deb job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,20 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Every step of a container job runs as root while the workspace keeps
+      # the runner uid, so git rejects the checkout as dubiously owned and
+      # exits 128. actions/checkout writes this same entry, but under a
+      # temporary HOME it discards when it finishes, so no later step sees it.
+      # Without this line both places this job reaches git die at 128:
+      # test/prepare-deb-test-context.sh under `just test-deb-source-contract`,
+      # and the `git archive` build-deb.sh takes the source tarball from.
+      # Ownership is the whole of what git checks, so the exception is all this
+      # needs. Only a container job needs it -- a job on the runner already
+      # owns its checkout, and build-rpm installs no git at all, so its
+      # checkout is the REST tarball and not a repository.
+      - name: Trust the workspace checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install system dependencies
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Debian release jobs trust the checkout they were handed**: tagging
+  v0.2.0-alpha.1 ran the release workflow for the first time since the Debian
+  source contract joined it, and both suites died on `fatal: detected dubious
+  ownership in repository at '/__w/facelock/facelock'` before a package was
+  built. A container job runs every step as root while the workspace keeps the
+  runner uid, so git rejects the checkout and exits 128; `actions/checkout`
+  writes the exception itself, but under a temporary `HOME` it discards when it
+  finishes, so no later step sees it. `build-deb` now takes the exception right
+  after checking out, the way `ci.yml` already does in the two jobs that need
+  it. `build-rpm` was unaffected and stays as it is: it installs no git, so
+  `actions/checkout` falls back to the REST tarball and leaves no repository
+  behind. `test/release-artifacts-contract.sh` now fails a containerized
+  release job that installs git without taking the exception, since a tag is
+  the only thing that runs this workflow.
+
 ## [0.2.0-alpha.1] - 2026-09-04
 
 ### Added

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -318,6 +318,16 @@ job_statements() {
     job_body "$1" | grep -v '^[[:space:]]*#' || true
 }
 
+# The whole text of the named step of one job, empty when it has no such step.
+named_step() {
+    awk -v needle="      - name: $2" '
+        function flush() { if (head == needle) printf "%s", step; step = ""; head = "" }
+        /^      - / { flush(); head = $0 }
+        { step = step $0 "\n" }
+        END { flush() }
+    ' <<<"$1"
+}
+
 # The first line of each step of one job, in order, as `keyword<TAB>value`.
 job_step_heads() {
     awk '
@@ -336,7 +346,7 @@ job_step_heads() {
 installs_git() {
     local joined
     joined="$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' <<<"$1")"
-    grep -Eq '(^|[[:space:]])(install|-S[a-z]*)[[:space:]].*[[:space:]]git([[:space:]]|$)' <<<"$joined"
+    grep -Eq '(^|[[:space:]])(install|-S[a-z]*)[[:space:]]+([^[:space:]]+[[:space:]]+)*git([[:space:]]|$)' <<<"$joined"
 }
 
 trusting_jobs=0
@@ -353,9 +363,12 @@ for job in "${expected_jobs[@]}"; do
         continue
     fi
     trusting_jobs=$((trusting_jobs + 1))
-    grep -Fq "name	$trust_step_name" <<<"$steps" ||
+    # Read the command out of the named step, not out of the job: a no-op step
+    # beside a `git config` line somewhere else is not the exception.
+    trust_step="$(named_step "$statements" "$trust_step_name")"
+    [ -n "$trust_step" ] ||
         fail "container job $job installs git and must trust the workspace checkout; git exits 128 on a checkout it does not own"
-    grep -Fq "$trust_step_run" <<<"$statements" ||
+    grep -Fq "$trust_step_run" <<<"$trust_step" ||
         fail "job $job must trust the workspace checkout with exactly: $trust_step_run"
     # Immediately after the checkout: nothing between them may reach git, and
     # the entry actions/checkout makes for itself is gone by the time it
@@ -1444,6 +1457,16 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "an exception kept past its git install" \
         's|^            git$||' \
         "trusts the workspace checkout but installs no git"
+    # git as the very first package of the install, with no token before it.
+    assert_workflow_mutation_rejected "a container job installing git first" \
+        's|^          dnf install -y \\$|          dnf install git \\|' \
+        "container job build-rpm installs git"
+    # The exception read out of the job rather than out of its step: a no-op
+    # trust step beside a real `git config` line in a later one.
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "the exception moved out of its step" \
+        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"\n\n      - name: Trust it later\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"|' \
+        "must trust the workspace checkout with exactly"
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "attestation left unbound to its job" \
         '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -282,6 +282,98 @@ nix_build_step="$(nix_step 'nix build')"
 printf '%s\n' "$nix_build_step" | grep -Eq '^ +continue-on-error: true$' ||
     fail "nix build depends on nixpkgs state and is documented as advisory; it must keep continue-on-error"
 
+# --------------------------------------- container jobs and checkout ownership
+#
+# A container job runs every step as root while the workspace keeps the runner
+# uid, so git rejects the checkout ("detected dubious ownership") and exits 128.
+# actions/checkout writes the exception itself, but under a temporary HOME it
+# discards when it finishes, so no later step sees it. This workflow runs only
+# on a tag, so no pull request exercises it: v0.2.0-alpha.1 (run 33983928629)
+# was the first run of both Debian legs and both died here before building a
+# deb.
+#
+# The trigger is git being installed, not any one recipe. A container job that
+# installs git gets a real git checkout, and anything it runs afterwards can
+# shell out to git -- `just test-deb-source-contract` reaches
+# test/prepare-deb-test-context.sh, and build-deb.sh takes its source tarball
+# from `git archive`. Proving the negative, that nothing in a job's transitive
+# script closure ever calls git, is the analysis that fails open, so the rule is
+# the coarse one. A container job that installs no git carries no requirement:
+# build-rpm installs none, actions/checkout falls back to the API tarball there
+# and leaves no repository behind. It acquires the requirement the day it
+# installs git.
+#
+# ci.yml already takes the exception in the two jobs that need it, and every
+# pull request runs ci.yml, so a regression there is visible immediately. This
+# gate covers release.yml because a tag is the only thing that runs it.
+trust_step_name='Trust the workspace checkout'
+# shellcheck disable=SC2016
+trust_step_run='run: git config --global --add safe.directory "$GITHUB_WORKSPACE"'
+
+# One job's body with whole-line comments removed: a commented-out package or
+# step must never pass as present. `grep -v` finds no match on an empty body,
+# which is a failure under `set -e`, so an empty result is allowed through and
+# the caller's own assertion reports it.
+job_statements() {
+    job_body "$1" | grep -v '^[[:space:]]*#' || true
+}
+
+# The first line of each step of one job, in order, as `keyword<TAB>value`.
+job_step_heads() {
+    awk '
+        /^      - / {
+            line = $0
+            sub(/^      - /, "", line)
+            split(line, parts, ": ")
+            print parts[1] "\t" substr(line, length(parts[1]) + 3)
+        }
+    ' <<<"$1"
+}
+
+# Whether one job installs git: a package-manager install naming git as a
+# package. Line continuations are joined first, so a package list spread over a
+# dozen lines reads as the one command it is.
+installs_git() {
+    local joined
+    joined="$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' <<<"$1")"
+    grep -Eq '(^|[[:space:]])(install|-S[a-z]*)[[:space:]].*[[:space:]]git([[:space:]]|$)' <<<"$joined"
+}
+
+trusting_jobs=0
+for job in "${expected_jobs[@]}"; do
+    statements="$(job_statements "$job")"
+    grep -Eq '^    container:' <<<"$statements" || continue
+    steps="$(job_step_heads "$statements")"
+    if ! installs_git "$statements"; then
+        # Fail closed in the other direction too: a job holding an exception it
+        # does not need has either lost its git install or gained a stray step.
+        if grep -Fq "name	$trust_step_name" <<<"$steps"; then
+            fail "job $job trusts the workspace checkout but installs no git; drop the step or restore the install"
+        fi
+        continue
+    fi
+    trusting_jobs=$((trusting_jobs + 1))
+    grep -Fq "name	$trust_step_name" <<<"$steps" ||
+        fail "container job $job installs git and must trust the workspace checkout; git exits 128 on a checkout it does not own"
+    grep -Fq "$trust_step_run" <<<"$statements" ||
+        fail "job $job must trust the workspace checkout with exactly: $trust_step_run"
+    # Immediately after the checkout: nothing between them may reach git, and
+    # the entry actions/checkout makes for itself is gone by the time it
+    # returns.
+    after_checkout="$(awk -F'\t' '
+        seen { print $2; exit }
+        $1 == "uses" && $2 ~ /^actions\/checkout@/ { seen = 1 }
+    ' <<<"$steps")"
+    [ -n "$after_checkout" ] ||
+        fail "job $job has no step after its checkout; the ownership exception has nowhere to go"
+    [ "$after_checkout" = "$trust_step_name" ] ||
+        fail "job $job must trust the workspace checkout immediately after checking it out, not after '$after_checkout'"
+done
+# A renamed `container:` key, or a job list that stopped containing one, would
+# turn every assertion above into a no-op.
+[ "$trusting_jobs" -gt 0 ] ||
+    fail "no containerized release job installs git; the checkout-ownership rule stopped covering anything"
+
 # The attesting set the helper pins must be exactly the artifacts the workflow
 # uploads, each bound to a job output. The artifact store is writable by every
 # job in the run; a job output is recorded under the job that produced it and
@@ -1332,6 +1424,26 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "flake evaluation that cannot fail" \
         's|^        run: nix flake check ./dist/nix --no-build$|        run: nix flake check ./dist/nix --no-build\n        continue-on-error: true|' \
         "flake evaluation must gate publication"
+
+    # The checkout-ownership exception. Removed, neutralized, displaced, or
+    # owed by a job that just acquired git: each is a tag-time-only failure,
+    # which is the class this whole gate exists for.
+    assert_workflow_mutation_rejected "a container job left untrusting" \
+        '/^      - name: Trust the workspace checkout$/,+1d' \
+        "must trust the workspace checkout"
+    assert_workflow_mutation_rejected "the ownership exception neutralized" \
+        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"|' \
+        "must trust the workspace checkout with exactly"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "the ownership exception taken late" \
+        's|^      - name: Trust the workspace checkout$|      - name: Report the workspace\n        run: ls "$GITHUB_WORKSPACE"\n\n      - name: Trust the workspace checkout|' \
+        "immediately after checking it out"
+    assert_workflow_mutation_rejected "a container job gaining git untrusted" \
+        's|^            rust cargo clang-devel|            git rust cargo clang-devel|' \
+        "container job build-rpm installs git"
+    assert_workflow_mutation_rejected "an exception kept past its git install" \
+        's|^            git$||' \
+        "trusts the workspace checkout but installs no git"
     # shellcheck disable=SC2016
     assert_workflow_mutation_rejected "attestation left unbound to its job" \
         '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \


### PR DESCRIPTION
## Summary

- add `Trust the workspace checkout` to `build-deb`, immediately after the checkout, matching `ci.yml`
- fail `test/release-artifacts-contract.sh` when a containerized release job installs git without that step
- cover the guard with seven workflow mutations: the step removed, neutralized, displaced, moved out of its own step, owed by a job that just gained git, owed by one that installs git first, and kept by one that lost it

## Why

Tagging v0.2.0-alpha.1 (run 33983928629) killed both Debian legs with `fatal: detected dubious ownership in repository at '/__w/facelock/facelock'`. A container job runs every step as root while the workspace keeps the runner uid, so git rejects the checkout and exits 128; `actions/checkout` writes the exception itself, but under a temporary `HOME` it discards when it finishes, so no later step sees it. `ci.yml` has carried the line since August in the two jobs that run git, and `release.yml` never got it, so every pull request passed and the tag did not. Nothing published: the RPM built and every downstream job skipped.

## Audit

Which release jobs need the exception, and which do not:

- `build-deb` needs it: container, installs git before checking out, and reaches git twice, through `test/prepare-deb-test-context.sh` under `just test-deb-source-contract` and through the `git archive` that `build-deb.sh` takes the source tarball from
- `build-rpm` does not: the fedora image installs no git, so `actions/checkout` logs "The repository will be downloaded using the GitHub REST API" and leaves no repository behind, and `build-rpm.sh` only excludes `.git` from a tar
- `metadata`, `build`, `download-ort`, `prepare-cargo-vendor`, `build-nix`, `publish-apt`, `publish`, `verify-copr`, `trigger-pages` do not: no container, so the steps already own the checkout, and `publish` runs `git rev-parse` and `git tag -v` as that same uid
- `publish-aur` does not: its uid change is a `docker run` over the AUR clone rather than the workspace, and it chowns into and back out of the container uid around `makepkg`
- `safe.directory` alone, without the `chown -R` and `chmod go-w` that sit beside it in `ci.yml`: ownership is the whole of what git checks here, and `catalog-check` already runs git against a container checkout with just the one line

The guard keys on the git install rather than on which recipes reach git. Calling a job safe otherwise means proving nothing in its transitive script closure ever shells out to git, and that analysis fails open, which is how this shipped.

## Validation

- `bash test/release-artifacts-contract.sh`
- `python3 test/check-agent-docs.py`, `python3 test/check-workflow-policy.py`
- `shellcheck -x test/release-artifacts-contract.sh`
- `just check`
- actionlint is not installed here, and no gate in the repo runs it

A tag is the only thing that runs `release.yml`, so the workflow change itself stays unexercised until the next release run. So does everything past the failing step in `build-deb`, which has never run on a tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Debian release builds that could fail when Git detected workspace ownership differences.
  - Release jobs now correctly trust the checked-out workspace before running Git operations.

- **Tests**
  - Added validation to ensure containerized release jobs configure Git workspace trust correctly.
  - Added coverage for missing, misplaced, disabled, and unnecessary trust configuration.

- **Documentation**
  - Documented the Debian release-build fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->