### PR TITLE
ci(packaging): Classify pull-request diffs per packaging lane

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -58,15 +58,19 @@ schedules:
 
 | When | What | Filter |
 |---|---|---|
-| Pull request | every lane | only when the diff reaches a package |
+| Pull request | every lane | per lane, only the lanes the diff reaches |
 | Nightly (07:00 UTC) | every lane | none |
 | `just release-preflight` | lane evidence uploaded by a green run at HEAD, or the marker a local `just test-packaging-matrix` wrote at HEAD | none |
 
 The pull-request filter is a `changes` job running
 `.github/workflows/scripts/classify-changes.sh`, plain bash over a merge-base
-diff. It is not GitHub's `paths:`, which strands a required check as pending
-forever, and not a third-party filter action, which would be another pinned SHA
-to review. Add a path there when a new file can reach a built package.
+diff and emits one output per lane (`deb`, `rpm`, `arch`, `release_binaries`,
+`release_matrix`). It is not GitHub's `paths:`, which strands a required check
+as pending forever, and not a third-party filter action, which would be another
+pinned SHA to review. Add a path there when a new file can reach a built
+package, mapped to one family's lane when only that family reads it and to
+every lane otherwise; the table is in docs/releasing.md and
+`just test-classify-changes` pins it.
 
 So a green pull request is **not** packaging-verified unless the packaging jobs
 actually ran on it. A Rust-only change that breaks the packaged runtime is caught

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -73,8 +73,9 @@ every lane otherwise; the table is in docs/releasing.md and
 `just test-classify-changes` pins it.
 
 So a green pull request is **not** packaging-verified unless the packaging jobs
-actually ran on it. A Rust-only change that breaks the packaged runtime is caught
-by the nightly matrix within a day, and by the release gate before it ships.
+actually ran on it. A Rust-only change runs only the release-binaries build on
+its pull request; if it breaks the packaged runtime, the nightly matrix catches
+it within a day, and the release gate before it ships.
 `just test-packaging-matrix` runs every lane locally and records each lane's
 evidence, for a maintainer without CI in reach; a run that skipped anything is
 refused, not recorded.

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -8,9 +8,11 @@ description: Pick and run the right facelock packaging or container test for a c
 CI runs the packaging lanes in `.github/workflows/packaging.yml`: both Debian
 suite gates, every declared Fedora lane, the Arch package built from the real
 `dist/PKGBUILD`, and the native version-ordering matrix. On a pull request they
-run **only when the diff reaches a package**. A `changes` job classifies the
-merge-base diff, and every lane sits behind
-`if: needs.changes.outputs.packaging == 'true'`. Unfiltered runs happen nightly
+run **only the lanes the diff reaches**. A `changes` job classifies the
+merge-base diff per lane, and each job sits behind its own output
+(`if: needs.changes.outputs.deb == 'true'`, `rpm`, `arch`, `release_binaries`,
+`release_matrix`; the path-to-lane table is in docs/releasing.md). Unfiltered
+runs happen nightly
 and at `just release-preflight`, which refuses to pass without complete lane
 evidence at HEAD: the `packaging-evidence-*` artifacts a green run uploads, or
 the record a local `just test-packaging-matrix` writes.

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -6,8 +6,8 @@ name: Packaging
 # Three schedules, because the full matrix takes about 1 h 45 min (measured
 # 2026-09-02) and most pull requests touch no packaging:
 #
-#   pull request   path-filtered by the `changes` job below, and never the
-#                  copr job -- mock needs a privileged container
+#   pull request   path-filtered per lane by the `changes` job below, and
+#                  never the copr job -- mock needs a privileged container
 #   nightly        the whole matrix, unfiltered
 #   release        `just release-preflight` refuses to pass without a green
 #                  run of this workflow at the release commit
@@ -38,8 +38,13 @@ jobs:
     name: Classify Changed Paths
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # One output per lane; see classify-changes.sh for the path-to-lane map.
     outputs:
