### PR TITLE
fix(setup): Seal an existing keyfile on the automatic encryption path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flags (#354). With a usable TPM an existing `encryption.key` is sealed into
   `encryption.key.sealed` rather than shadowed by a fresh random key; without one, an
   existing sealed key is left in place while the keyfile is minted, with a notice. The
-  orphaned-models guard on `--encryption auto` runs exactly when a key is minted.
+  orphaned-models guard on `--encryption auto` runs exactly when a key is minted, and a
+  minted sealed key now goes through the same shared key gate as a minted keyfile, so a
+  flagless `facelock setup` refuses to seal a new key over rows the missing one wrote.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   orphaned-models guard on `--encryption auto` runs exactly when a key is minted, and a
   minted sealed key now goes through the same shared key gate as a minted keyfile, so a
   flagless `facelock setup` refuses to seal a new key over rows the missing one wrote.
+  One input changes outcome rather than key identity: an `encryption.key` that is not a
+  32-byte AES key used to be ignored, with a fresh sealed key minted beside it, and is now
+  a refusal, because sealing is what the auto path does with an existing keyfile. The
+  refusal names the file, its size and the remedy (restore the real key, or remove it and
+  re-run), since it stops setup before it secures paths and writes its marker.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PAM line's placement above distribution skip guards and `abort_if_lid_closed = false` as
   the opt-out for a docked laptop with an external camera.
 
+- **`facelock setup --encryption auto` no longer mints a second key beside an existing one**
+  (#358): the automatic policy, which the non-interactive base also runs when no
+  `--encryption` flag is given, now makes the same key-carrying decision as the explicit
+  flags (#354). With a usable TPM an existing `encryption.key` is sealed into
+  `encryption.key.sealed` rather than shadowed by a fresh random key; without one, an
+  existing sealed key is left in place while the keyfile is minted, with a notice. The
+  orphaned-models guard on `--encryption auto` runs exactly when a key is minted.
+
 ### Added
 
 - **A synthetic camera for the camera-required test tiers** (#139): `just test-arch-loopback`
@@ -48,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `-deb`, `-rpm`, `-contract` and `-pins` (was `just test-upgrade-v014*`). v0.1.4 stays pinned for
   the retired-authselect fixture, and the COPR served-EVR gap record retires with the pin it excused.
 
+||||||| parent of 26777442 (fix(setup): Seal an existing keyfile on the automatic encryption path)
 ## [0.2.1] - 2026-09-07
 
 ### Changed

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1667,6 +1667,7 @@ fn handle_orphan_models_before_keygen(
 #[cfg(test)]
 mod orphan_guard_tests {
     use super::*;
+    use facelock_core::config::EncryptionMethod::{Keyfile, Tpm};
     use std::path::Path;
 
     fn config_with_db(db_path: &Path) -> Config {
@@ -1800,7 +1801,7 @@ mod orphan_guard_tests {
                 .unwrap();
         }
 
-        let refusal = keygen_refusal(&config_with_key(&db_path, &key_path))
+        let refusal = keygen_refusal(&config_with_key(&db_path, &key_path), Keyfile)
             .unwrap()
             .expect("the auto policy must refuse over encrypted rows");
         assert!(
@@ -1823,7 +1824,7 @@ mod orphan_guard_tests {
         }
 
         assert!(
-            keygen_refusal(&config_with_key(&db_path, &key_path))
+            keygen_refusal(&config_with_key(&db_path, &key_path), Keyfile)
                 .unwrap()
                 .is_none()
         );
@@ -1844,7 +1845,7 @@ mod orphan_guard_tests {
         let mut config = config_with_key(&db_path, &key_path);
         config.encryption.method = EncryptionMethod::None;
 
-        assert!(keygen_refusal(&config).unwrap().is_none());
+        assert!(keygen_refusal(&config, Keyfile).unwrap().is_none());
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
     }
 
@@ -1857,12 +1858,58 @@ mod orphan_guard_tests {
         let key_path = dir.path().join("encryption.key");
 
         assert!(
-            keygen_refusal(&config_with_key(&db_path, &key_path))
+            keygen_refusal(&config_with_key(&db_path, &key_path), Keyfile)
                 .unwrap()
                 .is_none()
         );
         assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
         assert!(!db_path.exists(), "the key gate must not create a database");
+    }
+
+    /// The TPM target asks the same question and must answer it without
+    /// writing the keyfile the keyfile target creates (#358): the sealing
+    /// path leaves no plaintext key behind, and it refuses over rows a key
+    /// nothing can reproduce would orphan.
+    #[test]
+    fn the_auto_policy_refuses_a_sealed_mint_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            let sealed = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+                .seal_embedding(&[0.5f32; 512])
+                .unwrap();
+            store
+                .add_model_raw("alice", "front", &sealed, true, "embedder")
+                .unwrap();
+        }
+
+        let refusal = keygen_refusal(&config_with_key(&db_path, &key_path), Tpm)
+            .unwrap()
+            .expect("a sealed mint must refuse over encrypted rows");
+        assert!(refusal.contains("software-encrypted"), "{refusal}");
+        assert!(!key_path.exists(), "the tpm gate must not write a keyfile");
+    }
+
+    #[test]
+    fn the_auto_policy_allows_a_sealed_mint_on_a_plaintext_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("encryption.key");
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            store
+                .add_model("alice", "front", &[0.5f32; 512], "embedder")
+                .unwrap();
+        }
+
+        assert!(
+            keygen_refusal(&config_with_key(&db_path, &key_path), Tpm)
+                .unwrap()
+                .is_none()
+        );
+        assert!(!key_path.exists(), "the tpm gate must not write a keyfile");
     }
 
     #[test]
@@ -1872,7 +1919,7 @@ mod orphan_guard_tests {
         let key_path = dir.path().join("encryption.key");
         std::fs::write(&db_path, b"not a sqlite database").unwrap();
 
-        let err = keygen_refusal(&config_with_key(&db_path, &key_path)).unwrap_err();
+        let err = keygen_refusal(&config_with_key(&db_path, &key_path), Keyfile).unwrap_err();
         let chain = format!("{err:#}");
         assert!(chain.contains("could not be read"), "{chain}");
         assert!(!key_path.exists());
@@ -3240,13 +3287,22 @@ fn run_non_interactive(plan: &SetupPlan) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Run the shared key gate for a setup path that is about to mint the
-/// encrypt-by-default key file, returning the refusal if there is one.
+/// Run the shared key gate for a setup path that is about to mint a key for
+/// `target`, returning the refusal if there is one.
 ///
 /// `open_existing`, never `create`: a database that is not there yet holds no
 /// templates to orphan, and the probe must not create one to prove it. Every
 /// other failure class means facelock cannot tell, which is a refusal.
-fn keygen_refusal(config: &Config) -> anyhow::Result<Option<String>> {
+///
+/// A `Keyfile` target runs the gate that also *writes* the key, because
+/// encrypt-by-default means the keyfile setup path's job is to create it. A
+/// `Tpm` target runs the pure predicate instead: the writing gate only ever
+/// writes a keyfile, and the sealing path must not leave a live plaintext key
+/// on disk on its way to the TPM.
+fn keygen_refusal(
+    config: &Config,
+    target: facelock_core::config::EncryptionMethod,
+) -> anyhow::Result<Option<String>> {
     // An absent database holds no template to orphan, and the probe must not
     // create one to prove it — but the rest of the gate (the symlink check,
     // the exclusive create) still has to run, and an empty store is exactly
@@ -3267,17 +3323,19 @@ fn keygen_refusal(config: &Config) -> anyhow::Result<Option<String>> {
             config.storage.db_path
         ),
     };
-    // The gate mints only for `method = "keyfile"`, and the caller reaches
-    // here precisely because the method is still `none` — it is about to
-    // write `keyfile` a few lines later. Ask the gate the question it will be
-    // answering, not the one the config still says.
-    let mut as_keyfile = config.clone();
-    as_keyfile.encryption.method = facelock_core::config::EncryptionMethod::Keyfile;
-    Ok(
-        facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, &as_keyfile)
-            .refusal()
-            .map(str::to_string),
-    )
+    // The caller reaches here precisely because the method is still `none` —
+    // it is about to write `target` a few lines later. Ask the gate the
+    // question it will be answering, not the one the config still says.
+    let mut as_target = config.clone();
+    as_target.encryption.method = target.clone();
+    Ok(match target {
+        facelock_core::config::EncryptionMethod::Keyfile => {
+            facelock_daemon::key_policy::ensure_encrypt_by_default_key(&store, &as_target)
+                .refusal()
+                .map(str::to_string)
+        }
+        _ => facelock_daemon::key_policy::key_creation_refusal(&store, &as_target),
+    })
 }
 
 /// Auto-configure encryption in non-interactive mode.
@@ -3337,6 +3395,15 @@ fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow
                     });
                 }
                 KeyAction::Mint => {
+                    // The same gate the keyfile branch below runs, asked of
+                    // the sealed key this is about to write: a key nothing on
+                    // disk can reproduce must not be minted over rows the
+                    // missing one sealed. `run_non_interactive` reaches this
+                    // branch with no `--encryption` flag and so never ran
+                    // `handle_orphan_models_before_keygen`.
+                    if let Some(refusal) = keygen_refusal(config, EncryptionMethod::Tpm)? {
+                        bail!("{refusal}");
+                    }
                     let pcr = if config.tpm.pcr_binding {
                         Some(config.tpm.pcr_indices.as_slice())
                     } else {
@@ -3376,7 +3443,7 @@ fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow
     // an offer to clear); this is the backstop for the automatic policy, which
     // `run_non_interactive` reaches with no flag at all — the command
     // `debian/postinst` tells operators to run.
-    if let Some(refusal) = keygen_refusal(config)? {
+    if let Some(refusal) = keygen_refusal(config, EncryptionMethod::Keyfile)? {
         bail!("{refusal}");
     }
     match action {

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -6609,6 +6609,74 @@ mod choice_tests {
         assert!(!key_path.exists(), "the tpm target must not mint a keyfile");
     }
 
+    /// The gate on the sealing mint, driven through `setup_encryption_auto`
+    /// rather than called directly: a host whose key artifacts are both gone
+    /// but whose database still holds encrypted rows must be refused, not
+    /// handed a new sealed key that leaves those rows dead.
+    #[cfg(feature = "tpm")]
+    #[test]
+    fn auto_policy_refuses_to_seal_a_new_key_over_encrypted_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("facelock.db");
+        let key_path = dir.path().join("facelock.key"); // absent
+        let sealed_path = dir.path().join("sealed.key"); // absent
+        {
+            let store = facelock_store::FaceStore::create(&db_path).unwrap();
+            let sealed = facelock_tpm::SoftwareSealer::from_key([0x11u8; 32])
+                .seal_embedding(&[0.5f32; 512])
+                .unwrap();
+            store
+                .add_model_raw("alice", "front", &sealed, true, "embedder")
+                .unwrap();
+        }
+
+        let mut config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        config.storage.db_path = db_path.to_string_lossy().into_owned();
+
+        let err = setup_encryption_auto(&config, Some(true))
+            .expect_err("a sealing mint over encrypted rows must be refused");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("refusing to write an encryption key"),
+            "the refusal must name the decision: {chain}"
+        );
+        assert!(
+            chain.contains("software-encrypted"),
+            "the refusal must name the rows at risk: {chain}"
+        );
+        assert!(!sealed_path.exists(), "no sealed key may be written");
+        assert!(!key_path.exists(), "no keyfile may be written either");
+    }
+
+    /// A keyfile that is not a 32-byte AES key cannot be sealed, and #358
+    /// routed that input from "mint a sealed key beside it" to a refusal.
+    /// The refusal has to say what to do about it: setup aborts before
+    /// `secure_setup_paths` and the setup marker, so an operator who cannot
+    /// act on the message is left with a half-applied run.
+    #[cfg(feature = "tpm")]
+    #[test]
+    fn auto_policy_refusal_over_a_malformed_keyfile_names_the_remedy() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let sealed_path = dir.path().join("sealed.key"); // absent
+        std::fs::write(&key_path, b"far too short").unwrap();
+
+        let config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        let err = setup_encryption_auto(&config, Some(true))
+            .expect_err("a keyfile that is not a key cannot be sealed");
+        let chain = format!("{err:#}");
+        assert!(chain.contains("32 bytes"), "{chain}");
+        assert!(
+            chain.contains(&key_path.display().to_string()),
+            "the refusal must name the file: {chain}"
+        );
+        assert!(
+            chain.contains("remove it"),
+            "the refusal must name the remedy: {chain}"
+        );
+        assert!(!sealed_path.exists(), "no sealed key may be written");
+    }
+
     /// The mirror of #358: keyfile absent, sealed key present, TPM unusable.
     /// Nothing can unseal it, so a keyfile is minted — and the sealed
     /// artifact stays on disk, as `--encryption keyfile` leaves it.
@@ -6697,7 +6765,8 @@ mod choice_tests {
 
         // With a usable TPM that keyfile is sealed, not shadowed by a fresh
         // sealed key (#358) — so no key is minted and the guard is skipped.
-        #[cfg(feature = "tpm")]
+        // True in either build: without the tpm feature the plan targets the
+        // keyfile, which already exists.
         assert!(!auto_encryption_needs_keygen(&config, true));
 
         // A sealed key nothing can unseal does not spare the keyfile target a

--- a/crates/facelock-cli/src/commands/setup.rs
+++ b/crates/facelock-cli/src/commands/setup.rs
@@ -1949,6 +1949,42 @@ fn plan_key_action(
     }
 }
 
+/// The automatic policy's decision (`--encryption auto`, and the
+/// non-interactive base with no flag): pick the target from TPM usability,
+/// then make the same key-carrying decision as [`plan_key_action`].
+///
+/// Pulled out (issue #358) because `setup_encryption_auto` kept its own
+/// inline `!sealed_path.exists()` check after #354 routed the explicit flags
+/// through `plan_key_action`, so it still minted a second key beside an
+/// existing keyfile. `tpm_usable` must already fold in whether TPM support
+/// is compiled in: without it the keyfile target is the only one reachable,
+/// and no sealed key can be unsealed, so `Keyfile` is planned with the TPM
+/// marked unusable.
+fn plan_auto_key_action(
+    tpm_usable: bool,
+    keyfile_exists: bool,
+    sealed_exists: bool,
+) -> (facelock_core::config::EncryptionMethod, KeyAction) {
+    use facelock_core::config::EncryptionMethod;
+
+    if tpm_usable {
+        (
+            EncryptionMethod::Tpm,
+            plan_key_action(EncryptionMethod::Tpm, keyfile_exists, sealed_exists, true),
+        )
+    } else {
+        (
+            EncryptionMethod::Keyfile,
+            plan_key_action(
+                EncryptionMethod::Keyfile,
+                keyfile_exists,
+                sealed_exists,
+                false,
+            ),
+        )
+    }
+}
+
 #[cfg(test)]
 mod plan_key_action_tests {
     use super::*;
@@ -2043,6 +2079,69 @@ mod plan_key_action_tests {
     #[should_panic(expected = "only consulted for a Tpm or Keyfile target")]
     fn none_target_is_never_consulted() {
         plan_key_action(EncryptionMethod::None, false, false, false);
+    }
+
+    // -- the automatic policy (issue #358) --
+    //
+    // `--encryption auto`, and the non-interactive base with no flag at all,
+    // pick the target from TPM usability and then must make the same
+    // key-carrying decision the explicit flags make.
+
+    /// The bug issue #358 reports: a keyfile with no sealed key on a
+    /// TPM-capable host must be sealed, not shadowed by a fresh random key.
+    #[test]
+    fn auto_with_a_usable_tpm_seals_an_existing_keyfile() {
+        assert_eq!(
+            plan_auto_key_action(true, true, false),
+            (EncryptionMethod::Tpm, KeyAction::SealExistingKeyfile)
+        );
+    }
+
+    #[test]
+    fn auto_with_a_usable_tpm_reuses_an_existing_sealed_key() {
+        assert_eq!(
+            plan_auto_key_action(true, false, true),
+            (EncryptionMethod::Tpm, KeyAction::ReuseExisting)
+        );
+        assert_eq!(
+            plan_auto_key_action(true, true, true),
+            (EncryptionMethod::Tpm, KeyAction::ReuseExisting)
+        );
+    }
+
+    #[test]
+    fn auto_with_a_usable_tpm_mints_only_when_no_artifact_exists() {
+        assert_eq!(
+            plan_auto_key_action(true, false, false),
+            (EncryptionMethod::Tpm, KeyAction::Mint)
+        );
+    }
+
+    #[test]
+    fn auto_without_a_tpm_reuses_an_existing_keyfile() {
+        assert_eq!(
+            plan_auto_key_action(false, true, false),
+            (EncryptionMethod::Keyfile, KeyAction::ReuseExisting)
+        );
+        assert_eq!(
+            plan_auto_key_action(false, true, true),
+            (EncryptionMethod::Keyfile, KeyAction::ReuseExisting)
+        );
+    }
+
+    /// The mirror case: a sealed key nothing can unseal is not key material
+    /// the keyfile target can carry forward, so it mints — the same answer
+    /// `--encryption keyfile` gives, and the sealed artifact stays on disk.
+    #[test]
+    fn auto_without_a_tpm_mints_a_keyfile_beside_an_unreachable_sealed_key() {
+        assert_eq!(
+            plan_auto_key_action(false, false, true),
+            (EncryptionMethod::Keyfile, KeyAction::Mint)
+        );
+        assert_eq!(
+            plan_auto_key_action(false, false, false),
+            (EncryptionMethod::Keyfile, KeyAction::Mint)
+        );
     }
 }
 
@@ -2310,19 +2409,18 @@ fn setup_encryption_none(config: &mut Config) -> anyhow::Result<()> {
 }
 
 /// True if the auto policy would mint a new key, and therefore needs the
-/// orphaned-models guard first.
+/// orphaned-models guard first. The same decision `setup_encryption_auto`
+/// acts on, so the guard runs exactly when a key is minted (#358).
 fn auto_encryption_needs_keygen(config: &Config, tpm_available: bool) -> bool {
     use facelock_core::config::EncryptionMethod;
 
     if config.encryption.method != EncryptionMethod::None {
         return false;
     }
-    let key_path = if tpm_available {
-        &config.encryption.sealed_key_path
-    } else {
-        &config.encryption.key_path
-    };
-    !Path::new(key_path).exists()
+    let keyfile_exists = Path::new(&config.encryption.key_path).exists();
+    let sealed_exists = Path::new(&config.encryption.sealed_key_path).exists();
+    let tpm_usable = tpm_available && cfg!(feature = "tpm");
+    plan_auto_key_action(tpm_usable, keyfile_exists, sealed_exists).1 == KeyAction::Mint
 }
 
 /// Apply `--encryption`. `theme` is `None` where prompting is not allowed.
@@ -3202,24 +3300,61 @@ fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow
         return Ok(());
     }
 
-    // Try TPM first
-    if tpm_available.unwrap_or_else(|| detect_tpm(config)) {
+    let key_path = Path::new(&config.encryption.key_path);
+    let sealed_path = Path::new(&config.encryption.sealed_key_path);
+    let keyfile_exists = key_path.exists();
+    let sealed_exists = sealed_path.exists();
+    // Without TPM support compiled in, a usable device is still not a target
+    // this build can seal to; the keyfile fallback is all it has.
+    let tpm_usable = tpm_available.unwrap_or_else(|| detect_tpm(config)) && cfg!(feature = "tpm");
+
+    // The same key-carrying decision the explicit `--encryption` flags make
+    // (#354), so the auto path never mints a second key beside an existing
+    // one (#358).
+    let (target, action) = plan_auto_key_action(tpm_usable, keyfile_exists, sealed_exists);
+
+    if target == EncryptionMethod::Tpm {
         #[cfg(feature = "tpm")]
         {
-            let sealed_path = Path::new(&config.encryption.sealed_key_path);
-            if !sealed_path.exists() {
-                let pcr = if config.tpm.pcr_binding {
-                    Some(config.tpm.pcr_indices.as_slice())
-                } else {
-                    None
-                };
-                let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
-                    .context("failed to initialize TPM")?;
-                facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
-                    .context("failed to generate and seal key")?;
-                Terminal.info(&SetupMessage::GeneratedTpmKeyAt {
-                    path: sealed_path.display().to_string(),
-                });
+            match action {
+                KeyAction::ReuseExisting => {
+                    Terminal.info(&SetupMessage::TpmSealedKeyPresent {
+                        path: sealed_path.display().to_string(),
+                    });
+                    if keyfile_exists {
+                        notice_if_keys_diverged(config, key_path, sealed_path);
+                    }
+                }
+                KeyAction::SealExistingKeyfile => {
+                    Terminal.info(&SetupMessage::SealingExistingKeyfile {
+                        key_path: key_path.display().to_string(),
+                        sealed_path: sealed_path.display().to_string(),
+                    });
+                    super::tpm::seal_existing_keyfile(config)
+                        .context("failed to seal the existing key with the TPM")?;
+                    Terminal.info(&SetupMessage::TpmSealedKeyWritten {
+                        path: sealed_path.display().to_string(),
+                    });
+                }
+                KeyAction::Mint => {
+                    let pcr = if config.tpm.pcr_binding {
+                        Some(config.tpm.pcr_indices.as_slice())
+                    } else {
+                        None
+                    };
+                    let mut tpm = facelock_tpm::TpmSealer::new(&config.tpm.tcti)
+                        .context("failed to initialize TPM")?;
+                    facelock_tpm::generate_and_seal_key(&mut tpm, sealed_path, pcr)
+                        .context("failed to generate and seal key")?;
+                    Terminal.info(&SetupMessage::GeneratedTpmKeyAt {
+                        path: sealed_path.display().to_string(),
+                    });
+                }
+                KeyAction::UnsealExistingSealed => {
+                    unreachable!(
+                        "plan_key_action never returns UnsealExistingSealed for a Tpm target"
+                    )
+                }
             }
             let mut config = config.clone();
             config.encryption.method = EncryptionMethod::Tpm;
@@ -3227,9 +3362,13 @@ fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow
             Terminal.info(&SetupMessage::EncryptionEnabledTpmAuto);
             return Ok(());
         }
+        #[cfg(not(feature = "tpm"))]
+        {
+            unreachable!("plan_auto_key_action never targets Tpm without the tpm feature")
+        }
     }
 
-    // Fall back to keyfile. Through the gate shared with the daemon, the
+    // Keyfile: reuse or mint. Through the gate shared with the daemon, the
     // one-shot path and `facelock encrypt`, so no writer of this key can drift
     // on when a replacement may be written over encrypted templates (#231).
     // `handle_orphan_models_before_keygen` still guards the interactive
@@ -3237,15 +3376,32 @@ fn setup_encryption_auto(config: &Config, tpm_available: Option<bool>) -> anyhow
     // an offer to clear); this is the backstop for the automatic policy, which
     // `run_non_interactive` reaches with no flag at all — the command
     // `debian/postinst` tells operators to run.
-    let key_path = Path::new(&config.encryption.key_path);
-    let existed = key_path.exists();
     if let Some(refusal) = keygen_refusal(config)? {
         bail!("{refusal}");
     }
-    if !existed && key_path.exists() {
-        Terminal.info(&SetupMessage::GeneratedKeyfileAt {
-            path: key_path.display().to_string(),
-        });
+    match action {
+        KeyAction::ReuseExisting => {
+            if sealed_exists {
+                notice_if_keys_diverged(config, key_path, sealed_path);
+            }
+        }
+        KeyAction::Mint => {
+            if key_path.exists() {
+                Terminal.info(&SetupMessage::GeneratedKeyfileAt {
+                    path: key_path.display().to_string(),
+                });
+            }
+            // No usable TPM can unseal it, so it could not be carried over;
+            // it stays on disk for when the TPM comes back.
+            if sealed_exists {
+                Terminal.notice(&SetupMessage::SealedKeyLeftInPlace {
+                    sealed_path: sealed_path.display().to_string(),
+                });
+            }
+        }
+        KeyAction::SealExistingKeyfile | KeyAction::UnsealExistingSealed => {
+            unreachable!("plan_auto_key_action never carries a key across for a Keyfile target")
+        }
     }
 
     let mut config = config.clone();
@@ -6296,6 +6452,159 @@ mod choice_tests {
         assert_eq!(config.encryption.method, EncryptionMethod::Tpm);
     }
 
+    // -- the automatic policy (issue #358): `--encryption auto`, and the
+    // -- non-interactive base with no flag, must make the same key-carrying
+    // -- decision as the explicit flags above.
+
+    /// A TPM that no seal can reach, so a test that takes the seal branch
+    /// fails at the TPM step rather than at the decision — which is what
+    /// these tests pin.
+    fn config_for_auto(
+        dir: &std::path::Path,
+        key_path: &std::path::Path,
+        sealed_path: &std::path::Path,
+    ) -> Config {
+        let mut config = config_for_key_dispatch(dir, key_path, sealed_path);
+        config.encryption.method = EncryptionMethod::None;
+        config.tpm.tcti = "device:/nonexistent/facelock-test-tpm".to_string();
+        config
+    }
+
+    /// The bug issue #358 reports: with a usable TPM, a keyfile and no
+    /// sealed key, the auto policy minted a fresh sealed key beside the
+    /// keyfile. It must seal the existing keyfile instead — here the seal
+    /// step fails (no TPM), and that failure is the proof that nothing was
+    /// minted first.
+    #[cfg(feature = "tpm")]
+    #[test]
+    fn auto_policy_seals_the_existing_keyfile_instead_of_minting() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let sealed_path = dir.path().join("sealed.key"); // absent
+        let original = [0x42u8; 32];
+        std::fs::write(&key_path, original).unwrap();
+
+        let config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        let err = setup_encryption_auto(&config, Some(true))
+            .expect_err("sealing must be attempted, and no TPM can answer here");
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("failed to seal the existing key"),
+            "the auto policy must seal the existing keyfile, not mint: {chain}"
+        );
+        assert_eq!(
+            std::fs::read(&key_path).unwrap().as_slice(),
+            &original[..],
+            "the keyfile must be left untouched"
+        );
+        assert!(!sealed_path.exists(), "no sealed key may be minted");
+    }
+
+    #[cfg(feature = "tpm")]
+    #[test]
+    fn auto_policy_reuses_an_existing_sealed_key_without_minting() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key"); // absent
+        let sealed_path = dir.path().join("sealed.key");
+        let sealed_bytes = b"an-existing-sealed-blob".to_vec();
+        std::fs::write(&sealed_path, &sealed_bytes).unwrap();
+
+        let config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        setup_encryption_auto(&config, Some(true)).expect("reuse must not fail");
+
+        assert_eq!(std::fs::read(&sealed_path).unwrap(), sealed_bytes);
+        assert!(!key_path.exists(), "the tpm target must not mint a keyfile");
+    }
+
+    /// The mirror of #358: keyfile absent, sealed key present, TPM unusable.
+    /// Nothing can unseal it, so a keyfile is minted — and the sealed
+    /// artifact stays on disk, as `--encryption keyfile` leaves it.
+    #[test]
+    fn auto_policy_mint_leaves_an_unusable_sealed_key_in_place() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key"); // absent
+        let sealed_path = dir.path().join("sealed.key");
+        let sealed_bytes = b"not-really-a-sealed-blob".to_vec();
+        std::fs::write(&sealed_path, &sealed_bytes).unwrap();
+
+        let config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        setup_encryption_auto(&config, Some(false)).expect("mint must not fail");
+
+        assert_eq!(std::fs::metadata(&key_path).unwrap().len(), 32);
+        assert_eq!(
+            std::fs::read(&sealed_path).unwrap(),
+            sealed_bytes,
+            "the unreachable sealed key must be left in place, not deleted"
+        );
+    }
+
+    #[test]
+    fn auto_policy_reuses_an_existing_keyfile_without_minting() {
+        let _lock = super::CONFIG_OVERRIDE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        struct OverrideGuard;
+        impl Drop for OverrideGuard {
+            fn drop(&mut self) {
+                facelock_core::paths::clear_process_config_override();
+            }
+        }
+        let (_cfg_dir, config_path) = temp_config("config.toml", "");
+        facelock_core::paths::set_process_config_override(config_path);
+        let _guard = OverrideGuard;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("facelock.key");
+        let sealed_path = dir.path().join("sealed.key"); // absent
+        let original = [0x42u8; 32];
+        std::fs::write(&key_path, original).unwrap();
+
+        let config = config_for_auto(dir.path(), &key_path, &sealed_path);
+        setup_encryption_auto(&config, Some(false)).expect("reuse must not fail");
+
+        assert_eq!(std::fs::read(&key_path).unwrap().as_slice(), &original[..]);
+        assert!(!sealed_path.exists());
+    }
+
     /// The orphaned-models guard must not become a prompt when no theme is
     /// available — that is the non-interactive path, and it must not hang.
     #[test]
@@ -6318,6 +6627,18 @@ mod choice_tests {
         config.encryption.method = EncryptionMethod::None;
         config.encryption.key_path = key.display().to_string();
         assert!(!auto_encryption_needs_keygen(&config, false));
+
+        // With a usable TPM that keyfile is sealed, not shadowed by a fresh
+        // sealed key (#358) — so no key is minted and the guard is skipped.
+        #[cfg(feature = "tpm")]
+        assert!(!auto_encryption_needs_keygen(&config, true));
+
+        // A sealed key nothing can unseal does not spare the keyfile target a
+        // mint, so the guard must run.
+        let (_dir, sealed) = temp_config("encryption.key.sealed", "not-a-sealed-blob");
+        config.encryption.key_path = "/nonexistent/facelock/encryption.key".to_string();
+        config.encryption.sealed_key_path = sealed.display().to_string();
+        assert!(auto_encryption_needs_keygen(&config, false));
     }
 }
 

