### PR TITLE
docs(install): describe the shipped 0.2.0 channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Facelock: Face Authentication for Linux
 
-> **Release status (checked 2026-09-05):** v0.1.4 is the latest stable release.
-> The current prerelease is
-> [v0.2.0-alpha.4](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4),
-> published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages.
-> Prereleases intentionally do not enter stable AUR, APT, or production COPR.
+> **Release status (checked 2026-09-06):** v0.2.0 is the latest stable release,
+> published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. The AUR
+> entries and both APT suites serve it. Production COPR is the exception: it
+> still serves v0.1.3, so Fedora users should take the direct RPM or the source
+> path until it catches up.
 
 A modern face authentication system for Linux PAM. Provides Windows Hello-style
 facial auth with IR-required capture and layered static-presentation checks,
@@ -20,45 +20,54 @@ telemetry. Your biometric data never leaves your machine.
 
 This installs the stable source-build package. `facelock-bin` is the prebuilt
 alternative and `facelock-git` follows development; all three AUR entries
-served version 0.1.4-1 when checked on 2026-09-05.
-The live `facelock-git` recipe still omitted its required ONNX Runtime
-dependency at that check; use the source-build prerequisites below instead of
-treating that AUR entry as a verified current-tree installation.
+served version 0.2.0-1 when checked on 2026-09-06, and each declares the
+`onnxruntime` dependency the binary loads at runtime.
 
 ```bash
 yay -S facelock           # or paru -S facelock
 ```
 
-### Debian / Ubuntu (APT status)
+### Debian / Ubuntu (APT)
 
 Debian-family release support is exactly Debian 13 (Trixie) and Ubuntu 26.04
-LTS (Resolute). Those exact suites are the 0.2.0 stable publication contract,
-but they are not currently served: clean checks of both codenamed `Release`
-URLs returned 404 on 2026-09-05. Do not add that source until a stable 0.2.0
-release publishes it.
+LTS (Resolute). Both codenamed suites are published at
+`https://tysmith.me/facelock/apt` and served 0.2.0 when checked on 2026-09-06:
 
-The future public base is `https://tysmith.me/facelock/apt`; this mapping is a
-release contract, not a currently usable repository:
-
-| Future stable target | Suite | Required package capability |
-|----------------------|-------|-----------------------------|
+| Supported target | Suite | Required package capability |
+|------------------|-------|-----------------------------|
 | Debian 13 | `trixie` | TPM |
 | Ubuntu 26.04 | `resolute` | TPM |
 
