### PR TITLE
ci(release): Run container release steps under the shell they are written in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,9 @@ jobs:
 
       - name: Build suite-specific .deb package
         id: deb
+        # scripts/release-versions.sh is bash, and a container step otherwise
+        # runs under the image's /bin/sh, which is dash on Debian and Ubuntu.
+        shell: bash
         run: |
           set -euo pipefail
           install -d -m700 /tmp/facelock-empty-cargo-home /tmp/facelock-empty-rustup-home
@@ -408,6 +411,9 @@ jobs:
 
       - name: Select the packages the validated metadata names
         id: rpm
+        # mapfile, process substitution and array expansion, none of which the
+        # image's /bin/sh has to provide.
+        shell: bash
         run: |
           set -euo pipefail
           source scripts/release-versions.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The release workflow's container steps run under the shell they are written
+  in**: tagging v0.2.0-alpha.2 built both Debian packages and then threw away
+  the result, because the step that reads the package version back died with
+  `source: not found`. A container job's steps run under the image's `/bin/sh`,
+  which is dash on Debian and Ubuntu and bash on Fedora, so the same step
+  passed in the RPM job and exited 127 in both Debian jobs. Swapping `source`
+  for `.` would not have helped: `scripts/release-versions.sh` is bash itself,
+  and a POSIX shell fails on its first line instead. Both steps now declare
+  `shell: bash`. `test/release-artifacts-contract.sh` fails any containerized
+  release step that uses bash-only syntax without declaring it, since a tag is
+  the only thing that runs this workflow and no local recipe or packaging lane
+  reaches these steps.
+
 ## [0.2.0-alpha.2] - 2026-09-05
 
 ### Added

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -387,6 +387,76 @@ done
 [ "$trusting_jobs" -gt 0 ] ||
     fail "no containerized release job installs git; the checkout-ownership rule stopped covering anything"
 
+# ------------------------------------------------------- container step shells
+#
+# A container job's `run:` steps execute under the image's /bin/sh, not bash.
+# Debian and Ubuntu point /bin/sh at dash; Fedora points it at bash. The same
+# step therefore runs green in build-rpm and exits 127 in build-deb, which is
+# what v0.2.0-alpha.2 (run 33992475158) found: `source scripts/release-versions.sh`
+# died with `source: not found` in both Debian legs, after build-deb.sh had
+# already built the package.
+#
+# Swapping `source` for `.` fixes nothing. scripts/release-versions.sh is bash
+# itself (`[[ =~ ]]`, BASH_REMATCH, `local -a`), so a POSIX shell fails on its
+# first line instead of on the sourcing. The rule is that the step declares the
+# shell it is written in, not that it avoids one builtin.
+#
+# Nothing else covers this: every local recipe and every packaging-CI lane runs
+# these scripts under bash, and a tag is the only thing that runs this workflow.
+bash_only_syntax='(^|[[:space:]])source[[:space:]]|\[\[|(^|[[:space:]])(mapfile|readarray)[[:space:]]|(^|[[:space:]])declare[[:space:]]|(^|[[:space:]])local[[:space:]]+-|<\(|<<<|\$\{#?[A-Za-z_][A-Za-z0-9_]*\[@\]\}'
+
+# Each step of one job as a NUL-separated record, so a body can be read whole.
+job_step_bodies() {
+    awk '
+        function flush() { if (step != "") printf "%s%c", step, 0; step = "" }
+        /^      - / { flush() }
+        { step = step $0 "\n" }
+        END { flush() }
+    ' <<<"$1"
+}
+
+# Only the script a step runs, never its name or its keys. `Validate Debian
+# source contract` is a step name carrying the word source, and matching it
+# would report a POSIX step as a bash one.
+step_run_script() {
+    awk '
+        /^        run:/ { inside = 1; next }
+        inside && /^        [A-Za-z]/ { inside = 0 }
+        inside { print }
+    ' <<<"$1"
+}
+
+bash_shelled_steps=0
+for job in "${expected_jobs[@]}"; do
+    statements="$(job_statements "$job")"
+    grep -Eq '^    container:' <<<"$statements" || continue
+    while IFS= read -r -d '' step; do
+        script="$(step_run_script "$step")"
+        [ -n "$script" ] || continue
+        grep -Eq "$bash_only_syntax" <<<"$script" || continue
+        bash_shelled_steps=$((bash_shelled_steps + 1))
+        step_name="$(sed -n 's/^      - name: //p' <<<"$step" | head -n 1)"
+        grep -Eq '^        shell: bash$' <<<"$step" ||
+            fail "container job $job runs bash-only syntax under the image's /bin/sh; declare 'shell: bash' on step: $step_name"
+    done < <(job_step_bodies "$statements")
+done
+# Both the syntax pattern and the container scan have to keep matching
+# something, or a rewrite of either turns the loop into a no-op.
+[ "$bash_shelled_steps" -gt 0 ] ||
+    fail "no containerized release step uses bash-only syntax; the step-shell rule stopped covering anything"
+
+# Positive control against the obvious over-match. `Validate Debian source
+# contract` carries the word source in its name and runs nothing bash, so it
+# stays on the image's /bin/sh. A rule that read step names instead of step
+# scripts would demand a shell key here and be wrong.
+posix_step="$(named_step "$(job_statements build-deb)" 'Validate Debian source contract')"
+[ -n "$posix_step" ] ||
+    fail "build-deb lost the Debian source contract step; the step-shell positive control proves nothing"
+if grep -Eq '^        shell:' <<<"$posix_step"; then
+    fail "the Debian source contract step declares a shell; the step-shell rule is matching step names"
+fi
+echo "release artifacts case: POSIX container step left on the image shell"
+
 # The attesting set the helper pins must be exactly the artifacts the workflow
 # uploads, each bound to a job output. The artifact store is writable by every
 # job in the run; a job output is recorded under the job that produced it and