-      packaging: ${{ steps.classify.outputs.packaging }}
+      deb: ${{ steps.classify.outputs.deb }}
+      rpm: ${{ steps.classify.outputs.rpm }}
+      arch: ${{ steps.classify.outputs.arch }}
+      release_binaries: ${{ steps.classify.outputs.release_binaries }}
+      release_matrix: ${{ steps.classify.outputs.release_matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -60,7 +65,7 @@ jobs:
     # Not GitHub's `paths:` filter: a workflow skipped that way leaves a
     # required check pending forever. A job-level `if:` reports "skipped",
     # which branch protection accepts. See classify-changes.sh.
-    if: needs.changes.outputs.packaging == 'true'
+    if: needs.changes.outputs.deb == 'true'
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -113,7 +118,7 @@ jobs:
     name: Release Binaries (Arch)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packaging == 'true'
+    if: needs.changes.outputs.release_binaries == 'true'
     timeout-minutes: 60
     container: docker.io/library/archlinux:base-devel@sha256:61f7de2dd88cc4ba1fe36c24cfe1a503c3936984492d6405eeab013ce6ac68c5
     steps:
@@ -154,7 +159,8 @@ jobs:
     name: Fedora ${{ matrix.release }} ${{ matrix.depth }}
     runs-on: ubuntu-latest
     needs: [changes, binaries]
-    if: needs.changes.outputs.packaging == 'true'
+    # `rpm` implies `release_binaries`, so the artifact is there when this runs.
+    if: needs.changes.outputs.rpm == 'true'
     timeout-minutes: 90
     env:
       # Checked, not trusted: the lane fails if the artifact did not land.
@@ -231,7 +237,7 @@ jobs:
     name: Fedora ${{ matrix.release }} COPR ${{ matrix.depth }}
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packaging == 'true' && github.event_name != 'pull_request'
+    if: needs.changes.outputs.rpm == 'true' && github.event_name != 'pull_request'
     # Twice the rpm job's budget: mock compiles the workspace and runs the
     # spec's %check inside the chroot before the lifecycle half starts.
     timeout-minutes: 120
@@ -284,7 +290,7 @@ jobs:
     name: Arch Package From dist/PKGBUILD
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packaging == 'true'
+    if: needs.changes.outputs.arch == 'true'
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -319,7 +325,7 @@ jobs:
     name: Release Version Ordering Matrix
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packaging == 'true'
+    if: needs.changes.outputs.release_matrix == 'true'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/scripts/classify-changes.sh
+++ b/.github/workflows/scripts/classify-changes.sh
@@ -10,7 +10,8 @@
 #   deb               both Debian suite lifecycle gates
 #   rpm               the Fedora direct-RPM lanes, and the COPR lanes off PR
 #   arch              the Arch package built from dist/PKGBUILD
-#   release_binaries  the Arch-container build the rpm lanes stage from
+#   release_binaries  the Arch-container build the rpm lanes stage from, and
+#                     the one lane a Rust-only diff runs
 #   release_matrix    the native version-ordering matrix
 #   packaging         any of the above
 #
@@ -32,8 +33,8 @@
 set -euo pipefail
 
 # `pattern=lanes`, first match wins, so a family-specific rule must precede the
-# generic rule for the same directory. Lanes are `deb`, `rpm`, `arch`, `matrix`
-# or `all`. Note that `*` in a bash pattern match crosses `/`, so `dist/*` is
+# generic rule for the same directory. Lanes are `deb`, `rpm`, `arch`, `matrix`,
+# `binaries` or `all`. Note that `*` in a bash pattern match crosses `/`, so `dist/*` is
 # `dist/**`.
 #
 # What a package is built from, plus what its scriptlets execute at install,
@@ -56,6 +57,12 @@ set -euo pipefail
 # lifecycle.rs owns the purge exclusion interval a Debian purge runs inside,
 # and daemon.rs is what postinst try-restarts and what pkg-validate.sh starts
 # under the hardened unit.
+#
+# Every other Rust file runs only the release-binaries build: `just
+# build-release` in the pinned Arch container proves the workspace still
+# compiles the way the packages consume it, in minutes rather than the hour
+# the lifecycle lanes take. The deb, rpm and Arch lifecycles stay nightly for
+# a Rust-only diff (docs/releasing.md, "Residual risk").
 RULES=(
     # Recipes.
     'debian/*=deb'
@@ -123,17 +130,20 @@ RULES=(
     'crates/facelock-cli/src/commands/pam.rs=all'
     'crates/facelock-cli/src/commands/daemon.rs=all'
     'crates/facelock-cli/src/lifecycle.rs=all'
+    'crates/*=binaries'
 )
 
-declare -A lane=([deb]=false [rpm]=false [arch]=false [matrix]=false)
+declare -A lane=([deb]=false [rpm]=false [arch]=false [matrix]=false [binaries]=false)
 
 select_lanes() {
     case "$1" in
-        all) lane[deb]=true; lane[rpm]=true; lane[arch]=true; lane[matrix]=true ;;
+        all) lane[deb]=true; lane[rpm]=true; lane[arch]=true; lane[matrix]=true; lane[binaries]=true ;;
         # Versions live in debian/changelog, the spec and the PKGBUILD, so any
-        # package lane also re-proves their ordering.
-        deb|rpm|arch) lane[$1]=true; lane[matrix]=true ;;
-        matrix) lane[matrix]=true ;;
+        # package lane also re-proves their ordering. The rpm lanes stage the
+        # release binaries, so rpm implies binaries.
+        rpm) lane[rpm]=true; lane[binaries]=true; lane[matrix]=true ;;
+        deb|arch) lane[$1]=true; lane[matrix]=true ;;
+        matrix|binaries) lane[$1]=true ;;
     esac
 }
 
@@ -143,7 +153,7 @@ emit() {
         [deb]="${lane[deb]}"
         [rpm]="${lane[rpm]}"
         [arch]="${lane[arch]}"
-        [release_binaries]="${lane[rpm]}"
+        [release_binaries]="${lane[binaries]}"
         [release_matrix]="${lane[matrix]}"
     )
     for name in deb rpm arch release_binaries release_matrix; do

--- a/.github/workflows/scripts/classify-changes.sh
+++ b/.github/workflows/scripts/classify-changes.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# Decide whether a diff can affect a built package.
+# Decide which packaging lanes a diff can affect.
 #
 # Usage: classify-changes.sh [BASE_REF [HEAD_REF]]
 #
-# Emits `packaging=true|false` on stdout and, when running under Actions, into
-# $GITHUB_OUTPUT so downstream jobs can gate on it with
-# `if: needs.changes.outputs.packaging == 'true'`.
+# Emits one `<lane>=true|false` line per lane on stdout and, when running
+# under Actions, into $GITHUB_OUTPUT so each job can gate on its own lane with
+# `if: needs.changes.outputs.<lane> == 'true'`:
+#
+#   deb               both Debian suite lifecycle gates
+#   rpm               the Fedora direct-RPM lanes, and the COPR lanes off PR
+#   arch              the Arch package built from dist/PKGBUILD
+#   release_binaries  the Arch-container build the rpm lanes stage from
+#   release_matrix    the native version-ordering matrix
+#   packaging         any of the above
 #
 # Why this and not a filter action or GitHub's own `paths:`
 #