--- a/crates/facelock-cli/src/commands/tpm.rs
+++ b/crates/facelock-cli/src/commands/tpm.rs
@@ -200,7 +200,19 @@ pub(crate) fn seal_existing_keyfile(config: &Config) -> Result<()> {
             .with_context(|| format!("failed to read key file {}", key_path.display()))?,
     );
     if key_data.len() != 32 {
-        anyhow::bail!("key file must be exactly 32 bytes, got {}", key_data.len());
+        // Actionable, because `facelock setup` now reaches this refusal on a
+        // path that used to mint instead (#358): the automatic policy seals
+        // an existing keyfile, and a file that is not an AES-256 key stops
+        // setup before it secures paths or writes its marker. Saying only
+        // "got 13" leaves the operator with a half-applied run and no move.
+        anyhow::bail!(
+            "key file {} must be exactly 32 bytes, got {}: it is not an AES-256 key \
+             facelock can seal. Restore the real key, or remove it and re-run to have \
+             a new key generated (any embeddings the original sealed become \
+             unreadable, so clear them with `facelock clear` if you take that route).",
+            key_path.display(),
+            key_data.len()
+        );
     }
     let mut key = [0u8; 32];
     key.copy_from_slice(&key_data);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,7 +161,7 @@ TPM aborts. Provider selection has its own fallback behavior, described below.
 | `--camera <PATH\|auto>` | a `/dev/video*` path, or `auto` | Re-classifies the attached devices and picks the single IR-capable node that advertises a format Facelock can decode. Zero usable IR devices and more than one are both errors that list what was found; an IR node excluded for formats such as Y8/Y10/Y12 is reported with its path and formats. | 1 |
 | `--models <standard\|balanced\|high>` | three presets | *no `auto`*: quality is a preference, not something the machine can report | 2 |
 | `--execution-provider <cpu\|cuda\|rocm\|openvino\|auto>` | provider name | Asks the installed ONNX Runtime which providers it was built with and takes the best, in the order cuda > rocm > openvino > cpu. Availability is a property of the runtime build, not of the hardware, and the choice is always printed. | 3 |
