### PR TITLE
perf(test): Run the release-artifacts mutations concurrently

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -213,7 +213,10 @@ run; fix the flake and re-run the failed jobs, never tag again.
 
 `test/release-artifacts-contract.sh` (`just test-release-artifacts`) proves this
 shape by fixture and by mutation. The workflow itself runs only on a tag, so
-the gate never tags anything to test it.
+the gate never tags anything to test it. Each mutation re-runs the script
+against a mutated copy; those runs execute concurrently, `FACELOCK_MUTATION_JOBS`
+at a time (default: one per CPU). Set `FACELOCK_MUTATION_JOBS=1` to run them
+one after another when debugging a mutation.
 
 #### Debian package channels
 

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 19,
-        "line": 575,
+        "line": 578,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -330,49 +330,49 @@
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 3,
-        "line": 311,
+        "line": 314,
         "sha256": "b2b12dbf5cd38fc21d68548042e8eae1e66f65faa6491f3564e75c7cb60abc22"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 4,
-        "line": 312,
+        "line": 315,
         "sha256": "5595bcc3f9aa3517450a5185fe037e24b0a8ec079eff27020bf5c5aef68ffdb0"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 5,
-        "line": 313,
+        "line": 316,
         "sha256": "d0d568788326024851d047fe1e316af83028cbf98b17a777fd64c4e784151809"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 13,
-        "line": 323,
+        "line": 326,
         "sha256": "cbe27321cd6d31c9676b5aa4998fd1b4f9195f719b00cda8f889c3b3b7dae276"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 15,
-        "line": 325,
+        "line": 328,
         "sha256": "a10a4c45881ab16f35605739e0375de3e5558bc495111b49c7929d9b2d1603a0"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "packaging-gates-in-ci",
         "ordinal": 8,
-        "line": 490,
+        "line": 493,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 8,
-        "line": 1145,
+        "line": 1148,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -381,70 +381,70 @@
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 2,
-        "line": 310,
+        "line": 313,
         "sha256": "d5ce836f401484bd835100b165e1c2234b437780616e27bb92f5403d0f22bc40"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 6,
-        "line": 314,
+        "line": 317,
         "sha256": "05d5991182864fc115e36763667a0d555cf256358ed52830129f8fd32ab925de"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 7,
-        "line": 315,
+        "line": 318,
         "sha256": "4830a79699c4a1fa28bbcdc2eb8e5712c7ac46f3fd2533bad0b097ab936e8413"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 8,
-        "line": 316,
+        "line": 319,
         "sha256": "b1b141623a6849ba1a180dfa8e3d7eb504da148110c930be20e240eabd2323f1"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 14,
-        "line": 324,
+        "line": 327,
         "sha256": "0aece5ddd58b51f2dccb3e634e59f06c2a38c4f9bd0439197688c4e548e8895b"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "local-distro-validation",
         "ordinal": 16,
-        "line": 326,
+        "line": 329,
         "sha256": "640b0dca78c96225ae70191f4312212e60c6367fca24cab33a803b0ee94c7847"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 1,
-        "line": 342,
+        "line": 345,
         "sha256": "d8ca765201bc57c001e20cd7532b17eae17b608c987aef950bd49b038209a291"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 3,
-        "line": 343,
+        "line": 346,
         "sha256": "942b015c794e1cca7d2229c0315e6a430ae3e08a91102a5f9ec9a5fafa61a8ec"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "fedora-lanes",
         "ordinal": 10,
-        "line": 380,
+        "line": 383,
         "sha256": "942b015c794e1cca7d2229c0315e6a430ae3e08a91102a5f9ec9a5fafa61a8ec"
       },
       {
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1145,
+        "line": 1148,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -8790,112 +8790,112 @@
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 1,
-          "line": 309,
+          "line": 312,
           "sha256": "21fbb4c9a7b22a0439e070e8122853880927532ba554ea0204fd0ede5fa3ebbb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 2,
-          "line": 310,
+          "line": 313,
           "sha256": "d5ce836f401484bd835100b165e1c2234b437780616e27bb92f5403d0f22bc40"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 3,
-          "line": 311,
+          "line": 314,
           "sha256": "b2b12dbf5cd38fc21d68548042e8eae1e66f65faa6491f3564e75c7cb60abc22"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 4,
-          "line": 312,
+          "line": 315,
           "sha256": "5595bcc3f9aa3517450a5185fe037e24b0a8ec079eff27020bf5c5aef68ffdb0"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 5,
-          "line": 313,
+          "line": 316,
           "sha256": "d0d568788326024851d047fe1e316af83028cbf98b17a777fd64c4e784151809"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 6,
-          "line": 314,
+          "line": 317,
           "sha256": "05d5991182864fc115e36763667a0d555cf256358ed52830129f8fd32ab925de"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 7,
-          "line": 315,
+          "line": 318,
           "sha256": "4830a79699c4a1fa28bbcdc2eb8e5712c7ac46f3fd2533bad0b097ab936e8413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 8,
-          "line": 316,
+          "line": 319,
           "sha256": "b1b141623a6849ba1a180dfa8e3d7eb504da148110c930be20e240eabd2323f1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 9,
-          "line": 317,
+          "line": 320,
           "sha256": "9fcc5f55faef0fe3ceebfa0d6e7beb5e0281ab1b037fd3153ace2b72b3a64202"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 10,
-          "line": 318,
+          "line": 321,
           "sha256": "2877908694a9c4d1e9a8e8ca4605edd81026d7666c65b3c69bd180646b513b53"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 11,
-          "line": 319,
+          "line": 322,
           "sha256": "872db5f82702e535cc961ca606e0d46e18f134bfdcd12c06171b9adffc9ef8e8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 12,
-          "line": 320,
+          "line": 323,
           "sha256": "3bdfbcbee168b92e2cf8f520a54a827c805903faed4712a781af561ea3246037"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 13,
-          "line": 323,
+          "line": 326,
           "sha256": "cbe27321cd6d31c9676b5aa4998fd1b4f9195f719b00cda8f889c3b3b7dae276"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 14,
-          "line": 324,
+          "line": 327,
           "sha256": "0aece5ddd58b51f2dccb3e634e59f06c2a38c4f9bd0439197688c4e548e8895b"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 15,
-          "line": 325,
+          "line": 328,
           "sha256": "a10a4c45881ab16f35605739e0375de3e5558bc495111b49c7929d9b2d1603a0"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "local-distro-validation",
           "ordinal": 16,
-          "line": 326,
+          "line": 329,
           "sha256": "640b0dca78c96225ae70191f4312212e60c6367fca24cab33a803b0ee94c7847"
         }
       ],
