### PR TITLE
test(justfile): Gate the tpm feature locally with check-tpm

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,6 +12,7 @@ paths:
 | Tier | What | How |
 |------|------|-----|
 | 1 | Unit tests | `cargo test --workspace` |
+| 1a | Lint and tests with the `tpm` feature, no TPM present | `just check-tpm` |
 | 2 | Hardware tests | `cargo test --workspace -- --ignored` |
 | 3 | Arch container PAM smoke | `just test-arch-pam` |
 | 3b | Arch container E2E (daemon) | `just test-arch-integration` |
@@ -28,6 +29,17 @@ paths:
 | 5 | Host PAM | After tiers 3-4, with root shell backup |
 
 **Never** install `pam_facelock.so` or edit `/etc/pam.d/*` on the host until container tests pass.
+
+Tier 1a is the feature half of tier 1. `cargo test --workspace` and `just lint`
+build the default feature set, so the `#[cfg(feature = "tpm")]` sites across
+the cli, daemon and tpm crates are never compiled and a regression inside one
+passes every other local gate (#386). `just check-tpm` runs `lint-tpm` and
+`test-tpm`, and `just check` runs it; `just test` does not, because the feature
+set is a second full compile and that is the inner loop. It proves the gated
+code compiles, lints and still makes the decisions its tests pin. It does not
+prove TPM behaviour: a developer machine has no TPM the test process can open,
+so sealed round trips fail to build a context rather than executing. Sealing,
+unsealing and PCR binding are proven by CI's `tpm-tests` job alone.
 
 Tier 3f is not a duplicate of 3e. 3e builds the direct `.rpm` from host
 binaries with a bundled ONNX Runtime; 3f rebuilds the package from source in a
@@ -52,7 +64,9 @@ module). The `build-and-test` job is a sequence of justfile recipes
 `check-pam-standalone`, `build-smoke-binaries`), so what CI checks is what the
 recipe says; there is no separate `cargo build` step because clippy
 `--all-targets` type-checks every target and `test` builds the workspace.
-`tpm-tests` is the only job that runs `cargo test --features tpm`.
+`tpm-tests` is the only job that runs the tests with the feature, and it runs
+`just test-tpm` — the same recipe `just check-tpm` calls — with `TCTI` pointed
+at swtpm, so it is the only place a sealed round trip actually executes.
 
 `.github/workflows/packaging.yml` gates the packaged artifacts: tiers 3d and 3e,
 both Debian suite lanes, and the native version-ordering matrix. It runs on three

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,8 @@ jobs:
             pam \
             tpm2-tss \
             swtpm \
-            python
+            python \
+            just
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -191,10 +192,14 @@ jobs:
       - name: Trust the workspace checkout
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # The recipe, not the command, so this job and `just check-tpm` cannot
+      # drift on what the feature test run is. The TCTI is what separates them:
+      # here it points at the swtpm above, so sealed round trips execute; a
+      # local run has no TPM and proves only the feature gates and decisions.
       - name: Run TPM tests
         env:
           TCTI: swtpm:host=localhost,port=2321
-        run: cargo test --workspace --features tpm
+        run: just test-tpm
 
   agent-docs:
     name: Agent Docs Consistency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs it on every pull request (`loopback-e2e`). A model-backed contract test pins the
   fixture inside the detector, IR-texture, quality, recognition and frame-variance bands.
 
