### PR TITLE
fix(encryption): keep templates readable when setup switches between tpm and keyfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `facelock-x86_64-linux-gnu` release asset, and therefore `facelock-bin`,
   is now built with the `tpm` feature, so `facelock setup` offers the
   TPM-protected key and an `encryption.method = "tpm"` config loads (#355).
+- **Switching encryption methods on the same machine no longer orphans templates** (#354):
+  every model row now records the key id of the key that sealed it. `facelock setup --encryption tpm`
+  with a plaintext keyfile present seals that key rather than minting a new one. Switching to keyfile
+  with a sealed key present and a usable TPM unseals it. The daemon and one-shot path load both the
+  configured method's key as primary and the other method's artifact best-effort as secondary, so
+  a row sealed under either key can still decrypt. Pre-V7 rows (NULL key id) are tried under both.
+  A new nullable `face_models.key_id` column (schema V7) records the truncated SHA-256 fingerprint
+  of each sealing key.
 
 ## [0.2.0] - 2026-09-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tracing",
  "tss-esapi",

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -235,6 +235,19 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
             .seal_bytes(blob)
             .with_context(|| format!("failed to encrypt embedding {id}"))?;
 
+        // The model names its key before its first row is sealed (#354): a
+        // failure later in this loop then never leaves a sealed row whose
+        // model records no key, which the decrypt path would have to open
+        // by blind trial. Plaintext rows ignore key_id, so recording it
+        // early is harmless for rows this run never reaches.
+        if sealed_models.insert(*model_id) {
+            store
+                .set_model_key_id(*model_id, Some(&key_id))
+                .with_context(|| {
+                    format!("failed to record the sealing key for model {model_id}")
+                })?;
+        }
+
         // Store with sealed=true and sealed column value distinguishes TPM (1) from software (2)
         // We use sealed=true since the DB uses a boolean flag; the version byte in the blob
         // distinguishes TPM from software encryption.
@@ -242,17 +255,7 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
             .update_embedding_sealed(*id, &encrypted_blob, true)
             .with_context(|| format!("failed to update embedding {id}"))?;
 
-        sealed_models.insert(*model_id);
         encrypted_count += 1;
-    }
-
-    // Every model that gained a sealed row now knows which key sealed it
-    // (#354) — a row naming no key falls back to a blind trial on decrypt,
-    // which this command can avoid simply by recording what it just did.
-    for model_id in sealed_models {
-        store
-            .set_model_key_id(model_id, Some(&key_id))
-            .with_context(|| format!("failed to record the sealing key for model {model_id}"))?;
     }
 
     println!("Encrypted {encrypted_count} embedding(s) with AES-256-GCM.");

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -214,7 +214,7 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     // Filter to unencrypted embeddings only
     let unencrypted: Vec<_> = all
         .iter()
-        .filter(|(_, _, blob, sealed)| !sealed && !facelock_tpm::is_software_encrypted(blob))
+        .filter(|(_, _, blob, sealed, _)| !sealed && !facelock_tpm::is_software_encrypted(blob))
         .collect();
 
     if unencrypted.is_empty() {
@@ -228,7 +228,7 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
     );
 
     let mut encrypted_count = 0u32;
-    for (id, _user, blob, _sealed) in &unencrypted {
+    for (id, _user, blob, _sealed, _model_id) in &unencrypted {
         let encrypted_blob = sealer
             .seal_bytes(blob)
             .with_context(|| format!("failed to encrypt embedding {id}"))?;
@@ -263,12 +263,12 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
     // Partition into software-encrypted and TPM-sealed embeddings
     let sw_encrypted: Vec<_> = all
         .iter()
-        .filter(|(_, _, blob, _)| facelock_tpm::is_software_encrypted(blob))
+        .filter(|(_, _, blob, _, _)| facelock_tpm::is_software_encrypted(blob))
         .collect();
 
     let tpm_sealed: Vec<_> = all
         .iter()
-        .filter(|(_, _, blob, _)| facelock_tpm::is_sealed(blob))
+        .filter(|(_, _, blob, _, _)| facelock_tpm::is_sealed(blob))
         .collect();
 
     if sw_encrypted.is_empty() && tpm_sealed.is_empty() {
@@ -287,7 +287,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
             sw_encrypted.len()
         );
 
-        for (id, _user, blob, _sealed) in &sw_encrypted {
+        for (id, _user, blob, _sealed, _model_id) in &sw_encrypted {
             // Unsealed plaintext template bytes, zeroized when `raw` drops —
             // the store-update error path included (#293). `Zeroizing`, not
             // `Wiped`: that guard is typed for embedding sets, and raw byte
@@ -314,7 +314,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
             let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
                 .context("failed to initialize TPM for unsealing")?;
 
-            for (id, _user, blob, _sealed) in &tpm_sealed {
+            for (id, _user, blob, _sealed, _model_id) in &tpm_sealed {
                 // Same wipe-on-drop as the software branch above (#293).
                 let raw = zeroize::Zeroizing::new(
                     tpm.unseal_bytes(blob)
@@ -616,7 +616,7 @@ mod tests {
         // Verify all start unencrypted
         let all = store.get_all_embeddings_raw().unwrap();
         assert_eq!(all.len(), 2);
-        for (_, _, blob, sealed) in &all {
+        for (_, _, blob, sealed, _) in &all {
             assert!(!sealed);
             assert!(!facelock_tpm::is_software_encrypted(blob));
         }
@@ -624,11 +624,11 @@ mod tests {
         // Encrypt all unencrypted
         let unencrypted: Vec<_> = all
             .iter()
-            .filter(|(_, _, blob, sealed)| !sealed && !facelock_tpm::is_software_encrypted(blob))
+            .filter(|(_, _, blob, sealed, _)| !sealed && !facelock_tpm::is_software_encrypted(blob))
             .collect();
         assert_eq!(unencrypted.len(), 2);
 
-        for (id, _, blob, _) in &unencrypted {
+        for (id, _, blob, _, _) in &unencrypted {
             let encrypted_blob = sealer.seal_bytes(blob).unwrap();
             store
                 .update_embedding_sealed(*id, &encrypted_blob, true)
@@ -637,7 +637,7 @@ mod tests {
 
         // Verify all are now encrypted
         let all = store.get_all_embeddings_raw().unwrap();
-        for (_, _, blob, sealed) in &all {
+        for (_, _, blob, sealed, _) in &all {
             assert!(sealed);
             assert!(facelock_tpm::is_software_encrypted(blob));
         }
@@ -645,11 +645,11 @@ mod tests {
         // Decrypt all
         let encrypted: Vec<_> = all
             .iter()
-            .filter(|(_, _, blob, _)| facelock_tpm::is_software_encrypted(blob))
+            .filter(|(_, _, blob, _, _)| facelock_tpm::is_software_encrypted(blob))
             .collect();
         assert_eq!(encrypted.len(), 2);
 
-        for (id, _, blob, _) in &encrypted {
+        for (id, _, blob, _, _) in &encrypted {
             let raw = sealer.unseal_bytes(blob).unwrap();
             store.update_embedding_sealed(*id, &raw, false).unwrap();
         }
@@ -688,7 +688,12 @@ mod tests {
 
         // Load with each row's own device id → decrypts.
         let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
-        let (_id, blob, sealed_flag, dev) = &rows[0];
+        let facelock_store::RawEmbeddingRow {
+            blob,
+            sealed: sealed_flag,
+            device_id: dev,
+            ..
+        } = &rows[0];
         assert!(*sealed_flag);
         let good_aad = config.security.device_aad(dev.as_deref());
         let dec = sealer
@@ -726,7 +731,7 @@ mod tests {
         let all = store.get_all_embeddings_raw().unwrap();
         let unencrypted: Vec<_> = all
             .iter()
-            .filter(|(_, _, blob, sealed)| !sealed && !facelock_tpm::is_software_encrypted(blob))
+            .filter(|(_, _, blob, sealed, _)| !sealed && !facelock_tpm::is_software_encrypted(blob))
             .collect();
 
         // Only alice's embedding should be in the unencrypted list

--- a/crates/facelock-cli/src/commands/encrypt.rs
+++ b/crates/facelock-cli/src/commands/encrypt.rs
@@ -227,8 +227,10 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
         unencrypted.len()
     );
 
+    let key_id = sealer.key_id();
     let mut encrypted_count = 0u32;
-    for (id, _user, blob, _sealed, _model_id) in &unencrypted {
+    let mut sealed_models = std::collections::BTreeSet::new();
+    for (id, _user, blob, _sealed, model_id) in &unencrypted {
         let encrypted_blob = sealer
             .seal_bytes(blob)
             .with_context(|| format!("failed to encrypt embedding {id}"))?;
@@ -240,7 +242,17 @@ pub fn run_encrypt(config: &Config, generate_key: bool) -> Result<()> {
             .update_embedding_sealed(*id, &encrypted_blob, true)
             .with_context(|| format!("failed to update embedding {id}"))?;
 
+        sealed_models.insert(*model_id);
         encrypted_count += 1;
+    }
+
+    // Every model that gained a sealed row now knows which key sealed it
+    // (#354) — a row naming no key falls back to a blind trial on decrypt,
+    // which this command can avoid simply by recording what it just did.
+    for model_id in sealed_models {
+        store
+            .set_model_key_id(model_id, Some(&key_id))
+            .with_context(|| format!("failed to record the sealing key for model {model_id}"))?;
     }
 
     println!("Encrypted {encrypted_count} embedding(s) with AES-256-GCM.");
@@ -277,6 +289,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
     }
 
     let mut decrypted_count = 0u32;
+    let mut unsealed_models = std::collections::BTreeSet::new();
 
     // Decrypt software-encrypted embeddings
     if !sw_encrypted.is_empty() {
@@ -287,7 +300,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
             sw_encrypted.len()
         );
 
-        for (id, _user, blob, _sealed, _model_id) in &sw_encrypted {
+        for (id, _user, blob, _sealed, model_id) in &sw_encrypted {
             // Unsealed plaintext template bytes, zeroized when `raw` drops —
             // the store-update error path included (#293). `Zeroizing`, not
             // `Wiped`: that guard is typed for embedding sets, and raw byte
@@ -301,6 +314,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
                 .update_embedding_sealed(*id, &raw, false)
                 .with_context(|| format!("failed to update embedding {id}"))?;
 
+            unsealed_models.insert(*model_id);
             decrypted_count += 1;
         }
     }
@@ -314,7 +328,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
             let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
                 .context("failed to initialize TPM for unsealing")?;
 
-            for (id, _user, blob, _sealed, _model_id) in &tpm_sealed {
+            for (id, _user, blob, _sealed, model_id) in &tpm_sealed {
                 // Same wipe-on-drop as the software branch above (#293).
                 let raw = zeroize::Zeroizing::new(
                     tpm.unseal_bytes(blob)
@@ -325,6 +339,7 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
                     .update_embedding_sealed(*id, &raw, false)
                     .with_context(|| format!("failed to update embedding {id}"))?;
 
+                unsealed_models.insert(*model_id);
                 decrypted_count += 1;
             }
         }
@@ -337,6 +352,15 @@ pub fn run_decrypt(config: &Config) -> Result<()> {
                 tpm_sealed.len()
             );
         }
+    }
+
+    // A plaintext row has no sealing key (#354): clear whatever key_id a
+    // model recorded rather than leaving a stale one that would misname the
+    // key on a later re-encrypt gone wrong.
+    for model_id in unsealed_models {
+        store
+            .set_model_key_id(model_id, None)
+            .with_context(|| format!("failed to clear the sealing key for model {model_id}"))?;
     }
 
     println!("Decrypted {decrypted_count} embedding(s) successfully.");
@@ -566,6 +590,46 @@ mod key_gate_tests {
         let store = FaceStore::open_existing(&db_path).unwrap();
         let (sealed, unsealed) = store.count_sealed().unwrap();
         assert_eq!((sealed, unsealed), (1, 0));
+        cleanup(&db_path);
+    }
+
+    /// #354: `run_encrypt` records which key sealed each row it touches, and
+    /// `run_decrypt` clears it back to NULL — a plaintext row has no sealing
+    /// key to name, and a stale one would misname the key on a later
+    /// re-encrypt under a different one.
+    #[test]
+    fn encrypt_then_decrypt_round_trips_the_key_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("encryption.key");
+        let db_path = temp_db("key-id-round-trip");
+        {
+            let store = FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "e")
+                .unwrap();
+        }
+
+        let config = config_for(&key_path, &db_path);
+        super::run_encrypt(&config, false).unwrap();
+
+        let sealer = facelock_tpm::SoftwareSealer::from_key_file(&key_path).unwrap();
+        let expected_key_id = sealer.key_id();
+
+        let store = FaceStore::open_existing(&db_path).unwrap();
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].key_id.as_deref(),
+            Some(expected_key_id.as_str()),
+            "the model's key_id must match the sealer that just encrypted it"
+        );
+
+        super::run_decrypt(&config).unwrap();
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(
+            rows[0].key_id, None,
+            "a plaintext row must not keep a stale sealing key"
+        );
         cleanup(&db_path);
     }
 }

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1779,11 +1779,184 @@ mod orphan_guard_tests {
     }
 }
 
+/// What a key-protection setup path should do about the key material itself,
+/// decided *before* anything touches disk or the TPM.
+///
+/// Pulled out as a pure function (issue #354) because the bug it fixes was a
+/// decision bug, not an I/O bug: `setup_encryption_tpm_key` used to mint a
+/// fresh random key whenever `encryption.key.sealed` was absent, even when
+/// `encryption.key` already held one — so re-running `facelock setup` after
+/// flipping `--encryption` could leave two unrelated keys on disk, each
+/// orphaning the rows sealed under the other. A pure function is exhaustively
+/// testable without a TPM or a filesystem, which an I/O-entangled version
+/// was not.
+#[derive(Debug, PartialEq, Eq)]
+enum KeyAction {
+    /// The artifact the target method reads from already exists; use it as-is.
+    ReuseExisting,
+    /// The target is TPM, no sealed key exists yet, but a plaintext keyfile
+    /// does: seal *that* key rather than minting a new one.
+    SealExistingKeyfile,
+    /// The target is a keyfile, none exists yet, but a TPM-sealed key does
+    /// and the TPM can unseal it: unseal *that* key into the keyfile rather
+    /// than minting a new one.
+    UnsealExistingSealed,
+    /// Neither artifact exists (or the target is a keyfile with a sealed key
+    /// present but no usable TPM to recover it from): there is no existing
+    /// key to carry over, so mint a new one.
+    Mint,
+}
+
+/// Decide what to do about the key material for a switch to `target`.
+///
+/// Never touches disk or the TPM: every input is a bool the caller has
+/// already determined, so this function is total and its whole behavior is
+/// the match below.
+fn plan_key_action(
+    target: facelock_core::config::EncryptionMethod,
+    keyfile_exists: bool,
+    sealed_exists: bool,
+    tpm_usable: bool,
+) -> KeyAction {
+    use facelock_core::config::EncryptionMethod;
+
+    match target {
+        EncryptionMethod::Tpm => {
+            if sealed_exists {
+                KeyAction::ReuseExisting
+            } else if keyfile_exists {
+                KeyAction::SealExistingKeyfile
+            } else {
+                KeyAction::Mint
+            }
+        }
+        EncryptionMethod::Keyfile => {
+            if keyfile_exists {
+                KeyAction::ReuseExisting
+            } else if sealed_exists && tpm_usable {
+                KeyAction::UnsealExistingSealed
+            } else {
+                KeyAction::Mint
+            }
+        }
+        // Neither setup_encryption_tpm_key nor setup_encryption_keyfile is
+        // ever reached with the config still at `None` — `apply_encryption_choice`
+        // and `wizard_encryption_setup` only call them once a Tpm/Keyfile
+        // target has been chosen.
+        EncryptionMethod::None => {
+            unreachable!("plan_key_action is only consulted for a Tpm or Keyfile target")
+        }
+    }
+}
+
+#[cfg(test)]
+mod plan_key_action_tests {
+    use super::*;
+    use facelock_core::config::EncryptionMethod;
+
+    // -- target: Tpm --
+
+    #[test]
+    fn tpm_target_reuses_an_existing_sealed_key() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Tpm, true, true, false),
+            KeyAction::ReuseExisting
+        );
+    }
+
+    #[test]
+    fn tpm_target_reuses_sealed_key_even_without_a_keyfile() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Tpm, false, true, true),
+            KeyAction::ReuseExisting
+        );
+    }
+
+    #[test]
+    fn tpm_target_seals_an_existing_keyfile_instead_of_minting() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Tpm, true, false, false),
+            KeyAction::SealExistingKeyfile
+        );
+    }
+
+    #[test]
+    fn tpm_target_mints_when_neither_artifact_exists() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Tpm, false, false, false),
+            KeyAction::Mint
+        );
+        // tpm_usable does not enter the Tpm-target decision at all.
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Tpm, false, false, true),
+            KeyAction::Mint
+        );
+    }
+
+    // -- target: Keyfile --
+
+    #[test]
+    fn keyfile_target_reuses_an_existing_keyfile() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, true, false, false),
+            KeyAction::ReuseExisting
+        );
+    }
+
+    #[test]
+    fn keyfile_target_reuses_keyfile_even_when_a_sealed_key_also_exists() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, true, true, true),
+            KeyAction::ReuseExisting
+        );
+    }
+
+    #[test]
+    fn keyfile_target_unseals_an_existing_sealed_key_when_the_tpm_is_usable() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, false, true, true),
+            KeyAction::UnsealExistingSealed
+        );
+    }
+
+    #[test]
+    fn keyfile_target_mints_when_a_sealed_key_exists_but_the_tpm_is_not_usable() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, false, true, false),
+            KeyAction::Mint
+        );
+    }
+
+    #[test]
+    fn keyfile_target_mints_when_neither_artifact_exists() {
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, false, false, false),
+            KeyAction::Mint
+        );
+        assert_eq!(
+            plan_key_action(EncryptionMethod::Keyfile, false, false, true),
+            KeyAction::Mint
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "only consulted for a Tpm or Keyfile target")]
+    fn none_target_is_never_consulted() {
+        plan_key_action(EncryptionMethod::None, false, false, false);
+    }
+}
+
 fn wizard_encryption_setup(theme: &ColorfulTheme, config: &mut Config) -> anyhow::Result<()> {
     Terminal.info(&SetupMessage::EncryptionIntro);
 
     // Detect TPM availability
     let tpm_available = detect_tpm(config);
+
+    if config.encryption.method == facelock_core::config::EncryptionMethod::Tpm && !tpm_available {
+        Terminal.notice(&SetupMessage::TpmConfiguredButUnavailable {
+            sealed_path: config.encryption.sealed_key_path.clone(),
+        });
+    }
 
     if tpm_available {
         let options = [
@@ -1801,46 +1974,87 @@ fn wizard_encryption_setup(theme: &ColorfulTheme, config: &mut Config) -> anyhow
         }
     }
 
-    setup_encryption_keyfile(config, Some(theme))
+    setup_encryption_keyfile(config, Some(theme), tpm_available)
 }
 
 /// Seal an AES key with the TPM and switch the config to it. Callers must have
 /// established that a TPM is usable.