@@ -19,19 +26,28 @@
 #   "skipped" conclusion instead, which branch protection accepts.
 #
 # The filter is deliberately generous. A false positive costs 30-60 minutes of
-# runner time; a false negative ships a broken package.
+# runner time; a false negative ships a broken package. A path that only one
+# family's recipe or harness reads selects that family's lane; everything else
+# that reaches a package selects every lane.
 set -euo pipefail
 
+# `pattern=lanes`, first match wins, so a family-specific rule must precede the
+# generic rule for the same directory. Lanes are `deb`, `rpm`, `arch`, `matrix`
+# or `all`. Note that `*` in a bash pattern match crosses `/`, so `dist/*` is
+# `dist/**`.
+#
 # What a package is built from, plus what its scriptlets execute at install,
-# upgrade and removal time.
+# upgrade and removal time:
 #
 #   debian/ dist/ .packit.yaml       the recipes themselves
-#   systemd/ dbus/ config/           payload the packages install and validate
+#   systemd/ dbus/ config/           payload every package installs and validates
 #   scripts/                         release identity, ORT/vendor bundles, and
 #                                    the source-install daemon lifecycle the
 #                                    deb and rpm gates re-enter
 #   test/                            the harnesses the gates are made of
 #   justfile                         every lane's entry point
+#   Cargo.toml Cargo.lock            the dependency closure the deb source
+#                                    build vendors and the spec bundles
 #   .github/workflows/               these gates, and the release workflow
 #
 # And the Rust the maintainer scripts call. `%preun`, Arch's `pre_remove` and
@@ -40,39 +56,120 @@ set -euo pipefail
 # lifecycle.rs owns the purge exclusion interval a Debian purge runs inside,
 # and daemon.rs is what postinst try-restarts and what pkg-validate.sh starts
 # under the hardened unit.
-#
-# Note that `*` in a bash pattern match crosses `/`, so `dist/*` is `dist/**`.
-PACKAGING_PATHS=(
-    'debian/*'
-    'dist/*'
-    'systemd/*'
-    'dbus/*'
-    'config/*'
-    'scripts/*'
-    'test/Containerfile*'
-    'test/*deb*'
-    'test/*rpm*'
-    'test/*pkg*'
-    'test/arch-package/*'
-    'justfile'
-    '.packit.yaml'
-    '.github/workflows/*'
-    '.github/actions/*'
-    'crates/facelock-cli/src/commands/pam.rs'
-    'crates/facelock-cli/src/commands/daemon.rs'
-    'crates/facelock-cli/src/lifecycle.rs'
+RULES=(
+    # Recipes.
+    'debian/*=deb'
+    'dist/apt/*=deb'
+    'dist/PKGBUILD*=arch'
+    'dist/facelock.install=arch'
+    'dist/facelock-pam-remove.hook=arch'
+    'dist/facelock.spec=rpm'
+    'dist/rpm/*=rpm'
+    '.packit.yaml=rpm'
+    'dist/*=all'
+
+    # Payload every package installs, and the scripts every recipe calls.
+    'systemd/*=all'
+    'dbus/*=all'
+    'config/*=all'
+    'scripts/*=all'
+
+    # Harnesses. The family-specific ones first; the shared validators, the
+    # base Containerfile the Arch image builds on, and the PAM/polkit/TPM
+    # checks every booted lane runs stay on every lane.
+    'test/Containerfile.deb*=deb'
+    'test/Containerfile.apt*=deb'
+    'test/*deb*=deb'
+    'test/*apt*=deb'
+    'test/Containerfile.arch*=arch'
+    'test/*arch*=arch'
+    'test/Containerfile.fedora=rpm'
+    'test/Containerfile.copr*=rpm'
+    'test/Containerfile.rpm*=rpm'
+    'test/Containerfile.packit=rpm'
+    'test/*rpm*=rpm'
+    'test/*copr*=rpm'
+    'test/*packit*=rpm'
+    'test/fedora-lane-image.sh=rpm'
+    'test/release-*=matrix'
+    'test/Containerfile*=all'
+    'test/*pkg*=all'
+    'test/packaging-evidence.py=all'
+    'test/polkit-agent-validate.sh=all'
+    'test/install-pamtester.sh=all'
+    'test/pam.d/*=all'
+    'test/tpm-pcr-e2e.sh=all'
+    'test/check-release-matrix.py=all'
+
+    # Entry points and the dependency closure.
+    'justfile=all'
+    'Cargo.toml=all'
+    'Cargo.lock=all'
+    'crates/*/Cargo.toml=all'
+
+    # The gates themselves and the release workflow. ci.yml and the other
+    # workflows never build a package and are not listed.
+    '.github/workflows/packaging.yml=all'
+    '.github/workflows/release.yml=all'
+    '.github/workflows/scripts/*deb*=deb'
+    '.github/workflows/scripts/*apt*=deb'
+    '.github/workflows/scripts/*rpm*=rpm'
+    '.github/workflows/scripts/*copr*=rpm'
+    '.github/workflows/scripts/*aur*=arch'
+    '.github/workflows/scripts/*=all'
+    '.github/actions/*=all'
+
+    # The Rust the maintainer scripts execute.
+    'crates/facelock-cli/src/commands/pam.rs=all'
+    'crates/facelock-cli/src/commands/daemon.rs=all'
+    'crates/facelock-cli/src/lifecycle.rs=all'
 )
 
-decide() {
-    local value="$1" reason="$2"
-    echo "packaging=$value  ($reason)"
-    if [ -n "${GITHUB_OUTPUT:-}" ]; then
-        echo "packaging=$value" >>"$GITHUB_OUTPUT"
-    fi
+declare -A lane=([deb]=false [rpm]=false [arch]=false [matrix]=false)
+
+select_lanes() {
+    case "$1" in
+        all) lane[deb]=true; lane[rpm]=true; lane[arch]=true; lane[matrix]=true ;;
+        # Versions live in debian/changelog, the spec and the PKGBUILD, so any
+        # package lane also re-proves their ordering.
+        deb|rpm|arch) lane[$1]=true; lane[matrix]=true ;;
+        matrix) lane[matrix]=true ;;
+    esac
+}
+
+emit() {
+    local reason="$1" any=false selected=()
+    local -A out=(
+        [deb]="${lane[deb]}"
+        [rpm]="${lane[rpm]}"
+        [arch]="${lane[arch]}"
+        [release_binaries]="${lane[rpm]}"
+        [release_matrix]="${lane[matrix]}"
+    )
+    for name in deb rpm arch release_binaries release_matrix; do
+        if [ "${out[$name]}" = true ]; then
+            any=true
+            selected+=("$name")
+        fi
+    done
+    out[packaging]="$any"
+    for name in deb rpm arch release_binaries release_matrix packaging; do
+        echo "$name=${out[$name]}"
+        if [ -n "${GITHUB_OUTPUT:-}" ]; then
+            echo "$name=${out[$name]}" >>"$GITHUB_OUTPUT"
+        fi
+    done
+    echo "packaging lanes: ${selected[*]:-none}  ($reason)"
     if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-        echo "packaging gates: **$value** -- $reason" >>"$GITHUB_STEP_SUMMARY"
+        echo "packaging lanes: **${selected[*]:-none}** -- $reason" >>"$GITHUB_STEP_SUMMARY"
     fi
     exit 0
+}
+
+# Fail open: when the diff cannot be classified, every lane runs.
+decide_all() {
+    select_lanes all
+    emit "$1"
 }
 
 event="${GITHUB_EVENT_NAME:-local}"