-Source entries written for v0.1.4 name the `main` or `legacy` suite. Both
-returned a signed `Release` file on 2026-09-05. The release policy says they
+Install the archive keyring, write a source entry naming your codename, then
+install the package:
+
+```bash
+sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
+  -o /usr/share/keyrings/tysmith-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" |
+  sudo tee /etc/apt/sources.list.d/facelock.list
+sudo apt update
+sudo apt install facelock
+```
+
+On Ubuntu 26.04, write `resolute` where that source line says `trixie`. Both
+suites are amd64 only. The [quickstart](docs/quickstart.md#published-packages)
+carries the signing key fingerprint to check the downloaded keyring against.
+
+Source entries written for v0.1.4 name the `main` or `legacy` suite. They
 keep working until 0.3.0: `main` maps to the Trixie package set and `legacy`
 serves signed empty indexes. At 0.3.0, `apt update` fails until the entry is
-removed. Bookworm, Noble, and Ubuntu 25.x have no future suite. Use the source
-build below for the current alpha tree.
+removed. Rewrite those entries to your operating system's codename now.
+Bookworm, Noble, and Ubuntu 25.x have no suite.
 
 ### Fedora (COPR)
 
-The supported COPR targets are Fedora 43, 44, and 45. On 2026-09-05, the
-production COPR served v0.1.3 on all three, behind the v0.1.4 stable release;
-use the source path below if you need the current tree. The staging COPR is a
-candidate channel, not a stable installation source. RHEL is not in the
-supported matrix.
+The supported COPR targets are Fedora 43, 44, and 45. On 2026-09-06 the
+production COPR served v0.1.3 on all three, behind the v0.2.0 stable release,
+so the commands below install 0.1.3 rather than the current release. Install
+the [direct 0.2.0 RPM](docs/quickstart.md#published-packages) or build from
+source until COPR catches up. The staging COPR is a candidate channel, not a
+stable installation source. RHEL is not in the supported matrix.
 
 ```bash
 sudo dnf install dnf5-plugins
@@ -303,8 +312,8 @@ each supported suite. Those builds are not publication proof: the release and
 every required asset must be present and verified. Stable releases publish
 AUR/APT and enable production COPR handling;
 prereleases must not enter those stable channels.
-[v0.2.0-alpha.4](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4)
-is a published prerelease with direct package assets. See
+[v0.2.0](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0) is the
+latest stable release, published with direct package assets. See
 [docs/releasing.md](docs/releasing.md) for the gates and versioning contract.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 # Facelock: Face Authentication for Linux
 
 > **Release status (checked 2026-09-06):** v0.2.0 is the latest stable release,
-> published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. The AUR
-> entries and both APT suites serve it. Production COPR is the exception: it
-> still serves v0.1.3, so Fedora users should take the direct RPM or the source
-> path until it catches up.
+> published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. Every
+> stable channel serves it: the three AUR entries, both APT suites, and the
+> production COPR.
 
 A modern face authentication system for Linux PAM. Provides Windows Hello-style
 facial auth with IR-required capture and layered static-presentation checks,
@@ -61,12 +60,11 @@ Bookworm, Noble, and Ubuntu 25.x have no suite.
 
 ### Fedora (COPR)
 
-The supported COPR targets are Fedora 43, 44, and 45. On 2026-09-06 the
-production COPR served v0.1.3 on all three, behind the v0.2.0 stable release,
-so the commands below install 0.1.3 rather than the current release. Install
-the [direct 0.2.0 RPM](docs/quickstart.md#published-packages) or build from
-source until COPR catches up. The staging COPR is a candidate channel, not a
-stable installation source. RHEL is not in the supported matrix.
+The supported COPR targets are Fedora 43, 44, and 45. The production COPR
+served 0.2.0-1 on all three when checked on 2026-09-06; the older 0.1.3 build
+stays in the repository, and `dnf` resolves to 0.2.0. The staging COPR is a
+candidate channel, not a stable installation source. RHEL is not in the
+supported matrix.
 
 ```bash
 sudo dnf install dnf5-plugins

--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ install the package:
 ```bash
 sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
   -o /usr/share/keyrings/tysmith-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" |
-  sudo tee /etc/apt/sources.list.d/facelock.list
+echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" | sudo tee /etc/apt/sources.list.d/facelock.list
 sudo apt update
 sudo apt install facelock
 ```
 
-On Ubuntu 26.04, write `resolute` where that source line says `trixie`. Both
+On Ubuntu 26.04, use `resolute` instead of `trixie` in the source line. Both
 suites are amd64 only. The [quickstart](docs/quickstart.md#published-packages)
 carries the signing key fingerprint to check the downloaded keyring against.
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -8,11 +8,12 @@ authentication path makes no network request and sends no telemetry.
 
 ## Quick Start
 
-The latest stable release is v0.1.4. The current
-[v0.2.0-alpha.4 prerelease](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4)
-provides direct Debian 13, Ubuntu 26.04, and Fedora 44 packages; it is
-intentionally absent from the stable AUR, APT, and production COPR channels.
-See [Quick Start](quickstart.md) for the exact package filenames.
+The latest stable release is
+[v0.2.0](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0), which
+provides direct Debian 13, Ubuntu 26.04, and Fedora 44 packages and is served
+by the AUR entries and both APT suites. Production COPR still serves v0.1.3.
+See [Quick Start](quickstart.md) for the exact package filenames, the APT
+source entry, and the current channel status.
 
 ```bash
 just build

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -11,9 +11,9 @@ authentication path makes no network request and sends no telemetry.
 The latest stable release is
 [v0.2.0](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0), which
 provides direct Debian 13, Ubuntu 26.04, and Fedora 44 packages and is served
-by the AUR entries and both APT suites. Production COPR still serves v0.1.3.
-See [Quick Start](quickstart.md) for the exact package filenames, the APT
-source entry, and the current channel status.
+by the AUR entries, both APT suites, and the production COPR. See
+[Quick Start](quickstart.md) for the exact package filenames, the APT source
+entry, and the current channel status.
 
 ```bash
 just build

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,8 +4,8 @@
 
 As checked on 2026-09-06,
 [v0.2.0](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0) is the
-latest stable release. The AUR entries and both APT suites serve it; the
-production COPR does not yet.
+latest stable release. Every stable channel serves it: the three AUR entries,
+both APT suites, and the production COPR.
 
 The following SHA256 values are pinned from the release's
 [MANIFEST.json](https://github.com/tyvsmith/facelock/releases/download/v0.2.0/MANIFEST.json).
@@ -89,10 +89,10 @@ Existing v0.1.4 entries naming `main` or `legacy` keep working until 0.3.0:
 At 0.3.0, `apt update` fails until the entry is removed. Rewrite those entries
 to your operating system's codename now.
 
-The production COPR targets Fedora 43, 44, and 45 only. On 2026-09-06 it served
-v0.1.3 on all three, behind stable v0.2.0, so the commands below install 0.1.3
-rather than the current release. Use the direct RPM above until COPR catches
-up. `tyvsmith/facelock-testing` is a staging/candidate project, not a stable
+The production COPR targets Fedora 43, 44, and 45 only. It served 0.2.0-1 on
+all three when checked on 2026-09-06. The older 0.1.3 build stays in the
+repository; `dnf` resolves to the newest, so no pinning is needed.
+`tyvsmith/facelock-testing` is a staging/candidate project, not a stable
 channel. RHEL is not in the supported matrix. Fedora's `dnf copr` command comes
 from `dnf5-plugins`; installing it is idempotent, and minimal installations may
 not include it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,13 +71,12 @@ install the package:
 ```bash
 sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
   -o /usr/share/keyrings/tysmith-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" |
-  sudo tee /etc/apt/sources.list.d/facelock.list
+echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" | sudo tee /etc/apt/sources.list.d/facelock.list
 sudo apt update
 sudo apt install facelock
 ```
 
-On Ubuntu 26.04, write `resolute` where that source line says `trixie`. The
+On Ubuntu 26.04, use `resolute` instead of `trixie` in the source line. The
 keyring holds one rsa4096 key, `Ty Smith (Package Signing)
 <packages@m.tysmith.me>`, fingerprint
 `E7F8A4C424C6D59BD38536B536A81FCD934C17CE`, checked on 2026-09-06. Confirm it

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,42 +2,44 @@
 
 ## Published packages
 
-As checked on 2026-09-05, v0.1.4 is the latest stable release. The current
-prerelease, [v0.2.0-alpha.4](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4),
-is published with direct package assets. Prereleases intentionally do not enter
-the stable AUR, APT, or production COPR channels.
+As checked on 2026-09-06,
+[v0.2.0](https://github.com/tyvsmith/facelock/releases/tag/v0.2.0) is the
+latest stable release. The AUR entries and both APT suites serve it; the
+production COPR does not yet.
 
 The following SHA256 values are pinned from the release's
-[MANIFEST.json](https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/MANIFEST.json).
+[MANIFEST.json](https://github.com/tyvsmith/facelock/releases/download/v0.2.0/MANIFEST.json).
 Each command chain verifies the downloaded bytes before invoking the package
 manager; stop if verification fails. These checks establish integrity against
 the reviewed release, not an independent signing or build attestation.
 
-For Debian 13 amd64, install the published alpha package directly:
+For Debian 13 amd64, install the published package directly:
 
 ```bash
-curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb &&
-printf '%s  %s\n' '36fede353b2eed7ab98e7ecf1ca4cca5ae7e6ab6820df8de27734c4a992467aa' 'facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb' | sha256sum --check - &&
-sudo apt install ./facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb
+curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock_0.2.0-1.deb13u1_amd64.deb &&
+printf '%s  %s\n' '2554a1dcd4eca7bb1e3c2f2fbafbffa31d2c6a84210d32e9e221ece9e6e8dace' 'facelock_0.2.0-1.deb13u1_amd64.deb' | sha256sum --check - &&
+sudo apt install ./facelock_0.2.0-1.deb13u1_amd64.deb
 ```
 
 For Ubuntu 26.04 amd64, use the corresponding suite build:
 
 ```bash
-curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb &&
-printf '%s  %s\n' 'cdddbdb6a3e7a1fa9ac56de0f8521ca9538ba01495ef9744aa18bc158646f8a2' 'facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb' | sha256sum --check - &&
-sudo apt install ./facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb
+curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock_0.2.0-1.ubuntu26.04.1_amd64.deb &&
+printf '%s  %s\n' 'ee4bc06963752bf39e888c2d10ba5229f256978d0b14b134463e19525b323d79' 'facelock_0.2.0-1.ubuntu26.04.1_amd64.deb' | sha256sum --check - &&
+sudo apt install ./facelock_0.2.0-1.ubuntu26.04.1_amd64.deb
 ```
 
-The dots in those download filenames are GitHub-safe stored names. Once
-installed, Debian reports the native versions `0.2.0~alpha.4-1~deb13u1` and
-`0.2.0~alpha.4-1~ubuntu26.04.1`; the tildes preserve prerelease ordering.
-Fedora 44 x86_64 users can install the direct release RPM:
+The dots in those download filenames are GitHub-safe stored names.
+`MANIFEST.json` records the native names `facelock_0.2.0-1~deb13u1_amd64.deb`
+and `facelock_0.2.0-1~ubuntu26.04.1_amd64.deb`, and Debian reports the
+installed versions `0.2.0-1~deb13u1` and `0.2.0-1~ubuntu26.04.1`. The bytes and
+the checksum are the same either way. Fedora 44 x86_64 users can install the
+direct release RPM:
 
 ```bash
-curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm &&
-printf '%s  %s\n' '788fb323f8dcb27f99591a175d40fcc05bd81afbe5e1efbcc01b48a19ffe26f1' 'facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm' | sha256sum --check - &&
-sudo dnf install ./facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm
+curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock-0.2.0-1.fc44.x86_64.rpm &&
+printf '%s  %s\n' '65cf7d3167979daa8d5af6f0e5c96c25d21c6b27b07a47d8dd212007fab725c5' 'facelock-0.2.0-1.fc44.x86_64.rpm' | sha256sum --check - &&
+sudo dnf install ./facelock-0.2.0-1.fc44.x86_64.rpm
 ```
 
 The separately downloadable `facelock`, PAM module, and polkit-agent binaries
@@ -45,46 +47,56 @@ are release components, not a complete installation. They do not install the
 configuration, models, service and D-Bus policy, PAM layout, or required shared
 libraries; use a native package or the source installation path instead.
 
-The published alpha.4 Debian and RPM package prompts say to run `setup` and
-then `enroll`. That second command is redundant when setup's enrollment step
-succeeds; run it only if enrollment was skipped or did not complete.
-
 Arch users can install the stable source-build AUR package. `facelock-bin` is
 the prebuilt alternative and `facelock-git` follows development; all three AUR
-entries served version 0.1.4-1 on 2026-09-05.
-The live `facelock-git` recipe still omitted its required ONNX Runtime
-dependency at that check. Its source tracks development, but it is not a
-verified current-tree installation path until the published recipe is fixed.
+entries served version 0.2.0-1 on 2026-09-06, and each declares the
+`onnxruntime` dependency the binary loads at runtime.
 
 ```bash
 yay -S facelock
 ```
 
-Debian 13 (`trixie`) and Ubuntu 26.04 LTS (`resolute`) on amd64 are the exact
-0.2.0 stable APT targets. They are not currently served: the clean-system
-checks of the documented `trixie` and `resolute` Release URLs returned 404 on
-2026-09-05. Do not add either source until a stable 0.2.0 release publishes it.
-Their future public base is `https://tysmith.me/facelock/apt`. This is release
-policy, not a claim that the suites are currently installable:
+Debian 13 (`trixie`) and Ubuntu 26.04 LTS (`resolute`) on amd64 are the 0.2.0
+stable APT targets. Both suites are published at
+`https://tysmith.me/facelock/apt` and served 0.2.0 when checked on 2026-09-06:
 
-| Future stable target | Suite | Architecture | Required capability |
-|----------------------|-------|--------------|---------------------|
+| Supported target | Suite | Architecture | Required capability |
+|------------------|-------|--------------|---------------------|
 | Debian 13 | `trixie` | amd64 | TPM |
 | Ubuntu 26.04 | `resolute` | amd64 | TPM |
 
-Existing v0.1.4 entries naming `main` or `legacy` returned signed Release
-metadata on 2026-09-05. Under the compatibility policy, these names keep working until
-0.3.0: starting with the 0.2.0 stable publication, `main` maps to the Trixie
-package set and `legacy` serves signed empty indexes. At 0.3.0, `apt update`
-fails until the entry is removed. The alpha is available only as direct release
-packages, not through APT; metadata availability alone does not verify package
-contents.
+Install the archive keyring, write a source entry naming your codename, then
+install the package:
 
-The production COPR targets Fedora 43, 44, and 45 only. On 2026-09-05 it served
-v0.1.3 on all three, behind stable v0.1.4. `tyvsmith/facelock-testing` is a
-staging/candidate project, not a stable channel. RHEL is not in the supported
-matrix. Fedora's `dnf copr` command comes from `dnf5-plugins`; installing it is
-idempotent, and minimal installations may not include it.
+```bash
+sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg \
+  -o /usr/share/keyrings/tysmith-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" |
+  sudo tee /etc/apt/sources.list.d/facelock.list
+sudo apt update
+sudo apt install facelock
+```
+
+On Ubuntu 26.04, write `resolute` where that source line says `trixie`. The
+keyring holds one rsa4096 key, `Ty Smith (Package Signing)
+<packages@m.tysmith.me>`, fingerprint
+`E7F8A4C424C6D59BD38536B536A81FCD934C17CE`, checked on 2026-09-06. Confirm it
+with `gpg --show-keys` before trusting the source; `signed-by` scopes that key
+to this repository alone, and `apt update` rejects the suite if the archive
+signature does not match.
+
+Existing v0.1.4 entries naming `main` or `legacy` keep working until 0.3.0:
+`main` maps to the Trixie package set and `legacy` serves signed empty indexes.
+At 0.3.0, `apt update` fails until the entry is removed. Rewrite those entries
+to your operating system's codename now.
+
+The production COPR targets Fedora 43, 44, and 45 only. On 2026-09-06 it served
+v0.1.3 on all three, behind stable v0.2.0, so the commands below install 0.1.3
+rather than the current release. Use the direct RPM above until COPR catches
+up. `tyvsmith/facelock-testing` is a staging/candidate project, not a stable
+channel. RHEL is not in the supported matrix. Fedora's `dnf copr` command comes
+from `dnf5-plugins`; installing it is idempotent, and minimal installations may
+not include it.
 
 ```bash
 sudo dnf install dnf5-plugins
@@ -157,7 +169,7 @@ A source build can compile and run non-inference commands such as `--help`,
 but enrollment, authentication, preview, and inference benchmarks require a
 separately installed compatible ONNX Runtime 1.20+ in a trusted runtime
 location. Merely adding a symlink does not repair a mismatched SONAME.
-The published alpha.4 `.deb` packages bundle the compatible CPU runtime 1.20.1;
+The published `.deb` packages bundle the compatible CPU runtime 1.20.1;
 this is not supplied by Cargo.
 
 ```bash

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,9 +5,9 @@
 The following is a dated 2026-09-06 observation: v0.2.0 is the latest published
 GitHub release. The `trixie` and `resolute` APT Release URLs return signed
 metadata for 0.2.0-1, `main` serves the same Trixie package, and `legacy`
-serves signed empty indexes. All three AUR entries serve 0.2.0-1. Production
-COPR still serves 0.1.3-1 on Fedora 43, 44, and 45, behind the stable release,
-so `dnf copr enable` installs 0.1.3 until a 0.2.0 build lands there. These are
+serves signed empty indexes. All three AUR entries serve 0.2.0-1. The
+production COPR serves 0.2.0-1 on Fedora 43, 44, and 45, from a build submitted
+by hand after the tagged release run failed to produce one. These are
 availability observations, not changes to the release policy below.
 
 ## Versioning

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,15 +2,13 @@
 
 ## Current channel observation
 
-The following is a dated 2026-09-05 observation: v0.1.4 was then the latest
-published GitHub release and the v0.2.0-alpha.1 tag pointed to commit `53385c5`
-but had no GitHub Release. The
-`trixie` and `resolute` APT Release URLs return 404; the compatibility `main`
-and `legacy` suites return signed Release metadata. Production COPR serves
-0.1.3-1 on Fedora 43, 44, and 45, not the stable 0.1.4-1 predecessor. These are
-availability observations, not changes to the release policy below. Since that
-audit, v0.2.0-alpha.4 has been published as a prerelease with direct artifacts;
-stable AUR, APT, and production COPR publication remains skipped by policy.
+The following is a dated 2026-09-06 observation: v0.2.0 is the latest published
+GitHub release. The `trixie` and `resolute` APT Release URLs return signed
+metadata for 0.2.0-1, `main` serves the same Trixie package, and `legacy`
+serves signed empty indexes. All three AUR entries serve 0.2.0-1. Production
+COPR still serves 0.1.3-1 on Fedora 43, 44, and 45, behind the stable release,
+so `dnf copr enable` installs 0.1.3 until a 0.2.0 build lands there. These are
+availability observations, not changes to the release policy below.
 
 ## Versioning
 
@@ -904,12 +902,12 @@ release remains unpublished.
    ```bash
    gpg --full-generate-key
    # Select RSA 4096, expiry 3y
-   # UID: Ty Smith Package Signing <packages@tysmith.me>
+   # UID: Ty Smith (Package Signing) <packages@m.tysmith.me>
    ```
 
 2. Export and add the private key as a GitHub secret:
    ```bash
-   gpg --armor --export-secret-keys "packages@tysmith.me" | gh secret set APT_GPG_PRIVATE_KEY
+   gpg --armor --export-secret-keys "packages@m.tysmith.me" | gh secret set APT_GPG_PRIVATE_KEY
    ```
 
 3. Add the passphrase as a GitHub secret:
@@ -941,7 +939,7 @@ Prerelease packages are never inserted into any of these stable suites.
 Stable publication requires exactly one suite-matching package for both
 codenames before signing or repository writes begin.
 
-The APT repo is hosted at `https://tysmith.me/facelock/apt/` alongside the docs site. The public keyring is at `https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg`.
+The APT repo is hosted at `https://tysmith.me/facelock/apt/` alongside the docs site. The public keyring is at `https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg`. It carried one rsa4096 key when checked on 2026-09-06: `Ty Smith (Package Signing) <packages@m.tysmith.me>`, fingerprint `E7F8A4C424C6D59BD38536B536A81FCD934C17CE`, expiring 2029-03-27. Rotate before that date; the published user documentation quotes this fingerprint, so update it in the same release.
 
 **GPG key rotation**: When the signing key expires, generate a new key, update the `APT_GPG_PRIVATE_KEY` and `APT_GPG_PASSPHRASE` secrets, and cut a new release. The public keyring is re-exported on every release, so users who re-fetch it will get the updated key.
 

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -57,15 +57,15 @@ case it actually exercised.
 
 ## Release and packaging status
 
-v0.1.4 is the latest published stable release. v0.2.0-alpha.4 is published as
-a prerelease with direct package artifacts. Prereleases do not enter stable
-APT, AUR, or production COPR. The production COPR currently serves
-v0.1.3; Fedora staging is a candidate channel. The exact supported release
-matrix is Fedora 43/44/45, Debian 13, and Ubuntu 26.04, not RHEL.
+v0.2.0 is the latest published stable release, with direct package artifacts.
+Prereleases do not enter stable APT, AUR, or production COPR. The AUR entries
+and both APT suites serve 0.2.0; the production COPR still serves v0.1.3, and
+Fedora staging is a candidate channel. The exact supported release matrix is
+Fedora 43/44/45, Debian 13, and Ubuntu 26.04, not RHEL.
 
 A stable release is expected to carry two suite-specific `.deb` artifacts for
-trixie and resolute. Alpha.4 carries direct suite packages, but that does not
-mean either future APT suite is currently published or installable.
+trixie and resolute. v0.2.0 carries both, and both codenamed APT suites are
+published from them.
 
 The Nix flake/module and OpenRC, runit, and s6 templates live in the source
 tree. Nix is not in nixpkgs and its derivation disables `doCheck`; the init

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -58,10 +58,10 @@ case it actually exercised.
 ## Release and packaging status
 
 v0.2.0 is the latest published stable release, with direct package artifacts.
-Prereleases do not enter stable APT, AUR, or production COPR. The AUR entries
-and both APT suites serve 0.2.0; the production COPR still serves v0.1.3, and
-Fedora staging is a candidate channel. The exact supported release matrix is
-Fedora 43/44/45, Debian 13, and Ubuntu 26.04, not RHEL.
+Prereleases do not enter stable APT, AUR, or production COPR. The AUR entries,
+both APT suites, and the production COPR all serve 0.2.0; Fedora staging is a
+candidate channel. The exact supported release matrix is Fedora 43/44/45,
+Debian 13, and Ubuntu 26.04, not RHEL.
 
 A stable release is expected to carry two suite-specific `.deb` artifacts for
 trixie and resolute. v0.2.0 carries both, and both codenamed APT suites are

--- a/docs/testing-walkthrough.md
+++ b/docs/testing-walkthrough.md
@@ -121,8 +121,8 @@ python3 test/docs-walkthrough/evidence.py validate "$EVIDENCE_DIR/evidence.json"
 
 Use `--require-pass` only when a passing outcome is required. A real
 publication absence is evidence, not a reason to rewrite the record as a pass.
-For example, the current clean Debian 13 `apt-trixie` run records that the
-future suite's Release URL returns 404; it does not establish a clean install.
+A clean `apt-trixie` run against an unpublished suite records the 404 its
+Release URL returned; that record is the outcome, not a failed run to retry.
 
 When an environmental prerequisite is deliberately unavailable, record an
 explicit blocked result rather than skipping silently. The generic runner

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -312,7 +312,7 @@
         "path": "README.md",
         "anchor": "arch-linux-aur",
         "ordinal": 1,
-        "line": 27,
+        "line": 26,
         "sha256": "d362fd362389741be7a261a22cf3cb04edfabb48d43d545e4685ca00b4a1c743"
       }
     ],
@@ -445,8 +445,8 @@
       {
         "path": "README.md",
         "anchor": "fedora-copr",
-        "ordinal": 2,
-        "line": 73,
+        "ordinal": 3,
+        "line": 71,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -454,8 +454,8 @@
       {
         "path": "README.md",
         "anchor": "fedora-copr",
-        "ordinal": 2,
-        "line": 73,
+        "ordinal": 3,
+        "line": 71,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -464,7 +464,7 @@
         "path": "README.md",
         "anchor": "from-source",
         "ordinal": 4,
-        "line": 90,
+        "line": 88,
         "sha256": "ee643003c3bebb06741967affae1785b90ae552fcbf30142419a9d7fa0415d59"
       }
     ],
@@ -509,28 +509,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 105,
+        "line": 103,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 113,
+        "line": 111,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 114,
+        "line": 112,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 250,
+        "line": 248,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],
@@ -578,28 +578,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 105,
+        "line": 103,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 113,
+        "line": 111,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 114,
+        "line": 112,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 250,
+        "line": 248,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -312,7 +312,7 @@
         "path": "README.md",
         "anchor": "arch-linux-aur",
         "ordinal": 1,
-        "line": 29,
+        "line": 27,
         "sha256": "d362fd362389741be7a261a22cf3cb04edfabb48d43d545e4685ca00b4a1c743"
       }
     ],
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 16,
-        "line": 525,
+        "line": 523,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -330,42 +330,42 @@
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 3,
-        "line": 313,
+        "line": 311,
         "sha256": "b2b12dbf5cd38fc21d68548042e8eae1e66f65faa6491f3564e75c7cb60abc22"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 4,
-        "line": 314,
+        "line": 312,
         "sha256": "5595bcc3f9aa3517450a5185fe037e24b0a8ec079eff27020bf5c5aef68ffdb0"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 5,
-        "line": 315,
+        "line": 313,
         "sha256": "d0d568788326024851d047fe1e316af83028cbf98b17a777fd64c4e784151809"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 13,
-        "line": 325,
+        "line": 323,
         "sha256": "cbe27321cd6d31c9676b5aa4998fd1b4f9195f719b00cda8f889c3b3b7dae276"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 15,
-        "line": 327,
+        "line": 325,
         "sha256": "a10a4c45881ab16f35605739e0375de3e5558bc495111b49c7929d9b2d1603a0"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1090,
+        "line": 1088,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -374,70 +374,70 @@
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 2,
-        "line": 312,
+        "line": 310,
         "sha256": "d5ce836f401484bd835100b165e1c2234b437780616e27bb92f5403d0f22bc40"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 6,
-        "line": 316,
+        "line": 314,
         "sha256": "05d5991182864fc115e36763667a0d555cf256358ed52830129f8fd32ab925de"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 7,
-        "line": 317,
+        "line": 315,
         "sha256": "4830a79699c4a1fa28bbcdc2eb8e5712c7ac46f3fd2533bad0b097ab936e8413"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 8,
-        "line": 318,
+        "line": 316,
         "sha256": "b1b141623a6849ba1a180dfa8e3d7eb504da148110c930be20e240eabd2323f1"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 14,
-        "line": 326,
+        "line": 324,
         "sha256": "0aece5ddd58b51f2dccb3e634e59f06c2a38c4f9bd0439197688c4e548e8895b"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 16,
-        "line": 328,
+        "line": 326,
         "sha256": "640b0dca78c96225ae70191f4312212e60c6367fca24cab33a803b0ee94c7847"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 1,
-        "line": 344,
+        "line": 342,
         "sha256": "d8ca765201bc57c001e20cd7532b17eae17b608c987aef950bd49b038209a291"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 3,
-        "line": 345,
+        "line": 343,
         "sha256": "942b015c794e1cca7d2229c0315e6a430ae3e08a91102a5f9ec9a5fafa61a8ec"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 10,
-        "line": 382,
+        "line": 380,
         "sha256": "942b015c794e1cca7d2229c0315e6a430ae3e08a91102a5f9ec9a5fafa61a8ec"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 6,
-        "line": 1090,
+        "line": 1088,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],
@@ -446,7 +446,7 @@
         "path": "README.md",
         "anchor": "fedora-copr",
         "ordinal": 2,
