### PR TITLE
fix(release): Expect the asset names GitHub stores, not the ones uploaded

### DIFF
--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -209,7 +209,7 @@ verify_assets() {
             [[ "$name" =~ ^${pattern}$ ]] && matches=$((matches + 1))
         done
         [ "$matches" -ne 0 ] ||
-            fail "unexpected release asset: $name; if an earlier run at another version left it behind, remove it with: gh release delete-asset \"\$TAG\" $name. If it differs from a canonical name only where a \`~\` became a \`.\`, GitHub stored the upload under a rewritten name and release_github_asset_name has to account for it -- do not delete it."
+            fail "unexpected release asset: $name; if an earlier run at another version left it behind, remove it with: gh release delete-asset \"\$TAG\" \"$name\". If it differs from a canonical name only where a \`~\` became a \`.\`, GitHub stored the upload under a rewritten name and release_github_asset_name has to account for it -- do not delete it."
         [ "$matches" -eq 1 ] ||
             fail "allowlist overlap: $name matches $matches canonical names"
     done
@@ -329,6 +329,7 @@ release_query() {
     python3 - "$mode" "$releases_json" "$tag" "$extra" <<'PY'
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -406,13 +407,32 @@ elif mode == "verify-published":
     manifest_bytes = manifest_path.read_bytes()
     manifest = json.loads(manifest_bytes)
     # The manifest records each artifact's own name; the API lists the name
-    # GitHub stored. `release_github_asset_name` in scripts/release-versions.sh
-    # is the authority for the rewrite, and test/release-artifacts-contract.sh
-    # holds this line to it.
+    # GitHub stored. This is the same rule as `release_github_asset_name` in
+    # scripts/release-versions.sh, including its refusal, and
+    # test/release-artifacts-contract.sh holds the two to the same answers.
+    # Refusing here matters as much as it does there: a name this rule cannot
+    # account for would otherwise mismatch at publish time, which is the late
+    # failure this whole conversion exists to prevent.
     def stored(name: str) -> str:
-        return name.replace("~", ".")
+        mapped = name.replace("~", ".")
+        if not re.fullmatch(r"[A-Za-z0-9._-]+", mapped):
+            raise SystemExit(
+                f"release assets: {manifest_path.name} names an asset whose stored name "
+                f"cannot be derived: {name}"
+            )
+        return mapped
 
-    expected = {stored(entry["name"]): (entry["size"], entry["sha256"]) for entry in manifest["assets"]}
+    # Built by hand rather than as a comprehension: two entries that differ
+    # only by `~` collapse to one stored name, and a comprehension would drop
+    # one silently and compare the survivor against both.
+    expected: dict[str, tuple] = {}
+    for entry in manifest["assets"]:
+        key = stored(entry["name"])
+        if key in expected:
+            raise SystemExit(
+                f"release assets: two {manifest_path.name} entries share the stored name {key}"
+            )
+        expected[key] = (entry["size"], entry["sha256"])
     # The manifest cannot cover itself; hold the uploaded copy to this file.
     expected[manifest_path.name] = (len(manifest_bytes), hashlib.sha256(manifest_bytes).hexdigest())
     listed = release.get("assets", [])

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -187,7 +187,7 @@ read_debian_suites() {
 verify_assets() {
     local expected_file="${1:?}" actual_file="${2:?}"
     local -a labels=() patterns=() actual=()
-    local label pattern name matches duplicate index
+    local label pattern name matches duplicate index delete_operand
 
     while IFS='	' read -r label pattern; do
         [ -n "$label" ] || continue
@@ -208,8 +208,12 @@ verify_assets() {
         for pattern in "${patterns[@]}"; do
             [[ "$name" =~ ^${pattern}$ ]] && matches=$((matches + 1))
         done
-        [ "$matches" -ne 0 ] ||
-            fail "unexpected release asset: $name; if an earlier run at another version left it behind, remove it with: gh release delete-asset \"\$TAG\" \"$name\". If it differs from a canonical name only where a \`~\` became a \`.\`, GitHub stored the upload under a rewritten name and release_github_asset_name has to account for it -- do not delete it."
+        if [ "$matches" -eq 0 ]; then
+            # The name reaches a command a human is invited to paste, and it
+            # arrives from an API listing rather than from this script.
+            printf -v delete_operand '%q' "$name"
+            fail "unexpected release asset: $name; if an earlier run at another version left it behind, remove it with: gh release delete-asset \"\$TAG\" $delete_operand. If it differs from a canonical name only where a \`~\` became a \`.\`, GitHub stored the upload under a rewritten name and release_github_asset_name has to account for it -- do not delete it."
+        fi
         [ "$matches" -eq 1 ] ||
             fail "allowlist overlap: $name matches $matches canonical names"
     done

--- a/.github/workflows/scripts/release-assets.sh
+++ b/.github/workflows/scripts/release-assets.sh
@@ -43,6 +43,19 @@ literal() {
 # `<label><TAB><anchored ERE>`; the RPMs' `%{?dist}` tag is decided inside the
 # pinned Fedora container, so those entries are patterns bound to the validated
 # epoch-version-release rather than literals.
+# The name to expect at one stage. `builders` compares the files the builders
+# staged, which carry the artifact's own name. `final` compares what the API
+# lists, and GitHub rewrites `~` when it accepts an upload, so the two stages
+# do not expect the same string for a Debian package.
+stage_asset_name() {
+    local stage="${1:?}" name="${2:?}"
+    if [ "$stage" = final ]; then
+        release_github_asset_name "$name" || return 1
+    else
+        printf '%s\n' "$name"
+    fi
+}
+
 expected_assets() {
     local version="${1:?}" debian_revision="${2:?}" rpm_counter="${3:?}"
     local prerelease="${4:?}" stage="${5:?}"
@@ -68,7 +81,7 @@ expected_assets() {
         debian_version="$(release_debian_version "$version" "$debian_revision" "$suite")" ||
             fail "cannot derive the $suite Debian version"
         printf 'deb-%s\t%s\n' "$suite" \
-            "$(literal "facelock_${debian_version}_${architecture}.deb")"
+            "$(literal "$(stage_asset_name "$stage" "facelock_${debian_version}_${architecture}.deb")")"
     done
 
     rpm_evr="$(release_rpm_evr "$version" "$rpm_counter")" ||
@@ -196,7 +209,7 @@ verify_assets() {
             [[ "$name" =~ ^${pattern}$ ]] && matches=$((matches + 1))
         done
         [ "$matches" -ne 0 ] ||
-            fail "unexpected release asset: $name; an earlier run at another version leaves one behind, and it is removed with: gh release delete-asset \"\$TAG\" $name"
+            fail "unexpected release asset: $name; if an earlier run at another version left it behind, remove it with: gh release delete-asset \"\$TAG\" $name. If it differs from a canonical name only where a \`~\` became a \`.\`, GitHub stored the upload under a rewritten name and release_github_asset_name has to account for it -- do not delete it."
         [ "$matches" -eq 1 ] ||
             fail "allowlist overlap: $name matches $matches canonical names"
     done
@@ -392,7 +405,14 @@ elif mode == "verify-published":
     manifest_path = Path(extra)
     manifest_bytes = manifest_path.read_bytes()
     manifest = json.loads(manifest_bytes)
-    expected = {entry["name"]: (entry["size"], entry["sha256"]) for entry in manifest["assets"]}
+    # The manifest records each artifact's own name; the API lists the name
+    # GitHub stored. `release_github_asset_name` in scripts/release-versions.sh
+    # is the authority for the rewrite, and test/release-artifacts-contract.sh
+    # holds this line to it.
+    def stored(name: str) -> str:
+        return name.replace("~", ".")
+
+    expected = {stored(entry["name"]): (entry["size"], entry["sha256"]) for entry in manifest["assets"]}
     # The manifest cannot cover itself; hold the uploaded copy to this file.
     expected[manifest_path.name] = (len(manifest_bytes), hashlib.sha256(manifest_bytes).hexdigest())
     listed = release.get("assets", [])

--- a/scripts/release-versions.sh
+++ b/scripts/release-versions.sh
@@ -482,3 +482,25 @@ release_write_github_outputs() {
         printf 'rpm-counter=%s\n' "$rpm_counter"
     } >> "$output_file"
 }
+
+# The name GitHub stores a release asset under, given the artifact's own file
+# name. GitHub rewrites characters outside a safe set when it accepts an
+# upload, so the name a release lists is not always the name that was uploaded.
+# Only `~` is affected by anything this project publishes: a Debian version
+# carries it both as the prerelease separator (0.2.0~alpha.3) and as the suite
+# suffix separator (-1~deb13u1), and v0.1.4 shipped neither, which is why the
+# round trip went unexercised until v0.2.0-alpha.3 failed on it.
+#
+# Refuse a name carrying anything else rather than guess how GitHub will treat
+# it. A wrong guess is not visible until a tag reaches the publish job, and the
+# whole point of this conversion is that the comparison against the API can be
+# trusted.
+release_github_asset_name() {
+    local name="${1:?}" mapped
+    mapped="${name//\~/.}"
+    if [[ ! "$mapped" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "release_github_asset_name: unsupported character in asset name: $name" >&2
+        return 1
+    fi
+    printf '%s\n' "$mapped"
+}

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -659,12 +659,15 @@ echo "release artifacts case: AUR publisher refusing a malformed binary digest r
 
 stable_expected="$work/expected-stable"
 "$helper_path" expected 0.2.0 1 1 false final >"$stable_expected"
+# `final` is the API-facing stage, so the Debian entries are the names GitHub
+# stores. This list asserted the uploaded names until v0.2.0-alpha.3, which is
+# why the contract passed while the publish job could not.
 for wanted in \
     'facelock-x86_64-linux-gnu' \
     'pam_facelock\.so' \
     'facelock-polkit-agent-x86_64-linux-gnu' \
-    'facelock_0\.2\.0-1~deb13u1_amd64\.deb' \
-    'facelock_0\.2\.0-1~ubuntu26\.04\.1_amd64\.deb' \
+    'facelock_0\.2\.0-1\.deb13u1_amd64\.deb' \
+    'facelock_0\.2\.0-1\.ubuntu26\.04\.1_amd64\.deb' \
     'facelock-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
     'facelock-debuginfo-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
     'facelock-debugsource-0\.2\.0-1\.fc[0-9]+\.x86_64\.rpm' \
@@ -676,7 +679,17 @@ done
 
 prerelease_expected="$work/expected-prerelease"
 "$helper_path" expected 0.2.0-alpha.1 1 1 true final >"$prerelease_expected"
-grep -Fq '	facelock_0\.2\.0~alpha\.1-1~deb13u1_amd64\.deb' "$prerelease_expected" ||
+# A prerelease carries `~` twice, as the upstream separator and again in the
+# suite suffix, so both stages are asserted: the builder writes the Debian name
+# and GitHub lists the rewritten one.
+grep -Fq '	facelock_0\.2\.0\.alpha\.1-1\.deb13u1_amd64\.deb' "$prerelease_expected" ||
+    fail "prerelease allowlist does not carry the Debian prerelease version as GitHub stores it"
+# Written to a file rather than piped: `grep -q` closes the pipe on its first
+# match, and the SIGPIPE that gives the producer fails the pipeline under
+# `set -o pipefail`.
+prerelease_staged="$work/expected-prerelease-builders"
+"$helper_path" expected 0.2.0-alpha.1 1 1 true builders >"$prerelease_staged"
+grep -Fq '	facelock_0\.2\.0~alpha\.1-1~deb13u1_amd64\.deb' "$prerelease_staged" ||
     fail "prerelease allowlist does not carry the Debian prerelease upstream version"
 grep -Fq '	facelock-0\.2\.0-0\.1\.alpha\.1\.fc[0-9]+\.x86_64\.rpm' "$prerelease_expected" ||
     fail "prerelease allowlist does not carry the monotonic RPM prerelease release"
@@ -724,23 +737,30 @@ apt-repo.tar.gz
 ASSETS
 }
 
-{ canonical_assets; echo MANIFEST.json; } >"$work/actual-ok"
+# What the builders write carries the Debian `~`; what the API lists after
+# upload does not. The allowlist enforcement below compares against the
+# `final` stage, so it needs the stored spelling.
+stored_assets() {
+    canonical_assets | sed 's/~/./g'
+}
+
+{ stored_assets; echo MANIFEST.json; } >"$work/actual-ok"
 "$helper_path" verify "$stable_expected" "$work/actual-ok" >/dev/null ||
     fail "the canonical asset set was rejected"
 
-{ canonical_assets; echo MANIFEST.json; echo "facelock-x86_64-linux-musl"; } >"$work/actual-extra"
+{ stored_assets; echo MANIFEST.json; echo "facelock-x86_64-linux-musl"; } >"$work/actual-extra"
 assert_rejects "extra release asset" "unexpected release asset" \
     verify "$stable_expected" "$work/actual-extra"
 
-{ canonical_assets; echo MANIFEST.json; } | grep -Fvx 'pam_facelock.so' >"$work/actual-missing"
+{ stored_assets; echo MANIFEST.json; } | grep -Fvx 'pam_facelock.so' >"$work/actual-missing"
 assert_rejects "missing release asset" "no release asset matches" \
     verify "$stable_expected" "$work/actual-missing"
 
-{ canonical_assets; echo MANIFEST.json; echo "pam_facelock.so"; } >"$work/actual-duplicate"
+{ stored_assets; echo MANIFEST.json; echo "pam_facelock.so"; } >"$work/actual-duplicate"
 assert_rejects "duplicate asset name" "duplicate release asset" \
     verify "$stable_expected" "$work/actual-duplicate"
 
-{ canonical_assets; echo MANIFEST.json; echo "facelock-0.2.0-1.fc45.x86_64.rpm"; } >"$work/actual-collision"
+{ stored_assets; echo MANIFEST.json; echo "facelock-0.2.0-1.fc45.x86_64.rpm"; } >"$work/actual-collision"
 assert_rejects "two assets claiming one canonical name" "more than one release asset" \
     verify "$stable_expected" "$work/actual-collision"
 
@@ -1037,8 +1057,8 @@ cat >"$work/release-rerun.json" <<'JSON'
 {"id": 42, "tag_name": "v0.2.0", "draft": true, "prerelease": false, "assets": [
   {"name": "facelock-x86_64-linux-gnu"}, {"name": "pam_facelock.so"},
   {"name": "facelock-polkit-agent-x86_64-linux-gnu"},
-  {"name": "facelock_0.2.0-1~deb13u1_amd64.deb"},
-  {"name": "facelock_0.2.0-1~ubuntu26.04.1_amd64.deb"},
+  {"name": "facelock_0.2.0-1.deb13u1_amd64.deb"},
+  {"name": "facelock_0.2.0-1.ubuntu26.04.1_amd64.deb"},
   {"name": "facelock-0.2.0-1.fc44.x86_64.rpm"},
   {"name": "facelock-debuginfo-0.2.0-1.fc44.x86_64.rpm"},
   {"name": "facelock-debugsource-0.2.0-1.fc44.x86_64.rpm"},
@@ -1328,10 +1348,17 @@ from pathlib import Path
 manifest_path, output, mode = sys.argv[1:4]
 manifest = json.loads(Path(manifest_path).read_text())
 payload = Path(manifest_path).read_bytes()
+# The API lists what GitHub stored, which is not always what was uploaded:
+# `~` is rewritten to `.`, so the Debian assets come back under a name the
+# manifest does not contain. Every mode below starts from that reality.
 assets = [
-    {"name": entry["name"], "size": entry["size"], "digest": f"sha256:{entry['sha256']}"}
+    {"name": entry["name"].replace("~", "."), "size": entry["size"],
+     "digest": f"sha256:{entry['sha256']}"}
     for entry in manifest["assets"]
 ]
+assert any("~" in entry["name"] for entry in manifest["assets"]), (
+    "the manifest fixture no longer carries a rewritten name, so this listing proves nothing"
+)
 assets.append({"name": "MANIFEST.json", "size": len(payload),
                "digest": "sha256:" + hashlib.sha256(payload).hexdigest()})
 if mode == "no-digest":
@@ -1354,6 +1381,21 @@ PY
 published_listing "$work/published-ok.json" exact
 "$helper_path" verify-published "$work/published-ok.json" v0.2.0 "$manifest" >/dev/null ||
     fail "a published asset list matching the manifest was rejected"
+
+# GitHub rewrites `~` when it accepts an upload, so a Debian asset is listed
+# under a name no builder produced: `facelock_0.2.0-1~deb13u1_amd64.deb` goes
+# up and `facelock_0.2.0-1.deb13u1_amd64.deb` comes back. v0.1.4 carried no
+# suite suffix and no prerelease separator, so nothing exercised the round trip
+# until v0.2.0-alpha.3 failed the publish job on it. Both directions are
+# pinned: the readback accepts the stored names, and the `final` allowlist
+# expects them.
+stored_deb="$("$helper_path" expected 0.2.0 1 1 false final | grep -c 'facelock_0\\.2\\.0-1\\.deb13u1_amd64\\.deb' || true)"
+[ "$stored_deb" -eq 1 ] ||
+    fail "the final allowlist must expect the Debian name GitHub stores, not the one uploaded"
+staged_deb="$("$helper_path" expected 0.2.0 1 1 false builders | grep -c 'facelock_0\\.2\\.0-1~deb13u1_amd64\\.deb' || true)"
+[ "$staged_deb" -eq 1 ] ||
+    fail "the builders allowlist must expect the Debian name the builder actually wrote"
+echo "release artifacts case: the GitHub asset-name rewrite is expected on both sides"
 published_listing "$work/published-no-digest.json" no-digest
 "$helper_path" verify-published "$work/published-no-digest.json" v0.2.0 "$manifest" >/dev/null ||
     fail "an API listing without digests must still pass on sizes"

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -1389,13 +1389,35 @@ published_listing "$work/published-ok.json" exact
 # until v0.2.0-alpha.3 failed the publish job on it. Both directions are
 # pinned: the readback accepts the stored names, and the `final` allowlist
 # expects them.
-stored_deb="$("$helper_path" expected 0.2.0 1 1 false final | grep -c 'facelock_0\\.2\\.0-1\\.deb13u1_amd64\\.deb' || true)"
+stored_deb="$("$helper_path" expected 0.2.0 1 1 false final | grep -Fc 'facelock_0\.2\.0-1\.deb13u1_amd64\.deb' || true)"
 [ "$stored_deb" -eq 1 ] ||
     fail "the final allowlist must expect the Debian name GitHub stores, not the one uploaded"
-staged_deb="$("$helper_path" expected 0.2.0 1 1 false builders | grep -c 'facelock_0\\.2\\.0-1~deb13u1_amd64\\.deb' || true)"
+staged_deb="$("$helper_path" expected 0.2.0 1 1 false builders | grep -Fc 'facelock_0\.2\.0-1~deb13u1_amd64\.deb' || true)"
 [ "$staged_deb" -eq 1 ] ||
     fail "the builders allowlist must expect the Debian name the builder actually wrote"
 echo "release artifacts case: the GitHub asset-name rewrite is expected on both sides"
+
+# The rewrite is written twice: once in shell for the allowlist, once in the
+# `verify-published` Python for the readback. Neither is reachable from the
+# other, so they are held to the same answers here, refusal included. A rule
+# that mapped names in one place and not the other would go green and then
+# mismatch at publish time, which is the failure this conversion exists to
+# prevent.
+rewrite_probe="$work/rewrite-probe"
+cat >"$work/rewrite-manifest.json" <<'JSON'
+{"assets": [{"name": "facelock_1.0.0-1~deb13u1_amd64.deb", "size": 1, "sha256": "00"},
+            {"name": "facelock_1.0.0-1+deb13u1_amd64.deb", "size": 1, "sha256": "01"}]}
+JSON
+printf '{"id":1,"tag_name":"v0.2.0","draft":true,"prerelease":false,"assets":[]}\n' >"$rewrite_probe"
+if "$helper_path" verify-published "$rewrite_probe" v0.2.0 "$work/rewrite-manifest.json" >"$work/rewrite-out" 2>&1; then
+    fail "the published readback accepted a manifest name whose stored name cannot be derived"
+fi
+grep -Fq 'stored name cannot be derived' "$work/rewrite-out" ||
+    fail "the readback refused an underivable name for another reason: $(cat "$work/rewrite-out")"
+if (source "$repo_root/scripts/release-versions.sh" && release_github_asset_name 'facelock_1.0.0-1+deb13u1_amd64.deb') >/dev/null 2>&1; then
+    fail "release_github_asset_name accepted a character the readback refuses"
+fi
+echo "release artifacts case: both sides of the asset-name rewrite refuse the same name"
 published_listing "$work/published-no-digest.json" no-digest
 "$helper_path" verify-published "$work/published-no-digest.json" v0.2.0 "$manifest" >/dev/null ||
     fail "an API listing without digests must still pass on sizes"


### PR DESCRIPTION
## Summary

- rewrite `~` to `.` when deriving the release asset names to compare against the API, via `release_github_asset_name`
- refuse a name carrying any character outside the set GitHub is known to preserve, instead of guessing at a mapping no gate can check before a tag
- match the published readback to `MANIFEST.json` through the same rewrite, keeping each artifact's own name in the manifest
- correct the allowlist assertions that pinned the uploaded names at the API-facing stage, which is why the contract passed while the publish job could not
- say what a name differing only by `~` means in the unexpected-asset refusal, whose remedy previously pointed at deleting a real asset

## Why

GitHub rewrites `~` when it accepts a release asset, so a Debian package uploaded as `facelock_0.2.0~alpha.3-1~deb13u1_amd64.deb` is listed as `facelock_0.2.0.alpha.3-1.deb13u1_amd64.deb`. The publish job compared the listing against the uploaded names and refused its own release: v0.2.0-alpha.3 built every artifact and failed on the final step. This is not prerelease-only, because `release_debian_version 0.2.0 1 trixie` is `0.2.0-1~deb13u1` and the suite suffix carries the character for a stable release too. v0.1.4 shipped `facelock_0.1.4-1_amd64.deb` with no suite suffix, so nothing exercised the round trip.

## Validation

- replayed the failed publish step against the live v0.2.0-alpha.3 draft, using the release listing the API returns and the `MANIFEST.json` that run attached: `verify` and `verify-published` both pass, and both fail on the same inputs without this change
- `verify-published` was never reached on the tag, so its failure on the real listing was confirmed here rather than inferred
- contract fixtures now model the rewrite, with the manifest holding an unrewritten name so the listing proves something


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release validation now correctly accounts for GitHub’s filename rewriting of Debian packages.
  - Asset checks distinguish between builder-stage names and final published names.
  - Validation detects naming collisions caused by filename rewriting.
  - Unsupported asset names are rejected with clearer error messages.
  - Unexpected or stale assets now produce safer deletion guidance.
  - Release checks consistently verify asset names during staging and after publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->