### PR TITLE
test(release): Roll the upgrade predecessor with the matrix, not a literal

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,7 +19,7 @@ paths:
 | 3d | Arch package from `dist/PKGBUILD` | `just test-arch-pkg` |
 | 3e | Fedora package lifecycle, every declared release | `just test-rpm-lanes` |
 | 3f | Fedora COPR path, rebuilt from source on system ORT | `just test-copr-lanes` |
-| 3g | Released v0.1.4 upgrade and rollback, deb and rpm | `just test-upgrade-v014` |
+| 3g | Released-predecessor upgrade and rollback, deb and rpm | `just test-upgrade-predecessor` |
 | 3a | Arch container E2E, camera-free | `just test-arch-camera-free` |
 | 3b | Arch container E2E (daemon), needs a camera | `just test-arch-integration` |
 | 3c | Arch container E2E (oneshot), needs a camera | `just test-arch-oneshot` |

--- a/.claude/skills/packaging-test/SKILL.md
+++ b/.claude/skills/packaging-test/SKILL.md
@@ -44,7 +44,7 @@ need `podman`; none in the routing table needs a camera.
 | `crates/pam-facelock/**`, `/etc/pam.d` handling | `just test-arch-pam` and `just check-pam-standalone` |
 | File layout, installed paths | `just test-arch-layout` |
 | D-Bus policy, daemon authorization, pre-flight exit codes, schema migrations | `just test-arch-camera-free` |
-| Store migrations, encryption keys, TPM sealing, maintainer scripts touching state | `just test-upgrade-v014` |
+| Store migrations, encryption keys, TPM sealing, maintainer scripts touching state | `just test-upgrade-predecessor` |
 
 `just test-deb` delegates to both exact supported-suite package gates. The
 remaining quick syntax-level check is `just test-rpm` (Fedora container), which
@@ -52,12 +52,19 @@ is weaker than `test-rpm-pkg` because it does not install and boot.
 
 ## Upgrading from what users already run
 
-`just test-upgrade-v014` is the only lane that installs a real published
-artifact. It downloads the v0.1.4 .deb and the v0.1.4 fc44 .rpm, pinned by asset
-id and SHA256 in `dist/release-matrix.json`, builds predecessor state with the
+`just test-upgrade-predecessor` is the only lane that installs a real published
+artifact. It downloads the .deb and the fc44 .rpm of the release
+`dist/release-matrix.json` names as `predecessors.current` — the newest one,
+pinned there by asset id and SHA256 — builds predecessor state with the
 **released** binary (plaintext rows, keyfile-encrypted rows, mixed rows, and two
 swtpm-sealed shapes), upgrades through apt or dnf to the locally built
 candidate, and then downgrades back.
+
+Nothing in the lane spells a release. Roll `predecessors.current` after a
+release ships and the lanes prove the upgrade users are actually performing;
+what the predecessor wrote (its schema version, its CLI spelling, the layout
+its scriptlets leave) is read off the pin and off the database rather than
+assumed.
 
 Run it after any change to store migrations, the encryption or TPM key paths, or
 a maintainer script that touches `/var/lib/facelock` or `/etc/facelock`. Those
@@ -67,10 +74,11 @@ all of them.
 
 Two cheap halves run without podman and are worth knowing:
 
-- `just test-upgrade-v014-contract` catches a declared state shape or fault case
-  with no implementation, a proof function nothing calls, and a lane
-  Containerfile that grew its own digest. Seconds, no network.
-- `just test-upgrade-v014-pins` asks GitHub whether the pinned assets are still
+- `just test-upgrade-predecessor-contract` catches a declared state shape or fault case
+  with no implementation, a proof function nothing calls, a lane
+  Containerfile that grew its own digest, and a lane file that spelled a
+  release tag instead of reading the pin. Seconds, no network.
+- `just test-upgrade-predecessor-pins` asks GitHub whether the pinned assets are still
   the assets it serves. Needs `gh`, catches a re-uploaded predecessor.
 
 The full lane needs the reviewed ONNX models (`just link-models`) and has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs it on every pull request (`loopback-e2e`). A model-backed contract test pins the
   fixture inside the detector, IR-texture, quality, recognition and frame-variance bands.
 
+### Changed
+
+- **The upgrade lanes now prove the newest released predecessor** (#367): `dist/release-matrix.json`
+  names it as `predecessors.current`, pinned to v0.2.1's published .deb and fc44 .rpm, and the lane
+  scripts, the release-matrix contract, the served-EVR preflight check and the candidate version all
+  read that field instead of a v0.1.4 literal. The recipes are `just test-upgrade-predecessor`,
+  `-deb`, `-rpm`, `-contract` and `-pins` (was `just test-upgrade-v014*`). v0.1.4 stays pinned for
+  the retired-authselect fixture, and the COPR served-EVR gap record retires with the pin it excused.
+
 ## [0.2.1] - 2026-09-07
 
 ### Changed

--- a/dist/release-matrix.json
+++ b/dist/release-matrix.json
@@ -71,12 +71,7 @@
       ],
       "required_forge_project": "github.com/tyvsmith/facelock",
       "prerelease_publication": false,
