### PR TITLE
test(loopback): Add loopback-up and loopback-down recipes for the synthetic camera nodes

### DIFF
--- a/docs/developer-commands.md
+++ b/docs/developer-commands.md
@@ -54,6 +54,8 @@ index, so substitute real values for metavariables before running a recipe.
 | `just link-models [src=]` | Populate models/*.onnx from an existing checkout or install tree |
 | `just lint` | Lint every workspace target with Clippy, denying warnings (matches CI). |
 | `just lint-tpm` | Lint every workspace target with the `tpm` feature enabled (matches CI). |
+| `just loopback-down` | Remove the facelock-synth-* loopback nodes and nothing else (one sudo prompt) |
+| `just loopback-up` | Add the two v4l2loopback nodes test-arch-loopback feeds (one sudo prompt) |
 | `just mo` | Compile and validate available PO catalogs into target/locale (requires msgfmt). |
 | `just pot` | Regenerate both gettext POT templates from source messages. |
 | `just release <version>` | Validate and update release versions, then print the commit/tag/push steps; does not publish. |
@@ -67,7 +69,7 @@ index, so substitute real values for metavariables before running a recipe.
 | `just test-arch-dev-shell` | Dev shell — interactive Arch container with host models for fast iteration (requires camera) |
 | `just test-arch-integration` | Automated daemon integration tests (Arch, requires camera) |
 | `just test-arch-layout` | Check installed state-directory permissions and enrollment-marker visibility in Arch. |
-| `just test-arch-loopback [ir=] [rgb=]` | Both camera-required E2E tiers against a synthetic v4l2loopback camera, recorded for release-preflight |
+| `just test-arch-loopback [ir=] [rgb=]` | See the recipe body and its prerequisites |
 | `just test-arch-oneshot` | Automated oneshot (daemonless) integration tests (Arch, requires camera) |
 | `just test-arch-package-select` | Test selection of the main Arch package rather than its debug split. |
 | `just test-arch-pam` | Automated PAM smoke tests (Arch container) |

--- a/docs/testing-safety.md
+++ b/docs/testing-safety.md
@@ -71,9 +71,14 @@ drifts frame to frame the way a person does. A second node fed `YUYV` is the
 non-IR camera the `require_ir` refusal assertions need; without it they
 report `SKIP`.
 
-The tier needs two idle loopback nodes the calling user can write. Loading
-the module needs root; the recipe does not do it and exits 2 with this when
-the nodes are missing:
+The tier needs two idle loopback nodes the calling user can write. Adding
+them needs root; the tier never elevates itself and exits 2 with the setup
+hint when they are missing. `just loopback-up` adds them and
+`just loopback-down` removes them, each printing the privileged commands it
+runs and prompting for `sudo` once. Run both as yourself, not under
+`sudo just`, so podman, cargo, and the record file stay owned by you.
+`loopback-down` matches nodes by the `facelock-synth-*` label, so a module
+loaded for something else is left alone. By hand, the same thing is:
 
 ```bash
 sudo modprobe v4l2loopback devices=2 video_nr=20,21 \

--- a/justfile
+++ b/justfile
@@ -684,17 +684,17 @@ loopback-up:
         echo "+ sudo modprobe v4l2loopback devices=0"
         sudo modprobe v4l2loopback devices=0
     fi
-    for pair in "mono:$ir" "color:$rgb"; do
-        role="${pair%%:*}"; node="${pair#*:}"
+    for pair in "mono:IR:$ir" "color:RGB:$rgb"; do
+        role="${pair%%:*}"; rest="${pair#*:}"; var="${rest%%:*}"; node="${rest#*:}"
         if [ -c "$node" ]; then
             sys="/sys/class/video4linux/$(basename "$node")"
             if [ -e "$sys/device" ]; then
-                echo "error: $node is a real camera ($(cat "$sys/name")); pick another with FACELOCK_LOOPBACK_${role^^}" >&2
+                echo "error: $node is a real camera ($(cat "$sys/name")); pick another with FACELOCK_LOOPBACK_$var" >&2
                 exit 2
             fi
             name="$(cat "$sys/name" 2>/dev/null || echo '?')"
             if [ "$name" != "facelock-synth-$role" ]; then
-                echo "error: $node is another tool's loopback ($name); pick a free node with FACELOCK_LOOPBACK_${role^^}" >&2
+                echo "error: $node is another tool's loopback ($name); pick a free node with FACELOCK_LOOPBACK_$var" >&2
                 exit 2
             fi
             echo "$node already exists ($name), keeping it"

--- a/justfile
+++ b/justfile
@@ -654,6 +654,74 @@ test-arch-camera-required: _require-clean-tree test-arch-integration test-arch-o
 #
 
 # Both camera-required E2E tiers against a synthetic v4l2loopback camera, recorded for release-preflight
+# The two v4l2loopback nodes `test-arch-loopback` feeds. Adding a node is a
+# root operation, so these recipes run exactly the privileged commands they
+# print, one sudo prompt, and nothing else elevated: `podman`, cargo, and the
+# tier itself stay rootless. Run them as yourself, never as `sudo just ...`,
+# which would make everything the session touches root-owned.
+#
+# `loopback-up` adds nodes only if they are missing and refuses a node that
+# is a real camera. `loopback-down` removes only nodes carrying the labels
+# below, so a module loaded for something else (NVbroadcast, OBS) is never
+# unloaded or touched.
+
+# Add the two v4l2loopback nodes test-arch-loopback feeds (one sudo prompt)
+loopback-up:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(id -u)" = 0 ]; then
+        echo "error: run 'just loopback-up' as yourself; it calls sudo for the commands that need it" >&2
+        exit 2
+    fi
+    ir="${FACELOCK_LOOPBACK_IR:-/dev/video20}"
+    rgb="${FACELOCK_LOOPBACK_RGB:-/dev/video21}"
+    if ! command -v v4l2loopback-ctl >/dev/null; then
+        echo "error: v4l2loopback-ctl not found (package v4l2loopback-utils; the module is v4l2loopback-dkms)" >&2
+        exit 2
+    fi
+    if [ ! -e /dev/v4l2loopback ]; then
+        echo "module not loaded; loading it with no devices so nodes can be added by label"
+        echo "+ sudo modprobe v4l2loopback devices=0"
+        sudo modprobe v4l2loopback devices=0
+    fi
+    for pair in "mono:$ir" "color:$rgb"; do
+        role="${pair%%:*}"; node="${pair#*:}"
+        if [ -c "$node" ]; then
+            sys="/sys/class/video4linux/$(basename "$node")"
+            if [ -e "$sys/device" ]; then
+                echo "error: $node is a real camera ($(cat "$sys/name")); pick another with FACELOCK_LOOPBACK_${role^^}" >&2
+                exit 2
+            fi
+            echo "$node already exists ($(cat "$sys/name" 2>/dev/null || echo '?')), keeping it"
+            continue
+        fi
+        echo "+ sudo v4l2loopback-ctl add -x 1 -n facelock-synth-$role $node"
+        sudo v4l2loopback-ctl add -x 1 -n "facelock-synth-$role" "$node"
+    done
+    echo "+ sudo udevadm settle && sudo chmod a+rw $ir $rgb"
+    sudo udevadm settle && sudo chmod a+rw "$ir" "$rgb"
+    echo "loopback nodes ready: $ir (mono) $rgb (color); run 'just test-arch-loopback'"
+
+# Remove the facelock-synth-* loopback nodes and nothing else (one sudo prompt)
+loopback-down:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(id -u)" = 0 ]; then
+        echo "error: run 'just loopback-down' as yourself; it calls sudo for the commands that need it" >&2
+        exit 2
+    fi
+    removed=0
+    for sys in /sys/class/video4linux/video*; do
+        [ -e "$sys/name" ] || continue
+        name="$(cat "$sys/name")"
+        case "$name" in facelock-synth-mono|facelock-synth-color) ;; *) continue ;; esac
+        node="/dev/$(basename "$sys")"
+        echo "+ sudo v4l2loopback-ctl delete $node   # $name"
+        sudo v4l2loopback-ctl delete "$node"
+        removed=$((removed + 1))
+    done
+    echo "removed $removed facelock loopback node(s); other v4l2loopback devices untouched"
+
 test-arch-loopback ir="" rgb="": _require-models _build-test-container
     #!/usr/bin/env bash
     set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -692,7 +692,12 @@ loopback-up:
                 echo "error: $node is a real camera ($(cat "$sys/name")); pick another with FACELOCK_LOOPBACK_${role^^}" >&2
                 exit 2
             fi
-            echo "$node already exists ($(cat "$sys/name" 2>/dev/null || echo '?')), keeping it"
+            name="$(cat "$sys/name" 2>/dev/null || echo '?')"
+            if [ "$name" != "facelock-synth-$role" ]; then
+                echo "error: $node is another tool's loopback ($name); pick a free node with FACELOCK_LOOPBACK_${role^^}" >&2
+                exit 2
+            fi
+            echo "$node already exists ($name), keeping it"
             continue
         fi
         echo "+ sudo v4l2loopback-ctl add -x 1 -n facelock-synth-$role $node"

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -546,7 +546,7 @@
         "path": "docs/testing-safety.md",
         "anchor": "host-pam-testing",
         "ordinal": 1,
-        "line": 162,
+        "line": 167,
         "sha256": "0677a306f44c09bf7779105645adecf936718a3add5e8a9384cd8819f219b449"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -10976,29 +10976,29 @@
         {
           "path": "docs/testing-safety.md",
           "anchor": "synthetic-camera",
-          "ordinal": 3,
-          "line": 79,
+          "ordinal": 6,
+          "line": 84,
           "sha256": "ee4c4711e86275d056aa8a3367270deebb196ba003cdeeac35b31914de4eb811"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "synthetic-camera",
-          "ordinal": 4,
-          "line": 81,
+          "ordinal": 7,
+          "line": 86,
           "sha256": "4eaab8587af0fc025bd63fe38538cf9a750b022c8fbf973323286639d39f9993"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "synthetic-camera",
-          "ordinal": 5,
-          "line": 92,
+          "ordinal": 8,
+          "line": 97,
           "sha256": "65279a5840a2659ca2c35f024f554d1956e8eb67486aafde734e7f6543784560"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "synthetic-camera",
-          "ordinal": 6,
-          "line": 93,
+          "ordinal": 9,
+          "line": 98,
           "sha256": "c4d9234892d190495cc5159579fc727ffad6c1166fe4c5bc3accafcdf331639e"
         }
       ],
@@ -11107,35 +11107,35 @@
           "path": "docs/testing-safety.md",
           "anchor": "development-configuration",
           "ordinal": 1,
-          "line": 136,
+          "line": 141,
           "sha256": "48d6b8aecaf932ce9c5e7f8943e9e680f516bd62a91a97583bbdf775c9f4c911"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "development-configuration",
           "ordinal": 2,
-          "line": 137,
+          "line": 142,
           "sha256": "fad0225732307d9b8666dc48f93369322752b5acd641d744cde3a6d1c99155de"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "development-configuration",
           "ordinal": 3,
-          "line": 138,
+          "line": 143,
           "sha256": "21df8681af24fdd4a24c8e7533d7c69725728fedd70374ac46b437b03686b526"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "development-configuration",
           "ordinal": 4,
-          "line": 139,
+          "line": 144,
           "sha256": "e1a93dce67650786cc6126129be6427d1a8a96c0560e61b310b30e44e61bde57"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "development-configuration",
           "ordinal": 5,
-          "line": 140,
+          "line": 145,
           "sha256": "db33444f34d115dce2f155297f23c717c86dd22e1e95cd0e44bf71ad6bec9fcf"
         }
       ],
@@ -11241,21 +11241,21 @@
           "path": "docs/testing-safety.md",
           "anchor": "logging",
           "ordinal": 1,
-          "line": 192,
+          "line": 197,
           "sha256": "b71e3793c76c15f20acfcf32c73851f60e7859007bb736c45ef44512afe49f3c"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "logging",
           "ordinal": 2,
-          "line": 193,
+          "line": 198,
           "sha256": "487f16174412556ab1080aea37045dc303ee6fe34b356029315dfd4c9e000d41"
         },
         {
           "path": "docs/testing-safety.md",
           "anchor": "logging",
           "ordinal": 3,
-          "line": 200,
+          "line": 205,
           "sha256": "01dd0a825d0876d8fe17a64f6cd934f852338f8ee393c1a85646ba116ffcaacd"
         }
       ],

--- a/test/loopback/run-loopback-tier.sh
+++ b/test/loopback/run-loopback-tier.sh
@@ -37,8 +37,9 @@ FPS=15
 
 setup_hint() {
     cat >&2 <<EOF
-       The tier needs two v4l2loopback nodes nothing else is feeding. On a
-       host where the module is not loaded:
+       The tier needs two v4l2loopback nodes nothing else is feeding.
+         just loopback-up        # adds them (one sudo prompt); loopback-down removes them
+       By hand, on a host where the module is not loaded:
          sudo modprobe v4l2loopback devices=2 video_nr=20,21 \\
              card_label=facelock-synth-mono,facelock-synth-color exclusive_caps=1,1
        If v4l2loopback is already loaded for something else, add nodes


### PR DESCRIPTION
- add `just loopback-up` and `just loopback-down`; each prints the privileged commands it runs and prompts for sudo once
- refuse to run as root, so `sudo just ...` never leaves podman images or the record file root-owned
- match nodes by the `facelock-synth-*` label on teardown, so NVbroadcast or OBS loopbacks are never touched
- point the tier's missing-node hint and `docs/testing-safety.md` at the recipes

## Why

The nodes are runtime-only and vanish on reboot, and making them permanent would put two synthetic cameras in every app's picker for the two minutes a run needs them. Test-time setup matches what CI already does, but it needs root, and the tier should never elevate itself.

## Validation

- `just loopback-up`, `just test-arch-loopback`, `just loopback-down` on this host, with NVbroadcast's loopback at video10 left in place
- `just check-docs`, `just check-agent-docs`, `test/check-workflow-policy.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `just loopback-up` and `just loopback-down` commands to create and remove the synthetic camera loopback nodes used for testing.
  - Setup now provides clearer guidance, prompts for required privileges once, and avoids affecting unrelated loopback devices.

- **Documentation**
  - Updated synthetic camera testing instructions, prerequisites, setup behavior, and cleanup guidance.
  - Updated developer command references and documentation walkthrough metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->