### PR TITLE
fix(daemon): Enumerate every ACPI lid device in the lid gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`abort_if_lid_closed` now sees every ACPI lid device** (#365): the daemon read only
+  `/proc/acpi/button/lid/LID0/state`, so a laptop whose firmware names the device `LID`,
+  `LID1` or anything else got no lid gate from the daemon, while the PAM module checked a
+  different fixed list. Both now enumerate `/proc/acpi/button/lid/*/state` from one shared
+  resolver: the lid is closed when any device reports `closed`, and no lid device counts as
+  open. `docs/contracts.md` and `docs/security.md` now say why the PAM line sits above
+  distribution skip guards (the module and daemon self-gate on SSH and lid) and that
+  `abort_if_lid_closed = false` is the opt-out for a docked laptop with an external camera.
+
 ### Added
 
 - **A synthetic camera for the camera-required test tiers** (#139): `just test-arch-loopback`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`abort_if_lid_closed` now sees every ACPI lid device** (#365): the daemon read only
-  `/proc/acpi/button/lid/LID0/state`, so a laptop whose firmware names the device `LID`,
-  `LID1` or anything else got no lid gate from the daemon, while the PAM module checked a
-  different fixed list. Both now enumerate `/proc/acpi/button/lid/*/state` from one shared
-  resolver: the lid is closed when any device reports `closed`, and no lid device counts as
-  open. `docs/contracts.md` and `docs/security.md` now say why the PAM line sits above
-  distribution skip guards (the module and daemon self-gate on SSH and lid) and that
-  `abort_if_lid_closed = false` is the opt-out for a docked laptop with an external camera.
+- **`abort_if_lid_closed` now sees every ACPI lid device** (#365): the PAM module checked a
+  fixed `LID0`/`LID`/`LID1` list and the daemon read only
+  `/proc/acpi/button/lid/LID0/state`, so a laptop whose firmware names the device anything
+  else was not lid-gated. Both call sites now enumerate `/proc/acpi/button/lid/*/state` from
+  one shared resolver: the lid is closed when any device reports `closed`, and no lid device
+  counts as open. Two behavior details come with that. The state file is matched by whole
+  word (`closed` as a field, not as a substring anywhere in the file), so a device whose
+  state merely contains the letters no longer reads as closed. And the resolver needs
+  **read permission on the lid directory**, where the old code needed only to open a known
+  file path; a caller whose namespace hides `/proc/acpi` now reports no lid device rather
+  than a failed read of one.
+- **Documented which lid gate actually fires**: the PAM module's, because it runs in the
+  calling process. The daemon's own lid gate is inert under the packaged unit, whose
+  `ProcSubset=pid` keeps `/proc/acpi` out of its mount namespace, so a D-Bus caller that
+  does not go through `pam_facelock.so` is not lid-gated. That is long-standing behavior,
+  not new here, and `docs/contracts.md` and `docs/security.md` now state it alongside the
+  PAM line's placement above distribution skip guards and `abort_if_lid_closed = false` as
+  the opt-out for a docked laptop with an external camera.
 
 ### Added
 

--- a/crates/facelock-daemon/src/auth.rs
+++ b/crates/facelock-daemon/src/auth.rs
@@ -303,7 +303,7 @@ pub fn pre_check_with_context(
         return Some(AuthOutcome::error(ErrorKind::SshSession));
     }
 
-    if !ctx.skip_lid_gate && config.security.abort_if_lid_closed && is_lid_closed() {
+    if !ctx.skip_lid_gate && config.security.abort_if_lid_closed && lid::is_lid_closed() {
         info!(user, "lid closed, aborting");
         return Some(AuthOutcome::error(ErrorKind::LidClosed));
     }
@@ -993,10 +993,17 @@ fn is_ssh_session() -> bool {
     std::env::var("SSH_CONNECTION").is_ok() || std::env::var("SSH_TTY").is_ok()
 }
 
-fn is_lid_closed() -> bool {
-    std::fs::read_to_string("/proc/acpi/button/lid/LID0/state")
-        .map(|s| s.contains("closed"))
-        .unwrap_or(false)
+/// The lid resolver, compiled from `pam-facelock`'s source so the daemon
+/// and the PAM module cannot disagree on which `/proc/acpi/button/lid/*`
+/// device counts (issue #365). The module cannot link this crate (its
+/// dependency ceiling is libc/toml/serde/zbus), so the source is shared
+/// the way `oneshot_exit.rs` is; the file's own tests run in both crates.
+mod lid {
+    #![allow(dead_code)]
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../pam-facelock/src/lid.rs"
+    ));
 }
 
 #[cfg(test)]
@@ -1474,11 +1481,6 @@ enabled = false
         if let Some(v) = old_tty {
             unsafe { std::env::set_var("SSH_TTY", v) };
         }
-    }
-
-    #[test]
-    fn lid_closed_returns_false_on_missing_file() {
-        let _result = is_lid_closed();
     }
 
     fn test_pre_check_config() -> Config {

--- a/crates/pam-facelock/src/lib.rs
+++ b/crates/pam-facelock/src/lib.rs
@@ -17,6 +17,10 @@ use serde::Deserialize;
 // against the binary's emission table (see the file header).
 mod oneshot_exit;
 
+// The lid resolver behind `abort_if_lid_closed`, dependency-free so
+// `facelock-daemon` can `include!` the same source (see the file header).
+mod lid;
+
 // ---------------------------------------------------------------------------
 // PAM constants
 // ---------------------------------------------------------------------------
@@ -434,21 +438,6 @@ fn is_ssh_session() -> bool {
                 .any(|var| var.starts_with(b"SSH_CONNECTION=") || var.starts_with(b"SSH_TTY="))
         })
         .unwrap_or(false)
-}
-
-/// Check if the laptop lid is closed
-fn is_lid_closed() -> bool {
-    // Try multiple lid paths (different ACPI implementations)
-    for lid_path in &[
-        "/proc/acpi/button/lid/LID0/state",
-        "/proc/acpi/button/lid/LID/state",
-        "/proc/acpi/button/lid/LID1/state",
-    ] {
-        if let Ok(contents) = std::fs::read_to_string(lid_path) {
-            return contents.contains("closed");
-        }
-    }
-    false
 }
 
 // ---------------------------------------------------------------------------
@@ -1140,7 +1129,7 @@ fn identify(pamh: *mut libc::c_void) -> libc::c_int {
         return PAM_IGNORE;
     }
 
-    if config.security.abort_if_lid_closed && is_lid_closed() {
+    if config.security.abort_if_lid_closed && lid::is_lid_closed() {
         log_auth(&service, "lid_closed", "?", LOG_INFO);
         return PAM_IGNORE;
     }

--- a/crates/pam-facelock/src/lid.rs
+++ b/crates/pam-facelock/src/lid.rs
@@ -73,16 +73,36 @@ mod tests {
     /// `tempfile` so this file stays dependency-free in both crates.
     struct LidRoot(PathBuf);
 
+    /// Create and return the first candidate directory that does not already
+    /// exist. `create_dir` is the exclusion primitive: it refuses a name
+    /// something else owns instead of adopting it, so a directory left by a
+    /// crashed run costs a retry rather than a panic or a shared fixture.
+    fn create_first_free<I: Iterator<Item = PathBuf>>(candidates: I) -> PathBuf {
+        for candidate in candidates {
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => return candidate,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => panic!("create {}: {e}", candidate.display()),
+            }
+        }
+        panic!("no free temp directory candidate");
+    }
+
     impl LidRoot {
         fn new(devices: &[(&str, Option<&str>)]) -> Self {
-            static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-            let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let root = std::env::temp_dir().join(format!(
-                "facelock-lid-{}-{}-{n}",
-                env!("CARGO_PKG_NAME"),
-                std::process::id()
-            ));
-            std::fs::create_dir_all(&root).unwrap();
+            static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let base = std::env::temp_dir();
+            let pid = std::process::id();
+            let crate_name = env!("CARGO_PKG_NAME");
+            let candidates = (0..64).map(|_| {
+                let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let nanos = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                base.join(format!("facelock-lid-{crate_name}-{pid}-{nanos}-{n}"))
+            });
+            let root = create_first_free(candidates);
             for (name, state) in devices {
                 let dir = root.join(name);
                 std::fs::create_dir(&dir).unwrap();
@@ -171,6 +191,38 @@ mod tests {
             LidState::Open,
         ),
     ];
+
+    /// A name a crashed run left behind (same PID, later reused) is skipped,
+    /// never adopted and never fatal. `create_dir` is the exclusion
+    /// primitive; this pins that its `AlreadyExists` is a retry.
+    #[test]
+    fn create_first_free_skips_a_taken_name() {
+        let taken = LidRoot::new(&[]);
+        let fresh = taken.0.with_extension("fresh");
+        let chosen = create_first_free(vec![taken.0.clone(), fresh.clone()].into_iter());
+        assert_eq!(chosen, fresh);
+        assert!(fresh.is_dir());
+        let _ = std::fs::remove_dir_all(&fresh);
+    }
+
+    /// Two fixtures never share a directory, so one test's devices cannot
+    /// leak into another's answer.
+    #[test]
+    fn lid_roots_are_unique_per_fixture() {
+        let a = LidRoot::new(&[("LID0", Some("state:      open\n"))]);
+        let b = LidRoot::new(&[("LID0", Some("state:      closed\n"))]);
+        assert_ne!(a.0, b.0);
+        assert_eq!(lid_state_under(&a.0), LidState::Open);
+        assert_eq!(lid_state_under(&b.0), LidState::Closed);
+    }
+
+    /// The kernel path is the whole contract with the firmware: a typo here
+    /// silently disables the gate on every machine, which is how issue #365
+    /// stayed invisible. Pinned as a literal, not derived from the constant.
+    #[test]
+    fn lid_root_is_the_kernel_acpi_button_path() {
+        assert_eq!(LID_ROOT, "/proc/acpi/button/lid");
+    }
 
     #[test]
     fn lid_state_under_matches_the_fixture_table() {

--- a/crates/pam-facelock/src/lid.rs
+++ b/crates/pam-facelock/src/lid.rs
@@ -1,0 +1,206 @@
+// The laptop-lid resolver behind `security.abort_if_lid_closed`. Dependency-
+// free on purpose (std only, no `use` of anything outside it): this file is
+// compiled twice — as `pam_facelock`'s `lid` module and `include!`d into
+// `facelock-daemon` (auth.rs) — so the PAM module and the daemon run one
+// resolver rather than two lists of device names. `pam_facelock.so` cannot
+// link facelock-core (its dependency ceiling is libc/toml/serde/zbus), so
+// sharing the source is what keeps the two gates agreeing (issue #365).
+//
+// The rule is Omarchy's `omarchy-hw-laptop-closed`: enumerate every
+// `/proc/acpi/button/lid/*/state` (the kernel names the device `LID0`,
+// `LID`, `LID1`, ... depending on the firmware) and treat the lid as closed
+// when any of them reports `closed`. No lid device at all means "absent",
+// which the gate reads as open: a desktop or a VM has no lid to be closed.
+
+/// Where the kernel exposes ACPI lid buttons.
+pub(crate) const LID_ROOT: &str = "/proc/acpi/button/lid";
+
+/// What the ACPI lid devices under one root report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LidState {
+    /// At least one lid device reports `closed`.
+    Closed,
+    /// At least one lid device is readable and none reports `closed`.
+    Open,
+    /// No readable lid device: no root, an empty root, or devices with no
+    /// readable `state` file.
+    Absent,
+}
+
+/// Resolve the lid state from every `<root>/*/state` file.
+///
+/// Order-independent: `Closed` if any device says so, `Open` if any device
+/// was readable, `Absent` otherwise. Stray files directly under the root and
+/// devices whose `state` cannot be read are skipped, never treated as closed.
+pub(crate) fn lid_state_under(root: &std::path::Path) -> LidState {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return LidState::Absent;
+    };
+    let mut readable = false;
+    for entry in entries.flatten() {
+        let Ok(contents) = std::fs::read_to_string(entry.path().join("state")) else {
+            continue;
+        };
+        readable = true;
+        if contents.split_whitespace().any(|word| word == "closed") {
+            return LidState::Closed;
+        }
+    }
+    if readable {
+        LidState::Open
+    } else {
+        LidState::Absent
+    }
+}
+
+/// The gate's reading of [`lid_state_under`]: only `Closed` aborts, so a
+/// machine with no lid device is treated as open.
+pub(crate) fn is_lid_closed_under(root: &std::path::Path) -> bool {
+    lid_state_under(root) == LidState::Closed
+}
+
+/// [`is_lid_closed_under`] on the real kernel root.
+pub(crate) fn is_lid_closed() -> bool {
+    is_lid_closed_under(std::path::Path::new(LID_ROOT))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A throwaway `/proc/acpi/button/lid` stand-in. Hand-rolled rather than
+    /// `tempfile` so this file stays dependency-free in both crates.
+    struct LidRoot(PathBuf);
+
+    impl LidRoot {
+        fn new(devices: &[(&str, Option<&str>)]) -> Self {
+            static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+            let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "facelock-lid-{}-{}-{n}",
+                env!("CARGO_PKG_NAME"),
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            for (name, state) in devices {
+                let dir = root.join(name);
+                std::fs::create_dir(&dir).unwrap();
+                if let Some(contents) = state {
+                    std::fs::write(dir.join("state"), contents).unwrap();
+                }
+            }
+            Self(root)
+        }
+    }
+
+    impl Drop for LidRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// One lid device directory: its name and its `state` file (None = a
+    /// device directory with no state file).
+    type Device = (&'static str, Option<&'static str>);
+
+    /// The fixture set both crates run: a name, the devices, and the answer.
+    /// The kernel's format is `state:      closed\n` / `state:      open\n`.
+    const FIXTURES: &[(&str, &[Device], LidState)] = &[
+        ("no devices", &[], LidState::Absent),
+        (
+            "LID0 open",
+            &[("LID0", Some("state:      open\n"))],
+            LidState::Open,
+        ),
+        (
+            "LID0 closed",
+            &[("LID0", Some("state:      closed\n"))],
+            LidState::Closed,
+        ),
+        (
+            "LID open",
+            &[("LID", Some("state:      open\n"))],
+            LidState::Open,
+        ),
+        (
+            "LID closed",
+            &[("LID", Some("state:      closed\n"))],
+            LidState::Closed,
+        ),
+        (
+            "LID1 closed",
+            &[("LID1", Some("state:      closed\n"))],
+            LidState::Closed,
+        ),
+        (
+            "firmware-named closed",
+            &[("LID9", Some("state:      closed\n"))],
+            LidState::Closed,
+        ),
+        (
+            "any closed wins",
+            &[
+                ("LID0", Some("state:      open\n")),
+                ("LID1", Some("state:      closed\n")),
+            ],
+            LidState::Closed,
+        ),
+        (
+            "all open",
+            &[
+                ("LID0", Some("state:      open\n")),
+                ("LID1", Some("state:      open\n")),
+            ],
+            LidState::Open,
+        ),
+        (
+            "device without state file",
+            &[("LID0", None)],
+            LidState::Absent,
+        ),
+        (
+            "unreadable device beside a closed one",
+            &[("LID0", None), ("LID1", Some("state:      closed\n"))],
+            LidState::Closed,
+        ),
+        ("empty state file", &[("LID0", Some(""))], LidState::Open),
+        (
+            "unknown state word",
+            &[("LID0", Some("state:      unknown\n"))],
+            LidState::Open,
+        ),
+    ];
+
+    #[test]
+    fn lid_state_under_matches_the_fixture_table() {
+        for (name, devices, expected) in FIXTURES {
+            let root = LidRoot::new(devices);
+            assert_eq!(lid_state_under(&root.0), *expected, "fixture: {name}");
+        }
+    }
+
+    #[test]
+    fn lid_state_under_missing_root_is_absent() {
+        let root = LidRoot::new(&[]);
+        let missing = root.0.join("does-not-exist");
+        assert_eq!(lid_state_under(&missing), LidState::Absent);
+    }
+
+    #[test]
+    fn lid_state_under_ignores_stray_files_in_the_root() {
+        let root = LidRoot::new(&[("LID0", Some("state:      open\n"))]);
+        std::fs::write(root.0.join("state"), "state:      closed\n").unwrap();
+        assert_eq!(lid_state_under(&root.0), LidState::Open);
+    }
+
+    #[test]
+    fn is_lid_closed_under_reads_only_closed_as_closed() {
+        let closed = LidRoot::new(&[("LID", Some("state:      closed\n"))]);
+        let open = LidRoot::new(&[("LID", Some("state:      open\n"))]);
+        let none = LidRoot::new(&[]);
+        assert!(is_lid_closed_under(&closed.0));
+        assert!(!is_lid_closed_under(&open.0));
+        assert!(!is_lid_closed_under(&none.0));
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ Controls how the PAM module reaches the face engine.
 |-----|------|---------|-------------|
 | `disabled` | bool | `false` | Disable face authentication entirely. PAM returns IGNORE, falling through to the next auth method. |
 | `abort_if_ssh` | bool | `true` | Refuse remote face auth. One-shot PAM uses its sanitized SSH environment; non-root daemon `Authenticate` requires a live D-Bus ProcessFD and a local logind session. `false` skips the daemon's ProcessFD/PID/logind/session lookup. Root bypasses only the daemon remote-session check. |
-| `abort_if_lid_closed` | bool | `true` | Refuse face auth when the laptop lid is closed (camera blocked). |
+| `abort_if_lid_closed` | bool | `true` | Refuse face auth when the laptop lid is closed (camera blocked). Closed means any `/proc/acpi/button/lid/*/state` reports `closed`, whatever the firmware names the device; no lid device counts as open. Set `false` for a docked laptop using an external camera with the lid shut. |
 | `require_ir` | bool | `true` | Require an IR camera for authentication. RGB cameras are trivially spoofed with a printed photo. Only set to `false` for development/testing. |
 | `require_frame_variance` | bool | `true` | Require multiple frames with different embeddings before accepting. Defends against static photo attacks. |
 | `frame_variance_max_similarity` | f32 | `0.985` | Maximum cosine similarity allowed between consecutive matched frames in the sliding window. Lower is stricter. Passive anti-photo check only; it does not stop video replay. |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1360,13 +1360,34 @@ The line sits **above** any distribution skip guard (Omarchy's
 `omarchy-hw-laptop-closed` / SSH / no-camera checks, or their equivalents)
 on purpose, and the writer does not add one. `pam_facelock.so` self-gates
 before it opens a camera or contacts the daemon: `security.disabled`,
-`abort_if_ssh` and `abort_if_lid_closed` each return `PAM_IGNORE`, and the
-daemon repeats the SSH and lid physical-presence gates in its own pre-flight
-(`pre_check`, before enrollment, the rate-limit check and `require_ir`), so a
-stack that reaches the line with the lid closed falls through to the next
-rule without a camera being opened. `abort_if_lid_closed = false` is the
-opt-out for a docked laptop that authenticates through an external camera
-with the lid shut; nothing in the stack needs to move for that.
+`abort_if_ssh` and `abort_if_lid_closed` each return `PAM_IGNORE`, so a stack
+that reaches the line with the lid closed falls through to the next rule with
+no camera opened. **The module is the gate that fires**, because it runs
+inside the calling process and reads that process's environment and an
+unrestricted `/proc`. `abort_if_lid_closed = false` is the opt-out for a
+docked laptop that authenticates through an external camera with the lid
+shut; nothing in the stack needs to move for that.
+
+What each physical-presence gate is worth behind the module is not uniform:
+
+| Path | `abort_if_ssh` | `abort_if_lid_closed` |
+|---|---|---|
+| `pam_facelock.so` | enforced, from the calling process's environment | enforced, from the calling process's `/proc` |
+| one-shot `facelock auth` | enforced in `pre_check` (PAM forwards `SSH_CONNECTION` / `SSH_TTY` into the child's allow-listed environment) | enforced in `pre_check`: the helper is an ordinary child of the PAM-using process, with no sandbox |
+| daemon `Authenticate` | enforced, by a different mechanism: for a non-root caller the D-Bus server resolves the caller's logind session (ProcessFD, then `GetSessionByPID`) and denies one whose `Remote` property is true. A root caller skips it, and a PAM `sudo` attempt arrives as UID 0 | **inert** |
+
+Two consequences worth stating plainly. The `abort_if_ssh` arm inside
+`pre_check` reads the *calling* environment, which is the right environment on
+the one-shot path and never carries `SSH_CONNECTION` inside the long-running
+daemon, so on the daemon path it is the logind check above that does the work.
+And `pre_check`'s lid gate cannot fire in the packaged daemon at all:
+`systemd/facelock-daemon.service` sets `ProcSubset=pid`, so `/proc/acpi` does
+not exist in the daemon's mount namespace and the resolver finds no lid
+device. **A caller that reaches `Authenticate` over D-Bus without going
+through `pam_facelock.so` is therefore not lid-gated.** Closing that needs a
+lid source the namespace keeps (logind's `LidClosed` property, say), not a
+wider `/proc`; this is long-standing behavior, not a property of the
+enumeration rule below, which the module and the one-shot both honor.
 
 **Lid rule.** Both gates resolve the lid the same way, from one shared
 source (`crates/pam-facelock/src/lid.rs`, compiled into the module and

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1356,6 +1356,27 @@ There is intentionally no `--control` option. A caller cannot silently
 substitute `required`, an extended control, or another stack policy for the
 line whose behavior downstream consumers and Facelock cleanup rely on.
 
+The line sits **above** any distribution skip guard (Omarchy's
+`omarchy-hw-laptop-closed` / SSH / no-camera checks, or their equivalents)
+on purpose, and the writer does not add one. `pam_facelock.so` self-gates
+before it opens a camera or contacts the daemon: `security.disabled`,
+`abort_if_ssh` and `abort_if_lid_closed` each return `PAM_IGNORE`, and the
+daemon repeats the SSH and lid physical-presence gates in its own pre-flight
+(`pre_check`, before enrollment, the rate-limit check and `require_ir`), so a
+stack that reaches the line with the lid closed falls through to the next
+rule without a camera being opened. `abort_if_lid_closed = false` is the
+opt-out for a docked laptop that authenticates through an external camera
+with the lid shut; nothing in the stack needs to move for that.
+
+**Lid rule.** Both gates resolve the lid the same way, from one shared
+source (`crates/pam-facelock/src/lid.rs`, compiled into the module and
+`include!`d by the daemon): every `/proc/acpi/button/lid/*/state` is read,
+whatever the firmware names the device (`LID0`, `LID`, `LID1`, ...); the lid
+is closed when any of them reports `closed`; a device whose `state` cannot be
+read is skipped; no readable device at all means no lid, which the gate
+treats as open. Only `closed` aborts, so a desktop, a VM or a missing
+`/proc/acpi` never blocks face auth.
+
 The line is inserted immediately before the first *logical* rule whose first
 ASCII-whitespace-delimited type token is `auth`, matched
 ASCII-case-insensitively and with Linux-PAM's optional leading `-`;

--- a/docs/security.md
+++ b/docs/security.md
@@ -1665,9 +1665,12 @@ password. The lid is resolved by enumerating every
 names it) from one source shared by the module and the daemon; the lid is
 closed when any device reports `closed`, and no lid device at all counts as
 open. `abort_if_lid_closed = false` is the opt-out for a docked laptop using an
-external camera with the lid shut. Failing direction: if the lid cannot be
-read, the attempt proceeds to the camera and times out to the password, the
-same fallback as every other unavailable-face case.
+external camera with the lid shut. Failing direction: a lid the resolver
+cannot read counts as open, so the attempt runs the normal camera
+authentication and its result decides the outcome. On a machine with no lid
+that reading is correct; on a laptop whose closed lid went undetected the
+blocked camera sees no face and the attempt ends at the timeout, with the
+stack continuing to the password.
 
 Operators who want face auth for only some actions under the PAM model should
 control it at the PAM layer (which service files include `pam_facelock.so`), not

--- a/docs/security.md
+++ b/docs/security.md
@@ -1652,6 +1652,23 @@ guarantees:
   which *does* gate the PAM path). So "unscoped across actions" does not mean
   "unscoped across defenses."
 
+**Placement above distribution skip guards.** The `auth sufficient
+pam_facelock.so` line goes above any distribution-owned skip guard (Omarchy's
+`omarchy-hw-laptop-closed`, an SSH or no-camera check) rather than behind one.
+That is deliberate: the module self-gates on `security.disabled`,
+`abort_if_ssh` and `abort_if_lid_closed` before it touches a camera or the
+daemon, and the daemon repeats the SSH and lid gates in its own pre-flight,
+ahead of enrollment, the rate limiter and `require_ir`. A closed lid therefore
+returns `PAM_IGNORE` from the module itself, and the stack continues to the
+password. The lid is resolved by enumerating every
+`/proc/acpi/button/lid/*/state` (`LID0`, `LID`, `LID1`, whatever the firmware
+names it) from one source shared by the module and the daemon; the lid is
+closed when any device reports `closed`, and no lid device at all counts as
+open. `abort_if_lid_closed = false` is the opt-out for a docked laptop using an
+external camera with the lid shut. Failing direction: if the lid cannot be
+read, the attempt proceeds to the camera and times out to the password, the
+same fallback as every other unavailable-face case.
+
 Operators who want face auth for only some actions under the PAM model should
 control it at the PAM layer (which service files include `pam_facelock.so`), not
 via `polkit.face_eligible_actions` (which the PAM path ignores). Per-action

--- a/docs/security.md
+++ b/docs/security.md
@@ -1657,10 +1657,25 @@ pam_facelock.so` line goes above any distribution-owned skip guard (Omarchy's
 `omarchy-hw-laptop-closed`, an SSH or no-camera check) rather than behind one.
 That is deliberate: the module self-gates on `security.disabled`,
 `abort_if_ssh` and `abort_if_lid_closed` before it touches a camera or the
-daemon, and the daemon repeats the SSH and lid gates in its own pre-flight,
-ahead of enrollment, the rate limiter and `require_ir`. A closed lid therefore
-returns `PAM_IGNORE` from the module itself, and the stack continues to the
-password. The lid is resolved by enumerating every
+daemon. A closed lid returns `PAM_IGNORE` from the module itself, and the
+stack continues to the password.
+
+The module is the gate that fires here, because it runs in the calling
+process, with that process's environment and an unrestricted `/proc`. Behind
+it the daemon is not a second copy of the same two gates. Its SSH refusal is
+real but differently built: for a non-root `Authenticate` caller the D-Bus
+server resolves the caller's logind session and denies a remote one (a root
+caller skips that check, and a PAM `sudo` attempt arrives as UID 0). Its lid
+gate is **inert under the packaged unit**: `systemd/facelock-daemon.service`
+sets `ProcSubset=pid`, so `/proc/acpi` is absent from the daemon's mount
+namespace and the resolver reports no lid device. A D-Bus caller that does not
+come through `pam_facelock.so` is therefore not lid-gated, and has not been;
+fixing that means finding the lid somewhere the sandbox keeps, such as
+logind's `LidClosed` property, rather than widening `/proc`. The one-shot
+`facelock auth` helper is unaffected: PAM spawns it as an ordinary child, so
+both gates run there.
+
+The lid is resolved by enumerating every
 `/proc/acpi/button/lid/*/state` (`LID0`, `LID`, `LID1`, whatever the firmware
 names it) from one source shared by the module and the daemon; the lid is
 closed when any device reports `closed`, and no lid device at all counts as

--- a/po/pam_facelock.pot
+++ b/po/pam_facelock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_facelock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 13:44-0700\n"
+"POT-Creation-Date: 2026-09-11 16:39-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: crates/pam-facelock/src/lib.rs:1175
+#: crates/pam-facelock/src/lib.rs:1164
 msgid "Identifying face..."
 msgstr ""
 
-#: crates/pam-facelock/src/lib.rs:1185 crates/pam-facelock/src/lib.rs:1199
-#: crates/pam-facelock/src/lib.rs:1241
+#: crates/pam-facelock/src/lib.rs:1174 crates/pam-facelock/src/lib.rs:1188
+#: crates/pam-facelock/src/lib.rs:1230
 msgid "Face recognized."
 msgstr ""


### PR DESCRIPTION
## Summary

- enumerate every `/proc/acpi/button/lid/*/state` in the lid gate; closed if any device reports `closed` as a whole word, absent (read as open) if none is readable
- run one resolver in both the daemon and `pam_facelock.so`: `crates/pam-facelock/src/lid.rs`, `include!`d by the daemon the way `oneshot_exit.rs` already is, so the PAM ceiling holds and the fixture table runs in both crates
- document which gate actually fires: the module's, in the caller's namespace. the daemon's lid gate is inert under the packaged unit's `ProcSubset=pid`, which keeps `/proc/acpi` out of its mount namespace, so a D-Bus caller that skips `pam_facelock.so` is not lid-gated
- record the daemon's SSH refusal where it lives: the D-Bus server's logind session lookup for a non-root `Authenticate` caller, not `pre_check`'s environment read
- note the two behavior details in `CHANGELOG.md`: whole-word match instead of substring, and read on the lid directory where the old code needed only open on a known path

## Why

The daemon read only `LID0/state`, so a laptop whose firmware names the lid device `LID` or `LID1` got no daemon-side gate even with `abort_if_lid_closed = true`, and the module checked a different fixed list, so the two halves disagreed. Omarchy's `omarchy-hw-laptop-closed` globs the directory; this matches it. Review then found that the daemon's gate cannot fire under the shipped unit at all, which is long-standing behavior but made the first draft of the docs false. The placement paragraph is what #338 tripped over.

## Validation

- `just fmt-check lint test`, `just check-pam-standalone`, `just check-docs`, `just pot`
- `cargo clippy --workspace --all-targets --features tpm -- -D warnings`
- `just test-cargo-vendor-contract`, since the daemon now `include!`s a file from another crate
- Arch container PAM tier, and the running daemon's `/proc/<pid>/mountinfo` checked for `subset=pid`

Fixes #365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Lid-closed detection now recognizes all supported ACPI lid device names, not just a single default name.
  - Systems with multiple lid devices are treated as closed if any readable device reports a closed state.
  - Devices without a detectable lid continue as open, while unreadable individual state files are skipped.

- **Documentation**
  - Clarified lid detection behavior, PAM enforcement, configuration options, and the opt-out for docked laptops.
  - Updated translation references to match current message locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->