### PR TITLE
fix(copr): declare enable_net on the packit copr_build jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,6 +15,7 @@
       "owner": "tyvsmith",
       "project": "facelock",
       "update_release": false,
+      "enable_net": true,
       "targets": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",
@@ -27,6 +28,7 @@
       "manual_trigger": true,
       "owner": "tyvsmith",
       "project": "facelock-testing",
+      "enable_net": true,
       "targets": [
         "fedora-43-x86_64",
         "fedora-44-x86_64",

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2192,7 +2192,15 @@ to an authenticated owner, so a public comparison cannot make that claim. It is
 the grant that failed silently for v0.1.4, which is why the release guide keeps
 it as a hand-confirmed setup step.
 
-Those three are the shape of a channel, not its contents. A second comparison
+The project's `enable_net` is only the default for a build that carries no value
+of its own, and a Packit-submitted build always carries one. Every `copr_build`
+job in `.packit.yaml` must therefore declare `enable_net: true` as well; Packit
+defaults it to false, and that default is what the chroot gets no matter what
+the project says. `test/check-release-matrix.py` enforces the job half, because
+it is checked-in state that no public COPR response exposes until a build has
+already run and already failed (#347).
+
+Those project properties are the shape of a channel, not its contents. A second comparison
 asks what it serves:
 `test/check-live-release-channels.py --expect-evr <EVR>` requires the project's
 latest **succeeded** build to carry the expected EVR. The latest succeeded build

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -653,11 +653,18 @@ crate feature `api-20` keeps the binary compatible with Fedora's runtime.)
    builds"**. The RPM is built from source and `cargo` fetches crates from
    crates.io during `%build`; COPR's build chroot is network-isolated by
    default, so this toggle is required or the build fails resolving crates.
+   The toggle is half of it: COPR takes network access per build, and a Packit
+   submission carries its own value. `.packit.yaml` must also declare
+   `enable_net: true` on every `copr_build` job, because Packit's default is
+   false and it wins over the project. See "Why v0.2.0 built nothing in COPR"
+   below.
 
-Step 4's allowlist and step 5 apply to both channels and are checked on every
-pull request by `python3 test/check-live-release-channels.py`, which reads them
-off the public project response. The permission grant is not public, so it stays
-a hand-confirmed step -- and it is the one that failed silently for v0.1.4.
+Step 4's allowlist and step 5's toggle apply to both channels and are checked on
+every pull request by `python3 test/check-live-release-channels.py`, which reads
+them off the public project response. Step 5's `.packit.yaml` half is not in that
+response and is checked by `test/check-release-matrix.py` instead. The permission
+grant is not public, so it stays a hand-confirmed step -- and it is the one
+that failed silently for v0.1.4.
 
 Verify the COPR build locally before relying on it with `just test-copr`, which
 reproduces the Packit SRPM + `mock` from-source rebuild on a Fedora chroot and
@@ -775,6 +782,42 @@ through `copr-cli` with an SRPM built locally. Name the three supported chroots:
 `copr-cli build` with no `-r` builds every chroot the project has enabled, which
 picks up the optional Rawhide one. This path needs a COPR API token in
 `~/.config/copr`, which the Packit CLI did not.
+
+##### Why v0.2.0 built nothing in COPR
+
+v0.2.0 fixed everything v0.1.4 got wrong. Packit triggered on the release event,
+reconciled the project, and submitted all three chroots under the canonical
+`0.2.0-1`. Every one of them then failed in `%build`, four minutes in, on
+`Could not resolve host: index.crates.io`.
+
+`enable_net` is a per-build value, not a project one. The project toggle is the
+default COPR applies to a build that does not carry its own, and a Packit
+submission always carries its own: Packit's `enable_net` defaults to false and
+is sent on every build it creates. So the toggle was on, the build task read
+`'enable_net': False`, and the chroot had no resolver while `cargo` needed
+crates.io. v0.1.3 is the control -- same spec, same project, and it built,
+because a human submitted it with `copr-cli`, which omits the field and lets the
+project default stand.
+
+Three things had to be true at once for this to reach production, and each is
+now closed:
+
+- **The gate read the wrong layer.** `test/check-live-release-channels.py`
+  compares the public project response, which is the only place `enable_net`
+  appears before a build exists, and the value there was correct.
+  `test/check-release-matrix.py` now requires `enable_net: true` on every
+  `copr_build` job in `.packit.yaml`, which is the layer that decides.
+- **The local lane hardcoded the answer.** `just test-copr` builds the Packit
+  SRPM and rebuilds it under `mock`, and it passed `--enable-network`
+  unconditionally, so it modelled a chroot COPR was never going to give it. The
+  lane now reads the flag out of `.packit.yaml` and gets the same network the
+  real submission would.
+- **The docs asked for the toggle and stopped.** Setup step 5 now names both
+  halves.
+
+Recovery is the hand-submitted build above. `copr-cli` sends no `enable_net`
+unless `--enable-net` is passed, so it inherits the project toggle and needs
+nothing else.
 
 ##### Staging COPR (`tyvsmith/facelock-testing`)
 

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -196,7 +196,10 @@ if response.get("enable_net") is not True:
         f"{args.channel} COPR {owner}/{project} builds have no internet access "
         f"(enable_net={response.get('enable_net')!r}); the RPM builds from source and cargo "
         "fetches crates during %build, so a build without it fails resolving crates. "
-        'Enable Settings -> "Enable internet access during builds" in the COPR web UI'
+        'Enable Settings -> "Enable internet access during builds" in the COPR web UI. '
+        "That toggle is only the default for a build that carries no value of its own; "
+        "a Packit-submitted build carries one, so .packit.yaml must declare "
+        "enable_net: true too"
     )
 forge_projects = response.get("packit_forge_projects_allowed")
 if not isinstance(forge_projects, list) or not all(isinstance(entry, str) for entry in forge_projects):

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -428,6 +428,22 @@ for job_index, job in enumerate(packit_jobs):
     )
     targets = set(target_list)
     require(len(target_list) == len(targets), f"{target_description} must be unique")