+///
+/// Dispatches on [`plan_key_action`] (issue #354): an existing plaintext
+/// keyfile is sealed as-is rather than replaced by a freshly minted key, so
+/// switching `--encryption` back and forth never leaves two unrelated keys on
+/// disk, each orphaning the rows sealed under the other.
 fn setup_encryption_tpm_key(
     config: &mut Config,
     theme: Option<&ColorfulTheme>,
 ) -> anyhow::Result<()> {
     use facelock_core::config::EncryptionMethod;
 
+    let key_path = Path::new(&config.encryption.key_path);
     let sealed_path = Path::new(&config.encryption.sealed_key_path);
-    if sealed_path.exists() {
-        Terminal.info(&SetupMessage::TpmSealedKeyPresent {
-            path: sealed_path.display().to_string(),
-        });
-    } else {
-        handle_orphan_models_before_keygen(config, theme)?;
-        Terminal.info(&SetupMessage::GeneratingTpmSealedKey);
-        let pcr = if config.tpm.pcr_binding {
-            Some(config.tpm.pcr_indices.as_slice())
-        } else {
-            None
-        };
-        #[cfg(feature = "tpm")]
-        {
-            let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                .context("failed to initialize TPM")?;
-            facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
-                .context("failed to generate and seal key")?;
-            Terminal.info(&SetupMessage::TpmSealedKeyWritten {
+    let keyfile_exists = key_path.exists();
+    let sealed_exists = sealed_path.exists();
+
+    // `plan_key_action` does not consult `tpm_usable` for a `Tpm` target, but
+    // every caller of this function has already established TPM usability
+    // (`apply_encryption_choice`'s explicit `detect_tpm` check, or
+    // `wizard_encryption_setup` only reaching here when `tpm_available`).
+    match plan_key_action(EncryptionMethod::Tpm, keyfile_exists, sealed_exists, true) {
+        KeyAction::ReuseExisting => {
+            Terminal.info(&SetupMessage::TpmSealedKeyPresent {
                 path: sealed_path.display().to_string(),
             });
+            if keyfile_exists {
+                notice_if_keys_diverged(config, key_path, sealed_path);
+            }
         }
-        #[cfg(not(feature = "tpm"))]
-        {
-            let _ = pcr;
-            anyhow::bail!("TPM support not compiled in (missing 'tpm' feature)");
+        KeyAction::SealExistingKeyfile => {
+            Terminal.info(&SetupMessage::SealingExistingKeyfile {
+                key_path: key_path.display().to_string(),
+                sealed_path: sealed_path.display().to_string(),
+            });
+            #[cfg(feature = "tpm")]
+            {
+                super::tpm::seal_existing_keyfile(config)
+                    .context("failed to seal the existing key with the TPM")?;
+                Terminal.info(&SetupMessage::TpmSealedKeyWritten {
+                    path: sealed_path.display().to_string(),
+                });
+            }
+            #[cfg(not(feature = "tpm"))]
+            {
+                anyhow::bail!("TPM support not compiled in (missing 'tpm' feature)");
+            }
+        }
+        KeyAction::Mint => {
+            handle_orphan_models_before_keygen(config, theme)?;
+            Terminal.info(&SetupMessage::GeneratingTpmSealedKey);
+            let pcr = if config.tpm.pcr_binding {
+                Some(config.tpm.pcr_indices.as_slice())
+            } else {
+                None
+            };
+            #[cfg(feature = "tpm")]
+            {
+                let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
+                    .context("failed to initialize TPM")?;
+                facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
+                    .context("failed to generate and seal key")?;
+                Terminal.info(&SetupMessage::TpmSealedKeyWritten {
+                    path: sealed_path.display().to_string(),
+                });
+            }
+            #[cfg(not(feature = "tpm"))]
+            {
+                let _ = pcr;
+                anyhow::bail!("TPM support not compiled in (missing 'tpm' feature)");
+            }
+        }
+        KeyAction::UnsealExistingSealed => {
+            unreachable!("plan_key_action never returns UnsealExistingSealed for a Tpm target")
         }
     }
+
     config.encryption.method = EncryptionMethod::Tpm;
     update_config_encryption(config, "tpm")?;
     Terminal.info(&SetupMessage::EncryptionEnabledTpm);
@@ -1848,25 +2062,76 @@ fn setup_encryption_tpm_key(
 }
 
 /// Generate (or reuse) a software keyfile and switch the config to it.
+///
+/// Dispatches on [`plan_key_action`] (issue #354), mirroring
+/// `setup_encryption_tpm_key`: an existing TPM-sealed key is unsealed into
+/// the keyfile as-is when the TPM can still read it, rather than replaced by
+/// a freshly minted key.
+///
+/// `tpm_usable` decides whether an existing sealed key can be recovered that
+/// way; pass the value the caller already has from `detect_tpm` rather than
+/// probing again.
 fn setup_encryption_keyfile(
     config: &mut Config,
     theme: Option<&ColorfulTheme>,
+    tpm_usable: bool,
 ) -> anyhow::Result<()> {
     use facelock_core::config::EncryptionMethod;
 
     let key_path = Path::new(&config.encryption.key_path);
-    if key_path.exists() {
-        Terminal.info(&SetupMessage::KeyfilePresent {
-            path: key_path.display().to_string(),
-        });
-    } else {
-        handle_orphan_models_before_keygen(config, theme)?;
-        Terminal.info(&SetupMessage::GeneratingKeyfile);
-        facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-            .context("failed to generate encryption key")?;
-        Terminal.info(&SetupMessage::KeyfileWritten {
-            path: key_path.display().to_string(),
-        });
+    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+    let keyfile_exists = key_path.exists();
+    let sealed_exists = sealed_path.exists();
+
+    match plan_key_action(
+        EncryptionMethod::Keyfile,
+        keyfile_exists,
+        sealed_exists,
+        tpm_usable,
+    ) {
+        KeyAction::ReuseExisting => {
+            Terminal.info(&SetupMessage::KeyfilePresent {
+                path: key_path.display().to_string(),
+            });
+            if sealed_exists {
+                notice_if_keys_diverged(config, key_path, sealed_path);
+            }
+        }
+        KeyAction::UnsealExistingSealed => {
+            Terminal.info(&SetupMessage::UnsealingExistingSealedKey {
+                sealed_path: sealed_path.display().to_string(),
+                key_path: key_path.display().to_string(),
+            });
+            #[cfg(feature = "tpm")]
+            {
+                super::tpm::unseal_into_keyfile(config)
+                    .context("failed to unseal the existing sealed key")?;
+                Terminal.info(&SetupMessage::KeyfileWritten {
+                    path: key_path.display().to_string(),
+                });
+            }
+            #[cfg(not(feature = "tpm"))]
+            {
+                anyhow::bail!("TPM support not compiled in (missing 'tpm' feature)");
+            }
+        }
+        KeyAction::Mint => {
+            handle_orphan_models_before_keygen(config, theme)?;
+            Terminal.info(&SetupMessage::GeneratingKeyfile);
+            facelock_tpm::SoftwareSealer::generate_key_file(key_path)
+                .context("failed to generate encryption key")?;
+            Terminal.info(&SetupMessage::KeyfileWritten {
+                path: key_path.display().to_string(),
+            });
+            if sealed_exists && !tpm_usable {
+                Terminal.notice(&SetupMessage::SealedKeyLeftInPlace {
+                    sealed_path: sealed_path.display().to_string(),
+                });
+            }
+        }
+        KeyAction::SealExistingKeyfile => {
+            unreachable!("plan_key_action never returns SealExistingKeyfile for a Keyfile target")
+        }
     }
 
     config.encryption.method = EncryptionMethod::Keyfile;
@@ -1874,6 +2139,60 @@ fn setup_encryption_keyfile(
     Terminal.info(&SetupMessage::EncryptionEnabledKeyfile);
 
     Ok(())
+}
+
+/// When both the plaintext keyfile and the TPM-sealed key exist, warn if they
+/// no longer carry the same key material — e.g. left behind by a `facelock
+/// setup` run from before this wave's guard existed.
+///
+/// A best-effort probe, not a gate: setup did not ask this question, so a
+/// read or unseal failure here must not fail setup. Either failure is logged
+/// at `debug!` and the function says nothing.
+#[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
+fn notice_if_keys_diverged(config: &Config, key_path: &Path, sealed_path: &Path) {
+    let keyfile_id = match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
+        Ok(sealer) => sealer.key_id(),
+        Err(e) => {
+            tracing::debug!(
+                "could not read {} to compare key ids: {e}",
+                key_path.display()
+            );
+            return;
+        }
+    };
+
+    #[cfg(feature = "tpm")]
+    {
+        let mut tpm = match facelock_tpm::TpmSealer::new(&config.tpm.tcti) {
+            Ok(tpm) => tpm,
+            Err(e) => {
+                tracing::debug!("could not initialize TPM to compare key ids: {e}");
+                return;
+            }
+        };
+        let sealed_id = match tpm.unseal_key_from_file(sealed_path) {
+            Ok(mut key) => {
+                let id = facelock_tpm::SoftwareSealer::key_id_for(&key);
+                use zeroize::Zeroize;
+                key.zeroize();
+                id
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "could not unseal {} to compare key ids: {e}",
+                    sealed_path.display()
+                );
+                return;
+            }
+        };
+
+        if keyfile_id != sealed_id {
+            Terminal.notice(&SetupMessage::DivergedKeysNotice {
+                key_path: key_path.display().to_string(),
+                sealed_path: sealed_path.display().to_string(),
+            });
+        }
+    }
 }
 
 /// Turn embedding encryption off, loudly.
@@ -1929,7 +2248,7 @@ fn apply_encryption_choice(
             }
             setup_encryption_tpm_key(config, theme)
         }
-        EncryptionChoice::Keyfile => setup_encryption_keyfile(config, theme),
+        EncryptionChoice::Keyfile => setup_encryption_keyfile(config, theme, detect_tpm(config)),
         EncryptionChoice::None => setup_encryption_none(config),
         EncryptionChoice::Auto => {
             if auto_encryption_needs_keygen(config, detect_tpm(config)) {
@@ -1960,7 +2279,15 @@ fn detect_tpm(config: &Config) -> bool {
                 true
             }
             Err(e) => {
-                tracing::debug!("TPM detected but not functional: {e}");
+                // A device node exists but the TPM did not answer: worth
+                // surfacing loudly, because the caller silently falls back to
+                // a software keyfile from here, and `debug!` alone left a
+                // transient TPM failure indistinguishable from "no TPM at all".
+                tracing::warn!("TPM device present but not functional: {e}");
+                Terminal.notice(&SetupMessage::TpmNotFunctional {
+                    tcti: config.tpm.tcti.clone(),
+                    reason: e.to_string(),
+                });
                 false
             }
         }
@@ -5617,6 +5944,133 @@ mod choice_tests {
         assert_eq!(config.encryption.method, EncryptionMethod::None);
         let result = std::fs::read_to_string(&path).unwrap();
         assert!(result.contains("method = \"none\""), "{result}");
+    }
+
+    // -- key-carrying dispatch (#354): a method switch must reuse whatever
+    // -- key material already exists rather than minting a fresh one and
+    // -- orphaning the rows sealed under the old one.
+
+    fn config_for_key_dispatch(
+        dir: &std::path::Path,
+        key_path: &std::path::Path,
+        sealed_path: &std::path::Path,
+    ) -> Config {
+        let mut config = base_config();
+        // A database that provably has nothing to orphan, so a Mint path in
+        // these tests never blocks on the orphan guard.
+        config.storage.db_path = dir
+            .join("facelock-absent.db")
+            .to_string_lossy()
+            .into_owned();
+        config.encryption.key_path = key_path.to_string_lossy().into_owned();
+        config.encryption.sealed_key_path = sealed_path.to_string_lossy().into_owned();
+        config
+    }
+
+    /// The regression this wave fixes: re-running setup with `--encryption
+    /// keyfile` over an already-present keyfile must reuse it byte-for-byte,
+    /// never mint a replacement that orphans models sealed under the original.
+    #[test]
+    fn keyfile_dispatch_reuses_an_existing_key_without_minting() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let sealed_path = dir.path().join("sealed.key"); // absent
+        let original = [0x42u8; 32];
+        std::fs::write(&key_path, original).unwrap();
+
+        let mut config = config_for_key_dispatch(dir.path(), &key_path, &sealed_path);
+        setup_encryption_keyfile(&mut config, None, false).expect("reuse must not fail");
+
+        assert_eq!(
+            std::fs::read(&key_path).unwrap().as_slice(),
+            &original[..],
+            "an existing keyfile must be reused byte-for-byte, not replaced"
+        );
+        assert_eq!(config.encryption.method, EncryptionMethod::Keyfile);
+    }
+
+    /// A sealed key with no usable TPM is not something `setup_encryption_keyfile`
+    /// can carry forward (nothing can unseal it), so it mints a fresh keyfile —
+    /// but it must leave the sealed artifact on disk rather than deleting it,
+    /// since models sealed under it stay readable once the TPM comes back.
+    #[test]
+    fn keyfile_dispatch_mint_leaves_an_unusable_sealed_key_in_place() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key"); // absent
+        let sealed_path = dir.path().join("sealed.key");
+        let sealed_bytes = b"not-really-a-sealed-blob".to_vec();
+        std::fs::write(&sealed_path, &sealed_bytes).unwrap();
+
+        let mut config = config_for_key_dispatch(dir.path(), &key_path, &sealed_path);
+        setup_encryption_keyfile(&mut config, None, false).expect("mint must not fail");
+
+        assert!(key_path.exists(), "a fresh keyfile must be minted");
+        assert_eq!(
+            std::fs::read(&sealed_path).unwrap(),
+            sealed_bytes,
+            "the unreachable sealed key must be left in place, not deleted"
+        );
+    }
+
+    /// Mirrors the keyfile case: re-running setup with `--encryption tpm` over
+    /// an already-sealed key must reuse it, never seal a fresh random key over
+    /// it — the bug issue #354 reports.
+    #[test]
+    fn tpm_dispatch_reuses_an_existing_sealed_key_without_minting() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key"); // absent
+        let sealed_path = dir.path().join("sealed.key");
+        let sealed_bytes = b"an-existing-sealed-blob".to_vec();
+        std::fs::write(&sealed_path, &sealed_bytes).unwrap();
+
+        let mut config = config_for_key_dispatch(dir.path(), &key_path, &sealed_path);
+        setup_encryption_tpm_key(&mut config, None).expect("reuse must not fail");
+
+        assert_eq!(
+            std::fs::read(&sealed_path).unwrap(),
+            sealed_bytes,
+            "an existing sealed key must be reused byte-for-byte, not replaced"
+        );
+        assert_eq!(config.encryption.method, EncryptionMethod::Tpm);
     }
 
     /// The orphaned-models guard must not become a prompt when no theme is

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -2251,10 +2251,14 @@ fn apply_encryption_choice(
         EncryptionChoice::Keyfile => setup_encryption_keyfile(config, theme, detect_tpm(config)),
         EncryptionChoice::None => setup_encryption_none(config),
         EncryptionChoice::Auto => {
-            if auto_encryption_needs_keygen(config, detect_tpm(config)) {
+            // One probe for both questions: each device-backed probe creates
+            // a TPM primary and prints a detection notice, so probing again
+            // inside the auto policy doubled both.
+            let tpm_available = detect_tpm(config);
+            if auto_encryption_needs_keygen(config, tpm_available) {
                 handle_orphan_models_before_keygen(config, theme)?;
             }
-            setup_encryption_auto(config)
+            setup_encryption_auto(config, Some(tpm_available))
         }
     }
 }
@@ -2991,7 +2995,7 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     match plan.encryption {
         // No theme: nothing here may prompt under a non-interactive base.
         Some(choice) => apply_encryption_choice(&mut config, choice, None)?,
-        None => setup_encryption_auto(&config)?,
+        None => setup_encryption_auto(&config, None)?,
     }
 
     secure_setup_paths(&config, Some(&manifest))?;
@@ -3080,7 +3084,11 @@ fn keygen_refusal(config: &Config) -> anyhow::Result<Option<String>> {
 
 /// Auto-configure encryption in non-interactive mode.
 /// Prefers TPM-sealed key if TPM is available, falls back to keyfile.
-fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
+///
+/// `tpm_available` carries a probe the caller already ran; `None` probes
+/// here, and only after the already-configured early return so a configured
+/// host never touches the TPM for a no-op.
+fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow::Result<()> {
     use facelock_core::config::EncryptionMethod;
 
     // Skip if already configured
@@ -3095,7 +3103,7 @@ fn setup_encryption_auto(config: &Config) -> anyhow::Result<()> {
     }
 
     // Try TPM first
-    if detect_tpm(config) {
+    if tpm_available.unwrap_or_else(|| detect_tpm(config)) {
         #[cfg(feature = "tpm")]
         {
             let sealed_path = Path::new(&config.encryption.sealed_key_path);

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -286,33 +286,26 @@ fn seal_key(config: &Config) -> Result<()> {
 /// `unseal_key` below and by `setup_encryption_keyfile`'s
 /// `UnsealExistingSealed` path (issue #354).
 ///
-/// Calls `generate_key_file` then overwrites it with the real unsealed key:
-/// kept as-is (rather than writing the key directly) so the file is created
-/// with the same one-`open(2)`-at-0600 path `generate_key_file` already uses,
-/// with no separate `chmod` window.
+/// The unsealed bytes go to the keyfile in one write (`write_key_file`):
+/// the previous mint-then-overwrite left a random placeholder key under the
+/// real name if the overwrite failed, which the next `setup` would reuse.
 #[cfg(feature = "tpm")]
 pub(crate) fn unseal_into_keyfile(config: &Config) -> Result<()> {
+    use zeroize::Zeroize;
+
     let key_path = Path::new(&config.encryption.key_path);
     let sealed_path = Path::new(&config.encryption.sealed_key_path);
 
     let mut tpm =
         facelock_tpm::TpmSealer::new(&config.tpm.tcti).context("failed to initialize TPM")?;
-    let key = tpm
+    let mut key = tpm
         .unseal_key_from_file(sealed_path)
         .context("failed to unseal key from TPM")?;
 
-    // Write plaintext key file
-    facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-        .context("failed to create key file")?;
-    // Overwrite with the actual unsealed key (generate_key_file creates a random one)
-    std::fs::write(key_path, key).context("failed to write unsealed key")?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600))
-            .context("failed to set key file permissions")?;
-    }
-    Ok(())
+    let written = facelock_tpm::SoftwareSealer::write_key_file(key_path, &key)
+        .context("failed to write unsealed key");
+    key.zeroize();
+    written
 }
 
 #[cfg_attr(not(feature = "tpm"), allow(unused_variables))]

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -183,6 +183,43 @@ fn status(config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Seal the plaintext keyfile at `config.encryption.key_path` to
+/// `config.encryption.sealed_key_path`, carrying the SAME key bytes across —
+/// no new key is minted. Does not touch the config file and does not print;
+/// callers own both. Shared by `seal_key` below and by
+/// `setup_encryption_tpm_key`'s `SealExistingKeyfile` path, so the two never
+/// mint two different keys for the same host (issue #354).
+#[cfg(feature = "tpm")]
+pub(crate) fn seal_existing_keyfile(config: &Config) -> Result<()> {
+    let key_path = Path::new(&config.encryption.key_path);
+    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+
+    // Read the plaintext key
+    let key_data = std::fs::read(key_path)
+        .with_context(|| format!("failed to read key file {}", key_path.display()))?;
+    if key_data.len() != 32 {
+        anyhow::bail!("key file must be exactly 32 bytes, got {}", key_data.len());
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&key_data);
+
+    let pcr = if config.tpm.pcr_binding {
+        Some(config.tpm.pcr_indices.as_slice())
+    } else {
+        None
+    };
+
+    let mut tpm =
+        facelock_tpm::TpmSealer::new(&config.tpm.tcti).context("failed to initialize TPM")?;
+    let seal_result = tpm.seal_key_to_file(&key, sealed_path, pcr);
+
+    // Zeroize the in-memory copy
+    use zeroize::Zeroize;
+    key.zeroize();
+
+    seal_result.context("failed to seal key with TPM")
+}
+
 #[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
 fn seal_key(config: &Config) -> Result<()> {
     #[cfg(feature = "tpm")]
@@ -206,30 +243,8 @@ fn seal_key(config: &Config) -> Result<()> {
             );
         }
 
-        // Read the plaintext key
-        let key_data = std::fs::read(key_path)
-            .with_context(|| format!("failed to read key file {}", key_path.display()))?;
-        if key_data.len() != 32 {
-            anyhow::bail!("key file must be exactly 32 bytes, got {}", key_data.len());
-        }
-        let mut key = [0u8; 32];
-        key.copy_from_slice(&key_data);
-
-        let pcr = if config.tpm.pcr_binding {
-            Some(config.tpm.pcr_indices.as_slice())
-        } else {
-            None
-        };
-
         println!("Sealing AES key with TPM...");
-        let mut tpm =
-            facelock_tpm::TpmSealer::new(&config.tpm.tcti).context("failed to initialize TPM")?;
-        tpm.seal_key_to_file(&key, sealed_path, pcr)
-            .context("failed to seal key with TPM")?;
-
-        // Zeroize the in-memory copy
-        use zeroize::Zeroize;
-        key.zeroize();
+        seal_existing_keyfile(config)?;
 
         // Update config to use tpm method
         super::setup::update_config_encryption_method(config, "tpm")?;
@@ -265,6 +280,41 @@ fn seal_key(config: &Config) -> Result<()> {
     }
 }
 
+/// Unseal `config.encryption.sealed_key_path` and write the SAME key bytes to
+/// `config.encryption.key_path` at 0600 — no new key is minted. Does not touch
+/// the config file and does not print; callers own both. Shared by
+/// `unseal_key` below and by `setup_encryption_keyfile`'s
+/// `UnsealExistingSealed` path (issue #354).
+///
+/// Calls `generate_key_file` then overwrites it with the real unsealed key:
+/// kept as-is (rather than writing the key directly) so the file is created
+/// with the same one-`open(2)`-at-0600 path `generate_key_file` already uses,
+/// with no separate `chmod` window.
+#[cfg(feature = "tpm")]
+pub(crate) fn unseal_into_keyfile(config: &Config) -> Result<()> {
+    let key_path = Path::new(&config.encryption.key_path);
+    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+
+    let mut tpm =
+        facelock_tpm::TpmSealer::new(&config.tpm.tcti).context("failed to initialize TPM")?;
+    let key = tpm
+        .unseal_key_from_file(sealed_path)
+        .context("failed to unseal key from TPM")?;
+
+    // Write plaintext key file
+    facelock_tpm::SoftwareSealer::generate_key_file(key_path)
+        .context("failed to create key file")?;
+    // Overwrite with the actual unsealed key (generate_key_file creates a random one)
+    std::fs::write(key_path, key).context("failed to write unsealed key")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600))
+            .context("failed to set key file permissions")?;
+    }
+    Ok(())
+}
+
 #[cfg_attr(not(feature = "tpm"), allow(unused_variables))]
 fn unseal_key(config: &Config) -> Result<()> {
     #[cfg(feature = "tpm")]
@@ -285,23 +335,7 @@ fn unseal_key(config: &Config) -> Result<()> {
         }
 
         println!("Unsealing AES key from TPM...");
-        let mut tpm =
-            facelock_tpm::TpmSealer::new(&config.tpm.tcti).context("failed to initialize TPM")?;
-        let key = tpm
-            .unseal_key_from_file(sealed_path)
-            .context("failed to unseal key from TPM")?;
-
-        // Write plaintext key file
-        facelock_tpm::SoftwareSealer::generate_key_file(key_path)
-            .context("failed to create key file")?;
-        // Overwrite with the actual unsealed key (generate_key_file creates a random one)
-        std::fs::write(key_path, key).context("failed to write unsealed key")?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600))
-                .context("failed to set key file permissions")?;
-        }
+        unseal_into_keyfile(config)?;
 
         // Update config to use keyfile method
         super::setup::update_config_encryption_method(config, "keyfile")?;

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -195,8 +195,10 @@ pub(crate) fn seal_existing_keyfile(config: &Config) -> Result<()> {
     let sealed_path = Path::new(&config.encryption.sealed_key_path);
 
     // Read the plaintext key
-    let key_data = std::fs::read(key_path)
-        .with_context(|| format!("failed to read key file {}", key_path.display()))?;
+    let key_data = zeroize::Zeroizing::new(
+        std::fs::read(key_path)
+            .with_context(|| format!("failed to read key file {}", key_path.display()))?,
+    );
     if key_data.len() != 32 {
         anyhow::bail!("key file must be exactly 32 bytes, got {}", key_data.len());
     }

--- a/crates/facelock-cli/src/direct.rs
+++ b/crates/facelock-cli/src/direct.rs
@@ -224,75 +224,37 @@ pub fn authenticate(config: &Config, user: &str) -> anyhow::Result<MatchResult> 
     }
 }
 
-/// Initialize a software sealer based on encryption config.
+/// Load the sealing keyring for `config`, logging a keyfile refusal at
+/// `debug` rather than `warn`.
 ///
-/// Returns the sealer and, when a configured method has none, the reason —
-/// mirroring the daemon's posture rather than propagating. That difference was
-/// not cosmetic: a hard failure here is taken by *every* one-shot caller
-/// (`auth`, `test`, `bench`, `preview`), and the encrypted-row check that
-/// produces it is global to the store, so one user's encrypted row disabled
-/// face authentication for every plaintext-only user on the machine — a
-/// lockout the daemon transport did not have. Enrollment fails closed on the
-/// reason ([`enroll`]); everything else serves the rows it can read.
+/// This mirrors the daemon's posture rather than propagating. That
+/// difference was not cosmetic: a hard failure here is taken by *every*
+/// one-shot caller (`auth`, `test`, `bench`, `preview`), and the
+/// encrypted-row check behind a refusal is global to the store, so one
+/// user's encrypted row disabled face authentication for every
+/// plaintext-only user on the machine — a lockout the daemon transport did
+/// not have. Enrollment fails closed on the reason ([`enroll`]); everything
+/// else serves the rows it can read.
+///
+/// `crate::keyring::SealingKeys::load` deliberately does not log a keyfile
+/// refusal itself, because this caller's posture differs from the daemon's:
+/// the daemon resolves this once at startup, so a `warn!` there is heard
+/// once, while `facelock auth` resolves it on every login. The same `warn!`
+/// here would spam syslog over a refusal that may not even name this
+/// caller's own row.
 ///
 /// `Err` stays `Err` for the TPM method, whose failures are configuration
 /// errors rather than a missing artifact the operator can restore.
