### PR TITLE
ci(release): pin just for the Ubuntu release builder

### DIFF
--- a/.github/workflows/scripts/install-ubuntu-deps.sh
+++ b/.github/workflows/scripts/install-ubuntu-deps.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The justfile needs just >= 1.36 (hyphenated variable names); Ubuntu noble
+# packages 1.21.0, which fails to parse it before building anything. Install
+# the same release the other builders and the maintainer's machine run,
+# pinned by digest from the project's published SHA256SUMS.
+JUST_VERSION="1.46.0"
+JUST_SHA256="79966e6e353f535ee7d1c6221641bcc8e3381c55b0d0a6dc6e54b34f9db36eaa"
+
 echo "=== Installing Ubuntu build dependencies ==="
 
 sudo apt-get update
@@ -10,10 +17,20 @@ sudo apt-get install -y \
   pkg-config \
   libssl-dev \
   clang \
-  just \
   libxkbcommon-dev \
   libwayland-dev \
   libtss2-dev \
   libtss2-tcti-tabrmd-dev
+
+echo "=== Installing just ${JUST_VERSION} ==="
+tarball="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+tmp="$(mktemp -d)"
+curl -fsSL --retry 3 -o "${tmp}/${tarball}" \
+  "https://github.com/casey/just/releases/download/${JUST_VERSION}/${tarball}"
+echo "${JUST_SHA256}  ${tmp}/${tarball}" | sha256sum -c -
+tar -xzf "${tmp}/${tarball}" -C "${tmp}" just
+sudo install -m 0755 "${tmp}/just" /usr/local/bin/just
+rm -rf "${tmp}"
+just --version
 
 echo "=== Ubuntu dependencies installed ==="

--- a/.github/workflows/scripts/install-ubuntu-deps.sh
+++ b/.github/workflows/scripts/install-ubuntu-deps.sh
@@ -25,12 +25,12 @@ sudo apt-get install -y \
 echo "=== Installing just ${JUST_VERSION} ==="
 tarball="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
 tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
 curl -fsSL --retry 3 -o "${tmp}/${tarball}" \
   "https://github.com/casey/just/releases/download/${JUST_VERSION}/${tarball}"
 echo "${JUST_SHA256}  ${tmp}/${tarball}" | sha256sum -c -
 tar -xzf "${tmp}/${tarball}" -C "${tmp}" just
 sudo install -m 0755 "${tmp}/just" /usr/local/bin/just
-rm -rf "${tmp}"
 just --version
 
 echo "=== Ubuntu dependencies installed ==="

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2463,7 +2463,10 @@ release until it does.
   `build` and `build-rpm` compile through `just build-release`, the recipe
   `just install` and the packaging lanes use, which carries the `tpm`
   feature; `build` fails if the resulting binary does not link
-  `libtss2-esys`.
+  `libtss2-esys`. The justfile needs just 1.36 or later, and the Ubuntu
+  builder's apt package is 1.21.0, so `install-ubuntu-deps.sh` installs a
+  just release pinned by version and digest; the release artifacts contract
+  refuses the apt package and any pin below that floor.
 - Every staged asset matches the SHA-256 its builder attested. Each builder
   writes a `release-digests-<slot>` artifact naming what it produced, the image
   it produced it in, and the components it consumed. An asset attested by no

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -28,6 +28,28 @@ fail() {
 [ -f "$workflow_path" ] || fail "missing release workflow: $workflow_path"
 [ -x "$helper_path" ] || fail "release asset helper must be executable: $helper_path"
 
+# ------------------------------------------------------------ builder tooling
+
+# The `build` job runs `just build-release` on ubuntu-latest, whose apt
+# package is just 1.21.0. The justfile needs 1.36 or later (hyphenated
+# variable names), and v0.2.1's first release run died on that parse before
+# compiling anything. The deps script pins a release by digest instead.
+deps_script=.github/workflows/scripts/install-ubuntu-deps.sh
+just_floor=1.36.0
+[ -x "$deps_script" ] || fail "Ubuntu deps script must be executable: $deps_script"
+if grep -v '^[[:space:]]*#' "$deps_script" | grep -Eq '^[[:space:]]+just[[:space:]]*\\?$'; then
+    fail "the Ubuntu deps script must not install just from apt (noble ships 1.21.0, below the $just_floor the justfile needs)"
+fi
+pinned_just="$(sed -n 's/^JUST_VERSION="\([0-9][0-9.]*\)"$/\1/p' "$deps_script")"
+[ -n "$pinned_just" ] || fail "the Ubuntu deps script must pin JUST_VERSION"
+[ "$(printf '%s\n' "$just_floor" "$pinned_just" | sort -V | head -n1)" = "$just_floor" ] ||
+    fail "the Ubuntu deps script pins just $pinned_just, below the $just_floor the justfile needs"
+grep -Eq '^JUST_SHA256="[0-9a-f]{64}"$' "$deps_script" ||
+    fail "the Ubuntu deps script must pin the just tarball digest as JUST_SHA256"
+grep -Fq 'sha256sum -c' "$deps_script" ||
+    fail "the Ubuntu deps script must verify the just tarball against JUST_SHA256"
+echo "release artifacts contract: Ubuntu builder pins just $pinned_just by digest"
+
 job_body() {
     awk -v job="$1" '
         $0 == "  " job ":" { inside = 1; next }

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -37,7 +37,10 @@ fail() {
 deps_script=.github/workflows/scripts/install-ubuntu-deps.sh
 just_floor=1.36.0
 [ -x "$deps_script" ] || fail "Ubuntu deps script must be executable: $deps_script"
-if grep -v '^[[:space:]]*#' "$deps_script" | grep -Eq '^[[:space:]]+just[[:space:]]*\\?$'; then
+# Join backslash continuations first, so `apt-get install -y just` on one
+# line and `just \` inside a multi-line package list are read the same way.
+if grep -v '^[[:space:]]*#' "$deps_script" | sed -e ':a' -e '/\\$/N; s/\\\n//; ta' |
+    grep -E 'apt(-get)?[[:space:]]+install' | grep -Eq '(^|[[:space:]])just([[:space:]]|$)'; then
     fail "the Ubuntu deps script must not install just from apt (noble ships 1.21.0, below the $just_floor the justfile needs)"
 fi
 pinned_just="$(sed -n 's/^JUST_VERSION="\([0-9][0-9.]*\)"$/\1/p' "$deps_script")"


### PR DESCRIPTION
- install just 1.46.0 from its GitHub release in `install-ubuntu-deps.sh`, verified against the published SHA256, instead of Ubuntu noble's 1.21.0 package
- refuse the apt package and any pin below 1.36 in `test/release-artifacts-contract.sh`
- note the floor in `docs/contracts.md`

The v0.2.1 release run (34158161926) failed in `Build Release Binaries` before compiling anything: just 1.21.0 cannot parse `_ort-version :=` at justfile:1122, the first time `just build-release` ran on the Ubuntu builder since #356. RPM was skipped as a dependent and `publish` never ran, so nothing was published. Debian trixie ships 1.40 and Fedora 44 ships 1.47, so the other builders are unaffected.

Refs #355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Ubuntu build environments now install a verified, version-pinned `just` release instead of relying on an older system package.
  - Existing Ubuntu development dependencies remain available through the system package manager.

- **Documentation**
  - Release artifact requirements now specify the minimum supported `just` version and checksum verification for Ubuntu builders.
  - Builds using outdated or unverified `just` installations are rejected.

- **Tests**
  - Improved validation detects unsupported `just` installations across complete package-install commands, including continued command lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->