### PR TITLE
build(release): build the binary asset with the tpm feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,15 @@ jobs:
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Build release
-        run: cargo build --release --workspace
+        run: cargo build --release --workspace --features tpm
 
       - name: Prepare artifacts
         run: |
           mkdir -p release
+          # facelock-bin (dist/PKGBUILD-bin) declares a tpm2-tss dependency,
+          # so the repackaged binary must actually link against it (#355).
+          ldd target/release/facelock | grep -q libtss2-esys \
+            || { echo "facelock is not linked against libtss2-esys: the tpm feature is missing" >&2; exit 1; }
           cp target/release/facelock release/facelock-x86_64-linux-gnu
           cp target/release/libpam_facelock.so release/pam_facelock.so
           cp target/release/facelock-polkit-agent release/facelock-polkit-agent-x86_64-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,10 @@ jobs:
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
+      # Through the recipe, so the asset is the binary `just install` and the
+      # packaging lanes build; the recipe carries the tpm feature.
       - name: Build release
-        run: cargo build --release --workspace --features tpm
+        run: just build-release
 
       - name: Prepare artifacts
         run: |
@@ -389,7 +391,7 @@ jobs:
             util-linux python3 \
             gcc gcc-c++ \
             wayland-devel libxkbcommon-devel \
-            tpm2-tss-devel
+            tpm2-tss-devel just
 
       - name: Download ORT bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -404,8 +406,10 @@ jobs:
       - name: Verify exact ORT bundle
         run: scripts/prepare-ort-bundle.sh verify onnxruntime
 
+      # Through the recipe, so the asset is the binary `just install` and the
+      # packaging lanes build; the recipe carries the tpm feature.
       - name: Build release
-        run: cargo build --release --workspace --features tpm
+        run: just build-release
 
       - name: Build RPM
         run: .github/workflows/scripts/build-rpm.sh "${{ needs.metadata.outputs.cargo-version }}" "${{ needs.metadata.outputs.rpm-counter }}"

--- a/.github/workflows/scripts/install-ubuntu-deps.sh
+++ b/.github/workflows/scripts/install-ubuntu-deps.sh
@@ -10,6 +10,7 @@ sudo apt-get install -y \
   pkg-config \
   libssl-dev \
   clang \
+  just \
   libxkbcommon-dev \
   libwayland-dev \
   libtss2-dev \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Package removal no longer aborts on a drifted vendor override** (#350): `pam remove --all` refused any `/etc/pam.d` file that shadows a vendor file and was not a byte-exact Facelock copy, even when the only Facelock content was its own canonical `auth      sufficient pam_facelock.so` (that exact spacing is what ownership is judged on). Omarchy's `/etc/pam.d/polkit-1` is such a file, so `pacman -R facelock` failed in the `PreTransaction` hook and the package could not be removed. The machine-wide cleanup now applies its ownership check to those files instead of refusing them outright: an owned canonical rule is removed in place and the file is kept, the in-place rewrite named removal already performed. A file edited after `pam add`, whose recorded hash no longer matches, is judged by the same canonical-line rule instead of blocking outright. Unowned references still block, and those blockers now name `facelock pam remove --service <name>` as the way out.
+- The `facelock-x86_64-linux-gnu` release asset, and therefore `facelock-bin`,
+  is now built with the `tpm` feature, so `facelock setup` offers the
+  TPM-protected key and an `encryption.method = "tpm"` config loads (#355).
 
 ## [0.2.0] - 2026-09-06
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2451,8 +2451,9 @@ release until it does.
   artifact other than its producer's is a builder's extra output; the release
   fails closed on it, and the failure names the remedy: fix the builder and
   re-run all jobs, since re-running only the failed job keeps the artifact.
-  `build` compiles the workspace with `--features tpm`, matching the deb and
-  rpm builders, and fails if the resulting binary does not link
+  `build` and `build-rpm` compile through `just build-release`, the recipe
+  `just install` and the packaging lanes use, which carries the `tpm`
+  feature; `build` fails if the resulting binary does not link
   `libtss2-esys`.
 - Every staged asset matches the SHA-256 its builder attested. Each builder
   writes a `release-digests-<slot>` artifact naming what it produced, the image

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2451,6 +2451,9 @@ release until it does.
   artifact other than its producer's is a builder's extra output; the release
   fails closed on it, and the failure names the remedy: fix the builder and
   re-run all jobs, since re-running only the failed job keeps the artifact.
+  `build` compiles the workspace with `--features tpm`, matching the deb and
+  rpm builders, and fails if the resulting binary does not link
+  `libtss2-esys`.
 - Every staged asset matches the SHA-256 its builder attested. Each builder
   writes a `release-digests-<slot>` artifact naming what it produced, the image
   it produced it in, and the components it consumed. An asset attested by no

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -151,12 +151,15 @@ if printf '%s\n' "$build_job" | grep -Fq 'SHA256SUMS'; then
     fail "the build job must not publish a partial checksum file; MANIFEST.json covers every asset"
 fi
 
+# `grep -q` exits at the first match; under pipefail an awk still writing a
+# body longer than its stdout buffer then dies of SIGPIPE, and the check
+# fails at random. Let grep consume the whole body instead.
 for producer in build build-deb build-rpm publish-apt; do
-    job_body "$producer" | grep -Eq '^[[:space:]]+name: release-[a-z-]+' ||
+    job_body "$producer" | grep -E '^[[:space:]]+name: release-[a-z-]+' >/dev/null ||
         fail "$producer must hand its release payload to publish as a workflow artifact"
 done
 for digest_producer in build download-ort prepare-cargo-vendor build-deb build-rpm publish-apt; do
-    job_body "$digest_producer" | grep -Fq 'release-digests-' ||
+    job_body "$digest_producer" | grep -F 'release-digests-' >/dev/null ||
         fail "$digest_producer must attest the digests of what it produced"
 done
 


### PR DESCRIPTION
- build the \`build\` and \`build-rpm\` release jobs through \`just build-release\`, the recipe \`just install\` and the packaging lanes already use, so the \`facelock-x86_64-linux-gnu\` asset carries the tpm feature like the deb, rpm, and source PKGBUILDs
- fail \`Prepare artifacts\` when the binary does not link \`libtss2-esys\`, so the feature cannot silently drop again
- install \`just\` in the Ubuntu and Fedora release builders
- let the release-artifacts contract test read whole job bodies; \`grep -q\` under pipefail raced awk once a body crossed its stdout buffer
- note the recipe in the contracts asset table and the fix in the changelog

Why: \`facelock-bin\` repackages this asset and already depends on \`tpm2-tss\`, but the binary had no TPM support, so \`facelock setup\` skipped the TPM key and a \`tpm\` config refused to load. The deps script has installed \`libtss2-dev\` since March, so the reason the flag was removed no longer holds.

Validation: release.yml parses; test/release-artifacts-contract.sh; a local \`--features tpm\` build links \`libtss2-esys\`

Fixes #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release binaries and RPM packages now include TPM support.
  - TPM-protected setup keys and `encryption.method = "tpm"` configuration are now available in release assets.
  - Whole-machine cleanup can safely correct certain managed local configuration drift while preserving the configuration file.

- **Documentation**
  - Updated release and contract documentation to clarify TPM support and cleanup behavior.

- **Chores**
  - Improved release artifact validation and consistency across distribution packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->