-| `--encryption <tpm\|keyfile\|none\|auto>` | method | Uses the TPM when a working TPM 2.0 is present, otherwise a software keyfile. | 5 |
+| `--encryption <tpm\|keyfile\|none\|auto>` | method | Uses the TPM when a working TPM 2.0 is present, otherwise a software keyfile. Carries an existing key across like the explicit values: a keyfile is sealed rather than shadowed by a fresh sealed key. | 5 |
 
 When `security.require_ir = true` and the wizard detects IR-classified nodes but
 all of them advertise only unsupported formats, camera selection is a fatal

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -446,7 +446,11 @@ the keyfile. A fresh key is minted only when no key artifact exists, behind the
 orphaned-models guard. When both artifacts exist and hold different keys, setup
 keeps the target's and prints a notice naming both files. A TPM device that
 exists but fails to initialize is reported (warn + notice) rather than silently
-downgrading to keyfile.
+downgrading to keyfile. `--encryption auto`, and the non-interactive base with
+no flag, make the same decision once the target is picked from TPM usability:
+a usable TPM seals an existing keyfile rather than minting beside it, and with
+no usable TPM an existing sealed key is left in place while a keyfile is
+minted (#358).
 
 ### facelock pam Semantics
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -450,7 +450,9 @@ downgrading to keyfile. `--encryption auto`, and the non-interactive base with
 no flag, make the same decision once the target is picked from TPM usability:
 a usable TPM seals an existing keyfile rather than minting beside it, and with
 no usable TPM an existing sealed key is left in place while a keyfile is
-minted (#358).
+minted (#358). Both mints consult the shared key gate below; the sealing one
+asks its predicate only, so the TPM path never leaves a plaintext keyfile
+behind.
 
 ### facelock pam Semantics
 

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -7006,14 +7006,14 @@
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 13,
-          "line": 1276,
+          "line": 1278,
           "sha256": "63c460d2967465f764a77bec938f1ab6183bba3b9758048020ee3de0d5dc3e82"
         },
         {
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 14,
-          "line": 1278,
+          "line": 1280,
           "sha256": "9d893de87b927d4a16bf54f82add2a2e2b2a9c56d12e4d04d2a27cbed5ef49c7"
         }
       ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -7006,14 +7006,14 @@
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 13,
-          "line": 1272,
+          "line": 1276,
           "sha256": "63c460d2967465f764a77bec938f1ab6183bba3b9758048020ee3de0d5dc3e82"
         },
         {
           "path": "docs/contracts.md",
           "anchor": "facelock-pam-semantics",
           "ordinal": 14,
-          "line": 1274,
+          "line": 1278,
           "sha256": "9d893de87b927d4a16bf54f82add2a2e2b2a9c56d12e4d04d2a27cbed5ef49c7"
         }
       ],