@@ -82,29 +179,32 @@ head="${2:-HEAD}"
 # Only a pull request is filtered. The nightly matrix and a manual dispatch are
 # unfiltered by design -- they exist to catch what path filtering cannot.
 if [ "$event" != "pull_request" ] && [ "$#" -eq 0 ]; then
-    decide true "$event runs the full matrix unfiltered"
+    decide_all "$event runs the full matrix unfiltered"
 fi
 
 if [ -z "$base" ]; then
-    decide true "no merge base to diff against"
+    decide_all "no merge base to diff against"
 fi
 
 if ! files="$(git diff --name-only "$base...$head" 2>&1)"; then
     echo "$files" >&2
-    decide true "cannot diff $base...$head"
+    decide_all "cannot diff $base...$head"
 fi
 
 if [ -z "$files" ]; then
-    decide true "empty diff against $base"
+    decide_all "empty diff against $base"
 fi
 
 matched=()
 while IFS= read -r file; do
     [ -n "$file" ] || continue
-    for pattern in "${PACKAGING_PATHS[@]}"; do
+    for rule in "${RULES[@]}"; do
+        pattern="${rule%=*}"
+        lanes="${rule##*=}"
         # shellcheck disable=SC2053  # the right side is a pattern on purpose
         if [[ $file == $pattern ]]; then
-            matched+=("$file")
+            matched+=("$file -> $lanes")
+            select_lanes "$lanes"
             break
         fi
     done