-fn init_software_sealer(
+fn load_sealing_keys(
     config: &Config,
     store: &FaceStore,
-) -> anyhow::Result<(Option<facelock_tpm::SoftwareSealer>, Option<String>)> {
-    match config.encryption.method {
-        EncryptionMethod::Keyfile => {
-            let key_path = Path::new(&config.encryption.key_path);
-            // Encrypt-by-default (finding #8): generate the key on first use so
-            // the keyfile default actually encrypts new templates. The gate is
-            // `facelock_daemon::key_policy`, shared with the daemon, `facelock
-            // setup` and `facelock encrypt`, so no writer of this key can
-            // drift on when a replacement may be written (#231).
-            if let Some(refusal) =
-                facelock_daemon::key_policy::ensure_encrypt_by_default_key(store, config).refusal()
-            {
-                debug!("{refusal}");
-                return Ok((None, Some(refusal.to_string())));
-            }
-            match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
-                Ok(sealer) => Ok((Some(sealer), None)),
-                Err(e) => {
-                    // Same as the daemon: an unreadable key over encrypted
-                    // rows must name what is at risk, not just the byte count.
-                    let complaint =
-                        format!("{} keyfile could not be read: {e}", key_path.display());
-                    let reason =
-                        match facelock_daemon::key_policy::encrypted_rows_at_risk(store, config) {
-                            Some(at_risk) => format!("{complaint} — {at_risk}"),
-                            None => complaint,
-                        };
-                    debug!("{reason}");
-                    Ok((None, Some(reason)))
-                }
-            }
-        }
-        EncryptionMethod::Tpm => {
-            #[cfg(feature = "tpm")]
-            {
-                let sealed_path = Path::new(&config.encryption.sealed_key_path);
-                let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                    .context("TPM initialization failed")?;
-                let key = tpm.unseal_key_from_file(sealed_path).with_context(|| {
-                    format!("failed to unseal AES key from {}", sealed_path.display())
-                })?;
-                Ok((Some(facelock_tpm::SoftwareSealer::from_key(key)), None))
-            }
-            #[cfg(not(feature = "tpm"))]
-            {
-                bail!(
-                    "encryption method is 'tpm' but TPM support is not compiled in \
-                     (rebuild with --features tpm)"
-                );
-            }
-        }
-        EncryptionMethod::None => Ok((None, None)),
+) -> anyhow::Result<facelock_daemon::keyring::SealingKeys> {
+    let keys = facelock_daemon::keyring::SealingKeys::load(config, store)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    if let Some(reason) = keys.primary_error() {
+        debug!("{reason}");
     }
+    Ok(keys)
 }
 
 /// Load user embeddings, decrypting software-encrypted or TPM-sealed blobs as
@@ -305,7 +267,8 @@ pub fn load_user_embeddings(
     config: &Config,
     user: &str,
 ) -> anyhow::Result<Vec<(u32, facelock_core::types::FaceEmbedding)>> {
-    let (software_sealer, sealer_error) = init_software_sealer(config, store)?;
+    let keys = load_sealing_keys(config, store)?;
+    let sealer_error = keys.primary_error().map(str::to_string);
 
     // Fast path: nothing is configured that could have written encrypted rows.
     // `seal_database` forces the raw path even without a software sealer, so a
@@ -314,7 +277,7 @@ pub fn load_user_embeddings(
     // corruption (same rule as the daemon).
     if !facelock_daemon::embeddings::needs_raw_rows(
         config,
-        software_sealer.is_some(),
+        keys.any_loaded(),
         sealer_error.is_some(),
     ) {
         return store
@@ -331,7 +294,7 @@ pub fn load_user_embeddings(
     facelock_daemon::embeddings::decrypt_user_embeddings(
         &raw_rows,
         config,
-        software_sealer.as_ref(),
+        &keys,
         facelock_daemon::embeddings::TpmAccess::Lazy {
             tcti: &config.tpm.tcti,
             sealer: None,
@@ -360,13 +323,14 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
     let store = open_store(config)?;
     let mut engine = load_engine(config)?;
 
-    // Initialize sealer if encryption is configured. Enrollment is the one
-    // one-shot path that fails CLOSED on an unavailable sealer: writing the
-    // template anyway would store a biometric as plaintext, which is the
-    // downgrade `ensure_enroll_encryption_allowed` exists to make explicit.
-    let (software_sealer, sealer_error) = init_software_sealer(config, &store)?;
-    if config.encryption.method != EncryptionMethod::None && software_sealer.is_none() {
-        let cause = sealer_error.unwrap_or_else(|| {
+    // Initialize the sealing keyring if encryption is configured. Enrollment
+    // is the one one-shot path that fails CLOSED on an unavailable primary:
+    // writing the template anyway would store a biometric as plaintext,
+    // which is the downgrade `ensure_enroll_encryption_allowed` exists to
+    // make explicit.
+    let keys = load_sealing_keys(config, &store)?;
+    if config.encryption.method != EncryptionMethod::None && keys.primary().is_none() {
+        let cause = keys.primary_error().map(str::to_string).unwrap_or_else(|| {
             "the configured encryption sealer could not be initialized".to_string()
         });
         bail!(
@@ -377,6 +341,7 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
             facelock_daemon::key_policy::sentence(&cause)
         );
     }
+    let key_id = keys.primary().map(|s| s.key_id());
 
     // Shared with daemon mode (facelock-daemon/src/enroll.rs): same quality
     // gate, angle-diversity check, rejection breakdown, and deadline. A local
@@ -389,8 +354,9 @@ pub fn enroll(config: &Config, user: &str, label: &str) -> anyhow::Result<(u32, 
         config,
         user,
         label,
-        software_sealer.as_ref(),
+        keys.primary(),
         device_id.as_deref(),
+        key_id.as_deref(),
         &CancelToken::new(),
     );
 
@@ -652,9 +618,12 @@ mod missing_key_tests {
             )
             .unwrap();
 
-        let (sealer, reason) = init_software_sealer(&config, &store).unwrap();
-        assert!(sealer.is_none());
-        let reason = reason.expect("the refusal must be recorded");
+        let keys = load_sealing_keys(&config, &store).unwrap();
+        assert!(keys.primary().is_none());
+        let reason = keys
+            .primary_error()
+            .expect("the refusal must be recorded")
+            .to_string();
         assert!(
             reason.contains("software-encrypted") && reason.contains("facelock clear"),
             "refusal must name what is at risk and the remedy: {reason}"
@@ -676,9 +645,9 @@ mod missing_key_tests {
             .add_model_raw("alice", "front", &[0u8; 2048], false, "embedder")
             .unwrap();
 
-        let (sealer, reason) = init_software_sealer(&config, &store).unwrap();
-        assert!(sealer.is_some());
-        assert!(reason.is_none());
+        let keys = load_sealing_keys(&config, &store).unwrap();
+        assert!(keys.primary().is_some());
+        assert!(keys.primary_error().is_none());
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
     }
 

--- a/crates/facelock-cli/src/message/setup.rs
+++ b/crates/facelock-cli/src/message/setup.rs
@@ -169,6 +169,43 @@ pub enum SetupMessage {
         count: u32,
     },
 
+    // -- carrying an existing key across an `--encryption` method change
+    // -- (issue #354): `setup_encryption_tpm_key` / `setup_encryption_keyfile`
+    // -- reuse the key already on disk instead of minting a new one.
+    SealingExistingKeyfile {
+        key_path: String,
+        sealed_path: String,
+    },
+    UnsealingExistingSealedKey {
+        sealed_path: String,
+        key_path: String,
+    },
+    /// The target is a keyfile, a TPM-sealed key already exists, but no
+    /// usable TPM can unseal it right now: a fresh keyfile is minted instead,
+    /// and the sealed key is left on disk rather than deleted.
+    SealedKeyLeftInPlace {
+        sealed_path: String,
+    },
+    /// Both a plaintext keyfile and a TPM-sealed key exist and no longer
+    /// carry the same key material — most likely left behind by a `facelock
+    /// setup` run from before this guard existed.
+    DivergedKeysNotice {
+        key_path: String,
+        sealed_path: String,
+    },
+    /// A TPM device node exists but did not initialize; surfaced because the
+    /// caller silently falls back to a software keyfile from here.
+    TpmNotFunctional {
+        tcti: String,
+        reason: String,
+    },
+    /// `encryption.method` is already `"tpm"`, but no usable TPM was found on
+    /// this run of the wizard: the sealed key stays in place, and this run
+    /// falls through to the keyfile choice.
+    TpmConfiguredButUnavailable {
+        sealed_path: String,
+    },
+
     // -- hyprlock handoff --
     HyprlockHint,
     HyprlockApplied {
@@ -377,6 +414,60 @@ impl Message for SetupMessage {
                 translate("  Removed {count} orphaned model(s)."),
                 &[("count", count.to_string())],
             ),
+            SealingExistingKeyfile {
+                key_path,
+                sealed_path,
+            } => fill(
+                translate(
+                    "  Sealing the existing key at {key_path} with the TPM (writing {sealed_path})...",
+                ),
+                &[
+                    ("key_path", key_path.clone()),
+                    ("sealed_path", sealed_path.clone()),
+                ],
+            ),
+            UnsealingExistingSealedKey {
+                sealed_path,
+                key_path,
+            } => fill(
+                translate(
+                    "  Unsealing the existing TPM-sealed key at {sealed_path} into {key_path}...",
+                ),
+                &[
+                    ("sealed_path", sealed_path.clone()),
+                    ("key_path", key_path.clone()),
+                ],
+            ),
+            SealedKeyLeftInPlace { sealed_path } => fill(
+                translate(
+                    "  NOTE: leaving the TPM-sealed key at {sealed_path} in place; models sealed under it stay readable while a TPM can still unseal it.",
+                ),
+                &[("sealed_path", sealed_path.clone())],
+            ),
+            DivergedKeysNotice {
+                key_path,
+                sealed_path,
+            } => fill(
+                translate(
+                    "  NOTE: {key_path} and {sealed_path} no longer hold the same key; models sealed under either stay readable only while that file is kept.",
+                ),
+                &[
+                    ("key_path", key_path.clone()),
+                    ("sealed_path", sealed_path.clone()),
+                ],
+            ),
+            TpmNotFunctional { tcti, reason } => fill(
+                translate(
+                    "  NOTE: a TPM device is present but not usable (tcti: {tcti}): {reason}. Falling back to a software keyfile.",
+                ),
+                &[("tcti", tcti.clone()), ("reason", reason.clone())],
+            ),
+            TpmConfiguredButUnavailable { sealed_path } => fill(
+                translate(
+                    "  NOTE: encryption.method is \"tpm\" but no usable TPM was found right now; the sealed key at {sealed_path} stays in place. Continuing with a software keyfile for this run.",
+                ),
+                &[("sealed_path", sealed_path.clone())],
+            ),
             HyprlockHint => translate(
                 "\n==> To finish hyprlock integration, run as your normal user:\n==>     facelock hyprlock enable",
             ),
@@ -400,7 +491,7 @@ impl Message for SetupMessage {
 /// above: no wildcard arm, so a variant that renders nothing does not build.
 #[cfg(test)]
 impl super::Samples for SetupMessage {
-    const VARIANT_COUNT: usize = 70;
+    const VARIANT_COUNT: usize = 76;
 
     fn samples() -> Vec<Self> {
         use SetupMessage::*;
@@ -486,6 +577,28 @@ impl super::Samples for SetupMessage {
             EncryptionEnabledKeyfileAuto,
             OrphanModelsWarning { db_path: s("/db") },
             OrphanModelsRemoved { count: 2 },
+            SealingExistingKeyfile {
+                key_path: s("/k"),
+                sealed_path: s("/s"),
+            },
+            UnsealingExistingSealedKey {
+                sealed_path: s("/s"),
+                key_path: s("/k"),
+            },
+            SealedKeyLeftInPlace {
+                sealed_path: s("/s"),
+            },
+            DivergedKeysNotice {
+                key_path: s("/k"),
+                sealed_path: s("/s"),
+            },
+            TpmNotFunctional {
+                tcti: s("device:/dev/tpmrm0"),
+                reason: s("e"),
+            },
+            TpmConfiguredButUnavailable {
+                sealed_path: s("/s"),
+            },
             HyprlockHint,
             HyprlockApplied { user: s("u") },
             BlankLine,
@@ -679,6 +792,54 @@ mod tests {
         assert_eq!(
             OrphanModelsRemoved { count: 3 }.localized(),
             "  Removed 3 orphaned model(s)."
+        );
+
+        // -- carrying an existing key across a method change (#354) --
+        assert_eq!(
+            SealingExistingKeyfile {
+                key_path: "/etc/facelock/facelock.key".into(),
+                sealed_path: "/etc/facelock/sealed.key".into(),
+            }
+            .localized(),
+            "  Sealing the existing key at /etc/facelock/facelock.key with the TPM (writing /etc/facelock/sealed.key)..."
+        );
+        assert_eq!(
+            UnsealingExistingSealedKey {
+                sealed_path: "/etc/facelock/sealed.key".into(),
+                key_path: "/etc/facelock/facelock.key".into(),
+            }
+            .localized(),
+            "  Unsealing the existing TPM-sealed key at /etc/facelock/sealed.key into /etc/facelock/facelock.key..."
+        );
+        assert_eq!(
+            SealedKeyLeftInPlace {
+                sealed_path: "/etc/facelock/sealed.key".into()
+            }
+            .localized(),
+            "  NOTE: leaving the TPM-sealed key at /etc/facelock/sealed.key in place; models sealed under it stay readable while a TPM can still unseal it."
+        );
+        assert_eq!(
+            DivergedKeysNotice {
+                key_path: "/etc/facelock/facelock.key".into(),
+                sealed_path: "/etc/facelock/sealed.key".into(),
+            }
+            .localized(),
+            "  NOTE: /etc/facelock/facelock.key and /etc/facelock/sealed.key no longer hold the same key; models sealed under either stay readable only while that file is kept."
+        );
+        assert_eq!(
+            TpmNotFunctional {
+                tcti: "device:/dev/tpmrm0".into(),
+                reason: "no such device".into(),
+            }
+            .localized(),
+            "  NOTE: a TPM device is present but not usable (tcti: device:/dev/tpmrm0): no such device. Falling back to a software keyfile."
+        );
+        assert_eq!(
+            TpmConfiguredButUnavailable {
+                sealed_path: "/etc/facelock/sealed.key".into()
+            }
+            .localized(),
+            "  NOTE: encryption.method is \"tpm\" but no usable TPM was found right now; the sealed key at /etc/facelock/sealed.key stays in place. Continuing with a software keyfile for this run."
         );
 
         // -- hyprlock handoff --

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -22,7 +22,7 @@
 use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::types::{DeviceBinding, FaceEmbedding, Wiped};
 use facelock_store::RawEmbeddingRow;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 use crate::keyring::SealingKeys;
 
@@ -243,7 +243,10 @@ fn decrypt_software_row(
         match candidate.unseal_embedding_with_aad(blob, aad.as_deref()) {
             Ok(embedding) => {
                 if index > 0 {
-                    info!(
+                    // `debug`, not `info`: this runs on every authentication
+                    // for every legacy row, so at `info` a diverged host
+                    // would log a line per row per attempt in steady state.
+                    debug!(
                         model_id = id,
                         key_id = %candidate.key_id(),
                         "legacy embedding decrypted under a secondary key"
@@ -299,10 +302,22 @@ fn software_decrypt_error(
 /// the refusal for a row whose `key_id` names a key nothing loaded, so the
 /// operator restores the artifact that matches the row rather than the one
 /// the current method already reads.
-fn other_key_artifact(config: &Config) -> &str {
+fn other_key_artifact(config: &Config) -> String {
     match config.encryption.method {
-        EncryptionMethod::Tpm => &config.encryption.key_path,
-        EncryptionMethod::Keyfile | EncryptionMethod::None => &config.encryption.sealed_key_path,
+        EncryptionMethod::Tpm => config.encryption.key_path.clone(),
+        EncryptionMethod::Keyfile | EncryptionMethod::None => {
+            let sealed = &config.encryption.sealed_key_path;
+            #[cfg(feature = "tpm")]
+            {
+                sealed.clone()
+            }
+            #[cfg(not(feature = "tpm"))]
+            {
+                // Restoring the sealed key alone cannot help here: this build
+                // has no TPM support to unseal it with.
+                format!("{sealed} under a build with the tpm feature (this one has none)")
+            }
+        }
     }
 }
 
@@ -792,8 +807,10 @@ mod tests {
         let keys = SealingKeys::from_parts(Some(primary), vec![(secondary_id.clone(), secondary)]);
 
         let capture = Capture(Arc::new(Mutex::new(Vec::new())));
+        // The fallback logs at `debug` (it runs per row per authentication).
         let subscriber = tracing_subscriber::fmt()
             .with_writer(capture.clone())
+            .with_max_level(tracing::Level::DEBUG)
             .with_ansi(false)
             .finish();
         let out = tracing::subscriber::with_default(subscriber, || {

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -21,6 +21,7 @@
 
 use facelock_core::config::Config;
 use facelock_core::types::{DeviceBinding, FaceEmbedding, Wiped};
+use facelock_store::RawEmbeddingRow;
 use tracing::warn;
 
 /// How the decrypt loop reaches a TPM sealer when a TPM-sealed row appears.
@@ -87,20 +88,21 @@ pub fn needs_raw_rows(
     software_sealer_active || config.tpm.seal_database || sealer_unavailable
 }
 
-/// Decrypt raw `(id, blob, sealed, device_id)` rows into embeddings.
+/// Decrypt raw [`RawEmbeddingRow`] rows into embeddings.
 ///
 /// Per row: software-encrypted blobs unseal with the configured key and this
 /// template's own device-derived AAD (opt-in, matching enroll); TPM-sealed
 /// blobs unseal through `tpm`; plaintext rows are size-checked and cast. The
 /// first failing row fails the whole load — a partial compare set would
-/// silently narrow authentication.
+/// silently narrow authentication. `key_id` is not consulted here (wave 1 of
+/// #354 only records it; a later wave uses it to pick the right key).
 ///
 /// Under hard device binding, rows with no device id are legacy unbound:
 /// they decrypt (never a lockout) and are reported once per load, before
 /// decryption, so a row failing elsewhere in the store does not hide them
 /// and the operator knows which templates to re-enroll (#312).
 pub fn decrypt_user_embeddings(
-    raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
+    raw_rows: &[RawEmbeddingRow],
     config: &Config,
     software_sealer: Option<&facelock_tpm::SoftwareSealer>,
     tpm: TpmAccess<'_>,
@@ -122,16 +124,13 @@ pub fn decrypt_user_embeddings(
 /// The models among `raw_rows` that stand as [`DeviceBinding::LegacyUnbound`]
 /// under the configured policy, each listed once. Empty unless
 /// `security.bind_device_aad` is on.
-fn unbound_model_ids(
-    raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
-    config: &Config,
-) -> Vec<u32> {
+fn unbound_model_ids(raw_rows: &[RawEmbeddingRow], config: &Config) -> Vec<u32> {
     let mut unbound: Vec<u32> = raw_rows
         .iter()
-        .filter(|(_, _, _, device_id)| {
-            config.classify_device_binding(device_id.as_deref()) == DeviceBinding::LegacyUnbound
+        .filter(|row| {
+            config.classify_device_binding(row.device_id.as_deref()) == DeviceBinding::LegacyUnbound
         })
-        .map(|(id, ..)| *id)
+        .map(|row| row.model_id)
         .collect();
     unbound.sort_unstable();
     unbound.dedup();
@@ -146,14 +145,21 @@ fn unbound_model_ids(
 /// from there the caller owns the plaintext, and every caller either wraps
 /// it or passes it to the wiping auth loop (D11).
 fn decrypt_rows_into(
-    raw_rows: &[(u32, Vec<u8>, bool, Option<String>)],
+    raw_rows: &[RawEmbeddingRow],
     config: &Config,
     software_sealer: Option<&facelock_tpm::SoftwareSealer>,
     mut tpm: TpmAccess<'_>,
     out: &mut Vec<(u32, FaceEmbedding)>,
 ) -> Result<(), String> {
     let mut guarded = Wiped::new(&mut *out);
-    for (id, blob, sealed, device_id) in raw_rows {
+    for RawEmbeddingRow {
+        model_id: id,
+        blob,
+        sealed,
+        device_id,
+        key_id: _,
+    } in raw_rows
+    {
         let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
             // Software-encrypted (version byte 0x02)
             let sealer = software_sealer.ok_or_else(|| {
@@ -216,9 +222,27 @@ fn decrypt_rows_into(
 mod tests {
     use super::*;
 
-    fn plaintext_row(id: u32, value: f32) -> (u32, Vec<u8>, bool, Option<String>) {
+    /// Build a [`RawEmbeddingRow`] for these tests. `key_id` is irrelevant to
+    /// the decrypt loop (wave 1 of #354 only records it), so every helper
+    /// here leaves it `None`.
+    fn raw_row(
+        model_id: u32,
+        blob: Vec<u8>,
+        sealed: bool,
+        device_id: Option<String>,
+    ) -> RawEmbeddingRow {
+        RawEmbeddingRow {
+            model_id,
+            blob,
+            sealed,
+            device_id,
+            key_id: None,
+        }
+    }
+
+    fn plaintext_row(id: u32, value: f32) -> RawEmbeddingRow {
         let emb: FaceEmbedding = [value; 512];
-        (id, bytemuck::cast_slice(&emb).to_vec(), false, None)
+        raw_row(id, bytemuck::cast_slice(&emb).to_vec(), false, None)
     }
 
     #[test]
@@ -234,7 +258,7 @@ mod tests {
     #[test]
     fn wrong_size_plaintext_row_fails_the_load() {
         let config = Config::parse("").unwrap();
-        let rows = vec![(7u32, vec![0u8; 100], false, None)];
+        let rows = vec![raw_row(7, vec![0u8; 100], false, None)];
         let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
         assert!(err.contains("invalid raw embedding size for id 7"), "{err}");
     }
@@ -245,7 +269,7 @@ mod tests {
         // Version byte 0x02 marks software encryption.
         let mut blob = vec![0x02u8];
         blob.extend_from_slice(&[0u8; 64]);
-        let rows = vec![(3u32, blob, true, None)];
+        let rows = vec![raw_row(3, blob, true, None)];
         let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
         assert_eq!(
             err,
@@ -262,7 +286,7 @@ mod tests {
 
         let emb: FaceEmbedding = [0.5; 512];
         let blob = sealer.seal_embedding(&emb).unwrap();
-        let rows = vec![(4u32, blob, true, None)];
+        let rows = vec![raw_row(4, blob, true, None)];
 
         let config = Config::parse("").unwrap();
         let out =
@@ -277,7 +301,7 @@ mod tests {
         let config = Config::parse("").unwrap();
         let mut blob = vec![0x01u8];
         blob.extend_from_slice(&[0u8; 64]);
-        let rows = vec![(5u32, blob, true, None)];
+        let rows = vec![raw_row(5, blob, true, None)];
         let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
         assert_eq!(err, "TPM-sealed embeddings exist but TPM is not available");
     }
@@ -291,7 +315,7 @@ mod tests {
         let config = Config::parse("").unwrap();
         let mut blob = vec![0x01u8];
         blob.extend_from_slice(&[0u8; 64]);
-        let rows = vec![(6u32, blob, true, None)];
+        let rows = vec![raw_row(6, blob, true, None)];
         let err = decrypt_user_embeddings(
             &rows,
             &config,
@@ -316,7 +340,7 @@ mod tests {
         // Row 3 fails: software-encrypted with no key configured.
         let mut blob = vec![0x02u8];
         blob.extend_from_slice(&[0u8; 64]);
-        rows.push((3u32, blob, true, None));
+        rows.push(raw_row(3, blob, true, None));
 
         let mut out = Vec::new();
         let err =
@@ -348,19 +372,19 @@ mod tests {
         let enrolled = "046d:085e:REAL";
         let aad = config.security.device_aad(Some(enrolled));
 
-        let row = |id: u32, value: f32, device_id: &str| {
+        let sealed_row = |id: u32, value: f32, device_id: &str| {
             let emb: FaceEmbedding = [value; 512];
             let blob = sealer
                 .seal_embedding_with_aad(&emb, aad.as_deref())
                 .unwrap();
-            (id, blob, true, Some(device_id.to_string()))
+            raw_row(id, blob, true, Some(device_id.to_string()))
         };
         // Rows 1-2 decrypt fine; row 3's recorded device id derives a
         // different AAD than it was sealed under.
         let rows = vec![
-            row(1, 0.25, enrolled),
-            row(2, 0.75, enrolled),
-            row(3, 0.5, "ffff:ffff:OTHER"),
+            sealed_row(1, 0.25, enrolled),
+            sealed_row(2, 0.75, enrolled),
+            sealed_row(3, 0.5, "ffff:ffff:OTHER"),
         ];
 
         let mut out = Vec::new();
@@ -409,9 +433,9 @@ mod tests {
         let legacy_emb: FaceEmbedding = [0.75; 512];
         let legacy_blob = sealer.seal_embedding_with_aad(&legacy_emb, None).unwrap();
         let rows = vec![
-            (1u32, bound_blob, true, Some(bound_id.to_string())),
-            (2u32, legacy_blob.clone(), true, None),
-            (2u32, legacy_blob, true, Some(String::new())),
+            raw_row(1, bound_blob, true, Some(bound_id.to_string())),
+            raw_row(2, legacy_blob.clone(), true, None),
+            raw_row(2, legacy_blob, true, Some(String::new())),
         ];
 
         let out = decrypt_user_embeddings(&rows, &hard, Some(&sealer), TpmAccess::Held(None))
@@ -436,7 +460,12 @@ mod tests {
 
         let emb: FaceEmbedding = [0.5; 512];
         let unbound_blob = sealer.seal_embedding_with_aad(&emb, None).unwrap();
-        let rows = vec![(9u32, unbound_blob, true, Some("046d:085e:".to_string()))];
+        let rows = vec![raw_row(
+            9,
+            unbound_blob,
+            true,
+            Some("046d:085e:".to_string()),
+        )];
 
         let hard = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
         let err = decrypt_user_embeddings(&rows, &hard, Some(&sealer), TpmAccess::Held(None))
@@ -465,7 +494,7 @@ mod tests {
         let bound = sealer
             .seal_embedding_with_aad(&emb, hard.security.device_aad(Some(id)).as_deref())
             .unwrap();
-        let rows = vec![(4u32, bound, true, Some(id.to_string()))];
+        let rows = vec![raw_row(4, bound, true, Some(id.to_string()))];
 
         let off = Config::parse("").unwrap();
         let err =
@@ -513,8 +542,8 @@ mod tests {
         let emb: FaceEmbedding = [0.5; 512];
         let unbound_blob = sealer.seal_embedding_with_aad(&emb, None).unwrap();
         let rows = vec![
-            (1u32, unbound_blob.clone(), true, None),
-            (2u32, unbound_blob, true, Some("046d:085e:".to_string())),
+            raw_row(1, unbound_blob.clone(), true, None),
+            raw_row(2, unbound_blob, true, Some("046d:085e:".to_string())),
         ];
         let hard = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
 

--- a/crates/facelock-daemon/src/embeddings.rs
+++ b/crates/facelock-daemon/src/embeddings.rs
@@ -19,10 +19,12 @@
 //! `DaemonResponse::Error`, the direct path in `anyhow`. They are
 //! machine-facing (they cross D-Bus and land in logs) and must not localize.
 
-use facelock_core::config::Config;
+use facelock_core::config::{Config, EncryptionMethod};
 use facelock_core::types::{DeviceBinding, FaceEmbedding, Wiped};
 use facelock_store::RawEmbeddingRow;
-use tracing::warn;
+use tracing::{info, warn};
+
+use crate::keyring::SealingKeys;
 
 /// How the decrypt loop reaches a TPM sealer when a TPM-sealed row appears.
 ///
@@ -90,12 +92,13 @@ pub fn needs_raw_rows(
 
 /// Decrypt raw [`RawEmbeddingRow`] rows into embeddings.
 ///
-/// Per row: software-encrypted blobs unseal with the configured key and this
-/// template's own device-derived AAD (opt-in, matching enroll); TPM-sealed
-/// blobs unseal through `tpm`; plaintext rows are size-checked and cast. The
-/// first failing row fails the whole load — a partial compare set would
-/// silently narrow authentication. `key_id` is not consulted here (wave 1 of
-/// #354 only records it; a later wave uses it to pick the right key).
+/// Per row: software-encrypted blobs unseal with this template's own
+/// device-derived AAD (opt-in, matching enroll) and the key that sealed it —
+/// a row naming a `key_id` (#354 wave 2 onward) is handed exactly that key
+/// from `keys`, and a pre-V7 row naming none is tried against every key
+/// `keys` has loaded, primary first. TPM-sealed blobs unseal through `tpm`;
+/// plaintext rows are size-checked and cast. The first failing row fails the
+/// whole load — a partial compare set would silently narrow authentication.
 ///
 /// Under hard device binding, rows with no device id are legacy unbound:
 /// they decrypt (never a lockout) and are reported once per load, before
@@ -104,7 +107,7 @@ pub fn needs_raw_rows(
 pub fn decrypt_user_embeddings(
     raw_rows: &[RawEmbeddingRow],
     config: &Config,
-    software_sealer: Option<&facelock_tpm::SoftwareSealer>,
+    keys: &SealingKeys,
     tpm: TpmAccess<'_>,
 ) -> Result<Vec<(u32, FaceEmbedding)>, String> {
     // Reported before decrypting, so the diagnostic reaches the log even
@@ -117,7 +120,7 @@ pub fn decrypt_user_embeddings(
         );
     }
     let mut results = Vec::with_capacity(raw_rows.len());
-    decrypt_rows_into(raw_rows, config, software_sealer, tpm, &mut results)?;
+    decrypt_rows_into(raw_rows, config, keys, tpm, &mut results)?;
     Ok(results)
 }
 
@@ -147,7 +150,7 @@ fn unbound_model_ids(raw_rows: &[RawEmbeddingRow], config: &Config) -> Vec<u32> 
 fn decrypt_rows_into(
     raw_rows: &[RawEmbeddingRow],
     config: &Config,
-    software_sealer: Option<&facelock_tpm::SoftwareSealer>,
+    keys: &SealingKeys,
     mut tpm: TpmAccess<'_>,
     out: &mut Vec<(u32, FaceEmbedding)>,
 ) -> Result<(), String> {
@@ -157,40 +160,19 @@ fn decrypt_rows_into(
         blob,
         sealed,
         device_id,
-        key_id: _,
+        key_id,
     } in raw_rows
     {
         let embedding = if *sealed && facelock_tpm::is_software_encrypted(blob) {
             // Software-encrypted (version byte 0x02)
-            let sealer = software_sealer.ok_or_else(|| {
-                format!("embedding {id} is software-encrypted but no key is configured")
-            })?;
-            let aad = config.security.device_aad(device_id.as_deref());
-            sealer
-                .unseal_embedding_with_aad(blob, aad.as_deref())
-                .map_err(|e| {
-                    let mut message = format!("software decryption failed for embedding {id}: {e}");
-                    // One cause the cipher cannot tell from a wrong key or a
-                    // corrupt blob: a row that records a device id but was
-                    // sealed before hard binding was enabled carries no AAD,
-                    // so it cannot open under the one derived now. Name that
-                    // possibility and its fix without asserting it.
-                    let has_id = device_id.as_deref().is_some_and(|d| !d.is_empty());
-                    if aad.is_some() {
-                        message.push_str(
-                            "; if this template predates security.bind_device_aad, re-enroll \
-                             to bind it",
-                        );
-                    } else if has_id {
-                        // The other direction: the flag was turned off, or
-                        // encryption disabled, over a store sealed under it.
-                        message.push_str(
-                            "; if this template was sealed under security.bind_device_aad, \
-                             re-enable it or re-enroll",
-                        );
-                    }
-                    message
-                })?
+            decrypt_software_row(
+                *id,
+                blob,
+                device_id.as_deref(),
+                key_id.as_deref(),
+                config,
+                keys,
+            )?
         } else if *sealed {
             // TPM-sealed (version byte 0x01/0x03)
             tpm.sealer()?
@@ -218,13 +200,119 @@ fn decrypt_rows_into(
     Ok(())
 }
 
+/// Decrypt one software-encrypted (version byte 0x02) row.
+///
+/// A row naming a `key_id` gets exactly that key — no trial against any
+/// other, even when one is loaded — and a lookup miss fails by name rather
+/// than falling back to "no key is configured", which was never true. A
+/// pre-V7 row naming none is tried against every key `keys` has loaded,
+/// primary first: AES-GCM makes this safe, because a wrong key fails the tag
+/// check rather than misreading the blob.
+fn decrypt_software_row(
+    id: u32,
+    blob: &[u8],
+    device_id: Option<&str>,
+    key_id: Option<&str>,
+    config: &Config,
+    keys: &SealingKeys,
+) -> Result<FaceEmbedding, String> {
+    let aad = config.security.device_aad(device_id);
+
+    if let Some(wanted) = key_id {
+        let sealer = keys.by_key_id(wanted).ok_or_else(|| {
+            format!(
+                "embedding {id} was sealed under key {wanted}, which is not loadable: restore \
+                 {} (the artifact for the other encryption method) or re-enroll",
+                other_key_artifact(config)
+            )
+        })?;
+        return sealer
+            .unseal_embedding_with_aad(blob, aad.as_deref())
+            .map_err(|e| software_decrypt_error(id, &e.to_string(), device_id, aad.is_some()));
+    }
+
+    // Pre-V7 row: no key_id recorded, so try every key this process has,
+    // primary first.
+    if !keys.any_loaded() {
+        return Err(format!(
+            "embedding {id} is software-encrypted but no key is configured"
+        ));
+    }
+    let mut last_error: Option<String> = None;
+    for (index, candidate) in keys.candidates_for_legacy_row().enumerate() {
+        match candidate.unseal_embedding_with_aad(blob, aad.as_deref()) {
+            Ok(embedding) => {
+                if index > 0 {
+                    info!(
+                        model_id = id,
+                        key_id = %candidate.key_id(),
+                        "legacy embedding decrypted under a secondary key"
+                    );
+                }
+                return Ok(embedding);
+            }
+            Err(e) => last_error = Some(e.to_string()),
+        }
+    }
+    let mut message = software_decrypt_error(
+        id,
+        last_error
+            .as_deref()
+            .unwrap_or("no loadable key could open it"),
+        device_id,
+        aad.is_some(),
+    );
+    message.push_str("; or sealed under a key that is no longer loadable");
+    Err(message)
+}
+
+/// The base "software decryption failed" message and its AAD hints, shared by
+/// the named-key and legacy-trial paths.
+///
+/// One cause the cipher cannot tell from a wrong key or a corrupt blob: a row
+/// that records a device id but was sealed before hard binding was enabled
+/// carries no AAD, so it cannot open under the one derived now. Name that
+/// possibility and its fix without asserting it.
+fn software_decrypt_error(
+    id: u32,
+    cause: &str,
+    device_id: Option<&str>,
+    aad_present: bool,
+) -> String {
+    let mut message = format!("software decryption failed for embedding {id}: {cause}");
+    let has_id = device_id.is_some_and(|d| !d.is_empty());
+    if aad_present {
+        message
+            .push_str("; if this template predates security.bind_device_aad, re-enroll to bind it");
+    } else if has_id {
+        // The other direction: the flag was turned off, or encryption
+        // disabled, over a store sealed under it.
+        message.push_str(
+            "; if this template was sealed under security.bind_device_aad, re-enable it or \
+             re-enroll",
+        );
+    }
+    message
+}
+
+/// The artifact the *other* encryption method would have written — named in
+/// the refusal for a row whose `key_id` names a key nothing loaded, so the
+/// operator restores the artifact that matches the row rather than the one
+/// the current method already reads.
+fn other_key_artifact(config: &Config) -> &str {
+    match config.encryption.method {
+        EncryptionMethod::Tpm => &config.encryption.key_path,
+        EncryptionMethod::Keyfile | EncryptionMethod::None => &config.encryption.sealed_key_path,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Build a [`RawEmbeddingRow`] for these tests. `key_id` is irrelevant to
-    /// the decrypt loop (wave 1 of #354 only records it), so every helper
-    /// here leaves it `None`.
+    /// Build a [`RawEmbeddingRow`] for these tests, with `key_id` left
+    /// `None` (a pre-V7/legacy row). Tests that need a row naming a key
+    /// construct a [`RawEmbeddingRow`] directly.
     fn raw_row(
         model_id: u32,
         blob: Vec<u8>,
@@ -249,7 +337,9 @@ mod tests {
     fn plaintext_rows_round_trip() {
         let config = Config::parse("").unwrap();
         let rows = vec![plaintext_row(1, 0.25), plaintext_row(2, 0.75)];
-        let out = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap();
+        let out =
+            decrypt_user_embeddings(&rows, &config, &SealingKeys::none(), TpmAccess::Held(None))
+                .unwrap();
         assert_eq!(out.len(), 2);
         assert_eq!(out[0], (1, [0.25; 512]));
         assert_eq!(out[1], (2, [0.75; 512]));
@@ -259,7 +349,9 @@ mod tests {
     fn wrong_size_plaintext_row_fails_the_load() {
         let config = Config::parse("").unwrap();
         let rows = vec![raw_row(7, vec![0u8; 100], false, None)];
-        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        let err =
+            decrypt_user_embeddings(&rows, &config, &SealingKeys::none(), TpmAccess::Held(None))
+                .unwrap_err();
         assert!(err.contains("invalid raw embedding size for id 7"), "{err}");
     }
 
@@ -270,7 +362,9 @@ mod tests {
         let mut blob = vec![0x02u8];
         blob.extend_from_slice(&[0u8; 64]);
         let rows = vec![raw_row(3, blob, true, None)];
-        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        let err =
+            decrypt_user_embeddings(&rows, &config, &SealingKeys::none(), TpmAccess::Held(None))
+                .unwrap_err();
         assert_eq!(
             err,
             "embedding 3 is software-encrypted but no key is configured"
@@ -289,8 +383,8 @@ mod tests {
         let rows = vec![raw_row(4, blob, true, None)];
 
         let config = Config::parse("").unwrap();
-        let out =
-            decrypt_user_embeddings(&rows, &config, Some(&sealer), TpmAccess::Held(None)).unwrap();
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
+        let out = decrypt_user_embeddings(&rows, &config, &keys, TpmAccess::Held(None)).unwrap();
         assert_eq!(out, vec![(4, emb)]);
     }
 
@@ -302,7 +396,9 @@ mod tests {
         let mut blob = vec![0x01u8];
         blob.extend_from_slice(&[0u8; 64]);
         let rows = vec![raw_row(5, blob, true, None)];
-        let err = decrypt_user_embeddings(&rows, &config, None, TpmAccess::Held(None)).unwrap_err();
+        let err =
+            decrypt_user_embeddings(&rows, &config, &SealingKeys::none(), TpmAccess::Held(None))
+                .unwrap_err();
         assert_eq!(err, "TPM-sealed embeddings exist but TPM is not available");
     }
 
@@ -319,7 +415,7 @@ mod tests {
         let err = decrypt_user_embeddings(
             &rows,
             &config,
-            None,
+            &SealingKeys::none(),
             TpmAccess::Lazy {
                 tcti: "device",
                 sealer: None,
@@ -343,8 +439,14 @@ mod tests {
         rows.push(raw_row(3, blob, true, None));
 
         let mut out = Vec::new();
-        let err =
-            decrypt_rows_into(&rows, &config, None, TpmAccess::Held(None), &mut out).unwrap_err();
+        let err = decrypt_rows_into(
+            &rows,
+            &config,
+            &SealingKeys::none(),
+            TpmAccess::Held(None),
+            &mut out,
+        )
+        .unwrap_err();
         assert!(err.contains("software-encrypted"), "{err}");
 
         assert_eq!(out.len(), 2, "rows 1-2 were decrypted before row 3 failed");
@@ -387,15 +489,10 @@ mod tests {
             sealed_row(3, 0.5, "ffff:ffff:OTHER"),
         ];
 
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
         let mut out = Vec::new();
-        let err = decrypt_rows_into(
-            &rows,
-            &config,
-            Some(&sealer),
-            TpmAccess::Held(None),
-            &mut out,
-        )
-        .unwrap_err();
+        let err =
+            decrypt_rows_into(&rows, &config, &keys, TpmAccess::Held(None), &mut out).unwrap_err();
         assert!(
             err.contains("software decryption failed for embedding 3"),
             "{err}"
@@ -438,7 +535,8 @@ mod tests {
             raw_row(2, legacy_blob, true, Some(String::new())),
         ];
 
-        let out = decrypt_user_embeddings(&rows, &hard, Some(&sealer), TpmAccess::Held(None))
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
+        let out = decrypt_user_embeddings(&rows, &hard, &keys, TpmAccess::Held(None))
             .expect("a legacy unbound row must never fail the load");
         assert_eq!(out.len(), 3, "every row authenticates");
         assert_eq!(out[1], (2, legacy_emb));
@@ -468,8 +566,8 @@ mod tests {
         )];
 
         let hard = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
-        let err = decrypt_user_embeddings(&rows, &hard, Some(&sealer), TpmAccess::Held(None))
-            .unwrap_err();
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
+        let err = decrypt_user_embeddings(&rows, &hard, &keys, TpmAccess::Held(None)).unwrap_err();
         assert!(
             err.contains("software decryption failed for embedding 9"),
             "{err}"
@@ -497,8 +595,8 @@ mod tests {
         let rows = vec![raw_row(4, bound, true, Some(id.to_string()))];
 
         let off = Config::parse("").unwrap();
-        let err =
-            decrypt_user_embeddings(&rows, &off, Some(&sealer), TpmAccess::Held(None)).unwrap_err();
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
+        let err = decrypt_user_embeddings(&rows, &off, &keys, TpmAccess::Held(None)).unwrap_err();
         assert!(
             err.contains("software decryption failed for embedding 4"),
             "{err}"
@@ -546,6 +644,7 @@ mod tests {
             raw_row(2, unbound_blob, true, Some("046d:085e:".to_string())),
         ];
         let hard = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
+        let keys = SealingKeys::from_parts(Some(sealer), vec![]);
 
         let capture = Capture(Arc::new(Mutex::new(Vec::new())));
         let subscriber = tracing_subscriber::fmt()
@@ -553,7 +652,7 @@ mod tests {
             .with_ansi(false)
             .finish();
         let result = tracing::subscriber::with_default(subscriber, || {
-            decrypt_user_embeddings(&rows, &hard, Some(&sealer), TpmAccess::Held(None))
+            decrypt_user_embeddings(&rows, &hard, &keys, TpmAccess::Held(None))
         });
 
         let err = result.expect_err("the pre-flag id row fails the load");
@@ -590,5 +689,193 @@ mod tests {
     fn a_refused_sealer_forces_raw_rows() {
         let plain = Config::parse("").unwrap();
         assert!(needs_raw_rows(&plain, false, true));
+    }
+
+    // --- #354 wave 2: decrypt under the key that sealed the row ---
+
+    /// A row naming a `key_id` that is a *secondary*, not the primary, still
+    /// decrypts — the whole point of the keyring: a template sealed under a
+    /// key this process no longer configures as primary keeps working as
+    /// long as that key is still loadable from somewhere.
+    #[test]
+    fn row_naming_a_secondary_key_decrypts_under_it() {
+        let primary = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32]);
+        let secondary = facelock_tpm::SoftwareSealer::from_key([0x22u8; 32]);
+        let secondary_id = secondary.key_id();
+
+        let emb: FaceEmbedding = [0.4; 512];
+        let blob = secondary.seal_embedding(&emb).unwrap();
+        let rows = vec![RawEmbeddingRow {
+            model_id: 10,
+            blob,
+            sealed: true,
+            device_id: None,
+            key_id: Some(secondary_id.clone()),
+        }];
+
+        let config = Config::parse("").unwrap();
+        let keys = SealingKeys::from_parts(Some(primary), vec![(secondary_id, secondary)]);
+        let out = decrypt_user_embeddings(&rows, &config, &keys, TpmAccess::Held(None)).unwrap();
+        assert_eq!(out, vec![(10, emb)]);
+    }
+
+    /// A row naming a key nothing loaded fails by name — not with "no key is
+    /// configured" (untrue: a primary is loaded) and not by silently trying
+    /// the primary anyway. The message names the artifact for the *other*
+    /// encryption method, since that is where a lost cross-method key lives.
+    #[test]
+    fn row_naming_an_unknown_key_id_fails_naming_the_other_artifact() {
+        let primary = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32]);
+        let elsewhere = facelock_tpm::SoftwareSealer::from_key([0x99u8; 32]);
+        let unknown_id = elsewhere.key_id();
+
+        let emb: FaceEmbedding = [0.4; 512];
+        let blob = elsewhere.seal_embedding(&emb).unwrap();
+        let rows = vec![RawEmbeddingRow {
+            model_id: 11,
+            blob,
+            sealed: true,
+            device_id: None,
+            key_id: Some(unknown_id.clone()),
+        }];
+
+        // method = keyfile, so the "other artifact" named is sealed_key_path.
+        let config = Config::parse("[encryption]\nmethod = \"keyfile\"\n").unwrap();
+        let keys = SealingKeys::from_parts(Some(primary), vec![]);
+        let err =
+            decrypt_user_embeddings(&rows, &config, &keys, TpmAccess::Held(None)).unwrap_err();
+        assert!(
+            err.contains(&format!("embedding 11 was sealed under key {unknown_id}")),
+            "{err}"
+        );
+        assert!(err.contains("not loadable"), "{err}");
+        assert!(err.contains(&config.encryption.sealed_key_path), "{err}");
+        assert!(err.contains("re-enroll"), "{err}");
+    }
+
+    /// A pre-V7 row (no `key_id`) sealed under a loaded secondary decrypts
+    /// through the trial, and the win is logged naming the model and key —
+    /// a store mid-migration (some rows tagged, some not) must not regress a
+    /// row that still opens under a key this process kept around.
+    #[test]
+    fn legacy_row_sealed_under_a_secondary_decrypts_through_the_trial() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct Capture(Arc<Mutex<Vec<u8>>>);
+        impl Write for Capture {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+            type Writer = Capture;
+            fn make_writer(&'a self) -> Capture {
+                self.clone()
+            }
+        }
+
+        let primary = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32]);
+        let secondary = facelock_tpm::SoftwareSealer::from_key([0x22u8; 32]);
+        let secondary_id = secondary.key_id();
+
+        let emb: FaceEmbedding = [0.6; 512];
+        let blob = secondary.seal_embedding(&emb).unwrap();
+        let rows = vec![raw_row(12, blob, true, None)];
+
+        let config = Config::parse("").unwrap();
+        let keys = SealingKeys::from_parts(Some(primary), vec![(secondary_id.clone(), secondary)]);
+
+        let capture = Capture(Arc::new(Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(capture.clone())
+            .with_ansi(false)
+            .finish();
+        let out = tracing::subscriber::with_default(subscriber, || {
+            decrypt_user_embeddings(&rows, &config, &keys, TpmAccess::Held(None))
+        })
+        .unwrap();
+        assert_eq!(out, vec![(12, emb)]);
+
+        let log = String::from_utf8(capture.0.lock().unwrap().clone()).unwrap();
+        assert!(log.contains("secondary key"), "{log}");
+        assert!(log.contains(&secondary_id), "{log}");
+    }
+
+    /// A legacy row sealed under a key that is neither the primary nor any
+    /// loaded secondary fails with the trial's own clause, distinct from "no
+    /// key is configured" (untrue: keys ARE loaded, just not this row's).
+    #[test]
+    fn legacy_row_sealed_under_an_unloaded_third_key_fails_with_the_trial_clause() {
+        let primary = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32]);
+        let secondary = facelock_tpm::SoftwareSealer::from_key([0x22u8; 32]);
+        let elsewhere = facelock_tpm::SoftwareSealer::from_key([0x33u8; 32]);
+
+        let emb: FaceEmbedding = [0.7; 512];
+        let blob = elsewhere.seal_embedding(&emb).unwrap();
+        let rows = vec![raw_row(13, blob, true, None)];
+
+        let config = Config::parse("").unwrap();
+        let keys = SealingKeys::from_parts(Some(primary), vec![(secondary.key_id(), secondary)]);
+        let err =
+            decrypt_user_embeddings(&rows, &config, &keys, TpmAccess::Held(None)).unwrap_err();
+        assert!(
+            err.contains("software decryption failed for embedding 13"),
+            "{err}"
+        );
+        assert!(
+            err.contains("sealed under a key that is no longer loadable"),
+            "{err}"
+        );
+    }
+
+    /// Naming a `key_id` is not a bypass of hard device binding: the same AAD
+    /// derivation applies whether or not the row names its key, and a forged
+    /// device id still fails to open a named-key row.
+    #[test]
+    fn named_key_row_still_enforces_hard_binding_aad() {
+        let primary = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32]);
+        let primary_id = primary.key_id();
+
+        let hard = Config::parse("[security]\nbind_device_aad = true\n").unwrap();
+        let device_id = "046d:085e:REAL";
+        let aad = hard.security.device_aad(Some(device_id));
+        let emb: FaceEmbedding = [0.3; 512];
+        let blob = primary
+            .seal_embedding_with_aad(&emb, aad.as_deref())
+            .unwrap();
+        let keys = SealingKeys::from_parts(Some(primary), vec![]);
+
+        let good_row = RawEmbeddingRow {
+            model_id: 20,
+            blob: blob.clone(),
+            sealed: true,
+            device_id: Some(device_id.to_string()),
+            key_id: Some(primary_id.clone()),
+        };
+        let out =
+            decrypt_user_embeddings(&[good_row], &hard, &keys, TpmAccess::Held(None)).unwrap();
+        assert_eq!(out, vec![(20, emb)]);
+
+        // A forged device id derives a different AAD, so the same named key
+        // still fails to open it: naming the key must not bypass binding.
+        let forged_row = RawEmbeddingRow {
+            model_id: 21,
+            blob,
+            sealed: true,
+            device_id: Some("ffff:ffff:forged".to_string()),
+            key_id: Some(primary_id),
+        };
+        let err = decrypt_user_embeddings(&[forged_row], &hard, &keys, TpmAccess::Held(None))
+            .unwrap_err();
+        assert!(
+            err.contains("software decryption failed for embedding 21"),
+            "{err}"
+        );
     }
 }

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -134,6 +134,7 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
     label: &str,
     sealer: Option<&SoftwareSealer>,
     device_id: Option<&str>,
+    key_id: Option<&str>,
     cancel: &CancelToken,
 ) -> EnrollOutcome {
     // Opt-in hard device binding (Plan 04): when enabled, fold this camera's
@@ -318,6 +319,7 @@ pub fn enroll<C: CameraSource, E: FaceProcessor>(
         label,
         sealer,
         device_id,
+        key_id,
         device_aad.as_deref(),
         &accepted,
         cancel,
@@ -364,6 +366,7 @@ fn persist_enrollment<S: EmbeddingSealer>(
     label: &str,
     sealer: Option<&S>,
     device_id: Option<&str>,
+    key_id: Option<&str>,
     device_aad: Option<&[u8]>,
     accepted: &[FaceEmbedding],
     cancel: &CancelToken,
@@ -414,7 +417,7 @@ fn persist_enrollment<S: EmbeddingSealer>(
         sealer.is_some(),
         embedder_model,
         device_id,
-        None,
+        key_id,
     ) {
         Ok(model_id) => {
             info!(
@@ -591,6 +594,7 @@ mod tests {
             "2026-08-08-1",
             None,
             None,
+            None,
             &CancelToken::new(),
         );
 
@@ -645,7 +649,7 @@ mod tests {
     ) -> EnrollOutcome {
         let config = Config::parse("[recognition]\ntimeout_secs = 2\n").unwrap();
         enroll(
-            camera, engine, store, &config, "alice", label, sealer, None, cancel,
+            camera, engine, store, &config, "alice", label, sealer, None, None, cancel,
         )
     }
 
@@ -784,6 +788,7 @@ mod tests {
             Some(&sealer),
             None,
             None,
+            None,
             &accepted,
             &CancelToken::new(),
         );
@@ -847,6 +852,7 @@ mod tests {
             "alice",
             "front",
             Some(&sealer),
+            None,
             None,
             None,
             &accepted,
@@ -917,6 +923,49 @@ mod tests {
             assert!(
                 known.contains(&plain),
                 "each row unseals to one of the accepted embeddings"
+            );
+        }
+    }
+
+    /// #354: the `key_id` passed in is what the persisted model carries —
+    /// this is the only writer of the column outside wave 1's `None`, and a
+    /// row that names the wrong key (or none) defeats the whole point of
+    /// recording it.
+    #[test]
+    fn persisted_model_carries_the_key_id_passed_in() {
+        let store = FaceStore::open_memory().unwrap();
+        let sealer = SoftwareSealer::from_key([7u8; 32]);
+        let key_id = sealer.key_id();
+        let accepted: Vec<FaceEmbedding> = [0, 40, 80]
+            .into_iter()
+            .map(fixtures::known_embedding)
+            .collect();
+
+        let outcome = persist_enrollment(
+            &store,
+            "",
+            "alice",
+            "front",
+            Some(&sealer),
+            None,
+            Some(key_id.as_str()),
+            None,
+            &accepted,
+            &CancelToken::new(),
+        );
+        let model_id = match outcome {
+            EnrollOutcome::Enrolled { model_id, .. } => model_id,
+            other => panic!("expected success, got: {other:?}"),
+        };
+
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows.len(), accepted.len());
+        for row in &rows {
+            assert_eq!(row.model_id, model_id);
+            assert_eq!(
+                row.key_id.as_deref(),
+                Some(key_id.as_str()),
+                "every row of the persisted model must carry the key_id passed to enroll"
             );
         }
     }
@@ -1016,6 +1065,7 @@ mod tests {
             &config,
             "alice",
             "front",
+            None,
             None,
             None,
             &CancelToken::new(),

--- a/crates/facelock-daemon/src/enroll.rs
+++ b/crates/facelock-daemon/src/enroll.rs
@@ -414,6 +414,7 @@ fn persist_enrollment<S: EmbeddingSealer>(
         sealer.is_some(),
         embedder_model,
         device_id,
+        None,
     ) {
         Ok(model_id) => {
             info!(

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -681,24 +681,15 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         {
             return;
         }
-        match SealingKeys::load(&self.config, &self.store) {
-            Ok(keys) => {
-                if keys.primary_error().is_none() {
-                    info!("encryption key is readable again — enrollment is no longer refused");
-                    // The compare set was decrypted (or not) under the old
-                    // decision; the next frame reloads it under this one.
-                    self.preview_embeddings = None;
-                }
-                self.keys = keys;
-            }
-            // `load` only returns `Err` for a `tpm` primary; the keyfile
-            // method this guard is scoped to always returns `Ok`, refused or
-            // not. Kept defensive rather than `unreachable!`: a future
-            // `load` change that starts erroring for `keyfile` too must not
-            // panic a running daemon on its next refresh.
-            Err(msg) => {
-                warn!("re-checking the encryption key failed: {msg}");
-            }
+        // Only the primary is re-resolved: the secondaries loaded at
+        // construction are unchanged, and reloading them would re-open the
+        // TPM on every attempt made while the keyfile stays missing.
+        self.keys.refresh_primary(&self.config, &self.store);
+        if self.keys.primary_error().is_none() {
+            info!("encryption key is readable again — enrollment is no longer refused");
+            // The compare set was decrypted (or not) under the old
+            // decision; the next frame reloads it under this one.
+            self.preview_embeddings = None;
         }
     }
 

--- a/crates/facelock-daemon/src/handler.rs
+++ b/crates/facelock-daemon/src/handler.rs
@@ -13,6 +13,7 @@ use crate::audit::AuditSource;
 use crate::auth::{self, AuthOutcome, CANCELLED_MESSAGE, PreCheckContext};
 use crate::cancel::CancelToken;
 use crate::enroll::{self, EnrollOutcome};
+use crate::keyring::SealingKeys;
 use crate::rate_limit::RateLimiter;
 
 /// Why an authentication is being run.
@@ -593,11 +594,11 @@ pub struct Handler<C: CameraSource, E: FaceProcessor> {
     /// feature this is the passthrough sealer, whose per-row unseal reports a
     /// clear "compile with tpm" error instead of misreading sealed blobs.
     tpm_sealer: Option<facelock_tpm::TpmSealer>,
-    software_sealer: Option<facelock_tpm::SoftwareSealer>,
-    /// Why the software sealer could not be initialized for a configured
-    /// encryption method. `Some` means enroll must fail CLOSED rather than
-    /// silently downgrade to plaintext biometric storage (auth is unaffected).
-    sealer_init_error: Option<String>,
+    /// The primary key that seals new rows, plus any secondary key still
+    /// needed to open a row a previous configuration sealed under a
+    /// different key (#354). Replaces the old separate `software_sealer` and
+    /// `sealer_init_error` fields — see [`crate::keyring::SealingKeys`].
+    keys: SealingKeys,
     /// Per-preview-session compare set (see [`PreviewEmbeddings`]). `None`
     /// between preview sessions; setting it back to `None` zeroizes the set.
     preview_embeddings: Option<PreviewEmbeddings>,
@@ -629,62 +630,19 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             None
         };
 
-        // Initialize software sealer based on encryption method. On failure for a
-        // method that requires encryption, we record `sealer_init_error` and leave
-        // the sealer `None` so ENROLL can fail closed (see `handle`). We do NOT
-        // fail the whole handler here: that would take the daemon down and block
-        // the auth path, which must keep falling through to password as before.
-        let mut sealer_init_error: Option<String> = None;
-        let software_sealer = match config.encryption.method {
-            EncryptionMethod::Keyfile => {
-                // Encrypt-by-default (finding #8): auto-generate the key on
-                // first use so a keyfile default actually encrypts — but only
-                // for a database that holds no encrypted row. `key_policy` is
-                // the one gate; the daemon, the one-shot path, `facelock
-                // setup` and `facelock encrypt` all mint through it, because a
-                // refusal wired into one writer is not a refusal (#231).
-                match Self::resolve_keyfile_sealer(&config, &store) {
-                    Ok(sealer) => Some(sealer),
-                    // Fail CLOSED on enroll: record the cause so `handle`
-                    // refuses to enroll rather than silently storing the
-                    // biometric template as plaintext (finding: silent
-                    // plaintext downgrade). Auth is untouched and keeps
-                    // falling through to password.
-                    Err(msg) => {
-                        warn!(
-                            "software encryption sealer unavailable — enroll will be refused: {msg}"
-                        );
-                        sealer_init_error = Some(msg);
-                        None
-                    }
-                }
-            }
-            EncryptionMethod::Tpm => {
-                #[cfg(feature = "tpm")]
-                {
-                    let sealed_path = std::path::Path::new(&config.encryption.sealed_key_path);
-                    let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                        .map_err(|e| format!("TPM initialization failed: {e}"))?;
-                    let key = tpm.unseal_key_from_file(sealed_path).map_err(|e| {
-                        format!(
-                            "failed to unseal AES key from {}: {e}",
-                            sealed_path.display()
-                        )
-                    })?;
-                    info!("AES key unsealed from TPM ({})", sealed_path.display());
-                    Some(facelock_tpm::SoftwareSealer::from_key(key))
-                }
-                #[cfg(not(feature = "tpm"))]
-                {
-                    return Err(
-                        "encryption method is 'tpm' but TPM support is not compiled in \
-                         (rebuild with --features tpm)"
-                            .into(),
-                    );
-                }
-            }
-            EncryptionMethod::None => None,
-        };
+        // Load the sealing keyring for the configured encryption method
+        // through the one shared loader (`crate::keyring`, #354): the daemon
+        // and the CLI's one-shot path used to each mint sealers on their own,
+        // which is exactly how a stale key survives a `facelock setup`
+        // method flip undetected. A `keyfile` refusal is recorded in
+        // `keys.primary_error()` so ENROLL can fail closed (see `handle`)
+        // without failing the whole handler — that would take the daemon
+        // down and block auth, which must keep falling through to password.
+        // A `tpm` primary that cannot be resolved is fatal, as before.
+        let keys = SealingKeys::load(&config, &store)?;
+        if let Some(msg) = keys.primary_error() {
+            warn!("software encryption sealer unavailable — enroll will be refused: {msg}");
+        }
 
         Ok(Self {
             config,
@@ -696,44 +654,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
             lease: CameraLease::new(camera_factory, warmup_frames_override),
             jpeg_buf: Vec::with_capacity(JPEG_BUF_CAPACITY),
             tpm_sealer,
-            software_sealer,
-            sealer_init_error,
+            keys,
             preview_embeddings: None,
         })
-    }
-
-    /// Resolve the keyfile sealer: mint the encrypt-by-default key when that
-    /// is allowed, then read it. `Err` is the reason enroll must fail closed.
-    fn resolve_keyfile_sealer(
-        config: &Config,
-        store: &FaceStore,
-    ) -> Result<facelock_tpm::SoftwareSealer, String> {
-        let key_path = std::path::Path::new(&config.encryption.key_path);
-        if let Some(refusal) =
-            crate::key_policy::ensure_encrypt_by_default_key(store, config).refusal()
-        {
-            return Err(refusal.to_string());
-        }
-        match facelock_tpm::SoftwareSealer::from_key_file(key_path) {
-            Ok(sealer) => {
-                info!(
-                    "software encryption sealer initialized from {}",
-                    key_path.display()
-                );
-                Ok(sealer)
-            }
-            Err(e) => {
-                let complaint = format!("{} keyfile could not be read: {e}", key_path.display());
-                // A key that cannot be read leaves an operator holding
-                // encrypted rows in exactly the predicament a missing one
-                // does. The generic byte-count complaint names neither what
-                // is at risk nor the artifact that brings it back.
-                match crate::key_policy::encrypted_rows_at_risk(store, config) {
-                    Some(at_risk) => Err(format!("{complaint} — {at_risk}")),
-                    None => Err(complaint),
-                }
-            }
-        }
     }
 
     /// Re-ask whether the keyfile sealer is available, for a handler that is
@@ -753,23 +676,29 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
     /// exclusive store section over one projection query, and can wait up
     /// to the busy timeout behind a concurrent enrollment.
     fn refresh_software_sealer(&mut self) {
-        if self.sealer_init_error.is_none()
+        if self.keys.primary_error().is_none()
             || self.config.encryption.method != EncryptionMethod::Keyfile
         {
             return;
         }
-        match Self::resolve_keyfile_sealer(&self.config, &self.store) {
-            Ok(sealer) => {
-                info!("encryption key is readable again — enrollment is no longer refused");
-                self.software_sealer = Some(sealer);
-                self.sealer_init_error = None;
-                // The compare set was decrypted (or not) under the old
-                // decision; the next frame reloads it under this one.
-                self.preview_embeddings = None;
+        match SealingKeys::load(&self.config, &self.store) {
+            Ok(keys) => {
+                if keys.primary_error().is_none() {
+                    info!("encryption key is readable again — enrollment is no longer refused");
+                    // The compare set was decrypted (or not) under the old
+                    // decision; the next frame reloads it under this one.
+                    self.preview_embeddings = None;
+                }
+                self.keys = keys;
             }
-            // Still refused — but report the *current* reason, which may name
-            // a different artifact than the one construction found.
-            Err(msg) => self.sealer_init_error = Some(msg),
+            // `load` only returns `Err` for a `tpm` primary; the keyfile
+            // method this guard is scoped to always returns `Ok`, refused or
+            // not. Kept defensive rather than `unreachable!`: a future
+            // `load` change that starts erroring for `keyfile` too must not
+            // panic a running daemon on its next refresh.
+            Err(msg) => {
+                warn!("re-checking the encryption key failed: {msg}");
+            }
         }
     }
 
@@ -802,10 +731,10 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         // the store called the database corrupt. The rows are unreadable
         // either way; which of the two things the operator is told decides
         // whether they restore a key or reinstall a database.
-        let refusal = self.sealer_init_error.clone();
+        let refusal = self.keys.primary_error().map(str::to_string);
         if !crate::embeddings::needs_raw_rows(
             &self.config,
-            self.software_sealer.is_some(),
+            self.keys.any_loaded(),
             refusal.is_some(),
         ) {
             // Fast path: no encryption, use standard method (no overhead)
@@ -829,7 +758,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
         crate::embeddings::decrypt_user_embeddings(
             &raw_rows,
             &self.config,
-            self.software_sealer.as_ref(),
+            &self.keys,
             crate::embeddings::TpmAccess::Held(self.tpm_sealer.as_mut()),
         )
         .map_err(|message| DaemonResponse::Error {
@@ -905,11 +834,15 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                 // legitimate `method = "none"` + `allow_plaintext` path is handled
                 // above and never reaches here (its sealer is intentionally None).
                 if self.config.encryption.method != EncryptionMethod::None
-                    && self.software_sealer.is_none()
+                    && self.keys.primary().is_none()
                 {
-                    let cause = self.sealer_init_error.clone().unwrap_or_else(|| {
-                        "the configured encryption sealer could not be initialized".to_string()
-                    });
+                    let cause = self
+                        .keys
+                        .primary_error()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| {
+                            "the configured encryption sealer could not be initialized".to_string()
+                        });
                     let message = format!(
                         "refusing to enroll: {} Storing your face would otherwise fall \
                          back to plaintext. Fix the keyfile path/permissions (or set \
@@ -937,6 +870,7 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     return DaemonResponse::Error { message };
                 }
                 let device_id = fingerprint.canonical_for_storage();
+                let key_id = self.keys.primary().map(|s| s.key_id());
                 let result = enroll::enroll(
                     camera,
                     &mut self.engine,
@@ -944,8 +878,9 @@ impl<C: CameraSource, E: FaceProcessor> Handler<C, E> {
                     &self.config,
                     &user,
                     &label,
-                    self.software_sealer.as_ref(),
+                    self.keys.primary(),
                     device_id.as_deref(),
+                    key_id.as_deref(),
                     cancel,
                 );
                 self.lease.finish(Outcome::from(&result), &self.config);

--- a/crates/facelock-daemon/src/keyring.rs
+++ b/crates/facelock-daemon/src/keyring.rs
@@ -147,6 +147,33 @@ impl SealingKeys {
     }
 
     /// The configured method's key — what enroll seals new rows under.
+    /// Re-resolve a keyfile primary that was refused or unreadable at the
+    /// last load, leaving every secondary as it is.
+    ///
+    /// The daemon calls this before each authentication and enrollment while
+    /// the primary is missing. Going through [`Self::load`] there would
+    /// re-open the TPM and retry the sealed-key unseal on every attempt,
+    /// warning each time it fails, for a secondary that has not changed.
+    /// A secondary that turns out to be the restored primary's own key is
+    /// dropped so the legacy trial never tries the same key twice.
+    ///
+    /// Only the keyfile method has a refreshable primary: a TPM primary that
+    /// fails fails [`Self::load`] itself, so no keyring exists to refresh.
+    pub fn refresh_primary(&mut self, config: &Config, store: &FaceStore) {
+        if config.encryption.method != EncryptionMethod::Keyfile || self.primary.is_some() {
+            return;
+        }
+        match resolve_keyfile_sealer(config, store) {
+            Ok(sealer) => {
+                let id = sealer.key_id();
+                self.secondary.retain(|(key_id, _)| *key_id != id);
+                self.primary = Some(sealer);
+                self.primary_error = None;
+            }
+            Err(msg) => self.primary_error = Some(msg),
+        }
+    }
+
     pub fn primary(&self) -> Option<&SoftwareSealer> {
         self.primary.as_ref()
     }
@@ -352,6 +379,53 @@ mod tests {
     /// stop `load` from returning — enroll fails closed on `primary_error`,
     /// but a running daemon still needs to be able to report the refusal
     /// rather than fail to build at all.
+    /// A restored keyfile lifts the refusal through `refresh_primary`
+    /// without touching the secondaries, and a secondary that held the
+    /// restored key is dropped so the legacy trial never tries it twice.
+    #[test]
+    fn refresh_primary_lifts_the_refusal_and_drops_a_duplicate_secondary() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+        let restored = SoftwareSealer::from_key([0x11u8; 32]);
+        store
+            .add_model_raw(
+                "alice",
+                "front",
+                &restored.seal_embedding(&[0.5f32; 512]).unwrap(),
+                true,
+                "embedder",
+            )
+            .unwrap();
+
+        // Refused: encrypted rows exist and the keyfile is absent.
+        let mut keys = SealingKeys::load(&config, &store).unwrap();
+        assert!(keys.primary().is_none());
+        let other = SoftwareSealer::from_key([0x22u8; 32]);
+        keys.secondary = vec![
+            (restored.key_id(), SoftwareSealer::from_key([0x11u8; 32])),
+            (other.key_id(), other),
+        ];
+
+        // Still absent: the refresh keeps the refusal and the secondaries.
+        keys.refresh_primary(&config, &store);
+        assert!(keys.primary().is_none());
+        assert!(keys.primary_error().is_some());
+        assert_eq!(keys.secondary.len(), 2);
+
+        SoftwareSealer::write_key_file(&key_path, &[0x11u8; 32]).unwrap();
+        keys.refresh_primary(&config, &store);
+        assert!(keys.primary_error().is_none());
+        assert_eq!(keys.primary().unwrap().key_id(), restored.key_id());
+        assert_eq!(
+            keys.secondary.len(),
+            1,
+            "the duplicate of the restored key is dropped"
+        );
+        assert_eq!(keys.candidates_for_legacy_row().count(), 2);
+    }
+
     #[test]
     fn keyfile_refusal_leaves_nothing_loaded_but_records_the_reason() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/facelock-daemon/src/keyring.rs
+++ b/crates/facelock-daemon/src/keyring.rs
@@ -1,0 +1,439 @@
+//! The runtime keyring: which key seals new rows, and which other keys can
+//! still open rows a previous configuration sealed.
+//!
+//! `facelock setup` flipping `encryption.method` between `tpm` and `keyfile`
+//! used to silently swap the AES key underneath every stored template (#354):
+//! both methods write through the same [`SoftwareSealer`] (AES-256-GCM), and
+//! the only difference is which 32 bytes back it, so switching methods leaves
+//! every row sealed under the *other* key merely unreadable — surfaced as an
+//! AAD-shaped decrypt error that named neither the missing key nor how to get
+//! it back. Since wave 1 of #354, every row records the `key_id` of whichever
+//! key sealed it, so a row that names one can be handed exactly that key
+//! instead of a blind trial.
+//!
+//! [`SealingKeys`] is the one loader both the daemon (`Handler::new`) and the
+//! CLI's one-shot path (`facelock-cli::direct`) call. A second copy of this
+//! policy is exactly how #354 happened in the first place — two writers
+//! minting keys independently — so it lives here once.
+
+use std::path::Path;
+
+use facelock_core::config::{Config, EncryptionMethod};
+use facelock_store::FaceStore;
+use facelock_tpm::SoftwareSealer;
+#[cfg(feature = "tpm")]
+use facelock_tpm::TpmSealer;
+#[cfg(not(feature = "tpm"))]
+use tracing::debug;
+use tracing::info;
+#[cfg(feature = "tpm")]
+use tracing::warn;
+
+/// The sealing keys available to a running daemon or a one-shot invocation:
+/// one primary that seals every new row, and zero or more secondaries kept
+/// only to open rows a previous configuration sealed under a different key.
+pub struct SealingKeys {
+    /// The configured method's key — what [`enroll`](crate::enroll::enroll)
+    /// seals new rows under. `None` only when the method is `keyfile` and the
+    /// key could not be resolved; the reason is in
+    /// [`SealingKeys::primary_error`] instead. A `tpm` primary that cannot be
+    /// resolved fails [`SealingKeys::load`] itself rather than leaving this
+    /// `None` — see there.
+    primary: Option<SoftwareSealer>,
+    /// Why enroll must fail closed rather than silently downgrade to
+    /// plaintext biometric storage: `Some` only when the configured method
+    /// requires encryption and [`SealingKeys::primary`] could not be
+    /// resolved. Replaces the old `Handler::sealer_init_error` field.
+    primary_error: Option<String>,
+    /// Other keys this process can still read rows under, by key id — loaded
+    /// best-effort from the artifact the *other* encryption method would
+    /// have used. Never minted: unlike the primary, this path never goes
+    /// through `key_policy::ensure_encrypt_by_default_key`, which must not be
+    /// given the chance to write a key here.
+    secondary: Vec<(String, SoftwareSealer)>,
+}
+
+impl SealingKeys {
+    /// `EncryptionMethod::None`: nothing seals new rows, nothing needs
+    /// opening.
+    pub fn none() -> Self {
+        Self {
+            primary: None,
+            primary_error: None,
+            secondary: Vec::new(),
+        }
+    }
+
+    /// Load the keyring for `config`. `store` is consulted only for the
+    /// encrypt-by-default decision a keyfile primary may need to make
+    /// ([`crate::key_policy::ensure_encrypt_by_default_key`]).
+    ///
+    /// - `method = "keyfile"`: the primary is resolved through the same
+    ///   encrypt-by-default gate every writer of that key already shares. A
+    ///   refusal there is recorded as [`SealingKeys::primary_error`] — with
+    ///   the primary left `None` — but secondaries are still attempted, so a
+    ///   daemon that cannot mint the new key can still read rows under a key
+    ///   it already has.
+    /// - `method = "tpm"`: a primary that cannot be resolved is fatal — the
+    ///   caller decides whether that means the handler fails to build or the
+    ///   one-shot path propagates.
+    /// - `method = "none"`: [`SealingKeys::none`].
+    ///
+    /// Secondary loading never fails the call: a PCR-bound unseal that no
+    /// longer matches this host, or a missing artifact, just means one fewer
+    /// key is available, logged once and moved past.
+    pub fn load(config: &Config, store: &FaceStore) -> Result<Self, String> {
+        match config.encryption.method {
+            EncryptionMethod::None => Ok(Self::none()),
+
+            EncryptionMethod::Keyfile => {
+                // Fail CLOSED on enroll: a caller records `primary_error` as
+                // the reason to refuse rather than store a biometric
+                // template as plaintext. Auth is untouched by a `None`
+                // primary — it falls through to whatever secondaries loaded.
+                //
+                // Logging this is left to the caller, deliberately: the
+                // daemon resolves this once at startup (and again only when
+                // recovering from a refusal), so a `warn!` there is heard
+                // once, while the one-shot CLI path resolves it on every
+                // invocation — `facelock auth` runs on every login — so the
+                // same `warn!` there would spam syslog over a refusal that
+                // may not even be this caller's problem (#231: the refusal
+                // is global to the store, one user's encrypted row can
+                // trigger it for everyone).
+                let (primary, primary_error) = match resolve_keyfile_sealer(config, store) {
+                    Ok(sealer) => (Some(sealer), None),
+                    Err(msg) => (None, Some(msg)),
+                };
+                let secondary = load_tpm_secondary(config, primary.as_ref());
+                Ok(Self {
+                    primary,
+                    primary_error,
+                    secondary,
+                })
+            }
+
+            EncryptionMethod::Tpm => {
+                #[cfg(feature = "tpm")]
+                {
+                    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+                    let mut tpm = TpmSealer::new(&config.tpm.tcti)
+                        .map_err(|e| format!("TPM initialization failed: {e}"))?;
+                    let key = tpm.unseal_key_from_file(sealed_path).map_err(|e| {
+                        format!(
+                            "failed to unseal AES key from {}: {e}",
+                            sealed_path.display()
+                        )
+                    })?;
+                    info!("AES key unsealed from TPM ({})", sealed_path.display());
+                    let primary = SoftwareSealer::from_key(key);
+                    let secondary = load_keyfile_secondary(config, &primary);
+                    Ok(Self {
+                        primary: Some(primary),
+                        primary_error: None,
+                        secondary,
+                    })
+                }
+                #[cfg(not(feature = "tpm"))]
+                {
+                    Err(
+                        "encryption method is 'tpm' but TPM support is not compiled in \
+                         (rebuild with --features tpm)"
+                            .into(),
+                    )
+                }
+            }
+        }
+    }
+
+    /// The configured method's key — what enroll seals new rows under.
+    pub fn primary(&self) -> Option<&SoftwareSealer> {
+        self.primary.as_ref()
+    }
+
+    /// Why enroll must fail closed, when it must.
+    pub fn primary_error(&self) -> Option<&str> {
+        self.primary_error.as_deref()
+    }
+
+    /// The sealer for `id`: the primary first, then any loaded secondary.
+    pub fn by_key_id(&self, id: &str) -> Option<&SoftwareSealer> {
+        if let Some(primary) = &self.primary
+            && primary.key_id() == id
+        {
+            return Some(primary);
+        }
+        self.secondary
+            .iter()
+            .find(|(key_id, _)| key_id == id)
+            .map(|(_, sealer)| sealer)
+    }
+
+    /// Every loaded key, primary first, worth trying against a pre-V7 row
+    /// that names none. Safe even for the wrong key: AES-GCM's tag check
+    /// simply fails a trial under the wrong key rather than misreading it.
+    pub fn candidates_for_legacy_row(&self) -> impl Iterator<Item = &SoftwareSealer> {
+        self.primary
+            .iter()
+            .chain(self.secondary.iter().map(|(_, sealer)| sealer))
+    }
+
+    /// Whether any key — primary or secondary — is available at all.
+    pub fn any_loaded(&self) -> bool {
+        self.primary.is_some() || !self.secondary.is_empty()
+    }
+
+    /// Build a keyring directly from its parts, bypassing [`Self::load`]'s
+    /// config-driven resolution. Only [`Self::load`] can produce a live
+    /// cross-method secondary outside of tests (it needs a real TPM to unseal
+    /// one), so unit tests that exercise `by_key_id`/`candidates_for_legacy_row`
+    /// build the shape they need here instead.
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        primary: Option<SoftwareSealer>,
+        secondary: Vec<(String, SoftwareSealer)>,
+    ) -> Self {
+        Self {
+            primary,
+            primary_error: None,
+            secondary,
+        }
+    }
+}
+
+/// Resolve the keyfile primary: mint the encrypt-by-default key when that is
+/// allowed, then read it. `Err` is the reason enroll must fail closed.
+///
+/// Moved here from `Handler` unchanged (#354 wave 2a) — the daemon and the
+/// CLI's one-shot path both called this same sequence independently before,
+/// which is the drift this module exists to close.
+fn resolve_keyfile_sealer(config: &Config, store: &FaceStore) -> Result<SoftwareSealer, String> {
+    let key_path = Path::new(&config.encryption.key_path);
+    if let Some(refusal) = crate::key_policy::ensure_encrypt_by_default_key(store, config).refusal()
+    {
+        return Err(refusal.to_string());
+    }
+    match SoftwareSealer::from_key_file(key_path) {
+        Ok(sealer) => {
+            info!(
+                "software encryption sealer initialized from {}",
+                key_path.display()
+            );
+            Ok(sealer)
+        }
+        Err(e) => {
+            // A key that cannot be read leaves an operator holding encrypted
+            // rows in exactly the predicament a missing one does. The generic
+            // byte-count complaint names neither what is at risk nor the
+            // artifact that brings it back.
+            let complaint = format!("{} keyfile could not be read: {e}", key_path.display());
+            match crate::key_policy::encrypted_rows_at_risk(store, config) {
+                Some(at_risk) => Err(format!("{complaint} — {at_risk}")),
+                None => Err(complaint),
+            }
+        }
+    }
+}
+
+/// Best-effort secondary for a keyfile primary: the TPM-sealed key at
+/// `sealed_key_path`, left over from before `facelock setup` flipped the
+/// method to `keyfile`. Never mints anything — only reads an artifact that is
+/// already there — and never blocks or spams: a PCR-bound unseal failing on
+/// this host is an expected way for an old key to simply not be available.
+fn load_tpm_secondary(
+    config: &Config,
+    #[cfg_attr(not(feature = "tpm"), allow(unused_variables))] primary: Option<&SoftwareSealer>,
+) -> Vec<(String, SoftwareSealer)> {
+    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+    if !sealed_path.exists() {
+        return Vec::new();
+    }
+    #[cfg(feature = "tpm")]
+    {
+        match TpmSealer::new(&config.tpm.tcti)
+            .and_then(|mut tpm| tpm.unseal_key_from_file(sealed_path))
+        {
+            Ok(key) => {
+                let sealer = SoftwareSealer::from_key(key);
+                let id = sealer.key_id();
+                // Same bytes as the primary (e.g. `facelock tpm seal-key`
+                // sealed the very key `key_path` already holds): nothing a
+                // secondary would add.
+                if primary.is_some_and(|p| p.key_id() == id) {
+                    return Vec::new();
+                }
+                info!(
+                    "secondary sealing key loaded from {} (key id {id})",
+                    sealed_path.display()
+                );
+                vec![(id, sealer)]
+            }
+            Err(e) => {
+                warn!(
+                    "secondary sealing key at {} could not be unsealed (PCR-bound unseal \
+                     failures are expected on some hosts): {e}",
+                    sealed_path.display()
+                );
+                Vec::new()
+            }
+        }
+    }
+    #[cfg(not(feature = "tpm"))]
+    {
+        debug!(
+            "a sealed key is present at {} but cannot be unsealed without the tpm feature",
+            sealed_path.display()
+        );
+        Vec::new()
+    }
+}
+
+/// Best-effort secondary for a TPM primary: the plain keyfile at `key_path`,
+/// left over from before `facelock setup` flipped the method to `tpm`. Read
+/// directly — this is just AES key bytes on disk, so no TPM feature or
+/// hardware is needed to open it.
+#[cfg(feature = "tpm")]
+fn load_keyfile_secondary(
+    config: &Config,
+    primary: &SoftwareSealer,
+) -> Vec<(String, SoftwareSealer)> {
+    let key_path = Path::new(&config.encryption.key_path);
+    if !key_path.exists() {
+        return Vec::new();
+    }
+    match SoftwareSealer::from_key_file(key_path) {
+        Ok(sealer) => {
+            let id = sealer.key_id();
+            if primary.key_id() == id {
+                return Vec::new();
+            }
+            info!(
+                "secondary sealing key loaded from {} (key id {id})",
+                key_path.display()
+            );
+            vec![(id, sealer)]
+        }
+        Err(e) => {
+            warn!(
+                "secondary sealing key at {} could not be read: {e}",
+                key_path.display()
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_for(key_path: &Path) -> Config {
+        Config::parse(&format!(
+            "[encryption]\nmethod = \"keyfile\"\nkey_path = \"{}\"\n",
+            key_path.display()
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn keyfile_primary_loads_from_a_generated_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+
+        let keys = SealingKeys::load(&config, &store).unwrap();
+        assert!(keys.primary().is_some());
+        assert!(keys.primary_error().is_none());
+        assert!(keys.any_loaded());
+    }
+
+    /// #231: a keyfile refusal (encrypted rows at risk, key missing) must not
+    /// stop `load` from returning — enroll fails closed on `primary_error`,
+    /// but a running daemon still needs to be able to report the refusal
+    /// rather than fail to build at all.
+    #[test]
+    fn keyfile_refusal_leaves_nothing_loaded_but_records_the_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let config = config_for(&key_path);
+        let store = FaceStore::open_memory().unwrap();
+        store
+            .add_model_raw(
+                "alice",
+                "front",
+                &SoftwareSealer::from_key([0x11u8; 32])
+                    .seal_embedding(&[0.5f32; 512])
+                    .unwrap(),
+                true,
+                "embedder",
+            )
+            .unwrap();
+
+        let keys = SealingKeys::load(&config, &store).unwrap();
+        assert!(keys.primary().is_none());
+        assert!(!keys.any_loaded());
+        let reason = keys.primary_error().expect("the refusal must be recorded");
+        assert!(reason.contains("facelock clear"), "{reason}");
+        assert!(!key_path.exists(), "a replacement key was written");
+    }
+
+    #[test]
+    fn none_method_has_nothing_loaded() {
+        let keys = SealingKeys::none();
+        assert!(keys.primary().is_none());
+        assert!(!keys.any_loaded());
+        assert!(keys.by_key_id("anything").is_none());
+        assert_eq!(keys.candidates_for_legacy_row().count(), 0);
+    }
+
+    #[test]
+    fn by_key_id_checks_the_primary_before_any_secondary() {
+        let primary = SoftwareSealer::from_key([0x11u8; 32]);
+        let secondary = SoftwareSealer::from_key([0x22u8; 32]);
+        let primary_id = primary.key_id();
+        let secondary_id = secondary.key_id();
+        let keys = SealingKeys::from_parts(Some(primary), vec![(secondary_id.clone(), secondary)]);
+
+        assert!(keys.by_key_id(&primary_id).is_some());
+        assert!(keys.by_key_id(&secondary_id).is_some());
+        assert!(keys.by_key_id("unknown").is_none());
+    }
+
+    #[test]
+    fn candidates_for_legacy_row_tries_the_primary_first() {
+        let primary = SoftwareSealer::from_key([0x11u8; 32]);
+        let secondary = SoftwareSealer::from_key([0x22u8; 32]);
+        let primary_id = primary.key_id();
+        let secondary_id = secondary.key_id();
+        let keys = SealingKeys::from_parts(Some(primary), vec![(secondary_id.clone(), secondary)]);
+
+        let ids: Vec<String> = keys
+            .candidates_for_legacy_row()
+            .map(|s| s.key_id())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![primary_id, secondary_id],
+            "primary must come first"
+        );
+    }
+
+    /// `facelock tpm seal-key`/`unseal-key`/`reseal` can leave both artifacts
+    /// holding the *same* key material. A secondary equal to the primary adds
+    /// nothing and must not appear twice in the candidate trial.
+    #[test]
+    fn a_secondary_equal_to_the_primary_is_not_a_second_candidate() {
+        let key = [0x33u8; 32];
+        let primary = SoftwareSealer::from_key(key);
+        let same_key_again = SoftwareSealer::from_key(key);
+        let id = primary.key_id();
+        // Simulating what `load_tpm_secondary`/`load_keyfile_secondary`
+        // already dedupe before ever constructing a `SealingKeys`: build the
+        // keyring as if that dedupe had NOT happened, to pin the invariant
+        // `by_key_id` relies on — a caller must never fail to find a key that
+        // is present under either name.
+        let keys = SealingKeys::from_parts(Some(primary), vec![(id.clone(), same_key_again)]);
+        assert!(keys.by_key_id(&id).is_some());
+    }
+}

--- a/crates/facelock-daemon/src/lib.rs
+++ b/crates/facelock-daemon/src/lib.rs
@@ -5,6 +5,7 @@ pub mod embeddings;
 pub mod enroll;
 pub mod handler;
 pub mod key_policy;
+pub mod keyring;
 pub mod liveness;
 pub mod quality;
 pub mod rate_limit;

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -2346,3 +2346,144 @@ fn restoring_the_key_lifts_the_refusal_for_authentication() {
 
     cleanup_db(&db_path);
 }
+
+// --- #354 wave 2: decrypt each template under the key that sealed it ---
+
+/// `facelock setup` flipping `encryption.method`'s key must not strand rows
+/// sealed under the previous one. Model A is enrolled through a real handler
+/// under K1 — proving wave 2a's writer wiring: `enroll` now records the row's
+/// `key_id`, not wave 1's `None`. Model B is then added directly, sealed
+/// under K2 with `key_id` set to K2's id, mirroring what a fresh enrollment
+/// after the key flip would record. A second handler is built with K2 as its
+/// primary — as `facelock setup` leaves it — and loads the user's compare
+/// set.
+///
+/// This host has no TPM, so the keyfile-primary secondary path (which reads a
+/// TPM-sealed artifact) never actually loads K1: `SealingKeys` correctly
+/// reports it as not loadable, and the load must fail naming model A's key
+/// id and the artifact to restore — never silently drop model A, and never
+/// report the store as corrupt. `embeddings.rs` unit tests
+/// (`row_naming_a_secondary_key_decrypts_under_it`,
+/// `legacy_row_sealed_under_a_secondary_decrypts_through_the_trial`) cover
+/// the successful decrypt-under-a-loaded-secondary branch directly, since
+/// forcing a live cross-method secondary through this handler would need
+/// real TPM hardware.
+#[test]
+fn a_key_swap_fails_the_load_naming_the_stranded_key_and_its_artifact() {
+    use facelock_core::config::EncryptionMethod;
+    use facelock_daemon::handler::Handler;
+    use facelock_daemon::rate_limit::RateLimiter;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key1_path = dir.path().join("k1.key");
+    let key2_path = dir.path().join("k2.key");
+    let db_path = temp_db_path("keyring-cross-method-swap");
+
+    let k1 = [0x11u8; 32];
+    let k2 = [0x22u8; 32];
+    std::fs::write(&key1_path, k1).unwrap();
+    std::fs::write(&key2_path, k2).unwrap();
+
+    let store = FaceStore::create(&db_path).unwrap();
+
+    // Enroll model A for real, under K1.
+    let mut config_a = test_config();
+    config_a.encryption.method = EncryptionMethod::Keyfile;
+    config_a.encryption.key_path = key1_path.to_string_lossy().into_owned();
+    config_a.storage.db_path = db_path.display().to_string();
+    let factory_a: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(640, 480, 40)));
+    let engine_a = MockFaceEngine::cycling(vec![
+        fixtures::known_embedding(0),
+        fixtures::known_embedding(40),
+        fixtures::known_embedding(80),
+        fixtures::known_embedding(120),
+    ]);
+    let mut handler_a = Handler::new(
+        config_a,
+        engine_a,
+        store,
+        RateLimiter::new(5, 60),
+        CameraCaps::default(),
+        Some(factory_a),
+        Some(0),
+    )
+    .expect("handler builds under K1");
+
+    match handler_a.handle(DaemonRequest::Enroll {
+        user: "alice".into(),
+        label: "front".into(),
+    }) {
+        DaemonResponse::Enrolled { .. } => {}
+        other => panic!("enrollment under K1 must succeed: {other:?}"),
+    }
+
+    let k1_id = facelock_tpm::SoftwareSealer::from_key(k1).key_id();
+    let rows_under_k1 = handler_a
+        .store
+        .get_user_embeddings_raw_with_device("alice")
+        .unwrap();
+    assert!(
+        rows_under_k1
+            .iter()
+            .all(|r| r.key_id.as_deref() == Some(k1_id.as_str())),
+        "enroll must record which key sealed the row: {rows_under_k1:?}"
+    );
+
+    // Insert model B directly, sealed under K2 — mirroring what a fresh
+    // enrollment after `facelock setup` flips the key would record.
+    let sealer2 = facelock_tpm::SoftwareSealer::from_key(k2);
+    let emb_b: facelock_core::types::FaceEmbedding = [0.5; 512];
+    let blob_b = sealer2.seal_embedding(&emb_b).unwrap();
+    let model_b_id = handler_a
+        .store
+        .add_model_raw("alice", "second", &blob_b, true, "embedder")
+        .unwrap();
+    handler_a
+        .store
+        .set_model_key_id(model_b_id, Some(&sealer2.key_id()))
+        .unwrap();
+
+    // A fresh handler whose primary is K2 — as if `facelock setup` had just
+    // flipped the configured key. No TPM is available on this host to load
+    // K1 as a secondary, so it is not loadable: the load must name it and
+    // the artifact to restore rather than reporting store corruption or
+    // silently dropping model A.
+    let mut config_b = test_config();
+    config_b.encryption.method = EncryptionMethod::Keyfile;
+    config_b.encryption.key_path = key2_path.to_string_lossy().into_owned();
+    let sealed_key_path = config_b.encryption.sealed_key_path.clone();
+    config_b.storage.db_path = db_path.display().to_string();
+    let store_b = FaceStore::open_existing(&db_path).unwrap();
+    let factory_b: MockCameraFactory = Box::new(move |_cfg| Ok(MockCamera::bright(640, 480, 5)));
+    let mut handler_b = Handler::new(
+        config_b,
+        MockFaceEngine::no_faces(),
+        store_b,
+        RateLimiter::new(5, 60),
+        CameraCaps::default(),
+        Some(factory_b),
+        None,
+    )
+    .expect("handler builds under K2");
+
+    match handler_b.handle_authenticate(
+        "alice".to_string(),
+        AuthIntent::Authenticate,
+        &CancelToken::new(),
+    ) {
+        DaemonResponse::Error { message } => {
+            assert!(
+                message.contains(&format!("was sealed under key {k1_id}")),
+                "{message}"
+            );
+            assert!(message.contains("not loadable"), "{message}");
+            assert!(message.contains(&sealed_key_path), "{message}");
+            assert!(message.contains("re-enroll"), "{message}");
+        }
+        other => panic!(
+            "a template sealed under an unloaded key must fail the load by name, got: {other:?}"
+        ),
+    }
+
+    cleanup_db(&db_path);
+}

--- a/crates/facelock-daemon/tests/daemon_integration.rs
+++ b/crates/facelock-daemon/tests/daemon_integration.rs
@@ -1146,7 +1146,8 @@ fn hard_binding_seals_under_the_enrolling_camera_aad_and_authenticates() {
     assert!(!rows.is_empty());
     let sealer = sealer_for(key_dir.path());
     let bound = device_binding_aad(Some("046d:085e:")).unwrap();
-    for (id, blob, sealed, device_id) in &rows {
+    for row in &rows {
+        let (id, blob, sealed, device_id) = (row.model_id, &row.blob, row.sealed, &row.device_id);
         assert!(sealed, "row {id} must be sealed");
         assert_eq!(device_id.as_deref(), Some("046d:085e:"));
         sealer
@@ -1196,7 +1197,8 @@ fn ordinary_encryption_seals_without_aad() {
         .unwrap();
     assert!(!rows.is_empty());
     let sealer = sealer_for(key_dir.path());
-    for (id, blob, sealed, _) in &rows {
+    for row in &rows {
+        let (id, blob, sealed) = (row.model_id, &row.blob, row.sealed);
         assert!(sealed, "row {id} must be sealed");
         sealer
             .unseal_embedding_with_aad(blob, None)

--- a/crates/facelock-store/src/db.rs
+++ b/crates/facelock-store/src/db.rs
@@ -19,6 +19,21 @@ use crate::migrations::run_migrations;
 /// minimum-capture count from this constant, so the two cannot drift.
 pub const MIN_EMBEDDINGS_PER_MODEL: usize = 3;
 
+/// One raw (possibly encrypted) embedding row, joined with its model's
+/// enrolling-camera and sealing-key identities.
+///
+/// Returned by [`FaceStore::get_user_embeddings_raw_with_device`]. `key_id` is
+/// `None` for a pre-V7 row or a plaintext (unencrypted) row — neither was ever
+/// tagged with which key sealed it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawEmbeddingRow {
+    pub model_id: u32,
+    pub blob: Vec<u8>,
+    pub sealed: bool,
+    pub device_id: Option<String>,
+    pub key_id: Option<String>,
+}
+
 /// How long an operation waits for another connection's write lock before
 /// giving up with [`StoreError::Busy`].
 ///
@@ -282,6 +297,7 @@ impl FaceStore {
         label: &str,
         embedder_model: &str,
         device_id: Option<&str>,
+        key_id: Option<&str>,
     ) -> Result<u32> {
         // Stored as INTEGER (i64) in SQLite. Cast keeps the code portable
         // across rusqlite versions (0.39+ no longer impls ToSql/FromSql for u64
@@ -292,8 +308,8 @@ impl FaceStore {
             .unwrap_or(0);
 
         tx.execute(
-            "INSERT INTO face_models (user, label, created_at, embedder_model, device_id) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![user, label, created_at, embedder_model, device_id],
+            "INSERT INTO face_models (user, label, created_at, embedder_model, device_id, key_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![user, label, created_at, embedder_model, device_id, key_id],
         )
         .map_err(|e| self.err(e))?;
 
@@ -313,7 +329,7 @@ impl FaceStore {
     ) -> Result<u32> {
         let tx = self.write_tx()?;
 
-        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
+        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id, None)?;
 
         let bytes: &[u8] = bytemuck::cast_slice(embedding.as_slice());
         tx.execute(
@@ -523,20 +539,18 @@ impl FaceStore {
     }
 
     /// Like [`FaceStore::get_user_embeddings_raw`], but also returns each row's
-    /// enrolling-camera `device_id` (NULL for legacy/unidentified templates).
+    /// enrolling-camera `device_id` (NULL for legacy/unidentified templates)
+    /// and the `key_id` of whichever key sealed it (NULL for a pre-V7 or
+    /// plaintext row).
     ///
     /// Used by the decrypt path when opt-in hard device binding
     /// (`security.bind_device_aad`) is active: the AAD for each blob is derived
     /// from its own template's `device_id`.
-    #[allow(clippy::type_complexity)]
-    pub fn get_user_embeddings_raw_with_device(
-        &self,
-        user: &str,
-    ) -> Result<Vec<(u32, Vec<u8>, bool, Option<String>)>> {
+    pub fn get_user_embeddings_raw_with_device(&self, user: &str) -> Result<Vec<RawEmbeddingRow>> {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT fm.id, fe.embedding, fe.sealed, fm.device_id
+                "SELECT fm.id, fe.embedding, fe.sealed, fm.device_id, fm.key_id
                  FROM face_models fm
                  JOIN face_embeddings fe ON fe.model_id = fm.id
                  WHERE fm.user = ?1",
@@ -545,11 +559,18 @@ impl FaceStore {
 
         let rows = stmt
             .query_map(params![user], |row| {
-                let id: u32 = row.get(0)?;
+                let model_id: u32 = row.get(0)?;
                 let blob: Vec<u8> = row.get(1)?;
                 let sealed: bool = row.get::<_, i64>(2)? != 0;
                 let device_id: Option<String> = row.get(3)?;
-                Ok((id, blob, sealed, device_id))
+                let key_id: Option<String> = row.get(4)?;
+                Ok(RawEmbeddingRow {
+                    model_id,
+                    blob,
+                    sealed,
+                    device_id,
+                    key_id,
+                })
             })
             .map_err(|e| self.err(e))?;
 
@@ -588,7 +609,7 @@ impl FaceStore {
     ) -> Result<u32> {
         let tx = self.write_tx()?;
 
-        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
+        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id, None)?;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
 
         tx.execute(
@@ -616,6 +637,7 @@ impl FaceStore {
     /// never mixed. Fewer than [`MIN_EMBEDDINGS_PER_MODEL`] blobs is refused
     /// with [`StoreError::Query`] before the transaction opens, whatever the
     /// caller's own gates said: a model that exists is a complete template.
+    #[allow(clippy::too_many_arguments)]
     pub fn replace_model_with_embeddings(
         &self,
         user: &str,
@@ -624,6 +646,7 @@ impl FaceStore {
         sealed: bool,
         embedder_model: &str,
         device_id: Option<&str>,
+        key_id: Option<&str>,
     ) -> Result<u32> {
         if embeddings.len() < MIN_EMBEDDINGS_PER_MODEL {
             return Err(StoreError::Query {
@@ -645,7 +668,8 @@ impl FaceStore {
         )
         .map_err(|e| self.err(e))?;
 
-        let model_id = self.insert_model_row(&tx, user, label, embedder_model, device_id)?;
+        let model_id =
+            self.insert_model_row(&tx, user, label, embedder_model, device_id, key_id)?;
         let sealed_int: i64 = if sealed { 1 } else { 0 };
 
         for data in embeddings {
@@ -680,6 +704,30 @@ impl FaceStore {
             return Err(StoreError::Query {
                 path: self.path.clone(),
                 detail: format!("embedding ID {embedding_id} not found"),
+            });
+        }
+        Ok(())
+    }
+
+    /// Set (or clear, with `None`) which key sealed `model_id`'s embeddings.
+    ///
+    /// A row's `key_id` and the sealed bytes underneath it are set separately
+    /// — this exists for the re-encrypt path, which knows a model's new key
+    /// identity before or after it rewrites the blobs, not necessarily in the
+    /// same statement as [`FaceStore::update_embedding_sealed`].
+    pub fn set_model_key_id(&self, model_id: u32, key_id: Option<&str>) -> Result<()> {
+        let affected = self
+            .conn
+            .execute(
+                "UPDATE face_models SET key_id = ?1 WHERE id = ?2",
+                params![key_id, model_id],
+            )
+            .map_err(|e| self.err(e))?;
+
+        if affected == 0 {
+            return Err(StoreError::Query {
+                path: self.path.clone(),
+                detail: format!("model ID {model_id} not found"),
             });
         }
         Ok(())
@@ -745,13 +793,16 @@ impl FaceStore {
     }
 
     /// Get all embeddings (all users) as raw bytes with sealed flag.
-    /// Returns (embedding_id, model_user, raw_bytes, sealed) tuples.
+    /// Returns (embedding_id, model_user, raw_bytes, sealed, model_id) tuples.
+    /// `model_id` is appended last, not inserted alongside `embedding_id`, so
+    /// existing positional destructuring of the first four fields is
+    /// unaffected by its addition.
     #[allow(clippy::type_complexity)]
-    pub fn get_all_embeddings_raw(&self) -> Result<Vec<(u32, String, Vec<u8>, bool)>> {
+    pub fn get_all_embeddings_raw(&self) -> Result<Vec<(u32, String, Vec<u8>, bool, u32)>> {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT fe.id, fm.user, fe.embedding, fe.sealed
+                "SELECT fe.id, fm.user, fe.embedding, fe.sealed, fm.id
                  FROM face_embeddings fe
                  JOIN face_models fm ON fm.id = fe.model_id",
             )
@@ -763,7 +814,8 @@ impl FaceStore {
                 let user: String = row.get(1)?;
                 let blob: Vec<u8> = row.get(2)?;
                 let sealed: bool = row.get::<_, i64>(3)? != 0;
-                Ok((id, user, blob, sealed))
+                let model_id: u32 = row.get(4)?;
+                Ok((id, user, blob, sealed, model_id))
             })
             .map_err(|e| self.err(e))?;
 
@@ -1307,15 +1359,66 @@ mod tests {
             .unwrap();
 
         let mut rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
-        rows.sort_by(|a, b| a.1.cmp(&b.1)); // by blob bytes for determinism
+        rows.sort_by(|a, b| a.blob.cmp(&b.blob)); // by blob bytes for determinism
 
         assert_eq!(rows.len(), 2);
         // blob-cam sorts before blob-legacy
-        assert_eq!(rows[0].1, b"blob-cam");
-        assert!(rows[0].2, "sealed flag should round-trip");
-        assert_eq!(rows[0].3.as_deref(), Some("046d:085e:S"));
-        assert_eq!(rows[1].1, b"blob-legacy");
-        assert_eq!(rows[1].3, None);
+        assert_eq!(rows[0].blob, b"blob-cam");
+        assert!(rows[0].sealed, "sealed flag should round-trip");
+        assert_eq!(rows[0].device_id.as_deref(), Some("046d:085e:S"));
+        assert_eq!(rows[0].key_id, None);
+        assert_eq!(rows[1].blob, b"blob-legacy");
+        assert_eq!(rows[1].device_id, None);
+    }
+
+    #[test]
+    fn replace_model_with_embeddings_key_id_round_trips() {
+        let store = FaceStore::open_memory().unwrap();
+        let blobs = blobs(3);
+        let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
+
+        store
+            .replace_model_with_embeddings(
+                "alice",
+                "front",
+                &refs,
+                true,
+                "w600k",
+                None,
+                Some("abc"),
+            )
+            .unwrap();
+
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows.len(), 3);
+        for row in &rows {
+            assert_eq!(row.key_id.as_deref(), Some("abc"), "key_id must round-trip");
+        }
+    }
+
+    #[test]
+    fn set_model_key_id_updates_and_clears() {
+        let store = FaceStore::open_memory().unwrap();
+        let emb = test_embedding();
+        let model_id = store.add_model("alice", "front", &emb, "").unwrap();
+
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows[0].key_id, None, "a freshly added model has no key_id");
+
+        store.set_model_key_id(model_id, Some("abc")).unwrap();
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows[0].key_id.as_deref(), Some("abc"));
+
+        store.set_model_key_id(model_id, None).unwrap();
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows[0].key_id, None, "None clears the key_id");
+    }
+
+    #[test]
+    fn set_model_key_id_on_a_missing_model_errors() {
+        let store = FaceStore::open_memory().unwrap();
+        let err = store.set_model_key_id(9999, Some("abc")).unwrap_err();
+        assert!(matches!(err, StoreError::Query { .. }), "got {err:?}");
     }
 
     #[test]
@@ -1434,6 +1537,7 @@ mod tests {
                 true,
                 "w600k",
                 Some("046d:085e:S"),
+                None,
             )
             .unwrap();
 
@@ -1465,7 +1569,7 @@ mod tests {
         let blobs = blobs(3);
         let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
         let new_front = store
-            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None, None)
             .unwrap();
 
         assert_ne!(new_front, old_front, "the replacement is a new row");
@@ -1527,7 +1631,7 @@ mod tests {
         let blobs = blobs(3);
         let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
         let err = store
-            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None, None)
             .unwrap_err();
         assert!(
             err.to_string().contains("injected insert failure"),
@@ -1554,7 +1658,7 @@ mod tests {
         let blobs = blobs(2);
         let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
         let err = store
-            .replace_model_with_embeddings("alice", "front", &refs, false, "", None)
+            .replace_model_with_embeddings("alice", "front", &refs, false, "", None, None)
             .unwrap_err();
         assert!(
             matches!(err, StoreError::Query { .. }) && err.to_string().contains("2 embeddings"),
@@ -1576,7 +1680,7 @@ mod tests {
         let old_id = store.add_model("alice", "front", &emb, "").unwrap();
 
         let err = store
-            .replace_model_with_embeddings("alice", "front", &[], false, "", None)
+            .replace_model_with_embeddings("alice", "front", &[], false, "", None, None)
             .unwrap_err();
         assert!(
             matches!(err, StoreError::Query { .. }),
@@ -1669,6 +1773,103 @@ mod tests {
             .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
             .unwrap();
         assert!(version >= 6);
+
+        let _ = std::fs::remove_file(&db_path);
+        let _ = std::fs::remove_file(sqlite_sidecar_path(&db_path, "-wal"));
+        let _ = std::fs::remove_file(sqlite_sidecar_path(&db_path, "-shm"));
+    }
+
+    #[test]
+    fn test_migration_v7_key_id_column() {
+        // Fresh DB is at the latest schema; key_id defaults to NULL.
+        let store = FaceStore::open_memory().unwrap();
+        let version: i64 = store
+            .conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert!(version >= 7, "schema should be at least V7, got {version}");
+
+        let model_id = store
+            .add_model("alice", "front", &test_embedding(), "")
+            .unwrap();
+        let rows = store.get_user_embeddings_raw_with_device("alice").unwrap();
+        assert_eq!(rows[0].model_id, model_id);
+        assert_eq!(rows[0].key_id, None, "a fresh row has no key_id");
+    }
+
+    #[test]
+    fn test_pre_v7_db_migrates_cleanly_without_data_loss() {
+        // Build a V6 database by hand (schema at V6: face_models has
+        // device_id but NOT key_id), seed a model + embedding, then reopen
+        // via FaceStore::open_existing to run migrations and confirm the row
+        // survives with a NULL key_id.
+        let db_path = std::env::temp_dir().join(format!(
+            "facelock-prev7-{}-{}.db",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "
+                CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+                CREATE TABLE face_models (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    embedder_model TEXT NOT NULL DEFAULT '',
+                    device_id TEXT,
+                    UNIQUE(user, label)
+                );
+                CREATE TABLE face_embeddings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    model_id INTEGER NOT NULL REFERENCES face_models(id) ON DELETE CASCADE,
+                    embedding BLOB NOT NULL,
+                    sealed INTEGER NOT NULL DEFAULT 0
+                );
+                CREATE TABLE rate_limit (user TEXT NOT NULL, attempt_time INTEGER NOT NULL);
+                INSERT INTO schema_version (version) VALUES (6);
+                INSERT INTO face_models (user, label, created_at, embedder_model, device_id)
+                    VALUES ('legacy', 'old-face', 1700000000, 'w600k_r50.onnx', '046d:085e:S');
+                ",
+            )
+            .unwrap();
+            let emb = test_embedding();
+            let bytes: &[u8] = bytemuck::cast_slice(emb.as_slice());
+            conn.execute(
+                "INSERT INTO face_embeddings (model_id, embedding) VALUES (1, ?1)",
+                params![bytes],
+            )
+            .unwrap();
+        }
+
+        // Reopen: migrations run, adding key_id. Via `open_existing`
+        // specifically — a present-but-old database is exactly the case that
+        // constructor must still migrate.
+        let store = FaceStore::open_existing(&db_path).unwrap();
+        let models = store.list_models("legacy").unwrap();
+        assert_eq!(models.len(), 1, "legacy model must survive migration");
+        assert_eq!(models[0].label, "old-face");
+        assert_eq!(
+            models[0].device_id.as_deref(),
+            Some("046d:085e:S"),
+            "the pre-existing device_id survives the V7 migration"
+        );
+
+        let rows = store.get_user_embeddings_raw_with_device("legacy").unwrap();
+        assert_eq!(rows.len(), 1, "embedding data must be intact");
+        assert_eq!(rows[0].key_id, None, "legacy row keeps NULL key_id");
+
+        let version: i64 = store
+            .conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert!(version >= 7);
 
         let _ = std::fs::remove_file(&db_path);
         let _ = std::fs::remove_file(sqlite_sidecar_path(&db_path, "-wal"));
@@ -1887,10 +2088,10 @@ mod tests {
         let all = store.get_all_embeddings_raw().unwrap();
         assert_eq!(all.len(), 2);
 
-        let alice_row = all.iter().find(|(_, u, _, _)| u == "alice").unwrap();
+        let alice_row = all.iter().find(|(_, u, _, _, _)| u == "alice").unwrap();
         assert!(!alice_row.3);
 
-        let bob_row = all.iter().find(|(_, u, _, _)| u == "bob").unwrap();
+        let bob_row = all.iter().find(|(_, u, _, _, _)| u == "bob").unwrap();
         assert!(bob_row.3);
         assert_eq!(bob_row.2, vec![0x01; 50]);
     }
@@ -1922,8 +2123,8 @@ mod tests {
             let started = std::time::Instant::now();
             let blobs = vec![vec![0u8; 8]; MIN_EMBEDDINGS_PER_MODEL];
             let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
-            let result =
-                enroller.replace_model_with_embeddings("alice", "front", &refs, false, "e", None);
+            let result = enroller
+                .replace_model_with_embeddings("alice", "front", &refs, false, "e", None, None);
             (result, observed.load(Ordering::SeqCst), started.elapsed())
         });
 
@@ -1976,7 +2177,7 @@ mod tests {
         let refs: Vec<&[u8]> = blobs.iter().map(Vec::as_slice).collect();
         FaceStore::open_existing(&db)
             .unwrap()
-            .replace_model_with_embeddings("alice", "front", &refs, false, "e", None)
+            .replace_model_with_embeddings("alice", "front", &refs, false, "e", None, None)
             .expect("the lock must be released when the section fails");
     }
 }

--- a/crates/facelock-store/src/lib.rs
+++ b/crates/facelock-store/src/lib.rs
@@ -2,5 +2,5 @@ pub mod db;
 pub mod error;
 pub mod migrations;
 
-pub use db::{FaceStore, MIN_EMBEDDINGS_PER_MODEL};
+pub use db::{FaceStore, MIN_EMBEDDINGS_PER_MODEL, RawEmbeddingRow};
 pub use error::{Result, StoreError};

--- a/crates/facelock-store/src/migrations.rs
+++ b/crates/facelock-store/src/migrations.rs
@@ -116,5 +116,19 @@ pub(crate) fn run_migrations(path: &Path, conn: &rusqlite::Connection) -> Result
         .map_err(|e| migration_err(path, e))?;
     }
 
+    if version < 7 {
+        // V7: record which key sealed each model (#354). Nullable — NULL means
+        // a pre-V7 row or a plaintext (unencrypted) row, neither of which was
+        // ever tagged with a key identity. Additive column, mirroring the V6
+        // pattern exactly.
+        conn.execute_batch(
+            "
+            ALTER TABLE face_models ADD COLUMN key_id TEXT;
+            INSERT OR REPLACE INTO schema_version (version) VALUES (7);
+        ",
+        )
+        .map_err(|e| migration_err(path, e))?;
+    }
+
     Ok(())
 }

--- a/crates/facelock-tpm/Cargo.toml
+++ b/crates/facelock-tpm/Cargo.toml
@@ -14,6 +14,7 @@ zeroize = "1"
 aes-gcm = "0.11"
 rand = "0.10"
 libc = "0.2"
+sha2 = "0.11"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -928,19 +928,31 @@ impl SoftwareSealer {
     /// gap between it and the open free to be followed.
     pub fn generate_key_file(path: &std::path::Path) -> Result<()> {
         use rand::Rng;
-        use std::io::Write;
         use zeroize::Zeroize;
+
+        let mut key = [0u8; AES_KEY_SIZE];
+        rand::rng().fill_bytes(&mut key);
+
+        let write_result = Self::write_key_file(path, &key);
+
+        key.zeroize();
+        write_result
+    }
+
+    /// Write `key` to `path` as the plaintext keyfile: one `O_NOFOLLOW`
+    /// create-or-truncate at 0600, the bytes, then `sync_all`. The file
+    /// never holds a partial or placeholder key under the real name; a
+    /// failed write leaves it truncated rather than holding a random key
+    /// that a later `setup` would adopt as genuine (#354).
+    pub fn write_key_file(path: &std::path::Path, key: &[u8; AES_KEY_SIZE]) -> Result<()> {
+        use std::io::Write;
 
         if facelock_core::fs_security::is_symlink(path) {
             return Err(FacelockError::Encryption(symlink_key_refusal(path)));
         }
 
-        let mut key = [0u8; AES_KEY_SIZE];
-        rand::rng().fill_bytes(&mut key);
-
-        let write_result = (|| -> Result<()> {
-            let mut file = facelock_core::fs_security::create_truncate_file_nofollow(path, 0o600)
-                .map_err(|e| {
+        let mut file = facelock_core::fs_security::create_truncate_file_nofollow(path, 0o600)
+            .map_err(|e| {
                 if facelock_core::fs_security::is_symlink(path) {
                     FacelockError::Encryption(symlink_key_refusal(path))
                 } else {
@@ -950,18 +962,14 @@ impl SoftwareSealer {
                     ))
                 }
             })?;
-            file.write_all(&key)
-                .and_then(|()| file.sync_all())
-                .map_err(|e| {
-                    FacelockError::Encryption(format!(
-                        "failed to write key file {}: {e}",
-                        path.display()
-                    ))
-                })
-        })();
-
-        key.zeroize();
-        write_result
+        file.write_all(key)
+            .and_then(|()| file.sync_all())
+            .map_err(|e| {
+                FacelockError::Encryption(format!(
+                    "failed to write key file {}: {e}",
+                    path.display()
+                ))
+            })
     }
 
     /// Create the default encryption key, refusing to replace one that exists.
@@ -1520,6 +1528,45 @@ mod tests {
         // Too short: version byte only
         let result = sealer.unseal_bytes(&[SOFTWARE_ENCRYPTED_VERSION_BYTE]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn write_key_file_stores_exactly_the_given_key_at_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("unsealed.key");
+        let key = [0x5au8; AES_KEY_SIZE];
+
+        SoftwareSealer::write_key_file(&key_path, &key).unwrap();
+
+        assert_eq!(std::fs::read(&key_path).unwrap(), key);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        let sealer = SoftwareSealer::from_key_file(&key_path).unwrap();
+        assert_eq!(sealer.key_id(), SoftwareSealer::key_id_for(&key));
+
+        // A second write replaces the bytes in place; no placeholder key
+        // ever stands under the real name between the two (#354).
+        let other = [0xa5u8; AES_KEY_SIZE];
+        SoftwareSealer::write_key_file(&key_path, &other).unwrap();
+        assert_eq!(std::fs::read(&key_path).unwrap(), other);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_key_file_refuses_a_symlink_at_the_key_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("elsewhere");
+        std::fs::write(&target, b"x").unwrap();
+        let link = dir.path().join("link.key");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = SoftwareSealer::write_key_file(&link, &[0u8; AES_KEY_SIZE]).unwrap_err();
+        assert!(err.to_string().contains("symlink"), "{err}");
+        assert_eq!(std::fs::read(&target).unwrap(), b"x");
     }
 
     #[test]

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -882,6 +882,37 @@ impl SoftwareSealer {
         Self { key }
     }
 
+    /// A lookup tag for which key sealed a row — not key material.
+    ///
+    /// Lowercase hex of the first 8 bytes of SHA-256 over the domain string
+    /// `b"facelock-key-id-v1"` followed by the 32 raw key bytes. A truncated
+    /// hash of a 256-bit random key reveals nothing usable about the key
+    /// itself; it exists only so a stored row can record which key sealed it,
+    /// so `facelock setup` flipping `encryption.method` (and thus the active
+    /// key) is detectable instead of silently producing undecryptable rows.
+    pub fn key_id(&self) -> String {
+        Self::key_id_for(&self.key)
+    }
+
+    /// [`Self::key_id`] for a caller holding raw key bytes but not a
+    /// [`SoftwareSealer`].
+    pub fn key_id_for(key: &[u8; AES_KEY_SIZE]) -> String {
+        use sha2::{Digest, Sha256};
+
+        const DOMAIN: &[u8] = b"facelock-key-id-v1";
+
+        let mut hasher = Sha256::new();
+        hasher.update(DOMAIN);
+        hasher.update(key);
+        let digest = hasher.finalize();
+
+        let mut id = String::with_capacity(16);
+        for byte in &digest[..8] {
+            id.push_str(&format!("{byte:02x}"));
+        }
+        id
+    }
+
     /// Generate a new random 256-bit key and write it to a file at 0600.
     ///
     /// The file is created at mode 0600 in the same `open(2)` that creates it
@@ -1424,6 +1455,41 @@ mod tests {
 
         let result = sealer2.unseal_embedding(&sealed);
         assert!(result.is_err(), "decryption with wrong key should fail");
+    }
+
+    #[test]
+    fn key_id_is_deterministic_for_the_same_key() {
+        let key = [0x42u8; 32];
+        let a = SoftwareSealer::from_key(key).key_id();
+        let b = SoftwareSealer::from_key(key).key_id();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn key_id_differs_for_different_keys() {
+        let a = SoftwareSealer::from_key([0x42u8; 32]).key_id();
+        let b = SoftwareSealer::from_key([0x43u8; 32]).key_id();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn key_id_is_16_lowercase_hex_chars() {
+        let id = SoftwareSealer::from_key([0x99u8; 32]).key_id();
+        assert_eq!(id.len(), 16);
+        assert!(
+            id.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "key_id must be lowercase hex: {id}"
+        );
+    }
+
+    #[test]
+    fn key_id_golden_value_for_the_all_zero_key() {
+        // Pinned: sha256(b"facelock-key-id-v1" || [0u8; 32])[..8] as lowercase
+        // hex. A change here means the key_id scheme changed, which silently
+        // orphans every row that already recorded the old id.
+        let id = SoftwareSealer::key_id_for(&[0u8; 32]);
+        assert_eq!(id, "923b1993e51ace05");
     }
 
     #[test]

--- a/crates/facelock-tpm/src/sealing.rs
+++ b/crates/facelock-tpm/src/sealing.rs
@@ -906,9 +906,11 @@ impl SoftwareSealer {
         hasher.update(key);
         let digest = hasher.finalize();
 
+        use std::fmt::Write;
         let mut id = String::with_capacity(16);
         for byte in &digest[..8] {
-            id.push_str(&format!("{byte:02x}"));
+            // Infallible on a String; the Result only exists for the trait.
+            let _ = write!(id, "{byte:02x}");
         }
         id
     }

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -439,6 +439,15 @@ errors instead of falling back to RGB when no usable IR candidate remains. An
 explicit `--camera /dev/videoN` remains an operator override and is still
 subject to the auth/open fail-closed checks.
 
+**Encryption method transitions (`--encryption`).** Switching to tpm with a
+keyfile present seals that key (same bytes) rather than minting a new one.
+Switching to keyfile with a sealed key present and a usable TPM unseals it into
+the keyfile. A fresh key is minted only when no key artifact exists, behind the
+orphaned-models guard. When both artifacts exist and hold different keys, setup
+keeps the target's and prints a notice naming both files. A TPM device that
+exists but fails to initialize is reported (warn + notice) rather than silently
+downgrading to keyfile.
+
 ### facelock pam Semantics
 
 `facelock pam add | remove | status` and the machine-wide
@@ -3421,6 +3430,18 @@ corruption for those it cannot, and still falls through to the password prompt. 
 the key artifact lifts the refusal at the next authentication or enrollment attempt without
 restarting the daemon.
 
+**Sealing key identity and the keyring (#354).** Every model row written from
+this version records the key id of the key that sealed it. The daemon and the
+one-shot path load the configured method's key as primary and, best-effort, the
+other method's artifact as secondary (keyfile under tpm; sealed key under
+keyfile when built with tpm). A secondary that fails to load is logged and
+ignored, never fatal, and never mints a key. A row naming a key id decrypts only
+under that key; if it is not loaded the load fails naming the other artifact. A
+pre-V7 row (NULL key id) is tried under the primary then each secondary. New
+enrollments always seal under the primary. `facelock tpm encrypt` sets key id;
+`facelock tpm decrypt` clears it. `tpm seal-key`, `unseal-key`, and `reseal`
+never touch rows.
+
 **Enrollment atomicity (#308).** An enrollment writes to the store exactly once, at the
 end: after every accepted embedding has passed the minimum-capture and angle-diversity
 gates and, with encryption on, been sealed, one transaction removes the previous model
@@ -3588,6 +3609,7 @@ CREATE TABLE face_models (
     created_at INTEGER NOT NULL,
     embedder_model TEXT NOT NULL DEFAULT '',  -- V5: embedder that produced the embeddings
     device_id TEXT,                           -- V6: enrolling camera fingerprint "vid:pid:serial" (NULL = legacy/uncoupled)
+    key_id TEXT,                              -- V7: truncated SHA-256 id of the sealing key (NULL = pre-V7 or plaintext)
     UNIQUE(user, label)
 );
 
@@ -3606,7 +3628,7 @@ CREATE TABLE rate_limit (
 
 Only failed authentication attempts are recorded in `rate_limit`, and only those where a face was actually detected (ADR 008 §4 — see §facelock test Semantics for the full charging rule). Daemon mode and oneshot mode share the same SQLite-backed window, so daemon restarts do not clear lockout state.
 
-**Schema version** is tracked in `schema_version`; migrations are additive and forward-only. Current version: **6**. Migration V6 adds the nullable `face_models.device_id` column (Plan 02 device coupling); pre-V6 databases open cleanly, keep their rows, and leave `device_id` NULL. NULL rows are governed by `security.bind_legacy_templates` (default allow-with-warn), so upgrades never lock a user out.
+**Schema version** is tracked in `schema_version`; migrations are additive and forward-only. Current version: **7**. Migration V7 adds the nullable `face_models.key_id` column, recording the truncated SHA-256 fingerprint of each sealing key; NULL indicates a pre-V7 row or plaintext embedding. Migration V6 adds the nullable `face_models.device_id` column (Plan 02 device coupling); pre-V6 databases open cleanly, keep their rows, and leave `device_id` NULL. NULL rows are governed by `security.bind_legacy_templates` (default allow-with-warn), so upgrades never lock a user out.
 
 `device_id` is the canonical fingerprint (`"vid:pid:serial"`) of the camera that enrolled the template. It is **model-granularity at best and forgeable by a programmable USB device** — advisory defense-in-depth, NOT attestation. See `docs/security.md` §Device Coupling.
 
@@ -3653,14 +3675,15 @@ as it was and reports the failure. Recreating a database it could not migrate
 would destroy every enrollment on the machine and look like a clean first run.
 
 **Downgrade is supported back to v0.1.4, with one limit.** Migrations are
-additive and forward-only: there is no down-migration from V6, and a package
-downgrade leaves `schema_version` at 6. What is guaranteed is that the older
+additive and forward-only: there is no down-migration from V7, and a package
+downgrade leaves `schema_version` at 7. What is guaranteed is that the older
 release still opens that database, reads its rows, and decrypts what it
-encrypted, because V6 only adds a nullable `face_models.device_id` column that
-older queries never name. What is **not** guaranteed is that rows written by the
-newer release carry data the older one understands: a `device_id` recorded after
-the upgrade is invisible to v0.1.4, so a template enrolled on the alpha and then
-rolled back is uncoupled from its camera rather than refused.
+encrypted, because V7 only adds a nullable `face_models.key_id` column that
+older queries never name, and V6 only adds a nullable `face_models.device_id`
+column that older queries never name. What is **not** guaranteed is that rows written by the
+newer release carry data the older one understands: a `key_id` recorded after
+the upgrade is invisible to an older release, so a template enrolled on the newer version and then
+rolled back decrypts under the single key that older release loads if that key is the one that sealed it.
 
 `just test-upgrade-v014` is the gate for all of the above. It runs both halves
 against the real published v0.1.4 artifacts; see `docs/releasing.md`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -724,6 +724,18 @@ falling back to the plaintext `encryption.key` backup once they have moved. Beca
 the still-valid blob, it is safe to run proactively before a firmware or kernel update.
 `facelock tpm unseal-check` reports which of the two recovery paths a machine is on.
 
+**The keyring and cross-method recovery (#354).** Every row records the key id
+that sealed it. On startup, the daemon and the one-shot path load the configured
+method's key as primary and, best-effort, the other method's artifact as
+secondary (plaintext keyfile when tpm is primary; sealed key when keyfile is
+primary). Loading the plaintext keyfile while method is tpm reads a 0600
+root-only file the `seal-key` backup tradeoff already documents, so at-rest
+confidentiality is unchanged. Trial-decrypting a legacy row under a secondary
+key is safe because AES-GCM authenticates before returning plaintext and cannot
+widen who authenticates. Recovery is to restore the other method's artifact (the
+sealed key if the keyfile is lost, or the keyfile if the sealed key is
+unreadable); that artifact is enough for rows sealed under it.
+
 **Why the default stays off.** The recommended setup keeps a plaintext `encryption.key`
 backup, so a PCR change costs a reseal instead of a re-enrollment. While that backup exists,
 PCR binding buys nothing against an attacker with disk access: the AES key sits beside the

--- a/po/facelock.pot
+++ b/po/facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-02 19:50-0700\n"
+"POT-Creation-Date: 2026-09-06 16:45-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -827,7 +827,7 @@ msgstr ""
 msgid "Daemon activation is still barred by {path}. Face authentication stays off until you remove that file and run `systemctl daemon-reload`, or reboot."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:193
+#: crates/facelock-cli/src/message/setup.rs:230
 #, python-brace-format
 msgid ""
 "\n"
@@ -844,79 +844,79 @@ msgid ""
 "    - PAM configuration\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:197
+#: crates/facelock-cli/src/message/setup.rs:234
 msgid ""
 "\n"
 "--- Step 1: Camera Selection ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:198
+#: crates/facelock-cli/src/message/setup.rs:235
 msgid ""
 "\n"
 "--- Step 2: Model Quality ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:199
+#: crates/facelock-cli/src/message/setup.rs:236
 msgid ""
 "\n"
 "--- Step 3: Inference Device ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:200
+#: crates/facelock-cli/src/message/setup.rs:237
 msgid ""
 "\n"
 "--- Step 4: Model Download ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:201
+#: crates/facelock-cli/src/message/setup.rs:238
 msgid ""
 "\n"
 "--- Step 5: Embedding Encryption ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:202
+#: crates/facelock-cli/src/message/setup.rs:239
 msgid ""
 "\n"
 "--- Step 6: Daemon Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:203
+#: crates/facelock-cli/src/message/setup.rs:240
 msgid ""
 "\n"
 "--- Step 7: Face Enrollment ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:205
+#: crates/facelock-cli/src/message/setup.rs:242
 msgid ""
 "\n"
 "--- Step 7: Face Enrollment (skipped, --no-enroll) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:207
+#: crates/facelock-cli/src/message/setup.rs:244
 msgid ""
 "\n"
 "--- Step 8: Test Recognition ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:209
+#: crates/facelock-cli/src/message/setup.rs:246
 msgid ""
 "\n"
 "--- Step 8: Test Recognition (skipped, no face enrolled) ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:211
+#: crates/facelock-cli/src/message/setup.rs:248
 msgid ""
 "\n"
 "--- Step 9: PAM Configuration ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:212
+#: crates/facelock-cli/src/message/setup.rs:249
 msgid ""
 "\n"
 "--- Setup Complete ---\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:215
+#: crates/facelock-cli/src/message/setup.rs:252
 #, python-brace-format
 msgid ""
 "  Camera detection failed: {error}\n"
@@ -924,230 +924,230 @@ msgid ""
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:221
+#: crates/facelock-cli/src/message/setup.rs:258
 #, python-brace-format
 msgid ""
 "  Model quality selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:227
+#: crates/facelock-cli/src/message/setup.rs:264
 #, python-brace-format
 msgid ""
 "  Inference device selection failed: {error}\n"
 "  Continuing with current setting: {current}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:233
+#: crates/facelock-cli/src/message/setup.rs:270
 #, python-brace-format
 msgid ""
 "  Model download failed: {error}\n"
 "  You can retry later with: sudo facelock setup --non-interactive"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:243
+#: crates/facelock-cli/src/message/setup.rs:280
 #, python-brace-format
 msgid ""
 "  Encryption setup failed: {error}\n"
 "  You can configure encryption later with: sudo facelock tpm encrypt --generate-key"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:249
+#: crates/facelock-cli/src/message/setup.rs:286
 #, python-brace-format
 msgid ""
 "  Enrollment failed: {error}\n"
 "  You can enroll later with: facelock enroll"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:254
+#: crates/facelock-cli/src/message/setup.rs:291
 #, python-brace-format
 msgid ""
 "  Test failed: {error}\n"
 "  You can test later with: facelock test"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:259
+#: crates/facelock-cli/src/message/setup.rs:296
 #, python-brace-format
 msgid ""
 "  Systemd setup failed: {error}\n"
 "  You can enable it later with: sudo facelock setup --systemd"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:265
+#: crates/facelock-cli/src/message/setup.rs:302
 #, python-brace-format
 msgid ""
 "  PAM setup failed: {error}\n"
 "  You can configure PAM later with: sudo facelock setup --pam"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:269
+#: crates/facelock-cli/src/message/setup.rs:306
 msgid "Would you like to enroll a face now?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:270
+#: crates/facelock-cli/src/message/setup.rs:307
 msgid "  Skipping face enrollment."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:271
+#: crates/facelock-cli/src/message/setup.rs:308
 msgid "Would you like to test recognition?"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:272
+#: crates/facelock-cli/src/message/setup.rs:309
 msgid "  Skipping recognition test."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:274
+#: crates/facelock-cli/src/message/setup.rs:311
 #, python-brace-format
 msgid "  Camera:     {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:278
+#: crates/facelock-cli/src/message/setup.rs:315
 #, python-brace-format
 msgid "  Models:     {dir} ({quality})"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:282
+#: crates/facelock-cli/src/message/setup.rs:319
 #, python-brace-format
 msgid "  Inference:  {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:286
+#: crates/facelock-cli/src/message/setup.rs:323
 #, python-brace-format
 msgid "  Database:   {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:290
+#: crates/facelock-cli/src/message/setup.rs:327
 #, python-brace-format
 msgid "  Encryption: {value}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:294
+#: crates/facelock-cli/src/message/setup.rs:331
 #, python-brace-format
 msgid "  Daemon:   {status}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:297
+#: crates/facelock-cli/src/message/setup.rs:334
 msgid "not configured (--no-systemd)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:298
+#: crates/facelock-cli/src/message/setup.rs:335
 msgid "configured from the command line"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:299
+#: crates/facelock-cli/src/message/setup.rs:336
 msgid "enabled (D-Bus activation)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:300
+#: crates/facelock-cli/src/message/setup.rs:337
 msgid "not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:302
+#: crates/facelock-cli/src/message/setup.rs:339
 #, python-brace-format
 msgid "  PAM:      {services}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:305
+#: crates/facelock-cli/src/message/setup.rs:342
 msgid "  PAM:      not configured (--no-pam)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:306
+#: crates/facelock-cli/src/message/setup.rs:343
 msgid "  PAM:      not configured"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:307
+#: crates/facelock-cli/src/message/setup.rs:344
 msgid "  Face:     enrolled"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:309
+#: crates/facelock-cli/src/message/setup.rs:346
 msgid "  Face:     not enrolled (--no-enroll; run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:311
+#: crates/facelock-cli/src/message/setup.rs:348
 msgid "  Face:     not enrolled (run `facelock enroll`)"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:312
+#: crates/facelock-cli/src/message/setup.rs:349
 msgid "facelock setup: preparing system...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:314
+#: crates/facelock-cli/src/message/setup.rs:351
 #, python-brace-format
 msgid "Checking {count} model(s)...\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:317
+#: crates/facelock-cli/src/message/setup.rs:354
 msgid ""
 "\n"
 "Setup complete."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:319
+#: crates/facelock-cli/src/message/setup.rs:356
 msgid ""
 "\n"
 "Setup complete. Run `facelock enroll` to register your face."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:321
+#: crates/facelock-cli/src/message/setup.rs:358
 msgid "  Directories created."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:323
+#: crates/facelock-cli/src/message/setup.rs:360
 #, python-brace-format
 msgid "  Created default config at {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:326
+#: crates/facelock-cli/src/message/setup.rs:363
 msgid ""
 "\n"
 "Enrolling face..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:328
+#: crates/facelock-cli/src/message/setup.rs:365
 msgid "  Setting up AES-256-GCM encryption for face embeddings."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:330
+#: crates/facelock-cli/src/message/setup.rs:367
 msgid "  TPM 2.0 detected and functional."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:332
+#: crates/facelock-cli/src/message/setup.rs:369
 #, python-brace-format
 msgid "  TPM-sealed key already exists at {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:335
+#: crates/facelock-cli/src/message/setup.rs:372
 msgid "  Generating and sealing AES key with TPM..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:337
+#: crates/facelock-cli/src/message/setup.rs:374
 #, python-brace-format
 msgid "  TPM-sealed key written to {path} (permissions: 0600)."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:340
+#: crates/facelock-cli/src/message/setup.rs:377
 msgid "  Encryption enabled (TPM-sealed key)."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:342
+#: crates/facelock-cli/src/message/setup.rs:379
 #, python-brace-format
 msgid "  Encryption key already exists at {path}."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:345
+#: crates/facelock-cli/src/message/setup.rs:382
 msgid "  Generating encryption key..."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:347
+#: crates/facelock-cli/src/message/setup.rs:384
 #, python-brace-format
 msgid "  Key written to {path} (permissions: 0600)."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:350
+#: crates/facelock-cli/src/message/setup.rs:387
 msgid "  Encryption enabled."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:352
+#: crates/facelock-cli/src/message/setup.rs:389
 msgid ""
 "  ⚠ WARNING: encryption disabled (--encryption=none).\n"
 "    Biometric templates will be stored UNENCRYPTED in the database.\n"
@@ -1155,30 +1155,30 @@ msgid ""
 "    security.allow_plaintext is also set in the config."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:355
+#: crates/facelock-cli/src/message/setup.rs:392
 #, python-brace-format
 msgid "  Encryption already configured ({method})."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:359
+#: crates/facelock-cli/src/message/setup.rs:396
 #, python-brace-format
 msgid "  [ok] Generated TPM-sealed encryption key at {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:363
+#: crates/facelock-cli/src/message/setup.rs:400
 msgid "  [ok] AES-256-GCM encryption enabled (TPM-sealed key)."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:366
+#: crates/facelock-cli/src/message/setup.rs:403
 #, python-brace-format
 msgid "  [ok] Generated encryption key at {path}"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:369
+#: crates/facelock-cli/src/message/setup.rs:406
 msgid "  [ok] AES-256-GCM encryption enabled."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:372
+#: crates/facelock-cli/src/message/setup.rs:409
 #, python-brace-format
 msgid ""
 "\n"
@@ -1186,19 +1186,49 @@ msgid ""
 "  encryption key is missing. Generating a new key would make them unreadable.\n"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:377
+#: crates/facelock-cli/src/message/setup.rs:414
 #, python-brace-format
 msgid "  Removed {count} orphaned model(s)."
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:381
+#: crates/facelock-cli/src/message/setup.rs:422
+#, python-brace-format
+msgid "  Sealing the existing key at {key_path} with the TPM (writing {sealed_path})..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:434
+#, python-brace-format
+msgid "  Unsealing the existing TPM-sealed key at {sealed_path} into {key_path}..."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:443
+#, python-brace-format
+msgid "  NOTE: leaving the TPM-sealed key at {sealed_path} in place; models sealed under it stay readable while a TPM can still unseal it."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:452
+#, python-brace-format
+msgid "  NOTE: {key_path} and {sealed_path} no longer hold the same key; models sealed under either stay readable only while that file is kept."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:461
+#, python-brace-format
+msgid "  NOTE: a TPM device is present but not usable (tcti: {tcti}): {reason}. Falling back to a software keyfile."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:467
+#, python-brace-format
+msgid "  NOTE: encryption.method is \"tpm\" but no usable TPM was found right now; the sealed key at {sealed_path} stays in place. Continuing with a software keyfile for this run."
+msgstr ""
+
+#: crates/facelock-cli/src/message/setup.rs:472
 msgid ""
 "\n"
 "==> To finish hyprlock integration, run as your normal user:\n"
 "==>     facelock hyprlock enable"
 msgstr ""
 
-#: crates/facelock-cli/src/message/setup.rs:384
+#: crates/facelock-cli/src/message/setup.rs:475
 #, python-brace-format
 msgid "  hyprlock integration applied for {user}."
 msgstr ""

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -650,7 +650,7 @@
         "path": "docs/security.md",
         "anchor": "c-encryption-at-rest-implemented--encrypted-by-default-plan-04",
         "ordinal": 19,
-        "line": 733,
+        "line": 745,
         "sha256": "08540ee4ee5e471b586a5c24a07b5cc333c4f1451e59e47ee59574b5ed24cc33"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -6952,14 +6952,14 @@
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 13,
-          "line": 1263,
+          "line": 1272,
           "sha256": "63c460d2967465f764a77bec938f1ab6183bba3b9758048020ee3de0d5dc3e82"
         },
         {
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 14,
-          "line": 1265,
+          "line": 1274,
           "sha256": "9d893de87b927d4a16bf54f82add2a2e2b2a9c56d12e4d04d2a27cbed5ef49c7"
         }
       ],
@@ -10590,7 +10590,7 @@
           "path": "docs/security.md",
           "anchor": "b-systemd-hardening-implemented",
           "ordinal": 3,
-          "line": 1535,
+          "line": 1547,
           "sha256": "8798eab946c173be56a1f11cc506ac362d12ba935d90fa159ae04196d6e6c692"
         }
       ],

--- a/test/upgrade-v014-contract.sh
+++ b/test/upgrade-v014-contract.sh
@@ -88,7 +88,7 @@ done
 run_shape_body="$(sed -n '/^run_shape() {/,/^}/p' "$lane")"
 [ -n "$run_shape_body" ] || fail "run_shape not found in the lane harness"
 for proof in \
-    assert_schema_v6_with_null_device_id \
+    assert_schema_v7_with_null_columns \
     assert_known_embedding_decrypts \
     assert_enrollment_marker_reconciled \
     assert_key_artifacts_preserved \

--- a/test/upgrade-v014-lane.sh
+++ b/test/upgrade-v014-lane.sh
@@ -15,7 +15,8 @@
 # 0.1.4 generated (or sealed, against a software TPM).
 #
 # What each shape proves after a native package-manager upgrade:
-#   * the V5 database migrated to V6 and legacy rows carry device_id = NULL
+#   * the V5 database migrated to V7 and legacy rows carry device_id = NULL
+#     and key_id = NULL
 #   * a **known embedding still decrypts** — the plaintext bytes are compared,
 #     not the file hash, because a file hash cannot tell a preserved key from a
 #     preserved ciphertext nobody can open any more
@@ -26,7 +27,7 @@
 #
 # Then the candidate is downgraded back to v0.1.4 — after the candidate daemon
 # has opened and migrated the database — and the released binary has to still
-# read its own encrypted rows. V6 has no down-migration, so this is the only
+# read its own encrypted rows. V7 has no down-migration, so this is the only
 # thing that says whether shipping the alpha strands a rollback.
 set -euo pipefail
 
@@ -643,8 +644,8 @@ PY
 
 # --- post-upgrade proofs ---------------------------------------------------
 
-assert_schema_v6_with_null_device_id() {
-    assert_eq 6 "$(schema_version)" "schema version after the candidate opened the database"
+assert_schema_v7_with_null_columns() {
+    assert_eq 7 "$(schema_version)" "schema version after the candidate opened the database"
     local columns
     columns="$(python3 - <<'PY'
 import sqlite3
@@ -660,11 +661,18 @@ PY
         *,device_id,*) ;;
         *) fail "V6 migration did not add face_models.device_id (columns: $columns)" ;;
     esac
+    case ",$columns," in
+        *,key_id,*) ;;
+        *) fail "V7 migration did not add face_models.key_id (columns: $columns)" ;;
+    esac
     # Legacy rows must stay uncoupled. A migration that invented a device id
-    # would bind every existing template to whatever camera happened to be
-    # plugged in during the upgrade.
+    # or a key id would bind every existing template to whatever camera
+    # happened to be plugged in during the upgrade, or to a key it was never
+    # sealed under.
     assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE device_id IS NOT NULL')" \
         "legacy rows left with a non-NULL device_id"
+    assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE key_id IS NOT NULL')" \
+        "legacy rows left with a non-NULL key_id"
 }
 
 # Which model's first embedding is the known fixture for a given shape. The
@@ -1056,7 +1064,7 @@ assert_real_password_behavior() {
 
 # --- the candidate daemon actually opens the database ----------------------
 #
-# The rollback question is not "does v0.1.4 read a V6 file" in the abstract, it
+# The rollback question is not "does v0.1.4 read a V7 file" in the abstract, it
 # is "does it read the file the alpha daemon has already opened, migrated and
 # written to". So the daemon runs for real before the downgrade.
 open_database_with_candidate_daemon() {
@@ -1067,11 +1075,11 @@ open_database_with_candidate_daemon() {
     # Wait for the outcome, not for a proxy that races it.
     # `reconcile_enrollment_markers` runs at daemon.rs:346, *before*
     # `build_handler_from`, and the migration happens inside it -- so the store
-    # reaches V6 partway through reconciliation. Polling on the schema version
+    # reaches V7 partway through reconciliation. Polling on the schema version
     # alone stopped the daemon mid-reconcile, which the Debian half won by luck
     # and the Fedora half lost.
     for _ in $(seq 1 120); do
-        if [ "$(schema_version)" = 6 ] &&
+        if [ "$(schema_version)" = 7 ] &&
             [ "$(marker_model_count)" = "$(database_model_count)" ]; then
             break
         fi
@@ -1083,7 +1091,7 @@ open_database_with_candidate_daemon() {
         echo "--- candidate daemon output ---" >&2
         tail -20 "$output" >&2 || true
     fi
-    assert_eq 6 "$(schema_version)" "schema version after the candidate daemon ran"
+    assert_eq 7 "$(schema_version)" "schema version after the candidate daemon ran"
 }
 
 database_model_count() {
@@ -1118,13 +1126,13 @@ assert_downgrade_usable() {
         "installed version after downgrade"
     ensure_system_bus
 
-    # V6 has no down-migration. The predecessor must still open the database the
+    # V7 has no down-migration. The predecessor must still open the database the
     # candidate migrated and read its enrollment state. `tpm status` is the
     # readback rather than `list`, which in v0.1.4 is a D-Bus call to a daemon
     # this phase deliberately does not run.
     released_facelock tpm status >>"$LOG" 2>&1 ||
-        fail "the released binary could not open the V6 database after rollback"
-    assert_eq 6 "$(schema_version)" "schema version is not rolled back by a package downgrade"
+        fail "the released binary could not open the V7 database after rollback"
+    assert_eq 7 "$(schema_version)" "schema version is not rolled back by a package downgrade"
 
     # The rollback claim is that the old binary can still *read the templates*,
     # so it decrypts the known embedding and the plaintext is compared. An exit
@@ -1185,7 +1193,7 @@ run_shape() {
         fail "the upgrade changed state it had to preserve"
     }
 
-    assert_schema_v6_with_null_device_id
+    assert_schema_v7_with_null_columns
     assert_known_embedding_decrypts "$shape"
     assert_enrollment_marker_reconciled
     assert_key_artifacts_preserved "$STATE_ROOT/$shape.before"
@@ -1353,14 +1361,14 @@ fault_positive_control() {
     local target="$FAULT_ROOT/control" status
     seed_fault_database "$target"
     status="$(run_fault_daemon "$target" 45)"
-    assert_eq 6 "$(fault_schema_version "$target")" \
+    assert_eq 7 "$(fault_schema_version "$target")" \
         "positive control: the candidate daemon migrates a healthy V5 database"
     assert_eq 3 "$(fault_row_count "$target")" "positive control: rows after migration"
     [ "$status" = 124 ] || {
         tail -20 "$target/daemon.log" >&2
         fail "positive control: the candidate daemon did not stay up (exit $status)"
     }
-    pass "positive control: a healthy V5 database migrates to V6"
+    pass "positive control: a healthy V5 database migrates to V7"
 }
 
 # Shared by the failure cases: the file is the same file, its rows are still


### PR DESCRIPTION
## Summary

- record on every model the id of the key that sealed it (schema V7, nullable `face_models.key_id`)
- load the configured method's key as primary and the other method's artifact as a best-effort secondary, in the daemon and the one-shot path
- decrypt a row under the key it names; try primary then secondaries for a pre-V7 row; fail the load naming the missing artifact instead of blaming AAD
- seal new enrollments under the primary only; `tpm encrypt` records the key id, `tpm decrypt` clears it
- make `setup` seal the existing keyfile into the TPM, or unseal the sealed key into a keyfile, instead of minting a second key
- surface a TPM that exists but fails to initialise, and a keyfile and sealed key that no longer agree
- write the unsealed key in one step; the old mint-then-overwrite could leave a random placeholder under the real name

## Why

Both encryption methods seal templates with the same AES-GCM blob, and the daemon held exactly one key, chosen by `encryption.method` at startup. Re-running `setup` minted a fresh key for the target method whenever its artifact was absent, even with the other method's key on disk, so a flip orphaned every earlier model and the error blamed AAD. `tpm seal-key` and `unseal-key` already carried the same bytes across methods; `setup` now does too, and the store remembers which key sealed each model for hosts that already diverged.

## Contract

- schema version 6 to 7; older releases never name the column, so downgrade to v0.1.4 still opens the database
- a diverged host authenticates on every model once both keys load at runtime; a key that cannot load fails that user's load naming the artifact to restore, the same fail-closed rule as before
- a build without the `tpm` feature never consults the sealed key, unchanged
- `setup_encryption_auto` (the `method = none` path) is unchanged and still mints; follow-up

| Path | Why it matters |
|---|---|
| `crates/facelock-daemon/src/keyring.rs` | `SealingKeys`: the one loader for primary and secondary keys *(start here)* |
| `crates/facelock-daemon/src/embeddings.rs` | per-row key selection and the legacy trial |
| `crates/facelock-cli/src/commands/setup.rs` | `plan_key_action` and the seal/unseal dispatch |
| `crates/facelock-cli/src/commands/tpm.rs` | key-preserving helpers shared with `setup`; `write_key_file` |
| `crates/facelock-store/src/migrations.rs` | V7 |
| `docs/contracts.md` | keyring rules, setup transitions, downgrade paragraph |

## Reviewer notes

- **Trial decrypt is scoped per user.** Rows are filtered by user before any key is tried, and AES-GCM fails the tag check under a wrong key, so the trial cannot widen who authenticates.
- **Secondary loads never mint.** They call `from_key_file` or the TPM unseal directly, never the encrypt-by-default gate.
- **Key id is a truncated SHA-256 of the key bytes** under a domain string; a lookup tag, not key material.

## Validation

- `just check`
- `cargo test` and `cargo clippy` with and without `--features tpm`
- `just test-upgrade-v014-contract` for the renamed V7 proof
- not run: the container upgrade lane and a hardware TPM flip on a real host

Fixes #354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Switching between TPM and keyfile encryption now preserves existing face templates.
  - Encryption recovery can use the configured method or an available alternate key, including for legacy templates.
  - Clearer setup messages explain TPM failures, key conflicts, fallback options, and recovery steps.
  - Authentication and enrollment now provide more specific feedback when required encryption keys are unavailable.

- **Bug Fixes**
  - Fixed key rotation and migration scenarios that could leave templates inaccessible.

- **Documentation**
  - Added guidance for encryption transitions, key recovery, and schema updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->