### PR TITLE
ci(build): Run the build job through just recipes and link only the smoke binaries

### DIFF
--- a/.claude/rules/pam-boundary.md
+++ b/.claude/rules/pam-boundary.md
@@ -26,5 +26,5 @@ in the wrong zbus feature set still fails CI — this has already cost two fixes
 (#107, #123), because the ceiling was documented and the backend was not.
 
 Run `just check-pam-standalone` after any change to `crates/pam-facelock/Cargo.toml`.
-CI runs the same guard as the "Verify pam-facelock dependency surface" step in
-`build-and-test`.
+CI runs the same recipe as the "Build pam-facelock in isolation and verify its
+dependency surface" step in `build-and-test`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -42,9 +42,15 @@ each; Rawhide is experimental and never a lane.
 
 ## What CI runs, and when
 
-`.github/workflows/ci.yml` gates every pull request: build, test, clippy, audit,
-the PAM standalone surface, agent docs, translation catalogs, and tier 3/3a in
-`container-pam-test`.
+`.github/workflows/ci.yml` gates every pull request: format, clippy (with and
+without `tpm`), test, docs contracts, the PAM standalone surface, audit, agent
+docs, translation catalogs, and tier 3/3a in `container-pam-test`. The
+`build-and-test` job is a sequence of justfile recipes (`fmt-check`, `lint`,
+`lint-tpm`, `test`, `check-docs`, `check-pam-standalone`,
+`build-smoke-binaries`), so what CI checks is what the recipe says; there is no
+separate `cargo build` step because clippy `--all-targets` type-checks every
+target and `test` builds the workspace. `tpm-tests` is the only job that runs
+`cargo test --features tpm`.
 
 `.github/workflows/packaging.yml` gates the packaged artifacts: tiers 3d and 3e,
 both Debian suite lanes, and the native version-ordering matrix. It runs on three

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,71 +35,56 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # cache-on-failure: a red run on a pull request still saves its
+      # dependency build, so the fix-up push starts warm instead of paying
+      # the full dependency compile again.
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-on-failure: true
 
       # Documentation tests enumerate tracked files from this root-owned container.
       - name: Trust the workspace checkout
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Every gate below is a justfile recipe so CI and `just check` share one
+      # definition; edit the recipe, not this file, to change what is checked.
+      #
+      # There is deliberately no plain `cargo build` step: `lint` runs clippy
+      # with --all-targets, which type-checks every target, and `test` builds
+      # the workspace for real. The two clippy passes stay because the `tpm`
+      # feature gates code in the cli, daemon and tpm crates. Tests run without
+      # the feature here; the `tpm-tests` job below runs them with it against
+      # swtpm. clippy and test share target/debug (dev profile), so the second
+      # reuses the first's build scripts and proc-macros.
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: just fmt-check
 
-      - name: Build workspace
-        run: cargo build --workspace
-
-      - name: Build workspace with TPM
-        run: cargo build --workspace --features tpm
-
-      # --all-targets so test/bench code is linted too; without it a
-      # deny-by-default lint in a test never fails CI. Keep in sync with the
-      # justfile `lint` recipe, which is the same command.
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: just lint
 
       - name: Run clippy with TPM
-        run: cargo clippy --workspace --all-targets --features tpm -- -D warnings
+        run: just lint-tpm
 
       - name: Run tests
-        run: cargo test --workspace
+        run: just test
 
       - name: Verify documented commands and walkthrough contracts
         run: just check-docs
 
-      # Build the PAM module ALONE — not via --workspace. `cargo build --workspace`
-      # unifies features across crates, so facelock-cli/facelock-polkit (which both
-      # request zbus ["tokio","blocking-api"]) silently repair an incoherent zbus
-      # feature set in pam-facelock. That masks a real breakage: zbus's `blocking`
-      # module is gated by `blocking-api`, NOT by the `blocking` feature, and with
-      # default-features off you must also pick a runtime (`tokio` or `async-io`).
-      # A standalone build is the only thing that proves the PAM crate compiles on
-      # its own. Keep in sync with `just check-pam-standalone`.
-      - name: Build pam-facelock in isolation
-        run: cargo build -p pam-facelock
+      # Builds the PAM module ALONE — not via --workspace — then guards its
+      # dependency surface. `cargo build --workspace` unifies features across
+      # crates, so facelock-cli/facelock-polkit silently repair an incoherent
+      # zbus feature set in pam-facelock; only a standalone build proves the
+      # crate compiles on its own. The forbidden-crate list and its rationale
+      # live with the recipe and in .claude/rules/pam-boundary.md.
+      - name: Build pam-facelock in isolation and verify its dependency surface
+        run: just check-pam-standalone
 
-      # The whole point of PR #107 is to keep the PAM module's dependency surface
-      # small, so forbid the async-io runtime backend: async-io/async-signal/polling
-      # plus the async-executor/async-fs/async-lock trio that only the async-io zbus
-      # backend pulls. We deliberately do NOT forbid signal-hook-registry: the
-      # correct tokio backend pulls it transitively via tokio's "process" feature,
-      # so listing it here would reject the very fix that shrinks the surface. If you
-      # think you need to add signal-hook-registry back, you have probably
-      # reintroduced the async-io backend — check for async-io first.
-      # Keep in sync with `just check-pam-standalone`.
-      - name: Verify pam-facelock dependency surface
-        run: |
-          cargo tree -p pam-facelock --edges normal --prefix none | awk '{print $1}' | sort -u > /tmp/pam-deps
-          echo "pam-facelock crate count: $(wc -l < /tmp/pam-deps)"
-          if grep -Eq '^(async-io|async-signal|async-executor|async-fs|async-lock|polling)$' /tmp/pam-deps; then
-            echo "forbidden async-io backend crates in pam-facelock (expected the tokio backend)"
-            exit 1
-          fi
-          echo "pam-facelock dependency guard passed"
-
-      - name: Build release binaries
-        run: |
-          cargo build --release --workspace
-          cargo build --release -p facelock-cli --features tpm
+      # Only the two files uploaded below are linked; see the recipe for why
+      # that is the single largest saving in this job.
+      - name: Build release binaries for the smoke tiers
+        run: just build-smoke-binaries
 
       - name: Upload release binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/developer-commands.md
+++ b/docs/developer-commands.md
@@ -36,6 +36,7 @@ index, so substitute real values for metavariables before running a recipe.
 | `just audit` | Scan Cargo.lock for RustSec advisories; requires cargo-audit and applies .cargo/audit.toml. |
 | `just build` | Build in debug mode (development) |
 | `just build-release` | Build in release mode (for install) |
+| `just build-smoke-binaries` | Build only the release `facelock` (tpm) and PAM module the CI smoke tiers consume. |
 | `just check` | Run local tests, lint, format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes. |
 | `just check-agent-docs [base=]` | Check repository instructions and lifecycle contracts; optional base ref adds a coupling check. |
 | `just check-docs` | Verify instructional coverage, references and parser acceptance (no example execution). |
@@ -51,6 +52,7 @@ index, so substitute real values for metavariables before running a recipe.
 | `just install-files` | Install pre-built binaries to system (requires root, no build) |
 | `just link-models [src=]` | Populate models/*.onnx from an existing checkout or install tree |
 | `just lint` | Lint every workspace target with Clippy, denying warnings (matches CI). |
+| `just lint-tpm` | Lint every workspace target with the `tpm` feature enabled (matches CI). |
 | `just mo` | Compile and validate available PO catalogs into target/locale (requires msgfmt). |
 | `just pot` | Regenerate both gettext POT templates from source messages. |
 | `just release <version>` | Validate and update release versions, then print the commit/tag/push steps; does not publish. |

--- a/justfile
+++ b/justfile
@@ -10,6 +10,17 @@ build-release:
     cargo build --release --workspace
     cargo build --release -p facelock-cli --features tpm
 
+# The CI smoke tiers consume two files: `facelock` (with tpm, as every package
+# ships it) and `libpam_facelock.so`. The release profile is fat LTO with one
+# codegen unit, so every final artifact is a multi-minute link that no cache
+# survives (rust-cache drops workspace crates). `build-release` links five of
+# them; this links the two that are uploaded, in one cargo invocation so the
+# shared dependencies compile once.
+
+# Build only the release `facelock` (tpm) and PAM module the CI smoke tiers consume.
+build-smoke-binaries:
+    cargo build --release -p facelock-cli -p pam-facelock --features facelock-cli/tpm
+
 # Run all unit tests
 test:
     cargo test --workspace
@@ -30,6 +41,14 @@ test-all:
 # Lint every workspace target with Clippy, denying warnings (matches CI).
 lint:
     cargo clippy --workspace --all-targets -- -D warnings
+
+# The `tpm` feature gates real code (`cfg(feature = "tpm")` across the cli,
+# daemon and tpm crates), so the default lint never sees it. CI runs both; a
+# lint that only passes without the feature ships in every packaged build.
+
+# Lint every workspace target with the `tpm` feature enabled (matches CI).
+lint-tpm:
+    cargo clippy --workspace --all-targets --features tpm -- -D warnings
 
 # Format check
 fmt-check:
@@ -52,7 +71,8 @@ audit:
 # it. The dep guard then forbids the async-io runtime backend (async-io/async-signal/
 # polling + the async-executor/async-fs/async-lock trio) while allowing
 # signal-hook-registry, which the correct tokio backend legitimately pulls via
-# tokio's "process" feature. Keep in sync with .github/workflows/ci.yml
+# tokio's "process" feature. CI runs this recipe; .claude/rules/pam-boundary.md
+# documents the same list, and `just check-agent-docs` holds the two together.
 
 # Build PAM independently and reject forbidden async-io backend dependencies.
 check-pam-standalone:

--- a/test/docs-inventory-test.py
+++ b/test/docs-inventory-test.py
@@ -24,12 +24,12 @@ class InventoryTest(unittest.TestCase):
     def test_container_workspace_tests_trust_only_the_checkout(self):
         workflow = (MODULE.ROOT / '.github/workflows/ci.yml').read_text()
         trust = '\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"'
-        for job in ('build-and-test', 'tpm-tests'):
+        for job, tests in (('build-and-test', 'run: just test'), ('tpm-tests', 'run: cargo test --workspace')):
             with self.subTest(job=job):
                 body = re.search(r'(?ms)^  ' + job + r':\n(.*?)(?=^  \S|\Z)', workflow)[1]
                 self.assertIn(trust, body)
                 self.assertLess(body.index('uses: actions/checkout@'), body.index(trust))
-                self.assertLess(body.index(trust), body.index('run: cargo test --workspace'))
+                self.assertLess(body.index(trust), body.index(tests))
 
     def test_source_archive_discovery_finds_new_docs_and_excludes_build_outputs(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- run every `build-and-test` step through a justfile recipe: `fmt-check`, `lint`, `lint-tpm`, `test`, `check-docs`, `check-pam-standalone`, `build-smoke-binaries`
- drop the two plain `cargo build` passes; clippy `--all-targets` type-checks every target and `cargo test` builds the workspace
- keep both clippy variants: `cfg(feature = "tpm")` gates 73 sites across the cli, daemon and tpm crates
- link only `facelock` (tpm) and `libpam_facelock.so` for the smoke tiers, in one cargo invocation, instead of five fat-LTO artifacts
- save the rust-cache on failure so a red pull request starts its next run warm
- document the job shape in `.claude/rules/testing.md` and `.claude/rules/pam-boundary.md`

## Why

The job took eleven minutes on `main`, seven of them in the release build: fat LTO with one codegen unit links every workspace binary from scratch on each run, because rust-cache drops workspace crates, and the smoke tiers download two of the five. The debug passes were four compiles of the same tree before the tests ran. Defining each step as a recipe means `just check` and CI cannot drift apart.

Test coverage is unchanged: `tpm-tests` was already the only job running `cargo test --features tpm` and still is. The release-profile build of `facelock-bench` and `facelock-polkit-agent` no longer runs on pull requests; the release workflow still builds them through `just build-release`.

## Validation

- `just fmt-check lint lint-tpm test check-pam-standalone check-docs build-smoke-binaries`
- `ldd target/release/facelock` links `libtss2-esys`
- `just check-workflow-policy`, `just test-classify-changes`, `just check-agent-docs`
- `python3 test/docs-inventory-test.py`