@@ -9149,56 +9149,56 @@
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 1,
-          "line": 500,
+          "line": 503,
           "sha256": "f7811975b03e056e3ddcad0ffabb2a88bc41aef7dc23e3a9140ddf88b04d9439"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 2,
-          "line": 501,
+          "line": 504,
           "sha256": "90194b9d2f624946e69e7c618aabc816035872c50da99d3f17d3d1692a239bce"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 3,
-          "line": 502,
+          "line": 505,
           "sha256": "a07a3db4c0fd5697107f1591eb62f6a2c9a2ac0d3801e25844e5c244f6688915"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 4,
-          "line": 503,
+          "line": 506,
           "sha256": "d9a223daf1f784e1bd0313866cfbfcff4b2b4958708dfab4674bc3ddc63de570"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 5,
-          "line": 504,
+          "line": 507,
           "sha256": "108c5e8edc6582d4ee70c2b8573afe99a7be3f4ad8ddd11fc2b12c44e7079568"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 6,
-          "line": 505,
+          "line": 508,
           "sha256": "017092419ea31d5de3fd4b6e7a52b2dd239d134f423f81bd0f5c38992c212208"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 7,
-          "line": 506,
+          "line": 509,
           "sha256": "a77a5aea7a4e8dcf9901e8ac5ee041109d525ce2f2bd7f018a21918d70da1326"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "release-preflight-recommended",
           "ordinal": 8,
-          "line": 507,
+          "line": 510,
           "sha256": "2b5e31a5fe163cb0998c87a9f505faf73a26e025df540bc210550dcb6cc27142"
         }
       ],
@@ -9344,231 +9344,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 596,
+          "line": 599,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 599,
+          "line": 602,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 600,
+          "line": 603,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 601,
+          "line": 604,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 602,
+          "line": 605,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 607,
+          "line": 610,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 608,
+          "line": 611,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 610,
+          "line": 613,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 611,
+          "line": 614,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 612,
+          "line": 615,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 613,
+          "line": 616,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 614,
+          "line": 617,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 615,
+          "line": 618,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 616,
+          "line": 619,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 619,
+          "line": 622,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 620,
+          "line": 623,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 621,
+          "line": 624,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 622,
+          "line": 625,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 623,
+          "line": 626,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 624,
+          "line": 627,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 625,
+          "line": 628,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 626,
+          "line": 629,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 627,
+          "line": 630,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 630,
+          "line": 633,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 631,
+          "line": 634,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 632,
+          "line": 635,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 633,
+          "line": 636,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 634,
+          "line": 637,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 635,
+          "line": 638,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 636,
+          "line": 639,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 637,
+          "line": 640,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 641,
+          "line": 644,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 645,
+          "line": 648,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -10039,21 +10039,21 @@
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 8,
-          "line": 821,
+          "line": 824,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 9,
-          "line": 822,
+          "line": 825,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
           "ordinal": 10,
-          "line": 823,
+          "line": 826,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -10135,14 +10135,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 927,
+          "line": 930,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 928,
+          "line": 931,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -10210,21 +10210,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 955,
+          "line": 958,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 962,
+          "line": 965,
           "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 967,
+          "line": 970,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10305,56 +10305,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 1008,
+          "line": 1011,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 1010,
+          "line": 1013,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 1014,
+          "line": 1017,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 1020,
+          "line": 1023,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 1021,
+          "line": 1024,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 1025,
+          "line": 1028,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 1026,
+          "line": 1029,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 1027,
+          "line": 1030,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -36,7 +36,9 @@ fail() {
 # FACELOCK_MUTATION_JOBS=1 keeps the runs serial for debugging. Runs share
 # nothing: each allocates its own mktemp work tree and only reads the checkout.
 work="$(mktemp -d "${TMPDIR:-/tmp}/facelock-release-artifacts.XXXXXX")"
-trap '[ -z "${mutation_scheduler:-}" ] || kill "$mutation_scheduler" 2>/dev/null; rm -rf -- "$work"' EXIT
+# The scheduler runs in its own process group so an early exit takes every
+# in-flight re-run down with it, not just xargs.
+trap '[ -z "${mutation_scheduler:-}" ] || kill -- -"$mutation_scheduler" 2>/dev/null; rm -rf -- "$work"' EXIT
 
 if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ] &&
     [ -z "${FACELOCK_RELEASE_ATTESTATIONS:-}" ]; then
@@ -69,7 +71,7 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
             index=$((index + 1))
         done >"$mutation_runs/queue"
         # shellcheck disable=SC2016
-        xargs -0 -n 3 -P "$mutation_jobs" -a "$mutation_runs/queue" -- bash -c '
+        setsid xargs -0 -n 3 -P "$mutation_jobs" -a "$mutation_runs/queue" -- bash -c '
             runs="$1" self="$2" index="$3" variable="$4" mutant="$5"
             if env "$variable=$mutant" bash "$self" >"$runs/$index.log" 2>&1; then
                 echo 0 >"$runs/$index.status"
@@ -86,11 +88,17 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
         local index=0 failures=0 entry verdict variable mutant label context needle status output
         for entry in "${mutation_queue[@]}"; do
             IFS=$'\t' read -r verdict variable mutant label context needle <<<"$entry"