+    # COPR resolves network access per build, not per project, and Packit sends
+    # the value: its `enable_net` defaults to false and overrides the project's
+    # "enable internet access during builds" toggle. v0.2.0 was submitted with
+    # the toggle on and the key absent, so all three chroots reached `%build`
+    # with no resolver and cargo failed on the crates.io index (#347). The live
+    # project comparison in test/check-live-release-channels.py cannot see this
+    # half: the effective value is only in the build task COPR never publishes
+    # until a build exists.
+    packit_enable_net = job.get("enable_net")
+    require(
+        packit_enable_net is True,
+        f"Packit copr_build job {job_index} must declare enable_net: true so the submitted "
+        "build gets network; the RPM builds from source and cargo fetches crates during "
+        "%build, and Packit's default is false regardless of the COPR project setting, "
+        f"got {packit_enable_net!r}",
+    )
     # Rawhide is experimental everywhere and a release target nowhere. The
     # allowlist below already excludes it; naming it first is what makes the
     # diagnostic say so instead of "undeclared target".
@@ -1263,6 +1279,8 @@ for phrase in (
     "separately reviewed amendment and full Fedora gates",
     "Arch Linux Archive snapshot 2026-08-18",
     "stable-tagged config",
+    "Why v0.2.0 built nothing in COPR",
+    "`enable_net` is a per-build value, not a project one",
 ):
     require(phrase in normalized_docs, f"release documentation omits matrix/version phrase: {phrase}")
 
@@ -1282,6 +1300,7 @@ for phrase in (
     "Rawhide cannot supply lifecycle, artifact, upgrade, rollback, served-version, or availability evidence",
     "separately reviewed amendment and full Fedora gates",
     "issue #236",
+    "Every `copr_build` job in `.packit.yaml` must therefore declare `enable_net: true`",
 ):
     require(phrase in normalized_contracts, f"system contracts omit release-channel phrase: {phrase}")
 
