### PR TITLE
ci(copr): Restore the production release trigger for stable 0.2.0

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,7 @@
   "jobs": [
     {
       "job": "copr_build",
-      "trigger": "ignore",
+      "trigger": "release",
       "owner": "tyvsmith",
       "project": "facelock",
       "update_release": false,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -585,12 +585,12 @@ Packit reads `.packit.yaml` from the released tag. Packit's documented
 `upstream_tag_exclude` filtering applies to downstream synchronization jobs,
 not to `copr_build`, so it is not a prerelease safety boundary.
 
-The prerelease-capable configuration keeps the production
-`tyvsmith/facelock` job at `trigger: ignore`. That makes an alpha-tagged config
-structurally incapable of selecting a release-triggered production project.
-Before a stable release, the maintainer deliberately changes that trigger to
-`release` in the stable-tagged config. `just release-preflight` rejects a
-production release job for a prerelease and rejects its absence for a stable.
+The production `tyvsmith/facelock` job sits at `trigger: release`, restored by
+hand for the stable release. A prerelease-capable configuration parks it back
+at `trigger: ignore`, which makes an alpha-tagged config structurally incapable
+of selecting a release-triggered production project. `just release-preflight`
+rejects a production release job for a prerelease and rejects its absence for a
+stable, so the trigger moves with the version instead of drifting away from it.
 The deliberate stable restoration targets `fedora-43-x86_64`,
 `fedora-44-x86_64`, and the separate `fedora-45-x86_64` branched target.
 Rawhide is Fedora 46 development in this matrix, not an alias for Fedora 45,


### PR DESCRIPTION
- flip the production COPR `copr_build` job from `trigger: ignore` to `trigger: release`, so Packit selects the project off a release event
- rewrite the `docs/releasing.md` passage that asserted the job sits at `ignore`
- **hold until the 0.2.0 version bump**: `test/check-release-matrix.py` enforces the pairing in both directions, so a prerelease requires `ignore` and merging this rejects every later prerelease preflight
- checked the enforcement across unset, stable and prerelease `RELEASE_MATRIX_VERSION` values; CI only ever runs the checker with it unset

The job was parked at `ignore` on 2026-08-18 so that no prerelease tag could reach the production project, which is what the 0.2.0 alphas needed. Stable 0.2.0 needs it back, and nothing else restores it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * COPR production builds now trigger automatically for releases.
  * Pull-request testing builds remain manually triggerable.

* **Documentation**
  * Updated release guidance for stable and prerelease configurations.
  * Added validation guidance to ensure build triggers match the release type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->