+- **A local gate for the `tpm` feature** (#386): `just check-tpm` runs `lint-tpm` and the new
+  `just test-tpm`, and `just check` now calls it, so the 80 `feature = "tpm"` cfg sites across
+  the cli, daemon and tpm crates are compiled and exercised locally instead of only in CI. It is deliberately outside `just test`, which is the inner loop and would pay a
+  second full compile of the workspace. A developer machine has no TPM the test process can
+  open, so the gate catches feature-gate and decision regressions, not sealing behaviour: the
+  swtpm-backed `tpm-tests` job stays the only place a sealed round trip executes, and it now
+  runs `just test-tpm` rather than its own copy of the command.
+
 ### Changed
 
 - **The upgrade lanes now prove the newest released predecessor** (#367): `dist/release-matrix.json`

--- a/docs/developer-commands.md
+++ b/docs/developer-commands.md
@@ -38,11 +38,12 @@ index, so substitute real values for metavariables before running a recipe.
 | `just build` | Build in debug mode (development) |
 | `just build-release` | Build in release mode (for install) |
 | `just build-smoke-binaries` | Build only the release `facelock` (tpm) and PAM module the CI smoke tiers consume. |
-| `just check` | Run local tests, lint, format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes. |
+| `just check` | Run local tests, lint (default and `tpm`), format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes. |
 | `just check-agent-docs [base=]` | Check repository instructions and lifecycle contracts; optional base ref adds a coupling check. |
 | `just check-docs` | Verify instructional coverage, references and parser acceptance (no example execution). |
 | `just check-package-names-live` | Resolve documented dependency names against live upstream repositories (network required). |
 | `just check-pam-standalone` | Build PAM independently and reject forbidden async-io backend dependencies. |
+| `just check-tpm` | Lint and test the workspace with `tpm`; catches gate regressions, not real TPM behaviour. |
 | `just check-workflow-policy` | Pin the trust boundary of the comment-triggered Claude workflow (docs/security.md, CI Trust Boundary). |
 | `just clean` | Clean build artifacts |
 | `just docs-inventory` | Report the tracked documentation, public recipes and Cargo executables as JSON. |
@@ -108,6 +109,7 @@ index, so substitute real values for metavariables before running a recipe.
 | `just test-rpm-smoke [release=45]` | Branched-release lane — build the package, then boot it for a runtime smoke |
 | `just test-source-install-daemon-lifecycle` | Preserve the daemon's pre-install runtime state across source file replacement. |
 | `just test-source-install-daemon-lifecycle-systemd` | Exercise the source-install barrier against a real systemd and system bus. |
+| `just test-tpm` | Run all unit tests with the `tpm` feature enabled (matches CI's swtpm job). |
 | `just test-upgrade-predecessor` | Both released-predecessor upgrade lanes — the stable entrypoint for #231 |
 | `just test-upgrade-predecessor-contract` | Released-predecessor upgrade lanes (#231) — container-free half, runs anywhere |
 | `just test-upgrade-predecessor-deb` | Debian half: install the real released .deb, upgrade to the candidate, roll back |

--- a/justfile
+++ b/justfile
@@ -50,6 +50,35 @@ lint:
 lint-tpm:
     cargo clippy --workspace --all-targets --features tpm -- -D warnings
 
+# CI's `tpm-tests` job runs this recipe against swtpm, so the feature test run
+# has one definition instead of two. What a run without a TPM does and does not
+# prove is documented on `check-tpm` below.
+
+# Run all unit tests with the `tpm` feature enabled (matches CI's swtpm job).
+test-tpm:
+    cargo test --workspace --features tpm
+
+# What this proves: the 80 `feature = "tpm"` cfg sites across the cli, daemon
+# and tpm crates — 41 positive gates plus the `not(...)` arms they pair with —
+# compile, lint clean, and that the decisions inside them still hold. `test` and `lint` build the default feature set only, so a
+# regression in a tpm-gated branch — a deleted guard in an `unreachable!()`
+# arm, a stale call signature, a dead match arm — passes every other local gate
+# (#386).
+#
+# What it does NOT prove: real TPM behaviour. A developer run has no TPM the
+# test process can open (`/dev/tpmrm0` is root:tss), so a sealed round trip
+# fails to build a context rather than executing, and the tests that need a
+# real device are written to assert that failure or are gated off. Sealing,
+# unsealing, PCR binding and key migration are proven only by CI's `tpm-tests`
+# job, which runs `just test-tpm` against swtpm. A green `check-tpm` is a
+# feature-gate and decision gate, not evidence that sealing works.
+#
+# In `check` and deliberately not in `test`: the feature set is a second full
+# compile of the workspace, and `test` is the inner loop.
+
+# Lint and test the workspace with `tpm`; catches gate regressions, not real TPM behaviour.
+check-tpm: lint-tpm test-tpm
+
 # Format check
 fmt-check:
     cargo fmt --all -- --check
@@ -152,8 +181,8 @@ docs-site-check:
 test-docs-walkthrough scenario identity output:
     python3 test/docs-walkthrough/run.py run --scenario "{{ scenario }}" --identity "{{ identity }}" --output "{{ output }}"
 
-# Run local tests, lint, format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes.
-check: test lint fmt-check audit check-pam-standalone check-agent-docs check-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-predecessor-contract test-release-artifacts
+# Run local tests, lint (default and `tpm`), format, audit, PAM isolation and documentation/install/release contracts; excludes full packaging and hardware lanes.
+check: test lint check-tpm fmt-check audit check-pam-standalone check-agent-docs check-docs test-source-install-daemon-lifecycle test-cargo-vendor-contract test-deb-source-contract test-deb-package-contract-test test-legacy-system-assets test-locale-install-contract test-classify-changes test-arch-package-select check-workflow-policy test-upgrade-predecessor-contract test-release-artifacts
 
 # The path filter that decides whether the packaging gates run on a pull
 # request. A pattern that stops matching fails nothing: it reports every deb,

--- a/test/docs-inventory-test.py
+++ b/test/docs-inventory-test.py
@@ -24,7 +24,7 @@ class InventoryTest(unittest.TestCase):
     def test_container_workspace_tests_trust_only_the_checkout(self):
         workflow = (MODULE.ROOT / '.github/workflows/ci.yml').read_text()
         trust = '\n        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"'
-        for job, tests in (('build-and-test', 'run: just test'), ('tpm-tests', 'run: cargo test --workspace')):
+        for job, tests in (('build-and-test', 'run: just test'), ('tpm-tests', 'run: just test-tpm')):
             with self.subTest(job=job):
                 body = re.search(r'(?ms)^  ' + job + r':\n(.*?)(?=^  \S|\Z)', workflow)[1]
                 self.assertIn(trust, body)


### PR DESCRIPTION
## Summary

- add `just check-tpm` (`lint-tpm` plus a new `just test-tpm`) and call it from `just check`
- keep it out of `just test`: the feature set is a second full workspace compile and that is the inner loop
- point CI's `tpm-tests` job at `just test-tpm` so the feature test run has one definition, not two
- state on the recipe, and in the testing rule, that a TPM-less run proves the feature gates and the decisions their tests pin, not sealing behaviour
- costs `just check` roughly 30s warm and 53s cold on a 32-core host

## Why

`just check` compiled the default feature set only, so the 80
`feature = "tpm"` cfg sites across the cli, daemon and tpm crates never built
locally and a regression inside one passed every local gate. #358 is the
worked example: a guard in `setup_encryption_auto`'s TPM branch could be
deleted with every `facelock-cli` test still green, because that branch is
`unreachable!()` without the feature.

## Validation

- mutation: deleted the `keygen_refusal` guard from the tpm-gated `Mint` arm of `setup_encryption_auto`, confirmed `just test` stays green while `just check-tpm` fails on `auto_policy_refuses_to_seal_a_new_key_over_encrypted_rows`, then restored it and rebuilt the crate clean
- `just check` end to end, plus `just check-docs`, `just check-agent-docs`, `test/check-workflow-policy.py`

Fixes #386