@@ -1331,6 +1350,17 @@ require(
 require(
     "staging_copr_targets" in copr_build_test,
     "COPR-equivalent gate does not check its chroot against the declared staging targets",
+)
+# The lane has to take the chroot's network from the same place COPR does. A
+# hardcoded `--enable-network` is what let it model a networked chroot that the
+# real submission never asked for, and pass while v0.2.0 failed on all three.
+require(
+    "${NETWORK_FLAG}" in copr_build_test and ".packit.yaml" in copr_build_test,
+    "COPR-equivalent gate does not derive its chroot network from .packit.yaml",
+)
+require(
+    "--isolation=simple --enable-network" not in copr_build_test,
+    "COPR-equivalent gate still hardcodes chroot network access",
 )
 # The COPR lifecycle lanes are the mock build plus the booted validation of what
 # it produced. Both halves have to stay in the source rebuild: the copr-mode

--- a/test/copr-build.sh
+++ b/test/copr-build.sh
@@ -5,8 +5,12 @@
 # from dist/facelock.spec, then mock builds the RPM from source in a clean
 # Fedora chroot, and the result is installed with dnf.
 #
-# `--enable-network` mirrors the COPR project's required "internet access during
-# builds" setting — the Rust build fetches crates from crates.io.
+# The chroot's network is read out of .packit.yaml rather than hardcoded. COPR
+# resolves network access per build and Packit sends the value, so a job without
+# `enable_net: true` builds with no resolver no matter what the project's
+# "internet access during builds" toggle says. Taking the flag from the config
+# is what makes this lane fail the way real COPR would; hardcoding
+# `--enable-network` is what let v0.2.0 pass here and fail there.
 #
 # /repo is mounted READ-ONLY; we copy it to a writable workdir because
 # `packit srpm` rewrites the spec file in place.
@@ -32,6 +36,26 @@ if sys.argv[1] not in targets:
 PY
 then
   echo "FAIL: undeclared COPR chroot"
+  exit 1
+fi
+
+# Every copr_build job has to agree, because one SRPM is rebuilt here for all of
+# them and a lane cannot model two different chroot networks at once.
+if ! NETWORK_FLAG=$(python3 - <<'NET'
+import json
+
+with open("/repo/.packit.yaml", encoding="utf-8") as handle:
+    jobs = json.load(handle)["jobs"]
+values = {job.get("enable_net") for job in jobs if job.get("job") == "copr_build"}
+if len(values) != 1:
+    raise SystemExit(f"copr_build jobs disagree on enable_net: {sorted(map(repr, values))}")
+enable_net = values.pop()
+if enable_net is not True and enable_net is not False:
+    raise SystemExit(f"copr_build enable_net must be a bool, got {enable_net!r}")
+print("--enable-network" if enable_net else "")
+NET
+); then
+  echo "FAIL: cannot read enable_net from .packit.yaml"
   exit 1
 fi
 
@@ -71,10 +95,10 @@ if [ -z "$SRPM" ] || [ ! -f "$SRPM" ]; then echo "FAIL: packit srpm produced no 
 cp "$SRPM" /tmp/ ; SRPM="/tmp/$(basename "$SRPM")"
 echo "SRPM: $SRPM"
 
-section "mock rebuild ($CHROOT, from source, --enable-network)"
+section "mock rebuild ($CHROOT, from source, network=${NETWORK_FLAG:-off})"
 useradd -G mock mockbuilder 2>/dev/null || true
 chmod 644 "$SRPM"
-if su mockbuilder -c "mock -r '$CHROOT' --isolation=simple --enable-network --rebuild '$SRPM' --resultdir /tmp/mock"; then
+if su mockbuilder -c "mock -r '$CHROOT' --isolation=simple ${NETWORK_FLAG} --rebuild '$SRPM' --resultdir /tmp/mock"; then
   echo "mock build: OK"
 else
   echo "FAIL: mock build failed"

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -365,7 +365,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1047,
+        "line": 1090,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -437,7 +437,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 6,
-        "line": 1047,
+        "line": 1090,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -9771,21 +9771,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 764,
+          "line": 771,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 765,
+          "line": 772,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 766,
+          "line": 773,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -9867,14 +9867,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 834,
+          "line": 877,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 835,
+          "line": 878,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -9942,21 +9942,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 862,
+          "line": 905,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 869,
+          "line": 912,
           "sha256": "2120970caf76141c5840f3c94b1f591cfd64be5b8b0909ba582421dcfc2130a2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 874,
+          "line": 917,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10037,56 +10037,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 913,
+          "line": 956,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 915,
+          "line": 958,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 919,
+          "line": 962,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 925,
+          "line": 968,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 926,
+          "line": 969,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 930,
+          "line": 973,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 931,
+          "line": 974,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 932,
+          "line": 975,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -795,46 +795,46 @@ valid_packit_staging_root="$tmp_root/packit-valid-staging"
 cp -R "$matrix_root" "$valid_packit_staging_root"
 replace_packit_staging_job \
     "$valid_packit_staging_root/.packit.yaml" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-45-x86_64","fedora-43-x86_64","fedora-44-x86_64"]}'
 RELEASE_MATRIX_VERSION=0.2.0 python3 "$valid_packit_staging_root/test/check-release-matrix.py" >/dev/null
 echo "release matrix Packit case: exact facelock-testing staging targets accepted"
 
 assert_extra_packit_job_rejected \
     "second facelock-testing staging job" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 
 assert_extra_packit_job_rejected \
     "third copr_build job with allowlisted targets" \
-    '{"job":"copr_build","trigger":"ignore","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"ignore","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}'
 assert_extra_packit_job_rejected \
     "canonical Rawhide target outside production and staging" \
-    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide"]}'
 assert_extra_packit_job_rejected \
     "fedora-all mutable alias" \
-    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-all"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-all"]}'
 assert_extra_packit_job_rejected \
     "fedora-development mutable alias" \
-    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development"]}'
 assert_extra_packit_job_rejected \
     "architecture-suffixed mutable alias" \