-        "line": 65,
+        "line": 74,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -455,7 +455,7 @@
         "path": "README.md",
         "anchor": "fedora-copr",
         "ordinal": 2,
-        "line": 65,
+        "line": 74,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -464,7 +464,7 @@
         "path": "README.md",
         "anchor": "from-source",
         "ordinal": 4,
-        "line": 82,
+        "line": 91,
         "sha256": "ee643003c3bebb06741967affae1785b90ae552fcbf30142419a9d7fa0415d59"
       }
     ],
@@ -473,7 +473,7 @@
         "path": "docs/releasing.md",
         "anchor": "builders-build-publish-publishes",
         "ordinal": 2,
-        "line": 211,
+        "line": 209,
         "sha256": "d73a11669eaedc13fd66e0c81aae2720400721af2e2c572b1ebc48cc026cc29c"
       }
     ],
@@ -509,28 +509,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 97,
+        "line": 106,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 105,
+        "line": 114,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 106,
+        "line": 115,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 242,
+        "line": 251,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],
@@ -578,28 +578,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 97,
+        "line": 106,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 105,
+        "line": 114,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 106,
+        "line": 115,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 242,
+        "line": 251,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -446,7 +446,7 @@
         "path": "README.md",
         "anchor": "fedora-copr",
         "ordinal": 2,
-        "line": 74,
+        "line": 73,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -455,7 +455,7 @@
         "path": "README.md",
         "anchor": "fedora-copr",
         "ordinal": 2,
-        "line": 74,
+        "line": 73,
         "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
       }
     ],
@@ -464,7 +464,7 @@
         "path": "README.md",
         "anchor": "from-source",
         "ordinal": 4,
-        "line": 91,
+        "line": 90,
         "sha256": "ee643003c3bebb06741967affae1785b90ae552fcbf30142419a9d7fa0415d59"
       }
     ],
@@ -509,28 +509,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 106,
+        "line": 105,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 114,
+        "line": 113,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 115,
+        "line": 114,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 251,
+        "line": 250,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],
@@ -578,28 +578,28 @@
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 1,
-        "line": 106,
+        "line": 105,
         "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 4,
-        "line": 114,
+        "line": 113,
         "sha256": "e75d40fad8fc39564478eb4a79fc737f644f9b056e395a761231e9d5ba87526a"
       },
       {
         "path": "README.md",
         "anchor": "post-install",
         "ordinal": 5,
-        "line": 115,
+        "line": 114,
         "sha256": "ffd01420441dd9f03d93c8cc6ee904634a47010b453fdb05d06b7bfee0c455b2"
       },
       {
         "path": "README.md",
         "anchor": "hyprlock-integration",
         "ordinal": 1,
-        "line": 251,
+        "line": 250,
         "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -1340,27 +1340,20 @@
           "anchor": "debian--ubuntu-apt",
           "ordinal": 2,
           "line": 47,
-          "sha256": "2c23cb438d760a78c3dbe9315a08258df691f9a0f01a83c44c776bf52bb9704b"
+          "sha256": "39cc6a6f465cccaad652684e38819b46c2b36d1b867c5dd50f06bfeed63e29a5"
         },
         {
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 3,
           "line": 48,
-          "sha256": "fbb4f2e9a16dfac090576af21bcca2afd1aa851a733ea602d0e09fbc4e9558c1"
+          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 4,
           "line": 49,
-          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
-        },
-        {
-          "path": "README.md",
-          "anchor": "debian--ubuntu-apt",
-          "ordinal": 5,
-          "line": 50,
           "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
         }
       ],
@@ -1381,7 +1374,7 @@
         {
           "id": "example-2",
           "adapter": "manual",
-          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" |",
+          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" | sudo tee /etc/apt/sources.list.d/facelock.list",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -1394,19 +1387,6 @@
         {
           "id": "example-3",
           "adapter": "manual",
-          "raw": "sudo tee /etc/apt/sources.list.d/facelock.list",
-          "classification": "executable",
-          "expect_exit": 0,
-          "expect_output": "",
-          "expect_state": [
-            "documented-effect-observed"
-          ],
-          "timeout_seconds": 1800,
-          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
-        },
-        {
-          "id": "example-4",
-          "adapter": "manual",
           "raw": "sudo apt update",
           "classification": "executable",
           "expect_exit": 0,
@@ -1418,7 +1398,7 @@
           "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
         },
         {
-          "id": "example-5",
+          "id": "example-4",
           "adapter": "manual",
           "raw": "sudo apt install facelock",
           "classification": "executable",
@@ -1466,21 +1446,21 @@
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 1,
-          "line": 73,
+          "line": 72,
           "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 2,
-          "line": 74,
+          "line": 73,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 3,
-          "line": 75,
+          "line": 74,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         }
       ],
@@ -1560,14 +1540,14 @@
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 1,
-          "line": 85,
+          "line": 84,
           "sha256": "d091076a0b6859d8a04b9e50b052b819a80d6a4fe3b6336bdbbda387de310be0"
         },
         {
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 2,
-          "line": 86,
+          "line": 85,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],
@@ -1634,7 +1614,7 @@
           "path": "README.md",
           "anchor": "post-install",
           "ordinal": 1,
-          "line": 106,
+          "line": 105,
           "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
         }
       ],
@@ -1689,7 +1669,7 @@
           "path": "README.md",
           "anchor": "uninstall",
           "ordinal": 1,
-          "line": 141,
+          "line": 140,
           "sha256": "d51310f315784b2a9c33e5d9294b3c51087ed1e1372dcfa10a29f3d34b1efbde"
         }
       ],
@@ -1743,28 +1723,28 @@
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 2,
-          "line": 254,
+          "line": 253,
           "sha256": "270315a785e93c84e21e959de6561428bf475b40b6096a19a5bdfc20555fa93d"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 3,
-          "line": 255,
+          "line": 254,
           "sha256": "599de770b8b0e87ca01f6837e309d01e9847d347fd850d18ded4eb14e86cc015"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 4,
-          "line": 256,
+          "line": 255,
           "sha256": "d3a74681ef70d90250e1ac050d1d8510753888e9da5dfee69b81ba6b1e5b3a3b"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 5,
-          "line": 257,
+          "line": 256,
           "sha256": "88017a21a68eb150eaaf2a5217d35e9b4d930661a74cdda87f8b3938f6073d15"
         }
       ],
@@ -1860,35 +1840,35 @@
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 1,
-          "line": 271,
+          "line": 270,
           "sha256": "f1c7b61a74c050d3b5044973e899c70b74cad56ae0d775a1c370227b2554e558"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 2,
-          "line": 272,
+          "line": 271,
           "sha256": "b4e7755cb3b54ed9400756f86c10c858a95d4439686e2d0a9bdb1752fd673066"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 3,
-          "line": 273,
+          "line": 272,
           "sha256": "501e0bb7eed827cbc90d37b2aa9536777f4893de0b075ef6269dacfba8f94671"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 4,
-          "line": 274,
+          "line": 273,
           "sha256": "0491e9aacca737903a046d7da3901ae168145ed83b3b07ce7ca67d1803b58d41"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 5,
-          "line": 275,
+          "line": 274,
           "sha256": "0d288d69cd7407b7c4f02c4f4d616356203ec2ae445f211d922317dbae06d6fb"
         }
       ],