-            status="$(cat "$mutation_runs/$index.status")"
-            output="$(cat "$mutation_runs/$index.log")"
+            # A run killed before it wrote its verdict (out of memory, say)
+            # counts as a failure with its own message, never as an abort.
+            status="$(cat "$mutation_runs/$index.status" 2>/dev/null || echo missing)"
+            output="$(cat "$mutation_runs/$index.log" 2>/dev/null || true)"
             index=$((index + 1))
-            case "$verdict" in
-                rejected)
+            case "$status:$verdict" in
+                missing:*)
+                    echo "release artifacts contract: $context run left no verdict: $output" >&2
+                    failures=$((failures + 1))
+                    ;;
+                *:rejected)
                     if [ "$status" = 0 ]; then
                         echo "release artifacts contract: release artifacts contract accepted $context" >&2
                         failures=$((failures + 1))
@@ -101,7 +109,7 @@ if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}
                         echo "release artifacts $label: $context rejected"
                     fi
                     ;;
-                accepted)
+                *:accepted)
                     if [ "$status" != 0 ]; then
                         echo "release artifacts contract: release artifacts contract rejected $context: $output" >&2
                         failures=$((failures + 1))

--- a/test/release-artifacts-contract.sh
+++ b/test/release-artifacts-contract.sh
@@ -23,10 +23,328 @@ fail() {
     exit 1
 }
 
-# ------------------------------------------------------------------ workflow
-
 [ -f "$workflow_path" ] || fail "missing release workflow: $workflow_path"
 [ -x "$helper_path" ] || fail "release asset helper must be executable: $helper_path"
