### PR TITLE
ci(packaging): Skip the Debian .dsc rebuild on pull requests

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -58,7 +58,7 @@ schedules:
 
 | When | What | Filter |
 |---|---|---|
-| Pull request | every lane | per lane, only the lanes the diff reaches |
+| Pull request | every lane; Debian lanes without the `.dsc` rebuild | per lane, only the lanes the diff reaches |
 | Nightly (07:00 UTC) | every lane | none |
 | `just release-preflight` | lane evidence uploaded by a green run at HEAD, or the marker a local `just test-packaging-matrix` wrote at HEAD | none |
 
@@ -71,6 +71,12 @@ pinned SHA to review. Add a path there when a new file can reach a built
 package, mapped to one family's lane when only that family reads it and to
 every lane otherwise; the table is in docs/releasing.md and
 `just test-classify-changes` pins it.
+
+The Debian lanes on a pull request run with `FACELOCK_DEB_SKIP_DSC_REBUILD=1`:
+the candidate `.deb` is still built from source and put through the booted
+lifecycle, but the clean-image rebuild of the emitted `.dsc`, a second full LTO
+compile, is left to the nightly and the dispatch (#337). Such a lane records
+`depth=partial`, which `just release-preflight` refuses.
 
 So a green pull request is **not** packaging-verified unless the packaging jobs
 actually ran on it. A Rust-only change runs only the release-binaries build on

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -67,6 +67,16 @@ jobs:
     # which branch protection accepts. See classify-changes.sh.
     if: needs.changes.outputs.deb == 'true'
     timeout-minutes: 90
+    env:
+      # A pull request skips the clean-image rebuild of the emitted .dsc, the
+      # second of the gate's two full release compiles: about ten of its
+      # twenty-six minutes, measured 2026-09-09, on lanes that have reached the
+      # cap above (#337). The lane then records depth=partial, so its evidence
+      # can never satisfy `just release-preflight` -- which refuses
+      # pull-request runs anyway. The nightly and a dispatch run keep the
+      # rebuild, so the source package is proven complete once a day and at
+      # every release commit.
+      FACELOCK_DEB_SKIP_DSC_REBUILD: ${{ github.event_name == 'pull_request' && '1' || '0' }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,8 +98,9 @@ jobs:
         uses: ./.github/actions/fetch-models
 
       # The suite gate builds the exact candidate .deb from source, rebuilds
-      # the .dsc, proves the dependency closure, then boots it under systemd
-      # for the install/upgrade/remove/purge lifecycle.
+      # the .dsc (nightly and dispatch only, see the job env), proves the
+      # dependency closure, then boots it under systemd for the
+      # install/upgrade/remove/purge lifecycle.
       - name: Run the ${{ matrix.suite }} package gate
         run: just ${{ matrix.recipe }}
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -475,6 +475,23 @@ not otherwise — survives its own pull request even when the filter fires. The
 nightly and the pre-release `workflow_dispatch` are unfiltered and do run them;
 locally, `just test-copr-lanes`.
 
+**The Debian lanes skip the `.dsc` rebuild on pull requests.** The full gate
+compiles the workspace twice per suite: once to assemble the candidate `.deb`,
+once more from the extracted `.dsc` in a clean image to prove the source
+package rebuilds standalone. Both are `lto = true` release builds and no cache
+applies, so the rebuild is about ten of the lane's twenty-six minutes on a
+runner that has reached the 90-minute cap (#337). `packaging.yml` sets
+`FACELOCK_DEB_SKIP_DSC_REBUILD=1` on pull requests, which drops that second
+compile and nothing else: the `.deb` is still built from source with the
+network denied, its dependency closure still proved, the booted lifecycle still
+run. A lane that skipped the rebuild records `depth=partial`, which the release
+matrix requires of nothing, so `just release-preflight` refuses it -- it refuses
+pull-request runs regardless. The nightly, the dispatch, and a local
+`just test-deb-*-pkg` or `just test-packaging-matrix` keep the rebuild. What
+survives a pull request, then, is an incomplete source package: a file the
+`.dsc` does not carry, or a build that only works from the Git checkout. The
+nightly catches it within a day, the release gate before anything ships.
+
 ### Release preflight (recommended)
 
 Run this before creating/pushing a release tag:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -487,8 +487,8 @@ network denied, its dependency closure still proved, the booted lifecycle still
 run. A lane that skipped the rebuild records `depth=partial`, which the release
 matrix requires of nothing, so `just release-preflight` refuses it -- it refuses
 pull-request runs regardless. The nightly, the dispatch, and a local
-`just test-deb-*-pkg` or `just test-packaging-matrix` keep the rebuild. What
-survives a pull request, then, is an incomplete source package: a file the
+`just test-deb` or `just test-packaging-matrix` keep the rebuild. What survives
+a pull request, then, is an incomplete source package: a file the
 `.dsc` does not carry, or a build that only works from the Git checkout. The
 nightly catches it within a day, the release gate before anything ships.
 

--- a/justfile
+++ b/justfile
@@ -1223,6 +1223,12 @@ test-deb: test-deb-trixie-pkg test-deb-resolute-pkg
 # the runner writes .packaging-evidence/<lane>.json from the validator's counts.
 # test/packaging-evidence.py derives what each lane must claim from
 # dist/release-matrix.json, so a claim that drifts from the matrix is refused.
+#
+# FACELOCK_DEB_SKIP_DSC_REBUILD=1 drops the clean-image .dsc rebuild, the
+# second of the gate's two full release compiles (#337). The lane then records
+# depth=partial, which the release matrix requires of nothing, so the
+# shortened run is never release evidence. packaging.yml sets it on pull
+# requests; the nightly, a dispatch and `just test-packaging-matrix` rebuild.
 
 # Debian 13 Trixie package — exact source build, TPM/PCR, and booted lifecycle.
 test-deb-trixie-pkg: (_require-models "1")
@@ -1235,7 +1241,9 @@ test-deb-trixie-pkg: (_require-models "1")
     podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
         facelock-deb-trixie-pkg \
         /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
-    PACKAGING_LANE='test-deb-trixie-pkg target=debian-trixie channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=full' \
+    depth=full
+    if [ "${FACELOCK_DEB_SKIP_DSC_REBUILD:-0}" = 1 ]; then depth=partial; fi
+    PACKAGING_LANE="test-deb-trixie-pkg target=debian-trixie channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=$depth" \
         test/run-pkg-validate-systemd.sh facelock-deb-trixie-pkg "$package"
 
 # Ubuntu 26.04 Resolute package — exact source build, TPM/PCR, and booted lifecycle.
@@ -1249,7 +1257,9 @@ test-deb-resolute-pkg: (_require-models "1")
     podman run --rm -v "$package:/facelock-test-package.deb:ro,Z" \
         facelock-deb-resolute-pkg \
         /bin/bash -c '/deb-package-lifecycle.sh install && exec /tpm-pcr-e2e.sh'
-    PACKAGING_LANE='test-deb-resolute-pkg target=ubuntu-resolute channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=full' \
+    depth=full
+    if [ "${FACELOCK_DEB_SKIP_DSC_REBUILD:-0}" = 1 ]; then depth=partial; fi
+    PACKAGING_LANE="test-deb-resolute-pkg target=ubuntu-resolute channel=apt build_origin=container-source-build runtime_policy=bundled-ort depth=$depth" \
         test/run-pkg-validate-systemd.sh facelock-deb-resolute-pkg "$package"
 
 # Same model requirement (and same opt-out) as the two Debian suite package gates.

--- a/test/build-deb-package-image.sh
+++ b/test/build-deb-package-image.sh
@@ -86,16 +86,26 @@ manifest="$(find "$artifact_dir" -maxdepth 1 -type f -name 'facelock_*.manifest'
     exit 1
 }
 
-podman build \
-    --build-arg "BASE_IMAGE=$base_image" \
-    --build-arg "SUITE=$suite" \
-    -t "$rebuild_image" \
-    -f "$context/test/Containerfile.deb-rebuild" \
-    "$context"
-podman run --rm --network=none \
-    -v "$artifact_dir:/artifacts:ro,Z" \
-    -v "$rebuild_dir:/rebuild:Z" \
-    "$rebuild_image" rebuild-dsc /artifacts /rebuild
+# The clean-image rebuild of the emitted .dsc is a second full release
+# compile, about ten of the gate's twenty-six minutes on a CI runner (#337).
+# FACELOCK_DEB_SKIP_DSC_REBUILD=1 leaves it out; the lane recipe then records
+# `depth=partial`, which `just release-preflight` refuses, so the shortened
+# gate can never stand in for the release gate. packaging.yml sets it on pull
+# requests only; the nightly and dispatch runs rebuild.
+if [ "${FACELOCK_DEB_SKIP_DSC_REBUILD:-0}" = 1 ]; then
+    echo "SKIP: clean-image .dsc rebuild (FACELOCK_DEB_SKIP_DSC_REBUILD=1); this run is not release evidence" >&2
+else
+    podman build \
+        --build-arg "BASE_IMAGE=$base_image" \
+        --build-arg "SUITE=$suite" \
+        -t "$rebuild_image" \
+        -f "$context/test/Containerfile.deb-rebuild" \
+        "$context"
+    podman run --rm --network=none \
+        -v "$artifact_dir:/artifacts:ro,Z" \
+        -v "$rebuild_dir:/rebuild:Z" \
+        "$rebuild_image" rebuild-dsc /artifacts /rebuild
+fi
 
 package_name="$(grep -E '\.deb$' "$manifest")"
 [ "$(printf '%s\n' "$package_name" | wc -l)" -eq 1 ] || {

--- a/test/deb-source-contract.sh
+++ b/test/deb-source-contract.sh
@@ -641,6 +641,21 @@ grep -Fq 'Containerfile.deb-rebuild' test/build-deb-package-image.sh ||
     fail "Debian package gate must use a source-rebuild-only image"
 grep -Fq 'Containerfile.deb-runtime' test/build-deb-package-image.sh ||
     fail "Debian package gate must install the release package in a separate runtime image"
+# The pull-request lane drops the second full compile (#337). What guards the
+# shortcut is the record: a run that skipped the rebuild must say so in a way
+# `just release-preflight` refuses, and only a pull request may ask for it.
+grep -Fq 'FACELOCK_DEB_SKIP_DSC_REBUILD' test/build-deb-package-image.sh ||
+    fail "Debian package gate must expose the .dsc rebuild opt-out the pull-request lane uses"
+# shellcheck disable=SC2016
+[ "$(grep -Fc 'if [ "${FACELOCK_DEB_SKIP_DSC_REBUILD:-0}" = 1 ]; then depth=partial; fi' justfile)" -eq 2 ] ||
+    fail "both Debian suite recipes must record depth=partial when the .dsc rebuild is skipped"
+packaging_workflow=".github/workflows/packaging.yml"
+[ "$(grep -Fc 'FACELOCK_DEB_SKIP_DSC_REBUILD' "$packaging_workflow")" -eq 1 ] ||
+    fail "packaging.yml must set FACELOCK_DEB_SKIP_DSC_REBUILD in exactly one place"
+# shellcheck disable=SC2016
+grep -Fxq "      FACELOCK_DEB_SKIP_DSC_REBUILD: \${{ github.event_name == 'pull_request' && '1' || '0' }}" \
+    "$packaging_workflow" ||
+    fail "packaging.yml must skip the Debian .dsc rebuild on pull requests only"
 # The assembler already validates the exact manifest with Debian tooling. The
 # host orchestrator must remain portable and must not require dpkg-deb.
 # shellcheck disable=SC2016

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 16,
-        "line": 546,
+        "line": 563,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -363,9 +363,16 @@
       },
       {
         "path": "docs/releasing.md",
+        "anchor": "packaging-gates-in-ci",
+        "ordinal": 8,
+        "line": 490,
+        "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
+      },
+      {
+        "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1113,
+        "line": 1130,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -437,7 +444,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 6,
-        "line": 1113,
+        "line": 1130,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -9095,49 +9095,49 @@
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 1,
-          "line": 483,
+          "line": 500,
           "sha256": "dedfaf04fd23448baa602a476c6e384ab674dfd1ad445e0c3e935b5a96a9a2f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 2,
-          "line": 484,
+          "line": 501,
           "sha256": "a07a3db4c0fd5697107f1591eb62f6a2c9a2ac0d3801e25844e5c244f6688915"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 3,
-          "line": 485,
+          "line": 502,
           "sha256": "d9a223daf1f784e1bd0313866cfbfcff4b2b4958708dfab4674bc3ddc63de570"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 4,
-          "line": 486,
+          "line": 503,
           "sha256": "108c5e8edc6582d4ee70c2b8573afe99a7be3f4ad8ddd11fc2b12c44e7079568"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 5,
-          "line": 487,
+          "line": 504,
           "sha256": "017092419ea31d5de3fd4b6e7a52b2dd239d134f423f81bd0f5c38992c212208"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 6,
-          "line": 488,
+          "line": 505,
           "sha256": "a77a5aea7a4e8dcf9901e8ac5ee041109d525ce2f2bd7f018a21918d70da1326"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 7,
-          "line": 489,
+          "line": 506,
           "sha256": "2b5e31a5fe163cb0998c87a9f505faf73a26e025df540bc210550dcb6cc27142"
         }
       ],
@@ -9270,231 +9270,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 567,
+          "line": 584,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 570,
+          "line": 587,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 571,
+          "line": 588,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 572,
+          "line": 589,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 573,
+          "line": 590,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 578,
+          "line": 595,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 579,
+          "line": 596,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 581,
+          "line": 598,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 582,
+          "line": 599,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 583,
+          "line": 600,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 584,
+          "line": 601,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 585,
+          "line": 602,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 586,
+          "line": 603,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 587,
+          "line": 604,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 590,
+          "line": 607,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 591,
+          "line": 608,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 592,
+          "line": 609,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 593,
+          "line": 610,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 594,
+          "line": 611,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 595,
+          "line": 612,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 596,
+          "line": 613,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 597,
+          "line": 614,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 598,
+          "line": 615,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 601,
+          "line": 618,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 602,
+          "line": 619,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 603,
+          "line": 620,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 604,
+          "line": 621,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 605,
+          "line": 622,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 606,
+          "line": 623,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 607,
+          "line": 624,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 608,
+          "line": 625,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 612,
+          "line": 629,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 616,
+          "line": 633,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -9965,21 +9965,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 792,
+          "line": 809,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 793,
+          "line": 810,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 794,
+          "line": 811,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -10061,14 +10061,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 898,
+          "line": 915,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 899,
+          "line": 916,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -10136,21 +10136,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 926,
+          "line": 943,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 933,
+          "line": 950,
           "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 938,
+          "line": 955,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10231,56 +10231,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 979,
+          "line": 996,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 981,
+          "line": 998,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 985,
+          "line": 1002,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 991,
+          "line": 1008,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 992,
+          "line": 1009,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 996,
+          "line": 1013,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 997,
+          "line": 1014,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 998,
+          "line": 1015,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -2926,6 +2926,36 @@ with open(sys.argv[1], encoding="utf-8") as handle:
 assert lane["depth"] == "partial", lane
 DEPTH
 
+# A Debian lane that skipped the clean-image .dsc rebuild -- what packaging.yml
+# asks for on a pull request (#337) -- records the same depth, and both suite
+# records are refused, so the shortened gate can never become release evidence.
+if run_packaging_matrix FACELOCK_DEB_SKIP_DSC_REBUILD=1 >"$tmp_root/evidence-no-rebuild.log" 2>&1; then
+    fail "test-packaging-matrix recorded a run whose Debian lanes skipped the .dsc rebuild"
+fi
+[ ! -e "$evidence_root/.packaging-matrix-verified" ] ||
+    fail "the skipped-rebuild run left a marker behind"
+for suite in trixie resolute; do
+    grep -q "lane test-deb-$suite-pkg: depth is 'partial'" "$tmp_root/evidence-no-rebuild.log" ||
+        fail "the skipped-rebuild refusal did not name test-deb-$suite-pkg's depth: $(cat "$tmp_root/evidence-no-rebuild.log")"
+    python3 - "$evidence_root/.packaging-evidence/test-deb-$suite-pkg.json" <<'DEPTH'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    lane = json.load(handle)
+assert lane["depth"] == "partial" and lane["status"] == "pass", lane
+DEPTH
+done
+python3 - "$evidence_root/.packaging-evidence/test-arch-pkg.json" <<'DEPTH'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    lane = json.load(handle)
+# The opt-out is Debian's alone; every other lane still records its full depth.
+assert lane["depth"] == "full", lane
+DEPTH
+
 evidence_case_index=0
 assert_evidence_refused() {
     local context="$1"


### PR DESCRIPTION
## Summary

- set `FACELOCK_DEB_SKIP_DSC_REBUILD=1` on the `deb` job for `pull_request` runs only
- honour it in `test/build-deb-package-image.sh`: drop the clean-image `rebuild-dsc` stage, nothing else
- record `depth=partial` from both `test-deb-*-pkg` recipes when it is set, so `release-preflight` refuses the record
- keep the nightly, the dispatch, and every local run on the full two-compile gate
- pin all of that in `deb-source-contract.sh` and add the skipped-rebuild case to the evidence harness

## Why

Each Debian suite lane compiles the workspace twice with LTO: once to assemble the candidate `.deb`, once more from the extracted `.dsc` in a clean image. Timings from the 2026-09-09 nightly put that rebuild at about 10 of the lane's 26 minutes on both suites, and resolute has already been cancelled at the 90-minute cap on a slow runner. The rebuild proves the source package is complete, which a pull request does not need to re-prove on every push; the record now says when it did not run, which is the gap the issue flagged.

## Validation

- `just test-deb-source-contract`, `just test-deb-package-contract-test`, `just test-release-contract`, `just check-workflow-policy`, `just check-agent-docs`
- mutation: forcing `depth=full` in one recipe makes the new evidence case fail
- trixie lane run locally through the recipe body with the opt-out set

Fixes #337