@@ -1996,21 +1976,21 @@
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 1,
-          "line": 304,
+          "line": 303,
           "sha256": "29e78a6c2780f8195dd6def758c19769a7af32bb935dcff29d1cc51025473ffa"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 2,
-          "line": 305,
+          "line": 304,
           "sha256": "c932b35fc3a91076a733f7102c49400e6bf24507e8de7243f9789c898295d73c"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 3,
-          "line": 306,
+          "line": 305,
           "sha256": "2a4f6d2e6732e2f4816ee15011101bdda9a56aea8068ac90a4c8a332cc11c8a4"
         }
       ],
@@ -7732,62 +7712,55 @@
           "anchor": "published-packages",
           "ordinal": 13,
           "line": 74,
-          "sha256": "2c23cb438d760a78c3dbe9315a08258df691f9a0f01a83c44c776bf52bb9704b"
+          "sha256": "39cc6a6f465cccaad652684e38819b46c2b36d1b867c5dd50f06bfeed63e29a5"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 14,
           "line": 75,
-          "sha256": "fbb4f2e9a16dfac090576af21bcca2afd1aa851a733ea602d0e09fbc4e9558c1"
+          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 15,
           "line": 76,
-          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
+          "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 16,
-          "line": 77,
-          "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
+          "ordinal": 19,
+          "line": 101,
+          "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 20,
           "line": 102,
-          "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
+          "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 21,
           "line": 103,
-          "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
+          "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 22,
-          "line": 104,
-          "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
+          "line": 109,
+          "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 23,
           "line": 110,
-          "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
-        },
-        {
-          "path": "docs/quickstart.md",
-          "anchor": "published-packages",
-          "ordinal": 24,
-          "line": 111,
           "sha256": "f64e829871b2f7998fdbf8a8f7c4a36f917acc719880c9d14bc6565a6f1607ca"
         }
       ],
@@ -7938,7 +7911,7 @@
         {
           "id": "example-12",
           "adapter": "manual",
-          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" |",
+          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" | sudo tee /etc/apt/sources.list.d/facelock.list",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7951,7 +7924,7 @@
         {
           "id": "example-13",
           "adapter": "manual",
-          "raw": "sudo tee /etc/apt/sources.list.d/facelock.list",
+          "raw": "sudo apt update",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7964,7 +7937,7 @@
         {
           "id": "example-14",
           "adapter": "manual",
-          "raw": "sudo apt update",
+          "raw": "sudo apt install facelock",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7977,7 +7950,7 @@
         {
           "id": "example-15",
           "adapter": "manual",
-          "raw": "sudo apt install facelock",
+          "raw": "sudo dnf install dnf5-plugins",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7990,7 +7963,7 @@
         {
           "id": "example-16",
           "adapter": "manual",
-          "raw": "sudo dnf install dnf5-plugins",
+          "raw": "sudo dnf copr enable tyvsmith/facelock",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -8003,7 +7976,7 @@
         {
           "id": "example-17",
           "adapter": "manual",
-          "raw": "sudo dnf copr enable tyvsmith/facelock",
+          "raw": "sudo dnf install facelock",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -8016,19 +7989,6 @@
         {
           "id": "example-18",
           "adapter": "manual",
-          "raw": "sudo dnf install facelock",
-          "classification": "executable",
-          "expect_exit": 0,
-          "expect_output": "",
-          "expect_state": [
-            "documented-effect-observed"
-          ],
-          "timeout_seconds": 1800,
-          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
-        },
-        {
-          "id": "example-19",
-          "adapter": "manual",
           "raw": "sudo facelock setup",
           "classification": "executable",
           "expect_exit": 0,
@@ -8040,7 +8000,7 @@
           "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
         },
         {
-          "id": "example-20",
+          "id": "example-19",
           "adapter": "manual",
           "raw": "sudo facelock test",
           "classification": "executable",
@@ -8091,112 +8051,112 @@
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 1,
-          "line": 135,
+          "line": 134,
           "sha256": "ff8195c4ae6218ff221c52bc8fddd04740ffe18424173f6bae17f94a689e13a2"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 2,
-          "line": 143,
+          "line": 142,
           "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 3,
-          "line": 144,
+          "line": 143,
           "sha256": "d083d8c1835c7a878a0028ffe95a9d8657a34bf54d9c77df60cf96f48fe8c42d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 4,
-          "line": 145,
+          "line": 144,
           "sha256": "688d76820168760e13f5199233f25c2fa8f6e0b0f4da4b0d4b6eee06564398b6"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 5,
-          "line": 151,
+          "line": 150,
           "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 6,
-          "line": 152,
+          "line": 151,
           "sha256": "01d7cf22bcecf66729c8d81a6ed4b9e9b796968f7d83ab5fe387b53eb8ea1ae0"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 8,
-          "line": 160,
+          "line": 159,
           "sha256": "d75ce10dd306f1d3969df3610179fe1364f05b90fa2be6b3d087c4badc3db984"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 9,
-          "line": 176,
+          "line": 175,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 10,
-          "line": 177,
+          "line": 176,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 15,
-          "line": 188,
+          "line": 187,
           "sha256": "fad0225732307d9b8666dc48f93369322752b5acd641d744cde3a6d1c99155de"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 16,
-          "line": 189,
+          "line": 188,
           "sha256": "21df8681af24fdd4a24c8e7533d7c69725728fedd70374ac46b437b03686b526"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 17,
-          "line": 190,
+          "line": 189,
           "sha256": "e1a93dce67650786cc6126129be6427d1a8a96c0560e61b310b30e44e61bde57"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 18,
-          "line": 191,
+          "line": 190,
           "sha256": "db33444f34d115dce2f155297f23c717c86dd22e1e95cd0e44bf71ad6bec9fcf"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 19,
-          "line": 203,
+          "line": 202,
           "sha256": "ee643003c3bebb06741967affae1785b90ae552fcbf30142419a9d7fa0415d59"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 20,
-          "line": 204,
+          "line": 203,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 21,
-          "line": 205,
+          "line": 204,
           "sha256": "f64e829871b2f7998fdbf8a8f7c4a36f917acc719880c9d14bc6565a6f1607ca"
         }
       ],
@@ -8448,35 +8408,35 @@
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 1,
-          "line": 244,
+          "line": 243,
           "sha256": "7047dae1de5957a90be1c7a3cfcc6abe298930cbfcdd6838f4a06295a7d565ce"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 2,
-          "line": 245,
+          "line": 244,
           "sha256": "97fe7e4851d163ea954392ba9c6fbfa704c8f3e1ef28996b794b45a7b4551907"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 3,
-          "line": 246,
+          "line": 245,
           "sha256": "d8e28448d4f6a66c71332ec6cc573065c0863083d2dde4dbd395d6fe1c8882a1"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 4,
-          "line": 247,
+          "line": 246,
           "sha256": "b01a1ffc2b4ef9721bb5ce35a004dd6ce17743083fa0670424a5caeb985dd7a6"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 5,
-          "line": 248,
+          "line": 247,
           "sha256": "c5daf997e938d2c8a1aeed87aaf0e3f000d211290ff0fdd9861be7ce2fa738ed"
         }
       ],
@@ -8583,21 +8543,21 @@
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 1,
-          "line": 260,
+          "line": 259,
           "sha256": "4547cf4ed51d13a8755d4c904f2a1773778fb1af9481d51ac64373378ec09873"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 3,
-          "line": 275,
+          "line": 274,
           "sha256": "b2eaa0d6e49d61a0a83ddb30434dfff25bda1608545252375dd2eeca201b320a"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 4,
-          "line": 276,
+          "line": 275,
           "sha256": "cd370c0da2fc6b4b0a0c94762df10329fb29a2eec64e260f87f372c4856d9178"
         }
       ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -1278,7 +1278,7 @@
           "path": "README.md",
           "anchor": "arch-linux-aur",
           "ordinal": 1,
-          "line": 29,
+          "line": 27,
           "sha256": "d362fd362389741be7a261a22cf3cb04edfabb48d43d545e4685ca00b4a1c743"
         }
       ],
@@ -1287,6 +1287,140 @@
           "id": "example-1",
           "adapter": "manual",
           "raw": "yay -S facelock           # or paru -S facelock",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        }
+      ]
+    },
+    {
+      "id": "manual-section-3ad7ae00f336",
+      "target": "section-specific-guest",
+      "channel": "github-alpha",
+      "adapter": "manual",
+      "generated_section": true,
+      "source_role": "ordered-occurrence",
+      "review_status": "candidate",
+      "review_reason": "mechanically grouped commands; a human must review section fixtures, exit expectations and applicability before execution",
+      "title": "README.md#debian--ubuntu-apt",
+      "minimum_level": "booted-vm",
+      "requirements": [
+        "human-command-review",
+        "section-prerequisites",
+        "fixture-bindings",
+        "observed-postconditions",
+        "human-pam-recovery"
+      ],
+      "prerequisites": [
+        "restore a pristine disposable guest for this section",
+        "read the enclosing section and earlier prerequisite headings",
+        "bind every user, path, service, device, package and secret placeholder to guest-local fixtures",
+        "record intentionally failing commands with their documented expected outcome"
+      ],
+      "fixtures": {
+        "binding_policy": "explicit reviewer-supplied guest-local bindings; no host paths or credentials"
+      },
+      "restore": "restore the recorded pristine snapshot; retain sanitized evidence outside the guest",
+      "timeout_seconds": 1800,
+      "sources": [
+        {
+          "path": "README.md",
+          "anchor": "debian--ubuntu-apt",
+          "ordinal": 1,
+          "line": 45,
+          "sha256": "b077c77e49cfc12a5cf375bc2dac3169eef7f59c1516d4a7bb320a69cfda3edd"
+        },
+        {
+          "path": "README.md",
+          "anchor": "debian--ubuntu-apt",
+          "ordinal": 2,
+          "line": 47,
+          "sha256": "2c23cb438d760a78c3dbe9315a08258df691f9a0f01a83c44c776bf52bb9704b"
+        },
+        {
+          "path": "README.md",
+          "anchor": "debian--ubuntu-apt",
+          "ordinal": 3,
+          "line": 48,
+          "sha256": "fbb4f2e9a16dfac090576af21bcca2afd1aa851a733ea602d0e09fbc4e9558c1"
+        },
+        {
+          "path": "README.md",
+          "anchor": "debian--ubuntu-apt",
+          "ordinal": 4,
+          "line": 49,
+          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
+        },
+        {
+          "path": "README.md",
+          "anchor": "debian--ubuntu-apt",
+          "ordinal": 5,
+          "line": 50,
+          "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
+        }
+      ],
+      "steps": [
+        {
+          "id": "example-1",
+          "adapter": "manual",
+          "raw": "sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg  -o /usr/share/keyrings/tysmith-archive-keyring.gpg",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-2",
+          "adapter": "manual",
+          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" |",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-3",
+          "adapter": "manual",
+          "raw": "sudo tee /etc/apt/sources.list.d/facelock.list",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-4",
+          "adapter": "manual",
+          "raw": "sudo apt update",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-5",
+          "adapter": "manual",
+          "raw": "sudo apt install facelock",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -1332,21 +1466,21 @@
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 1,
-          "line": 64,
+          "line": 73,
           "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 2,
-          "line": 65,
+          "line": 74,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
           "ordinal": 3,
-          "line": 66,
+          "line": 75,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         }
       ],
@@ -1426,14 +1560,14 @@
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 1,
-          "line": 76,
+          "line": 85,
           "sha256": "d091076a0b6859d8a04b9e50b052b819a80d6a4fe3b6336bdbbda387de310be0"
         },
         {
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 2,
-          "line": 77,
+          "line": 86,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],
@@ -1500,7 +1634,7 @@
           "path": "README.md",
           "anchor": "post-install",
           "ordinal": 1,
-          "line": 97,
+          "line": 106,
           "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
         }
       ],
@@ -1555,7 +1689,7 @@
           "path": "README.md",
           "anchor": "uninstall",
           "ordinal": 1,
-          "line": 132,
+          "line": 141,
           "sha256": "d51310f315784b2a9c33e5d9294b3c51087ed1e1372dcfa10a29f3d34b1efbde"
         }
       ],
@@ -1609,28 +1743,28 @@
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 2,
-          "line": 245,
+          "line": 254,
           "sha256": "270315a785e93c84e21e959de6561428bf475b40b6096a19a5bdfc20555fa93d"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 3,
-          "line": 246,
+          "line": 255,
           "sha256": "599de770b8b0e87ca01f6837e309d01e9847d347fd850d18ded4eb14e86cc015"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 4,
-          "line": 247,
+          "line": 256,
           "sha256": "d3a74681ef70d90250e1ac050d1d8510753888e9da5dfee69b81ba6b1e5b3a3b"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 5,