@@ -1388,6 +1458,15 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         echo "release artifacts mutation: $context rejected"
     }
 
+    assert_workflow_mutation_rejected "the deb step left on the image shell" \
+        '/^      - name: Build suite-specific \.deb package$/,/^        run: \|$/{/^        shell: bash$/d}' \
+        "declare 'shell: bash' on step: Build suite-specific .deb package"
+    assert_workflow_mutation_rejected "the rpm step left on the image shell" \
+        '/^      - name: Select the packages the validated metadata names$/,/^        run: \|$/{/^        shell: bash$/d}' \
+        "declare 'shell: bash' on step: Select the packages the validated metadata names"
+    assert_workflow_mutation_rejected "a container step shell weakened to sh" \
+        's/^        shell: bash$/        shell: sh/' \
+        "runs bash-only syntax under the image's /bin/sh"
     assert_workflow_mutation_rejected "public release creation" \
         's/^          draft: true$//' \
         "must create the GitHub release as a draft"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -418,10 +418,21 @@ job_step_bodies() {
 # Only the script a step runs, never its name or its keys. `Validate Debian
 # source contract` is a step name carrying the word source, and matching it
 # would report a POSIX step as a bash one.
+#
+# All three spellings of `run:` count. A one-line `run: <command>` carries its
+# whole script on the key's own line, and a step written `- run: <command>`
+# carries it there with no name at all; reading only the indented block below
+# the key would skip both and leave the rule enforcing nothing on them.
 step_run_script() {
     awk '
-        /^        run:/ { inside = 1; next }
-        inside && /^        [A-Za-z]/ { inside = 0 }
+        function emit(text) {
+            sub(/^[[:space:]]*-?[[:space:]]*run:[[:space:]]*/, "", text)
+            # A block scalar indicator introduces the script, it is not script.
+            if (text ~ /^[|>][0-9+-]*$/) return
+            if (text != "") print text
+        }
+        /^      - run:/ || /^        run:/ { emit($0); inside = 1; next }
+        inside && (/^      - / || /^        [A-Za-z]/) { inside = 0 }
         inside { print }
     ' <<<"$1"
 }
@@ -1466,6 +1477,12 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         "declare 'shell: bash' on step: Select the packages the validated metadata names"
     assert_workflow_mutation_rejected "a container step shell weakened to sh" \
         's/^        shell: bash$/        shell: sh/' \
+        "runs bash-only syntax under the image's /bin/sh"
+    assert_workflow_mutation_rejected "a one-line container step turning bash" \
+        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|        run: [[ -d cargo-vendor ]] \&\& scripts/prepare-cargo-vendor.sh verify cargo-vendor|' \
+        "declare 'shell: bash' on step: Verify exact Cargo vendor bundle"
+    assert_workflow_mutation_rejected "a nameless container step turning bash" \
+        '/^      - name: Verify exact Cargo vendor bundle$/,+1c\      - run: [[ -d cargo-vendor ]] && scripts/prepare-cargo-vendor.sh verify cargo-vendor' \
         "runs bash-only syntax under the image's /bin/sh"
     assert_workflow_mutation_rejected "public release creation" \
         's/^          draft: true$//' \

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -1484,6 +1484,28 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
     assert_workflow_mutation_rejected "a nameless container step turning bash" \
         '/^      - name: Verify exact Cargo vendor bundle$/,+1c\      - run: [[ -d cargo-vendor ]] && scripts/prepare-cargo-vendor.sh verify cargo-vendor' \
         "runs bash-only syntax under the image's /bin/sh"
+
+    # The other direction of the step-shell rule: a workflow it must not
+    # reject. Whole-line YAML comments never reach the scanner because
+    # job_statements strips them first, so a comment illustrating bash syntax
+    # is documentation and not a step written in bash. Pinned because the
+    # stripping happens a long way from the scan, and a later rewrite reading
+    # job_body directly would make this comment look like script.
+    assert_workflow_mutation_accepted() {
+        local context="$1" expression="$2"
+        local mutated
+        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
+        sed -E "$expression" "$workflow_path" >"$mutated"
+        if cmp -s "$workflow_path" "$mutated"; then
+            fail "$context mutation did not change the workflow"
+        fi
+        FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$self" >/dev/null 2>&1 ||
+            fail "release artifacts contract rejected $context"
+        echo "release artifacts case: $context accepted"
+    }
+
+    assert_workflow_mutation_accepted "a container step commented with bash syntax" \
+        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|&\n        # example: [[ -f file ]] \&\& mapfile -t x < <(echo hi)|'
     assert_workflow_mutation_rejected "public release creation" \
         's/^          draft: true$//' \
         "must create the GitHub release as a draft"


### PR DESCRIPTION
## Summary

- declare `shell: bash` on the two container-job steps written in bash: `build-deb`'s package step and `build-rpm`'s package-selection step
- fail any containerized release step that uses bash-only syntax without declaring it, in `test/release-artifacts-contract.sh`
- scope the new rule to a step's `run:` script, so a step *named* "Validate Debian source contract" is not read as one that calls `source`

## Why

A container job's steps run under the image's `/bin/sh`. Debian and Ubuntu point that at dash and Fedora points it at bash, so a step written in bash passes in `build-rpm` and exits 127 in `build-deb`. Tagging v0.2.0-alpha.2 built both Debian packages and then lost them: the step that reads the package version back died on `source scripts/release-versions.sh` after `build-deb.sh` had already emitted its manifest. Nothing before a tag can catch this, because every local recipe and every packaging lane runs these scripts under bash.

Replacing `source` with `.` would not fix it. `scripts/release-versions.sh` uses `[[ =~ ]]`, `BASH_REMATCH` and `local -a`, so a POSIX shell fails on its first line instead of on the sourcing. The rule is that a step declares the shell it is written in.

## Validation

- reproduced both directions inside the pinned `debian:13` image: the step's script exits 127 under `sh` and returns the correct package version under `bash`
- confirmed `/bin/sh` is dash in the pinned `debian:13` and `ubuntu:26.04` images and bash in the pinned `fedora:44` image, which is why only the Debian legs failed
- three workflow mutations for the new rule: each step's declaration dropped, and every declaration weakened to `shell: sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed containerized Debian and RPM release steps that could fail when Bash-specific commands ran under the default `/bin/sh` shell.
  - Release workflow steps now explicitly use Bash where required.

- **Tests**
  - Expanded release workflow validation to cover inline and unnamed container steps.
  - Added checks to detect undeclared Bash usage in containerized release steps.

- **Documentation**
  - Added an Unreleased changelog entry describing the release workflow fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->