-      "served_evr_exact": true,
-      "served_evr_gap": {
-        "expected_evr": "0.1.4-1",
-        "served_evr": "0.2.0-1",
-        "issue": 333
-      }
+      "served_evr_exact": true
     },
     "staging": {
       "owner": "tyvsmith",
@@ -115,9 +110,39 @@
     }
   },
   "predecessors": {
-    "reviewed_on": "2026-09-02",
-    "resolved_with": "gh api repos/tyvsmith/facelock/releases/tags/v0.1.4",
+    "reviewed_on": "2026-09-11",
+    "resolved_with": "gh api repos/tyvsmith/facelock/releases/tags/<tag>",
     "repository": "tyvsmith/facelock",
+    "current": "v0.2.1",
+    "v0.2.1": {
+      "tag": "v0.2.1",
+      "release_id": 384353326,
+      "published_at": "2026-09-07T23:06:46Z",
+      "upstream_version": "0.2.1",
+      "rpm_evr": "0.2.1-1",
+      "lanes": {
+        "deb-trixie": {
+          "suite": "trixie",
+          "asset_id": 549503982,
+          "asset_node_id": "RA_kwDORmgtH84gwMPu",
+          "name": "facelock_0.2.1-1.deb13u1_amd64.deb",
+          "url": "https://github.com/tyvsmith/facelock/releases/download/v0.2.1/facelock_0.2.1-1.deb13u1_amd64.deb",
+          "sha256": "52bbf54f86d2d39739a4d880865e62bbf439767c70071654d0e485f66ac1bf1e",
+          "size": 11689412,
+          "package_version": "0.2.1-1~deb13u1"
+        },
+        "rpm-fedora": {
+          "release": "44",
+          "asset_id": 549503986,
+          "asset_node_id": "RA_kwDORmgtH84gwMPy",
+          "name": "facelock-0.2.1-1.fc44.x86_64.rpm",
+          "url": "https://github.com/tyvsmith/facelock/releases/download/v0.2.1/facelock-0.2.1-1.fc44.x86_64.rpm",
+          "sha256": "f9db3ae18e7e48e3b10bc7528a09505c3e16e66e3de89b1370a8d693026085cc",
+          "size": 13081694,
+          "package_version": "0.2.1-1.fc44"
+        }
+      }
+    },
     "v0.1.4": {
       "tag": "v0.1.4",
       "release_id": 332190914,

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -2244,12 +2244,14 @@ distinguishes them, and every other caller treats both as failure. The release
 workflow's `verify-copr` job polls it after publication, because Packit submits
 the COPR build off the published release event and no job in the release run can
 observe that submission. `just release-preflight` runs `--expect-predecessor`,
-which resolves the EVR from the pinned predecessor's `rpm_evr`.
+which resolves the EVR from the `rpm_evr` of the release `predecessors.current`
+names. The matrix may pin more than one release; `current` is the newest, and
+`test/check-release-matrix.py` fails if it is not.
 
 A release that production COPR never received may be recorded as
 `copr_channels.production.served_evr_gap`, naming the EVR owed, the EVR served,
-and the issue that owns it. The record is pinned at both ends: it must excuse
-exactly the pinned predecessor's EVR, and it stops matching the moment the
+and the issue that owns it. No gap is recorded now. The record is pinned at both
+ends: it must excuse exactly the current predecessor's EVR, and it stops matching the moment the
 channel serves anything other than the EVR it names. Both ends are read under
 the channel's own `served_evr_exact`, so on production a suffixed rebuild of the
 EVR the record names no longer matches it.
@@ -2258,8 +2260,8 @@ Only `--expect-predecessor` consults the record. A gap describes a release that
 already shipped without reaching COPR, which is preflight's question;
 `verify-copr` asks `--expect-evr` about the release it is publishing, and a
 record that could answer that would silence the job on the failure it exists to
-report. The record excuses no other release, and the next predecessor pin fails
-the matrix contract until it is updated or deleted.
+report. The record excuses no other release, and rolling `predecessors.current`
+fails the matrix contract until the record is updated or deleted.
 
 A pre-tag attestation binds the candidate commit to the EVRs each channel
 serves, the artifact and repository digests, the signing key fingerprints, and
@@ -3691,8 +3693,12 @@ newer release carry data the older one understands: a `key_id` recorded after
 the upgrade is invisible to an older release, so a template enrolled on the newer version and then
 rolled back decrypts under the single key that older release loads if that key is the one that sealed it.
 
-`just test-upgrade-v014` is the gate for all of the above. It runs both halves
-against the real published v0.1.4 artifacts; see `docs/releasing.md`.
+`just test-upgrade-predecessor` is the gate for all of the above. It runs both
+halves against the real published artifacts of the release
+`dist/release-matrix.json` pins as `predecessors.current`, which is the newest
+one; see `docs/releasing.md`. So the lane proves the round trip to and from that
+release. Support further back rests on the additive, forward-only argument
+above, not on a lane that exercises it.
 
 ## IPC Protocol
 

--- a/docs/developer-commands.md
+++ b/docs/developer-commands.md
@@ -108,11 +108,11 @@ index, so substitute real values for metavariables before running a recipe.
 | `just test-rpm-smoke [release=45]` | Branched-release lane — build the package, then boot it for a runtime smoke |
 | `just test-source-install-daemon-lifecycle` | Preserve the daemon's pre-install runtime state across source file replacement. |
 | `just test-source-install-daemon-lifecycle-systemd` | Exercise the source-install barrier against a real systemd and system bus. |
-| `just test-upgrade-v014` | Both released-predecessor upgrade lanes — the stable entrypoint for #231 |
-| `just test-upgrade-v014-contract` | Released-predecessor upgrade lanes (#231) — container-free half, runs anywhere |
-| `just test-upgrade-v014-deb` | Debian half: install the real v0.1.4 .deb, upgrade to the candidate, roll back |
-| `just test-upgrade-v014-pins` | Confirm the pinned v0.1.4 assets are still the assets GitHub serves (needs gh) |
-| `just test-upgrade-v014-rpm` | Fedora half: same proof against the released fc44 RPM |
+| `just test-upgrade-predecessor` | Both released-predecessor upgrade lanes — the stable entrypoint for #231 |
+| `just test-upgrade-predecessor-contract` | Released-predecessor upgrade lanes (#231) — container-free half, runs anywhere |
+| `just test-upgrade-predecessor-deb` | Debian half: install the real released .deb, upgrade to the candidate, roll back |
+| `just test-upgrade-predecessor-pins` | Confirm the pinned predecessor assets are still the assets GitHub serves (needs gh) |
+| `just test-upgrade-predecessor-rpm` | Fedora half: same proof against the released fc44 RPM |
 | `just uninstall` | Remove source-installed system assets through sudo; retain biometric state and models. |
 | `just uninstall-files` | Uninstall files from system (requires root, called by uninstall) |
 | `just version` | Show current version |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -564,7 +564,8 @@ authority: Fedora 43/44/45 are required and Rawhide is the only optional
 experimental chroot. Rawhide may be present or absent; a missing required
 chroot or any unknown extra is release-blocking drift. Preflight goes one step
 further than CI and asks what production COPR actually serves: the EVR of the
-predecessor pinned in `dist/release-matrix.json`. The checker never modifies the
+release `dist/release-matrix.json` names as `predecessors.current`, which is the
+newest release pinned there. The checker never modifies the
 project. Preflight always runs
 `packit config validate --offline` against `.packit.yaml`, in the digest-pinned
 Fedora container built from
@@ -809,12 +810,22 @@ canonical EVR, not to ask for it somewhere that breaks the other channel.
 
 `just release-preflight` asks the same question about the previous release:
 `test/check-live-release-channels.py --expect-predecessor` requires production
-COPR to serve the EVR pinned in `predecessors`. The v0.1.4 build was never
-backfilled — 0.2.0 supersedes it — so that gap is recorded in
-`copr_channels.production.served_evr_gap` and reported rather than failed. The
-record names both EVRs and issue #333, and it retires itself: once the
-predecessor pin moves past v0.1.4 the release matrix contract fails until the
-record is deleted.
+COPR to serve the EVR of the release `predecessors.current` names.
+
+**Record the gap when a release never reached COPR.** The v0.1.4 build was never
+backfilled — 0.2.0 supersedes it — and while v0.1.4 was the pin, preflight would
+have failed on a channel nobody was going to fix, so the gap lived in
+`copr_channels.production.served_evr_gap`: the EVR owed, the EVR served, and the
+issue that owns it. A record like that is reported rather than failed, and only
+by `--expect-predecessor`.
+
+No gap is recorded now. Rolling the pin to v0.2.1 retired the last one, exactly
+as designed: the record must excuse the *current* predecessor's EVR, so
+`test/check-release-matrix.py` fails the moment `predecessors.current` moves
+past the release it names, and the fix is to delete the record (or, if the new
+predecessor genuinely never reached COPR, to re-record it against that EVR with
+its own issue). Write one only for a release that shipped without reaching COPR
+and that nobody is going to backfill.
 
 A recovery after a failed submission is a hand-submitted build from a checkout
 of the tag. Packit reacts only to *new* release events, so re-publishing is not
@@ -1152,50 +1163,85 @@ Since facelock is a PAM module, broken releases can lock users out. Every releas
 
 ### Upgrading from the last release
 
-`just test-upgrade-v014` proves that state written by v0.1.4 survives an upgrade
-to the candidate and a rollback back to v0.1.4. Two lanes, Debian trixie and
-Fedora 44, each install the real published artifact rather than a synthesized
-older build of the candidate.
+`just test-upgrade-predecessor` proves that state written by the last release
+survives an upgrade to the candidate and a rollback back to it. Two lanes,
+Debian trixie and Fedora 44, each install the real published artifact rather
+than a synthesized older build of the candidate.
 
-**What the lanes pin.** `dist/release-matrix.json` carries a `predecessors` block
-holding the GitHub release id, the asset id, the SHA256 and the byte size of
-each predecessor artifact. The lane Containerfiles take those as build args and
-carry no digest of their own, so one review changes the pin everywhere.
-`just test-upgrade-v014-pins` asks the release API whether those assets are still
-the assets it serves, which is how a re-uploaded or substituted predecessor gets
-caught before a lane silently proves something about a different file.
+**Which release the lanes prove.** `dist/release-matrix.json` names it:
+`predecessors.current`. The block may pin more than one release — v0.1.4 stays
+because the retired-authselect fixture is built from its RPM and no other build
+of that package exists — and `current` is required to be the newest of them, so
+the lanes prove the upgrade users are actually performing. Roll it as part of
+the release that follows a published one (below); before #367 it sat at v0.1.4
+through two releases, so the 0.2.0-to-0.2.1 upgrade — the one everybody
+performed — was never exercised.
+
+**Rolling the pin.** Resolve the new release with
+`gh api repos/tyvsmith/facelock/releases/tags/vX.Y.Z`, add a block beside the
+existing ones carrying the release id, publication timestamp, upstream version,
+`rpm_evr`, and for each lane the asset id, node id, name, URL, SHA256 and byte
+size; point `current` at it; bump `reviewed_on`. Then
+`python3 test/check-release-matrix.py`, `just test-upgrade-predecessor-pins` and
+`just test-upgrade-predecessor`. A recorded `served_evr_gap` must be deleted or
+re-recorded in the same change — see "Record the gap" above.
+
+**What the lanes pin.** The `predecessors` block holds the GitHub release id,
+the asset id, the SHA256 and the byte size of each predecessor artifact. The
+lane Containerfiles take those as build args and carry no digest of their own,
+so one review changes the pin everywhere.
+`just test-upgrade-predecessor-pins` asks the release API whether those assets
+are still the assets it serves, which is how a re-uploaded or substituted
+predecessor gets caught before a lane silently proves something about a
+different file.
 
 **What the lane images carry.** Each image installs the runtime libraries the
-released binary needs before the predecessor goes on. v0.1.4 wrote its Debian
-control file by hand and never declared libxkbcommon0, which its own binary
-links, so that release cannot start on a minimal Debian 13 at all. The candidate
-is built from `debian/control` and derives the list with `${shlibs:Depends}`.
-Nothing is masked by supplying it: candidate dependency resolution belongs to
+released binary needs before the predecessor goes on, and only where that
+release needs them. v0.1.4 wrote its Debian control file by hand and never
+declared libxkbcommon0, which its own binary links, so that release cannot start
+on a minimal Debian 13 at all; every release from 0.2.0 on is built from
+`debian/control` and derives the list with `${shlibs:Depends}`, so the image
+supplies the library only when the pinned predecessor predates 0.2.0. Nothing is
+masked by supplying it: candidate dependency resolution belongs to
 `test/deb-dependency-closure.sh` on a pristine suite base.
 
-**What the lanes build.** Predecessor state comes from the released v0.1.4
+**What the lanes build.** Predecessor state comes from the released
 binary, never from the candidate: plaintext rows, keyfile-encrypted rows, mixed
 rows, and two swtpm-sealed shapes, one PCR-bound and one not. Each shape also
-carries a modified config, the reviewed models, an enrollment marker, an audit
-log and a hand-wired PAM service, because v0.1.4 has no `facelock pam`
-subcommand and that is the shape a real upgrade finds.
+carries a modified config, the reviewed models, a stale enrollment marker, an
+audit log and a hand-wired PAM service, which is the shape a real upgrade finds
+— and the only shape available at all from a release before 0.2.0, which has no
+`facelock pam` subcommand.
 
-**What each lane proves after the upgrade.** The V5 database reaches V6 with
-legacy rows at `device_id = NULL`. A known embedding still decrypts to the exact
-plaintext it was enrolled as, which a file hash cannot show: a preserved key and
-a preserved ciphertext nobody can open any more hash identically. No key
-artifact is replaced and none appears that was not there before. Modes converge
-to ADR 010 without content changing. The enrollment marker keeps its owner and
-mode and its content is reconciled against the database rather than preserved
-byte for byte — the one piece of state the upgrade is supposed to rewrite
-(#137). The administrator's PAM service is byte-identical, a correct password
-still authenticates, and a wrong one still fails.
+**What each lane proves after the upgrade.** The database ends at V7 with every
+row the predecessor wrote intact: a row from an older schema gains
+`device_id = NULL` and `key_id = NULL` rather than an invented coupling, and a
+row a V7 predecessor wrote keeps the `key_id` its release recorded. A known
+embedding still decrypts to the exact plaintext it was enrolled as, which a file
+hash cannot show: a preserved key and a preserved ciphertext nobody can open any
+more hash identically. No key artifact is replaced and none appears that was not
+there before. Modes end at ADR 010 without content changing — tightened from a
+release that predates the layout, untouched from one that already has it. The
+enrollment marker keeps its owner and mode and its content is reconciled against
+the database rather than preserved byte for byte — the one piece of state the
+upgrade is supposed to rewrite (#137). The administrator's PAM service is
+byte-identical, a correct password still authenticates, and a wrong one still
+fails.
+
+**Nothing in the lane spells a release.** The upgrade lane scripts read the pin
+and the predecessor's own database: which schema it wrote, whether its CLI
+groups `encrypt` under `tpm` (ADR 009, 0.2.0), and whether its scriptlets
+already leave the ADR 010 layout. `just test-upgrade-predecessor-contract`
+fails on a tag literal reappearing in any of them, which is how the pin stops
+rotting again.
 
 **Version ordering on a development tree.** Until `just release` bumps the
-workspace, the candidate .deb built from the tree is `0.1.4-1~deb13u1`, which
-sorts *below* the published `0.1.4-1`. The lanes build the same payload as an
-upgrade-test version instead, and every run prints the version it chose and why.
-Once the workspace version sorts above 0.1.4 the re-versioning stops and
+workspace, the candidate .deb built from the tree carries the same version as
+the published predecessor, which does not sort *above* it. The lanes build the
+same payload as an upgrade-test version instead — the predecessor's patch
+version plus one, so the default rolls with the pin — and every run prints the
+version it chose and why. Once the workspace version sorts above the
+predecessor the re-versioning stops and
 `FACELOCK_UPGRADE_TEST_VERSION` becomes a no-op: the lane installs the shipped
 version exactly. The native comparator inside the container decides either way,
 so a lane can never quietly become a downgrade test. Whatever version it lands
@@ -1211,17 +1257,18 @@ a previously published prerelease.
 release's `pam-auth-update` profile shipped `Default: yes`, so installing it
 switched Facelock on in `common-auth`. The packaged profile is `Default: no`
 now, which applies to fresh installs; an upgrade leaves the global stack exactly
-as it found it, and the lane fails if it is edited in either direction. Removing
-an enabled profile would take face authentication away from someone using it, so
-the lane treats that as the more dangerous direction, not a clean result.
+as it found it whichever release it comes from, and the lane fails if it is
+edited in either direction. Removing an enabled profile would take face
+authentication away from someone using it, so the lane treats that as the more
+dangerous direction, not a clean result.
 
 **Where it runs.** Locally, by design: a cached run is about twenty minutes and
 a cold one considerably more, so `packaging.yml` does not carry it and a
 nightly-only job is the follow-up. `just check` runs the container-free contract
-(`just test-upgrade-v014-contract`), so a broken lane definition still fails
-every pull request.
+(`just test-upgrade-predecessor-contract`), so a broken lane definition still
+fails every pull request.
 
-**Rollback.** The candidate daemon starts and migrates the database before the
-downgrade, so the predecessor is handed the file production would hand it. V6
-has no down-migration and the schema stays at 6 after the package rolls back.
+**Rollback.** The candidate daemon starts and opens the database before the
+downgrade, so the predecessor is handed the file production would hand it. V7
+has no down-migration and the schema stays at 7 after the package rolls back.
 See `docs/contracts.md` for what that does and does not guarantee.

--- a/justfile
+++ b/justfile
@@ -153,7 +153,7 @@ test-docs-walkthrough scenario identity output:
     python3 test/docs-walkthrough/run.py run --scenario "{{ scenario }}" --identity "{{ identity }}" --output "{{ output }}"
 
 # Run local tests, lint, format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes.
-check: test lint fmt-check audit check-pam-standalone check-agent-docs check-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-v014-contract test-release-artifacts
+check: test lint fmt-check audit check-pam-standalone check-agent-docs check-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-predecessor-contract test-release-artifacts
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,
@@ -1424,33 +1424,33 @@ test-rpm-smoke release="45": (_fedora-lane-image release) _require-release-binar
 test-rpm-lanes: (test-rpm-pkg "43") (test-rpm-pkg "44") (test-rpm-smoke "45")
 
 # Released-predecessor upgrade lanes (#231) — container-free half, runs anywhere
-test-upgrade-v014-contract:
-    bash test/upgrade-v014-contract.sh
+test-upgrade-predecessor-contract:
+    bash test/upgrade-predecessor-contract.sh
 
-# Confirm the pinned v0.1.4 assets are still the assets GitHub serves (needs gh)
-test-upgrade-v014-pins:
-    bash test/upgrade-v014-predecessor.sh deb-trixie --verify-live
-    bash test/upgrade-v014-predecessor.sh rpm-fedora --verify-live
+# Confirm the pinned predecessor assets are still the assets GitHub serves (needs gh)
+test-upgrade-predecessor-pins:
+    bash test/upgrade-predecessor-pin.sh deb-trixie --verify-live
+    bash test/upgrade-predecessor-pin.sh rpm-fedora --verify-live
 
-# Debian half: install the real v0.1.4 .deb, upgrade to the candidate, roll back
-test-upgrade-v014-deb: test-upgrade-v014-contract _require-models
+# Debian half: install the real released .deb, upgrade to the candidate, roll back
+test-upgrade-predecessor-deb: test-upgrade-predecessor-contract _require-models
     #!/usr/bin/env bash
     set -euo pipefail
-    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-v014-deb.XXXXXX")"
+    artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-predecessor-deb.XXXXXX")"
     trap 'rm -rf -- "$artifact_dir"' EXIT
     candidate="$artifact_dir/facelock-candidate.deb"
-    test/build-upgrade-v014-image.sh deb facelock-upgrade-v014-deb "$candidate"
-    test/run-upgrade-v014-systemd.sh deb facelock-upgrade-v014-deb "$candidate"
+    test/build-upgrade-predecessor-image.sh deb facelock-upgrade-predecessor-deb "$candidate"
+    test/run-upgrade-predecessor-systemd.sh deb facelock-upgrade-predecessor-deb "$candidate"
 
 # Fedora half: same proof against the released fc44 RPM
-test-upgrade-v014-rpm: test-upgrade-v014-contract _require-models _require-release-binaries
+test-upgrade-predecessor-rpm: test-upgrade-predecessor-contract _require-models _require-release-binaries
     #!/usr/bin/env bash
     set -euo pipefail
-    test/build-upgrade-v014-image.sh rpm facelock-upgrade-v014-rpm
-    test/run-upgrade-v014-systemd.sh rpm facelock-upgrade-v014-rpm
+    test/build-upgrade-predecessor-image.sh rpm facelock-upgrade-predecessor-rpm
+    test/run-upgrade-predecessor-systemd.sh rpm facelock-upgrade-predecessor-rpm
 
 # Both released-predecessor upgrade lanes — the stable entrypoint for #231
-test-upgrade-v014: test-upgrade-v014-deb test-upgrade-v014-rpm
+test-upgrade-predecessor: test-upgrade-predecessor-deb test-upgrade-predecessor-rpm
 
 # Packit config schema gate — runs the real `packit` in a digest-pinned Fedora container
 test-packit-config:
@@ -1760,7 +1760,7 @@ release-preflight tag='':
     # Enabled chroots say the project is shaped right; they say nothing about
     # what it serves. The v0.1.4 COPR build never landed and the chroot check
     # passed for three months (#333), so preflight asks production for the EVR
-    # the pinned predecessor should have left behind.
+    # the predecessor `predecessors.current` names should have left behind.
     python3 test/check-live-release-channels.py --expect-predecessor || failed=1
 
     echo ""

--- a/test/Containerfile.upgrade-predecessor-deb
+++ b/test/Containerfile.upgrade-predecessor-deb
@@ -1,5 +1,5 @@
-# Debian upgrade lane (#231, Track K): the released v0.1.4 .deb baked in, the
-# locally built candidate mounted at run time.
+# Debian upgrade lane (#231, Track K): the released predecessor .deb baked in,
+# the locally built candidate mounted at run time.
 #
 # BASE_IMAGE is the booted Debian runtime image test/build-deb-package-image.sh
 # produces — it already carries systemd, pamtester, python3 and the swtpm stack
@@ -11,25 +11,30 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-# Harness tooling, not a candidate dependency. The released v0.1.4 .deb
-# hand-wrote `Depends: libpam-runtime, dbus, libtss2-esys-3.0.2-0t64` and missed
-# libxkbcommon0, which its own binary links against, so v0.1.4's `facelock`
-# refuses to start on a clean Debian 13. The candidate uses ${shlibs:Depends}
-# and declares it. This lane builds predecessor state with the released binary,
-# so it has to supply what that release forgot to ask for.
-#
-# Nothing is masked by this: dependency resolution for the candidate is
-# test/deb-dependency-closure.sh's job on a pristine suite base, not this
-# lane's. The two Fedora lane images install libxkbcommon for the same reason.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libxkbcommon0 && \
-    rm -rf /var/lib/apt/lists/*
-
 ARG FACELOCK_PREDECESSOR_URL
 ARG FACELOCK_PREDECESSOR_SHA256
 ARG FACELOCK_PREDECESSOR_SIZE
 ARG FACELOCK_PREDECESSOR_VERSION
+ARG FACELOCK_PREDECESSOR_UPSTREAM
 ARG FACELOCK_CANDIDATE_VERSION
+
+# Harness tooling for one predecessor, not a candidate dependency. The v0.1.4
+# .deb hand-wrote `Depends: libpam-runtime, dbus, libtss2-esys-3.0.2-0t64` and
+# missed libxkbcommon0, which its own binary links against, so that release's
+# `facelock` refuses to start on a clean Debian 13. Every release from 0.2.0 on
+# is built from debian/control with ${shlibs:Depends} and declares it, so the
+# accommodation is applied only when the pinned predecessor predates that:
+# supplying it for a release that asks for it itself would prove nothing, and
+# the lane must not carry a v0.1.4 habit past the pin that needed it (#367).
+#
+# Nothing is masked by this: dependency resolution for the candidate is
+# test/deb-dependency-closure.sh's job on a pristine suite base, not this
+# lane's. The two Fedora lane images install libxkbcommon for the same reason.
+RUN if dpkg --compare-versions "$FACELOCK_PREDECESSOR_UPSTREAM" lt 0.2.0; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends libxkbcommon0 && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Size as well as digest: a truncated or proxy-rewritten fetch that still
 # happens to be some valid .deb is caught by the digest, and a fetch that
@@ -45,9 +50,10 @@ RUN mkdir -p /artifacts && \
         = "$FACELOCK_PREDECESSOR_VERSION" && \
     printf '%s\n' "$FACELOCK_PREDECESSOR_SHA256" > /artifacts/predecessor.sha256 && \
     printf '%s\n' "$FACELOCK_PREDECESSOR_VERSION" > /artifacts/predecessor.version && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_UPSTREAM" > /artifacts/predecessor.upstream && \
     printf '%s\n' "$FACELOCK_CANDIDATE_VERSION" > /artifacts/candidate.version
 
-COPY test/upgrade-v014-lane.sh /upgrade-v014-lane.sh
-RUN chmod +x /upgrade-v014-lane.sh
+COPY test/upgrade-predecessor-lane.sh /upgrade-predecessor-lane.sh
+RUN chmod +x /upgrade-predecessor-lane.sh
 
 CMD ["/lib/systemd/systemd"]

--- a/test/Containerfile.upgrade-predecessor-rpm
+++ b/test/Containerfile.upgrade-predecessor-rpm
@@ -1,4 +1,4 @@
-# Fedora upgrade lane (#231, Track K): the released v0.1.4 fc44 RPM baked in
+# Fedora upgrade lane (#231, Track K): the released predecessor fc44 RPM baked in
 # beside a candidate built here from the same host binaries and the production
 # spec.
 #
@@ -55,6 +55,7 @@ ARG FACELOCK_PREDECESSOR_URL
 ARG FACELOCK_PREDECESSOR_SHA256
 ARG FACELOCK_PREDECESSOR_SIZE
 ARG FACELOCK_PREDECESSOR_VERSION
+ARG FACELOCK_PREDECESSOR_UPSTREAM
 
 RUN curl --proto '=https' --tlsv1.2 --output /artifacts/facelock-predecessor.rpm \
         -fsSL "$FACELOCK_PREDECESSOR_URL" && \
@@ -64,9 +65,10 @@ RUN curl --proto '=https' --tlsv1.2 --output /artifacts/facelock-predecessor.rpm
     test "$(rpm -qp --qf '%{VERSION}-%{RELEASE}' /artifacts/facelock-predecessor.rpm)" \
         = "$FACELOCK_PREDECESSOR_VERSION" && \
     printf '%s\n' "$FACELOCK_PREDECESSOR_SHA256" > /artifacts/predecessor.sha256 && \
-    printf '%s\n' "$FACELOCK_PREDECESSOR_VERSION" > /artifacts/predecessor.version
+    printf '%s\n' "$FACELOCK_PREDECESSOR_VERSION" > /artifacts/predecessor.version && \
+    printf '%s\n' "$FACELOCK_PREDECESSOR_UPSTREAM" > /artifacts/predecessor.upstream
 
-COPY test/upgrade-v014-lane.sh /upgrade-v014-lane.sh
-RUN chmod +x /upgrade-v014-lane.sh
+COPY test/upgrade-predecessor-lane.sh /upgrade-predecessor-lane.sh
+RUN chmod +x /upgrade-predecessor-lane.sh
 
 CMD ["/usr/lib/systemd/systemd"]

--- a/test/build-upgrade-predecessor-image.sh
+++ b/test/build-upgrade-predecessor-image.sh
@@ -2,8 +2,8 @@
 # Build one released-predecessor upgrade lane image (#231, Track K).
 #
 # Usage:
-#   build-upgrade-v014-image.sh deb <image> <candidate-deb-output>
-#   build-upgrade-v014-image.sh rpm <image>
+#   build-upgrade-predecessor-image.sh deb <image> <candidate-deb-output>
+#   build-upgrade-predecessor-image.sh rpm <image>
 #
 # The Debian half reuses test/build-deb-package-image.sh, so the candidate is
 # the same artifact the Debian lifecycle gate proves; the Fedora half derives
@@ -24,17 +24,17 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # splicing strings here.
 # shellcheck source=/dev/null
 source "$repo_root/scripts/release-versions.sh"
-family="${1:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
-image="${2:?usage: build-upgrade-v014-image.sh <deb|rpm> <image> [candidate-output]}"
+family="${1:?usage: build-upgrade-predecessor-image.sh <deb|rpm> <image> [candidate-output]}"
+image="${2:?usage: build-upgrade-predecessor-image.sh <deb|rpm> <image> [candidate-output]}"
 
-candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)"
+candidate_version="$(bash "$repo_root/test/upgrade-predecessor-candidate-version.sh" version)"
 workspace_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -1)"
-predecessor_version="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" \
+predecessor_version="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" \
     "$([ "$family" = deb ] && echo deb-trixie || echo rpm-fedora)" upstream_version)"
 
 # Always say which version the candidate is built as and why. A lane that
 # silently re-versions is a lane whose result nobody can interpret later.
-if [ "$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" restamped)" = true ]; then
+if [ "$(bash "$repo_root/test/upgrade-predecessor-candidate-version.sh" restamped)" = true ]; then
     cat >&2 <<EOF
 NOTE: candidate version $candidate_version (re-versioned).
       The workspace is at $workspace_version, which does not sort above the
@@ -61,18 +61,18 @@ predecessor_build_args() {
     local lane="$1" line
     while IFS= read -r line; do
         printf '%s\n--build-arg\n' "$line" | tac
-    done < <(bash "$repo_root/test/upgrade-v014-predecessor.sh" "$lane" --build-args)
+    done < <(bash "$repo_root/test/upgrade-predecessor-pin.sh" "$lane" --build-args)
 }
 
 case "$family" in
     deb)
-        candidate_output="${3:?usage: build-upgrade-v014-image.sh deb <image> <candidate-deb-output>}"
+        candidate_output="${3:?usage: build-upgrade-predecessor-image.sh deb <image> <candidate-deb-output>}"
         [ "$#" -eq 3 ] || {
-            echo "usage: build-upgrade-v014-image.sh deb <image> <candidate-deb-output>" >&2
+            echo "usage: build-upgrade-predecessor-image.sh deb <image> <candidate-deb-output>" >&2
             exit 2
         }
         base_image="$image-base"
-        raw_candidate="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-v014-deb.XXXXXX")"
+        raw_candidate="$(mktemp -d "${TMPDIR:-/tmp}/facelock-upgrade-predecessor-deb.XXXXXX")"
         trap 'rm -rf -- "$raw_candidate"' EXIT
         "$repo_root/test/build-deb-package-image.sh" trixie "$base_image" \
             "$raw_candidate/facelock.deb"
@@ -120,13 +120,13 @@ case "$family" in
             --build-arg "BASE_IMAGE=$base_image" \
             --build-arg "FACELOCK_CANDIDATE_VERSION=$lane_version" \
             "${pin_args[@]}" \
-            -t "$image" -f "$repo_root/test/Containerfile.upgrade-v014-deb" "$repo_root"
+            -t "$image" -f "$repo_root/test/Containerfile.upgrade-predecessor-deb" "$repo_root"
 
         install -m 0444 -- "$raw_candidate/candidate.deb" "$candidate_output"
         ;;
     rpm)
         [ "$#" -eq 2 ] || {
-            echo "usage: build-upgrade-v014-image.sh rpm <image>" >&2
+            echo "usage: build-upgrade-predecessor-image.sh rpm <image>" >&2
             exit 2
         }
         # The Fedora lane packages host-built binaries rather than compiling in
@@ -163,7 +163,7 @@ EOF
             done
         fi
 
-        release="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" rpm-fedora release)"
+        release="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" rpm-fedora release)"
         base_fedora="$(bash "$repo_root/test/fedora-lane-image.sh" "$release")"
         ort_version="$(
             for ort in /usr/lib/libonnxruntime.so /usr/lib64/libonnxruntime.so; do
@@ -190,7 +190,7 @@ EOF
             --build-arg "FACELOCK_CANDIDATE_RPM_VERSION=$rpm_version" \
             --build-arg "FACELOCK_CANDIDATE_RPM_RELEASE=$rpm_release" \
             "${pin_args[@]}" \
-            -t "$image" -f "$repo_root/test/Containerfile.upgrade-v014-rpm" "$repo_root"
+            -t "$image" -f "$repo_root/test/Containerfile.upgrade-predecessor-rpm" "$repo_root"
         ;;
     *)
         echo "unsupported upgrade lane family: $family" >&2

--- a/test/check-live-release-channels.py
+++ b/test/check-live-release-channels.py
@@ -247,13 +247,20 @@ if args.expect_predecessor:
     predecessors = matrix.get("predecessors")
     if not isinstance(predecessors, dict):
         fail("release matrix declares no predecessors block")
-    tags = sorted(tag for tag in predecessors if tag.startswith("v"))
-    if len(tags) != 1:
-        fail(f"release matrix must pin exactly one released predecessor, found {tags}")
-    expected_evr = predecessors[tags[0]].get("rpm_evr")
+    # The matrix may pin several releases; `current` names the one a running
+    # system is upgrading from, and that is the only one production COPR is
+    # asked about. Reading "the single pinned tag" instead is what tied this
+    # gate to v0.1.4 long after 0.2.1 shipped (#367).
+    tag = predecessors.get("current")
+    if not isinstance(tag, str) or not tag:
+        fail("release matrix predecessors block names no current predecessor")
+    release = predecessors.get(tag)
+    if not isinstance(release, dict):
+        fail(f"release matrix predecessors.current names {tag}, which is not pinned")
+    expected_evr = release.get("rpm_evr")
     if not isinstance(expected_evr, str) or not expected_evr:
-        fail(f"release matrix predecessor {tags[0]} declares no RPM EVR")
-    expected_for = f" (pinned predecessor {tags[0]})"
+        fail(f"release matrix predecessor {tag} declares no RPM EVR")
+    expected_for = f" (pinned predecessor {tag})"
 else:
     expected_evr = args.expect_evr
     expected_for = ""

--- a/test/check-release-matrix.py
+++ b/test/check-release-matrix.py
@@ -1711,7 +1711,7 @@ print("release matrix contract: OK")
 #
 # Separate block on purpose: everything above reasons about what this release
 # publishes, this one reasons about what an installed system is upgrading FROM.
-# The upgrade lanes (`just test-upgrade-v014`) download real GitHub release
+# The upgrade lanes (`just test-upgrade-predecessor`) download real GitHub release
 # assets, so the pin has to be strong enough that a re-uploaded or substituted
 # asset fails the lane instead of silently changing what was proven. Asset id
 # plus SHA256 plus byte size is that pin: the id survives a rename, the digest
@@ -1736,8 +1736,32 @@ require(
 
 predecessor_tags = sorted(key for key in predecessors if key.startswith("v"))
 require(
-    predecessor_tags == ["v0.1.4"],
-    f"predecessors must pin exactly the v0.1.4 release, got {predecessor_tags}",
+    bool(predecessor_tags),
+    "predecessors must pin at least one released predecessor",
+)
+# More than one release may stay pinned -- v0.1.4 is still the only build of
+# the retired-authselect package that exists -- so which one the upgrade lanes
+# and the preflight served-EVR gate use is named rather than inferred. It is
+# the newest pinned release, because that is the upgrade users actually perform
+# after it ships; a `current` that lags a pinned release is the #367 failure,
+# where the lanes proved 0.1.4-to-candidate while 0.2.1 was what people ran.
+current_predecessor = predecessors.get("current")
+require(
+    isinstance(current_predecessor, str) and current_predecessor in predecessor_tags,
+    f"predecessors.current must name a pinned release, got {current_predecessor!r} "
+    f"(pinned: {predecessor_tags})",
+)
+newest_predecessor = max(predecessor_tags, key=lambda tag: version_triple(tag[1:]))
+require(
+    current_predecessor == newest_predecessor,
+    f"predecessors.current is {current_predecessor}, but {newest_predecessor} is pinned and newer; "
+    "the upgrade lanes must prove the newest released predecessor",
+)
+# v0.1.4 stays pinned for as long as the retired-authselect fixture needs it,
+# and that fixture is held to this pin below.
+require(
+    "v0.1.4" in predecessor_tags,
+    "predecessors must keep pinning v0.1.4 while the retired-authselect fixture reads its digest",
 )
 
 declared_apt_suites = set(matrix["apt_suites"]) - {"compat"}
@@ -1826,11 +1850,12 @@ for tag in predecessor_tags:
 
 # Production COPR never received the v0.1.4 build: Packit's submission failed on
 # every target and nobody noticed for three months (#333). Preflight requires
-# the channel to serve the predecessor, so that unfixed history is recorded as a
-# gap rather than silently tolerated. The record is pinned to both EVRs -- the
-# one owed and the one served -- and to the predecessor above, so it cannot
-# outlive what it excuses: the next predecessor pin makes it fail here, and any
+# the channel to serve the predecessor, so an unfixed history like that is
+# recorded as a gap rather than silently tolerated. The record is pinned to both
+# EVRs -- the one owed and the one served -- and to the current predecessor, so
+# it cannot outlive what it excuses: rolling the pin makes it fail here, and any
 # change to what COPR serves makes it stop matching in the live checker.
+# No gap is recorded now: production COPR serves the EVR the pin owes.
 served_evr_gap = production_copr.get("served_evr_gap")
 if served_evr_gap is not None:
     require(isinstance(served_evr_gap, dict), "production COPR served EVR gap must be an object")
@@ -1839,9 +1864,9 @@ if served_evr_gap is not None:
         f"production COPR served EVR gap fields drifted: {sorted(served_evr_gap)}",
     )
     require(
-        served_evr_gap.get("expected_evr") == predecessors[predecessor_tags[0]]["rpm_evr"],
-        "production COPR served EVR gap must excuse the pinned predecessor, "
-        f"got {served_evr_gap.get('expected_evr')!r}",
+        served_evr_gap.get("expected_evr") == predecessors[current_predecessor]["rpm_evr"],
+        "production COPR served EVR gap must excuse the current pinned predecessor "
+        f"{current_predecessor}, got {served_evr_gap.get('expected_evr')!r}",
     )
     require(
         isinstance(served_evr_gap.get("served_evr"), str)
@@ -1863,10 +1888,23 @@ for relative_path in ("test/Containerfile.rpm-authselect", "test/build-rpm-auths
         f"{relative_path} pins a different v0.1.4 RPM digest than the release matrix",
     )
 
+# The upgrade lane resolver reads whichever release `current` names, so nothing
+# in it may spell a tag. A literal here is how the pin stopped moving (#367).
+predecessor_resolver = (ROOT / "test/upgrade-predecessor-pin.sh").read_text()
+require(
+    'predecessors.get("current")' in predecessor_resolver,
+    "test/upgrade-predecessor-pin.sh must resolve the predecessor through predecessors.current",
+)
+for tag in predecessor_tags:
+    require(
+        f'"{tag}"' not in predecessor_resolver,
+        f"test/upgrade-predecessor-pin.sh names {tag} instead of reading predecessors.current",
+    )
+
 # The upgrade lanes must read the pin from here rather than carry their own.
 for relative_path in (
-    "test/Containerfile.upgrade-v014-deb",
-    "test/Containerfile.upgrade-v014-rpm",
+    "test/Containerfile.upgrade-predecessor-deb",
+    "test/Containerfile.upgrade-predecessor-rpm",
 ):
     lane_source = (ROOT / relative_path).read_text()
     embedded = re.findall(r"\b[0-9a-f]{64}\b", lane_source)

--- a/test/docs-walkthrough/cases.json
+++ b/test/docs-walkthrough/cases.json
@@ -321,7 +321,7 @@
         "path": "docs/releasing.md",
         "anchor": "release-preflight-recommended",
         "ordinal": 19,
-        "line": 578,
+        "line": 579,
         "sha256": "655d50b2ad3658f69f4548aa1da652750d17bec282f550281f9cc518912ca460"
       }
     ],
@@ -372,7 +372,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 8,
-        "line": 1148,
+        "line": 1159,
         "sha256": "45f087a5c09ff21da36fd7763813fdc1ddbc4627af61d1b795636ab1a3fb3448"
       }
     ],
@@ -444,7 +444,7 @@
         "path": "docs/releasing.md",
         "anchor": "upgrade-safety",
         "ordinal": 7,
-        "line": 1148,
+        "line": 1159,
         "sha256": "4981bfb4bf82b5fffa2693be6c87209a35f34a2496e6f5ecddbc52cde3a0ca0f"
       }
     ],

--- a/test/docs-walkthrough/manual-sections.json
+++ b/test/docs-walkthrough/manual-sections.json
@@ -9344,231 +9344,231 @@
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 1,
-          "line": 599,
+          "line": 600,
           "sha256": "ce117958431b95a2b1b7736900f985d21b06e2b5672c9332ca300f7e2f728cec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 2,
-          "line": 602,
+          "line": 603,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 3,
-          "line": 603,
+          "line": 604,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 4,
-          "line": 604,
+          "line": 605,
           "sha256": "eade2495c1c8af468788a81f22b4748844fb7e378dcb7b838f5b6a94478eca4a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 5,
-          "line": 605,
+          "line": 606,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 6,
-          "line": 610,
+          "line": 611,
           "sha256": "5b6566b30a1c74929651fbf4d529d0b2bc03d901c23fb56fccf98720af6a3f52"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 7,
-          "line": 611,
+          "line": 612,
           "sha256": "d91ae6717b7b7778b93b9020d48bc3759649decdaa9abad31f36fa82cf0964e2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 8,
-          "line": 613,
+          "line": 614,
           "sha256": "c9a3615c4b78b410f6374730cc6ae2a6f84f3cfc991e1d62afefeafdea301e7a"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 9,
-          "line": 614,
+          "line": 615,
           "sha256": "80b4949070e5c55d722d81d45af49fe18736316ae34f61992bb2500c59fbf83e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 10,
-          "line": 615,
+          "line": 616,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 11,
-          "line": 616,
+          "line": 617,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 12,
-          "line": 617,
+          "line": 618,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 13,
-          "line": 618,
+          "line": 619,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 14,
-          "line": 619,
+          "line": 620,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 15,
-          "line": 622,
+          "line": 623,
           "sha256": "a1d2a470e9757ca1a468b4129de0e79687de54106b68c041ce621be96ad5f4f9"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 16,
-          "line": 623,
+          "line": 624,
           "sha256": "aa17fd000eb5853bf3764379438d5d60e6b847ef03e6028108af9563da1226d4"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 17,
-          "line": 624,
+          "line": 625,
           "sha256": "69a5e09dc6213aebcc57177e7aae3f399a2d5d3aae7842563b239795c0f3b0da"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 18,
-          "line": 625,
+          "line": 626,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 19,
-          "line": 626,
+          "line": 627,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 20,
-          "line": 627,
+          "line": 628,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 21,
-          "line": 628,
+          "line": 629,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 22,
-          "line": 629,
+          "line": 630,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 23,
-          "line": 630,
+          "line": 631,
           "sha256": "ecc78bda27b832c6956a35bdf1ee8fb759f85425a9e8c85d28edb523bb6779f5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 24,
-          "line": 633,
+          "line": 634,
           "sha256": "760d01df3d4b65d21ee36ae04052a37b260f722c68cf58ce52947c41720e08aa"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 25,
-          "line": 634,
+          "line": 635,
           "sha256": "88d89d47a06c2521dd75cba1300449b6861770cc6db54e68046a24baac5a5770"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 26,
-          "line": 635,
+          "line": 636,
           "sha256": "7e3163129541b685b8df8bb22a871dfcff84227081f53a25599b5cffd3900af2"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 27,
-          "line": 636,
+          "line": 637,
           "sha256": "436f245d1d2ff52f45e4708def3db88264f00a69f14ac45f3974e91213865413"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 28,
-          "line": 637,
+          "line": 638,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 29,
-          "line": 638,
+          "line": 639,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 30,
-          "line": 639,
+          "line": 640,
           "sha256": "c1fe02ee74644b70083160af86534e360016dcbd5aa98097d7a570640e508a14"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 31,
-          "line": 640,
+          "line": 641,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 32,
-          "line": 644,
+          "line": 645,
           "sha256": "1548e502c894199d945d62477c663ac76551ae0a415c54d023829c8374fc5e20"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "aur-arch-linux",
           "ordinal": 33,
-          "line": 648,
+          "line": 649,
           "sha256": "2bb449e3f1e527e7ecac90a956b1a6b5722b264c3cfae4611d0cc62aa0265ba3"
         }
       ],
@@ -10038,22 +10038,22 @@
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
-          "ordinal": 8,
-          "line": 824,
+          "ordinal": 9,
+          "line": 835,
           "sha256": "4f8c8f6471b5acc7be9447a1cc5a4ef869157bce60d91c20e453570df45d3af5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
-          "ordinal": 9,
-          "line": 825,
+          "ordinal": 10,
+          "line": 836,
           "sha256": "330b0e0d48e5cadecc7312bd0e67d8fe2c885d0d4ff881e165c92d12cd5de072"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "why-v014-never-reached-copr",
-          "ordinal": 10,
-          "line": 826,
+          "ordinal": 11,
+          "line": 837,
           "sha256": "eafacd9bcae280d0368ab135f72ec91b7e2d8399382e1050b67ef96cd5e94ff8"
         }
       ],
@@ -10135,14 +10135,14 @@
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 2,
-          "line": 930,
+          "line": 941,
           "sha256": "4fc7ae86753f046827e1eaf821e79f8502c861494f431ee06e627c16a0f582c5"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "pre-tag-attestation",
           "ordinal": 3,
-          "line": 931,
+          "line": 942,
           "sha256": "9daf87a90676b422783ead7510dc9cd9df3f7d35ec73a7f6b720b249814ed638"
         }
       ],
@@ -10210,21 +10210,21 @@
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 1,
-          "line": 958,
+          "line": 969,
           "sha256": "3a7b17c8cfba23ce48b71f39c7a8e55fa570bf8596dac8e00622eaa2fd8f67b6"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 2,
-          "line": 965,
+          "line": 976,
           "sha256": "bc5050fd8434b234ad64a8e1d0e102b7193ed203126d768b32c0f72286addf7f"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "apt-debianubuntu",
           "ordinal": 3,
-          "line": 970,
+          "line": 981,
           "sha256": "07aef43e7726b1c28642fe5034e46b275bb0175b1a8bf8b2ab09125586f97c02"
         }
       ],
@@ -10305,56 +10305,56 @@
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 1,
-          "line": 1011,
+          "line": 1022,
           "sha256": "bd978c87c0aadfa54d4ba4f05b48f51ea4197e79703f972a5b6e2e7db17facd1"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 2,
-          "line": 1013,
+          "line": 1024,
           "sha256": "6fbda588a984496fe15cc3910c5759c7f24c1920e358e38865bdf3f599bf2eaf"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 3,
-          "line": 1017,
+          "line": 1028,
           "sha256": "496912e98f06a6851cefff636f7f9a738aea9093d8ca87d32427a71fc0d4e710"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 4,
-          "line": 1023,
+          "line": 1034,
           "sha256": "db66421d7339cfe66576a3d1816ccd849e3cce082609ed202f033e8766850f5e"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 5,
-          "line": 1024,
+          "line": 1035,
           "sha256": "fe9e350dccdf906c3c342fa6d20e264cf09012c885bbc76709d25df82a557eec"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 6,
-          "line": 1028,
+          "line": 1039,
           "sha256": "9b13396a2d62293086b0bfda57435689ba59dde26f4398d2eba7624ef80916eb"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 7,
-          "line": 1029,
+          "line": 1040,
           "sha256": "1770d6f9d00ebdeba4277b6bd833aebdfe61df440fdc0e7cf518616c0f4fb84d"
         },
         {
           "path": "docs/releasing.md",
           "anchor": "manual-aur-update-fallback",
           "ordinal": 8,
-          "line": 1030,
+          "line": 1041,
           "sha256": "c32f2b1a66f8a79deadb74f533f3075c60a629df343b89e8c4477d40fa960ba8"
         }
       ],

--- a/test/release-version-contract.sh
+++ b/test/release-version-contract.sh
@@ -371,12 +371,14 @@ cp "$repo_root/test/Containerfile.fedora" "$matrix_root/test/"
 cp "$repo_root/.dockerignore" "$matrix_root/"
 cp "$repo_root/test/fedora-lane-image.sh" "$matrix_root/test/"
 # The released-predecessor upgrade lanes (#231). check-release-matrix.py holds
-# the v0.1.4 RPM digest equal across the authselect fixture and the matrix, and
-# refuses a lane Containerfile that grew a digest of its own, so all three have
-# to be staged or the checker dies before asserting either.
+# the v0.1.4 RPM digest equal across the authselect fixture and the matrix,
+# refuses a lane Containerfile that grew a digest of its own, and requires the
+# pin resolver to read `predecessors.current` rather than a tag (#367), so all
+# four have to be staged or the checker dies before asserting any of them.
 cp "$repo_root/test/build-rpm-authselect-fixtures.sh" "$matrix_root/test/"
-cp "$repo_root/test/Containerfile.upgrade-v014-deb" "$matrix_root/test/"
-cp "$repo_root/test/Containerfile.upgrade-v014-rpm" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.upgrade-predecessor-deb" "$matrix_root/test/"
+cp "$repo_root/test/Containerfile.upgrade-predecessor-rpm" "$matrix_root/test/"
+cp "$repo_root/test/upgrade-predecessor-pin.sh" "$matrix_root/test/"
 cp "$repo_root/.github/workflows/packaging.yml" "$matrix_root/.github/workflows/"
 cp "$repo_root/test/copr-build.sh" "$matrix_root/test/"
 cp "$repo_root/test/packit-config-validate.sh" "$matrix_root/test/"
@@ -1055,6 +1057,34 @@ assert_matrix_mutation_rejected \
     "Packit release target Fedora 45 to Rawhide" \
     ".packit.yaml" \
     's/"fedora-45-x86_64"/"fedora-rawhide-x86_64"/'
+
+# Which release the upgrade lanes and the preflight served-EVR gate ask about
+# (#367). The matrix may pin several, so `current` names one, and it has to be
+# the newest pinned release: a `current` left behind is exactly the state that
+# proved 0.1.4-to-candidate for the two releases after it. The sed matches
+# whatever tag is current and repoints it at the oldest pin the matrix keeps.
+assert_matrix_mutation_rejected \
+    "current predecessor left behind a newer pinned release" \
+    "dist/release-matrix.json" \
+    's/"current": "v[0-9][0-9.]*"/"current": "v0.1.4"/' \
+    "the upgrade lanes must prove the newest released predecessor"
+assert_matrix_mutation_rejected \
+    "predecessors naming no current release" \
+    "dist/release-matrix.json" \
+    '/^    "current": /d' \
+    "predecessors.current must name a pinned release"
+assert_matrix_mutation_rejected \
+    "current predecessor naming a release nothing pins" \
+    "dist/release-matrix.json" \
+    's/"current": "v[0-9][0-9.]*"/"current": "v9.9.9"/' \
+    "predecessors.current must name a pinned release"
+# The retired-authselect fixture is the reason more than one release stays
+# pinned, and it reads the v0.1.4 RPM digest out of this block.
+assert_matrix_mutation_rejected \
+    "v0.1.4 unpinned while the authselect fixture still reads its digest" \
+    "dist/release-matrix.json" \
+    's/^    "v0\.1\.4": {$/    "v0.1.4-retired": {/' \
+    "while the retired-authselect fixture reads its digest"
 
 # The APT signing key fingerprint is pinned so a rotation cannot silently
 # leave the published docs quoting a key that is no longer in the keyring:
@@ -1990,6 +2020,66 @@ if [ -n "$served_gap_expected" ]; then
 else
     echo "release channel case: no served EVR gap recorded, nothing to excuse"
 fi
+
+# `--expect-predecessor` asks about the release `predecessors.current` names,
+# never about whichever pinned tag happens to sort first. Reading "the single
+# pinned tag" is how preflight kept asking production COPR for 0.1.4-1 while
+# 0.2.1 was the release people were upgrading from (#367). Both halves are
+# here: the real matrix resolves the current pin, and a copy whose `current`
+# points at the older pin resolves that one instead.
+predecessor_pin_field() {
+    python3 -c 'import json,sys
+matrix = json.load(open(sys.argv[1], encoding="utf-8"))
+predecessors = matrix["predecessors"]
+tag = predecessors["current"] if sys.argv[2] == "current" else sys.argv[2]
+print(tag if sys.argv[3] == "tag" else predecessors[tag]["rpm_evr"])' "$1" "$2" "$3"
+}
+
+current_predecessor_tag="$(predecessor_pin_field "$repo_root/dist/release-matrix.json" current tag)"
+current_predecessor_evr="$(predecessor_pin_field "$repo_root/dist/release-matrix.json" current evr)"
+served_predecessor_case "predecessor EVR resolved from predecessors.current" \
+    "$tmp_root/served-ok.json" 2 \
+    "does not serve facelock-$current_predecessor_evr (pinned predecessor $current_predecessor_tag)"
+
+# The same question against a matrix whose `current` names the older pin. A
+# checker that ignored the field would ask for the same EVR both times.
+predecessor_current_root="$tmp_root/live-channel-predecessor-current"
+rm -rf "$predecessor_current_root"
+mkdir -p "$predecessor_current_root/dist" "$predecessor_current_root/test"
+cp "$repo_root/test/check-live-release-channels.py" "$predecessor_current_root/test/"
+older_predecessor_tag="$(python3 - "$repo_root/dist/release-matrix.json" \
+    "$predecessor_current_root/dist/release-matrix.json" <<'PY'
+import json
+import sys
+
+matrix = json.loads(open(sys.argv[1], encoding="utf-8").read())
+predecessors = matrix["predecessors"]
+tags = [tag for tag in predecessors if tag.startswith("v")]
+oldest = min(tags, key=lambda tag: tuple(int(part) for part in tag[1:].split(".")[:3]))
+if oldest == predecessors["current"]:
+    raise SystemExit("the matrix pins one predecessor; this case needs the older one too")
+predecessors["current"] = oldest
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump(matrix, handle, indent=2)
+print(oldest)
+PY
+)" || fail "could not stage a matrix whose current predecessor is the older pin"
+older_predecessor_evr="$(predecessor_pin_field "$predecessor_current_root/dist/release-matrix.json" \
+    current evr)"
+[ "$older_predecessor_evr" != "$current_predecessor_evr" ] ||
+    fail "the older predecessor pin carries the same EVR as the current one; the case proves nothing"
+predecessor_current_status=0
+predecessor_current_output=$(python3 \
+    "$predecessor_current_root/test/check-live-release-channels.py" --expect-predecessor \
+    --response-file "$live_copr_supported_with_rawhide" \
+    --package-response-file "$tmp_root/served-ok.json" 2>&1) || predecessor_current_status=$?
+[ "$predecessor_current_status" = 2 ] ||
+    fail "repointed predecessor case exited $predecessor_current_status, expected 2: $predecessor_current_output"
+case "$predecessor_current_output" in
+    *"does not serve facelock-$older_predecessor_evr (pinned predecessor $older_predecessor_tag)"*) ;;
+    *) fail "the live checker did not follow predecessors.current: $predecessor_current_output" ;;
+esac
+echo "release channel case: predecessor EVR follows predecessors.current"
 
 served_no_expectation_status=0
 served_no_expectation_output=$(python3 "$repo_root/test/check-live-release-channels.py" \

--- a/test/run-upgrade-predecessor-systemd.sh
+++ b/test/run-upgrade-predecessor-systemd.sh
@@ -2,8 +2,8 @@
 # Boot one released-predecessor upgrade lane under systemd and run its harness.
 #
 # Usage:
-#   run-upgrade-v014-systemd.sh deb <image> <candidate.deb>
-#   run-upgrade-v014-systemd.sh rpm <image>
+#   run-upgrade-predecessor-systemd.sh deb <image> <candidate.deb>
+#   run-upgrade-predecessor-systemd.sh rpm <image>
 #
 # systemd is not optional here. The lane starts and stops the packaged daemon,
 # and the rollback proof turns on the candidate daemon having actually opened
@@ -12,15 +12,15 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-family="${1:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
-image="${2:?usage: run-upgrade-v014-systemd.sh <deb|rpm> <image> [candidate.deb]}"
+family="${1:?usage: run-upgrade-predecessor-systemd.sh <deb|rpm> <image> [candidate.deb]}"
+image="${2:?usage: run-upgrade-predecessor-systemd.sh <deb|rpm> <image> [candidate.deb]}"
 
 mounts=()
 case "$family" in
     deb)
-        candidate="${3:?usage: run-upgrade-v014-systemd.sh deb <image> <candidate.deb>}"
+        candidate="${3:?usage: run-upgrade-predecessor-systemd.sh deb <image> <candidate.deb>}"
         [ "$#" -eq 3 ] || {
-            echo "usage: run-upgrade-v014-systemd.sh deb <image> <candidate.deb>" >&2
+            echo "usage: run-upgrade-predecessor-systemd.sh deb <image> <candidate.deb>" >&2
             exit 2
         }
         [ -f "$candidate" ] && [ ! -L "$candidate" ] || {
@@ -32,7 +32,7 @@ case "$family" in
         ;;
     rpm)
         [ "$#" -eq 2 ] || {
-            echo "usage: run-upgrade-v014-systemd.sh rpm <image>" >&2
+            echo "usage: run-upgrade-predecessor-systemd.sh rpm <image>" >&2
             exit 2
         }
         ;;
@@ -91,4 +91,4 @@ done
     exit 1
 }
 
-podman exec "$cid" /upgrade-v014-lane.sh "$family"
+podman exec "$cid" /upgrade-predecessor-lane.sh "$family"

--- a/test/upgrade-predecessor-candidate-version.sh
+++ b/test/upgrade-predecessor-candidate-version.sh
@@ -4,28 +4,32 @@
 # An upgrade lane needs a candidate that sorts strictly above the pinned
 # predecessor, and on a development tree it does not have one: the workspace
 # version stays at the last release until `just release` bumps it, so the .deb
-# built from it is `0.1.4-1~deb13u1` — *below* the published `0.1.4-1`, and the
-# lane would be testing a downgrade.
+# built from it carries the predecessor's own upstream version with a suffixed
+# revision — which sorts *below* the published one — and the lane would be
+# testing a downgrade.
 #
 # So the version is chosen, not assumed. When the workspace version already
 # sorts above the predecessor the candidate is built exactly as it ships; when
 # it does not, the lane builds the same payload as the upgrade-test version
-# below and says so. This mirrors what the retired-authselect fixture already
-# does (test/build-rpm-authselect-fixtures.sh builds its candidate at 0.2.0),
-# and the native comparator inside the container is still the authority — a
-# wrong answer here fails the lane rather than passing quietly.
+# and says so: the predecessor's patch version plus one unless
+# FACELOCK_UPGRADE_TEST_VERSION overrides it, so the default rolls with the
+# pin rather than sitting at a literal that stops sorting above it. This
+# mirrors what the retired-authselect fixture already does
+# (test/build-rpm-authselect-fixtures.sh builds its candidate at 0.2.0), and
+# the native comparator inside the container is still the authority — a wrong
+# answer here fails the lane rather than passing quietly.
 #
-# Usage: upgrade-v014-candidate-version.sh <version|restamped>
+# Usage: upgrade-predecessor-candidate-version.sh <version|restamped>
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-field="${1:?usage: upgrade-v014-candidate-version.sh <version|restamped>}"
+field="${1:?usage: upgrade-predecessor-candidate-version.sh <version|restamped>}"
 [ "$#" -eq 1 ] || {
-    echo "usage: upgrade-v014-candidate-version.sh <version|restamped>" >&2
+    echo "usage: upgrade-predecessor-candidate-version.sh <version|restamped>" >&2
     exit 2
 }
 
-FACELOCK_UPGRADE_TEST_VERSION="${FACELOCK_UPGRADE_TEST_VERSION:-0.2.0}" \
+FACELOCK_UPGRADE_TEST_VERSION="${FACELOCK_UPGRADE_TEST_VERSION:-}" \
 python3 - "$repo_root" "$field" <<'PY'
 import os
 import re
@@ -43,7 +47,10 @@ def triple(version):
 
 
 matrix = __import__("json").loads((root / "dist/release-matrix.json").read_text())
-predecessor = matrix["predecessors"]["v0.1.4"]["upstream_version"]
+predecessors = matrix["predecessors"]
+predecessor = predecessors[predecessors["current"]]["upstream_version"]
+major, minor, patch = triple(predecessor)
+default_test_version = f"{major}.{minor}.{patch + 1}"
 
 cargo = (root / "Cargo.toml").read_text()
 match = re.search(r'(?m)^version = "([^"]+)"', cargo)
@@ -54,7 +61,8 @@ workspace = match.group(1)
 if triple(workspace) > triple(predecessor):
     version, restamped = workspace, "false"
 else:
-    version, restamped = os.environ["FACELOCK_UPGRADE_TEST_VERSION"], "true"
+    version = os.environ["FACELOCK_UPGRADE_TEST_VERSION"] or default_test_version
+    restamped = "true"
 
 if triple(version) <= triple(predecessor):
     raise SystemExit(

--- a/test/upgrade-predecessor-contract.sh
+++ b/test/upgrade-predecessor-contract.sh
@@ -255,6 +255,30 @@ done
 grep -Fq 'dpkg --compare-versions "$FACELOCK_PREDECESSOR_UPSTREAM" lt 0.2.0' \
     "$repo_root/test/Containerfile.upgrade-predecessor-deb" ||
     fail "the Debian lane image no longer gates its pre-0.2.0 dependency accommodation on the pinned predecessor"
+# The store is created by the released binary, whichever release that is: an
+# `encrypt` that creates one before 0.2.0, the daemon's own startup after,
+# because from 0.2.1 on that verb refuses a database that is not there.
+grep -Eq '^create_database_with_released_binary\(\)' "$lane" ||
+    fail "the lane defines no create_database_with_released_binary"
+sed -n '/^seed_released_database() {/,/^}/p' "$lane" |
+    grep -q create_database_with_released_binary ||
+    fail "seed_released_database no longer creates the store with the released binary"
+
+# And the stale marker is planted after that, never before. Running the
+# released daemon reconciles markers at startup, so a marker planted first
+# comes back fresh and `assert_enrollment_marker_reconciled` then proves only
+# that some daemon rewrote it, not that the upgrade did.
+seed_shape_body="$(sed -n '/^seed_shape() {/,/^}/p' "$lane")"
+seed_database_line="$(printf '%s\n' "$seed_shape_body" | grep -n 'seed_released_database' |
+    head -1 | cut -d: -f1)"
+marker_line="$(printf '%s\n' "$seed_shape_body" | grep -n 'plant_stale_enrollment_marker' |
+    head -1 | cut -d: -f1)"
+if [ -z "$seed_database_line" ] || [ -z "$marker_line" ]; then
+    fail "seed_shape no longer both seeds the released database and plants the stale marker"
+elif [ "$marker_line" -le "$seed_database_line" ]; then
+    fail "seed_shape plants the stale enrollment marker before the released binary creates its store"
+fi
+
 # The predecessor's schema is whatever the pinned release writes, recorded when
 # it creates its first database. A literal here is the #367 failure in another
 # spelling: 0.2.1 writes V7, so "the predecessor wrote V5" is only ever true of

--- a/test/upgrade-predecessor-contract.sh
+++ b/test/upgrade-predecessor-contract.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Container-free contract for the released-predecessor upgrade lanes (#231).
 #
-# `just test-upgrade-v014` boots two containers, builds a package in each, and
-# takes the better part of an hour. Everything that can rot without a container
-# is checked here instead, so the failure arrives in seconds:
+# `just test-upgrade-predecessor` boots two containers, builds a package in
+# each, and takes the better part of an hour. Everything that can rot without a
+# container is checked here instead, so the failure arrives in seconds:
 #
 #   * a declared state shape or fault case with no implementation behind it
 #   * a proof function that exists but nothing calls — the rot mode
@@ -11,13 +11,15 @@
 #   * the known-embedding digest drifting apart from the Debian lifecycle gate's
 #     copy of the same fixture
 #   * a lane Containerfile growing its own predecessor pin
+#   * a lane file spelling a release tag instead of reading the pinned
+#     predecessor the matrix names (#367)
 #   * a candidate version that does not sort above the predecessor
 #
 # It is wired into `just check` through the lane recipes and can be run alone.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-lane="$repo_root/test/upgrade-v014-lane.sh"
+lane="$repo_root/test/upgrade-predecessor-lane.sh"
 failures=0
 
 fail() {
@@ -32,23 +34,23 @@ require_file() {
 # --- the lane files exist and parse ---------------------------------------
 
 for path in \
-    "$repo_root/test/upgrade-v014-lane.sh" \
-    "$repo_root/test/upgrade-v014-predecessor.sh" \
-    "$repo_root/test/upgrade-v014-candidate-version.sh" \
-    "$repo_root/test/build-upgrade-v014-image.sh" \
-    "$repo_root/test/run-upgrade-v014-systemd.sh" \
-    "$repo_root/test/Containerfile.upgrade-v014-deb" \
-    "$repo_root/test/Containerfile.upgrade-v014-rpm"; do
+    "$repo_root/test/upgrade-predecessor-lane.sh" \
+    "$repo_root/test/upgrade-predecessor-pin.sh" \
+    "$repo_root/test/upgrade-predecessor-candidate-version.sh" \
+    "$repo_root/test/build-upgrade-predecessor-image.sh" \
+    "$repo_root/test/run-upgrade-predecessor-systemd.sh" \
+    "$repo_root/test/Containerfile.upgrade-predecessor-deb" \
+    "$repo_root/test/Containerfile.upgrade-predecessor-rpm"; do
     require_file "$path"
 done
 [ "$failures" -eq 0 ] || exit 1
 
 for script in \
-    "$repo_root/test/upgrade-v014-lane.sh" \
-    "$repo_root/test/upgrade-v014-predecessor.sh" \
-    "$repo_root/test/upgrade-v014-candidate-version.sh" \
-    "$repo_root/test/build-upgrade-v014-image.sh" \
-    "$repo_root/test/run-upgrade-v014-systemd.sh"; do
+    "$repo_root/test/upgrade-predecessor-lane.sh" \
+    "$repo_root/test/upgrade-predecessor-pin.sh" \
+    "$repo_root/test/upgrade-predecessor-candidate-version.sh" \
+    "$repo_root/test/build-upgrade-predecessor-image.sh" \
+    "$repo_root/test/run-upgrade-predecessor-systemd.sh"; do
     bash -n "$script" || fail "${script#"$repo_root"/} does not parse"
     [ -x "$script" ] || fail "${script#"$repo_root"/} is not executable"
 done
@@ -150,7 +152,7 @@ fi
 # The Fedora lane packages host-built binaries, so it can test code that is not
 # this checkout. The freshness guard in the image builder is the only thing that
 # notices, and a green run without it means nothing.
-grep -q 'is older than the workspace source' "$repo_root/test/build-upgrade-v014-image.sh" ||
+grep -q 'is older than the workspace source' "$repo_root/test/build-upgrade-predecessor-image.sh" ||
     fail "the Fedora lane no longer refuses release binaries older than the source"
 
 # The concurrent-key case has to separate O_EXCL from O_TRUNC. One key file on
@@ -192,13 +194,18 @@ done
 # --- the lane Containerfiles take the pin, never carry one ----------------
 
 for containerfile in \
-    "$repo_root/test/Containerfile.upgrade-v014-deb" \
-    "$repo_root/test/Containerfile.upgrade-v014-rpm"; do
+    "$repo_root/test/Containerfile.upgrade-predecessor-deb" \
+    "$repo_root/test/Containerfile.upgrade-predecessor-rpm"; do
     for arg in FACELOCK_PREDECESSOR_URL FACELOCK_PREDECESSOR_SHA256 \
-        FACELOCK_PREDECESSOR_SIZE FACELOCK_PREDECESSOR_VERSION; do
+        FACELOCK_PREDECESSOR_SIZE FACELOCK_PREDECESSOR_VERSION \
+        FACELOCK_PREDECESSOR_UPSTREAM; do
         grep -Eq "^ARG $arg\$" "$containerfile" ||
             fail "${containerfile#"$repo_root"/} does not take $arg as a build arg"
     done
+    # The upstream version has to reach the lane, not just the image build:
+    # every release-specific branch inside the lane reads it from there.
+    grep -Fq '/artifacts/predecessor.upstream' "$containerfile" ||
+        fail "${containerfile#"$repo_root"/} does not write the pinned upstream version into the image"
     if grep -qE '\b[0-9a-f]{64}\b' "$containerfile"; then
         fail "${containerfile#"$repo_root"/} carries its own digest instead of the matrix pin"
     fi
@@ -208,13 +215,54 @@ done
 
 for pair in "deb-trixie:deb" "rpm-fedora:rpm"; do
     lane_name="${pair%%:*}"
-    resolved="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" "$lane_name" --build-args)" ||
+    resolved="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" "$lane_name" --build-args)" ||
         fail "predecessor lane $lane_name does not resolve"
-    for key in URL SHA256 SIZE NAME VERSION; do
+    for key in URL SHA256 SIZE NAME VERSION UPSTREAM; do
         printf '%s\n' "$resolved" | grep -q "^FACELOCK_PREDECESSOR_$key=." ||
             fail "predecessor lane $lane_name resolved no $key"
     done
 done
+
+# --- nothing here spells a release; the matrix names it -------------------
+#
+# #367: the lanes proved 0.1.4-to-candidate long after 0.2.0 and 0.2.1 shipped,
+# because the tag was a literal in the resolver and every accommodation was a
+# literal in the lane. The pin now names the release it is rolled to
+# (`predecessors.current`), and each of these files must read it rather than
+# grow a tag of its own again.
+grep -Fq 'predecessors.get("current")' "$repo_root/test/upgrade-predecessor-pin.sh" ||
+    fail "test/upgrade-predecessor-pin.sh no longer resolves the predecessor through predecessors.current"
+grep -Fq 'predecessors["current"]' "$repo_root/test/upgrade-predecessor-candidate-version.sh" ||
+    fail "test/upgrade-predecessor-candidate-version.sh no longer reads the predecessor through predecessors.current"
+# shellcheck disable=SC2016 # the lane's own assignment is the literal sought
+grep -Fq 'PREDECESSOR_UPSTREAM="$(cat "$PREDECESSOR_UPSTREAM_FILE")"' "$lane" ||
+    fail "the lane no longer reads the pinned predecessor's upstream version from the image"
+grep -Eq '^predecessor_before\(\)' "$lane" ||
+    fail "the lane defines no predecessor_before, so nothing can key off the pinned version"
+for layout in legacy adr010; do
+    grep -Eq "^[[:space:]]+$layout\)" "$lane" ||
+        fail "the lane no longer dispatches the $layout predecessor layout"
+done
+for path in test/upgrade-predecessor-pin.sh test/upgrade-predecessor-candidate-version.sh \
+    test/upgrade-predecessor-lane.sh; do
+    if grep -nE '^[^#]*"v[0-9]+\.[0-9]+\.[0-9]+"' "$repo_root/$path" >/dev/null; then
+        fail "$path pins a release tag in code; the pin is dist/release-matrix.json's predecessors.current"
+    fi
+done
+# The one Debian accommodation a modern predecessor must not get: v0.1.4's
+# hand-written control file missed libxkbcommon0, and supplying it for a
+# release that declares its own dependencies would mask a real packaging bug.
+grep -Fq 'dpkg --compare-versions "$FACELOCK_PREDECESSOR_UPSTREAM" lt 0.2.0' \
+    "$repo_root/test/Containerfile.upgrade-predecessor-deb" ||
+    fail "the Debian lane image no longer gates its pre-0.2.0 dependency accommodation on the pinned predecessor"
+# The predecessor's schema is whatever the pinned release writes, recorded when
+# it creates its first database. A literal here is the #367 failure in another
+# spelling: 0.2.1 writes V7, so "the predecessor wrote V5" is only ever true of
+# a pin nobody rolled.
+# shellcheck disable=SC2016 # the retired assertion is the literal sought
+if grep -Fq 'assert_eq 5 "$(schema_version)"' "$lane"; then
+    fail "the lane asserts the predecessor wrote V5 instead of recording what it wrote"
+fi
 
 # --- --verify-live judges a live asset the way the pin means it -----------
 #
@@ -232,16 +280,16 @@ verify_live_stub() {
 printf '%s\n' "$answer"
 STUB
     chmod +x "$stub_dir/gh"
-    PATH="$stub_dir:$PATH" bash "$repo_root/test/upgrade-v014-predecessor.sh" \
+    PATH="$stub_dir:$PATH" bash "$repo_root/test/upgrade-predecessor-pin.sh" \
         deb-trixie --verify-live >"$stub_dir/out" 2>&1 || status=$?
     printf '%s\n' "$status"
     cat "$stub_dir/out"
     rm -rf "$stub_dir"
 }
 
-pinned_name="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie name)"
-pinned_size="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie size)"
-pinned_sha="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie sha256)"
+pinned_name="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" deb-trixie name)"
+pinned_size="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" deb-trixie size)"
+pinned_sha="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" deb-trixie sha256)"
 tab="$(printf '\t')"
 
 assert_verify_live() {
@@ -263,12 +311,12 @@ assert_verify_live "a digest that moved" \
     "serves a different digest"
 assert_verify_live "a size that moved" \
     "$pinned_name$tab$((pinned_size + 1))${tab}sha256:$pinned_sha" 1 \
-    "pinned asset $(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie asset_id) changed"
+    "pinned asset $(bash "$repo_root/test/upgrade-predecessor-pin.sh" deb-trixie asset_id) changed"
 assert_verify_live "a deleted asset" "" 1 "no longer serves asset id"
 
 # --- the candidate sorts above the predecessor ----------------------------
 
-candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" version)" ||
+candidate_version="$(bash "$repo_root/test/upgrade-predecessor-candidate-version.sh" version)" ||
     fail "the candidate version does not resolve"
 [ -n "$candidate_version" ] || fail "the candidate version is empty"
 
@@ -283,7 +331,7 @@ candidate_version="$(bash "$repo_root/test/upgrade-v014-candidate-version.sh" ve
 # it sorts *above* the real release, so the lane's own upgrade guard stays
 # quiet while it proves the wrong thing.
 
-builder="$repo_root/test/build-upgrade-v014-image.sh"
+builder="$repo_root/test/build-upgrade-predecessor-image.sh"
 # shellcheck disable=SC2016 # the builder's own source line is the literal sought
 grep -Fq 'source "$repo_root/scripts/release-versions.sh"' "$builder" ||
     fail "the image builder no longer derives packaging versions from scripts/release-versions.sh"
@@ -295,8 +343,8 @@ if grep -Fq '${target#*-}' "$builder"; then
     fail "the image builder still cuts the Debian revision at the first hyphen"
 fi
 for arg in FACELOCK_CANDIDATE_RPM_VERSION FACELOCK_CANDIDATE_RPM_RELEASE; do
-    grep -Eq "^ARG $arg\$" "$repo_root/test/Containerfile.upgrade-v014-rpm" ||
-        fail "test/Containerfile.upgrade-v014-rpm does not take $arg as a build arg"
+    grep -Eq "^ARG $arg\$" "$repo_root/test/Containerfile.upgrade-predecessor-rpm" ||
+        fail "test/Containerfile.upgrade-predecessor-rpm does not take $arg as a build arg"
 done
 # shellcheck disable=SC2016 # the helper's own default is the literal sought
 grep -Fq 'RPM_RELEASE="${3:-1}"' "$repo_root/test/build-rpm-prebuilt.sh" ||
@@ -305,8 +353,8 @@ grep -Fq 'RPM_RELEASE="${3:-1}"' "$repo_root/test/build-rpm-prebuilt.sh" ||
 # shellcheck source=/dev/null
 source "$repo_root/scripts/release-versions.sh"
 
-predecessor_deb="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" deb-trixie package_version)"
-predecessor_rpm="$(bash "$repo_root/test/upgrade-v014-predecessor.sh" rpm-fedora package_version)"
+predecessor_deb="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" deb-trixie package_version)"
+predecessor_rpm="$(bash "$repo_root/test/upgrade-predecessor-pin.sh" rpm-fedora package_version)"
 
 assert_version() {
     local expected="$1" actual="$2" context="$3"
@@ -352,18 +400,18 @@ done
 # --- the entrypoints stay wired -------------------------------------------
 
 justfile="$repo_root/justfile"
-for recipe in test-upgrade-v014 test-upgrade-v014-deb test-upgrade-v014-rpm \
-    test-upgrade-v014-contract test-upgrade-v014-pins; do
+for recipe in test-upgrade-predecessor test-upgrade-predecessor-deb test-upgrade-predecessor-rpm \
+    test-upgrade-predecessor-contract test-upgrade-predecessor-pins; do
     grep -Eq "^$recipe([ :])" "$justfile" || fail "justfile has no $recipe recipe"
 done
-grep -q "test/build-upgrade-v014-image.sh deb" "$justfile" ||
-    fail "test-upgrade-v014-deb does not build its lane image"
-grep -q "test/build-upgrade-v014-image.sh rpm" "$justfile" ||
-    fail "test-upgrade-v014-rpm does not build its lane image"
+grep -q "test/build-upgrade-predecessor-image.sh deb" "$justfile" ||
+    fail "test-upgrade-predecessor-deb does not build its lane image"
+grep -q "test/build-upgrade-predecessor-image.sh rpm" "$justfile" ||
+    fail "test-upgrade-predecessor-rpm does not build its lane image"
 
 skill="$repo_root/.claude/skills/packaging-test/SKILL.md"
-grep -q 'just test-upgrade-v014' "$skill" ||
-    fail "the packaging-test skill does not route anything to just test-upgrade-v014"
+grep -q 'just test-upgrade-predecessor' "$skill" ||
+    fail "the packaging-test skill does not route anything to just test-upgrade-predecessor"
 
 if [ "$failures" -ne 0 ]; then
     echo "FAIL: $failures upgrade-lane contract violation(s)" >&2

--- a/test/upgrade-predecessor-lane.sh
+++ b/test/upgrade-predecessor-lane.sh
@@ -518,17 +518,6 @@ seed_common_state() {
     stage_models
     printf '%s\n' upgrade-lane-payload >/var/lib/facelock/models/upgrade-lane.payload
     chmod 0644 /var/lib/facelock/models/upgrade-lane.payload
-    # Deliberately stale. A release before 0.2.0 shipped no enrollment markers,
-    # so an upgraded system's marker either does not exist or describes a
-    # database it has since diverged from; a later release writes one, but
-    # nothing in this seed phase enrolls through it, so its marker is just as
-    # stale by the time the upgrade lands. The candidate daemon reconciles it
-    # at startup (#137), and `assert_enrollment_marker_reconciled` is what
-    # proves it did.
-    printf '%s\n' '{"models":0,"updated":"2020-01-01T00:00:00Z"}' \
-        >/var/lib/facelock/enrolled/testuser
-    chown testuser:testuser /var/lib/facelock/enrolled/testuser
-    chmod 0600 /var/lib/facelock/enrolled/testuser
     printf '%s\n' complete >/var/lib/facelock/setup.complete
     chmod 0600 /var/lib/facelock/setup.complete
     printf '%s\n' '{"event":"auth","user":"testuser"}' >/var/log/facelock/audit.jsonl
@@ -548,15 +537,56 @@ account   required   pam_unix.so
 EOF
 }
 
-# The released binary creates and migrates its own database. Nothing here uses
-# a candidate command: `facelock` on PATH is the predecessor for the whole seed
-# phase.
-#
-# `encrypt` is the one subcommand that opens the store read-write and runs
-# migrations without a camera. `list` is a D-Bus call to the daemon and
-# `tpm status` opens read-only, so neither creates a schema. Every shape
-# therefore bootstraps its database through the keyfile path and then becomes
-# whatever shape it is.
+# The enrollment marker an upgrade has to reconcile, planted after the released
+# binary has created its database so that nothing in the seed phase can quietly
+# reconcile it first. A release before 0.2.0 shipped no markers at all, so an
+# upgraded system's marker either does not exist or describes a database it has
+# since diverged from; a later release writes one, and the rows this lane adds
+# by hand leave it just as stale. The candidate daemon reconciles it at startup
+# (#137), and `assert_enrollment_marker_reconciled` is what proves it did.
+plant_stale_enrollment_marker() {
+    printf '%s\n' '{"models":0,"updated":"2020-01-01T00:00:00Z"}' \
+        >/var/lib/facelock/enrolled/testuser
+    chown testuser:testuser /var/lib/facelock/enrolled/testuser
+    chmod 0600 /var/lib/facelock/enrolled/testuser
+}
+
+# How the released binary brings its own store into existence. Before 0.2.0
+# `encrypt` created and migrated it on first use. From 0.2.1 on that verb
+# refuses a database that is not there ("no database at ..."), and what creates
+# one on a real system is the daemon's own startup -- so that is what runs, the
+# released daemon, bounded and then stopped. Nothing here is a candidate
+# command: `facelock` on PATH is the predecessor for the whole seed phase.
+create_database_with_released_binary() {
+    if [ "$PREDECESSOR_LAYOUT" = legacy ]; then
+        released_encrypt >>"$LOG" 2>&1
+        return
+    fi
+    local output=/tmp/facelock-released-daemon.log pid created=
+    stop_packaged_daemon
+    RUST_LOG=warn facelock daemon >"$output" 2>&1 &
+    pid=$!
+    for _ in $(seq 1 120); do
+        if [ -f /var/lib/facelock/facelock.db ] &&
+            [ -n "$(schema_version 2>/dev/null || true)" ]; then
+            created=1
+            break
+        fi
+        sleep 0.5
+    done
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    [ -n "$created" ] || {
+        echo "--- released daemon output ---" >&2
+        tail -20 "$output" >&2 || true
+        return 1
+    }
+}
+
+# The released binary creates and migrates its own database. `list` is a D-Bus
+# call to the daemon and `tpm status` opens read-only, so neither creates a
+# schema; every shape bootstraps through the keyfile path above and then
+# becomes whatever shape it is.
 #
 # The schema version it writes is recorded, not asserted to a literal: it is
 # what the post-upgrade proofs compare against, and a release from 0.2.1 on
@@ -566,7 +596,7 @@ EOF
 seed_released_database() {
     released_encrypt_generate_key >>"$LOG" 2>&1 ||
         fail "the released binary could not generate its encryption key"
-    released_encrypt >>"$LOG" 2>&1 ||
+    create_database_with_released_binary ||
         fail "the released binary could not create and migrate its database"
     [ -f /var/lib/facelock/facelock.db ] ||
         fail "the released binary did not create its database"
@@ -628,13 +658,14 @@ seed_shape_tpm_pcr_bound() { seed_shape_tpm_common; }
 
 seed_shape() {
     local shape="$1"
-    # Bootstrap on the keyfile path whatever the shape, because that is the only
-    # released code path that will create the schema. `write_config` keeps the
+    # Bootstrap on the keyfile path whatever the shape, because that is the
+    # released path that creates the schema. `write_config` keeps the
     # shape's own PCR selection from the first byte, so a bound shape seals
     # under the PCRs it is meant to.
     write_config "$shape" keyfile
     seed_common_state
     seed_released_database
+    plant_stale_enrollment_marker
     case "$shape" in
         plaintext) seed_shape_plaintext ;;
         keyfile) seed_shape_keyfile ;;

--- a/test/upgrade-predecessor-lane.sh
+++ b/test/upgrade-predecessor-lane.sh
@@ -3,32 +3,44 @@
 #
 # Runs inside a booted container that already holds two artifacts:
 #
-#   /artifacts/facelock-predecessor.<ext>  the real published v0.1.4 asset,
-#                                          pinned by asset id + SHA256 in
-#                                          dist/release-matrix.json
+#   /artifacts/facelock-predecessor.<ext>  the real published asset of the
+#                                          predecessor dist/release-matrix.json
+#                                          names as `current`, pinned there by
+#                                          asset id + SHA256
 #   /artifacts/facelock-candidate.<ext>    the locally built candidate
 #
 # Predecessor state is built with the **released** binary, not with this
-# checkout's: the question is whether what v0.1.4 actually wrote survives, and
-# a fixture written by the candidate would only prove the candidate agrees with
-# itself. Every encrypted shape is encrypted by the 0.1.4 binary under a key
-# 0.1.4 generated (or sealed, against a software TPM).
+# checkout's: the question is whether what the predecessor actually wrote
+# survives, and a fixture written by the candidate would only prove the
+# candidate agrees with itself. Every encrypted shape is encrypted by the
+# released binary under a key it generated (or sealed, against a software TPM).
+#
+# The lane spells no release. What the predecessor wrote -- its schema version,
+# the CLI that writes it, the layout its scriptlets leave -- is read off the
+# pinned upstream version and the database itself, so rolling the pin (#367)
+# changes what is proven without editing this file. Where a release before
+# 0.2.0 differs (V5 schema, top-level `encrypt`, the pre-ADR 010 layout and
+# the retired `facelock` group) the branch says so, and it is the only place
+# such a release is accommodated.
 #
 # What each shape proves after a native package-manager upgrade:
-#   * the V5 database migrated to V7 and legacy rows carry device_id = NULL
-#     and key_id = NULL
+#   * the database reaches V7 and every row the predecessor wrote is intact:
+#     a pre-V7 row gains device_id = NULL and key_id = NULL rather than an
+#     invented coupling, a V7 row keeps the key_id its release recorded
 #   * a **known embedding still decrypts** — the plaintext bytes are compared,
 #     not the file hash, because a file hash cannot tell a preserved key from a
 #     preserved ciphertext nobody can open any more
 #   * no key artifact was replaced, and none appeared that did not exist before
-#   * modes converged to ADR 010 without touching content
+#   * modes converged to ADR 010 without touching content -- tightened from a
+#     release that predates it, left exactly alone from one that already has it
 #   * the pre-existing PAM path is byte-identical and still authenticates, with
 #     a real correct password succeeding and a real wrong password failing
 #
-# Then the candidate is downgraded back to v0.1.4 — after the candidate daemon
-# has opened and migrated the database — and the released binary has to still
-# read its own encrypted rows. V7 has no down-migration, so this is the only
-# thing that says whether shipping the alpha strands a rollback.
+# Then the candidate is downgraded back to the predecessor — after the
+# candidate daemon has opened and migrated the database — and the released
+# binary has to still read its own encrypted rows. V7 has no down-migration, so
+# this is the only thing that says whether shipping the candidate strands a
+# rollback.
 set -euo pipefail
 
 FAMILY="${1:-}"
@@ -36,7 +48,7 @@ case "$FAMILY" in
     deb) EXT=deb ;;
     rpm) EXT=rpm ;;
     *)
-        echo "usage: upgrade-v014-lane.sh <deb|rpm>" >&2
+        echo "usage: upgrade-predecessor-lane.sh <deb|rpm>" >&2
         exit 2
         ;;
 esac
@@ -45,11 +57,56 @@ PREDECESSOR="/artifacts/facelock-predecessor.$EXT"
 CANDIDATE="/artifacts/facelock-candidate.$EXT"
 PREDECESSOR_SHA256_FILE=/artifacts/predecessor.sha256
 PREDECESSOR_VERSION_FILE=/artifacts/predecessor.version
+PREDECESSOR_UPSTREAM_FILE=/artifacts/predecessor.upstream
 CANDIDATE_VERSION_FILE=/artifacts/candidate.version
 
-STATE_ROOT=/run/facelock-upgrade-v014
-LOG=/tmp/facelock-upgrade-v014.log
-PAM_SERVICE=facelock-upgrade-v014
+# The pinned predecessor's upstream version, written by the lane image from
+# the same matrix row that pinned the asset. Everything release-specific below
+# keys off it or off what the released binary is observed to write.
+[ -s "$PREDECESSOR_UPSTREAM_FILE" ] || {
+    echo "FAIL: $PREDECESSOR_UPSTREAM_FILE is missing or empty; rebuild the lane image" >&2
+    exit 1
+}
+PREDECESSOR_UPSTREAM="$(cat "$PREDECESSOR_UPSTREAM_FILE")"
+
+# Is the pinned predecessor older than the given upstream version? Numeric
+# triples, so 0.2.10 sorts above 0.2.9; a version that does not parse fails
+# rather than sorting somewhere.
+predecessor_before() {
+    python3 - "$PREDECESSOR_UPSTREAM" "$1" <<'PY'
+import re
+import sys
+
+
+def triple(version):
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not match:
+        raise SystemExit(f"unparseable version: {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+raise SystemExit(0 if triple(sys.argv[1]) < triple(sys.argv[2]) else 1)
+PY
+}
+
+# The two things about a predecessor that its version decides rather than its
+# database: ADR 010 landed in 0.2.0 (the 0711/0700 layout, the `facelock`
+# group retired, `facelock pam` added) and so did the ADR 009 CLI regrouping
+# that moved `encrypt`/`decrypt` under `tpm`. A release before that is
+# "legacy" here; one from 0.2.0 on already has the layout the candidate
+# expects, so the upgrade must leave it exactly alone.
+if predecessor_before 0.2.0; then
+    PREDECESSOR_LAYOUT=legacy
+else
+    PREDECESSOR_LAYOUT=adr010
+fi
+# The schema version the released binary writes, observed when it creates its
+# first database (seed_released_database) rather than assumed from the version.
+PREDECESSOR_SCHEMA=
+
+STATE_ROOT=/run/facelock-upgrade-predecessor
+LOG=/tmp/facelock-upgrade-predecessor.log
+PAM_SERVICE=facelock-upgrade-predecessor
 PAM_PATH="/etc/pam.d/$PAM_SERVICE"
 # The stack a distribution actually authenticates through, as opposed to the
 # lane's own service. An upgrade must not edit it in either direction.
@@ -69,7 +126,7 @@ KNOWN_EMBEDDING_SHA256=82a0081de4c338fc91c362ed4d2ab615bca1dd45152aaa713322b5482
 
 # Every state shape this lane builds with the released binary. A shape added
 # here without a `seed_shape_*` function fails immediately rather than being
-# skipped, and test/upgrade-v014-contract.sh holds this list against the
+# skipped, and test/upgrade-predecessor-contract.sh holds this list against the
 # functions that implement it.
 SHAPES=(plaintext keyfile mixed tpm-pcr-unbound tpm-pcr-bound)
 
@@ -119,8 +176,8 @@ case "$FAMILY" in
         # It is needed here and not in the synthesized-predecessor lane because
         # that lane rebuilds the candidate's own payload as the older package,
         # so its packaged config.toml is byte-identical across the upgrade and
-        # dpkg never asks. A real v0.1.4 ships a different config.toml, so the
-        # modified file this lane plants does provoke the prompt -- and an
+        # dpkg never asks. A real released .deb ships its own config.toml, so
+        # the modified file this lane plants does provoke the prompt -- and an
         # unanswered prompt is `end of file on stdin at conffile prompt`, not a
         # preserved config.
         apt_transaction() {
@@ -186,9 +243,10 @@ ensure_system_bus() {
 # org.facelock.Daemon and exits non-zero -- which reads exactly like the daemon
 # refusing to serve, and is not.
 # The candidate refuses to be uninstalled while a PAM service still references
-# pam_facelock.so, so the reference goes first. The predecessor has no such
-# guard, which is why the Debian half never needed this: after a rollback it is
-# always v0.1.4 that gets removed.
+# pam_facelock.so, so the reference goes first. A predecessor from 0.2.0 on
+# carries the same guard; one before it does not, which is why the Debian half
+# never needed this while a pre-0.2.0 release was the pin (after a rollback it
+# is always the predecessor that gets removed).
 remove_installed_package() {
     rm -f "$PAM_PATH"
     pkg_remove
@@ -220,6 +278,12 @@ assert_pinned_artifacts() {
     expected_version="$(cat "$PREDECESSOR_VERSION_FILE")"
     assert_eq "$expected_version" "$(pkg_file_version "$PREDECESSOR")" \
         "pinned predecessor package version"
+    # The upstream version every release-specific branch below keys off has to
+    # be the version of the package actually installed, not a stale build arg.
+    case "$expected_version" in
+        "$PREDECESSOR_UPSTREAM"-*) ;;
+        *) fail "pinned predecessor upstream $PREDECESSOR_UPSTREAM is not the package version $expected_version" ;;
+    esac
     assert_eq "$(cat "$CANDIDATE_VERSION_FILE")" "$(pkg_file_version "$CANDIDATE")" \
         "candidate package version"
 
@@ -325,8 +389,8 @@ config_pcr_binding() {
 
 # Three embeddings per model, matching what a real enrollment writes since the
 # store floor landed. The first is the known fixture whose plaintext this lane
-# compares after the upgrade; the other two exist so the row count is what a
-# 0.1.4 enrollment would actually have left behind.
+# compares after the upgrade; the other two exist so the row count is what an
+# enrollment on the predecessor would actually have left behind.
 insert_plaintext_rows() {
     local label="$1"
     python3 - "$label" <<'PY'
@@ -364,6 +428,29 @@ released_facelock() {
     facelock "$@"
 }
 
+# The released binary's key-material verbs. ADR 009 (0.2.0) moved `encrypt`
+# and `decrypt` under the `tpm` group; before that they were top-level. The
+# group prefix is resolved once here so every seed and rollback step spells the
+# verb, never the release it belongs to.
+if [ "$PREDECESSOR_LAYOUT" = legacy ]; then
+    RELEASED_KEY_GROUP=()
+else
+    RELEASED_KEY_GROUP=(tpm)
+fi
+
+released_encrypt() {
+    released_facelock "${RELEASED_KEY_GROUP[@]}" encrypt
+}
+
+released_encrypt_generate_key() {
+    released_facelock "${RELEASED_KEY_GROUP[@]}" encrypt --generate-key
+}
+
+# `--config` is a global option: it precedes the verb group, not the verb.
+released_decrypt_with_config() {
+    released_facelock --config "$1" "${RELEASED_KEY_GROUP[@]}" decrypt
+}
+
 # The daemon loads models at startup, so the shape phases need the real ones.
 # The lane runner stages them read-only at /facelock-test-models; a lane without
 # them cannot open the database with the candidate daemon and says so rather
@@ -379,12 +466,12 @@ stage_models() {
         fail "no reviewed ONNX models staged at /facelock-test-models"
 }
 
-# The layout v0.1.4 leaves behind. Its postinst runs systemd-sysusers and
-# systemd-tmpfiles and then chowns the state directories to root:facelock 0750
-# (models to root:root 0755); ADR 010 retired that group and tightened those
-# modes. Seeding the new modes here, as this lane first did, meant the upgrade
-# had nothing to tighten and every mode assertion passed on state the lane had
-# already put in the right shape.
+# The layout a release before 0.2.0 leaves behind. Its postinst runs
+# systemd-sysusers and systemd-tmpfiles and then chowns the state directories
+# to root:facelock 0750 (models to root:root 0755); ADR 010 retired that group
+# and tightened those modes. Seeding the new modes here, as this lane first
+# did, meant the upgrade had nothing to tighten and every mode assertion passed
+# on state the lane had already put in the right shape.
 #
 # `pam-backups` is deliberately absent: it is new-layout, and the candidate's
 # postinst has to create it.
@@ -405,8 +492,24 @@ seed_legacy_layout() {
     install -d -m0750 /var/lib/facelock/enrolled
 }
 
+# The layout a release from 0.2.0 on leaves behind: exactly ADR 010, created
+# by its own postinst and repeated here only so a directory that postinst
+# leaves to first use exists before the fixtures go in. Nothing is loosened,
+# because nothing is supposed to move: assert_adr010_modes requires the upgrade
+# to change no mode at all when the predecessor already has the layout.
+seed_adr010_layout() {
+    install -d -o root -g root -m0711 /var/lib/facelock /var/lib/facelock/enrolled
+    install -d -o root -g root -m0755 /var/lib/facelock/models
+    install -d -o root -g root -m0700 /var/lib/facelock/pam-backups \
+        /var/log/facelock /var/log/facelock/snapshots
+}
+
 seed_common_state() {
-    seed_legacy_layout
+    case "$PREDECESSOR_LAYOUT" in
+        legacy) seed_legacy_layout ;;
+        adr010) seed_adr010_layout ;;
+        *) fail "unknown predecessor layout: $PREDECESSOR_LAYOUT" ;;
+    esac
 
     # The reviewed models the candidate daemon has to load, plus a payload of
     # this lane's own: an upgrade has no business touching either, and both
@@ -415,10 +518,13 @@ seed_common_state() {
     stage_models
     printf '%s\n' upgrade-lane-payload >/var/lib/facelock/models/upgrade-lane.payload
     chmod 0644 /var/lib/facelock/models/upgrade-lane.payload
-    # Deliberately stale: v0.1.4 shipped no enrollment markers, so an upgraded
-    # system's marker either does not exist or describes a database it has since
-    # diverged from. The candidate daemon reconciles it at startup (#137), and
-    # `assert_enrollment_marker_reconciled` is what proves it did.
+    # Deliberately stale. A release before 0.2.0 shipped no enrollment markers,
+    # so an upgraded system's marker either does not exist or describes a
+    # database it has since diverged from; a later release writes one, but
+    # nothing in this seed phase enrolls through it, so its marker is just as
+    # stale by the time the upgrade lands. The candidate daemon reconciles it
+    # at startup (#137), and `assert_enrollment_marker_reconciled` is what
+    # proves it did.
     printf '%s\n' '{"models":0,"updated":"2020-01-01T00:00:00Z"}' \
         >/var/lib/facelock/enrolled/testuser
     chown testuser:testuser /var/lib/facelock/enrolled/testuser
@@ -430,9 +536,10 @@ seed_common_state() {
     printf '%s\n' snapshot >/var/log/facelock/snapshots/upgrade-lane.jpg
     chmod 0600 /var/log/facelock/snapshots/upgrade-lane.jpg
 
-    # The PAM path an 0.1.4 administrator would have wired by hand: v0.1.4 has
-    # no `facelock pam` subcommand, so this is the shape the upgrade actually
-    # finds on a real system.
+    # A PAM service wired by hand. Before 0.2.0 there was no `facelock pam`
+    # subcommand, so this is the only shape an upgrade from such a release
+    # finds; an administrator on a later release can still write one, and the
+    # upgrade must leave it byte-identical either way.
     install -Dm0644 /dev/stdin "$PAM_PATH" <<EOF
 #%PAM-1.0
 auth      sufficient pam_facelock.so
@@ -442,21 +549,37 @@ EOF
 }
 
 # The released binary creates and migrates its own database. Nothing here uses
-# a candidate command: `facelock` on PATH is v0.1.4 for the whole seed phase.
+# a candidate command: `facelock` on PATH is the predecessor for the whole seed
+# phase.
 #
-# v0.1.4 has exactly one subcommand that opens the store read-write and runs
-# migrations without a camera: `facelock encrypt`. `list` is a D-Bus call to the
-# daemon and `tpm status` opens read-only, so neither creates a schema. Every
-# shape therefore bootstraps its database through the keyfile path and then
-# becomes whatever shape it is.
+# `encrypt` is the one subcommand that opens the store read-write and runs
+# migrations without a camera. `list` is a D-Bus call to the daemon and
+# `tpm status` opens read-only, so neither creates a schema. Every shape
+# therefore bootstraps its database through the keyfile path and then becomes
+# whatever shape it is.
+#
+# The schema version it writes is recorded, not asserted to a literal: it is
+# what the post-upgrade proofs compare against, and a release from 0.2.1 on
+# already writes V7, so "migrated from V5" is only one of the things this lane
+# can be proving. Anything outside the V5..V7 range is a binary this lane does
+# not understand and fails here rather than in an assertion that assumed it.
 seed_released_database() {
-    released_facelock encrypt --generate-key >>"$LOG" 2>&1 ||
+    released_encrypt_generate_key >>"$LOG" 2>&1 ||
         fail "the released binary could not generate its encryption key"
-    released_facelock encrypt >>"$LOG" 2>&1 ||
+    released_encrypt >>"$LOG" 2>&1 ||
         fail "the released binary could not create and migrate its database"
     [ -f /var/lib/facelock/facelock.db ] ||
         fail "the released binary did not create its database"
-    assert_eq 5 "$(schema_version)" "schema version written by the released binary"
+    local written
+    written="$(schema_version)"
+    case "$written" in
+        5 | 6 | 7) ;;
+        *) fail "the released binary wrote schema version $written, outside the V5..V7 range this lane knows" ;;
+    esac
+    if [ -n "$PREDECESSOR_SCHEMA" ] && [ "$PREDECESSOR_SCHEMA" != "$written" ]; then
+        fail "the released binary wrote schema version $written after writing $PREDECESSOR_SCHEMA for an earlier shape"
+    fi
+    PREDECESSOR_SCHEMA="$written"
 }
 
 seed_shape_plaintext() {
@@ -470,14 +593,14 @@ seed_shape_plaintext() {
 
 seed_shape_keyfile() {
     insert_plaintext_rows keyfile
-    released_facelock encrypt >>"$LOG" 2>&1 ||
+    released_encrypt >>"$LOG" 2>&1 ||
         fail "the released binary could not encrypt its rows"
     assert_eq "3|0" "$(sealed_counts)" "keyfile shape row encryption"
 }
 
 seed_shape_mixed() {
     insert_plaintext_rows encrypted-half
-    released_facelock encrypt >>"$LOG" 2>&1 ||
+    released_encrypt >>"$LOG" 2>&1 ||
         fail "the released binary could not encrypt its rows"
     # A second enrollment that never went through `encrypt`: the mixed database
     # a user gets by enrolling again after turning encryption on.
@@ -495,7 +618,7 @@ seed_shape_tpm_common() {
     grep -Eq '^[[:space:]]*method[[:space:]]*=[[:space:]]*"tpm"' /etc/facelock/config.toml ||
         fail "sealing did not move the configured encryption method to tpm"
     insert_plaintext_rows tpm
-    released_facelock encrypt >>"$LOG" 2>&1 ||
+    released_encrypt >>"$LOG" 2>&1 ||
         fail "the released binary could not encrypt rows under the sealed key"
     assert_eq "3|0" "$(sealed_counts)" "TPM shape row encryption"
 }
@@ -620,25 +743,37 @@ snapshot_model_files() {
 # Row identity by content, not by file digest: the database file legitimately
 # changes across a migration, so comparing it byte for byte would either fail
 # always or be relaxed into proving nothing.
+#
+# The V6 and V7 columns are part of a row's identity only when the predecessor
+# wrote them: for an older schema they do not exist before the upgrade and are
+# what the migration adds, so assert_schema_v7_with_null_columns owns them
+# instead. For a V7 predecessor the key_id it recorded is state the upgrade has
+# to preserve, and this is where a rewritten one is caught.
 snapshot_rows() {
-    python3 - <<'PY'
+    FACELOCK_PREDECESSOR_SCHEMA="$PREDECESSOR_SCHEMA" python3 - <<'PY'
 import hashlib
+import os
 import sqlite3
 
+schema = int(os.environ["FACELOCK_PREDECESSOR_SCHEMA"])
+columns = ["fm.user", "fm.label", "fm.created_at", "fm.embedder_model"]
+if schema >= 6:
+    columns.append("fm.device_id")
+if schema >= 7:
+    columns.append("fm.key_id")
+columns += ["fe.embedding", "fe.sealed"]
 connection = sqlite3.connect("file:/var/lib/facelock/facelock.db?mode=ro", uri=True)
 rows = connection.execute(
-    "SELECT fm.user, fm.label, fm.created_at, fm.embedder_model, fe.embedding, fe.sealed "
+    f"SELECT {', '.join(columns)} "
     "FROM face_models AS fm JOIN face_embeddings AS fe ON fe.model_id = fm.id "
     "ORDER BY fm.label, fe.id"
 ).fetchall()
 connection.close()
 if not rows:
     raise SystemExit("snapshot found no enrollment rows")
-for user, label, created_at, embedder, blob, sealed in rows:
-    print(
-        f"row|{user}|{label}|{created_at}|{embedder}|{sealed}|"
-        f"{len(blob)}|{hashlib.sha256(blob).hexdigest()}"
-    )
+for *identity, blob, sealed in rows:
+    fields = "|".join(str(value) for value in identity)
+    print(f"row|{fields}|{sealed}|{len(blob)}|{hashlib.sha256(blob).hexdigest()}")
 PY
 }
 
@@ -665,14 +800,21 @@ PY
         *,key_id,*) ;;
         *) fail "V7 migration did not add face_models.key_id (columns: $columns)" ;;
     esac
-    # Legacy rows must stay uncoupled. A migration that invented a device id
-    # or a key id would bind every existing template to whatever camera
-    # happened to be plugged in during the upgrade, or to a key it was never
-    # sealed under.
+    # Rows the predecessor wrote must stay uncoupled. A migration that invented
+    # a device id would bind every existing template to whatever camera
+    # happened to be plugged in during the upgrade; no shape enrolls through a
+    # camera, so a non-NULL device_id can only have been invented, whatever
+    # schema the predecessor wrote.
     assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE device_id IS NOT NULL')" \
-        "legacy rows left with a non-NULL device_id"
-    assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE key_id IS NOT NULL')" \
-        "legacy rows left with a non-NULL key_id"
+        "predecessor rows left with a non-NULL device_id"
+    # key_id is decided by which schema wrote the rows. Before V7 there was no
+    # such column, so the migration must not bind a row to a key it was never
+    # sealed under; from V7 on the predecessor's `encrypt` records the key id
+    # itself, and snapshot_rows holds it byte-identical across the upgrade.
+    if [ "$PREDECESSOR_SCHEMA" -lt 7 ]; then
+        assert_eq 0 "$(sqlite_query 'SELECT COUNT(*) FROM face_models WHERE key_id IS NOT NULL')" \
+            "pre-V7 rows left with a non-NULL key_id"
+    fi
 }
 
 # Which model's first embedding is the known fixture for a given shape. The
@@ -769,9 +911,10 @@ assert_known_embedding_decrypts() {
 }
 
 # The enrollment marker is the one piece of state an upgrade is *supposed* to
-# rewrite. `facelock is-enrolled` reads it, v0.1.4 never wrote one, and a marker
-# left describing a database it has diverged from answers "not enrolled" for a
-# user whose face authentication works (#137). So the contract is not byte
+# rewrite. `facelock is-enrolled` reads it, releases before 0.2.0 never wrote
+# one, and a marker left describing a database it has diverged from answers
+# "not enrolled" for a user whose face authentication works (#137). So the
+# contract is not byte
 # identity, which would happily preserve a marker that lies. It is that the
 # marker still exists, is still the user's own private file, and now agrees with
 # the database.
@@ -969,11 +1112,12 @@ record_adr010_modes() {
 
 # ADR 010 modes. The packaged scriptlets tighten these on an upgrade from a
 # release that predates the layout; content must be untouched while they do.
+# From a release that already has the layout they must change nothing.
 #
 # Every path is required to exist afterwards. A `continue` on a missing path
 # made all of this optional, and `pam-backups` in particular only exists
-# because the candidate's postinst creates it -- so its absence is the failure
-# this is here to catch, not a case to skip.
+# because a postinst creates it -- so its absence is the failure this is here
+# to catch, not a case to skip.
 assert_adr010_modes() {
     local shape="$1" expected path actual before tightened=0
     while read -r expected path; do
@@ -987,15 +1131,29 @@ assert_adr010_modes() {
         fi
     done < <(adr010_expectations)
 
-    # At least one path has to have actually moved. If the predecessor already
-    # left everything at the ADR 010 values, this lane is asserting nothing
-    # about the upgrade and the legacy seeding above has silently stopped
-    # working.
-    [ "$tightened" -gt 0 ] ||
-        fail "no ADR 010 path changed across the upgrade: nothing was tightened"
+    case "$PREDECESSOR_LAYOUT" in
+        legacy)
+            # At least one path has to have actually moved. If the predecessor
+            # already left everything at the ADR 010 values, this lane is
+            # asserting nothing about the upgrade and the legacy seeding above
+            # has silently stopped working.
+            [ "$tightened" -gt 0 ] ||
+                fail "no ADR 010 path changed across the upgrade: nothing was tightened"
+            ;;
+        adr010)
+            # The predecessor already had the layout, so the only correct
+            # upgrade is one that touched no mode. A path that was "tightened"
+            # here was loosened by the seed or by the predecessor's own
+            # scriptlets, and either is a bug this lane must not paper over.
+            [ "$tightened" -eq 0 ] ||
+                fail "$tightened ADR 010 path(s) changed across an upgrade from a release that already had the layout"
+            ;;
+        *) fail "unknown predecessor layout: $PREDECESSOR_LAYOUT" ;;
+    esac
 
     # ADR 010 retired the group outright; an upgrade from a release that had
-    # one must remove it rather than leave a group owning nothing.
+    # one must remove it rather than leave a group owning nothing, and no
+    # later release may bring it back.
     ! getent group facelock >/dev/null 2>&1 ||
         fail "the retired facelock group survived the upgrade"
 }
@@ -1064,11 +1222,12 @@ assert_real_password_behavior() {
 
 # --- the candidate daemon actually opens the database ----------------------
 #
-# The rollback question is not "does v0.1.4 read a V7 file" in the abstract, it
-# is "does it read the file the alpha daemon has already opened, migrated and
-# written to". So the daemon runs for real before the downgrade.
+# The rollback question is not "does the predecessor read a V7 file" in the
+# abstract, it is "does it read the file the candidate daemon has already
+# opened, migrated and written to". So the daemon runs for real before the
+# downgrade.
 open_database_with_candidate_daemon() {
-    local output=/tmp/facelock-candidate-daemon.log pid
+    local output=/tmp/facelock-candidate-daemon.log pid opened=
     stop_packaged_daemon
     RUST_LOG=warn facelock daemon >"$output" 2>&1 &
     pid=$!
@@ -1081,16 +1240,23 @@ open_database_with_candidate_daemon() {
     for _ in $(seq 1 120); do
         if [ "$(schema_version)" = 7 ] &&
             [ "$(marker_model_count)" = "$(database_model_count)" ]; then
+            opened=1
             break
         fi
         sleep 0.5
     done
     kill -TERM "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
-    if [ "$(marker_model_count)" != "$(database_model_count)" ]; then
+    # Timing out is fatal, not a note. Against a predecessor that already wrote
+    # V7 the schema assertion below holds whether or not the daemon ever ran,
+    # so the reconciled marker is the only thing left that says it opened the
+    # store -- and the seeded marker disagrees with the database on purpose, so
+    # it can only agree here because the daemon rewrote it.
+    [ -n "$opened" ] || {
         echo "--- candidate daemon output ---" >&2
         tail -20 "$output" >&2 || true
-    fi
+        fail "the candidate daemon did not open the database and reconcile the marker within 60s"
+    }
     assert_eq 7 "$(schema_version)" "schema version after the candidate daemon ran"
 }
 
@@ -1128,8 +1294,8 @@ assert_downgrade_usable() {
 
     # V7 has no down-migration. The predecessor must still open the database the
     # candidate migrated and read its enrollment state. `tpm status` is the
-    # readback rather than `list`, which in v0.1.4 is a D-Bus call to a daemon
-    # this phase deliberately does not run.
+    # readback rather than `list`, which is a D-Bus call to a daemon this phase
+    # deliberately does not run.
     released_facelock tpm status >>"$LOG" 2>&1 ||
         fail "the released binary could not open the V7 database after rollback"
     assert_eq 7 "$(schema_version)" "schema version is not rolled back by a package downgrade"
@@ -1140,7 +1306,7 @@ assert_downgrade_usable() {
     label="$(shape_probe_label "$shape")"
     stage_probe "$probe"
     if [ "$shape" != plaintext ]; then
-        released_facelock --config "$probe/config.toml" decrypt >>"$LOG" 2>&1 ||
+        released_decrypt_with_config "$probe/config.toml" >>"$LOG" 2>&1 ||
             fail "the released binary could not decrypt its own rows after rollback"
     fi
     digest="$(probe_known_embedding_digest "$probe/probe.db" "$label")" ||
@@ -1218,7 +1384,7 @@ run_shape() {
 # name it never gets to claim here. Each case runs it against its own config,
 # so nothing here can reach the system database.
 
-FAULT_ROOT=/run/facelock-upgrade-v014/fault
+FAULT_ROOT=/run/facelock-upgrade-predecessor/fault
 # Filled to capacity for the disk-full case. /dev/shm is a real filesystem with
 # a real, small size limit, so the ENOSPC is the kernel's rather than a
 # simulation, and it needs no privilege this lane does not already have.
@@ -1622,4 +1788,4 @@ fi
 run_faults
 
 echo
-echo "OK: $FAMILY v0.1.4 upgrade, rollback and fault matrix"
+echo "OK: $FAMILY $PREDECESSOR_UPSTREAM upgrade, rollback and fault matrix (predecessor schema V$PREDECESSOR_SCHEMA, $PREDECESSOR_LAYOUT layout)"

--- a/test/upgrade-predecessor-pin.sh
+++ b/test/upgrade-predecessor-pin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Resolve one pinned released predecessor from dist/release-matrix.json.
+# Resolve the current pinned released predecessor from dist/release-matrix.json.
 #
 # The upgrade lanes (#231) install a real published artifact, so the pin has to
 # be strong enough that a re-uploaded or substituted asset fails the lane rather
@@ -8,10 +8,16 @@
 # reader. Lane Containerfiles take the fields as build args and never carry a
 # digest of their own; test/check-release-matrix.py enforces that.
 #
+# Which predecessor: `predecessors.current` names it (#367). The matrix may pin
+# more than one release -- v0.1.4 stays for the retired-authselect fixture --
+# but the lanes prove the upgrade users will actually perform, which is from
+# the newest release, and test/check-release-matrix.py holds `current` to that.
+# Nothing here spells a tag.
+#
 # Usage:
-#   upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field>
-#   upgrade-v014-predecessor.sh <lane> --build-args     # podman --build-arg list
-#   upgrade-v014-predecessor.sh <lane> --verify-live    # re-resolve against the API
+#   upgrade-predecessor-pin.sh <deb-trixie|rpm-fedora> <field>
+#   upgrade-predecessor-pin.sh <lane> --build-args     # podman --build-arg list
+#   upgrade-predecessor-pin.sh <lane> --verify-live    # re-resolve against the API
 #
 # --verify-live needs `gh` and network. It never downloads the asset: it asks
 # the release API what the pinned asset id is now and rejects a name, size or
@@ -22,10 +28,10 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-lane="${1:?usage: upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
-field="${2:?usage: upgrade-v014-predecessor.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
+lane="${1:?usage: upgrade-predecessor-pin.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
+field="${2:?usage: upgrade-predecessor-pin.sh <deb-trixie|rpm-fedora> <field|--build-args|--verify-live>}"
 [ "$#" -eq 2 ] || {
-    echo "usage: upgrade-v014-predecessor.sh <lane> <field|--build-args|--verify-live>" >&2
+    echo "usage: upgrade-predecessor-pin.sh <lane> <field|--build-args|--verify-live>" >&2
     exit 2
 }
 
@@ -46,7 +52,11 @@ matrix_path, lane, field = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(matrix_path, encoding="utf-8") as handle:
     matrix = json.load(handle)
 
-release = matrix["predecessors"]["v0.1.4"]
+predecessors = matrix["predecessors"]
+current = predecessors.get("current")
+if not isinstance(current, str) or current not in predecessors:
+    raise SystemExit(f"release matrix predecessors.current does not name a pinned release: {current!r}")
+release = predecessors[current]
 row = release["lanes"][lane]
 if field == "tag":
     print(release["tag"])
@@ -70,7 +80,8 @@ case "$field" in
             "FACELOCK_PREDECESSOR_SHA256=$(read_lane sha256)" \
             "FACELOCK_PREDECESSOR_SIZE=$(read_lane size)" \
             "FACELOCK_PREDECESSOR_NAME=$(read_lane name)" \
-            "FACELOCK_PREDECESSOR_VERSION=$(read_lane package_version)"
+            "FACELOCK_PREDECESSOR_VERSION=$(read_lane package_version)" \
+            "FACELOCK_PREDECESSOR_UPSTREAM=$(read_lane upstream_version)"
         ;;
     --verify-live)
         command -v gh >/dev/null 2>&1 || {


### PR DESCRIPTION
## Summary

- name the release the upgrade lanes prove in `dist/release-matrix.json` as `predecessors.current`, pinned to v0.2.1's .deb and fc44 .rpm by asset id, digest and size
- require `current` to be the newest pinned release, so a pin left behind fails `test/check-release-matrix.py`
- keep v0.1.4 pinned: the retired-authselect fixture is built from its RPM and no other build of that package exists
- resolve the predecessor through `current` in the lane pin resolver, the candidate version, and `check-live-release-channels.py --expect-predecessor` (what `just release-preflight` asks)
- delete `copr_channels.production.served_evr_gap`; production COPR serves the EVR the new pin owes
- key the lane's release-specific behaviour off the pinned version rather than a tag: the ADR 009 `tpm encrypt` spelling, the ADR 010 layout, the pre-0.2.0 `libxkbcommon0` accommodation
- record the schema the predecessor writes instead of asserting V5, and hold a V7 predecessor's `key_id` across the upgrade
- create the seed database by starting the released daemon, since `tpm encrypt` refuses a database that is not there from 0.2.1 on, and plant the stale enrollment marker after that so nothing reconciles it before the upgrade does
- fail the lane when the candidate daemon never opens the database, which the schema assertion alone stopped proving once the predecessor already wrote V7
- default the candidate's upgrade-test version to the predecessor's patch plus one
- rename `just test-upgrade-v014*` to `just test-upgrade-predecessor*`, and the files behind them

## Why

The lanes and the preflight served-EVR gate both read the predecessor by the literal key `v0.1.4`, so they kept proving 0.1.4-to-candidate through 0.2.0 and 0.2.1 while every user was upgrading from one of those. Preflight failed on 2026-09-07 for the same reason: it asked production COPR for 0.1.4-1 while the channel served 0.2.0-1, and #366 papered over that with a gap record rather than moving the pin. Making the pin a matrix field means rolling it after a release is a data edit, and the contract now fails when it is skipped.

## Validation

- `just test-upgrade-predecessor-contract`, `test/release-version-contract.sh`, `python3 test/check-release-matrix.py`, `just test-release-artifacts`, `just check-docs`
- `just test-upgrade-predecessor-pins` against the live release API
- `check-live-release-channels.py --expect-predecessor` against live production COPR
- the Debian upgrade lane locally against the v0.2.1 predecessor: all five state shapes, rollback, and the fault matrix

The Fedora half is unrun here; both lanes are local-only by design and no CI job carries them.

Fixes #367


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Upgrade testing now targets the newest released predecessor selected from the release matrix, rather than a fixed version.
  - Upgrade and rollback coverage now supports varying predecessor versions, database schemas, package layouts, and encryption behavior.
  - Release validation now confirms predecessor pins, package metadata, and served release-channel versions remain consistent.
  - Upgrade-test commands and related documentation now use the `test-upgrade-predecessor` naming.

- **Documentation**
  - Updated testing, release, contract, and developer guidance to describe predecessor-driven upgrade validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->