-          "line": 248,
+          "line": 257,
           "sha256": "88017a21a68eb150eaaf2a5217d35e9b4d930661a74cdda87f8b3938f6073d15"
         }
       ],
@@ -1726,35 +1860,35 @@
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 1,
-          "line": 262,
+          "line": 271,
           "sha256": "f1c7b61a74c050d3b5044973e899c70b74cad56ae0d775a1c370227b2554e558"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 2,
-          "line": 263,
+          "line": 272,
           "sha256": "b4e7755cb3b54ed9400756f86c10c858a95d4439686e2d0a9bdb1752fd673066"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 3,
-          "line": 264,
+          "line": 273,
           "sha256": "501e0bb7eed827cbc90d37b2aa9536777f4893de0b075ef6269dacfba8f94671"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 4,
-          "line": 265,
+          "line": 274,
           "sha256": "0491e9aacca737903a046d7da3901ae168145ed83b3b07ce7ca67d1803b58d41"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 5,
-          "line": 266,
+          "line": 275,
           "sha256": "0d288d69cd7407b7c4f02c4f4d616356203ec2ae445f211d922317dbae06d6fb"
         }
       ],
@@ -1862,21 +1996,21 @@
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 1,
-          "line": 295,
+          "line": 304,
           "sha256": "29e78a6c2780f8195dd6def758c19769a7af32bb935dcff29d1cc51025473ffa"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 2,
-          "line": 296,
+          "line": 305,
           "sha256": "c932b35fc3a91076a733f7102c49400e6bf24507e8de7243f9789c898295d73c"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 3,
-          "line": 297,
+          "line": 306,
           "sha256": "2a4f6d2e6732e2f4816ee15011101bdda9a56aea8068ac90a4c8a332cc11c8a4"
         }
       ],
@@ -2623,14 +2757,14 @@
           "path": "book/src/introduction.md",
           "anchor": "quick-start",
           "ordinal": 1,
-          "line": 18,
+          "line": 19,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "book/src/introduction.md",
           "anchor": "quick-start",
           "ordinal": 2,
-          "line": 19,
+          "line": 20,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],
@@ -7521,104 +7655,139 @@
           "anchor": "published-packages",
           "ordinal": 1,
           "line": 19,
-          "sha256": "0462ca496f450df619dcb4017984317e2652a2f95199478ea00bd4049627cf5d"
+          "sha256": "1d6e1a12b5452f7e1405c351ae26ae835ac16049c0d1cda67a2f53b2bf1bf57e"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 2,
           "line": 20,
-          "sha256": "8a44c0f2ebc009dad4c635c729b8ea100a31ef138c790b1aac603f1d933befd6"
+          "sha256": "0b813d1650febb4c1f31bc560b2f2aa580705c5c9d3ab12b4b1f5ec793fd2c5d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 3,
           "line": 21,
-          "sha256": "aa870f21166f41c57777a308416bee32579b5a576defb53386e782e08b9ff2f0"
+          "sha256": "471d1af3689109841837003b2b4ac60d47aaf9bf4319a34e15efa7e718e6832d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 4,
           "line": 27,
-          "sha256": "0b6dc704c7ad78639d4add20f86767c63033b82a655dd22a1d2f8e0fee82101b"
+          "sha256": "b9174d7ed497aa3b5529de96441715a34dbf6911366c8540731e66832a563e9b"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 5,
           "line": 28,
-          "sha256": "2b1f79dd8dba60e5633cd7bdb91c69f285a7eacf8fc960bcf79751c8ed79a7a3"
+          "sha256": "e00503ff233549fc1daec3cc10235f5b30ac78b9cfcd0dc47ad2fff194837335"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 6,
           "line": 29,
-          "sha256": "a38ce36833889aff4b8d395a88ea0afbed96a04d44bb13db5bb84855932ebe9e"
+          "sha256": "abd70088acd0fac4631a0dfd52a239499e4216ac2c0305fc43cfcedfda6c3db7"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 7,
-          "line": 38,
-          "sha256": "0181235db7ef5c749f69a9627f17c9c871a949b3bf1c1eedf94698e6d108803f"
+          "line": 40,
+          "sha256": "aa0671dacc44c2c48feaad62d25bf3a02c0c1aceb940b6786a3114e1eedb9d9d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 8,
-          "line": 39,
-          "sha256": "783e95edfb969caae3953df306370a18bcd29281e887b6c6ff12d8c8c1729e6b"
+          "line": 41,
+          "sha256": "db669176a1278005f8bcde5d1682cc1d3a13c93f49f9a0c55c2e54b44a23e118"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 9,
-          "line": 40,
-          "sha256": "e77b03fb327a535d75580081d05b8d9d416ace643e8006ffe07acb93a4b15984"
+          "line": 42,
+          "sha256": "cfa218cac036ffaa7bdee6b59410296dc357d89a8926ec3befb2adb42a6511ff"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 11,
-          "line": 60,
+          "line": 56,
           "sha256": "9593a0eb481eee53b056644aa9c6086216e05d959961113efacd5a304b99699d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
+          "ordinal": 12,
+          "line": 72,
+          "sha256": "b077c77e49cfc12a5cf375bc2dac3169eef7f59c1516d4a7bb320a69cfda3edd"
+        },
+        {
+          "path": "docs/quickstart.md",
+          "anchor": "published-packages",
+          "ordinal": 13,
+          "line": 74,
+          "sha256": "2c23cb438d760a78c3dbe9315a08258df691f9a0f01a83c44c776bf52bb9704b"
+        },
+        {
+          "path": "docs/quickstart.md",
+          "anchor": "published-packages",
           "ordinal": 14,
-          "line": 90,
-          "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
+          "line": 75,
+          "sha256": "fbb4f2e9a16dfac090576af21bcca2afd1aa851a733ea602d0e09fbc4e9558c1"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 15,
-          "line": 91,
-          "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
+          "line": 76,
+          "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
           "ordinal": 16,
-          "line": 92,
+          "line": 77,
+          "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
+        },
+        {
+          "path": "docs/quickstart.md",
+          "anchor": "published-packages",
+          "ordinal": 20,
+          "line": 102,
+          "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
+        },
+        {
+          "path": "docs/quickstart.md",
+          "anchor": "published-packages",
+          "ordinal": 21,
+          "line": 103,
+          "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
+        },
+        {
+          "path": "docs/quickstart.md",
+          "anchor": "published-packages",
+          "ordinal": 22,
+          "line": 104,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 17,
-          "line": 98,
+          "ordinal": 23,
+          "line": 110,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 18,
-          "line": 99,
+          "ordinal": 24,
+          "line": 111,
           "sha256": "f64e829871b2f7998fdbf8a8f7c4a36f917acc719880c9d14bc6565a6f1607ca"
         }
       ],