+
+# --------------------------------------------------------- mutations: queued
+
+# Every mutant below re-runs this whole script, and a run that must be
+# accepted pays the full static pass. So the mutants are written first and
+# their runs start in the background, FACELOCK_MUTATION_JOBS at a time
+# (default: one per CPU), while this process goes on with its own static pass;
+# the verdicts are read out in queue order at the end, under "mutations".
+# FACELOCK_MUTATION_JOBS=1 keeps the runs serial for debugging. Runs share
+# nothing: each allocates its own mktemp work tree and only reads the checkout.
+work="$(mktemp -d "${TMPDIR:-/tmp}/facelock-release-artifacts.XXXXXX")"
+trap '[ -z "${mutation_scheduler:-}" ] || kill "$mutation_scheduler" 2>/dev/null; rm -rf -- "$work"' EXIT
+
+if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ] &&
+    [ -z "${FACELOCK_RELEASE_ATTESTATIONS:-}" ]; then
+    mutation_root="$work/mutations"
+    mutation_runs="$mutation_root/runs"
+    mkdir -p "$mutation_runs"
+    mutation_jobs="${FACELOCK_MUTATION_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+    case "$mutation_jobs" in
+        '' | *[!0-9]* | 0) fail "FACELOCK_MUTATION_JOBS must be a positive integer: '$mutation_jobs'" ;;
+    esac
+    mutation_queue=()
+
+    # queue_mutation VERDICT VARIABLE MUTANT LABEL CONTEXT [NEEDLE]
+    #   VERDICT   rejected: the run must fail and its output must carry NEEDLE
+    #             accepted: the run must pass
+    #   VARIABLE  the env var that points the re-run at MUTANT
+    #   LABEL     the word after "release artifacts" in the success line
+    queue_mutation() {
+        mutation_queue+=("$1	$2	$3	$4	$5	${6:-}")
+    }
+
+    # One re-run per queued mutant, bounded by xargs -P. The runner always
+    # exits 0 and leaves the verdict in $index.status beside $index.log, so a
+    # failed contract never stops the scheduler early.
+    launch_mutations() {
+        local index=0 entry verdict variable mutant label context needle
+        for entry in "${mutation_queue[@]}"; do
+            IFS=$'\t' read -r verdict variable mutant label context needle <<<"$entry"
+            printf '%s\0%s\0%s\0' "$index" "$variable" "$mutant"
+            index=$((index + 1))
+        done >"$mutation_runs/queue"
+        # shellcheck disable=SC2016
+        xargs -0 -n 3 -P "$mutation_jobs" -a "$mutation_runs/queue" -- bash -c '
+            runs="$1" self="$2" index="$3" variable="$4" mutant="$5"
+            if env "$variable=$mutant" bash "$self" >"$runs/$index.log" 2>&1; then
+                echo 0 >"$runs/$index.status"
+            else
+                echo 1 >"$runs/$index.status"
+            fi' _ "$mutation_runs" "$self" &
+        mutation_scheduler=$!
+    }
+
+    # Every verdict in queue order; every failure listed before the gate exits.
+    report_mutations() {
+        wait "$mutation_scheduler" || fail "the mutation runner failed"
+        mutation_scheduler=""
+        local index=0 failures=0 entry verdict variable mutant label context needle status output
+        for entry in "${mutation_queue[@]}"; do
+            IFS=$'\t' read -r verdict variable mutant label context needle <<<"$entry"
+            status="$(cat "$mutation_runs/$index.status")"
+            output="$(cat "$mutation_runs/$index.log")"
+            index=$((index + 1))
+            case "$verdict" in
+                rejected)
+                    if [ "$status" = 0 ]; then
+                        echo "release artifacts contract: release artifacts contract accepted $context" >&2
+                        failures=$((failures + 1))
+                    elif ! printf '%s\n' "$output" | grep -Fq "$needle"; then
+                        echo "release artifacts contract: $context mutation failed for an unrelated reason: $output" >&2
+                        failures=$((failures + 1))
+                    else
+                        echo "release artifacts $label: $context rejected"
+                    fi
+                    ;;
+                accepted)
+                    if [ "$status" != 0 ]; then
+                        echo "release artifacts contract: release artifacts contract rejected $context: $output" >&2
+                        failures=$((failures + 1))
+                    else
+                        echo "release artifacts $label: $context accepted"
+                    fi
+                    ;;
+            esac
+        done
+        [ "$failures" = 0 ] || fail "$failures of ${#mutation_queue[@]} mutation runs failed"
+    }
+
+    # The attesting set is the only thing standing between an extra artifact
+    # and forged provenance in MANIFEST.json, so prove the check is load-bearing.
+    assert_loader_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local loader=.github/workflows/scripts/release_attestations.py
+        local mutant
+        mutant="$mutation_root/release_attestations-$(printf '%s' "$context" | tr ' ' '-').py"
+        sed -E "$expression" "$loader" >"$mutant"
+        if cmp -s "$loader" "$mutant"; then
+            fail "$context mutation did not change the attestation loader"
+        fi
+        queue_mutation rejected FACELOCK_RELEASE_ATTESTATIONS "$mutant" mutation "$context" "$needle"
+    }
+
+    assert_loader_mutation_rejected "an unpinned attesting set" \
+        's/^    unexpected = sorted\(set\(present\) - set\(expected\)\)$/    unexpected = []/' \
+        "extra digest artifact forging another job's provenance: helper accepted"
+    assert_loader_mutation_rejected "attestations trusted to name their own job" \
+        's/^        if document.get\("job"\) != job:$/        if False:/' \
+        "attestation declaring a job that is not its slot: helper accepted"
+    assert_loader_mutation_rejected "attestations not held to their job outputs" \
+        's/^        if actual != recorded:$/        if False:/' \
+        "attestation replaced after its job recorded it: helper accepted"
+    assert_loader_mutation_rejected "a missing job output tolerated" \
+        's/^        if not isinstance\(recorded, str\) or not DIGEST.fullmatch\(recorded\):$/        if False:/' \
+        "attesting job that recorded no output"
+    assert_loader_mutation_rejected "build images taken from the attestation" \
+        's/^        if document.get\("image"\) != image:$/        if False:/' \
+        "attestation swapping its build image: helper accepted"
+    assert_loader_mutation_rejected "component keys taken from the attestation" \
+        's/^        if sorted\(document.get\("components", \{\}\)\) != components:$/        if False:/' \
+        "attestation adding a component: helper accepted"
+
+    # The helper itself, mutated into a tree of its own so the checkout stays
+    # clean: it resolves the repository root from its own location.
+    assert_helper_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local root mutant
+        root="$mutation_root/helper-$(printf '%s' "$context" | tr ' ' '-')"
+        mkdir -p "$root/.github/workflows/scripts"
+        ln -s "$repo_root/scripts" "$root/scripts"
+        ln -s "$repo_root/dist" "$root/dist"
+        cp .github/workflows/scripts/release_attestations.py "$root/.github/workflows/scripts/"
+        mutant="$root/.github/workflows/scripts/release-assets.sh"
+        sed -E "$expression" "$helper_path" >"$mutant"
+        chmod +x "$mutant"
+        if cmp -s "$helper_path" "$mutant"; then
+            fail "$context mutation did not change the release asset helper"
+        fi
+        queue_mutation rejected FACELOCK_RELEASE_ASSETS "$mutant" mutation "$context" "$needle"
+    }
+
+    # shellcheck disable=SC2016
+    assert_helper_mutation_rejected "an empty suite list tolerated" \
+        's/^    \[ -n "\$listing" \] \|\| fail "the release matrix names no Debian suite.*$/    [ -n "$listing" ] || return 0/' \
+        "allowlist from a matrix with no suite: helper accepted"
+    assert_helper_mutation_rejected "python running with the working directory on its path" \
+        's/^export PYTHONSAFEPATH=1$/: # safe path disabled/' \
+        "imported a module from its working directory"
+
+    assert_workflow_mutation_rejected() {
+        local context="$1" expression="$2" needle="$3"
+        local mutated
+        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
+        sed -E "$expression" "$workflow_path" >"$mutated"
+        if cmp -s "$workflow_path" "$mutated"; then
+            fail "$context mutation did not change the workflow"
+        fi
+        queue_mutation rejected FACELOCK_RELEASE_WORKFLOW "$mutated" mutation "$context" "$needle"
+    }
+
+    assert_workflow_mutation_rejected "the deb step left on the image shell" \
+        '/^      - name: Build suite-specific \.deb package$/,/^        run: \|$/{/^        shell: bash$/d}' \
+        "declare 'shell: bash' on step: Build suite-specific .deb package"
+    assert_workflow_mutation_rejected "the rpm step left on the image shell" \
+        '/^      - name: Select the packages the validated metadata names$/,/^        run: \|$/{/^        shell: bash$/d}' \
+        "declare 'shell: bash' on step: Select the packages the validated metadata names"
+    assert_workflow_mutation_rejected "a container step shell weakened to sh" \
+        's/^        shell: bash$/        shell: sh/' \
+        "runs bash-only syntax under the image's /bin/sh"
+    assert_workflow_mutation_rejected "a one-line container step turning bash" \
+        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|        run: [[ -d cargo-vendor ]] \&\& scripts/prepare-cargo-vendor.sh verify cargo-vendor|' \
+        "declare 'shell: bash' on step: Verify exact Cargo vendor bundle"
+    assert_workflow_mutation_rejected "a nameless container step turning bash" \
+        '/^      - name: Verify exact Cargo vendor bundle$/,+1c\      - run: [[ -d cargo-vendor ]] && scripts/prepare-cargo-vendor.sh verify cargo-vendor' \
+        "runs bash-only syntax under the image's /bin/sh"
+
+    # The other direction of the step-shell rule: a workflow it must not
+    # reject. Whole-line YAML comments never reach the scanner because
+    # job_statements strips them first, so a comment illustrating bash syntax
+    # is documentation and not a step written in bash. Pinned because the
+    # stripping happens a long way from the scan, and a later rewrite reading
+    # job_body directly would make this comment look like script.
+    assert_workflow_mutation_accepted() {
+        local context="$1" expression="$2"
+        local mutated
+        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
+        sed -E "$expression" "$workflow_path" >"$mutated"
+        if cmp -s "$workflow_path" "$mutated"; then
+            fail "$context mutation did not change the workflow"
+        fi
+        queue_mutation accepted FACELOCK_RELEASE_WORKFLOW "$mutated" case "$context"
+    }
+
+    assert_workflow_mutation_accepted "a container step commented with bash syntax" \
+        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|&\n        # example: [[ -f file ]] \&\& mapfile -t x < <(echo hi)|'
+    assert_workflow_mutation_rejected "public release creation" \
+        's/^          draft: true$//' \
+        "must create the GitHub release as a draft"
+    assert_workflow_mutation_rejected "builder holding the release write scope" \
+        '0,/^      contents: read$/s//      contents: write/' \
+        "only the publish job may hold contents: write"
+    # The mutation expressions below name literal workflow text, not shell
+    # expansions.
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "builder holding the publication credential" \
+        's/^      - name: Build release$/      - name: Build release\n        env:\n          TOKEN: ${{ secrets.RELEASE_PAT }}/' \
+        "builders produce artifacts only"
+    assert_workflow_mutation_rejected "builder writing the release directly" \
+        's|^      - name: Upload the APT repository artifact$|      - name: Write the release\n        uses: softprops/action-gh-release@0000\n\n      - name: Upload the APT repository artifact|' \
+        "builders produce artifacts only"
+    assert_workflow_mutation_rejected "compiling in the publishing job" \
+        's|^      - name: Verify the maintainer tag$|      - name: Rebuild\n        run: cargo build --release\n\n      - name: Verify the maintainer tag|' \
+        "must not compile or package anything"
+    # Neutralized, not deleted: the step stays in place as a no-op with its
+    # old text in a comment, which is what a careless edit leaves behind.
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "unverified tag" \
+        's|^( *)\$HELPER verify-tag .*|\1: # verify-tag disabled|' \
+        'must run $HELPER verify-tag'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "unverified builder attestations" \
+        's|^( *)run: \$HELPER verify-digests .*|\1run: ": # verify-digests disabled"|' \
+        'must run $HELPER verify-digests'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "manifest upload skipped" \
+        's|^( *)run: gh release upload "\$TAG" MANIFEST\.json --clobber$|\1: # disabled|' \
+        'must run gh release upload "$TAG" MANIFEST.json'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "no revalidation before the flip" \
+        's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \
+        'must run PRERELEASE" final'
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "final readback comparing names only" \
+        's|^( *)\$HELPER verify-published .*|\1: # verify-published disabled|' \
+        'must run $HELPER verify-published'
+    assert_workflow_mutation_rejected "two runs publishing one tag" \
+        '/^concurrency:$/,/^$/d' \
+        "must declare a concurrency group"
+    assert_workflow_mutation_rejected "runs cancelling the one in progress" \
+        's/^  cancel-in-progress: false$/  cancel-in-progress: true/' \
+        "never cancel it"
+    assert_workflow_mutation_rejected "flake evaluation that cannot fail" \
+        's|^        run: nix flake check ./dist/nix --no-build$|        run: nix flake check ./dist/nix --no-build\n        continue-on-error: true|' \
+        "flake evaluation must gate publication"
+
+    # The checkout-ownership exception. Removed, neutralized, displaced, or
+    # owed by a job that just acquired git: each is a tag-time-only failure,
+    # which is the class this whole gate exists for.
+    assert_workflow_mutation_rejected "a container job left untrusting" \
+        '/^      - name: Trust the workspace checkout$/,+1d' \
+        "must trust the workspace checkout"
+    assert_workflow_mutation_rejected "the ownership exception neutralized" \
+        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"|' \
+        "must trust the workspace checkout with exactly"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "the ownership exception taken late" \
+        's|^      - name: Trust the workspace checkout$|      - name: Report the workspace\n        run: ls "$GITHUB_WORKSPACE"\n\n      - name: Trust the workspace checkout|' \
+        "immediately after checking it out"
+    assert_workflow_mutation_rejected "a container job gaining git untrusted" \
+        's|^            rust cargo clang-devel|            git rust cargo clang-devel|' \
+        "container job build-rpm installs git"
+    assert_workflow_mutation_rejected "an exception kept past its git install" \
+        's|^            git$||' \
+        "trusts the workspace checkout but installs no git"
+    # git as the very first package of the install, with no token before it.
+    assert_workflow_mutation_rejected "a container job installing git first" \
+        's|^          dnf install -y \\$|          dnf install git \\|' \
+        "container job build-rpm installs git"
+    # The exception read out of the job rather than out of its step: a no-op
+    # trust step beside a real `git config` line in a later one.
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "the exception moved out of its step" \
+        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"\n\n      - name: Trust it later\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"|' \
+        "must trust the workspace checkout with exactly"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "attestation left unbound to its job" \
+        '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \
+        "declares no attestation output"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "one suite of the matrix left unbound" \
+        '/^      attestation-resolute: /d' \
+        "differs from the release workflow's attestation outputs"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "job outputs not passed through env" \
+        's/^          JOB_OUTPUTS: \$\{\{ toJSON\(needs\) \}\}$/          JOB_OUTPUTS: fixed/' \
+        "through exactly one env value"
+    assert_workflow_mutation_rejected "pages rebuild before publication" \
+        's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
+        "trigger-pages must run after the release is published"
+    assert_workflow_mutation_rejected "COPR verification dropped" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^  trigger-pages:$/!d}' \
+        "release jobs drifted"
+    assert_workflow_mutation_rejected "COPR verification open to prereleases" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    if: /d}' \
+        "verify-copr must be stable-only"
+    assert_workflow_mutation_rejected "COPR verification polling without a deadline" \
+        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    timeout-minutes: /d}' \
+        "verify-copr polls and must carry its own timeout"
+    assert_workflow_mutation_rejected "release upload without the publication token" \
+        '0,/^          token: \$\{\{ secrets.RELEASE_PAT \}\}$/s///' \
+        "every release upload must pass the publication token"
+    # shellcheck disable=SC2016
+    assert_workflow_mutation_rejected "tag rewritten at publication" \
+        's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
+        "publishing must not send a tag or target commitish"
+
+    # Quote style is not semantics: a double-quoted --suite value must parse
+    # the same as the single-quoted one the workflow uses today, so extraction
+    # cannot silently go blind the day someone swaps the quoting.
+    suite_double_quoted="$mutation_root/release-suite-double-quoted.yml"
+    sed -E 's/--suite .(\$\{\{ matrix\.suite \}\})./--suite "\1"/' \
+        "$workflow_path" >"$suite_double_quoted"
+    cmp -s "$workflow_path" "$suite_double_quoted" &&
+        fail "double-quoted suite mutation did not change the workflow"
+    queue_mutation accepted FACELOCK_RELEASE_WORKFLOW "$suite_double_quoted" mutation "double-quoted --suite value"
+
+    launch_mutations
+fi
+
+# ------------------------------------------------------------------ workflow
 
 
 job_body() {
@@ -642,9 +960,6 @@ if grep -Eq "${git_command}push" "$helper_path"; then
 fi
 
 # ------------------------------------------------------- helper: by fixture
-
-work="$(mktemp -d "${TMPDIR:-/tmp}/facelock-release-artifacts.XXXXXX")"
-trap 'rm -rf -- "$work"' EXIT
 
 assert_rejects() {
     local context="$1" needle="$2"
@@ -1477,260 +1792,8 @@ assert_rejects "published asset the manifest does not cover" "not covered" \
     verify-published "$work/published-unlisted.json" v0.2.0 "$manifest"
 # ------------------------------------------------------------------ mutations
 
-if [ -z "${FACELOCK_RELEASE_WORKFLOW:-}" ] && [ -z "${FACELOCK_RELEASE_ASSETS:-}" ] &&
-    [ -z "${FACELOCK_RELEASE_ATTESTATIONS:-}" ]; then
-    mutation_root="$work/mutations"
-    mkdir -p "$mutation_root"
-
-    # The attesting set is the only thing standing between an extra artifact
-    # and forged provenance in MANIFEST.json, so prove the check is load-bearing.
-    assert_loader_mutation_rejected() {
-        local context="$1" expression="$2" needle="$3"
-        local loader=.github/workflows/scripts/release_attestations.py
-        local mutant
-        mutant="$mutation_root/release_attestations-$(printf '%s' "$context" | tr ' ' '-').py"
-        sed -E "$expression" "$loader" >"$mutant"
-        if cmp -s "$loader" "$mutant"; then
-            fail "$context mutation did not change the attestation loader"
-        fi
-        local output
-        if output="$(FACELOCK_RELEASE_ATTESTATIONS="$mutant" bash "$self" 2>&1)"; then
-            fail "release artifacts contract accepted $context"
-        fi
-        printf '%s\n' "$output" | grep -Fq "$needle" ||
-            fail "$context mutation failed for an unrelated reason: $output"
-        echo "release artifacts mutation: $context rejected"
-    }
-
-    assert_loader_mutation_rejected "an unpinned attesting set" \
-        's/^    unexpected = sorted\(set\(present\) - set\(expected\)\)$/    unexpected = []/' \
-        "extra digest artifact forging another job's provenance: helper accepted"
-    assert_loader_mutation_rejected "attestations trusted to name their own job" \
-        's/^        if document.get\("job"\) != job:$/        if False:/' \
-        "attestation declaring a job that is not its slot: helper accepted"
-    assert_loader_mutation_rejected "attestations not held to their job outputs" \
-        's/^        if actual != recorded:$/        if False:/' \
-        "attestation replaced after its job recorded it: helper accepted"
-    assert_loader_mutation_rejected "a missing job output tolerated" \
-        's/^        if not isinstance\(recorded, str\) or not DIGEST.fullmatch\(recorded\):$/        if False:/' \
-        "attesting job that recorded no output"
-    assert_loader_mutation_rejected "build images taken from the attestation" \
-        's/^        if document.get\("image"\) != image:$/        if False:/' \
-        "attestation swapping its build image: helper accepted"
-    assert_loader_mutation_rejected "component keys taken from the attestation" \
-        's/^        if sorted\(document.get\("components", \{\}\)\) != components:$/        if False:/' \
-        "attestation adding a component: helper accepted"
-
-    # The helper itself, mutated into a tree of its own so the checkout stays
-    # clean: it resolves the repository root from its own location.
-    assert_helper_mutation_rejected() {
-        local context="$1" expression="$2" needle="$3"
-        local root mutant
-        root="$mutation_root/helper-$(printf '%s' "$context" | tr ' ' '-')"
-        mkdir -p "$root/.github/workflows/scripts"
-        ln -s "$repo_root/scripts" "$root/scripts"
-        ln -s "$repo_root/dist" "$root/dist"
-        cp .github/workflows/scripts/release_attestations.py "$root/.github/workflows/scripts/"
-        mutant="$root/.github/workflows/scripts/release-assets.sh"
-        sed -E "$expression" "$helper_path" >"$mutant"
-        chmod +x "$mutant"
-        if cmp -s "$helper_path" "$mutant"; then
-            fail "$context mutation did not change the release asset helper"
-        fi
-        local output
-        if output="$(FACELOCK_RELEASE_ASSETS="$mutant" bash "$self" 2>&1)"; then
-            fail "release artifacts contract accepted $context"
-        fi
-        printf '%s\n' "$output" | grep -Fq "$needle" ||
-            fail "$context mutation failed for an unrelated reason: $output"
-        echo "release artifacts mutation: $context rejected"
-    }
-
-    # shellcheck disable=SC2016
-    assert_helper_mutation_rejected "an empty suite list tolerated" \
-        's/^    \[ -n "\$listing" \] \|\| fail "the release matrix names no Debian suite.*$/    [ -n "$listing" ] || return 0/' \
-        "allowlist from a matrix with no suite: helper accepted"
-    assert_helper_mutation_rejected "python running with the working directory on its path" \
-        's/^export PYTHONSAFEPATH=1$/: # safe path disabled/' \
-        "imported a module from its working directory"
-
-    assert_workflow_mutation_rejected() {
-        local context="$1" expression="$2" needle="$3"
-        local mutated
-        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
-        sed -E "$expression" "$workflow_path" >"$mutated"
-        if cmp -s "$workflow_path" "$mutated"; then
-            fail "$context mutation did not change the workflow"
-        fi
-        local output
-        if output="$(FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$self" 2>&1)"; then
-            fail "release artifacts contract accepted $context"
-        fi
-        printf '%s\n' "$output" | grep -Fq "$needle" ||
-            fail "$context mutation failed for an unrelated reason: $output"
-        echo "release artifacts mutation: $context rejected"
-    }
-
-    assert_workflow_mutation_rejected "the deb step left on the image shell" \
-        '/^      - name: Build suite-specific \.deb package$/,/^        run: \|$/{/^        shell: bash$/d}' \
-        "declare 'shell: bash' on step: Build suite-specific .deb package"
-    assert_workflow_mutation_rejected "the rpm step left on the image shell" \
-        '/^      - name: Select the packages the validated metadata names$/,/^        run: \|$/{/^        shell: bash$/d}' \
-        "declare 'shell: bash' on step: Select the packages the validated metadata names"
-    assert_workflow_mutation_rejected "a container step shell weakened to sh" \
-        's/^        shell: bash$/        shell: sh/' \
-        "runs bash-only syntax under the image's /bin/sh"
-    assert_workflow_mutation_rejected "a one-line container step turning bash" \
-        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|        run: [[ -d cargo-vendor ]] \&\& scripts/prepare-cargo-vendor.sh verify cargo-vendor|' \
-        "declare 'shell: bash' on step: Verify exact Cargo vendor bundle"
-    assert_workflow_mutation_rejected "a nameless container step turning bash" \
-        '/^      - name: Verify exact Cargo vendor bundle$/,+1c\      - run: [[ -d cargo-vendor ]] && scripts/prepare-cargo-vendor.sh verify cargo-vendor' \
-        "runs bash-only syntax under the image's /bin/sh"
-
-    # The other direction of the step-shell rule: a workflow it must not
-    # reject. Whole-line YAML comments never reach the scanner because
-    # job_statements strips them first, so a comment illustrating bash syntax
-    # is documentation and not a step written in bash. Pinned because the
-    # stripping happens a long way from the scan, and a later rewrite reading
-    # job_body directly would make this comment look like script.
-    assert_workflow_mutation_accepted() {
-        local context="$1" expression="$2"
-        local mutated
-        mutated="$mutation_root/release-$(printf '%s' "$context" | tr ' ' '-').yml"
-        sed -E "$expression" "$workflow_path" >"$mutated"
-        if cmp -s "$workflow_path" "$mutated"; then
-            fail "$context mutation did not change the workflow"
-        fi
-        FACELOCK_RELEASE_WORKFLOW="$mutated" bash "$self" >/dev/null 2>&1 ||
-            fail "release artifacts contract rejected $context"
-        echo "release artifacts case: $context accepted"
-    }
-
-    assert_workflow_mutation_accepted "a container step commented with bash syntax" \
-        's|^        run: scripts/prepare-cargo-vendor\.sh verify cargo-vendor$|&\n        # example: [[ -f file ]] \&\& mapfile -t x < <(echo hi)|'
-    assert_workflow_mutation_rejected "public release creation" \
-        's/^          draft: true$//' \
-        "must create the GitHub release as a draft"
-    assert_workflow_mutation_rejected "builder holding the release write scope" \
-        '0,/^      contents: read$/s//      contents: write/' \
-        "only the publish job may hold contents: write"
-    # The mutation expressions below name literal workflow text, not shell
-    # expansions.
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "builder holding the publication credential" \
-        's/^      - name: Build release$/      - name: Build release\n        env:\n          TOKEN: ${{ secrets.RELEASE_PAT }}/' \
-        "builders produce artifacts only"
-    assert_workflow_mutation_rejected "builder writing the release directly" \
-        's|^      - name: Upload the APT repository artifact$|      - name: Write the release\n        uses: softprops/action-gh-release@0000\n\n      - name: Upload the APT repository artifact|' \
-        "builders produce artifacts only"
-    assert_workflow_mutation_rejected "compiling in the publishing job" \
-        's|^      - name: Verify the maintainer tag$|      - name: Rebuild\n        run: cargo build --release\n\n      - name: Verify the maintainer tag|' \
-        "must not compile or package anything"
-    # Neutralized, not deleted: the step stays in place as a no-op with its
-    # old text in a comment, which is what a careless edit leaves behind.
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "unverified tag" \
-        's|^( *)\$HELPER verify-tag .*|\1: # verify-tag disabled|' \
-        'must run $HELPER verify-tag'
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "unverified builder attestations" \
-        's|^( *)run: \$HELPER verify-digests .*|\1run: ": # verify-digests disabled"|' \
-        'must run $HELPER verify-digests'
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "manifest upload skipped" \
-        's|^( *)run: gh release upload "\$TAG" MANIFEST\.json --clobber$|\1: # disabled|' \
-        'must run gh release upload "$TAG" MANIFEST.json'
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "no revalidation before the flip" \
-        's|^( *)\$HELPER expected "\$VERSION" "\$DEBIAN_REVISION" "\$RPM_COUNTER" "\$PRERELEASE" final .*|\1: # final readback disabled|' \
-        'must run PRERELEASE" final'
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "final readback comparing names only" \
-        's|^( *)\$HELPER verify-published .*|\1: # verify-published disabled|' \
-        'must run $HELPER verify-published'
-    assert_workflow_mutation_rejected "two runs publishing one tag" \
-        '/^concurrency:$/,/^$/d' \
-        "must declare a concurrency group"
-    assert_workflow_mutation_rejected "runs cancelling the one in progress" \
-        's/^  cancel-in-progress: false$/  cancel-in-progress: true/' \
-        "never cancel it"
-    assert_workflow_mutation_rejected "flake evaluation that cannot fail" \
-        's|^        run: nix flake check ./dist/nix --no-build$|        run: nix flake check ./dist/nix --no-build\n        continue-on-error: true|' \
-        "flake evaluation must gate publication"
-
-    # The checkout-ownership exception. Removed, neutralized, displaced, or
-    # owed by a job that just acquired git: each is a tag-time-only failure,
-    # which is the class this whole gate exists for.
-    assert_workflow_mutation_rejected "a container job left untrusting" \
-        '/^      - name: Trust the workspace checkout$/,+1d' \
-        "must trust the workspace checkout"
-    assert_workflow_mutation_rejected "the ownership exception neutralized" \
-        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"|' \
-        "must trust the workspace checkout with exactly"
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "the ownership exception taken late" \
-        's|^      - name: Trust the workspace checkout$|      - name: Report the workspace\n        run: ls "$GITHUB_WORKSPACE"\n\n      - name: Trust the workspace checkout|' \
-        "immediately after checking it out"
-    assert_workflow_mutation_rejected "a container job gaining git untrusted" \
-        's|^            rust cargo clang-devel|            git rust cargo clang-devel|' \
-        "container job build-rpm installs git"
-    assert_workflow_mutation_rejected "an exception kept past its git install" \
-        's|^            git$||' \
-        "trusts the workspace checkout but installs no git"
-    # git as the very first package of the install, with no token before it.
-    assert_workflow_mutation_rejected "a container job installing git first" \
-        's|^          dnf install -y \\$|          dnf install git \\|' \
-        "container job build-rpm installs git"
-    # The exception read out of the job rather than out of its step: a no-op
-    # trust step beside a real `git config` line in a later one.
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "the exception moved out of its step" \
-        's|^        run: git config --global --add safe\.directory .*$|        run: ": # trust disabled"\n\n      - name: Trust it later\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"|' \
-        "must trust the workspace checkout with exactly"
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "attestation left unbound to its job" \
-        '0,/^      attestation: \$\{\{ steps.attest.outputs.sha256 \}\}$/s///' \
-        "declares no attestation output"
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "one suite of the matrix left unbound" \
-        '/^      attestation-resolute: /d' \
-        "differs from the release workflow's attestation outputs"
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "job outputs not passed through env" \
-        's/^          JOB_OUTPUTS: \$\{\{ toJSON\(needs\) \}\}$/          JOB_OUTPUTS: fixed/' \
-        "through exactly one env value"
-    assert_workflow_mutation_rejected "pages rebuild before publication" \
-        's/^    needs: \[publish-apt, publish\]$/    needs: [publish-apt]/' \
-        "trigger-pages must run after the release is published"
-    assert_workflow_mutation_rejected "COPR verification dropped" \
-        '/^  verify-copr:$/,/^  trigger-pages:$/{/^  trigger-pages:$/!d}' \
-        "release jobs drifted"
-    assert_workflow_mutation_rejected "COPR verification open to prereleases" \
-        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    if: /d}' \
-        "verify-copr must be stable-only"
-    assert_workflow_mutation_rejected "COPR verification polling without a deadline" \
-        '/^  verify-copr:$/,/^  trigger-pages:$/{/^    timeout-minutes: /d}' \
-        "verify-copr polls and must carry its own timeout"
-    assert_workflow_mutation_rejected "release upload without the publication token" \
-        '0,/^          token: \$\{\{ secrets.RELEASE_PAT \}\}$/s///' \
-        "every release upload must pass the publication token"
-    # shellcheck disable=SC2016
-    assert_workflow_mutation_rejected "tag rewritten at publication" \
-        's/^      TAG: \$\{\{ github.ref_name \}\}$/      TAG: ${{ github.ref_name }}\n      TAG_TARGET: target_commitish/' \
-        "publishing must not send a tag or target commitish"
-
-    # Quote style is not semantics: a double-quoted --suite value must parse
-    # the same as the single-quoted one the workflow uses today, so extraction
-    # cannot silently go blind the day someone swaps the quoting.
-    suite_double_quoted="$mutation_root/release-suite-double-quoted.yml"
-    sed -E 's/--suite .(\$\{\{ matrix\.suite \}\})./--suite "\1"/' \
-        "$workflow_path" >"$suite_double_quoted"
-    cmp -s "$workflow_path" "$suite_double_quoted" &&
-        fail "double-quoted suite mutation did not change the workflow"
-    if ! output="$(FACELOCK_RELEASE_WORKFLOW="$suite_double_quoted" bash "$self" 2>&1)"; then
-        fail "release artifacts contract rejected a double-quoted --suite value: $output"
-    fi
-    echo "release artifacts mutation: double-quoted --suite value accepted"
+if [ -n "${mutation_scheduler:-}" ]; then
+    report_mutations
 fi
 
 # The helper's Python runs from whatever directory the workflow is in; a module


### PR DESCRIPTION
## Summary

- write the 44 mutants before the static pass and start their re-runs in the background, `xargs -P` bounded by `FACELOCK_MUTATION_JOBS` (default: one per CPU), while the parent runs its own checks
- read the verdicts out in queue order at the end; list every failure before the gate exits instead of stopping at the first
- keep `FACELOCK_MUTATION_JOBS=1` as the serial path for debugging a mutation
- leave the set of mutations, their expressions and needles unchanged

## Why

Each mutation check re-runs the whole contract against a mutated copy, and the two runs that must be accepted pay the full static pass, so one invocation took over three minutes locally and 184s in the Agent Docs Consistency job. The runs share nothing (each allocates its own mktemp tree and only reads the checkout), so they can overlap with each other and with the parent's static pass. Locally the gate drops from about 3m30s to 35s; with four jobs, the CI runner's shape, to about 65s.

## Validation

- `just test-release-artifacts` three times at the default parallelism, output diffed line for line against the serial run
- `FACELOCK_MUTATION_JOBS=1` and `=4`
- one mutation neutralized to a harmless edit, then one needle broken: each run reports that failure and still lists the other 43 verdicts
- `just check-agent-docs`, `just check-docs`, `shellcheck -S warning`

Fixes #376