@@ -113,7 +213,7 @@ done <<<"$files"
 echo "changed files: $(echo "$files" | wc -l)"
 if [ ${#matched[@]} -gt 0 ]; then
     printf 'packaging path: %s\n' "${matched[@]}"
-    decide true "${#matched[@]} changed file(s) reach a package"
+    emit "${#matched[@]} changed file(s) reach a package"
 fi
 
-decide false "no changed file reaches a package"
+emit "no changed file reaches a package"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -442,21 +442,25 @@ lane.
 | `test/release-*` | release_matrix |
 | the rest of `dist/`, `systemd/`, `dbus/`, `config/`, `scripts/`, `justfile`, `Cargo.toml`, `Cargo.lock`, `crates/*/Cargo.toml`, `test/Containerfile*`, `test/*pkg*`, the shared PAM/polkit/TPM validators, `.github/workflows/packaging.yml`, `.github/workflows/release.yml`, the other workflow scripts, `.github/actions/` | all |
 | `crates/facelock-cli/src/commands/pam.rs`, `commands/daemon.rs`, `lifecycle.rs` | all |
+| any other file under `crates/` | release_binaries |
 
 Any package lane also selects `release_matrix`, since the versions it orders
-live in `debian/changelog`, the spec and the PKGBUILD. The Rust files are
-listed because `facelock pam remove --all` runs from `%preun`, from Arch's
+live in `debian/changelog`, the spec and the PKGBUILD; `rpm` also selects
+`release_binaries`, which it stages from. The three Rust files are listed because `facelock pam remove --all` runs from `%preun`, from Arch's
 `pre_remove` and from Debian's `prerm`, so a change to that command can abort a
 package removal without touching a packaging file. `ci.yml` and the other
 non-packaging workflows select nothing; a container digest bump inside
 `packaging.yml` itself still selects every lane, because a path cannot say
 which job's image moved. `just test-classify-changes` pins the table.
 
-**Residual risk.** Path filtering means a change that touches no packaging path
-can still break the *packaged* runtime. A Rust change to daemon startup, a new
-runtime dependency, a file the spec does not ship: each of those leaves its own
-pull request green with every packaging job reported as skipped. Do not read
-that as packaging-verified. The nightly matrix catches it within a day, and the
+**Residual risk.** A Rust change outside those three files runs only the
+`release_binaries` lane on its own pull request: `just build-release` in the
+pinned Arch container, which proves the workspace still compiles the way the
+packages consume it, in minutes. It does not build or boot a package. A Rust
+change to daemon startup, a new runtime dependency, a file the spec does not
+ship: each of those leaves its own pull request green with the deb, rpm and
+Arch lifecycle jobs reported as skipped. Do not read that as
+packaging-verified. The nightly matrix catches it within a day, and the
 release gate below catches it before anything ships. When a change is
 packaging-relevant in a way the filter cannot see, run the lane by hand or add
 the path to `classify-changes.sh`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -414,7 +414,7 @@ Three schedules, because the full matrix takes about 1 h 45 min (measured
 
 | When | Lanes | Filtered |
 |---|---|---|
-| Pull request | all but `copr` | yes, only when the diff reaches a package |
+| Pull request | all but `copr` | yes, per lane, only the lanes the diff reaches |
 | Nightly, 07:00 UTC | all | no |
 | `just release-preflight` | evidence of a green run at HEAD | no |
 
@@ -423,15 +423,34 @@ mock needs a privileged container.
 
 The pull-request filter is a `changes` job running
 `.github/workflows/scripts/classify-changes.sh`, which classifies the merge-base
-diff in plain bash. It covers `debian/`, `dist/`, `systemd/`, `dbus/`,
-`config/`, `scripts/`, the packaging halves of `test/`, the justfile,
-`.packit.yaml`, `.github/workflows/`, and the Rust the maintainer scripts
-execute. `facelock pam remove --all` runs from `%preun`, from Arch's
+diff in plain bash and emits one output per lane. Each job gates on its own
+output -- `if: needs.changes.outputs.deb == 'true'` for the Debian suites,
+`rpm` for Fedora, `arch` for the Arch package, `release_binaries` for the
+Arch-container build the Fedora lanes stage from, `release_matrix` for the
+version-ordering matrix -- which reports a real "skipped" conclusion; GitHub's
+own `paths:` filter would leave a required check pending forever instead.
+
+A path only one family's recipe or harness reads selects that family's lane.
+Everything else that reaches a package selects every lane; when in doubt, every
+lane.
+
+| Changed path | Lanes |
+|---|---|
+| `debian/`, `dist/apt/`, `test/*deb*`, `test/*apt*`, `.github/workflows/scripts/*deb*` | deb |
+| `dist/facelock.spec`, `dist/rpm/`, `.packit.yaml`, `test/Containerfile.{fedora,copr*,rpm*,packit}`, `test/*rpm*`, `test/*copr*`, `test/fedora-lane-image.sh`, `.github/workflows/scripts/*rpm*` | rpm, release_binaries |
+| `dist/PKGBUILD*`, `dist/facelock.install`, `dist/facelock-pam-remove.hook`, `test/*arch*`, `.github/workflows/scripts/*aur*` | arch |
+| `test/release-*` | release_matrix |
+| the rest of `dist/`, `systemd/`, `dbus/`, `config/`, `scripts/`, `justfile`, `Cargo.toml`, `Cargo.lock`, `crates/*/Cargo.toml`, `test/Containerfile*`, `test/*pkg*`, the shared PAM/polkit/TPM validators, `.github/workflows/packaging.yml`, `.github/workflows/release.yml`, the other workflow scripts, `.github/actions/` | all |
+| `crates/facelock-cli/src/commands/pam.rs`, `commands/daemon.rs`, `lifecycle.rs` | all |
+
+Any package lane also selects `release_matrix`, since the versions it orders
+live in `debian/changelog`, the spec and the PKGBUILD. The Rust files are
+listed because `facelock pam remove --all` runs from `%preun`, from Arch's
 `pre_remove` and from Debian's `prerm`, so a change to that command can abort a
-package removal without touching a packaging file. Each lane then gates on
-`if: needs.changes.outputs.packaging == 'true'`, which reports a real "skipped"
-conclusion; GitHub's own `paths:` filter would leave a required check pending
-forever instead.
+package removal without touching a packaging file. `ci.yml` and the other
+non-packaging workflows select nothing; a container digest bump inside
+`packaging.yml` itself still selects every lane, because a path cannot say
+which job's image moved. `just test-classify-changes` pins the table.
 
 **Residual risk.** Path filtering means a change that touches no packaging path
 can still break the *packaged* runtime. A Rust change to daemon startup, a new

--- a/test/classify-changes-test.sh
+++ b/test/classify-changes-test.sh
@@ -2,11 +2,12 @@
 # Exercise .github/workflows/scripts/classify-changes.sh against real merge-base
 # diffs in a throwaway repository.
 #
-# The classifier decides whether the packaging gates run on a pull request. A
+# The classifier decides which packaging lanes run on a pull request. A
 # pattern that stops matching does not fail anything -- it silently reports
-# "skipped" for every deb, rpm and Arch lane, and the pull request goes green
-# without a package having been built. That is the failure this file exists to
-# make loud.
+# "skipped" for a deb, rpm or Arch lane, and the pull request goes green
+# without that package having been built. That is the failure this file exists
+# to make loud. The other direction matters too: a family-specific path that
+# starts selecting every lane costs the Debian long pole on each pull request.
 #
 # The `rust-only` case is not an oversight. It pins the documented residual risk
 # (docs/releasing.md): a change touching no packaging path is not gated by its
@@ -32,16 +33,26 @@ for f in \
     docs/releasing.md \
     debian/control \
     dist/facelock.spec \
+    dist/PKGBUILD \
+    dist/release-matrix.json \
+    Cargo.toml \
+    Cargo.lock \
     justfile \
     .packit.yaml \
     systemd/facelock-daemon.service \
     crates/facelock-cli/src/lifecycle.rs \
+    crates/facelock-face/Cargo.toml \
     crates/facelock-cli/src/commands/pam.rs \
     crates/facelock-cli/src/commands/enroll.rs \
     crates/facelock-daemon/src/handler.rs \
     test/deb-package-contract.sh \
     test/Containerfile.rpm-e2e \
-    .github/workflows/ci.yml
+    test/arch-package-validate.sh \
+    test/pkg-validate.sh \
+    test/release-native-ordering.sh \
+    .github/workflows/ci.yml \
+    .github/workflows/packaging.yml \
+    .github/workflows/scripts/build-deb.sh
 do
     mkdir -p "$(dirname "$f")"
     printf 'base\n' > "$f"
@@ -51,10 +62,19 @@ git -c user.email=test@example.invalid -c user.name=test commit --quiet -m base
 base="$(git rev-parse HEAD)"
 
 failures=0
+# The lanes the classifier selected, as `deb,rpm,arch,release_binaries,
+# release_matrix` in that fixed order, or `none`.
 classification() {
-    GITHUB_EVENT_NAME="$1" bash "$script" "${@:2}" 2>/dev/null |
-        sed -n 's/^packaging=\([a-z]*\).*/\1/p'
+    local selected
+    selected="$(GITHUB_EVENT_NAME="$1" bash "$script" "${@:2}" 2>/dev/null |
+        sed -n 's/^\(deb\|rpm\|arch\|release_binaries\|release_matrix\)=true$/\1/p' |
+        paste -sd,)"
+    echo "${selected:-none}"
 }
+all=deb,rpm,arch,release_binaries,release_matrix
+deb=deb,release_matrix
+rpm=rpm,release_binaries,release_matrix
+arch=arch,release_matrix
 
 expect_diff() {
     local want="$1" name="$2"
@@ -85,27 +105,43 @@ expect_event() {
     fi
 }
 
-echo "classify-changes -- a diff that reaches a package"
-expect_diff true debian debian/control
-expect_diff true spec dist/facelock.spec
-expect_diff true systemd-unit systemd/facelock-daemon.service
-expect_diff true packit .packit.yaml
-expect_diff true justfile justfile
-expect_diff true test-harness test/deb-package-contract.sh
-expect_diff true containerfile test/Containerfile.rpm-e2e
-expect_diff true workflow .github/workflows/ci.yml
-expect_diff true pam-command crates/facelock-cli/src/commands/pam.rs
-expect_diff true purge-lifecycle crates/facelock-cli/src/lifecycle.rs
-expect_diff true mixed docs/releasing.md debian/control
+echo "classify-changes -- a diff that reaches every lane"
+expect_diff "$all" systemd-unit systemd/facelock-daemon.service
+expect_diff "$all" justfile justfile
+expect_diff "$all" cargo-lock-only Cargo.lock
+expect_diff "$all" workspace-manifest Cargo.toml
+expect_diff "$all" crate-manifest crates/facelock-face/Cargo.toml
+expect_diff "$all" shared-validator test/pkg-validate.sh
+expect_diff "$all" release-matrix-json dist/release-matrix.json
+expect_diff "$all" packaging-workflow .github/workflows/packaging.yml
+expect_diff "$all" pam-command crates/facelock-cli/src/commands/pam.rs
+expect_diff "$all" purge-lifecycle crates/facelock-cli/src/lifecycle.rs
+# Renovate #306: a container digest bump inside packaging.yml. The path cannot
+# say which job's image moved, so every lane runs -- by design, not by accident.
+expect_diff "$all" digest-bump .github/workflows/ci.yml .github/workflows/packaging.yml
 
-echo "classify-changes -- a diff that does not"
-expect_diff false docs-only docs/releasing.md README.md
-expect_diff false rust-only crates/facelock-cli/src/commands/enroll.rs crates/facelock-daemon/src/handler.rs
+echo "classify-changes -- a diff that reaches one family"
+expect_diff "$deb" debian debian/control
+expect_diff "$deb" deb-harness test/deb-package-contract.sh
+expect_diff "$deb" deb-release-script .github/workflows/scripts/build-deb.sh
+expect_diff "$deb" mixed docs/releasing.md debian/control
+expect_diff "$rpm" spec dist/facelock.spec
+expect_diff "$rpm" packit .packit.yaml
+expect_diff "$rpm" rpm-containerfile test/Containerfile.rpm-e2e
+expect_diff "$arch" pkgbuild dist/PKGBUILD
+expect_diff "$arch" arch-harness test/arch-package-validate.sh
+expect_diff release_matrix ordering-harness test/release-native-ordering.sh
+expect_diff deb,arch,release_matrix deb-and-arch debian/control dist/PKGBUILD
+
+echo "classify-changes -- a diff that reaches no lane"
+expect_diff none docs-only docs/releasing.md README.md
+expect_diff none ci-workflow-only .github/workflows/ci.yml
+expect_diff none rust-only crates/facelock-cli/src/commands/enroll.rs crates/facelock-daemon/src/handler.rs
 
 echo "classify-changes -- unfiltered events and fail-open"
-expect_event true schedule
-expect_event true workflow_dispatch
-expect_event true pull_request   # no base to diff against
+expect_event "$all" schedule
+expect_event "$all" workflow_dispatch
+expect_event "$all" pull_request   # no base to diff against
 
 if [ "$failures" -ne 0 ]; then
     echo "$failures classification case(s) failed" >&2

--- a/test/classify-changes-test.sh
+++ b/test/classify-changes-test.sh
@@ -9,9 +9,10 @@
 # to make loud. The other direction matters too: a family-specific path that
 # starts selecting every lane costs the Debian long pole on each pull request.
 #
-# The `rust-only` case is not an oversight. It pins the documented residual risk
-# (docs/releasing.md): a change touching no packaging path is not gated by its
-# own pull request, only by the nightly matrix and the release gate.
+# The `rust-only` case pins the documented residual risk (docs/releasing.md): a
+# Rust change outside the maintainer-script files runs only the release-binaries
+# build on its own pull request; the deb, rpm and Arch lifecycles wait for the
+# nightly matrix and the release gate.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -75,6 +76,7 @@ all=deb,rpm,arch,release_binaries,release_matrix
 deb=deb,release_matrix
 rpm=rpm,release_binaries,release_matrix
 arch=arch,release_matrix
+binaries=release_binaries
 
 expect_diff() {
     local want="$1" name="$2"
@@ -133,10 +135,13 @@ expect_diff "$arch" arch-harness test/arch-package-validate.sh
 expect_diff release_matrix ordering-harness test/release-native-ordering.sh
 expect_diff deb,arch,release_matrix deb-and-arch debian/control dist/PKGBUILD
 
+echo "classify-changes -- a Rust diff reaches only the release-binaries build"
+expect_diff "$binaries" rust-only crates/facelock-cli/src/commands/enroll.rs crates/facelock-daemon/src/handler.rs
+expect_diff deb,release_binaries,release_matrix rust-and-debian crates/facelock-daemon/src/handler.rs debian/control
+
 echo "classify-changes -- a diff that reaches no lane"
 expect_diff none docs-only docs/releasing.md README.md
 expect_diff none ci-workflow-only .github/workflows/ci.yml
-expect_diff none rust-only crates/facelock-cli/src/commands/enroll.rs crates/facelock-daemon/src/handler.rs
 
 echo "classify-changes -- unfiltered events and fail-open"
 expect_event "$all" schedule

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 16,
-        "line": 523,
+        "line": 542,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -365,7 +365,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1090,
+        "line": 1109,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -437,7 +437,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 6,
-        "line": 1090,
+        "line": 1109,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 16,
-        "line": 542,
+        "line": 546,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -365,7 +365,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1109,
+        "line": 1113,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -437,7 +437,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 6,
-        "line": 1109,
+        "line": 1113,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -9095,49 +9095,49 @@
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 1,
-          "line": 479,
+          "line": 483,
           "sha256": "dedfaf04fd23448baa602a476c6e384ab674dfd1ad445e0c3e935b5a96a9a2f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 2,
-          "line": 480,
+          "line": 484,
           "sha256": "a07a3db4c0fd5697107f1591eb62f6a2c9a2ac0d3801e25844e5c244f6688915"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 3,
-          "line": 481,
+          "line": 485,
           "sha256": "d9a223daf1f784e1bd0313866cfbfcff4b2b4958708dfab4674bc3ddc63de570"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 4,
-          "line": 482,
+          "line": 486,
           "sha256": "108c5e8edc6582d4ee70c2b8573afe99a7be3f4ad8ddd11fc2b12c44e7079568"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 5,
-          "line": 483,
+          "line": 487,
           "sha256": "017092419ea31d5de3fd4b6e7a52b2dd239d134f423f81bd0f5c38992c212208"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 6,
-          "line": 484,
+          "line": 488,
           "sha256": "a77a5aea7a4e8dcf9901e8ac5ee041109d525ce2f2bd7f018a21918d70da1326"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 7,
-          "line": 485,
+          "line": 489,
           "sha256": "2b5e31a5fe163cb0998c87a9f505faf73a26e025df540bc210550dcb6cc27142"
         }
       ],
@@ -9270,231 +9270,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 563,
+          "line": 567,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 566,
+          "line": 570,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 567,
+          "line": 571,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 568,
+          "line": 572,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 569,
+          "line": 573,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 574,
+          "line": 578,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 575,
+          "line": 579,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 577,
+          "line": 581,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 578,
+          "line": 582,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 579,
+          "line": 583,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 580,
+          "line": 584,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 581,
+          "line": 585,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 582,
+          "line": 586,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 583,
+          "line": 587,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 586,
+          "line": 590,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 587,
+          "line": 591,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 588,
+          "line": 592,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 589,
+          "line": 593,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 590,
+          "line": 594,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 591,
+          "line": 595,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 592,
+          "line": 596,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 593,
+          "line": 597,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 594,
+          "line": 598,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 597,
+          "line": 601,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 598,
+          "line": 602,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 599,
+          "line": 603,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 600,
+          "line": 604,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 601,
+          "line": 605,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 602,
+          "line": 606,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 603,
+          "line": 607,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 604,
+          "line": 608,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 608,
+          "line": 612,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 612,
+          "line": 616,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -9965,21 +9965,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 788,
+          "line": 792,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 789,
+          "line": 793,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 790,
+          "line": 794,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -10061,14 +10061,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 894,
+          "line": 898,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 895,
+          "line": 899,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -10136,21 +10136,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 922,
+          "line": 926,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 929,
+          "line": 933,
           "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 934,
+          "line": 938,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10231,56 +10231,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 975,
+          "line": 979,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 977,
+          "line": 981,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 981,
+          "line": 985,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 987,
+          "line": 991,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 988,
+          "line": 992,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 992,
+          "line": 996,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 993,
+          "line": 997,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 994,
+          "line": 998,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -9095,49 +9095,49 @@
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 1,
-          "line": 460,
+          "line": 479,
           "sha256": "dedfaf04fd23448baa602a476c6e384ab674dfd1ad445e0c3e935b5a96a9a2f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 2,
-          "line": 461,
+          "line": 480,
           "sha256": "a07a3db4c0fd5697107f1591eb62f6a2c9a2ac0d3801e25844e5c244f6688915"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 3,
-          "line": 462,
+          "line": 481,
           "sha256": "d9a223daf1f784e1bd0313866cfbfcff4b2b4958708dfab4674bc3ddc63de570"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 4,
-          "line": 463,
+          "line": 482,
           "sha256": "108c5e8edc6582d4ee70c2b8573afe99a7be3f4ad8ddd11fc2b12c44e7079568"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 5,
-          "line": 464,
+          "line": 483,
           "sha256": "017092419ea31d5de3fd4b6e7a52b2dd239d134f423f81bd0f5c38992c212208"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 6,
-          "line": 465,
+          "line": 484,
           "sha256": "a77a5aea7a4e8dcf9901e8ac5ee041109d525ce2f2bd7f018a21918d70da1326"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 7,
-          "line": 466,
+          "line": 485,
           "sha256": "2b5e31a5fe163cb0998c87a9f505faf73a26e025df540bc210550dcb6cc27142"
         }
       ],