@@ -7626,7 +7795,7 @@
         {
           "id": "example-1",
           "adapter": "manual",
-          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb &&",
+          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock_0.2.0-1.deb13u1_amd64.deb &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7639,7 +7808,7 @@
         {
           "id": "example-2",
           "adapter": "manual",
-          "raw": "printf '%s  %s\\n' '36fede353b2eed7ab98e7ecf1ca4cca5ae7e6ab6820df8de27734c4a992467aa' 'facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb' | sha256sum --check - &&",
+          "raw": "printf '%s  %s\\n' '2554a1dcd4eca7bb1e3c2f2fbafbffa31d2c6a84210d32e9e221ece9e6e8dace' 'facelock_0.2.0-1.deb13u1_amd64.deb' | sha256sum --check - &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7652,7 +7821,7 @@
         {
           "id": "example-3",
           "adapter": "manual",
-          "raw": "sudo apt install ./facelock_0.2.0.alpha.4-1.deb13u1_amd64.deb",
+          "raw": "sudo apt install ./facelock_0.2.0-1.deb13u1_amd64.deb",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7665,7 +7834,7 @@
         {
           "id": "example-4",
           "adapter": "manual",
-          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb &&",
+          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock_0.2.0-1.ubuntu26.04.1_amd64.deb &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7678,7 +7847,7 @@
         {
           "id": "example-5",
           "adapter": "manual",
-          "raw": "printf '%s  %s\\n' 'cdddbdb6a3e7a1fa9ac56de0f8521ca9538ba01495ef9744aa18bc158646f8a2' 'facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb' | sha256sum --check - &&",
+          "raw": "printf '%s  %s\\n' 'ee4bc06963752bf39e888c2d10ba5229f256978d0b14b134463e19525b323d79' 'facelock_0.2.0-1.ubuntu26.04.1_amd64.deb' | sha256sum --check - &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7691,7 +7860,7 @@
         {
           "id": "example-6",
           "adapter": "manual",
-          "raw": "sudo apt install ./facelock_0.2.0.alpha.4-1.ubuntu26.04.1_amd64.deb",
+          "raw": "sudo apt install ./facelock_0.2.0-1.ubuntu26.04.1_amd64.deb",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7704,7 +7873,7 @@
         {
           "id": "example-7",
           "adapter": "manual",
-          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0-alpha.4/facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm &&",
+          "raw": "curl -fLO https://github.com/tyvsmith/facelock/releases/download/v0.2.0/facelock-0.2.0-1.fc44.x86_64.rpm &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7717,7 +7886,7 @@
         {
           "id": "example-8",
           "adapter": "manual",
-          "raw": "printf '%s  %s\\n' '788fb323f8dcb27f99591a175d40fcc05bd81afbe5e1efbcc01b48a19ffe26f1' 'facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm' | sha256sum --check - &&",
+          "raw": "printf '%s  %s\\n' '65cf7d3167979daa8d5af6f0e5c96c25d21c6b27b07a47d8dd212007fab725c5' 'facelock-0.2.0-1.fc44.x86_64.rpm' | sha256sum --check - &&",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7730,7 +7899,7 @@
         {
           "id": "example-9",
           "adapter": "manual",
-          "raw": "sudo dnf install ./facelock-0.2.0-0.4.alpha.4.fc44.x86_64.rpm",
+          "raw": "sudo dnf install ./facelock-0.2.0-1.fc44.x86_64.rpm",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7756,7 +7925,7 @@
         {
           "id": "example-11",
           "adapter": "manual",
-          "raw": "sudo dnf install dnf5-plugins",
+          "raw": "sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg  -o /usr/share/keyrings/tysmith-archive-keyring.gpg",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7769,7 +7938,7 @@
         {
           "id": "example-12",
           "adapter": "manual",
-          "raw": "sudo dnf copr enable tyvsmith/facelock",
+          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" |",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7782,7 +7951,7 @@
         {
           "id": "example-13",
           "adapter": "manual",
-          "raw": "sudo dnf install facelock",
+          "raw": "sudo tee /etc/apt/sources.list.d/facelock.list",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7795,7 +7964,7 @@
         {
           "id": "example-14",
           "adapter": "manual",
-          "raw": "sudo facelock setup",
+          "raw": "sudo apt update",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -7807,6 +7976,71 @@
         },
         {
           "id": "example-15",
+          "adapter": "manual",
+          "raw": "sudo apt install facelock",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-16",
+          "adapter": "manual",
+          "raw": "sudo dnf install dnf5-plugins",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-17",
+          "adapter": "manual",
+          "raw": "sudo dnf copr enable tyvsmith/facelock",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-18",
+          "adapter": "manual",
+          "raw": "sudo dnf install facelock",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-19",
+          "adapter": "manual",
+          "raw": "sudo facelock setup",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-20",
           "adapter": "manual",
           "raw": "sudo facelock test",
           "classification": "executable",
@@ -7857,112 +8091,112 @@
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 1,
-          "line": 123,
+          "line": 135,
           "sha256": "ff8195c4ae6218ff221c52bc8fddd04740ffe18424173f6bae17f94a689e13a2"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 2,
-          "line": 131,
+          "line": 143,
           "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 3,
-          "line": 132,
+          "line": 144,
           "sha256": "d083d8c1835c7a878a0028ffe95a9d8657a34bf54d9c77df60cf96f48fe8c42d"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 4,
-          "line": 133,
+          "line": 145,
           "sha256": "688d76820168760e13f5199233f25c2fa8f6e0b0f4da4b0d4b6eee06564398b6"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 5,
-          "line": 139,
+          "line": 151,
           "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 6,
-          "line": 140,
+          "line": 152,
           "sha256": "01d7cf22bcecf66729c8d81a6ed4b9e9b796968f7d83ab5fe387b53eb8ea1ae0"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 8,
-          "line": 148,
+          "line": 160,
           "sha256": "d75ce10dd306f1d3969df3610179fe1364f05b90fa2be6b3d087c4badc3db984"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 9,
-          "line": 164,
+          "line": 176,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 10,
-          "line": 165,
+          "line": 177,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 15,
-          "line": 176,
+          "line": 188,
           "sha256": "fad0225732307d9b8666dc48f93369322752b5acd641d744cde3a6d1c99155de"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 16,
-          "line": 177,
+          "line": 189,
           "sha256": "21df8681af24fdd4a24c8e7533d7c69725728fedd70374ac46b437b03686b526"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 17,
-          "line": 178,
+          "line": 190,
           "sha256": "e1a93dce67650786cc6126129be6427d1a8a96c0560e61b310b30e44e61bde57"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 18,
-          "line": 179,
+          "line": 191,
           "sha256": "db33444f34d115dce2f155297f23c717c86dd22e1e95cd0e44bf71ad6bec9fcf"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 19,
-          "line": 191,
+          "line": 203,
           "sha256": "ee643003c3bebb06741967affae1785b90ae552fcbf30142419a9d7fa0415d59"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 20,
-          "line": 192,
+          "line": 204,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "source-build-prerequisites",
           "ordinal": 21,
-          "line": 193,
+          "line": 205,
           "sha256": "f64e829871b2f7998fdbf8a8f7c4a36f917acc719880c9d14bc6565a6f1607ca"
         }
       ],
@@ -8214,35 +8448,35 @@
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 1,
-          "line": 232,
+          "line": 244,
           "sha256": "7047dae1de5957a90be1c7a3cfcc6abe298930cbfcdd6838f4a06295a7d565ce"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 2,
-          "line": 233,
+          "line": 245,
           "sha256": "97fe7e4851d163ea954392ba9c6fbfa704c8f3e1ef28996b794b45a7b4551907"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 3,
-          "line": 234,
+          "line": 246,
           "sha256": "d8e28448d4f6a66c71332ec6cc573065c0863083d2dde4dbd395d6fe1c8882a1"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 4,
-          "line": 235,
+          "line": 247,
           "sha256": "b01a1ffc2b4ef9721bb5ce35a004dd6ce17743083fa0670424a5caeb985dd7a6"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "explore-safely",
           "ordinal": 5,
-          "line": 236,
+          "line": 248,
           "sha256": "c5daf997e938d2c8a1aeed87aaf0e3f000d211290ff0fdd9861be7ce2fa738ed"
         }
       ],
@@ -8349,21 +8583,21 @@
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 1,
-          "line": 248,
+          "line": 260,
           "sha256": "4547cf4ed51d13a8755d4c904f2a1773778fb1af9481d51ac64373378ec09873"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 3,
-          "line": 263,
+          "line": 275,
           "sha256": "b2eaa0d6e49d61a0a83ddb30434dfff25bda1608545252375dd2eeca201b320a"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "package-lifecycle-and-retained-data",
           "ordinal": 4,
-          "line": 264,
+          "line": 276,
           "sha256": "cd370c0da2fc6b4b0a0c94762df10329fb29a2eec64e260f87f372c4856d9178"
         }
       ],
@@ -8445,21 +8679,21 @@
           "path": "docs/releasing.md",
           "anchor": "automated-recommended",
           "ordinal": 1,
-          "line": 77,
+          "line": 75,
           "sha256": "a9f574ec661d3125f29382308db0eb3bbf7652389b49d1bf41c4728f7b5f3885"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "automated-recommended",
           "ordinal": 2,
-          "line": 79,
+          "line": 77,
           "sha256": "1a220c2385020dbc6d853be67d1d89243424d6bc01da6391b73745a94eb51cdb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "automated-recommended",
           "ordinal": 7,
-          "line": 92,
+          "line": 90,
           "sha256": "090133abf7496a183de2ede915b3c07456de52d4d69186c20414253349729ab0"
         }
       ],
@@ -8542,112 +8776,112 @@
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 1,
-          "line": 311,
+          "line": 309,
           "sha256": "21fbb4c9a7b22a0439e070e8122853880927532ba554ea0204fd0ede5fa3ebbb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 2,
-          "line": 312,
+          "line": 310,
           "sha256": "d5ce836f401484bd835100b165e1c2234b437780616e27bb92f5403d0f22bc40"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 3,
-          "line": 313,
+          "line": 311,
           "sha256": "b2b12dbf5cd38fc21d68548042e8eae1e66f65faa6491f3564e75c7cb60abc22"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 4,
-          "line": 314,
+          "line": 312,
           "sha256": "5595bcc3f9aa3517450a5185fe037e24b0a8ec079eff27020bf5c5aef68ffdb0"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 5,
-          "line": 315,
+          "line": 313,
           "sha256": "d0d568788326024851d047fe1e316af83028cbf98b17a777fd64c4e784151809"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 6,
-          "line": 316,
+          "line": 314,
           "sha256": "05d5991182864fc115e36763667a0d555cf256358ed52830129f8fd32ab925de"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 7,
-          "line": 317,
+          "line": 315,
           "sha256": "4830a79699c4a1fa28bbcdc2eb8e5712c7ac46f3fd2533bad0b097ab936e8413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 8,
-          "line": 318,
+          "line": 316,
           "sha256": "b1b141623a6849ba1a180dfa8e3d7eb504da148110c930be20e240eabd2323f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 9,
-          "line": 319,
+          "line": 317,
           "sha256": "9fcc5f55faef0fe3ceebfa0d6e7beb5e0281ab1b037fd3153ace2b72b3a64202"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 10,
-          "line": 320,
+          "line": 318,
           "sha256": "2877908694a9c4d1e9a8e8ca4605edd81026d7666c65b3c69bd180646b513b53"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 11,
-          "line": 321,
+          "line": 319,
           "sha256": "872db5f82702e535cc961ca606e0d46e18f134bfdcd12c06171b9adffc9ef8e8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 12,
-          "line": 322,
+          "line": 320,
           "sha256": "3bdfbcbee168b92e2cf8f520a54a827c805903faed4712a781af561ea3246037"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 13,
-          "line": 325,
+          "line": 323,
           "sha256": "cbe27321cd6d31c9676b5aa4998fd1b4f9195f719b00cda8f889c3b3b7dae276"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 14,
-          "line": 326,
+          "line": 324,
           "sha256": "0aece5ddd58b51f2dccb3e634e59f06c2a38c4f9bd0439197688c4e548e8895b"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 15,
-          "line": 327,
+          "line": 325,
           "sha256": "a10a4c45881ab16f35605739e0375de3e5558bc495111b49c7929d9b2d1603a0"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 16,
-          "line": 328,
+          "line": 326,
           "sha256": "640b0dca78c96225ae70191f4312212e60c6367fca24cab33a803b0ee94c7847"
         }
       ],
@@ -8901,49 +9135,49 @@
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 1,
-          "line": 462,
+          "line": 460,
           "sha256": "dedfaf04fd23448baa602a476c6e384ab674dfd1ad445e0c3e935b5a96a9a2f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 2,
-          "line": 463,
+          "line": 461,
           "sha256": "a07a3db4c0fd5697107f1591eb62f6a2c9a2ac0d3801e25844e5c244f6688915"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 3,
-          "line": 464,
+          "line": 462,
           "sha256": "d9a223daf1f784e1bd0313866cfbfcff4b2b4958708dfab4674bc3ddc63de570"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 4,
-          "line": 465,
+          "line": 463,
           "sha256": "108c5e8edc6582d4ee70c2b8573afe99a7be3f4ad8ddd11fc2b12c44e7079568"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 5,
-          "line": 466,
+          "line": 464,
           "sha256": "017092419ea31d5de3fd4b6e7a52b2dd239d134f423f81bd0f5c38992c212208"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 6,
-          "line": 467,
+          "line": 465,
           "sha256": "a77a5aea7a4e8dcf9901e8ac5ee041109d525ce2f2bd7f018a21918d70da1326"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 7,
-          "line": 468,
+          "line": 466,
           "sha256": "2b5e31a5fe163cb0998c87a9f505faf73a26e025df540bc210550dcb6cc27142"
         }
       ],
@@ -9076,231 +9310,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 546,
+          "line": 544,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 549,
+          "line": 547,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 550,
+          "line": 548,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 551,
+          "line": 549,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 552,
+          "line": 550,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 557,
+          "line": 555,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 558,
+          "line": 556,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 560,
+          "line": 558,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 561,
+          "line": 559,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 562,
+          "line": 560,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 563,
+          "line": 561,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 564,
+          "line": 562,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 565,
+          "line": 563,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 566,
+          "line": 564,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 569,
+          "line": 567,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 570,
+          "line": 568,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 571,
+          "line": 569,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 572,
+          "line": 570,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 573,
+          "line": 571,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 574,
+          "line": 572,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 575,
+          "line": 573,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 576,
+          "line": 574,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 577,
+          "line": 575,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 580,
+          "line": 578,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 581,
+          "line": 579,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 582,
+          "line": 580,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 583,
+          "line": 581,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 584,
+          "line": 582,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 585,
+          "line": 583,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 586,
+          "line": 584,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 587,
+          "line": 585,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 591,
+          "line": 589,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 595,
+          "line": 593,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -9771,21 +10005,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 771,
+          "line": 769,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 772,
+          "line": 770,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 773,
+          "line": 771,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -9867,14 +10101,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 877,
+          "line": 875,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 878,
+          "line": 876,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -9942,21 +10176,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 905,
+          "line": 903,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 912,
-          "sha256": "2120970caf76141c5840f3c94b1f591cfd64be5b8b0909ba582421dcfc2130a2"
+          "line": 910,
+          "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 917,
+          "line": 915,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -9977,7 +10211,7 @@
         {
           "id": "example-2",
           "adapter": "manual",
-          "raw": "gpg --armor --export-secret-keys \"packages@tysmith.me\" | gh secret set APT_GPG_PRIVATE_KEY",
+          "raw": "gpg --armor --export-secret-keys \"packages@m.tysmith.me\" | gh secret set APT_GPG_PRIVATE_KEY",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -10037,56 +10271,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 956,
+          "line": 954,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 958,
+          "line": 956,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 962,
+          "line": 960,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 968,
+          "line": 966,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 969,
+          "line": 967,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 973,
+          "line": 971,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 974,
+          "line": 972,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 975,
+          "line": 973,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],
@@ -13013,7 +13247,8 @@
         "human-command-review",
         "section-prerequisites",
         "fixture-bindings",
-        "observed-postconditions"
+        "observed-postconditions",
+        "human-pam-recovery"
       ],
       "prerequisites": [
         "restore a pristine disposable guest for this section",
@@ -13031,49 +13266,98 @@
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 1,
-          "line": 362,
-          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
+          "line": 358,
+          "sha256": "2ea50ce44183686500ad4e9a7583f47d4477efcba1a3852a55ebfca43d427c8c"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 2,
-          "line": 362,
-          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
+          "line": 359,
+          "sha256": "39cc6a6f465cccaad652684e38819b46c2b36d1b867c5dd50f06bfeed63e29a5"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 3,
-          "line": 362,
-          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
+          "line": 360,
+          "sha256": "fe381e868a9481334ade7579a806ed8330cfd3ba1f5fceefbc40547e77ea46e3"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 4,
-          "line": 362,
-          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
+          "line": 363,
+          "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 5,
-          "line": 362,
-          "sha256": "b3f70d1b1c9cab5524d00a5c658ebd69e63cf592ffbbf1e7ea456604846747fc"
+          "line": 366,
+          "sha256": "8d5c472cde3f3e4834455ea132df1cd26fa7eb26b5a2ef18148e9e316d5571eb"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 6,
-          "line": 362,
+          "line": 366,
           "sha256": "50573ac999b4f7516852df798aafddb1ef893a0352b7c1c7559b984eb5a40bbc"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 7,
-          "line": 362,
+          "line": 366,
+          "sha256": "5091ecd9f04a903af2f78e817245c573946f975af06bcd5ea4dcbda39ef4fb29"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 8,
+          "line": 367,
+          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 9,
+          "line": 367,
+          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 10,
+          "line": 367,
+          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 11,
+          "line": 367,
+          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 12,
+          "line": 367,
+          "sha256": "b3f70d1b1c9cab5524d00a5c658ebd69e63cf592ffbbf1e7ea456604846747fc"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 13,
+          "line": 367,
+          "sha256": "50573ac999b4f7516852df798aafddb1ef893a0352b7c1c7559b984eb5a40bbc"
+        },
+        {
+          "path": "website/index.html",
+          "anchor": "install-debian",
+          "ordinal": 14,
+          "line": 367,
           "sha256": "8d5c472cde3f3e4834455ea132df1cd26fa7eb26b5a2ef18148e9e316d5571eb"
         }
       ],
