### PR TITLE
test(packaging): Probe the deb-only lane selection

### DIFF
--- a/test/deb-package-contract.sh
+++ b/test/deb-package-contract.sh
@@ -252,3 +252,5 @@ if [ -n "$stage" ]; then
 fi
 
 echo "deb package contract: ok"
+
+# probe: deb-only diff for the per-lane classifier (#371); this branch is closed unmerged


### PR DESCRIPTION
throwaway probe for #371: a deb-harness-only diff should run the two Debian lanes and the ordering matrix, and skip arch, release binaries and Fedora. closed unmerged once observed