@@ -9270,231 +9270,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 544,
+          "line": 563,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 547,
+          "line": 566,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 548,
+          "line": 567,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 549,
+          "line": 568,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 550,
+          "line": 569,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 555,
+          "line": 574,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 556,
+          "line": 575,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 558,
+          "line": 577,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 559,
+          "line": 578,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 560,
+          "line": 579,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 561,
+          "line": 580,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 562,
+          "line": 581,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 563,
+          "line": 582,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 564,
+          "line": 583,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 567,
+          "line": 586,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 568,
+          "line": 587,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 569,
+          "line": 588,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 570,
+          "line": 589,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 571,
+          "line": 590,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 572,
+          "line": 591,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 573,
+          "line": 592,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 574,
+          "line": 593,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 575,
+          "line": 594,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 578,
+          "line": 597,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 579,
+          "line": 598,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 580,
+          "line": 599,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 581,
+          "line": 600,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 582,
+          "line": 601,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 583,
+          "line": 602,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 584,
+          "line": 603,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 585,
+          "line": 604,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 589,
+          "line": 608,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 593,
+          "line": 612,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -9965,21 +9965,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 769,
+          "line": 788,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 770,
+          "line": 789,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 771,
+          "line": 790,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -10061,14 +10061,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 875,
+          "line": 894,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 876,
+          "line": 895,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -10136,21 +10136,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 903,
+          "line": 922,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 910,
+          "line": 929,
           "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 915,
