### PR TITLE
fix(build): Stop shipping worktree checkouts as build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,13 +8,10 @@ target/
 # test/Containerfile.copr-e2e can install the exact artifact under test.
 !target/copr-lane/facelock.rpm
 
-# Worktree checkouts, which live inside the main checkout. `target/` above is
-# root-anchored, so it does not match their build artifacts and every build run
-# from the main checkout streams them as context. Building from inside a
-# worktree is unaffected: the context root is that worktree, which holds no
-# nested worktrees of its own.
-.worktrees/
-.claude/worktrees/
+# Worktree checkouts live inside the main checkout and can contain their own build artifacts.
+# Exclude them from the build context to avoid accidentally streaming nested checkouts.
+/.worktrees/
+/.claude/worktrees/
 
 # Git history not needed in containers
 .git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,14 @@ target/
 # test/Containerfile.copr-e2e can install the exact artifact under test.
 !target/copr-lane/facelock.rpm
 
+# Worktree checkouts, which live inside the main checkout. `target/` above is
+# root-anchored, so it does not match their build artifacts and every build run
+# from the main checkout streams them as context. Building from inside a
+# worktree is unaffected: the context root is that worktree, which holds no
+# nested worktrees of its own.
+.worktrees/
+.claude/worktrees/
+
 # Git history not needed in containers
 .git/
 


### PR DESCRIPTION
- exclude `.worktrees/` and `.claude/worktrees/` from the build context
- `target/` is root-anchored, so it never matched `.worktrees/*/target/` or `.claude/worktrees/*/target/`; both roots live inside the main checkout and hold 508 GB today
- verified with a fixture: with only `target/` excluded, an exported image contained both nested `target/` trees; with these two patterns it contained neither
- builds run from inside a worktree are unaffected — the context root is that worktree, and a worktree holds no nested worktrees of its own


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build exclusions to omit worktree directories located at the checkout root, while leaving similarly named directories elsewhere unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->