### PR TITLE
fix(loopback): Address open review threads on the synthetic camera tier

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -60,7 +60,7 @@ schedules:
 
 | When | What | Filter |
 |---|---|---|
-| Pull request | every lane; Debian lanes without the `.dsc` rebuild | per lane, only the lanes the diff reaches |
+| Pull request | every lane except COPR; Debian lanes without the `.dsc` rebuild | per lane, only the lanes the diff reaches |
 | Nightly (07:00 UTC) | every lane | none |
 | `just release-preflight` | lane evidence uploaded by a green run at HEAD, or the marker a local `just test-packaging-matrix` wrote at HEAD | none |
 
@@ -81,8 +81,9 @@ compile, is left to the nightly and the dispatch (#337). Such a lane records
 `depth=partial`, which `just release-preflight` refuses.
 
 So a green pull request is **not** packaging-verified unless the packaging jobs
-actually ran on it. A Rust-only change runs only the release-binaries build on
-its pull request; if it breaks the packaged runtime, the nightly matrix catches
+actually ran on it. A change to Rust source alone (Cargo manifests and the
+lockfile reach every lane) runs only the release-binaries build on its pull
+request; if it breaks the packaged runtime, the nightly matrix catches
 it within a day, and the release gate before it ships.
 `just test-packaging-matrix` runs every lane locally and records each lane's
 evidence, for a maintainer without CI in reach; a run that skipped anything is

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -81,10 +81,11 @@ compile, is left to the nightly and the dispatch (#337). Such a lane records
 `depth=partial`, which `just release-preflight` refuses.
 
 So a green pull request is **not** packaging-verified unless the packaging jobs
-actually ran on it. A change to Rust source alone (Cargo manifests and the
-lockfile reach every lane) runs only the release-binaries build on its pull
-request; if it breaks the packaged runtime, the nightly matrix catches
-it within a day, and the release gate before it ships.
+actually ran on it. A change to Rust source alone runs only the release-binaries
+build on its pull request, except `pam.rs`, `daemon.rs`, and `lifecycle.rs` in
+`facelock-cli`, which the classifier routes to every lane along with Cargo
+manifests and the lockfile; if it breaks the packaged runtime, the nightly
+matrix catches it within a day, and the release gate before it ships.
 `just test-packaging-matrix` runs every lane locally and records each lane's
 evidence, for a maintainer without CI in reach; a run that skipped anything is
 refused, not recorded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,8 +390,12 @@ jobs:
     name: Synthetic Camera E2E
     runs-on: ubuntu-latest
     needs: build-and-test
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download release binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/crates/facelock-daemon/tests/synthetic_face_contract.rs
+++ b/crates/facelock-daemon/tests/synthetic_face_contract.rs
@@ -121,16 +121,23 @@ fn synthetic_sequence_sits_inside_every_live_gate() {
         "consecutive similarity: min={min_consecutive:.4} max={max_consecutive:.4} seam={wrap:.4}"
     );
 
-    let mut min_to_first = 1.0f32;
-    for (i, emb) in embeddings.iter().enumerate().skip(1) {
-        let sim = cosine_similarity(&embeddings[0], emb);
-        min_to_first = min_to_first.min(sim);
-        assert!(
-            sim >= CONTAINER_RECOGNITION_THRESHOLD,
-            "frame {i}: similarity to frame 0 is {sim:.4}, below the recognition threshold"
-        );
+    // Enrollment stores whichever consecutive window the feeder was on, and
+    // authentication takes the best match of a live frame against that
+    // window. The worst case is a live frame against a window that does not
+    // contain it, so every pair of frames has to clear the threshold, not
+    // just every frame against frame 0.
+    let mut min_pair = 1.0f32;
+    for (i, a) in embeddings.iter().enumerate() {
+        for (j, b) in embeddings.iter().enumerate().skip(i + 1) {
+            let sim = cosine_similarity(a, b);
+            min_pair = min_pair.min(sim);
+            assert!(
+                sim >= CONTAINER_RECOGNITION_THRESHOLD,
+                "frames {i} and {j}: similarity {sim:.4} is below the recognition threshold"
+            );
+        }
     }
-    eprintln!("similarity to frame 0: min={min_to_first:.4}");
+    eprintln!("pairwise similarity: min={min_pair:.4}");
 
     // Enrollment accepts up to ENROLL_WINDOW consecutive frames, starting
     // wherever the feeder happens to be. Every such window needs one pair

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -436,8 +436,8 @@ lane.
 
 | Changed path | Lanes |
 |---|---|
-| `debian/`, `dist/apt/`, `test/*deb*`, `test/*apt*`, `.github/workflows/scripts/*deb*` | deb |
-| `dist/facelock.spec`, `dist/rpm/`, `.packit.yaml`, `test/Containerfile.{fedora,copr*,rpm*,packit}`, `test/*rpm*`, `test/*copr*`, `test/fedora-lane-image.sh`, `.github/workflows/scripts/*rpm*` | rpm, release_binaries |
+| `debian/`, `dist/apt/`, `test/*deb*`, `test/*apt*`, `.github/workflows/scripts/*deb*`, `.github/workflows/scripts/*apt*` | deb |
+| `dist/facelock.spec`, `dist/rpm/`, `.packit.yaml`, `test/Containerfile.{fedora,copr*,rpm*,packit}`, `test/*rpm*`, `test/*copr*`, `test/*packit*`, `test/fedora-lane-image.sh`, `.github/workflows/scripts/*rpm*`, `.github/workflows/scripts/*copr*` | rpm, release_binaries |
 | `dist/PKGBUILD*`, `dist/facelock.install`, `dist/facelock-pam-remove.hook`, `test/*arch*`, `.github/workflows/scripts/*aur*` | arch |
 | `test/release-*` | release_matrix |
 | the rest of `dist/`, `systemd/`, `dbus/`, `config/`, `scripts/`, `justfile`, `Cargo.toml`, `Cargo.lock`, `crates/*/Cargo.toml`, `test/Containerfile*`, `test/*pkg*`, the shared PAM/polkit/TPM validators, `.github/workflows/packaging.yml`, `.github/workflows/release.yml`, the other workflow scripts, `.github/actions/` | all |
@@ -1140,7 +1140,8 @@ Since facelock is a PAM module, broken releases can lock users out. Every releas
 4. Pass `just test-arch-loopback` (synthetic camera, no person) or
    `just test-arch-camera-required` (a camera and a person in frame, the only
    run that proves real-sensor recognition) against the final release commit;
-   `just release-preflight` fails until one has
+   `just release-preflight` fails until one tier has run at that commit, or a
+   hand-run tier has been acknowledged at it
 5. Pass `just test-rpm` and `just test-deb` (multi-distro package validation)
 6. Not change PAM auth semantics without explicit changelog entry
 5. Preserve `/etc/pam.d/sudo` backup on install (`/var/lib/facelock/pam-backups/sudo.<timestamp>`)

--- a/justfile
+++ b/justfile
@@ -657,8 +657,14 @@ test-arch-camera-required: _require-clean-tree test-arch-integration test-arch-o
 test-arch-loopback ir="" rgb="": _require-models _build-test-container
     #!/usr/bin/env bash
     set -euo pipefail
+    # The script binds its positionals as IR then RGB, so an RGB-only call
+    # must still fill the IR slot or the RGB node would be fed as the IR one.
+    ir_node="{{ ir }}"
+    if [ -z "$ir_node" ] && [ -n "{{ rgb }}" ]; then
+        ir_node="${FACELOCK_LOOPBACK_IR:-/dev/video20}"
+    fi
     args=()
-    [ -n "{{ ir }}" ] && args+=("{{ ir }}")
+    [ -n "$ir_node" ] && args+=("$ir_node")
     [ -n "{{ rgb }}" ] && args+=("{{ rgb }}")
     if [ -n "${FACELOCK_LIVE_TIMEOUT:-}" ] && [[ ! "$FACELOCK_LIVE_TIMEOUT" =~ ^[0-9]+(\.[0-9]+)?[smhd]?$ ]]; then
         echo "error: FACELOCK_LIVE_TIMEOUT='$FACELOCK_LIVE_TIMEOUT' is not a timeout(1) duration (e.g. 300s, 5m)" >&2

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -372,7 +372,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 8,
-        "line": 1144,
+        "line": 1145,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -444,7 +444,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1144,
+        "line": 1145,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],


### PR DESCRIPTION
## Summary

- fill the IR slot when `just test-arch-loopback` is called with only an RGB node, so the RGB node is no longer fed as the IR one
- give the Synthetic Camera E2E job `contents: read` only and stop persisting the checkout token
- assert every pair of synthetic frames clears the recognition threshold, not only each frame against frame 0
- document the COPR exception, the manifest and lockfile exception, three classifier rules missing from the lane table, and what the preflight tier gate needs

## Why

Review threads on #371 and #377 that were still open at merge. The recipe bug silently swaps the two loopback roles. The contract test only proved recognition against frame 0, while enrollment stores an arbitrary window and auth takes the best match against it, so a low pair between two later frames could pass the test and fail the tier.

## Validation

- `cargo test -p facelock-daemon --test synthetic_face_contract -- --ignored` against the real models
- `just check-workflow-policy`, `just check-docs`, `just fmt-check`
- `just --dry-run test-arch-loopback "" /dev/video21` to confirm the IR slot is filled

Refs #371 #377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified CI lane scheduling and Rust-change verification behavior.
  - Expanded release-path guidance for Debian/APT and COPR-related changes.
  - Added a release safety check requiring camera-tier validation or explicit acknowledgment.

- **Testing**
  - Strengthened synthetic face-sequence validation by checking all frame pairs.
  - Improved loopback test setup when only an RGB device is provided.
  - Updated documentation walkthrough references.

- **Security**
  - Reduced credential exposure during end-to-end test checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->