### PR DESCRIPTION
## Summary

- route `--encryption auto` (and the flagless non-interactive base) through a new `plan_auto_key_action`: pick the target from TPM usability, then reuse `plan_key_action` from #354
- seal an existing `encryption.key` through `seal_existing_keyfile` when the TPM is usable, instead of minting a fresh sealed key beside it
- leave an existing sealed key in place, with the `SealedKeyLeftInPlace` notice, when no usable TPM can unseal it and the keyfile is minted
- make `auto_encryption_needs_keygen` dispatch on the same plan, so the orphaned-models guard runs exactly when a key is minted
- document the auto transition in `docs/contracts.md`, `docs/cli.md` and the changelog

## Why

#354 fixed the explicit `--encryption tpm|keyfile` values and the wizard, but `setup_encryption_auto` kept its own inline `!sealed_path.exists()` check. A TPM-capable host with `method = "none"`, a keyfile and no sealed blob therefore ended up with two unrelated keys on disk and the config on `tpm`. The mirror case, sealed blob present and keyfile absent with the TPM unusable, minted silently with no notice.

## Validation

- new pure tests on `plan_auto_key_action` and setup-level tests on `setup_encryption_auto` for the seal, reuse and mint-beside-sealed cases (the seal test pins the decision by pointing the TCTI at a device that cannot answer)
- `cargo test --workspace --features tpm`, `cargo clippy --workspace --all-targets --features tpm -- -D warnings`
- `just fmt-check lint test check-docs`
- not run: no container tier exercises `facelock setup --encryption auto` against a swtpm; `test-deb-*-pkg` drives `tpm seal-key` only

Fixes #358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic encryption setup now preserves existing keys instead of creating duplicates.
  * Existing keyfiles are sealed when a usable TPM is available; otherwise, existing sealed keys remain while a keyfile is created.
  * Key-generation safeguards now run only when a new key is required.
  * Invalid keyfiles now stop setup with clearer recovery guidance.

* **Documentation**
  * Updated encryption setup guidance and contracts to describe automatic key reuse and preservation behavior.
  * Corrected documentation references in the manual walkthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->