@@ -13081,7 +13365,7 @@
         {
           "id": "example-1",
           "adapter": "manual",
-          "raw": "main",
+          "raw": "sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg -o /usr/share/keyrings/tysmith-archive-keyring.gpg",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13094,7 +13378,7 @@
         {
           "id": "example-2",
           "adapter": "manual",
-          "raw": "legacy",
+          "raw": "echo \"deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock\" | sudo tee /etc/apt/sources.list.d/facelock.list",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13107,7 +13391,7 @@
         {
           "id": "example-3",
           "adapter": "manual",
-          "raw": "main",
+          "raw": "sudo apt update && sudo apt install facelock",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13120,7 +13404,7 @@
         {
           "id": "example-4",
           "adapter": "manual",
-          "raw": "legacy",
+          "raw": "sudo facelock setup",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13133,7 +13417,7 @@
         {
           "id": "example-5",
           "adapter": "manual",
-          "raw": "apt update",
+          "raw": "resolute",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13158,6 +13442,97 @@
         },
         {
           "id": "example-7",
+          "adapter": "manual",
+          "raw": ".deb",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-8",
+          "adapter": "manual",
+          "raw": "main",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-9",
+          "adapter": "manual",
+          "raw": "legacy",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-10",
+          "adapter": "manual",
+          "raw": "main",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-11",
+          "adapter": "manual",
+          "raw": "legacy",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-12",
+          "adapter": "manual",
+          "raw": "apt update",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-13",
+          "adapter": "manual",
+          "raw": "trixie",
+          "classification": "executable",
+          "expect_exit": 0,
+          "expect_output": "",
+          "expect_state": [
+            "documented-effect-observed"
+          ],
+          "timeout_seconds": 1800,
+          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
+        },
+        {
+          "id": "example-14",
           "adapter": "manual",
           "raw": "resolute",
           "classification": "executable",
@@ -13205,21 +13580,21 @@
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 1,
-          "line": 376,
+          "line": 382,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 2,
-          "line": 377,
+          "line": 383,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         },
         {
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 3,
-          "line": 380,
+          "line": 386,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         }
       ],
@@ -13299,28 +13674,28 @@
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 1,
-          "line": 414,
+          "line": 421,
           "sha256": "a3fc2994d459b28929eddd20bb7e85f077845642fb89e330c3e03cbe66264bb3"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 2,
-          "line": 415,
+          "line": 422,
           "sha256": "ec83c5e11815f6e2c810bbf770be6d0cb5e4403614eb8810a2f59278e0a1170b"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 3,
-          "line": 416,
+          "line": 423,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 4,
-          "line": 417,
+          "line": 424,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -1278,7 +1278,7 @@
           "path": "README.md",
           "anchor": "arch-linux-aur",
           "ordinal": 1,
-          "line": 27,
+          "line": 26,
           "sha256": "d362fd362389741be7a261a22cf3cb04edfabb48d43d545e4685ca00b4a1c743"
         }
       ],
@@ -1332,28 +1332,28 @@
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 1,
-          "line": 45,
+          "line": 44,
           "sha256": "b077c77e49cfc12a5cf375bc2dac3169eef7f59c1516d4a7bb320a69cfda3edd"
         },
         {
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 2,
-          "line": 47,
+          "line": 46,
           "sha256": "39cc6a6f465cccaad652684e38819b46c2b36d1b867c5dd50f06bfeed63e29a5"
         },
         {
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 3,
-          "line": 48,
+          "line": 47,
           "sha256": "bec61f0cc5aa5062a5d2ff6b8fabf8bbaf4973e379679cf1408a26d13d3ee0ca"
         },
         {
           "path": "README.md",
           "anchor": "debian--ubuntu-apt",
           "ordinal": 4,
-          "line": 49,
+          "line": 48,
           "sha256": "5647298b8460512fdc69d40fc4e49e6d2f2d1fe51260df207cb9943907e59167"
         }
       ],
@@ -1445,22 +1445,22 @@
         {
           "path": "README.md",
           "anchor": "fedora-copr",
-          "ordinal": 1,
-          "line": 72,
+          "ordinal": 2,
+          "line": 70,
           "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
-          "ordinal": 2,
-          "line": 73,
+          "ordinal": 3,
+          "line": 71,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "README.md",
           "anchor": "fedora-copr",
-          "ordinal": 3,
-          "line": 74,
+          "ordinal": 4,
+          "line": 72,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         }
       ],
@@ -1540,14 +1540,14 @@
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 1,
-          "line": 84,
+          "line": 82,
           "sha256": "d091076a0b6859d8a04b9e50b052b819a80d6a4fe3b6336bdbbda387de310be0"
         },
         {
           "path": "README.md",
           "anchor": "from-source",
           "ordinal": 2,
-          "line": 85,
+          "line": 83,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],
@@ -1614,7 +1614,7 @@
           "path": "README.md",
           "anchor": "post-install",
           "ordinal": 1,
-          "line": 105,
+          "line": 103,
           "sha256": "13ece4f24ba1175dd24829a6e605712bee3c028c5505562d6f7dc6616ef1bb63"
         }
       ],
@@ -1669,7 +1669,7 @@
           "path": "README.md",
           "anchor": "uninstall",
           "ordinal": 1,
-          "line": 140,
+          "line": 138,
           "sha256": "d51310f315784b2a9c33e5d9294b3c51087ed1e1372dcfa10a29f3d34b1efbde"
         }
       ],
@@ -1723,28 +1723,28 @@
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 2,
-          "line": 253,
+          "line": 251,
           "sha256": "270315a785e93c84e21e959de6561428bf475b40b6096a19a5bdfc20555fa93d"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 3,
-          "line": 254,
+          "line": 252,
           "sha256": "599de770b8b0e87ca01f6837e309d01e9847d347fd850d18ded4eb14e86cc015"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 4,
-          "line": 255,
+          "line": 253,
           "sha256": "d3a74681ef70d90250e1ac050d1d8510753888e9da5dfee69b81ba6b1e5b3a3b"
         },
         {
           "path": "README.md",
           "anchor": "hyprlock-integration",
           "ordinal": 5,
-          "line": 256,
+          "line": 254,
           "sha256": "88017a21a68eb150eaaf2a5217d35e9b4d930661a74cdda87f8b3938f6073d15"
         }
       ],
@@ -1840,35 +1840,35 @@
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 1,
-          "line": 270,
+          "line": 268,
           "sha256": "f1c7b61a74c050d3b5044973e899c70b74cad56ae0d775a1c370227b2554e558"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 2,
-          "line": 271,
+          "line": 269,
           "sha256": "b4e7755cb3b54ed9400756f86c10c858a95d4439686e2d0a9bdb1752fd673066"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 3,
-          "line": 272,
+          "line": 270,
           "sha256": "501e0bb7eed827cbc90d37b2aa9536777f4893de0b075ef6269dacfba8f94671"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 4,
-          "line": 273,
+          "line": 271,
           "sha256": "0491e9aacca737903a046d7da3901ae168145ed83b3b07ce7ca67d1803b58d41"
         },
         {
           "path": "README.md",
           "anchor": "testing",
           "ordinal": 5,
-          "line": 274,
+          "line": 272,
           "sha256": "0d288d69cd7407b7c4f02c4f4d616356203ec2ae445f211d922317dbae06d6fb"
         }
       ],
@@ -1976,21 +1976,21 @@
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 1,
-          "line": 303,
+          "line": 301,
           "sha256": "29e78a6c2780f8195dd6def758c19769a7af32bb935dcff29d1cc51025473ffa"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 2,
-          "line": 304,
+          "line": 302,
           "sha256": "c932b35fc3a91076a733f7102c49400e6bf24507e8de7243f9789c898295d73c"
         },
         {
           "path": "README.md",
           "anchor": "releasing",
           "ordinal": 3,
-          "line": 305,
+          "line": 303,
           "sha256": "2a4f6d2e6732e2f4816ee15011101bdda9a56aea8068ac90a4c8a332cc11c8a4"
         }
       ],
@@ -7731,35 +7731,35 @@
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 19,
+          "ordinal": 20,
           "line": 101,
           "sha256": "2e795222d6d436e587ec1690c6a50343257ba9c66f6e2510ee0bd6fd65cfa5be"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 20,
+          "ordinal": 21,
           "line": 102,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 21,
+          "ordinal": 22,
           "line": 103,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 22,
+          "ordinal": 23,
           "line": 109,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         },
         {
           "path": "docs/quickstart.md",
           "anchor": "published-packages",
-          "ordinal": 23,
+          "ordinal": 24,
           "line": 110,
           "sha256": "f64e829871b2f7998fdbf8a8f7c4a36f917acc719880c9d14bc6565a6f1607ca"
         }
@@ -13254,69 +13254,48 @@
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 5,
-          "line": 366,
-          "sha256": "8d5c472cde3f3e4834455ea132df1cd26fa7eb26b5a2ef18148e9e316d5571eb"
+          "line": 367,
+          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 6,
-          "line": 366,
-          "sha256": "50573ac999b4f7516852df798aafddb1ef893a0352b7c1c7559b984eb5a40bbc"
+          "line": 367,
+          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 7,
-          "line": 366,
-          "sha256": "5091ecd9f04a903af2f78e817245c573946f975af06bcd5ea4dcbda39ef4fb29"
+          "line": 367,
+          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 8,
           "line": 367,
-          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
+          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 9,
           "line": 367,
-          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
+          "sha256": "b3f70d1b1c9cab5524d00a5c658ebd69e63cf592ffbbf1e7ea456604846747fc"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
           "ordinal": 10,
           "line": 367,
-          "sha256": "0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605"
-        },
-        {
-          "path": "website/index.html",
-          "anchor": "install-debian",
-          "ordinal": 11,
-          "line": 367,
-          "sha256": "c49fea7425fa7f8699897a97c159c6690267d9003bb78c53fafa8fc15c325d84"
-        },
-        {
-          "path": "website/index.html",
-          "anchor": "install-debian",
-          "ordinal": 12,
-          "line": 367,
-          "sha256": "b3f70d1b1c9cab5524d00a5c658ebd69e63cf592ffbbf1e7ea456604846747fc"
-        },
-        {
-          "path": "website/index.html",
-          "anchor": "install-debian",
-          "ordinal": 13,
-          "line": 367,
           "sha256": "50573ac999b4f7516852df798aafddb1ef893a0352b7c1c7559b984eb5a40bbc"
         },
         {
           "path": "website/index.html",
           "anchor": "install-debian",
-          "ordinal": 14,
+          "ordinal": 11,
           "line": 367,
           "sha256": "8d5c472cde3f3e4834455ea132df1cd26fa7eb26b5a2ef18148e9e316d5571eb"
         }