-    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-development-aarch64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing Rawhide target" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-rawhide-x86_64"]}' \
     "targets Rawhide"
 assert_extra_packit_job_rejected \
     "Rawhide target outside production and staging" \
-    '{"job":"copr_build","trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"release","owner":"other-owner","project":"facelock-scratch","targets":["fedora-rawhide-x86_64"]}'
 assert_staging_packit_job_rejected \
     "facelock-testing incomplete staging targets" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64"]}' \
     "Packit staging COPR targets drifted"
 assert_extra_packit_job_rejected \
     "duplicate targets outside production and staging" \
-    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-43-x86_64"]}'
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":["fedora-43-x86_64","fedora-43-x86_64"]}'
 assert_extra_packit_job_rejected \
     "invalid targets outside production and staging" \
-    '{"job":"copr_build","trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":"fedora-43-x86_64"}'
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","owner":"tyvsmith","project":"facelock-scratch","targets":"fedora-43-x86_64"}'
 
 assert_matrix_mutation_rejected \
     "RPM authselect scriptlet dependency" \
@@ -1078,20 +1078,39 @@ assert_matrix_mutation_rejected \
     "staging COPR must not declare optional experimental chroots"
 assert_staging_packit_job_rejected \
     "Packit staging job deleted" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-retired","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-retired","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit must define exactly one staging COPR job"
 assert_staging_packit_job_rejected \
     "Packit staging job made release-triggered" \
-    '{"job":"copr_build","trigger":"release","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"release","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR trigger"
 assert_staging_packit_job_rejected \
     "Packit staging job made automatic" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":false,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":false,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR job must stay manually triggered"
 assert_staging_packit_job_rejected \
     "Packit staging job owner drifted" \
-    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"packit","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    '{"job":"copr_build","enable_net":true,"trigger":"pull_request","manual_trigger":true,"owner":"packit","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
     "Packit staging COPR owner"
+# COPR takes network access per build and Packit sends the value, so the job key
+# is the one that decides -- the project toggle every other gate reads is only
+# the fallback for a build that carries none. v0.2.0 was submitted with the
+# toggle on, the key absent, and no resolver in any of the three chroots. Both
+# the omission and an explicit false are rejected, because Packit's default is
+# false and an absent key is not a milder version of it.
+assert_staging_packit_job_rejected \
+    "Packit staging job without enable_net" \
+    '{"job":"copr_build","trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    "must declare enable_net: true"
+assert_staging_packit_job_rejected \
+    "Packit staging job with enable_net disabled" \
+    '{"job":"copr_build","enable_net":false,"trigger":"pull_request","manual_trigger":true,"owner":"tyvsmith","project":"facelock-testing","targets":["fedora-43-x86_64","fedora-44-x86_64","fedora-45-x86_64"]}' \
+    "must declare enable_net: true"
+assert_matrix_mutation_rejected \
+    "Packit jobs stripped of enable_net" \
+    ".packit.yaml" \
+    '/"enable_net": true,/d' \
+    "must declare enable_net: true"
 
 # The staging trigger and copr_channels.staging.provisioned move together. An
 # unprovisioned project must not be the target of every pull request's Packit


### PR DESCRIPTION
## Why

COPR resolves network access per build, and a Packit-submitted build carries its own value rather than inheriting the project's. Packit defaults `enable_net` to false and sends it on every build it creates, so the project's "internet access during builds" toggle never applied to v0.2.0 and all three chroots failed in `%build` on an unresolvable crates.io index. Every gate and the local COPR lane reported green, because one reads the project response and the other hardcoded the answer.

- declare `enable_net: true` on both `copr_build` jobs in `.packit.yaml`
- require the key on every `copr_build` job in `test/check-release-matrix.py`, the layer no live project comparison can reach before a build exists
- read the mock network flag out of `.packit.yaml` in `test/copr-build.sh` instead of passing `--enable-network` unconditionally
- name both halves of the setting in the COPR setup steps and add the v0.2.0 post-mortem to `docs/releasing.md`
- record the job-level requirement in `docs/contracts.md`
- cover the omission and an explicit false in `test/release-version-contract.sh`
- refresh walkthrough source pins for the shifted `docs/releasing.md` line numbers

## Validation

- `test/check-release-matrix.py`
- `test/release-version-contract.sh`
- `just check-docs`
- `just test-packit-config`
- `just test-copr 44`

Closes #347


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release and pull-request builds now have network access enabled, preventing failures caused by missing per-build network settings.
  - Release checks now detect missing or disabled network access before builds run.

- **Documentation**
  - Updated release guidance to explain required network configuration, validation steps, local testing, and recovery procedures.
  - Clarified that project-level and build-level network settings are validated separately.

- **Tests**
  - Build simulations now reflect the configured network mode and verify required settings across release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->