### PR TITLE
build(release): re-record the COPR predecessor gap against the served 0.2.0-1

### DIFF
--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -74,7 +74,7 @@
       "served_evr_exact": true,
       "served_evr_gap": {
         "expected_evr": "0.1.4-1",
-        "served_evr": "0.1.3-1",
+        "served_evr": "0.2.0-1",
         "issue": 333
       }
     },


### PR DESCRIPTION
- re-record `copr_channels.production.served_evr_gap.served_evr` as `0.2.0-1`, the build production COPR serves today
- keep the pinned predecessor at v0.1.4 and issue #333 as the owner

`just release-preflight v0.2.1` fails on the live channel check: the gap record excused COPR serving 0.1.3-1 instead of the pinned 0.1.4-1, and 0.2.0-1 matches neither, so the record expired as designed. Rolling the predecessor pin to v0.2.0 is the durable fix; it needs the upgrade lanes to read the pinned tag instead of `v0.1.4`, tracked separately.

Refs #333