+          "line": 934,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10231,56 +10231,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 956,
+          "line": 975,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 958,
+          "line": 977,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 962,
+          "line": 981,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 968,
+          "line": 987,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 969,
+          "line": 988,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 973,
+          "line": 992,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 974,
+          "line": 993,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 975,
+          "line": 994,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],


### PR DESCRIPTION
## Summary

- emit `deb`, `rpm`, `arch`, `release_binaries` and `release_matrix` from `classify-changes.sh` instead of one `packaging` boolean
- gate each `packaging.yml` job on its own lane; `copr` stays off pull requests; the nightly stays unfiltered
- map a path only one family reads to that family's lane; keep every shared or ambiguous path on all lanes
- drop `ci.yml` and the other non-packaging workflows from the classifier; keep `packaging.yml` and `release.yml` on all lanes
- add `Cargo.toml`, `Cargo.lock` and `crates/*/Cargo.toml` as all-lane paths, since the dependency closure is what the deb source build vendors and the spec bundles
- pin the lane map in `test/classify-changes-test.sh` and document it in `docs/releasing.md`

## Why

A pull request that touched only a PKGBUILD or only `debian/` ran every lane, and the Debian suite gates are the long pole on each one (#337). Per-lane outputs let a family-specific diff run only its own lane while the conservative default stays: when in doubt, all lanes.

## Validation

- `just test-classify-changes` covers digest-only bump, Cargo.lock-only, debian-only, PKGBUILD-only, spec-only, crate manifest, rust-only, ci-workflow-only, mixed deb+arch, and the unfiltered events
- `just check-workflow-policy`, `just check-docs`, `just check-agent-docs`

Refs #337


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI/CD**
  - Pull requests now run only the packaging and release lanes affected by changed files.
  - Packaging checks are selected independently for Debian, RPM, Arch, binaries, and release matrices.
  - Unfiltered events continue to run all applicable lanes, while COPR remains excluded from pull requests.

- **Documentation**
  - Updated packaging and release documentation to describe lane-specific filtering and path mappings.

- **Tests**
  - Updated classifier and documentation checks for lane-specific selection and revised documentation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->