@@ -13377,7 +13356,7 @@
         {
           "id": "example-5",
           "adapter": "manual",
-          "raw": "resolute",
+          "raw": "main",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13390,7 +13369,7 @@
         {
           "id": "example-6",
           "adapter": "manual",
-          "raw": "trixie",
+          "raw": "legacy",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13403,7 +13382,7 @@
         {
           "id": "example-7",
           "adapter": "manual",
-          "raw": ".deb",
+          "raw": "main",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13416,7 +13395,7 @@
         {
           "id": "example-8",
           "adapter": "manual",
-          "raw": "main",
+          "raw": "legacy",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13429,7 +13408,7 @@
         {
           "id": "example-9",
           "adapter": "manual",
-          "raw": "legacy",
+          "raw": "apt update",
           "classification": "executable",
           "expect_exit": 0,
           "expect_output": "",
@@ -13442,45 +13421,6 @@
         {
           "id": "example-10",
           "adapter": "manual",
-          "raw": "main",
-          "classification": "executable",
-          "expect_exit": 0,
-          "expect_output": "",
-          "expect_state": [
-            "documented-effect-observed"
-          ],
-          "timeout_seconds": 1800,
-          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
-        },
-        {
-          "id": "example-11",
-          "adapter": "manual",
-          "raw": "legacy",
-          "classification": "executable",
-          "expect_exit": 0,
-          "expect_output": "",
-          "expect_state": [
-            "documented-effect-observed"
-          ],
-          "timeout_seconds": 1800,
-          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
-        },
-        {
-          "id": "example-12",
-          "adapter": "manual",
-          "raw": "apt update",
-          "classification": "executable",
-          "expect_exit": 0,
-          "expect_output": "",
-          "expect_state": [
-            "documented-effect-observed"
-          ],
-          "timeout_seconds": 1800,
-          "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
-        },
-        {
-          "id": "example-13",
-          "adapter": "manual",
           "raw": "trixie",
           "classification": "executable",
           "expect_exit": 0,
@@ -13492,7 +13432,7 @@
           "expectation_review": "confirm the documented outcome and record any expected nonzero exit before execution"
         },
         {
-          "id": "example-14",
+          "id": "example-11",
           "adapter": "manual",
           "raw": "resolute",
           "classification": "executable",
@@ -13540,21 +13480,21 @@
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 1,
-          "line": 382,
+          "line": 381,
           "sha256": "8eba45884730ed55afa2db83c25b9c3705d77ef531e049660a90a340c7fa6271"
         },
         {
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 2,
-          "line": 383,
+          "line": 382,
           "sha256": "cca1272f7cd7cdad6f442a207120a0fe883056fa32d47a38752e2b5835dc147e"
         },
         {
           "path": "website/index.html",
           "anchor": "install-fedora",
           "ordinal": 3,
-          "line": 386,
+          "line": 385,
           "sha256": "ca4e91b10e08b3eea684df028fbcf56cc07df5f8abd9b5adc0dc30d78a7cc355"
         }
       ],
@@ -13634,28 +13574,28 @@
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 1,
-          "line": 421,
+          "line": 420,
           "sha256": "a3fc2994d459b28929eddd20bb7e85f077845642fb89e330c3e03cbe66264bb3"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 2,
-          "line": 422,
+          "line": 421,
           "sha256": "ec83c5e11815f6e2c810bbf770be6d0cb5e4403614eb8810a2f59278e0a1170b"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 3,
-          "line": 423,
+          "line": 422,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "website/index.html",
           "anchor": "install-source",
           "ordinal": 4,
-          "line": 424,
+          "line": 423,
           "sha256": "6082e4887a6f179f954cd8675b9e9f70206b23a40a9585b84f3fe9cb5f19bdef"
         }
       ],

--- a/website/index.html
+++ b/website/index.html
@@ -363,7 +363,7 @@
               <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
-          <p class="install-note">Ubuntu 26.04 writes <code>resolute</code> in place of <code>trixie</code>. <a href="docs/quickstart.html#published-packages">Check the keyring fingerprint</a> before trusting the source, or install the suite-specific <code>.deb</code> directly from the release.</p>
+          <p class="install-note">On Ubuntu 26.04, use <code>resolute</code> instead of <code>trixie</code> in the source line. <a href="docs/quickstart.html#published-packages">Check the keyring fingerprint</a> before trusting the source, or install the suite-specific <code>.deb</code> directly from the release.</p>
           <p class="install-note migration">Under the compatibility policy, existing v0.1.4 entries naming <code>main</code> or <code>legacy</code> keep working until 0.3.0. <code>main</code> maps to Trixie and <code>legacy</code> exports empty indexes. At 0.3.0, <code>apt update</code> fails until the entry is removed. Rewrite those entries to <code>trixie</code> or <code>resolute</code> now.</p>
         </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -311,7 +311,7 @@
       <div class="section-header center">
         <div class="section-label">Quick Install</div>
         <h2 class="section-title">Choose an installation channel</h2>
-        <p class="section-desc">Channel status checked 2026-09-06: <a href="https://github.com/tyvsmith/facelock/releases/tag/v0.2.0">v0.2.0</a> is the latest stable release, published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. The AUR entries and both APT suites serve it. Production COPR still serves v0.1.3.</p>
+        <p class="section-desc">Channel status checked 2026-09-06: <a href="https://github.com/tyvsmith/facelock/releases/tag/v0.2.0">v0.2.0</a> is the latest stable release, published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. Every stable channel serves it: the three AUR entries, both APT suites, and the production COPR.</p>
       </div>
 
       <div class="install-block">
@@ -363,7 +363,7 @@
               <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
-          <p class="install-note">On Ubuntu 26.04, use <code>resolute</code> instead of <code>trixie</code> in the source line. <a href="docs/quickstart.html#published-packages">Check the keyring fingerprint</a> before trusting the source, or install the suite-specific <code>.deb</code> directly from the release.</p>
+          <p class="install-note">On Ubuntu 26.04, use the resolute suite instead of trixie in the source line. <a href="docs/quickstart.html#published-packages">Check the keyring fingerprint</a> before trusting the source, or install the suite-specific Debian package directly from the release.</p>
           <p class="install-note migration">Under the compatibility policy, existing v0.1.4 entries naming <code>main</code> or <code>legacy</code> keep working until 0.3.0. <code>main</code> maps to Trixie and <code>legacy</code> exports empty indexes. At 0.3.0, <code>apt update</code> fails until the entry is removed. Rewrite those entries to <code>trixie</code> or <code>resolute</code> now.</p>
         </div>
 
@@ -376,8 +376,7 @@
               <span class="terminal-title">terminal</span>
             </div>
             <div class="terminal-body">
-              <div><span class="comment"># Supported Fedora targets: 43/44/45. Production COPR served v0.1.3 on 2026-09-06,</span></div>
-              <div><span class="comment"># behind stable 0.2.0, so these commands install 0.1.3, not the current release.</span></div>
+              <div><span class="comment"># Supported Fedora targets: 43/44/45. Production COPR served 0.2.0-1 on 2026-09-06.</span></div>
               <div><span class="comment"># The copr subcommand requires dnf5-plugins; see the prerequisite notes.</span></div>
               <div><span class="prompt">$</span> <span class="command">sudo dnf copr enable tyvsmith/facelock</span></div>
               <div><span class="prompt">$</span> <span class="command">sudo dnf install facelock</span></div>
@@ -386,7 +385,7 @@
               <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
-          <p class="install-note"><a href="docs/quickstart.html#published-packages">Install the checksum-verified 0.2.0 RPM directly</a> until the production COPR catches up.</p>
+          <p class="install-note">The older 0.1.3 build stays in the repository, and dnf resolves to 0.2.0. <a href="docs/quickstart.html#published-packages">A checksum-verified RPM</a> is also published on the release.</p>
         </div>
 
         <div id="install-nixos" class="install-panel" role="tabpanel" hidden>

--- a/website/index.html
+++ b/website/index.html
@@ -311,7 +311,7 @@
       <div class="section-header center">
         <div class="section-label">Quick Install</div>
         <h2 class="section-title">Choose an installation channel</h2>
-        <p class="section-desc">Channel status checked 2026-09-05: v0.1.4 is the latest stable release. <a href="https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4">v0.2.0-alpha.4</a> is published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. Prereleases do not enter stable AUR, APT, or production COPR.</p>
+        <p class="section-desc">Channel status checked 2026-09-06: <a href="https://github.com/tyvsmith/facelock/releases/tag/v0.2.0">v0.2.0</a> is the latest stable release, published with direct Debian 13, Ubuntu 26.04, and Fedora 44 packages. The AUR entries and both APT suites serve it. Production COPR still serves v0.1.3.</p>
       </div>
 
       <div class="install-block">
@@ -350,16 +350,21 @@
               <span class="terminal-title">terminal</span>
             </div>
             <div class="terminal-body">
-              <div><span class="comment"># Planned 0.2.0 stable suites:</span></div>
+              <div><span class="comment"># Published 0.2.0 suites:</span></div>
               <div><span class="output">Debian 13 — trixie — amd64 — TPM</span></div>
               <div><span class="output">Ubuntu 26.04 — resolute — amd64 — TPM</span></div>
               <div>&nbsp;</div>
-              <div><span class="comment"># Future public base: https://tysmith.me/facelock/apt</span></div>
-              <div><span class="comment"># Stable APT suites are not published yet.</span></div>
-              <div><a href="https://github.com/tyvsmith/facelock/releases/tag/v0.2.0-alpha.4">Install the suite-specific alpha.4 .deb directly from the release.</a></div>
+              <div><span class="comment"># Public base: https://tysmith.me/facelock/apt. Write your own codename below.</span></div>
+              <div><span class="prompt">$</span> <span class="command">sudo curl -fsSL https://tysmith.me/facelock/apt/tysmith-archive-keyring.gpg -o /usr/share/keyrings/tysmith-archive-keyring.gpg</span></div>
+              <div><span class="prompt">$</span> <span class="command">echo "deb [signed-by=/usr/share/keyrings/tysmith-archive-keyring.gpg] https://tysmith.me/facelock/apt trixie facelock" | sudo tee /etc/apt/sources.list.d/facelock.list</span></div>
+              <div><span class="prompt">$</span> <span class="command">sudo apt update &amp;&amp; sudo apt install facelock</span></div>
+              <div>&nbsp;</div>
+              <div><span class="comment"># Run the interactive setup wizard</span></div>
+              <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
-          <p class="install-note migration">Under the compatibility policy, existing v0.1.4 entries naming <code>main</code> or <code>legacy</code> keep working until 0.3.0. The 0.2.0 stable publisher will map <code>main</code> to Trixie and export empty <code>legacy</code> indexes. At 0.3.0, <code>apt update</code> fails until the entry is removed. Do not rewrite an existing entry to <code>trixie</code> or <code>resolute</code> before those suites are actually published.</p>
+          <p class="install-note">Ubuntu 26.04 writes <code>resolute</code> in place of <code>trixie</code>. <a href="docs/quickstart.html#published-packages">Check the keyring fingerprint</a> before trusting the source, or install the suite-specific <code>.deb</code> directly from the release.</p>
+          <p class="install-note migration">Under the compatibility policy, existing v0.1.4 entries naming <code>main</code> or <code>legacy</code> keep working until 0.3.0. <code>main</code> maps to Trixie and <code>legacy</code> exports empty indexes. At 0.3.0, <code>apt update</code> fails until the entry is removed. Rewrite those entries to <code>trixie</code> or <code>resolute</code> now.</p>
         </div>
 
         <div id="install-fedora" class="install-panel" role="tabpanel" hidden>
@@ -371,7 +376,8 @@
               <span class="terminal-title">terminal</span>
             </div>
             <div class="terminal-body">
-              <div><span class="comment"># Supported Fedora targets: 43/44/45; production served v0.1.3 on 2026-09-05.</span></div>
+              <div><span class="comment"># Supported Fedora targets: 43/44/45. Production COPR served v0.1.3 on 2026-09-06,</span></div>
+              <div><span class="comment"># behind stable 0.2.0, so these commands install 0.1.3, not the current release.</span></div>
               <div><span class="comment"># The copr subcommand requires dnf5-plugins; see the prerequisite notes.</span></div>
               <div><span class="prompt">$</span> <span class="command">sudo dnf copr enable tyvsmith/facelock</span></div>
               <div><span class="prompt">$</span> <span class="command">sudo dnf install facelock</span></div>
@@ -380,6 +386,7 @@
               <div><span class="prompt">$</span> <span class="command">sudo facelock setup</span></div>
             </div>
           </div>
+          <p class="install-note"><a href="docs/quickstart.html#published-packages">Install the checksum-verified 0.2.0 RPM directly</a> until the production COPR catches up.</p>
         </div>
 
         <div id="install-nixos" class="install-panel" role="tabpanel" hidden>


### PR DESCRIPTION
## Why

The published install docs still describe the pre-release world. They name v0.1.4 as latest stable, hand out alpha.4 download commands whose URLs still resolve, report both APT suites as 404, and warn users away from an AUR recipe that now works. A user following them installs 0.2.0~alpha.4 or skips a live channel.

## What

- replace the alpha.4 `.deb` and `.rpm` commands with the v0.2.0 assets and their `MANIFEST.json` checksums
- add the APT install path, absent from every user-facing doc until now: keyring fetch, `signed-by` source entry, `resolute` substitution
- record the archive signing key fingerprint and fix its UID in the rotation steps
- drop the `facelock-git` ONNX Runtime warning; all three AUR recipes declare `onnxruntime`
- state that production COPR now serves 0.2.0 on Fedora 43, 44 and 45
- drop the obsolete note about package prompts asking for `enroll`

## Notes

- production COPR served 0.1.3 when this branch opened and picked up 0.2.0 mid-review, from the hand-submitted build; the Fedora text was rewritten rather than shipping the warning it started with
- GitHub rewrites the tilde in the Debian asset names, so the download URLs use the dotted names while `MANIFEST.json` keeps the native ones; the quickstart says so
- `test/docs-walkthrough/cases.json` pins moved by line only, every `sha256` unchanged

## Validation

- `just check-docs`, `just check-agent-docs`, `just test-release-contract`
- every documented install command run verbatim in a clean container: APT on Debian 13 and Ubuntu 26.04, the direct `.deb`, the direct `.rpm`, and `dnf copr enable` on Fedora 44
- live checks of the APT suites, the three AUR recipes, the keyring fingerprint, and the release download URLs against their manifest checksums

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and release guidance for stable v0.2.0 across APT, AUR, and production COPR.
  * Added verified SHA256 checksums and current installation commands for Debian, Ubuntu, and Fedora packages.
  * Clarified supported Fedora versions, retained older builds, package availability, and source-build details.
  * Updated APT repository, signing-key, compatibility, dependency, and package-component information.
  * Refreshed testing, release, and walkthrough documentation, including unpublished APT run behavior and package verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->