### PR TITLE
ci(test): disable pacman's download timeout in the Arch containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A new nullable `face_models.key_id` column (schema V7) records the truncated SHA-256 fingerprint
   of each sealing key.
 
+### Changed
+
+- The Arch test containers now disable pacman's download timeout, so a slow
+  transfer from the pinned `archive.archlinux.org` mirror no longer aborts
+  the whole transaction and fails the job (#332).
+
 ## [0.2.0] - 2026-09-06
 
 ### Added

--- a/test/Containerfile
+++ b/test/Containerfile
@@ -3,6 +3,15 @@ FROM docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220
 
 RUN printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
+# The pinned archive above serves large packages slowly enough that pacman's
+# low-speed abort ("Operation too slow... transferred the last 10 seconds")
+# kills the whole transaction. Disable that timeout instead of the pin.
+RUN if grep -q '^#DisableDownloadTimeout' /etc/pacman.conf; then \
+        sed -i 's/^#DisableDownloadTimeout/DisableDownloadTimeout/' /etc/pacman.conf; \
+    else \
+        sed -i '0,/^\[options\]/s//[options]\nDisableDownloadTimeout/' /etc/pacman.conf; \
+    fi
+
 # Install dependencies
 # `sqlite` provides the sqlite3 CLI used by the device-coupling E2E assertions
 # (Plan 02) to inspect/seed face_models.device_id deterministically.

--- a/test/Containerfile.arch-e2e
+++ b/test/Containerfile.arch-e2e
@@ -15,6 +15,15 @@ FROM docker.io/library/archlinux:base-devel@sha256:714acd1eef9ae997d95691b1c5220
 # whatever Arch shipped this morning.
 RUN printf '%s\n' 'Server = https://archive.archlinux.org/repos/2026/08/18/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
+# The pinned archive above serves large packages slowly enough that pacman's
+# low-speed abort ("Operation too slow... transferred the last 10 seconds")
+# kills the whole transaction. Disable that timeout instead of the pin.
+RUN if grep -q '^#DisableDownloadTimeout' /etc/pacman.conf; then \
+        sed -i 's/^#DisableDownloadTimeout/DisableDownloadTimeout/' /etc/pacman.conf; \
+    else \
+        sed -i '0,/^\[options\]/s//[options]\nDisableDownloadTimeout/' /etc/pacman.conf; \
+    fi
+
 # base-devel already supplies sudo (makepkg --syncdeps calls pacman through it),
 # gettext (msgfmt, for the recipe's locale stanza) and fakeroot. git is not in
 # base-devel and cargo wants it for any git-sourced crate; util-linux supplies


### PR DESCRIPTION
- set `DisableDownloadTimeout` in `/etc/pacman.conf` in both Arch test containers
- keep the pinned `archive.archlinux.org` mirror; only the low-speed abort goes

A slow archive transfer trips pacman's 10-second low-speed abort and kills the whole transaction, failing the job. The mirror pin is contract-enforced and stays.

Fixes #332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of Arch-based package installation when downloads from the pinned archive mirror are slow.
  - Prevented low-speed download timeouts from interrupting Arch test container setup.

- **Documentation**
  - Updated the unreleased changelog to document the improved handling of slow package downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->